### PR TITLE
feat: migrate task details layout to unified webapp

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
@@ -14,9 +14,6 @@ const config: KnipConfig = {
 		'src/shared/feature-flags.ts',
 		'shared-test-modules/mock-handlers.ts',
 		'src/shared/browser-storage/session-storage.ts',
-		'src/shared/http/request.ts',
-		'shared-test-modules/api-mocks/process-definitions.ts',
-		'shared-test-modules/api-mocks/user-tasks.ts',
 		'shared-test-modules/api-mocks/process-definition-statistics.ts',
 		'shared-test-modules/api-mocks/incident-statistics.ts',
 		// TODO(#55735): remove when consumer migration is complete

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-handlers.ts
@@ -74,6 +74,11 @@ const mockSaasTokenEndpoint = createEndpointMock({
 	method: 'GET',
 });
 
+const mockGetUserTaskEndpoint = createEndpointMock({
+	endpoint: endpoints.getUserTask.getUrl({userTaskKey: ':userTaskKey'}),
+	method: endpoints.getUserTask.method,
+});
+
 export {
 	mockCurrentUserEndpoint,
 	mockLoginEndpoint,
@@ -81,6 +86,7 @@ export {
 	mockSystemConfigurationEndpoint,
 	mockLicenseEndpoint,
 	mockSaasTokenEndpoint,
+	mockGetUserTaskEndpoint,
 	mockQueryUserTasksEndpoint,
 	mockQueryProcessDefinitionsEndpoint,
 	mockGetProcessDefinitionInstanceStatisticsEndpoint,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routeTree.gen.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routeTree.gen.ts
@@ -24,7 +24,10 @@ import { Route as AuthOperateDecisionsRouteImport } from './routes/_auth/operate
 import { Route as AuthOperateBatchOperationsRouteImport } from './routes/_auth/operate/batch-operations'
 import { Route as AuthTasklistTasksRouteRouteImport } from './routes/_auth/tasklist/_tasks/route'
 import { Route as AuthTasklistTasksIndexRouteImport } from './routes/_auth/tasklist/_tasks/index'
-import { Route as AuthTasklistTasksIdRouteImport } from './routes/_auth/tasklist/_tasks/$id'
+import { Route as AuthTasklistTasksUserTaskKeyRouteRouteImport } from './routes/_auth/tasklist/_tasks/$userTaskKey/route'
+import { Route as AuthTasklistTasksUserTaskKeyIndexRouteImport } from './routes/_auth/tasklist/_tasks/$userTaskKey/index'
+import { Route as AuthTasklistTasksUserTaskKeyProcessRouteImport } from './routes/_auth/tasklist/_tasks/$userTaskKey/process'
+import { Route as AuthTasklistTasksUserTaskKeyHistoryRouteImport } from './routes/_auth/tasklist/_tasks/$userTaskKey/history'
 
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
@@ -101,11 +104,30 @@ const AuthTasklistTasksIndexRoute = AuthTasklistTasksIndexRouteImport.update({
   path: '/',
   getParentRoute: () => AuthTasklistTasksRouteRoute,
 } as any)
-const AuthTasklistTasksIdRoute = AuthTasklistTasksIdRouteImport.update({
-  id: '/$id',
-  path: '/$id',
-  getParentRoute: () => AuthTasklistTasksRouteRoute,
-} as any)
+const AuthTasklistTasksUserTaskKeyRouteRoute =
+  AuthTasklistTasksUserTaskKeyRouteRouteImport.update({
+    id: '/$userTaskKey',
+    path: '/$userTaskKey',
+    getParentRoute: () => AuthTasklistTasksRouteRoute,
+  } as any)
+const AuthTasklistTasksUserTaskKeyIndexRoute =
+  AuthTasklistTasksUserTaskKeyIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => AuthTasklistTasksUserTaskKeyRouteRoute,
+  } as any)
+const AuthTasklistTasksUserTaskKeyProcessRoute =
+  AuthTasklistTasksUserTaskKeyProcessRouteImport.update({
+    id: '/process',
+    path: '/process',
+    getParentRoute: () => AuthTasklistTasksUserTaskKeyRouteRoute,
+  } as any)
+const AuthTasklistTasksUserTaskKeyHistoryRoute =
+  AuthTasklistTasksUserTaskKeyHistoryRouteImport.update({
+    id: '/history',
+    path: '/history',
+    getParentRoute: () => AuthTasklistTasksUserTaskKeyRouteRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof AuthIndexRoute
@@ -120,8 +142,11 @@ export interface FileRoutesByFullPath {
   '/tasklist/processes': typeof AuthTasklistProcessesRoute
   '/admin/': typeof AuthAdminIndexRoute
   '/operate/': typeof AuthOperateIndexRoute
-  '/tasklist/$id': typeof AuthTasklistTasksIdRoute
+  '/tasklist/$userTaskKey': typeof AuthTasklistTasksUserTaskKeyRouteRouteWithChildren
   '/tasklist/': typeof AuthTasklistTasksIndexRoute
+  '/tasklist/$userTaskKey/history': typeof AuthTasklistTasksUserTaskKeyHistoryRoute
+  '/tasklist/$userTaskKey/process': typeof AuthTasklistTasksUserTaskKeyProcessRoute
+  '/tasklist/$userTaskKey/': typeof AuthTasklistTasksUserTaskKeyIndexRoute
 }
 export interface FileRoutesByTo {
   '/login': typeof LoginRoute
@@ -134,7 +159,9 @@ export interface FileRoutesByTo {
   '/tasklist/processes': typeof AuthTasklistProcessesRoute
   '/admin': typeof AuthAdminIndexRoute
   '/operate': typeof AuthOperateIndexRoute
-  '/tasklist/$id': typeof AuthTasklistTasksIdRoute
+  '/tasklist/$userTaskKey/history': typeof AuthTasklistTasksUserTaskKeyHistoryRoute
+  '/tasklist/$userTaskKey/process': typeof AuthTasklistTasksUserTaskKeyProcessRoute
+  '/tasklist/$userTaskKey': typeof AuthTasklistTasksUserTaskKeyIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -152,8 +179,11 @@ export interface FileRoutesById {
   '/_auth/tasklist/processes': typeof AuthTasklistProcessesRoute
   '/_auth/admin/': typeof AuthAdminIndexRoute
   '/_auth/operate/': typeof AuthOperateIndexRoute
-  '/_auth/tasklist/_tasks/$id': typeof AuthTasklistTasksIdRoute
+  '/_auth/tasklist/_tasks/$userTaskKey': typeof AuthTasklistTasksUserTaskKeyRouteRouteWithChildren
   '/_auth/tasklist/_tasks/': typeof AuthTasklistTasksIndexRoute
+  '/_auth/tasklist/_tasks/$userTaskKey/history': typeof AuthTasklistTasksUserTaskKeyHistoryRoute
+  '/_auth/tasklist/_tasks/$userTaskKey/process': typeof AuthTasklistTasksUserTaskKeyProcessRoute
+  '/_auth/tasklist/_tasks/$userTaskKey/': typeof AuthTasklistTasksUserTaskKeyIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -170,8 +200,11 @@ export interface FileRouteTypes {
     | '/tasklist/processes'
     | '/admin/'
     | '/operate/'
-    | '/tasklist/$id'
+    | '/tasklist/$userTaskKey'
     | '/tasklist/'
+    | '/tasklist/$userTaskKey/history'
+    | '/tasklist/$userTaskKey/process'
+    | '/tasklist/$userTaskKey/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/login'
@@ -184,7 +217,9 @@ export interface FileRouteTypes {
     | '/tasklist/processes'
     | '/admin'
     | '/operate'
-    | '/tasklist/$id'
+    | '/tasklist/$userTaskKey/history'
+    | '/tasklist/$userTaskKey/process'
+    | '/tasklist/$userTaskKey'
   id:
     | '__root__'
     | '/_auth'
@@ -201,8 +236,11 @@ export interface FileRouteTypes {
     | '/_auth/tasklist/processes'
     | '/_auth/admin/'
     | '/_auth/operate/'
-    | '/_auth/tasklist/_tasks/$id'
+    | '/_auth/tasklist/_tasks/$userTaskKey'
     | '/_auth/tasklist/_tasks/'
+    | '/_auth/tasklist/_tasks/$userTaskKey/history'
+    | '/_auth/tasklist/_tasks/$userTaskKey/process'
+    | '/_auth/tasklist/_tasks/$userTaskKey/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -317,12 +355,33 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthTasklistTasksIndexRouteImport
       parentRoute: typeof AuthTasklistTasksRouteRoute
     }
-    '/_auth/tasklist/_tasks/$id': {
-      id: '/_auth/tasklist/_tasks/$id'
-      path: '/$id'
-      fullPath: '/tasklist/$id'
-      preLoaderRoute: typeof AuthTasklistTasksIdRouteImport
+    '/_auth/tasklist/_tasks/$userTaskKey': {
+      id: '/_auth/tasklist/_tasks/$userTaskKey'
+      path: '/$userTaskKey'
+      fullPath: '/tasklist/$userTaskKey'
+      preLoaderRoute: typeof AuthTasklistTasksUserTaskKeyRouteRouteImport
       parentRoute: typeof AuthTasklistTasksRouteRoute
+    }
+    '/_auth/tasklist/_tasks/$userTaskKey/': {
+      id: '/_auth/tasklist/_tasks/$userTaskKey/'
+      path: '/'
+      fullPath: '/tasklist/$userTaskKey/'
+      preLoaderRoute: typeof AuthTasklistTasksUserTaskKeyIndexRouteImport
+      parentRoute: typeof AuthTasklistTasksUserTaskKeyRouteRoute
+    }
+    '/_auth/tasklist/_tasks/$userTaskKey/process': {
+      id: '/_auth/tasklist/_tasks/$userTaskKey/process'
+      path: '/process'
+      fullPath: '/tasklist/$userTaskKey/process'
+      preLoaderRoute: typeof AuthTasklistTasksUserTaskKeyProcessRouteImport
+      parentRoute: typeof AuthTasklistTasksUserTaskKeyRouteRoute
+    }
+    '/_auth/tasklist/_tasks/$userTaskKey/history': {
+      id: '/_auth/tasklist/_tasks/$userTaskKey/history'
+      path: '/history'
+      fullPath: '/tasklist/$userTaskKey/history'
+      preLoaderRoute: typeof AuthTasklistTasksUserTaskKeyHistoryRouteImport
+      parentRoute: typeof AuthTasklistTasksUserTaskKeyRouteRoute
     }
   }
 }
@@ -358,14 +417,36 @@ const AuthOperateRouteRouteChildren: AuthOperateRouteRouteChildren = {
 const AuthOperateRouteRouteWithChildren =
   AuthOperateRouteRoute._addFileChildren(AuthOperateRouteRouteChildren)
 
+interface AuthTasklistTasksUserTaskKeyRouteRouteChildren {
+  AuthTasklistTasksUserTaskKeyHistoryRoute: typeof AuthTasklistTasksUserTaskKeyHistoryRoute
+  AuthTasklistTasksUserTaskKeyProcessRoute: typeof AuthTasklistTasksUserTaskKeyProcessRoute
+  AuthTasklistTasksUserTaskKeyIndexRoute: typeof AuthTasklistTasksUserTaskKeyIndexRoute
+}
+
+const AuthTasklistTasksUserTaskKeyRouteRouteChildren: AuthTasklistTasksUserTaskKeyRouteRouteChildren =
+  {
+    AuthTasklistTasksUserTaskKeyHistoryRoute:
+      AuthTasklistTasksUserTaskKeyHistoryRoute,
+    AuthTasklistTasksUserTaskKeyProcessRoute:
+      AuthTasklistTasksUserTaskKeyProcessRoute,
+    AuthTasklistTasksUserTaskKeyIndexRoute:
+      AuthTasklistTasksUserTaskKeyIndexRoute,
+  }
+
+const AuthTasklistTasksUserTaskKeyRouteRouteWithChildren =
+  AuthTasklistTasksUserTaskKeyRouteRoute._addFileChildren(
+    AuthTasklistTasksUserTaskKeyRouteRouteChildren,
+  )
+
 interface AuthTasklistTasksRouteRouteChildren {
-  AuthTasklistTasksIdRoute: typeof AuthTasklistTasksIdRoute
+  AuthTasklistTasksUserTaskKeyRouteRoute: typeof AuthTasklistTasksUserTaskKeyRouteRouteWithChildren
   AuthTasklistTasksIndexRoute: typeof AuthTasklistTasksIndexRoute
 }
 
 const AuthTasklistTasksRouteRouteChildren: AuthTasklistTasksRouteRouteChildren =
   {
-    AuthTasklistTasksIdRoute: AuthTasklistTasksIdRoute,
+    AuthTasklistTasksUserTaskKeyRouteRoute:
+      AuthTasklistTasksUserTaskKeyRouteRouteWithChildren,
     AuthTasklistTasksIndexRoute: AuthTasklistTasksIndexRoute,
   }
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/_tasks/$userTaskKey/history.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/_tasks/$userTaskKey/history.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_auth/tasklist/_tasks/$userTaskKey/history')({
+	component: function HistoryTabPlaceholder() {
+		return <div data-testid="history-tab-content" />;
+	},
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/_tasks/$userTaskKey/index.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/_tasks/$userTaskKey/index.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_auth/tasklist/_tasks/$userTaskKey/')({
+	component: function TaskTabPlaceholder() {
+		return <div data-testid="task-tab-content" />;
+	},
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/_tasks/$userTaskKey/process.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/_tasks/$userTaskKey/process.tsx
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createFileRoute} from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_auth/tasklist/_tasks/$userTaskKey/process')({
+	component: function ProcessTabPlaceholder() {
+		return <div data-testid="process-tab-content" />;
+	},
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/_tasks/$userTaskKey/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/_tasks/$userTaskKey/route.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect} from 'react';
+import {createFileRoute, notFound, Outlet, useNavigate} from '@tanstack/react-router';
+import {useSuspenseQuery} from '@tanstack/react-query';
+import {queries} from '#/shared/http/queries';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
+import {TaskDetailPage} from '#/tasklist/pages/TaskDetailPage';
+import {DetailsSkeleton} from '#/tasklist/modules/task-details/components/DetailsSkeleton';
+import type {UserTask} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestErrorSchema} from '#/shared/http/request';
+
+const POLLING_STATES: UserTask['state'][] = ['CANCELING', 'UPDATING', 'COMPLETING', 'ASSIGNING'];
+
+export const Route = createFileRoute('/_auth/tasklist/_tasks/$userTaskKey')({
+	loader: async ({context: {queryClient}, params: {userTaskKey}}) => {
+		try {
+			await queryClient.ensureQueryData(queries.getUserTask(userTaskKey));
+		} catch (error) {
+			const result = requestErrorSchema.safeParse(error);
+
+			if (result.success && result.data.response?.status === 404) {
+				throw notFound({routeId: '/_auth/tasklist/_tasks/$userTaskKey'});
+			}
+
+			throw error;
+		}
+	},
+	pendingComponent: () => <DetailsSkeleton data-testid="details-skeleton" />,
+	component: function TaskDetailRoute() {
+		const {userTaskKey} = Route.useParams();
+		const navigate = useNavigate();
+
+		const {data: task, refetch} = useSuspenseQuery({
+			...queries.getUserTask(userTaskKey),
+			refetchInterval(query) {
+				const state = query.state.data?.state;
+				if (state && POLLING_STATES.includes(state)) {
+					return 5000;
+				}
+				return false;
+			},
+		});
+
+		const {data: currentUser} = useSuspenseQuery(queries.getCurrentUser());
+
+		useEffect(() => {
+			if (task.state === 'CANCELED') {
+				notificationsStore.displayNotification({
+					kind: 'info',
+					title: 'Process instance cancelled',
+					subtitle: `${task.processName ?? task.processDefinitionId} (${task.processInstanceKey})`,
+					isDismissable: true,
+				});
+				navigate({to: '/tasklist'});
+			}
+		}, [navigate, task.processInstanceKey, task.processName, task.state, task.processDefinitionId]);
+
+		return (
+			<TaskDetailPage task={task} currentUser={currentUser} refetch={refetch}>
+				<Outlet />
+			</TaskDetailPage>
+		);
+	},
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/_tasks/$userTaskKey/route.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/routes/_auth/tasklist/_tasks/$userTaskKey/route.tsx
@@ -7,6 +7,7 @@
  */
 
 import {useEffect} from 'react';
+import {t} from 'i18next';
 import {createFileRoute, notFound, Outlet, useNavigate} from '@tanstack/react-router';
 import {useSuspenseQuery} from '@tanstack/react-query';
 import {queries} from '#/shared/http/queries';
@@ -54,7 +55,7 @@ export const Route = createFileRoute('/_auth/tasklist/_tasks/$userTaskKey')({
 			if (task.state === 'CANCELED') {
 				notificationsStore.displayNotification({
 					kind: 'info',
-					title: 'Process instance cancelled',
+					title: t('tasklist.processInstanceCancelledNotification'),
 					subtitle: `${task.processName ?? task.processDefinitionId} (${task.processInstanceKey})`,
 					isDismissable: true,
 				});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/browser-storage/local-storage.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/browser-storage/local-storage.ts
@@ -17,6 +17,7 @@ const {
 } = createBrowserStorage(localStorage, {
 	theme: z.enum(['light', 'dark', 'system']),
 	wasReloaded: z.boolean(),
+	'tasklist.areNativeNotificationsEnabled': z.boolean(),
 	'tasklist.hasCompletedTask': z.boolean(),
 	'tasklist.customFilters': z.record(z.string(), namedCustomFiltersSchema),
 	'operate.panelStates': z.record(z.string(), z.union([z.boolean(), z.array(z.number())])),

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/header/useNavbar.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/header/useNavbar.ts
@@ -11,6 +11,7 @@ import {useTranslation} from 'react-i18next';
 import type {C3NavigationAppProps, C3NavigationNavBarElement} from '@camunda/camunda-composite-components';
 import type {CurrentUser} from '@camunda/camunda-api-zod-schemas/8.10';
 import {tracking} from '#/shared/tracking';
+import {useHasRouteMatch} from '#/shared/useHasRouteMatch';
 import {useCallback} from 'react';
 
 type NavbarConfig = {
@@ -37,12 +38,9 @@ const tabRoutes = {
 function useNavbar(currentUser: CurrentUser): NavbarConfig {
 	const {t} = useTranslation();
 	const matchRoute = useMatchRoute();
+	const hasRouteMatch = useHasRouteMatch();
 	const {authorizedComponents} = currentUser;
 
-	const hasRouteMatch = useCallback(
-		(...routes: FileRouteTypes['to'][]) => routes.some((to) => matchRoute({to}) !== false),
-		[matchRoute],
-	);
 	const hasComponentRouteMatch = useCallback(
 		(component: 'tasklist' | 'admin' | 'operate') => matchRoute({to: `/${component}`, fuzzy: true}) !== false,
 		[matchRoute],
@@ -67,7 +65,14 @@ function useNavbar(currentUser: CurrentUser): NavbarConfig {
 						{
 							key: 'tasks',
 							label: t('tasklist.headerNavItemTasks'),
-							isCurrentPage: !hasRouteMatch('/tasklist/processes') && hasRouteMatch('/tasklist', '/tasklist/$id'),
+							isCurrentPage:
+								!hasRouteMatch('/tasklist/processes') &&
+								hasRouteMatch(
+									'/tasklist',
+									'/tasklist/$userTaskKey',
+									'/tasklist/$userTaskKey/process',
+									'/tasklist/$userTaskKey/history',
+								),
 							routeProps: {
 								to: tabRoutes['tasklistIndex'],
 								onClick: () => {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/endpoints.ts
@@ -15,6 +15,8 @@ import {
 	type GetIncidentProcessInstanceStatisticsByErrorRequestBody,
 	type GetIncidentProcessInstanceStatisticsByDefinitionRequestBody,
 	type QueryBatchOperationsRequestBody,
+	type UserTask,
+	type ProcessDefinition,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {getBootConfig} from '#/shared/config/getBootConfig';
 import {mergePathname} from './mergePathname';
@@ -142,6 +144,20 @@ const endpoints = {
 		new Request(getFullURL(unifiedAPIEndpoints.getBatchOperation.getUrl({batchOperationKey})), {
 			...BASE_REQUEST_OPTIONS,
 			method: unifiedAPIEndpoints.getBatchOperation.method,
+			headers: {'Content-Type': 'application/json'},
+		}),
+
+	getUserTask: ({userTaskKey}: Pick<UserTask, 'userTaskKey'>) =>
+		new Request(getFullURL(unifiedAPIEndpoints.getUserTask.getUrl({userTaskKey})), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.getUserTask.method,
+			headers: {'Content-Type': 'application/json'},
+		}),
+
+	getProcessDefinitionXml: ({processDefinitionKey}: Pick<ProcessDefinition, 'processDefinitionKey'>) =>
+		new Request(getFullURL(unifiedAPIEndpoints.getProcessDefinitionXml.getUrl({processDefinitionKey})), {
+			...BASE_REQUEST_OPTIONS,
+			method: unifiedAPIEndpoints.getProcessDefinitionXml.method,
 			headers: {'Content-Type': 'application/json'},
 		}),
 };

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/queries.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/http/queries.ts
@@ -11,6 +11,7 @@ import type {
 	GetSystemConfigurationResponseBody,
 	CurrentUser,
 	License,
+	UserTask,
 	QueryUserTasksRequestBody,
 	QueryUserTasksResponseBody,
 	QueryProcessDefinitionsRequestBody,
@@ -30,6 +31,8 @@ const queryKeys = {
 	systemConfiguration: () => ['systemConfiguration'] as const,
 	license: () => ['license'] as const,
 	userTasks: (body: QueryUserTasksRequestBody) => ['userTasks', body] as const,
+	userTask: (userTaskKey: string) => ['userTask', userTaskKey] as const,
+	processDefinitionXml: (processDefinitionKey: string) => ['processDefinitionXml', processDefinitionKey] as const,
 	queryProcessDefinitions: (body: QueryProcessDefinitionsRequestBody) => ['queryProcessDefinitions', body] as const,
 	getProcessDefinitionInstanceStatistics: (body: GetProcessDefinitionInstanceStatisticsRequestBody) =>
 		['getProcessDefinitionInstanceStatistics', body] as const,
@@ -126,6 +129,18 @@ const queries = {
 			},
 		});
 	},
+
+	getUserTask: (userTaskKey: string) =>
+		queryOptions({
+			queryKey: queryKeys.userTask(userTaskKey),
+			queryFn: async (): Promise<UserTask> => {
+				const {response, error} = await request(endpoints.getUserTask({userTaskKey}));
+				if (error !== null) {
+					throw error;
+				}
+				return response.json();
+			},
+		}),
 
 	getProcessDefinitionInstanceStatistics: (body: GetProcessDefinitionInstanceStatisticsRequestBody) =>
 		queryOptions({

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/os-notifications/requestPermission.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/os-notifications/requestPermission.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+async function requestPermission() {
+	if (!('Notification' in window)) {
+		return;
+	}
+
+	return Notification.requestPermission();
+}
+
+export {requestPermission};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/useHasRouteMatch.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/useHasRouteMatch.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useCallback} from 'react';
+import {useMatchRoute, type RegisteredRouter} from '@tanstack/react-router';
+
+type FileRouteTypes = RegisteredRouter['routeTree']['types']['fileRouteTypes'];
+
+function useHasRouteMatch() {
+	const matchRoute = useMatchRoute();
+
+	return useCallback(
+		(...routes: FileRouteTypes['to'][]) => routes.some((to) => matchRoute({to}) !== false),
+		[matchRoute],
+	);
+}
+
+export {useHasRouteMatch};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/AvailableTasks.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/AvailableTasks.test.tsx
@@ -40,7 +40,7 @@ describe('<AvailableTasks />', () => {
 					onScrollUp={noop}
 				/>
 			),
-			{path: '/tasklist/$id', initialEntry: '/tasklist/1'},
+			{path: '/tasklist/$userTaskKey', initialEntry: '/tasklist/1'},
 		);
 
 		await expect.element(screen.getByText('First Task')).toBeVisible();
@@ -83,7 +83,7 @@ describe('<AvailableTasks />', () => {
 					/>
 				</div>
 			),
-			{path: '/tasklist/$id', initialEntry: '/tasklist/1'},
+			{path: '/tasklist/$userTaskKey', initialEntry: '/tasklist/1'},
 		);
 
 		await userEvent.wheel(screen.getByTestId('scrollable-list'), {delta: {y: 10000}});
@@ -110,7 +110,7 @@ describe('<AvailableTasks />', () => {
 					/>
 				</div>
 			),
-			{path: '/tasklist/$id', initialEntry: '/tasklist/1'},
+			{path: '/tasklist/$userTaskKey', initialEntry: '/tasklist/1'},
 		);
 
 		await userEvent.wheel(screen.getByTestId('scrollable-list'), {delta: {y: 10000}});
@@ -136,7 +136,7 @@ describe('<AvailableTasks />', () => {
 					/>
 				</div>
 			),
-			{path: '/tasklist/$id', initialEntry: '/tasklist/1'},
+			{path: '/tasklist/$userTaskKey', initialEntry: '/tasklist/1'},
 		);
 
 		const scrollableList = screen.getByTestId('scrollable-list');
@@ -166,7 +166,7 @@ describe('<AvailableTasks />', () => {
 					/>
 				</div>
 			),
-			{path: '/tasklist/$id', initialEntry: '/tasklist/1'},
+			{path: '/tasklist/$userTaskKey', initialEntry: '/tasklist/1'},
 		);
 
 		const scrollableList = screen.getByTestId('scrollable-list');

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/Task.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/Task.test.tsx
@@ -30,7 +30,7 @@ const baseProps = {
 describe('<Task />', () => {
 	it('should render the task display name and process name', async () => {
 		const screen = await renderWithRouter(() => <Task {...baseProps} />, {
-			path: '/tasklist/$id',
+			path: '/tasklist/$userTaskKey',
 			initialEntry: '/tasklist/other-task',
 		});
 
@@ -40,7 +40,7 @@ describe('<Task />', () => {
 
 	it('should render a link with an accessible label for an unassigned task', async () => {
 		const screen = await renderWithRouter(() => <Task {...baseProps} assignee={null} />, {
-			path: '/tasklist/$id',
+			path: '/tasklist/$userTaskKey',
 			initialEntry: '/tasklist/other-task',
 		});
 
@@ -49,7 +49,7 @@ describe('<Task />', () => {
 
 	it('should render an "assigned to me" label', async () => {
 		const screen = await renderWithRouter(() => <Task {...baseProps} assignee={currentUser.username} />, {
-			path: '/tasklist/$id',
+			path: '/tasklist/$userTaskKey',
 			initialEntry: '/tasklist/other-task',
 		});
 
@@ -58,7 +58,7 @@ describe('<Task />', () => {
 
 	it('should render an "assigned task" label', async () => {
 		const screen = await renderWithRouter(() => <Task {...baseProps} assignee="john.doe" />, {
-			path: '/tasklist/$id',
+			path: '/tasklist/$userTaskKey',
 			initialEntry: '/tasklist/other-task',
 		});
 
@@ -67,7 +67,7 @@ describe('<Task />', () => {
 
 	it('should render the priority label', async () => {
 		const screen = await renderWithRouter(() => <Task {...baseProps} priority={80} />, {
-			path: '/tasklist/$id',
+			path: '/tasklist/$userTaskKey',
 			initialEntry: '/tasklist/other-task',
 		});
 
@@ -76,7 +76,7 @@ describe('<Task />', () => {
 
 	it('should not render the priority label', async () => {
 		const screen = await renderWithRouter(() => <Task {...baseProps} priority={null} />, {
-			path: '/tasklist/$id',
+			path: '/tasklist/$userTaskKey',
 			initialEntry: '/tasklist/other-task',
 		});
 

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/Task.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/Task.tsx
@@ -51,8 +51,8 @@ const Task = React.forwardRef<HTMLDivElement, Props>(
 		ref,
 	) => {
 		const {t} = useTranslation();
-		const {id: openTaskId} = useParams({strict: false});
-		const isActive = openTaskId === taskId;
+		const {userTaskKey} = useParams({strict: false});
+		const isActive = userTaskKey === taskId;
 
 		const creationDate = formatISODateTime(creationDateString);
 		const completionDate = formatISODate(completionDateString);
@@ -69,8 +69,8 @@ const Task = React.forwardRef<HTMLDivElement, Props>(
 			<article className={cn(styles.container, {[styles.active!]: isActive})}>
 				<Link
 					className={styles.taskLink}
-					to="/tasklist/$id"
-					params={{id: taskId}}
+					to="/tasklist/$userTaskKey"
+					params={{userTaskKey: taskId}}
 					aria-label={getNavLinkLabel({
 						displayName,
 						assigneeId: assignee,

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/ActiveTransitionLoadingText.module.scss
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/ActiveTransitionLoadingText.module.scss
@@ -6,9 +6,17 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {TaskDetailPage} from '#/tasklist/pages/TaskDetailPage';
-import {createFileRoute} from '@tanstack/react-router';
+@use '@carbon/type';
 
-export const Route = createFileRoute('/_auth/tasklist/_tasks/$id')({
-	component: TaskDetailPage,
-});
+.container {
+	width: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: end;
+	gap: var(--cds-spacing-03);
+}
+
+.message {
+	@include type.type-style('label-02');
+	color: var(--cds-text-secondary);
+}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/ActiveTransitionLoadingText.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/ActiveTransitionLoadingText.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Loading} from '@carbon/react';
+import {useTranslation} from 'react-i18next';
+import styles from './ActiveTransitionLoadingText.module.scss';
+
+type Props = {
+	taskState:
+		| 'CREATED'
+		| 'COMPLETED'
+		| 'CANCELED'
+		| 'FAILED'
+		| 'ASSIGNING'
+		| 'UPDATING'
+		| 'COMPLETING'
+		| 'CANCELING'
+		| 'CREATING';
+};
+
+const ActiveTransitionLoadingText: React.FC<Props> = ({taskState}) => {
+	const {t} = useTranslation();
+
+	const statusLoadingMessage: Record<Props['taskState'], string | null> = {
+		CREATED: null,
+		CREATING: null,
+		ASSIGNING: null,
+		COMPLETED: null,
+		CANCELED: null,
+		FAILED: null,
+		UPDATING: t('tasklist.taskStateUpdatingMessage'),
+		CANCELING: t('tasklist.taskStateCancelingMessage'),
+		COMPLETING: t('tasklist.taskDetailsCompletingTaskMessage'),
+	};
+
+	if (statusLoadingMessage[taskState] === null) {
+		return null;
+	}
+
+	return (
+		<div className={styles.container}>
+			<Loading small withOverlay={false} />
+			<p className={styles.message}>{statusLoadingMessage[taskState]}</p>
+		</div>
+	);
+};
+
+export {ActiveTransitionLoadingText};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/Aside.module.scss
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/Aside.module.scss
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+@use '@carbon/type';
+
+.itemHeading {
+	color: var(--cds-text-secondary);
+	@include type.type-style('body-short-01');
+}
+
+.itemBody {
+	color: var(--cds-text-primary);
+	@include type.type-style('body-short-01');
+}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/Aside.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/Aside.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ContainedList, ContainedListItem, Tag} from '@carbon/react';
+import {useTranslation} from 'react-i18next';
+import type {CurrentUser} from '@camunda/camunda-api-zod-schemas/8.10';
+import {formatISODateTime} from '#/tasklist/modules/dates/formatDateRelative';
+import {getPriorityLabel} from '#/tasklist/modules/available-tasks/getPriorityLabel';
+import styles from './Aside.module.scss';
+import layoutStyles from './taskDetailsLayoutCommon.module.scss';
+
+type Props = {
+	creationDate: string;
+	completionDate: string | null | undefined;
+	dueDate: string | null | undefined;
+	followUpDate: string | null | undefined;
+	priority: number | null | undefined;
+	candidateUsers: string[];
+	candidateGroups: string[];
+	tenantId: string;
+	user: CurrentUser;
+};
+
+const Aside: React.FC<Props> = ({
+	creationDate,
+	completionDate,
+	dueDate,
+	followUpDate,
+	priority,
+	candidateUsers,
+	candidateGroups,
+	tenantId,
+	user,
+}) => {
+	const {t} = useTranslation();
+	const taskTenant = user.tenants.length > 1 ? user.tenants.find((tenant) => tenant.tenantId === tenantId) : undefined;
+	const candidates = [...(candidateUsers ?? []), ...(candidateGroups ?? [])];
+
+	return (
+		<aside className={layoutStyles.aside} aria-label={t('tasklist.taskDetailsRightPanel')}>
+			<ContainedList label={t('tasklist.taskDetailsDetailsLabel')} kind="disclosed">
+				<>
+					{taskTenant === undefined ? null : (
+						<ContainedListItem>
+							<span className={styles.itemHeading}>{t('tasklist.taskDetailsTenantLabel')}</span>
+							<br />
+							<span className={styles.itemBody}>{taskTenant.name}</span>
+						</ContainedListItem>
+					)}
+				</>
+				<ContainedListItem>
+					<span className={styles.itemHeading}>{t('tasklist.taskDetailsCreationDateLabel')}</span>
+					<br />
+					<span className={styles.itemBody}>{formatISODateTime(creationDate)?.absolute.text ?? creationDate}</span>
+				</ContainedListItem>
+				<ContainedListItem>
+					<span className={styles.itemHeading}>{t('tasklist.taskDetailsCandidatesLabel')}</span>
+					<br />
+					{candidates.length === 0 ? (
+						<span className={styles.itemBody}>{t('tasklist.taskDetailsNoCandidatesLabel')}</span>
+					) : null}
+					{candidates.map((candidate) => (
+						<Tag size="sm" type="gray" key={candidate}>
+							{candidate}
+						</Tag>
+					))}
+				</ContainedListItem>
+				{typeof priority === 'number' ? (
+					<ContainedListItem>
+						<span className={styles.itemHeading}>{t('tasklist.taskDetailsPriorityLabel')}</span>
+						<br />
+						<span className={styles.itemBody}>{getPriorityLabel(priority).short}</span>
+					</ContainedListItem>
+				) : null}
+				{completionDate ? (
+					<ContainedListItem>
+						<span className={styles.itemHeading}>{t('tasklist.taskDetailsCompletionDateLabel')}</span>
+						<br />
+						<span className={styles.itemBody}>
+							{formatISODateTime(completionDate)?.absolute.text ?? completionDate}
+						</span>
+					</ContainedListItem>
+				) : null}
+				<ContainedListItem>
+					<span className={styles.itemHeading}>{t('tasklist.taskDetailsDueDateLabel')}</span>
+					<br />
+					<span className={styles.itemBody}>
+						{dueDate ? (formatISODateTime(dueDate)?.absolute.text ?? dueDate) : t('tasklist.taskDetailsNoDueDateLabel')}
+					</span>
+				</ContainedListItem>
+				{followUpDate ? (
+					<ContainedListItem>
+						<span className={styles.itemHeading}>{t('tasklist.taskDetailsFollowUpDateLabel')}</span>
+						<br />
+						<span className={styles.itemBody}>{formatISODateTime(followUpDate)?.absolute.text ?? followUpDate}</span>
+					</ContainedListItem>
+				) : null}
+			</ContainedList>
+		</aside>
+	);
+};
+
+export {Aside};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/DetailsSkeleton.module.scss
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/DetailsSkeleton.module.scss
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+.margin0 {
+	margin: 0;
+}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/DetailsSkeleton.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/DetailsSkeleton.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ButtonSkeleton, ContainedList, ContainedListItem, Section, SkeletonText, TabsSkeleton} from '@carbon/react';
+import styles from './DetailsSkeleton.module.scss';
+import layoutStyles from './taskDetailsLayoutCommon.module.scss';
+
+type Props = {
+	'data-testid'?: string;
+};
+
+const DetailsSkeleton: React.FC<Props> = (props) => {
+	return (
+		<div className={layoutStyles.container} data-testid={props['data-testid']}>
+			<Section className={layoutStyles.content}>
+				<header className={layoutStyles.header}>
+					<div className={layoutStyles.headerLeftContainer}>
+						<SkeletonText width="150px" />
+						<SkeletonText width="100px" className={styles.margin0} />
+					</div>
+					<div className={layoutStyles.headerRightContainer}>
+						<SkeletonText width="100px" className={styles.margin0} />
+						<ButtonSkeleton size="sm" />
+					</div>
+				</header>
+				<TabsSkeleton className={layoutStyles.tabs} />
+			</Section>
+			<aside className={layoutStyles.aside}>
+				<ContainedList label={<SkeletonText width="100px" className={styles.margin0} />} kind="disclosed">
+					<ContainedListItem>
+						<SkeletonText width="75px" />
+						<SkeletonText width="125px" />
+					</ContainedListItem>
+					<ContainedListItem>
+						<SkeletonText width="75px" />
+						<SkeletonText width="125px" />
+					</ContainedListItem>
+					<ContainedListItem>
+						<SkeletonText width="75px" />
+						<SkeletonText width="125px" />
+					</ContainedListItem>
+					<ContainedListItem>
+						<SkeletonText width="75px" />
+						<SkeletonText width="125px" />
+					</ContainedListItem>
+					<ContainedListItem>
+						<SkeletonText width="75px" />
+						<SkeletonText width="125px" />
+					</ContainedListItem>
+				</ContainedList>
+			</aside>
+		</div>
+	);
+};
+
+export {DetailsSkeleton};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TabListNav.module.scss
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TabListNav.module.scss
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+:global(.cds--tabs__nav-link).hidden {
+	display: none;
+	visibility: hidden;
+}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TabListNav.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TabListNav.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useNavigate} from '@tanstack/react-router';
+import {cn} from '#/shared/cn';
+import styles from './TabListNav.module.scss';
+import layoutStyles from './taskDetailsLayoutCommon.module.scss';
+
+type TabItem = {
+	key: string;
+	title: string;
+	label: string;
+	selected: boolean;
+	to: string;
+	visible?: boolean;
+};
+
+type Props = {
+	className?: string;
+	label: string;
+	items: TabItem[];
+};
+
+const TabListNav: React.FC<Props> = ({className, label, items}) => {
+	const navigate = useNavigate();
+
+	return (
+		<nav className={cn(className, layoutStyles.tabs, 'cds--tabs')}>
+			<div className="cds--tab--list" aria-label={label}>
+				{items.map(({key, title, label: itemLabel, selected, to, visible}) => {
+					const isHidden = visible === false;
+					return (
+						<button
+							key={key}
+							type="button"
+							role="link"
+							aria-label={itemLabel}
+							aria-current={selected ? 'page' : undefined}
+							className={cn({[styles.hidden!]: isHidden}, 'cds--tabs__nav-item', 'cds--tabs__nav-link', {
+								'cds--tabs__nav-item--selected': selected,
+							})}
+							hidden={isHidden}
+							aria-hidden={isHidden}
+							onClick={() => navigate({to})}
+						>
+							<div className="cds--tabs__nav-item-label-wrapper">
+								<span className="cds--tabs__nav-item-label">{title}</span>
+							</div>
+						</button>
+					);
+				})}
+			</div>
+		</nav>
+	);
+};
+
+export {TabListNav};
+export type {TabItem};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TaskDetailsHeader.module.scss
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TaskDetailsHeader.module.scss
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+@use '@carbon/type';
+
+.taskName {
+	color: var(--cds-text-primary);
+	@include type.type-style('body-short-02');
+}
+
+.processName {
+	display: inline-flex;
+	align-items: center;
+	color: var(--cds-text-secondary);
+	@include type.type-style('label-01');
+}
+
+.taskStatus {
+	display: inline-flex;
+	align-items: center;
+	color: var(--cds-text-secondary);
+	@include type.type-style('label-01');
+}
+
+.taskAssignee {
+	display: inline-flex;
+	align-items: center;
+	color: var(--cds-text-secondary);
+	@include type.type-style('label-01');
+}
+
+.assignButtonContainer {
+	flex-shrink: 0;
+	display: flex;
+	align-items: center;
+}
+
+.alignItemsCenter {
+	align-items: center;
+}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TaskDetailsHeader.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TaskDetailsHeader.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useTranslation} from 'react-i18next';
+import {Stack} from '@carbon/react';
+import {CheckmarkFilled} from '@carbon/react/icons';
+import type {CurrentUser} from '@camunda/camunda-api-zod-schemas/8.10';
+import {AssigneeTag} from '#/tasklist/modules/available-tasks/components/AssigneeTag';
+import {ActiveTransitionLoadingText} from './ActiveTransitionLoadingText';
+import styles from './TaskDetailsHeader.module.scss';
+import layoutStyles from './taskDetailsLayoutCommon.module.scss';
+
+type Props = {
+	taskName: string;
+	processName: string;
+	assignee: string | null;
+	taskState:
+		| 'CREATED'
+		| 'COMPLETED'
+		| 'CANCELED'
+		| 'FAILED'
+		| 'ASSIGNING'
+		| 'UPDATING'
+		| 'COMPLETING'
+		| 'CANCELING'
+		| 'CREATING';
+	assignButton: React.ReactNode;
+	user: CurrentUser;
+};
+
+const TaskDetailsHeader: React.FC<Props> = ({taskName, processName, assignee, taskState, user, assignButton}) => {
+	const {t} = useTranslation();
+
+	function renderRightContent() {
+		switch (taskState) {
+			case 'COMPLETED':
+				return (
+					<span
+						className={styles.taskStatus}
+						data-testid="completion-label"
+						title={t('tasklist.taskDetailsTaskCompletedBy')}
+					>
+						<Stack className={styles.alignItemsCenter} orientation="horizontal" gap={2}>
+							<CheckmarkFilled size={16} color="green" />
+							{assignee ? (
+								<>
+									{t('tasklist.taskDetailsTaskCompletedBy') + ' '}
+									<span className={styles.taskAssignee} data-testid="assignee">
+										<AssigneeTag currentUser={user} assignee={assignee} isShortFormat />
+									</span>
+								</>
+							) : (
+								t('tasklist.taskAssignmentStatusCompleted')
+							)}
+						</Stack>
+					</span>
+				);
+			case 'CREATED':
+			case 'CANCELED':
+			case 'FAILED':
+				return (
+					<>
+						<span className={styles.taskAssignee} data-testid="assignee">
+							<AssigneeTag currentUser={user} assignee={assignee} isShortFormat={false} />
+						</span>
+						<span className={styles.assignButtonContainer}>{assignButton}</span>
+					</>
+				);
+			case 'UPDATING':
+			case 'CANCELING':
+				return (
+					<>
+						<ActiveTransitionLoadingText taskState={taskState} />
+						<span className={styles.taskAssignee} data-testid="assignee">
+							<AssigneeTag currentUser={user} assignee={assignee} isShortFormat={false} />
+						</span>
+					</>
+				);
+			case 'COMPLETING':
+				return (
+					<span className={styles.taskAssignee} data-testid="assignee">
+						<AssigneeTag currentUser={user} assignee={assignee} isShortFormat={false} />
+					</span>
+				);
+			case 'ASSIGNING':
+				return <span className={styles.assignButtonContainer}>{assignButton}</span>;
+			case 'CREATING':
+				return <ActiveTransitionLoadingText taskState={taskState} />;
+		}
+	}
+
+	return (
+		<header className={layoutStyles.header} title={t('tasklist.taskDetailsHeader')}>
+			<div className={layoutStyles.headerLeftContainer}>
+				<span className={styles.taskName}>{taskName}</span>
+				<span className={styles.processName}>{processName}</span>
+			</div>
+			<div className={layoutStyles.headerRightContainer}>{renderRightContent()}</div>
+		</header>
+	);
+};
+
+export {TaskDetailsHeader};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TaskDetailsLayout.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TaskDetailsLayout.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Section} from '@carbon/react';
+import {useTranslation} from 'react-i18next';
+import type {RegisteredRouter} from '@tanstack/react-router';
+import type {CurrentUser, UserTask} from '@camunda/camunda-api-zod-schemas/8.10';
+import {useHasRouteMatch} from '#/shared/useHasRouteMatch';
+import {TurnOnNotificationPermission} from './TurnOnNotificationPermission';
+import {TaskDetailsHeader} from './TaskDetailsHeader';
+import {TabListNav, type TabItem} from './TabListNav';
+import {Aside} from './Aside';
+import layoutStyles from './taskDetailsLayoutCommon.module.scss';
+
+type FileRouteTypes = RegisteredRouter['routeTree']['types']['fileRouteTypes'];
+type TypeSafeTabItem = Omit<TabItem, 'to'> & {to: FileRouteTypes['to']};
+
+type Props = {
+	task: UserTask;
+	currentUser: CurrentUser;
+	assignButton: React.ReactNode;
+	children: React.ReactNode;
+};
+
+const TaskDetailsLayout: React.FC<Props> = ({task, currentUser, assignButton, children}) => {
+	const {t} = useTranslation();
+	const hasRouteMatch = useHasRouteMatch();
+	const tabs = [
+		{
+			key: 'task',
+			title: t('tasklist.taskDetailsTaskTabLabel'),
+			label: t('tasklist.taskDetailsShowTaskLabel'),
+			selected: hasRouteMatch('/tasklist/$userTaskKey'),
+			to: '/tasklist/$userTaskKey',
+		},
+		{
+			key: 'process',
+			title: t('tasklist.taskDetailsProcessTabLabel'),
+			label: t('tasklist.taskDetailsShowBpmnProcessLabel'),
+			selected: hasRouteMatch('/tasklist/$userTaskKey/process'),
+			to: '/tasklist/$userTaskKey/process',
+		},
+		{
+			key: 'history',
+			title: t('tasklist.taskDetailsHistoryTabLabel'),
+			label: t('tasklist.taskDetailsShowHistoryLabel'),
+			selected: hasRouteMatch('/tasklist/$userTaskKey/history'),
+			to: '/tasklist/$userTaskKey/history',
+		},
+	] satisfies TypeSafeTabItem[];
+
+	return (
+		<div className={layoutStyles.container} data-testid="details-info">
+			<Section className={layoutStyles.content} level={4}>
+				<TurnOnNotificationPermission />
+				<TaskDetailsHeader
+					taskName={task.name ?? task.elementId}
+					processName={task.processName ?? task.processDefinitionId}
+					assignee={task.assignee ?? null}
+					taskState={task.state}
+					user={currentUser}
+					assignButton={assignButton}
+				/>
+				<TabListNav label={t('tasklist.taskDetailsNavLabel')} items={tabs} />
+				{children}
+			</Section>
+			<Aside
+				creationDate={task.creationDate}
+				completionDate={task.completionDate}
+				dueDate={task.dueDate}
+				followUpDate={task.followUpDate}
+				priority={task.priority}
+				candidateUsers={task.candidateUsers}
+				candidateGroups={task.candidateGroups}
+				tenantId={task.tenantId}
+				user={currentUser}
+			/>
+		</div>
+	);
+};
+
+export {TaskDetailsLayout};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TurnOnNotificationPermission.module.scss
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TurnOnNotificationPermission.module.scss
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+.actionableNotification {
+	max-inline-size: initial;
+}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TurnOnNotificationPermission.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/TurnOnNotificationPermission.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ActionableNotification} from '@carbon/react';
+import {useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import {requestPermission} from '#/shared/os-notifications/requestPermission';
+import {tracking} from '#/shared/tracking';
+import {getStateLocally, storeStateLocally} from '#/shared/browser-storage/local-storage';
+import styles from './TurnOnNotificationPermission.module.scss';
+
+const TurnOnNotificationPermission: React.FC = () => {
+	const {t} = useTranslation();
+	const areNativeNotificationsEnabled = getStateLocally('tasklist.areNativeNotificationsEnabled');
+	const [isEnabled, setIsEnabled] = useState(
+		'Notification' in window && Notification.permission === 'default' && !(areNativeNotificationsEnabled === false),
+	);
+
+	if (!isEnabled) {
+		return null;
+	}
+
+	return (
+		<div>
+			<ActionableNotification
+				inline
+				kind="info"
+				role="status"
+				aria-live="polite"
+				title={t('tasklist.turnOnNotificationTitle')}
+				subtitle={t('tasklist.turnOnNotificationSubtitle')}
+				actionButtonLabel={t('tasklist.turnOnNotificationsActionButton')}
+				onActionButtonClick={async () => {
+					const result = await requestPermission();
+					if (result !== undefined) {
+						tracking.track({
+							eventName: 'tasklist:os-notification-permission-requested',
+							outcome: result,
+						});
+					}
+					if (result !== 'default') {
+						setIsEnabled(false);
+					}
+				}}
+				onClose={() => {
+					setIsEnabled(false);
+					storeStateLocally('tasklist.areNativeNotificationsEnabled', false);
+				}}
+				className={styles.actionableNotification}
+				lowContrast
+			/>
+		</div>
+	);
+};
+
+export {TurnOnNotificationPermission};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/taskDetailsLayoutCommon.module.scss
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/taskDetailsLayoutCommon.module.scss
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+@use '@carbon/layout';
+
+.container {
+	width: 100%;
+	height: 100%;
+	display: grid;
+	grid-template-columns: 1fr layout.to-rem(312px);
+	overflow: auto;
+}
+
+.content {
+	padding-top: var(--cds-spacing-05);
+	display: flex;
+	flex-direction: column;
+	flex-wrap: nowrap;
+	align-items: center;
+	gap: var(--cds-spacing-03);
+	overflow-y: auto;
+}
+
+.header {
+	width: 100%;
+	padding: 0 var(--cds-spacing-05);
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	align-items: center;
+	gap: var(--cds-spacing-05);
+}
+
+.headerLeftContainer {
+	display: flex;
+	flex-direction: column;
+}
+
+.headerRightContainer {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: var(--cds-spacing-05);
+	margin-left: auto;
+}
+
+.aside {
+	height: 100%;
+	padding-top: var(--cds-spacing-05);
+	border-left: 1px solid var(--cds-border-subtle);
+	display: flex;
+	flex-direction: column;
+	overflow: auto;
+}
+
+.tabs {
+	border-top: 1px solid var(--cds-border-subtle);
+	border-bottom: 1px solid var(--cds-border-subtle);
+}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/pages/TaskDetailPage.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/pages/TaskDetailPage.tsx
@@ -6,12 +6,22 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useParams} from '@tanstack/react-router';
+import type {CurrentUser, UserTask} from '@camunda/camunda-api-zod-schemas/8.10';
+import {TaskDetailsLayout} from '#/tasklist/modules/task-details/components/TaskDetailsLayout';
 
-const TaskDetailPage: React.FC = () => {
-	const {id} = useParams({from: '/_auth/tasklist/_tasks/$id'});
+type Props = {
+	task: UserTask;
+	currentUser: CurrentUser;
+	refetch: () => void;
+	children: React.ReactNode;
+};
 
-	return <h1>{id}</h1>;
+const TaskDetailPage: React.FC<Props> = ({task, currentUser, children}) => {
+	return (
+		<TaskDetailsLayout task={task} currentUser={currentUser} assignButton={null}>
+			{children}
+		</TaskDetailsLayout>
+	);
 };
 
 export {TaskDetailPage};

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/component-routes.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/component-routes.test.ts
@@ -12,6 +12,7 @@ import {
 	mockCurrentUserEndpoint,
 	mockGetIncidentProcessInstanceStatisticsByErrorEndpoint,
 	mockGetProcessDefinitionInstanceStatisticsEndpoint,
+	mockGetUserTaskEndpoint,
 	mockLicenseEndpoint,
 	mockQueryUserTasksEndpoint,
 	mockSystemConfigurationEndpoint,
@@ -168,6 +169,9 @@ test.describe('component routes', () => {
 			mockLicenseEndpoint({successResponse: HttpResponse.json(createLicense())}),
 			mockQueryUserTasksEndpoint({
 				successResponse: HttpResponse.json(createQueryUserTasksResponse()),
+			}),
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json({}, {status: 404}),
 			}),
 		);
 

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/tasklist-index.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/tasklist-index.test.ts
@@ -11,6 +11,7 @@ import {HttpResponse} from 'msw';
 import {z} from 'zod';
 import {
 	mockCurrentUserEndpoint,
+	mockGetUserTaskEndpoint,
 	mockLicenseEndpoint,
 	mockQueryUserTasksEndpoint,
 	mockSystemConfigurationEndpoint,
@@ -61,6 +62,9 @@ test.beforeEach(({network}) => {
 		}),
 		mockQueryUserTasksEndpoint({
 			successResponse: HttpResponse.json(createQueryUserTasksResponse()),
+		}),
+		mockGetUserTaskEndpoint({
+			successResponse: HttpResponse.json(createUserTask()),
 		}),
 	);
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/test/visual/tasklist.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/visual/tasklist.test.ts
@@ -10,6 +10,7 @@ import {test, expect} from '#/pw-modules/test-extend';
 import {HttpResponse} from 'msw';
 import {
 	mockCurrentUserEndpoint,
+	mockGetUserTaskEndpoint,
 	mockLicenseEndpoint,
 	mockQueryUserTasksEndpoint,
 	mockSystemConfigurationEndpoint,
@@ -50,7 +51,12 @@ test('should match the tasklist processes page snapshot', async ({tasklistProces
 	await expect(page).toHaveScreenshot();
 });
 
-test('should match the tasklist 404 page snapshot', async ({notFoundPage, page}) => {
+test('should match the tasklist 404 page snapshot', async ({notFoundPage, page, network}) => {
+	network.use(
+		mockGetUserTaskEndpoint({
+			successResponse: HttpResponse.json({}, {status: 404}),
+		}),
+	);
 	await page.goto('/tasklist/nonexistent/page');
 	await expect(notFoundPage.heading).toBeVisible();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Migrate task details layout and fixes existing tests. Tests for these migrated parts will come in a follow up PR

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related #53942
