### PR TITLE
pg/54114-mode-change-actuator

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -17,12 +17,14 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
@@ -70,7 +72,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RestControllerEndpoint(id = "cluster")
 public class ClusterEndpoint {
   private static final Set<String> ALLOWED_QUERY_PARAMETERS =
-      Set.of("dryRun", "force", "replicationFactor");
+      Set.of("dryRun", "force", "replicationFactor", "mode");
 
   private final ClusterConfigurationManagementRequestSender requestSender;
 
@@ -497,6 +499,13 @@ public class ClusterEndpoint {
     } catch (final Exception exception) {
       return ClusterApiUtils.mapError(exception);
     }
+  }
+
+  @PatchMapping(path = "/mode")
+  public ResponseEntity<?> updateMode(
+      @RequestParam final Mode mode, @RequestParam(defaultValue = "false") final boolean dryRun) {
+    final var request = new ModeChangeRequest(mode, dryRun);
+    return ClusterApiUtils.mapOperationResponse(requestSender.modeChange(request).join());
   }
 
   /**

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -501,6 +501,14 @@ public class ClusterEndpoint {
     }
   }
 
+  /**
+   * This endpoint is to be used internally and as a testing tool. The complete mode transition
+   * endpoint will be accessible through the Management REST API.
+   *
+   * @param mode The requested {@link Mode} to transition the member to
+   * @param dryRun Whether to perform a dry run of the mode change
+   * @return The operations to transition the member to the requested mode
+   */
   @PatchMapping(path = "/mode")
   public ResponseEntity<?> updateMode(
       @RequestParam final Mode mode, @RequestParam(defaultValue = "false") final boolean dryRun) {

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -11,16 +11,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.util.Either;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class ClusterEndpointTest {
@@ -111,5 +119,72 @@ final class ClusterEndpointTest {
             MemberId.from("1"),
             MemberState.initializeAsActive(
                 Map.of(1, PartitionState.active(2, DynamicPartitionConfig.init()))));
+  }
+
+  @Nested
+  class ModeChangeEndpoint {
+    @Test
+    void shouldAllowModeQueryParameter() {
+      // given
+      final var endpoint = createEndpoint();
+      final var request = mock(HttpServletRequest.class);
+      when(request.getParameterMap()).thenReturn(Map.of("mode", new String[] {"RECOVERING"}));
+
+      // when - then
+      assertThatCode(() -> endpoint.validateRequestParameters(request)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldRequestModeChangeToRecovering() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+      final var changeResponse =
+          new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
+      when(sender.modeChange(new ModeChangeRequest(Mode.RECOVERING, false)))
+          .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
+
+      // when
+      final var response = endpoint.updateMode(Mode.RECOVERING, false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(202);
+      verify(sender).modeChange(new ModeChangeRequest(Mode.RECOVERING, false));
+    }
+
+    @Test
+    void shouldRequestModeChangeToProcessing() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+      final var changeResponse =
+          new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
+      when(sender.modeChange(new ModeChangeRequest(Mode.PROCESSING, false)))
+          .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
+
+      // when
+      final var response = endpoint.updateMode(Mode.PROCESSING, false);
+
+      // then
+      assertThat(response.getStatusCode().value()).isEqualTo(202);
+      verify(sender).modeChange(new ModeChangeRequest(Mode.PROCESSING, false));
+    }
+
+    @Test
+    void shouldPassDryRunFlagOnModeChange() {
+      // given
+      final var sender = mock(ClusterConfigurationManagementRequestSender.class);
+      final var endpoint = new ClusterEndpoint(sender);
+      final var changeResponse =
+          new ClusterConfigurationChangeResponse(1L, Map.of(), Map.of(), List.of());
+      when(sender.modeChange(new ModeChangeRequest(Mode.RECOVERING, true)))
+          .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
+
+      // when
+      endpoint.updateMode(Mode.RECOVERING, true);
+
+      // then
+      verify(sender).modeChange(new ModeChangeRequest(Mode.RECOVERING, true));
+    }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ModeChangeAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ModeChangeAcceptanceIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ClientStatusException;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@ZeebeIntegration
+@Timeout(value = 60, unit = TimeUnit.SECONDS)
+final class ModeChangeAcceptanceIT {
+
+  private static final int BROKERS_COUNT = 3;
+  private static final int PARTITIONS_COUNT = 3;
+
+  @TestZeebe(purgeAfterEach = false)
+  static TestCluster cluster =
+      TestCluster.builder()
+          .withEmbeddedGateway(true)
+          .withBrokersCount(BROKERS_COUNT)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withReplicationFactor(1)
+          .build();
+
+  private static final String JOB_TYPE = "job";
+  @AutoClose CamundaClient camundaClient;
+
+  @BeforeEach
+  void setUp() {
+    camundaClient = cluster.availableGateway().newClientBuilder().preferRestOverGrpc(false).build();
+  }
+
+  @Test
+  void shouldCycleBetweenRecoveryAndProcessing() {
+    // given
+    final var processId = "mode-change-test-process";
+    Utils.deployProcessModel(camundaClient, JOB_TYPE, processId);
+    final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+    for (int i = 0; i < 3; i++) {
+      // when - transition to RECOVERING
+      final var toRecovering = actuator.updateMode("RECOVERING", false);
+      Awaitility.await("Cluster transitions to RECOVERING (iteration " + i + ")")
+          .timeout(Duration.ofMinutes(2))
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(toRecovering));
+
+      // then - a series of PI creation attempts must all fail across all partitions
+      Awaitility.await("All PI creations blocked in RECOVERING mode (iteration " + i + ")")
+          .timeout(Duration.ofSeconds(30))
+          .untilAsserted(() -> assertAllCreateInstanceAttemptsFail(processId));
+
+      // when - transition back to PROCESSING
+      final var toProcessing = actuator.updateMode("PROCESSING", false);
+      Awaitility.await("Cluster transitions to PROCESSING (iteration " + i + ")")
+          .timeout(Duration.ofMinutes(2))
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(toProcessing));
+
+      // then - PI creation must succeed on every partition after returning to processing mode
+      final var createdKeys =
+          Utils.createInstanceWithAJobOnAllPartitions(
+              camundaClient, JOB_TYPE, PARTITIONS_COUNT, false, processId);
+      assertThat(createdKeys.stream().map(Protocol::decodePartitionId).collect(Collectors.toSet()))
+          .describedAs(
+              "All %d partitions have at least one created process instance (iteration %d)",
+              PARTITIONS_COUNT, i)
+          .containsExactlyInAnyOrderElementsOf(
+              IntStream.rangeClosed(1, PARTITIONS_COUNT).boxed().collect(Collectors.toList()));
+    }
+  }
+
+  /**
+   * Issues {@code PARTITIONS_COUNT * 2} create-process-instance requests and asserts that every
+   * single one fails. The double-multiple ensures each partition is targeted at least twice given
+   * round-robin routing.
+   */
+  private void assertAllCreateInstanceAttemptsFail(final String processId) {
+    IntStream.range(0, PARTITIONS_COUNT * 2)
+        .forEach(
+            j ->
+                assertThatThrownBy(
+                        () ->
+                            camundaClient
+                                .newCreateInstanceCommand()
+                                .bpmnProcessId(processId)
+                                .latestVersion()
+                                .send()
+                                .join())
+                    .describedAs("PI creation attempt %d should be rejected in RECOVERING mode", j)
+                    .isInstanceOf(ClientStatusException.class));
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -359,6 +359,17 @@ public interface ClusterActuator {
   PlannedOperationsResponse patchPartitionDistribution(
       @RequestBody final PartitionDistributionConfig config, @Param boolean dryRun);
 
+  /**
+   * Requests a cluster mode change.
+   *
+   * @param mode the target mode, e.g. {@code "RECOVERING"} or {@code "PROCESSING"}
+   * @param dryRun if true, changes are not applied but only simulated
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("PATCH /mode?mode={mode}&dryRun={dryRun}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse updateMode(@Param final String mode, @Param boolean dryRun);
+
   // -- BrokerId dispatch methods (default) --
 
   /**


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce mode change actuator endpoint under `PATCH /cluster/mode`, wired to the cluster configuration change sequence.

Add `ModeChangeAcceptanceIT`, performing a series of transitions betweeen `RECOVERING` and `PROCESSING` that verifies the brokers correctly perform the transistions. 

Currently, `ModeChangeAcceptanceIT` runs with RF=1 as the partition manager startup during transitions is synchronous and causes deadlock, as a patition leader can't be elected when starting partition managers in a sequence per broker. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54114
