### PR TITLE
ci: skip protobuf-changes detection on workflow_dispatch

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -169,7 +169,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (steps.filter-common.outputs.protobuf-change == 'true' && github.event_name != 'schedule')
+        (steps.filter-common.outputs.protobuf-change == 'true' && github.event_name != 'schedule' && github.event_name != 'workflow_dispatch')
       }}
   openapi-changes:
     description: Output whether any C8 OpenAPI code has changed


### PR DESCRIPTION
## Summary

The `Protobuf Backwards Compatibility` job fails on every manually triggered CI run (`workflow_dispatch`) — see [run 28170247265](https://github.com/camunda/camunda/actions/runs/28170247265/job/83432388022):

```
buf breaking --against https://github.com/camunda/camunda.git#format=git,commit=
Failure: invalid options: "format=git,commit="
```

The job builds buf's `--against` ref from `BASE_SHA = pull_request.base.sha || merge_group.base_sha || github.event.before`. None of those are set on `workflow_dispatch`, so the `commit=` parameter is empty and buf rejects it.

Backwards-compatibility checks aren't meaningful on manual dispatches anyway. The paths-filter action already gates `protobuf-changes` off for `schedule`; this extends that to `workflow_dispatch`, keeping the event routing in one place.

## Test plan

- [ ] Manually dispatch the CI workflow on `main` and confirm `Protobuf Backwards Compatibility` is skipped
- [ ] Open a PR touching a `.proto` file and confirm the job still runs on `pull_request`

🤖 Generated with [Claude Code](https://claude.com/claude-code)