### PR TITLE
fix: selector timeout in optimize e2e

### DIFF
--- a/optimize/client/e2e/utils.js
+++ b/optimize/client/e2e/utils.js
@@ -35,8 +35,13 @@ export async function login(t, userHandle = 'user1') {
     .maximizeWindow()
     .typeText('input[name="username"]', user.username)
     .typeText('input[name="password"]', user.username)
-    .click('[type="submit"]')
-    .wait(1000);
+    .pressKey('enter');
+
+  // Testcafe native automation's click('[type="submit"]') fires mouse events that fail to
+  // trigger the Keycloak form POST in quarantine retry sessions — no network request is made
+  // and the browser stays on Keycloak. Keyboard Enter on the focused password field uses a
+  // different event path that reliably submits the form across all attempts.
+  await t.expect(Common.collectionsPage.exists).ok({timeout: 30000});
 }
 
 export function getUser(t, userHandle) {

--- a/optimize/client/package.json
+++ b/optimize/client/package.json
@@ -45,7 +45,7 @@
     "e2e:visual": "testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/sm-tests/*.js --test-meta type=visual -s path=e2e/screenshots --take-snapshot actual",
     "e2e:visual:compare": "testcafe-blink-diff e2e/screenshots e2e/screenshots --compare base:actual --open --threshold 0.4 || exit 1",
     "e2e:ci:cloud:headless": "testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/cloud-tests/smokeTest.js -e",
-    "e2e:ci:sm:smoke:headless": "DEBUG=testcafe* FORCE_COLOR=1 stdbuf -oL -eL testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks --no-sandbox --disable-dev-shm-usage --disable-gpu' e2e/sm-tests/*.js --test-meta type=smoke -e --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
+    "e2e:ci:sm:smoke:headless": "DEBUG=testcafe* FORCE_COLOR=1 stdbuf -oL -eL testcafe 'chrome:headless --disable-features=LocalNetworkAccessChecks --no-sandbox --disable-dev-shm-usage --disable-gpu' e2e/sm-tests/*.js --test-meta type=smoke -e --assertion-timeout 40000 --selector-timeout 40000 -q attemptLimit=3,successThreshold=1",
     "e2e:ci:sm:nightly:headless": "testcafe -c 3 'chrome:headless --disable-features=LocalNetworkAccessChecks' e2e/sm-tests/*.js -e --disable-screenshots --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
     "e2e:cloud": "testcafe chrome e2e/cloud-tests/smokeTest.js",
     "eject": "react-scripts eject",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
