### PR TITLE
fix: restore to the tenant's partition directory

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.broker.raft.ZeebeEntryValidator;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
@@ -30,7 +29,6 @@ import java.time.Duration;
 import org.slf4j.Logger;
 
 public final class RaftPartitionFactory {
-  public static final String GROUP_NAME = Protocol.DEFAULT_PARTITION_GROUP_NAME;
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private final BrokerCfg brokerCfg;
 
@@ -60,7 +58,7 @@ public final class RaftPartitionFactory {
   public static Path getPartitionDirectory(
       final PartitionId partitionId, final String dataDirectory) {
     return Paths.get(dataDirectory)
-        .resolve(GROUP_NAME)
+        .resolve(partitionId.group())
         .resolve("partitions")
         .resolve(String.valueOf(partitionId.number()));
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionDirectoryStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionDirectoryStep.java
@@ -8,11 +8,11 @@
 package io.camunda.zeebe.broker.partitioning.startup.steps;
 
 import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
+import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
-import java.nio.file.Paths;
 
 public final class PartitionDirectoryStep implements StartupStep<PartitionStartupContext> {
 
@@ -30,14 +30,10 @@ public final class PartitionDirectoryStep implements StartupStep<PartitionStartu
   @Override
   public ActorFuture<PartitionStartupContext> startup(final PartitionStartupContext context) {
     final var result = context.concurrencyControl().<PartitionStartupContext>createFuture();
-    final var dataDirectory = Paths.get(context.brokerConfig().getData().getDirectory());
+    final var dataDirectory = context.brokerConfig().getData().getDirectory();
     final var partitionId = context.partitionMetadata().id();
     final var partitionDirectory =
-        dataDirectory
-            .resolve(partitionId.group())
-            .resolve("partitions")
-            .resolve(String.valueOf(partitionId.number()));
-
+        RaftPartitionFactory.getPartitionDirectory(partitionId, dataDirectory);
     try {
       FileUtil.ensureDirectoryExists(partitionDirectory);
       result.complete(context.partitionDirectory(partitionDirectory));


### PR DESCRIPTION
Restore now writes a partition's data into its physical tenant's directory instead of always using the default partition group.

`RaftPartitionFactory.getPartitionDirectory` derived the directory from the hard-coded `GROUP_NAME` (`"default"`), so restoring a non-default physical tenant's partition placed its data under `<data>/default/partitions/<id>` rather than `<data>/<tenant>/partitions/<id>`. It now derives the group from the partition's own `PartitionId` (`partitionId.group()`), and `PartitionDirectoryStep` reuses the same helper so the live and restore paths agree.

For a default-only cluster the behavior is unchanged (`partitionId.group()` is `"default"`), so there is no impact on released versions and no backport is needed.

Stacked on #55746 (the refactor that exposes the composite `PartitionId`); review/merge that first. Part of the physical-tenants work tracked by #55118.
