### PR TITLE
AgentHistory RDBMS write path

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -439,4 +439,96 @@
     </addColumn>
   </changeSet>
 
+  <changeSet id="create_agent_history_table" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="${prefix}AGENT_HISTORY"/>
+      </not>
+    </preConditions>
+    <createTable tableName="${prefix}AGENT_HISTORY">
+      <column name="AGENT_HISTORY_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="AGENT_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ELEMENT_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="ROOT_PROCESS_INSTANCE_KEY" type="BIGINT"/>
+      <column name="PROCESS_DEFINITION_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
+      <column name="TENANT_ID" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="PARTITION_ID" type="INTEGER"/>
+      <column name="JOB_KEY" type="BIGINT"/>
+      <column name="JOB_LEASE" type="NVARCHAR(${userCharColumnSize})"/>
+      <column name="ITERATION" type="INTEGER"/>
+      <column name="ROLE" type="VARCHAR(20)"/>
+      <column name="COMMIT_STATUS" type="VARCHAR(20)"/>
+      <column name="PRODUCED_AT" type="TIMESTAMP WITH TIME ZONE(3)"/>
+      <column name="INPUT_TOKENS" type="BIGINT"/>
+      <column name="OUTPUT_TOKENS" type="BIGINT"/>
+      <column name="DURATION_MS" type="BIGINT"/>
+      <column name="CONTENT" type="CLOB"/>
+      <column name="TOOL_CALLS" type="CLOB"/>
+    </createTable>
+
+    <modifySql dbms="mariadb,mysql">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+    <modifySql dbms="mssql">
+      <replace replace="datetime2" with="DATETIMEOFFSET"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_agent_history_pi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_HISTORY_PI_KEY"
+          tableName="${prefix}AGENT_HISTORY"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_HISTORY"
+      indexName="${prefix}IDX_AGENT_HISTORY_PI_KEY">
+      <column name="PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_agent_history_rpi_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_HISTORY_RPI_KEY"
+          tableName="${prefix}AGENT_HISTORY"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_HISTORY"
+      indexName="${prefix}IDX_AGENT_HISTORY_RPI_KEY">
+      <column name="ROOT_PROCESS_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_agent_history_agent_instance_key_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_HISTORY_AGENT_INSTANCE_KEY"
+          tableName="${prefix}AGENT_HISTORY"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_HISTORY"
+      indexName="${prefix}IDX_AGENT_HISTORY_AGENT_INSTANCE_KEY">
+      <column name="AGENT_INSTANCE_KEY"/>
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_agent_history_tenant_id_index" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists indexName="${prefix}IDX_AGENT_HISTORY_TENANT_ID"
+          tableName="${prefix}AGENT_HISTORY"/>
+      </not>
+    </preConditions>
+    <createIndex tableName="${prefix}AGENT_HISTORY"
+      indexName="${prefix}IDX_AGENT_HISTORY_TENANT_ID">
+      <column name="TENANT_ID"/>
+    </createIndex>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsTableNames.java
@@ -26,6 +26,7 @@ public final class RdbmsTableNames {
       List.of(
           "AGENT_INSTANCE_ELEMENT_INSTANCE",
           "AGENT_INSTANCE",
+          "AGENT_HISTORY",
           "AUDIT_LOG",
           "AUTHORIZATIONS",
           "BATCH_OPERATION_ITEM",

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentHistoryMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentHistoryMapper.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+
+public interface AgentHistoryMapper extends ProcessInstanceDependantMapper {
+
+  void insert(AgentHistoryDbModel model);
+
+  void updateCommitStatus(AgentHistoryDbModel model);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsMapperBundle.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsMapperBundle.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.AgentHistoryMapper;
 import io.camunda.db.rdbms.sql.AgentInstanceMapper;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
 import io.camunda.db.rdbms.sql.AuthorizationMapper;
@@ -50,6 +51,7 @@ import org.apache.ibatis.session.SqlSessionFactory;
 public record RdbmsMapperBundle(
     SqlSessionFactory sqlSessionFactory,
     VendorDatabaseProperties vendorDatabaseProperties,
+    AgentHistoryMapper agentHistoryMapper,
     AgentInstanceMapper agentInstanceMapper,
     AuditLogMapper auditLogMapper,
     AuthorizationMapper authorizationMapper,
@@ -94,6 +96,7 @@ public record RdbmsMapperBundle(
     return new RdbmsMapperBundle(
         sqlSessionFactory,
         vendorDatabaseProperties,
+        sqlSession.getMapper(AgentHistoryMapper.class),
         sqlSession.getMapper(AgentInstanceMapper.class),
         sqlSession.getMapper(AuditLogMapper.class),
         sqlSession.getMapper(AuthorizationMapper.class),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -58,6 +58,7 @@ public class RdbmsWriterFactory {
         mapperBundle.correlatedMessageSubscriptionMapper(),
         mapperBundle.clusterVariableMapper(),
         mapperBundle.historyDeletionMapper(),
+        mapperBundle.agentHistoryMapper(),
         mapperBundle.agentInstanceMapper(),
         mapperBundle.waitStateMapper());
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriters.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.AgentHistoryMapper;
 import io.camunda.db.rdbms.sql.AgentInstanceMapper;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
 import io.camunda.db.rdbms.sql.BatchOperationMapper;
@@ -32,6 +33,7 @@ import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.sql.WaitStateMapper;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.service.AgentHistoryWriter;
 import io.camunda.db.rdbms.write.service.AgentInstanceWriter;
 import io.camunda.db.rdbms.write.service.AuditLogWriter;
 import io.camunda.db.rdbms.write.service.AuthorizationWriter;
@@ -109,6 +111,7 @@ public class RdbmsWriters {
       final CorrelatedMessageSubscriptionMapper correlatedMessageSubscriptionMapper,
       final ClusterVariableMapper clusterVariableMapper,
       final HistoryDeletionMapper historyDeletionMapper,
+      final AgentHistoryMapper agentHistoryMapper,
       final AgentInstanceMapper agentInstanceMapper,
       final WaitStateMapper waitStateMapper) {
     this.executionQueue = executionQueue;
@@ -184,6 +187,9 @@ public class RdbmsWriters {
         new HistoryDeletionWriter(executionQueue, historyDeletionMapper));
     writers.put(GlobalListenerWriter.class, new GlobalListenerWriter(executionQueue));
     writers.put(DeployedResourceWriter.class, new DeployedResourceWriter(executionQueue));
+    writers.put(
+        AgentHistoryWriter.class,
+        new AgentHistoryWriter(executionQueue, agentHistoryMapper, vendorDatabaseProperties));
     writers.put(
         AgentInstanceWriter.class,
         new AgentInstanceWriter(executionQueue, agentInstanceMapper, vendorDatabaseProperties));
@@ -308,6 +314,10 @@ public class RdbmsWriters {
 
   public DeployedResourceWriter getResourceWriter() {
     return getWriter(DeployedResourceWriter.class);
+  }
+
+  public AgentHistoryWriter getAgentHistoryWriter() {
+    return getWriter(AgentHistoryWriter.class);
   }
 
   public AgentInstanceWriter getAgentInstanceWriter() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.domain;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.db.rdbms.write.util.TruncateUtil;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
@@ -26,7 +27,8 @@ import org.slf4j.LoggerFactory;
 public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AgentHistoryDbModel.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
 
   private long agentHistoryKey;
   private long agentInstanceKey;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
@@ -1,0 +1,512 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.db.rdbms.write.util.TruncateUtil;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AgentHistoryDbModel.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private long agentHistoryKey;
+  private long agentInstanceKey;
+  private long elementInstanceKey;
+  private long processInstanceKey;
+  private long rootProcessInstanceKey;
+  private String processDefinitionId;
+  private long processDefinitionKey;
+  private String tenantId;
+  private int partitionId;
+  private long jobKey;
+  private String jobLease;
+  private Integer iteration;
+  private AgentInstanceHistoryRole role;
+  private AgentInstanceHistoryCommitStatus commitStatus;
+  private OffsetDateTime producedAt;
+  private long inputTokens;
+  private long outputTokens;
+  private long durationMs;
+  private String content;
+  private List<ContentItem> contentItems;
+  private String toolCalls;
+  private List<ToolCall> toolCallValues;
+
+  public AgentHistoryDbModel() {}
+
+  @Override
+  public AgentHistoryDbModel copy(
+      final Function<ObjectBuilder<AgentHistoryDbModel>, ObjectBuilder<AgentHistoryDbModel>>
+          copyFunction) {
+    return copyFunction.apply(toBuilder()).build();
+  }
+
+  public ObjectBuilder<AgentHistoryDbModel> toBuilder() {
+    return new Builder()
+        .agentHistoryKey(agentHistoryKey)
+        .agentInstanceKey(agentInstanceKey)
+        .elementInstanceKey(elementInstanceKey)
+        .processInstanceKey(processInstanceKey)
+        .rootProcessInstanceKey(rootProcessInstanceKey)
+        .processDefinitionId(processDefinitionId)
+        .processDefinitionKey(processDefinitionKey)
+        .tenantId(tenantId)
+        .partitionId(partitionId)
+        .jobKey(jobKey)
+        .jobLease(jobLease)
+        .iteration(iteration)
+        .role(role)
+        .commitStatus(commitStatus)
+        .producedAt(producedAt)
+        .inputTokens(inputTokens)
+        .outputTokens(outputTokens)
+        .durationMs(durationMs)
+        // route through the getter so DB-hydrated models (only `content` JSON populated)
+        // are lazily deserialized and the structured form is preserved on the copy
+        .contentItems(contentItems())
+        // route through the getter so DB-hydrated models (only `toolCalls` JSON populated)
+        // are lazily deserialized and the structured form is preserved on the copy
+        .toolCallValues(toolCallValues());
+  }
+
+  public long agentHistoryKey() {
+    return agentHistoryKey;
+  }
+
+  public void agentHistoryKey(final long agentHistoryKey) {
+    this.agentHistoryKey = agentHistoryKey;
+  }
+
+  public long agentInstanceKey() {
+    return agentInstanceKey;
+  }
+
+  public void agentInstanceKey(final long agentInstanceKey) {
+    this.agentInstanceKey = agentInstanceKey;
+  }
+
+  public long elementInstanceKey() {
+    return elementInstanceKey;
+  }
+
+  public void elementInstanceKey(final long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+  }
+
+  public long processInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public void processInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  public long rootProcessInstanceKey() {
+    return rootProcessInstanceKey;
+  }
+
+  public void rootProcessInstanceKey(final long rootProcessInstanceKey) {
+    this.rootProcessInstanceKey = rootProcessInstanceKey;
+  }
+
+  public String processDefinitionId() {
+    return processDefinitionId;
+  }
+
+  public void processDefinitionId(final String processDefinitionId) {
+    this.processDefinitionId = processDefinitionId;
+  }
+
+  public long processDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void processDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String tenantId() {
+    return tenantId;
+  }
+
+  public void tenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public int partitionId() {
+    return partitionId;
+  }
+
+  public void partitionId(final int partitionId) {
+    this.partitionId = partitionId;
+  }
+
+  public long jobKey() {
+    return jobKey;
+  }
+
+  public void jobKey(final long jobKey) {
+    this.jobKey = jobKey;
+  }
+
+  public String jobLease() {
+    return jobLease;
+  }
+
+  public void jobLease(final String jobLease) {
+    this.jobLease = jobLease;
+  }
+
+  public void truncateJobLease(final int sizeLimit, final Integer byteLimit) {
+    if (TruncateUtil.shouldTruncate(jobLease, sizeLimit, byteLimit)) {
+      jobLease = TruncateUtil.truncateValue(jobLease, sizeLimit, byteLimit);
+    }
+  }
+
+  public Integer iteration() {
+    return iteration;
+  }
+
+  public void iteration(final Integer iteration) {
+    this.iteration = iteration;
+  }
+
+  public AgentInstanceHistoryRole role() {
+    return role;
+  }
+
+  public void role(final AgentInstanceHistoryRole role) {
+    this.role = role;
+  }
+
+  public AgentInstanceHistoryCommitStatus commitStatus() {
+    return commitStatus;
+  }
+
+  public void commitStatus(final AgentInstanceHistoryCommitStatus commitStatus) {
+    this.commitStatus = commitStatus;
+  }
+
+  public OffsetDateTime producedAt() {
+    return producedAt;
+  }
+
+  public void producedAt(final OffsetDateTime producedAt) {
+    this.producedAt = producedAt;
+  }
+
+  public long inputTokens() {
+    return inputTokens;
+  }
+
+  public void inputTokens(final long inputTokens) {
+    this.inputTokens = inputTokens;
+  }
+
+  public long outputTokens() {
+    return outputTokens;
+  }
+
+  public void outputTokens(final long outputTokens) {
+    this.outputTokens = outputTokens;
+  }
+
+  public long durationMs() {
+    return durationMs;
+  }
+
+  public void durationMs(final long durationMs) {
+    this.durationMs = durationMs;
+  }
+
+  public String content() {
+    return content;
+  }
+
+  /**
+   * Setter used by MyBatis when hydrating this model from the DB. Stores the raw JSON and
+   * invalidates the cached structured form so the next {@link #contentItems()} call re-derives from
+   * the new JSON (otherwise readers see stale data).
+   */
+  public void content(final String content) {
+    this.content = content;
+    contentItems = null;
+  }
+
+  /**
+   * Returns the structured content list. If only the JSON form (set via {@link #content(String)},
+   * e.g. when the model is hydrated from the DB) is present, the JSON is deserialized lazily and
+   * cached on the model.
+   */
+  public List<ContentItem> contentItems() {
+    if (contentItems == null && content != null && !content.isEmpty()) {
+      contentItems = deserializeContentItems(content);
+    }
+    return contentItems;
+  }
+
+  /**
+   * Sets the structured content list and derives the JSON form from it. The JSON is what MyBatis
+   * writes to the {@code AGENT_HISTORY.CONTENT} CLOB column.
+   */
+  public void contentItems(final List<ContentItem> contentItems) {
+    this.contentItems = contentItems;
+    content = serializeContentItems(contentItems);
+  }
+
+  private static List<ContentItem> deserializeContentItems(final String json) {
+    if (json == null || json.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    try {
+      return MAPPER.readValue(json, new TypeReference<>() {});
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to deserialize agent history content items", e);
+      return Collections.emptyList();
+    }
+  }
+
+  private static String serializeContentItems(final List<ContentItem> items) {
+    if (items == null || items.isEmpty()) {
+      return null;
+    }
+
+    try {
+      return MAPPER.writeValueAsString(items);
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to serialize agent history content items", e);
+      return null;
+    }
+  }
+
+  public String toolCalls() {
+    return toolCalls;
+  }
+
+  /**
+   * Setter used by MyBatis when hydrating this model from the DB. Stores the raw JSON and
+   * invalidates the cached structured form so the next {@link #toolCallValues()} call re-derives
+   * from the new JSON (otherwise readers see stale data).
+   */
+  public void toolCalls(final String toolCalls) {
+    this.toolCalls = toolCalls;
+    toolCallValues = null;
+  }
+
+  /**
+   * Returns the structured tool-call list. If only the JSON form (set via {@link
+   * #toolCalls(String)}, e.g. when the model is hydrated from the DB) is present, the JSON is
+   * deserialized lazily and cached on the model.
+   */
+  public List<ToolCall> toolCallValues() {
+    if (toolCallValues == null && toolCalls != null && !toolCalls.isEmpty()) {
+      toolCallValues = deserializeToolCallValues(toolCalls);
+    }
+    return toolCallValues;
+  }
+
+  /**
+   * Sets the structured tool-call list and derives the JSON form from it. The JSON is what MyBatis
+   * writes to the {@code AGENT_HISTORY.TOOL_CALLS} CLOB column.
+   */
+  public void toolCallValues(final List<ToolCall> toolCallValues) {
+    this.toolCallValues = toolCallValues;
+    toolCalls = serializeToolCallValues(toolCallValues);
+  }
+
+  private static List<ToolCall> deserializeToolCallValues(final String json) {
+    if (json == null || json.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    try {
+      return MAPPER.readValue(json, new TypeReference<>() {});
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to deserialize agent history tool calls", e);
+      return Collections.emptyList();
+    }
+  }
+
+  private static String serializeToolCallValues(final List<ToolCall> toolCallValues) {
+    if (toolCallValues == null || toolCallValues.isEmpty()) {
+      return null;
+    }
+
+    try {
+      return MAPPER.writeValueAsString(toolCallValues);
+    } catch (final JsonProcessingException e) {
+      LOG.error("Failed to serialize agent history tool calls", e);
+      return null;
+    }
+  }
+
+  public static class Builder implements ObjectBuilder<AgentHistoryDbModel> {
+
+    private long agentHistoryKey;
+    private long agentInstanceKey;
+    private long elementInstanceKey;
+    private long processInstanceKey;
+    private long rootProcessInstanceKey;
+    private String processDefinitionId;
+    private long processDefinitionKey;
+    private String tenantId;
+    private int partitionId;
+    private long jobKey;
+    private String jobLease;
+    private Integer iteration;
+    private AgentInstanceHistoryRole role;
+    private AgentInstanceHistoryCommitStatus commitStatus;
+    private OffsetDateTime producedAt;
+    private long inputTokens;
+    private long outputTokens;
+    private long durationMs;
+    private List<ContentItem> contentItems;
+    private List<ToolCall> toolCallValues;
+
+    public Builder agentHistoryKey(final long agentHistoryKey) {
+      this.agentHistoryKey = agentHistoryKey;
+      return this;
+    }
+
+    public Builder agentInstanceKey(final long agentInstanceKey) {
+      this.agentInstanceKey = agentInstanceKey;
+      return this;
+    }
+
+    public Builder elementInstanceKey(final long elementInstanceKey) {
+      this.elementInstanceKey = elementInstanceKey;
+      return this;
+    }
+
+    public Builder processInstanceKey(final long processInstanceKey) {
+      this.processInstanceKey = processInstanceKey;
+      return this;
+    }
+
+    public Builder rootProcessInstanceKey(final long rootProcessInstanceKey) {
+      this.rootProcessInstanceKey = rootProcessInstanceKey;
+      return this;
+    }
+
+    public Builder processDefinitionId(final String processDefinitionId) {
+      this.processDefinitionId = processDefinitionId;
+      return this;
+    }
+
+    public Builder processDefinitionKey(final long processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public Builder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public Builder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
+    public Builder jobKey(final long jobKey) {
+      this.jobKey = jobKey;
+      return this;
+    }
+
+    public Builder jobLease(final String jobLease) {
+      this.jobLease = jobLease;
+      return this;
+    }
+
+    public Builder iteration(final Integer iteration) {
+      this.iteration = iteration;
+      return this;
+    }
+
+    public Builder role(final AgentInstanceHistoryRole role) {
+      this.role = role;
+      return this;
+    }
+
+    public Builder commitStatus(final AgentInstanceHistoryCommitStatus commitStatus) {
+      this.commitStatus = commitStatus;
+      return this;
+    }
+
+    public Builder producedAt(final OffsetDateTime producedAt) {
+      this.producedAt = producedAt;
+      return this;
+    }
+
+    public Builder inputTokens(final long inputTokens) {
+      this.inputTokens = inputTokens;
+      return this;
+    }
+
+    public Builder outputTokens(final long outputTokens) {
+      this.outputTokens = outputTokens;
+      return this;
+    }
+
+    public Builder durationMs(final long durationMs) {
+      this.durationMs = durationMs;
+      return this;
+    }
+
+    public Builder contentItems(final List<ContentItem> contentItems) {
+      this.contentItems = contentItems;
+      return this;
+    }
+
+    public Builder toolCallValues(final List<ToolCall> toolCallValues) {
+      this.toolCallValues = toolCallValues;
+      return this;
+    }
+
+    @Override
+    public AgentHistoryDbModel build() {
+      final var result = new AgentHistoryDbModel();
+      result.agentHistoryKey(agentHistoryKey);
+      result.agentInstanceKey(agentInstanceKey);
+      result.elementInstanceKey(elementInstanceKey);
+      result.processInstanceKey(processInstanceKey);
+      result.rootProcessInstanceKey(rootProcessInstanceKey);
+      result.processDefinitionId(processDefinitionId);
+      result.processDefinitionKey(processDefinitionKey);
+      result.tenantId(tenantId);
+      result.partitionId(partitionId);
+      result.jobKey(jobKey);
+      result.jobLease(jobLease);
+      result.iteration(iteration);
+      result.role(role);
+      result.commitStatus(commitStatus);
+      result.producedAt(producedAt);
+      result.inputTokens(inputTokens);
+      result.outputTokens(outputTokens);
+      result.durationMs(durationMs);
+      result.contentItems(contentItems);
+      result.toolCallValues(toolCallValues);
+      return result;
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -11,6 +11,7 @@ public enum ContextType {
   // delete+insert is used for AGENT_INSTANCE_ELEMENT_INSTANCE child rows, so order must be
   // preserved to ensure DELETE runs before INSERT
   AGENT_INSTANCE(true),
+  AGENT_HISTORY(false),
   AUDIT_LOG(false),
   AUTHORIZATION(true),
   BATCH_OPERATION(false),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -11,6 +11,9 @@ public enum ContextType {
   // delete+insert is used for AGENT_INSTANCE_ELEMENT_INSTANCE child rows, so order must be
   // preserved to ensure DELETE runs before INSERT
   AGENT_INSTANCE(true),
+  // only INSERT (CREATED) and UPDATE (COMMITTED/DISCARDED) are issued — no delete+insert pattern;
+  // INSERT-before-UPDATE ordering within a batch is guaranteed by optimizeQueueOrder's
+  // WriteStatementType sort, so no explicit preservation is needed here
   AGENT_HISTORY(false),
   AUDIT_LOG(false),
   AUTHORIZATION(true),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentHistoryWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AgentHistoryWriter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.AgentHistoryMapper;
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+
+public class AgentHistoryWriter extends ProcessInstanceDependant implements RdbmsWriter {
+
+  private final ExecutionQueue executionQueue;
+  private final VendorDatabaseProperties vendorDatabaseProperties;
+
+  public AgentHistoryWriter(
+      final ExecutionQueue executionQueue,
+      final AgentHistoryMapper mapper,
+      final VendorDatabaseProperties vendorDatabaseProperties) {
+    super(mapper);
+    this.executionQueue = executionQueue;
+    this.vendorDatabaseProperties = vendorDatabaseProperties;
+  }
+
+  public void create(final AgentHistoryDbModel model) {
+    model.truncateJobLease(
+        vendorDatabaseProperties.userCharColumnSize(),
+        vendorDatabaseProperties.charColumnMaxBytes());
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.AGENT_HISTORY,
+            WriteStatementType.INSERT,
+            model.agentHistoryKey(),
+            "io.camunda.db.rdbms.sql.AgentHistoryMapper.insert",
+            model));
+  }
+
+  public void updateCommitStatus(final AgentHistoryDbModel model) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.AGENT_HISTORY,
+            WriteStatementType.UPDATE,
+            model.agentHistoryKey(),
+            "io.camunda.db.rdbms.sql.AgentHistoryMapper.updateCommitStatus",
+            model));
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="io.camunda.db.rdbms.sql.AgentHistoryMapper">
+
+  <!-- ===== WRITE operations ===== -->
+
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AgentHistoryDbModel">
+    INSERT INTO ${prefix}AGENT_HISTORY (
+      AGENT_HISTORY_KEY,
+      AGENT_INSTANCE_KEY,
+      ELEMENT_INSTANCE_KEY,
+      PROCESS_INSTANCE_KEY,
+      ROOT_PROCESS_INSTANCE_KEY,
+      PROCESS_DEFINITION_ID,
+      PROCESS_DEFINITION_KEY,
+      TENANT_ID,
+      PARTITION_ID,
+      JOB_KEY,
+      JOB_LEASE,
+      ITERATION,
+      ROLE,
+      COMMIT_STATUS,
+      PRODUCED_AT,
+      INPUT_TOKENS,
+      OUTPUT_TOKENS,
+      DURATION_MS,
+      CONTENT,
+      TOOL_CALLS
+    )
+    VALUES (
+      #{agentHistoryKey},
+      #{agentInstanceKey},
+      #{elementInstanceKey},
+      #{processInstanceKey},
+      #{rootProcessInstanceKey},
+      #{processDefinitionId},
+      #{processDefinitionKey},
+      #{tenantId},
+      #{partitionId},
+      #{jobKey},
+      #{jobLease},
+      #{iteration},
+      #{role},
+      #{commitStatus},
+      #{producedAt, jdbcType=TIMESTAMP},
+      #{inputTokens},
+      #{outputTokens},
+      #{durationMs},
+      #{content, jdbcType=CLOB},
+      #{toolCalls, jdbcType=CLOB}
+    )
+  </insert>
+
+  <update id="updateCommitStatus" parameterType="io.camunda.db.rdbms.write.domain.AgentHistoryDbModel">
+    UPDATE ${prefix}AGENT_HISTORY
+    SET COMMIT_STATUS = #{commitStatus}
+    WHERE AGENT_HISTORY_KEY = #{agentHistoryKey}
+  </update>
+
+  <delete id="deleteRootProcessInstanceRelatedData">
+    <bind name="tableName" value="'AGENT_HISTORY'"/>
+    <bind name="primaryKeyColumn" value="'AGENT_HISTORY_KEY'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.rootProcessInstanceHistoryDeletion"/>
+  </delete>
+
+  <delete id="deleteProcessInstanceRelatedData">
+    <bind name="tableName" value="'AGENT_HISTORY'"/>
+    <bind name="primaryKeyColumn" value="'AGENT_HISTORY_KEY'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
+  </delete>
+
+</mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterFactoryTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/RdbmsWriterFactoryTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.AgentHistoryMapper;
 import io.camunda.db.rdbms.sql.AgentInstanceMapper;
 import io.camunda.db.rdbms.sql.AuditLogMapper;
 import io.camunda.db.rdbms.sql.AuthorizationMapper;
@@ -87,6 +88,7 @@ class RdbmsWriterFactoryTest {
     return new RdbmsMapperBundle(
         mock(SqlSessionFactory.class),
         mock(VendorDatabaseProperties.class),
+        mock(AgentHistoryMapper.class),
         mock(AgentInstanceMapper.class),
         mock(AuditLogMapper.class),
         mock(AuthorizationMapper.class),

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModelTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AgentHistoryDbModelTest {
+
+  @Test
+  void shouldSerializeContentToJson() {
+    // given
+    final var item = new ContentItem(ContentType.TEXT, "hello", null, null);
+
+    // when
+    final var model = new AgentHistoryDbModel.Builder().contentItems(List.of(item)).build();
+
+    // then — serialized CLOB field is populated and contains the content text
+    assertThat(model.contentItems()).containsExactly(item);
+    assertThat(model.content()).contains("\"text\":\"hello\"");
+  }
+
+  @Test
+  void shouldDeserializeContentFromJson() {
+    // given — simulate a model hydrated from the DB: only the JSON form is populated
+    final var model = new AgentHistoryDbModel();
+    model.content("[{\"contentType\":\"TEXT\",\"text\":\"hello\",\"documentReference\":null}]");
+
+    // when
+    final List<ContentItem> deserialized = model.contentItems();
+
+    // then
+    assertThat(deserialized).hasSize(1);
+    assertThat(deserialized.getFirst().contentType()).isEqualTo(ContentType.TEXT);
+    assertThat(deserialized.getFirst().text()).isEqualTo("hello");
+  }
+
+  @Test
+  void shouldSerializeToolCallsToJson() {
+    // given
+    final var toolCall = new ToolCall("call-1", "myTool", "el-1", null);
+
+    // when
+    final var model = new AgentHistoryDbModel.Builder().toolCallValues(List.of(toolCall)).build();
+
+    // then — serialized CLOB field is populated and contains the tool name
+    assertThat(model.toolCallValues()).containsExactly(toolCall);
+    assertThat(model.toolCalls()).contains("\"toolName\":\"myTool\"");
+  }
+
+  @Test
+  void shouldDeserializeToolCallsFromJson() {
+    // given — simulate a model hydrated from the DB: only the JSON form is populated
+    final var model = new AgentHistoryDbModel();
+    model.toolCalls("[{\"toolCallId\":\"call-1\",\"toolName\":\"myTool\",\"elementId\":\"el-1\"}]");
+
+    // when
+    final List<ToolCall> deserialized = model.toolCallValues();
+
+    // then
+    assertThat(deserialized).hasSize(1);
+    assertThat(deserialized.getFirst().toolCallId()).isEqualTo("call-1");
+    assertThat(deserialized.getFirst().toolName()).isEqualTo("myTool");
+    assertThat(deserialized.getFirst().elementId()).isEqualTo("el-1");
+  }
+
+  @Test
+  void shouldReturnNullForNullOrEmptyLists() {
+    // given — empty list passed to builder
+    final var modelWithEmptyContent =
+        new AgentHistoryDbModel.Builder().contentItems(List.of()).build();
+    final var modelWithEmptyToolCalls =
+        new AgentHistoryDbModel.Builder().toolCallValues(List.of()).build();
+
+    // then — empty list serializes to null JSON (not "[]"), so the CLOB columns are null
+    assertThat(modelWithEmptyContent.content()).isNull();
+    assertThat(modelWithEmptyToolCalls.toolCalls()).isNull();
+  }
+
+  @Test
+  void shouldInvalidateCacheOnMyBatisSetter() {
+    // given — model with both forms populated (cache primed)
+    final var item = new ContentItem(ContentType.TEXT, "original", null, null);
+    final var model = new AgentHistoryDbModel.Builder().contentItems(List.of(item)).build();
+    assertThat(model.contentItems().getFirst().text()).isEqualTo("original");
+
+    // when — the JSON form is replaced (simulates the model being re-hydrated from the DB)
+    model.content("[{\"contentType\":\"TEXT\",\"text\":\"replaced\",\"documentReference\":null}]");
+
+    // then — the cached list is invalidated and the next read re-derives from the new JSON
+    assertThat(model.contentItems()).hasSize(1);
+    assertThat(model.contentItems().getFirst().text()).isEqualTo("replaced");
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModelTest.java
@@ -11,8 +11,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentMetadata;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentReference;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class AgentHistoryDbModelTest {
@@ -85,6 +89,26 @@ class AgentHistoryDbModelTest {
     // then — empty list serializes to null JSON (not "[]"), so the CLOB columns are null
     assertThat(modelWithEmptyContent.content()).isNull();
     assertThat(modelWithEmptyToolCalls.toolCalls()).isNull();
+  }
+
+  @Test
+  void shouldSerializeDocumentContentWithExpiresAt() {
+    // given — DocumentMetadata with a non-null expiresAt field (OffsetDateTime)
+    final var expiresAt = OffsetDateTime.parse("2030-01-01T00:00:00Z");
+    final var metadata =
+        new DocumentMetadata(
+            "application/pdf", "report.pdf", expiresAt, 1024L, null, null, Map.of());
+    final var docRef = new DocumentReference("store-1", "doc-1", null, metadata);
+    final var item = new ContentItem(ContentType.DOCUMENT, null, docRef, null);
+
+    // when
+    final var model = new AgentHistoryDbModel.Builder().contentItems(List.of(item)).build();
+
+    // then — JavaTimeModule must be registered; without it the MAPPER would throw and return null
+    assertThat(model.content())
+        .as("content must not be null — OffsetDateTime serialization requires JavaTimeModule")
+        .isNotNull();
+    assertThat(model.content()).contains("expiresAt");
   }
 
   @Test

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModelTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModelTest.java
@@ -89,6 +89,15 @@ class AgentHistoryDbModelTest {
     // then — empty list serializes to null JSON (not "[]"), so the CLOB columns are null
     assertThat(modelWithEmptyContent.content()).isNull();
     assertThat(modelWithEmptyToolCalls.toolCalls()).isNull();
+
+    // given — null list passed to builder
+    final var modelWithNullContent = new AgentHistoryDbModel.Builder().contentItems(null).build();
+    final var modelWithNullToolCalls =
+        new AgentHistoryDbModel.Builder().toolCallValues(null).build();
+
+    // then — null list also results in null JSON (not "[]")
+    assertThat(modelWithNullContent.content()).isNull();
+    assertThat(modelWithNullToolCalls.toolCalls()).isNull();
   }
 
   @Test

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AgentHistoryWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/AgentHistoryWriterTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.sql.AgentHistoryMapper;
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class AgentHistoryWriterTest {
+
+  private final ExecutionQueue executionQueue = mock(ExecutionQueue.class);
+  private final AgentHistoryMapper mapper = mock(AgentHistoryMapper.class);
+  private final VendorDatabaseProperties vendorDatabaseProperties =
+      mock(VendorDatabaseProperties.class);
+  private final AgentHistoryWriter writer =
+      new AgentHistoryWriter(executionQueue, mapper, vendorDatabaseProperties);
+
+  AgentHistoryWriterTest() {
+    when(vendorDatabaseProperties.userCharColumnSize()).thenReturn(Integer.MAX_VALUE);
+    when(vendorDatabaseProperties.charColumnMaxBytes()).thenReturn(null);
+  }
+
+  @Test
+  void shouldQueueInsertOnCreate() {
+    // given
+    final var model = buildModel(1L, "myLease");
+
+    // when
+    writer.create(model);
+
+    // then
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.AGENT_HISTORY,
+                    WriteStatementType.INSERT,
+                    1L,
+                    "io.camunda.db.rdbms.sql.AgentHistoryMapper.insert",
+                    model)));
+  }
+
+  @Test
+  void shouldQueueUpdateOnUpdateCommitStatus() {
+    // given
+    final var model = buildModel(2L, "otherLease");
+
+    // when
+    writer.updateCommitStatus(model);
+
+    // then
+    verify(executionQueue)
+        .executeInQueue(
+            eq(
+                new QueueItem(
+                    ContextType.AGENT_HISTORY,
+                    WriteStatementType.UPDATE,
+                    2L,
+                    "io.camunda.db.rdbms.sql.AgentHistoryMapper.updateCommitStatus",
+                    model)));
+  }
+
+  @Test
+  void shouldTruncateJobLeaseOnCreate() {
+    // given — column size of 10; value longer than 10 chars
+    when(vendorDatabaseProperties.userCharColumnSize()).thenReturn(10);
+    final String longLease = "a".repeat(20);
+    final var model = buildModel(3L, longLease);
+
+    // when
+    writer.create(model);
+
+    // then — jobLease is truncated in-place to the column size limit
+    assertThat(model.jobLease()).hasSize(10);
+    assertThat(longLease).startsWith(model.jobLease());
+  }
+
+  private AgentHistoryDbModel buildModel(final long key, final String jobLease) {
+    return new AgentHistoryDbModel.Builder()
+        .agentHistoryKey(key)
+        .agentInstanceKey(100L)
+        .elementInstanceKey(200L)
+        .processInstanceKey(300L)
+        .rootProcessInstanceKey(400L)
+        .processDefinitionId("myProcess")
+        .processDefinitionKey(500L)
+        .tenantId("myTenant")
+        .partitionId(1)
+        .jobKey(600L)
+        .jobLease(jobLease)
+        .role(AgentInstanceHistoryRole.USER)
+        .commitStatus(AgentInstanceHistoryCommitStatus.PENDING)
+        .producedAt(OffsetDateTime.now())
+        .build();
+  }
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
@@ -55,9 +55,10 @@ class RdbmsDbModelCoverageArchTest {
           "UsageMetricTUStatisticsDbModel", // TU statistics variant; covered by UsageMetricIT
           "UsageMetricTenantStatisticsDbModel", // tenant statistics variant; covered by
           // UsageMetricIT
-          "UsageMetricTUTenantStatisticsDbModel" // TU tenant statistics variant; covered by
+          "UsageMetricTUTenantStatisticsDbModel", // TU tenant statistics variant; covered by
           // UsageMetricIT
-          );
+          // Write-path only; AgentHistoryIT will be added with the read-path (#55271)
+          "AgentHistoryDbModel");
 
   // IT class simple names scanned from test-jars once at class-load time.
   static final Set<String> IT_SIMPLE_NAMES =

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
@@ -68,8 +68,9 @@ class RdbmsDbModelSortITCoverageArchTest {
           "CorrelatedMessageSubscriptionDbModel", // composite-key lookup, not a browseable list
           "HistoryDeletionDbModel", // transient internal records
           "SequenceFlowDbModel", // graph element, no ordering needed
-          "UsageMetricDbModel" // statistical aggregation
-          );
+          "UsageMetricDbModel", // statistical aggregation
+          // Write-path only; AgentHistorySortIT will be added with the read-path (#55271)
+          "AgentHistoryDbModel");
 
   // SortIT class simple names scanned from test-jars once at class-load time.
   static final Set<String> SORT_IT_SIMPLE_NAMES =

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -17,6 +17,7 @@ import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.HistoryDeletionService;
 import io.camunda.exporter.rdbms.RdbmsExporter.Builder;
 import io.camunda.exporter.rdbms.cache.RdbmsCacheRegistry;
+import io.camunda.exporter.rdbms.handlers.AgentHistoryExportHandler;
 import io.camunda.exporter.rdbms.handlers.AgentInstanceExportHandler;
 import io.camunda.exporter.rdbms.handlers.AuditLogExportHandler;
 import io.camunda.exporter.rdbms.handlers.ClusterVariableExportHandler;
@@ -262,6 +263,9 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.AGENT_INSTANCE,
         new AgentInstanceExportHandler(rdbmsWriters.getAgentInstanceWriter()));
+    builder.withHandler(
+        ValueType.AGENT_HISTORY,
+        new AgentHistoryExportHandler(rdbmsWriters.getAgentHistoryWriter()));
     builder.withHandler(
         ValueType.PROCESS_INSTANCE,
         new SequenceFlowExportHandler(rdbmsWriters.getSequenceFlowWriter()));

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel.Builder;
+import io.camunda.db.rdbms.write.service.AgentHistoryWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.exporter.rdbms.utils.DateUtil;
+import io.camunda.exporter.rdbms.utils.ExportUtil;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentMetadata;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.DocumentReference;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryEmbeddedToolCallValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryMessageContentValue;
+import io.camunda.zeebe.protocol.record.value.DocumentReferenceValue;
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+public class AgentHistoryExportHandler implements RdbmsExportHandler<AgentHistoryRecordValue> {
+
+  private static final Set<AgentHistoryIntent> EXPORTABLE_INTENTS =
+      Set.of(
+          AgentHistoryIntent.CREATED, AgentHistoryIntent.COMMITTED, AgentHistoryIntent.DISCARDED);
+
+  private final AgentHistoryWriter writer;
+
+  public AgentHistoryExportHandler(final AgentHistoryWriter writer) {
+    this.writer = writer;
+  }
+
+  @Override
+  public boolean canExport(final Record<AgentHistoryRecordValue> record) {
+    return record.getIntent() instanceof final AgentHistoryIntent intent
+        && EXPORTABLE_INTENTS.contains(intent);
+  }
+
+  @Override
+  public void export(final Record<AgentHistoryRecordValue> record) {
+    final var intent = (AgentHistoryIntent) record.getIntent();
+    final var model = mapToDbModel(record, intent);
+    if (intent == AgentHistoryIntent.CREATED) {
+      writer.create(model);
+    } else {
+      writer.updateCommitStatus(model);
+    }
+  }
+
+  private AgentHistoryDbModel mapToDbModel(
+      final Record<AgentHistoryRecordValue> record, final AgentHistoryIntent intent) {
+    final var value = record.getValue();
+    final long producedAtMillis =
+        value.getProducedAt() > 0 ? value.getProducedAt() : record.getTimestamp();
+
+    return new Builder()
+        .agentHistoryKey(record.getKey())
+        .agentInstanceKey(value.getAgentInstanceKey())
+        .elementInstanceKey(value.getElementInstanceKey())
+        .processInstanceKey(value.getProcessInstanceKey())
+        .rootProcessInstanceKey(value.getRootProcessInstanceKey())
+        .processDefinitionId(value.getBpmnProcessId())
+        .processDefinitionKey(value.getProcessDefinitionKey())
+        .tenantId(value.getTenantId())
+        .partitionId(record.getPartitionId())
+        .jobKey(value.getJobKey())
+        .jobLease(value.getJobLease())
+        .iteration(ExportUtil.positiveOrNull(value.getIteration()))
+        .role(mapRole(value.getRole()))
+        .commitStatus(mapCommitStatus(intent))
+        .producedAt(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(producedAtMillis)))
+        .inputTokens(value.getMetrics().getInputTokens())
+        .outputTokens(value.getMetrics().getOutputTokens())
+        .durationMs(value.getMetrics().getDurationMs())
+        .contentItems(mapContent(value.getContent()))
+        .toolCallValues(mapToolCalls(value.getToolCalls()))
+        .build();
+  }
+
+  private static AgentInstanceHistoryRole mapRole(
+      final io.camunda.zeebe.protocol.record.value.AgentHistoryRole protocolRole) {
+    return switch (protocolRole) {
+      case USER -> AgentInstanceHistoryRole.USER;
+      case ASSISTANT -> AgentInstanceHistoryRole.ASSISTANT;
+      case TOOL_RESULT -> AgentInstanceHistoryRole.TOOL_RESULT;
+      case UNSPECIFIED ->
+          throw new IllegalStateException(
+              "should never happen — protocol UNSPECIFIED is always overwritten before export");
+    };
+  }
+
+  private static AgentInstanceHistoryCommitStatus mapCommitStatus(final AgentHistoryIntent intent) {
+    return switch (intent) {
+      case CREATED -> AgentInstanceHistoryCommitStatus.PENDING;
+      case COMMITTED -> AgentInstanceHistoryCommitStatus.COMMITTED;
+      case DISCARDED -> AgentInstanceHistoryCommitStatus.DISCARDED;
+      default ->
+          throw new IllegalStateException(
+              "Unexpected AgentHistoryIntent on an exported record: " + intent);
+    };
+  }
+
+  private static List<ContentItem> mapContent(
+      final List<? extends AgentHistoryMessageContentValue> content) {
+    return content.stream()
+        .map(
+            c ->
+                switch (c.getContentType()) {
+                  case TEXT ->
+                      new ContentItem(
+                          ContentType.TEXT, ExportUtil.emptyToNull(c.getText()), null, null);
+                  case DOCUMENT ->
+                      new ContentItem(
+                          ContentType.DOCUMENT,
+                          null,
+                          mapDocumentReference(c.getDocumentReference()),
+                          null);
+                  case OBJECT -> new ContentItem(ContentType.OBJECT, null, null, c.getObject());
+                  case UNSPECIFIED ->
+                      throw new IllegalStateException(
+                          "should never happen — protocol UNSPECIFIED is always overwritten before export");
+                })
+        .toList();
+  }
+
+  private static DocumentReference mapDocumentReference(final DocumentReferenceValue ref) {
+    if (ref == null) {
+      return null;
+    }
+
+    final var meta = ref.getMetadata();
+    final var expiresAt =
+        meta.getExpiresAt() > 0
+            ? DateUtil.toOffsetDateTime(Instant.ofEpochMilli(meta.getExpiresAt()))
+            : null;
+    final Long processInstanceKey =
+        meta.getProcessInstanceKey() > 0 ? meta.getProcessInstanceKey() : null;
+    return new DocumentReference(
+        ref.getStoreId(),
+        ref.getDocumentId(),
+        ExportUtil.emptyToNull(ref.getContentHash()),
+        new DocumentMetadata(
+            meta.getContentType(),
+            meta.getFileName(),
+            expiresAt,
+            meta.getSize(),
+            ExportUtil.emptyToNull(meta.getProcessDefinitionId()),
+            processInstanceKey,
+            meta.getCustomProperties()));
+  }
+
+  private static List<ToolCall> mapToolCalls(
+      final List<? extends AgentHistoryEmbeddedToolCallValue> toolCalls) {
+    return toolCalls.stream()
+        .map(
+            t ->
+                new ToolCall(
+                    t.getToolCallId(),
+                    t.getToolName(),
+                    ExportUtil.emptyToNull(t.getElementId()),
+                    t.getArguments()))
+        .toList();
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ExportUtil.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ExportUtil.java
@@ -74,4 +74,16 @@ public class ExportUtil {
   public static String emptyToNull(final String value) {
     return value == null || value.isEmpty() ? null : value;
   }
+
+  /**
+   * Returns {@code null} when {@code value} is zero or negative, otherwise boxes and returns the
+   * value.
+   *
+   * <p>Use this when mapping optional integer fields from protocol records to DB models. Protocol
+   * {@code int} fields default to {@code 0} when not set by the sender, but nullable DB columns
+   * should store {@code null} to correctly represent "absent".
+   */
+  public static Integer positiveOrNull(final int value) {
+    return value > 0 ? value : null;
+  }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
@@ -1,0 +1,494 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+import io.camunda.db.rdbms.write.service.AgentHistoryWriter;
+import io.camunda.exporter.rdbms.utils.DateUtil;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryEmbeddedToolCallValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMessageContentValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMetricsValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AgentHistoryExportHandlerTest {
+
+  private static final Set<AgentHistoryIntent> EXPORTABLE_INTENTS =
+      EnumSet.of(
+          AgentHistoryIntent.CREATED, AgentHistoryIntent.COMMITTED, AgentHistoryIntent.DISCARDED);
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  @Mock private AgentHistoryWriter writer;
+  @Captor private ArgumentCaptor<AgentHistoryDbModel> modelCaptor;
+
+  private AgentHistoryExportHandler handler;
+
+  static Stream<AgentHistoryIntent> exportableIntents() {
+    return EXPORTABLE_INTENTS.stream();
+  }
+
+  static Stream<AgentHistoryIntent> nonExportableIntents() {
+    return Stream.of(AgentHistoryIntent.values())
+        .filter(Predicate.not(EXPORTABLE_INTENTS::contains));
+  }
+
+  @BeforeEach
+  void setUp() {
+    handler = new AgentHistoryExportHandler(writer);
+  }
+
+  @ParameterizedTest(name = "Should export record with intent: {0}")
+  @MethodSource("exportableIntents")
+  void shouldExportRecord(final AgentHistoryIntent intent) {
+    // given
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(ValueType.AGENT_HISTORY, r -> r.withIntent(intent));
+
+    // when / then
+    assertThat(handler.canExport(record)).isTrue();
+  }
+
+  @ParameterizedTest(name = "Should not export record with unsupported intent: {0}")
+  @MethodSource("nonExportableIntents")
+  void shouldNotExportRecord(final AgentHistoryIntent intent) {
+    // given
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(ValueType.AGENT_HISTORY, r -> r.withIntent(intent));
+
+    // when / then
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldCallCreateOnCreatedIntent() {
+    // given
+    final long historyKey = 42L;
+    final var recordValue = buildRecordValue();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r ->
+                r.withIntent(AgentHistoryIntent.CREATED)
+                    .withKey(historyKey)
+                    .withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final AgentHistoryDbModel model = modelCaptor.getValue();
+
+    // identity fields mapped from record.getKey(), not value.getAgentHistoryKey()
+    assertThat(model.agentHistoryKey()).isEqualTo(historyKey);
+    assertThat(model.agentInstanceKey()).isEqualTo(recordValue.getAgentInstanceKey());
+    assertThat(model.elementInstanceKey()).isEqualTo(recordValue.getElementInstanceKey());
+    assertThat(model.processInstanceKey()).isEqualTo(recordValue.getProcessInstanceKey());
+    assertThat(model.rootProcessInstanceKey()).isEqualTo(recordValue.getRootProcessInstanceKey());
+    assertThat(model.processDefinitionId()).isEqualTo(recordValue.getBpmnProcessId());
+    assertThat(model.processDefinitionKey()).isEqualTo(recordValue.getProcessDefinitionKey());
+    assertThat(model.tenantId()).isEqualTo(recordValue.getTenantId());
+    assertThat(model.partitionId()).isEqualTo(record.getPartitionId());
+    assertThat(model.jobKey()).isEqualTo(recordValue.getJobKey());
+    assertThat(model.jobLease()).isEqualTo(recordValue.getJobLease());
+    assertThat(model.iteration()).isEqualTo(recordValue.getIteration());
+
+    // role
+    assertThat(model.role().name()).isEqualTo(recordValue.getRole().name());
+
+    // commit status derived from intent
+    assertThat(model.commitStatus()).isEqualTo(AgentInstanceHistoryCommitStatus.PENDING);
+
+    // producedAt taken from value (non-zero)
+    assertThat(model.producedAt())
+        .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(recordValue.getProducedAt())));
+
+    // metrics
+    assertThat(model.inputTokens()).isEqualTo(recordValue.getMetrics().getInputTokens());
+    assertThat(model.outputTokens()).isEqualTo(recordValue.getMetrics().getOutputTokens());
+    assertThat(model.durationMs()).isEqualTo(recordValue.getMetrics().getDurationMs());
+
+    // content and tool calls mapped
+    assertThat(model.content()).isNotNull();
+    assertThat(model.toolCalls()).isNotNull();
+  }
+
+  @Test
+  void shouldCallUpdateCommitStatusOnCommittedIntent() {
+    // given
+    final long historyKey = 43L;
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r ->
+                r.withIntent(AgentHistoryIntent.COMMITTED)
+                    .withKey(historyKey)
+                    .withValue(buildRecordValue()));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).updateCommitStatus(modelCaptor.capture());
+    assertThat(modelCaptor.getValue().agentHistoryKey()).isEqualTo(historyKey);
+    assertThat(modelCaptor.getValue().commitStatus())
+        .isEqualTo(AgentInstanceHistoryCommitStatus.COMMITTED);
+  }
+
+  @Test
+  void shouldCallUpdateCommitStatusOnDiscardedIntent() {
+    // given
+    final long historyKey = 44L;
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r ->
+                r.withIntent(AgentHistoryIntent.DISCARDED)
+                    .withKey(historyKey)
+                    .withValue(buildRecordValue()));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).updateCommitStatus(modelCaptor.capture());
+    assertThat(modelCaptor.getValue().agentHistoryKey()).isEqualTo(historyKey);
+    assertThat(modelCaptor.getValue().commitStatus())
+        .isEqualTo(AgentInstanceHistoryCommitStatus.DISCARDED);
+  }
+
+  @Test
+  void shouldMapIterationToNullWhenNotPositive() {
+    // given — zero and negative values
+    final var zeroIteration =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withIteration(0)
+            .build();
+    final var negativeIteration =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withIteration(-1)
+            .build();
+
+    final Record<AgentHistoryRecordValue> zeroRecord =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(50L).withValue(zeroIteration));
+    final Record<AgentHistoryRecordValue> negativeRecord =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r ->
+                r.withIntent(AgentHistoryIntent.CREATED).withKey(51L).withValue(negativeIteration));
+
+    // when — both records exported
+    handler.export(zeroRecord);
+    handler.export(negativeRecord);
+
+    // then — both should produce iteration=null
+    verify(writer, times(2)).create(modelCaptor.capture());
+    assertThat(modelCaptor.getAllValues())
+        .extracting(AgentHistoryDbModel::iteration)
+        .containsOnly((Integer) null);
+  }
+
+  @Test
+  void shouldMapEmptyElementIdToNull() {
+    // given — tool call with empty elementId
+    final var toolCall =
+        ImmutableAgentHistoryEmbeddedToolCallValue.builder()
+            .withToolCallId("call-1")
+            .withToolName("myTool")
+            .withElementId("") // empty → should map to null
+            .build();
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withToolCalls(List.of(toolCall))
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(52L).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final var mappedToolCall = modelCaptor.getValue().toolCallValues().getFirst();
+    assertThat(mappedToolCall.elementId()).isNull();
+  }
+
+  @Test
+  void shouldMapProducedAtFallbackToRecordTimestamp() {
+    // given — producedAt=0 means "not set"; handler falls back to record.getTimestamp()
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withProducedAt(0L)
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(53L).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    assertThat(modelCaptor.getValue().producedAt())
+        .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+  }
+
+  @ParameterizedTest(name = "[{index}] Should map role ''{0}'' to entity role")
+  @EnumSource(
+      value = AgentHistoryRole.class,
+      names = {"UNSPECIFIED"},
+      mode = Mode.EXCLUDE)
+  void shouldMapAllRoles(final AgentHistoryRole protocolRole) {
+    // given
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withRole(protocolRole)
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(54L).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then — entity role name matches protocol role name
+    verify(writer).create(modelCaptor.capture());
+    assertThat(modelCaptor.getValue().role().name()).isEqualTo(protocolRole.name());
+  }
+
+  @Test
+  void shouldThrowOnUnspecifiedRole() {
+    // given
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withRole(AgentHistoryRole.UNSPECIFIED)
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(55L).withValue(recordValue));
+
+    // when / then
+    assertThatThrownBy(() -> handler.export(record)).isInstanceOf(IllegalStateException.class);
+  }
+
+  @ParameterizedTest(name = "[{index}] Should map content type ''{0}''")
+  @EnumSource(
+      value = AgentHistoryContentType.class,
+      names = {"UNSPECIFIED"},
+      mode = Mode.EXCLUDE)
+  void shouldMapAllContentTypes(final AgentHistoryContentType protocolContentType) {
+    // given — one content block of the given type
+    final var contentBuilder =
+        ImmutableAgentHistoryMessageContentValue.builder()
+            .withContentType(protocolContentType)
+            .withText("someText");
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withContent(List.of(contentBuilder.build()))
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(56L).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final var mappedItem = modelCaptor.getValue().contentItems().getFirst();
+    assertThat(mappedItem.contentType().name()).isEqualTo(protocolContentType.name());
+  }
+
+  @Test
+  void shouldThrowOnUnspecifiedContentType() {
+    // given
+    final var content =
+        ImmutableAgentHistoryMessageContentValue.builder()
+            .withContentType(AgentHistoryContentType.UNSPECIFIED)
+            .withText("ignored")
+            .build();
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withContent(List.of(content))
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(57L).withValue(recordValue));
+
+    // when / then
+    assertThatThrownBy(() -> handler.export(record)).isInstanceOf(IllegalStateException.class);
+  }
+
+  @ParameterizedTest(name = "Should map commit status for intent: {0}")
+  @EnumSource(
+      value = AgentHistoryIntent.class,
+      names = {"CREATED", "COMMITTED", "DISCARDED"})
+  void shouldMapCommitStatusFromIntent(final AgentHistoryIntent intent) {
+    // given
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(intent).withKey(58L).withValue(buildRecordValue()));
+
+    // when
+    handler.export(record);
+
+    // then
+    if (intent == AgentHistoryIntent.CREATED) {
+      verify(writer).create(modelCaptor.capture());
+    } else {
+      verify(writer).updateCommitStatus(modelCaptor.capture());
+    }
+
+    final AgentInstanceHistoryCommitStatus expected =
+        switch (intent) {
+          case CREATED -> AgentInstanceHistoryCommitStatus.PENDING;
+          case COMMITTED -> AgentInstanceHistoryCommitStatus.COMMITTED;
+          case DISCARDED -> AgentInstanceHistoryCommitStatus.DISCARDED;
+          default -> throw new IllegalStateException("unexpected intent in test: " + intent);
+        };
+    assertThat(modelCaptor.getValue().commitStatus()).isEqualTo(expected);
+  }
+
+  @ParameterizedTest(name = "Should map COMMITTED and DISCARDED records without throwing: {0}")
+  @EnumSource(
+      value = AgentHistoryIntent.class,
+      names = {"COMMITTED", "DISCARDED"})
+  void shouldMapCommittedAndDiscardedWithoutThrowing(final AgentHistoryIntent intent) {
+    // given
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(intent).withKey(59L).withValue(buildRecordValue()));
+
+    // when / then — no exception thrown
+    handler.export(record);
+    verify(writer).updateCommitStatus(modelCaptor.capture());
+    assertThat(modelCaptor.getValue()).isNotNull();
+  }
+
+  @Test
+  void shouldMapTextContentType() {
+    // given — TEXT content item
+    final var content =
+        ImmutableAgentHistoryMessageContentValue.builder()
+            .withContentType(AgentHistoryContentType.TEXT)
+            .withText("hello")
+            .build();
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withContent(List.of(content))
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(60L).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final var mappedItem = modelCaptor.getValue().contentItems().getFirst();
+    assertThat(mappedItem.contentType()).isEqualTo(ContentType.TEXT);
+    assertThat(mappedItem.text()).isEqualTo("hello");
+    assertThat(mappedItem.documentReference()).isNull();
+  }
+
+  /**
+   * Builds a fully-populated record value that will not throw during export. In particular: - role
+   * is non-UNSPECIFIED - metrics is populated - content has a TEXT item (no UNSPECIFIED content
+   * type) - producedAt is > 0
+   */
+  private AgentHistoryRecordValue buildRecordValue() {
+    final var textContent =
+        ImmutableAgentHistoryMessageContentValue.builder()
+            .withContentType(AgentHistoryContentType.TEXT)
+            .withText("test content")
+            .build();
+    final var toolCall =
+        ImmutableAgentHistoryEmbeddedToolCallValue.builder()
+            .withToolCallId("call-1")
+            .withToolName("myTool")
+            .withElementId("el-1")
+            .build();
+    return ImmutableAgentHistoryRecordValue.builder()
+        .withAgentHistoryKey(1L)
+        .withAgentInstanceKey(100L)
+        .withElementInstanceKey(200L)
+        .withProcessInstanceKey(300L)
+        .withRootProcessInstanceKey(400L)
+        .withBpmnProcessId("myProcess")
+        .withProcessDefinitionKey(500L)
+        .withTenantId("myTenant")
+        .withJobKey(600L)
+        .withJobLease("myLease")
+        .withIteration(1)
+        .withRole(AgentHistoryRole.ASSISTANT)
+        .withProducedAt(1_700_000_000_000L)
+        .withContent(List.of(textContent))
+        .withToolCalls(List.of(toolCall))
+        .withMetrics(
+            ImmutableAgentHistoryMetricsValue.builder()
+                .withInputTokens(10L)
+                .withOutputTokens(5L)
+                .withDurationMs(100L)
+                .build())
+        .build();
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
@@ -27,6 +27,8 @@ import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryEmbeddedToolC
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMessageContentValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryMetricsValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableAgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDocumentReferenceMetadataValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableDocumentReferenceValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.time.Instant;
 import java.util.EnumSet;
@@ -448,6 +450,62 @@ class AgentHistoryExportHandlerTest {
     assertThat(mappedItem.contentType()).isEqualTo(ContentType.TEXT);
     assertThat(mappedItem.text()).isEqualTo("hello");
     assertThat(mappedItem.documentReference()).isNull();
+  }
+
+  @Test
+  void shouldMapDocumentContentType() {
+    // given — DOCUMENT content item with a fully-populated document reference
+    final long expiresAtMs = 1_800_000_000_000L;
+    final long docProcessInstanceKey = 999L;
+    final var metadata =
+        ImmutableDocumentReferenceMetadataValue.builder()
+            .withExpiresAt(expiresAtMs)
+            .withSize(2048L)
+            .withProcessInstanceKey(docProcessInstanceKey)
+            .withContentType("application/pdf")
+            .withFileName("report.pdf")
+            .withProcessDefinitionId("my-process")
+            .build();
+    final var docRef =
+        ImmutableDocumentReferenceValue.builder()
+            .withDocumentId("doc-42")
+            .withStoreId("store-1")
+            .withContentHash("sha256abc")
+            .withMetadata(metadata)
+            .build();
+    final var documentContent =
+        ImmutableAgentHistoryMessageContentValue.builder()
+            .withContentType(AgentHistoryContentType.DOCUMENT)
+            .withDocumentReference(docRef)
+            .build();
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withContent(List.of(documentContent))
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(61L).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final var mappedItem = modelCaptor.getValue().contentItems().getFirst();
+    assertThat(mappedItem.contentType()).isEqualTo(ContentType.DOCUMENT);
+    assertThat(mappedItem.text()).isNull();
+    final var mappedRef = mappedItem.documentReference();
+    assertThat(mappedRef).isNotNull();
+    assertThat(mappedRef.documentId()).isEqualTo("doc-42");
+    assertThat(mappedRef.storeId()).isEqualTo("store-1");
+    assertThat(mappedRef.contentHash()).isEqualTo("sha256abc");
+    assertThat(mappedRef.metadata()).isNotNull();
+    assertThat(mappedRef.metadata().expiresAt())
+        .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(expiresAtMs)));
+    assertThat(mappedRef.metadata().processInstanceKey()).isEqualTo(docProcessInstanceKey);
+    assertThat(mappedRef.metadata().processDefinitionId()).isEqualTo("my-process");
   }
 
   /**


### PR DESCRIPTION
## Description

Implements the RDBMS exporter write path for `AGENT_HISTORY` records, following the AgentInstance write path (PR #53612) as the reference implementation.

`AGENT_HISTORY` records have three intents:
- `CREATED` — full row insert with all fields populated
- `COMMITTED` — status update only (`commitStatus` → `COMMITTED`)
- `DISCARDED` — status update only (`commitStatus` → `DISCARDED`)

The implementation spans three modules:
- `db/rdbms-schema` — Liquibase migration for the `AGENT_HISTORY` table and indexes
- `db/rdbms` — `AgentHistoryDbModel`, `AgentHistoryMapper` (Java + XML), `AgentHistoryWriter`, `ContextType.AGENT_HISTORY`, wiring in `RdbmsWriters` and `RdbmsMapperBundle`
- `zeebe/exporters/rdbms-exporter` — `AgentHistoryExportHandler` with full field mapping, registration in `RdbmsExporterWrapper`, `ExportUtil.positiveOrNull`

A latent data-loss bug was caught during testing: the bare `ObjectMapper` in `AgentHistoryDbModel` cannot serialize `DocumentMetadata.expiresAt` (`OffsetDateTime`). Fixed by registering `JavaTimeModule`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55262
closes #51521