### PR TITLE
fix: broker health accounts for all physical tenants' partitions

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -71,7 +71,8 @@ public final class Broker implements AutoCloseable {
     healthCheckService =
         new BrokerHealthCheckService(
             nodeId.memberId(),
-            new HealthTreeMetrics(systemContext.getMeterRegistry(), Tag.of("partition", "none")));
+            new HealthTreeMetrics(systemContext.getMeterRegistry(), Tag.of("partition", "none")),
+            systemContext.getPhysicalTenantIds().known());
 
     final var startupContext =
         new BrokerStartupContextImpl(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/PartitionRaftListener.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/PartitionRaftListener.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker;
 
+import io.atomix.primitive.partition.PartitionId;
+
 /**
  * Can be implemented and used to react on partition role changes, like on Leader on Actor should be
  * started and on Follower one should be removed.
@@ -20,7 +22,7 @@ public interface PartitionRaftListener {
    * @param partitionId the corresponding partition id
    * @param term the current term
    */
-  void onBecameRaftFollower(final int partitionId, final long term);
+  void onBecameRaftFollower(final PartitionId partitionId, final long term);
 
   /**
    * Is called by the {@link io.camunda.zeebe.broker.system.partitions.ZeebePartition} on starting
@@ -30,5 +32,5 @@ public interface PartitionRaftListener {
    * @param partitionId the corresponding partition id
    * @param term the current term
    */
-  void onBecameRaftLeader(final int partitionId, final long term);
+  void onBecameRaftLeader(final PartitionId partitionId, final long term);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -296,7 +296,7 @@ public final class PartitionManagerImpl
     final var localMemberId = localMemberId();
     final var memberPartitions = localPartitions();
 
-    healthCheckService.registerBootstrapPartitions(memberPartitions);
+    healthCheckService.registerBootstrapPartitions(partitionGroup, memberPartitions);
 
     if (DEFAULT_GROUP_NAME.equals(partitionGroup)) {
       clusterConfigurationService.registerPartitionChangeExecutors(this, this);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -296,10 +296,9 @@ public final class PartitionManagerImpl
     final var localMemberId = localMemberId();
     final var memberPartitions = localPartitions();
 
-    // BrokerHealthCheckService tracks a single set of bootstrap partitions. Only the default
-    // physical tenant participates in the broker health check for now; other tenants are invisible.
+    healthCheckService.registerBootstrapPartitions(memberPartitions);
+
     if (DEFAULT_GROUP_NAME.equals(partitionGroup)) {
-      healthCheckService.registerBootstrapPartitions(memberPartitions);
       clusterConfigurationService.registerPartitionChangeExecutors(this, this);
     }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 
@@ -95,6 +96,11 @@ import org.slf4j.Logger;
 public final class BrokerHealthCheckService extends Actor implements PartitionRaftListener {
 
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
+  /* The physical tenants this broker is configured to run. The broker is only ready once every one
+  of them has registered its bootstrap partitions, so that a tenant that never started (and thus
+  never contributed its partitions) cannot be mistaken for "no partitions to wait for". */
+  private final Set<String> expectedPhysicalTenants;
+  private final Set<String> registeredPhysicalTenants = ConcurrentHashMap.newKeySet();
   /* Tracks the install status of every bootstrap partition the broker is responsible for, keyed by
   its full PartitionId (partition group + id). Each physical tenant registers its own partitions, so
   this map accumulates across all tenants. Stays null until the first registration so that an
@@ -106,15 +112,22 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   private final HealthMonitor healthMonitor;
 
   public BrokerHealthCheckService(
-      final MemberId nodeId, final HealthTreeMetrics healthGraphMetrics) {
+      final MemberId nodeId,
+      final HealthTreeMetrics healthGraphMetrics,
+      final Set<String> expectedPhysicalTenants) {
+    this.expectedPhysicalTenants = Set.copyOf(expectedPhysicalTenants);
     healthMonitor =
         new CriticalComponentsHealthMonitor(
             "Broker-" + nodeId, actor, healthGraphMetrics, Optional.empty(), LOG);
   }
 
-  public void registerBootstrapPartitions(final Collection<PartitionMetadata> partitions) {
-    // Called once per physical tenant during startup, so accumulate rather than replace: each call
-    // adds the tenant's partitions without dropping the ones registered by previous tenants.
+  public void registerBootstrapPartitions(
+      final String physicalTenantId, final Collection<PartitionMetadata> partitions) {
+    // Called once per physical tenant during startup. Record the tenant even when it has no local
+    // partitions, so readiness can tell "tenant started with nothing to install" apart from "tenant
+    // never started". Accumulate rather than replace so a later tenant's call does not drop the
+    // partitions registered by previous tenants.
+    registeredPhysicalTenants.add(physicalTenantId);
     if (partitionInstallStatus == null) {
       partitionInstallStatus = new ConcurrentHashMap<>();
     }
@@ -126,11 +139,15 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   }
 
   public boolean isBrokerReady() {
-    // Ready once every registered partition (across all physical tenants) has been installed.
-    // Computed live from the map so that partitions registered by a later physical tenant still
-    // gate readiness even if an earlier tenant's partitions were already installed.
+    // Ready once every expected physical tenant has registered and every one of their partitions
+    // has been installed. Both conditions are evaluated live: requiring all tenants prevents a
+    // missing tenant from being silently ignored, and reading the map directly lets partitions
+    // registered by a later tenant still gate readiness even if an earlier tenant already finished.
     final var status = partitionInstallStatus;
-    return brokerStarted && status != null && !status.containsValue(false);
+    return brokerStarted
+        && registeredPhysicalTenants.containsAll(expectedPhysicalTenants)
+        && status != null
+        && !status.containsValue(false);
   }
 
   public String componentName() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -136,6 +136,9 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
           partitionInstallStatus.putIfAbsent(metadata.id(), false);
           healthMonitor.monitorComponent(ZeebePartition.componentName(metadata.id()));
         });
+    // A late-registering tenant can be the event that completes readiness, so re-check on the actor
+    // thread (where readyLogged is owned).
+    actor.run(this::logBrokerReadyOnce);
   }
 
   public boolean isBrokerReady() {
@@ -177,11 +180,23 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
     return actor.call(
         () -> {
           partitionInstallStatus.put(partitionId, true);
-          if (!readyLogged && !partitionInstallStatus.containsValue(false)) {
-            readyLogged = true;
-            LOG.info("All partitions are installed. Broker is ready!");
-          }
+          logBrokerReadyOnce();
         });
+  }
+
+  /**
+   * Logs the "broker is ready" transition exactly once, when the broker first actually becomes
+   * ready. Readiness can flip on any of three events (a partition install, a physical tenant
+   * registering, or the broker startup completing), so this is invoked from all of them. Gated on
+   * the full {@link #isBrokerReady()} criteria rather than just "all known partitions installed",
+   * so it never claims readiness before every expected tenant has registered and the broker has
+   * started. Must run on the actor thread, since {@code readyLogged} is not otherwise synchronized.
+   */
+  private void logBrokerReadyOnce() {
+    if (!readyLogged && isBrokerReady()) {
+      readyLogged = true;
+      LOG.info("All partitions are installed. Broker is ready!");
+    }
   }
 
   @Override
@@ -222,7 +237,11 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   }
 
   public void setBrokerStarted() {
-    actor.run(() -> brokerStarted = true);
+    actor.run(
+        () -> {
+          brokerStarted = true;
+          logBrokerReadyOnce();
+        });
   }
 
   public boolean isBrokerStarted() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.monitoring;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -94,7 +95,7 @@ import org.slf4j.Logger;
 public final class BrokerHealthCheckService extends Actor implements PartitionRaftListener {
 
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
-  private Map<Integer, Boolean> partitionInstallStatus;
+  private Map<PartitionId, Boolean> partitionInstallStatus;
   /* set to true when all partitions are installed. Once set to true, it is never
   changed. */
   private volatile boolean allPartitionsInstalled = false;
@@ -110,8 +111,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
 
   public void registerBootstrapPartitions(final Collection<PartitionMetadata> partitions) {
     partitionInstallStatus =
-        partitions.stream()
-            .collect(Collectors.toMap(metadata -> metadata.id().number(), p -> false));
+        partitions.stream().collect(Collectors.toMap(PartitionMetadata::id, p -> false));
     partitions.forEach(
         metadata ->
             healthMonitor.monitorComponent(ZeebePartition.componentName(metadata.id().number())));
@@ -127,13 +127,13 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   }
 
   @Override
-  public void onBecameRaftFollower(final int partitionId, final long term) {
+  public void onBecameRaftFollower(final PartitionId partitionId, final long term) {
     checkState();
     updateBrokerReadyStatus(partitionId);
   }
 
   @Override
-  public void onBecameRaftLeader(final int partitionId, final long term) {
+  public void onBecameRaftLeader(final PartitionId partitionId, final long term) {
     checkState();
     updateBrokerReadyStatus(partitionId);
   }
@@ -144,7 +144,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
     }
   }
 
-  private ActorFuture<Void> updateBrokerReadyStatus(final int partitionId) {
+  private ActorFuture<Void> updateBrokerReadyStatus(final PartitionId partitionId) {
     return actor.call(
         () -> {
           if (!allPartitionsInstalled) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -134,7 +134,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
     partitions.forEach(
         metadata -> {
           partitionInstallStatus.putIfAbsent(metadata.id(), false);
-          healthMonitor.monitorComponent(ZeebePartition.componentName(metadata.id().number()));
+          healthMonitor.monitorComponent(ZeebePartition.componentName(metadata.id()));
         });
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 
 /*
@@ -95,10 +95,13 @@ import org.slf4j.Logger;
 public final class BrokerHealthCheckService extends Actor implements PartitionRaftListener {
 
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
-  private Map<PartitionId, Boolean> partitionInstallStatus;
-  /* set to true when all partitions are installed. Once set to true, it is never
-  changed. */
-  private volatile boolean allPartitionsInstalled = false;
+  /* Tracks the install status of every bootstrap partition the broker is responsible for, keyed by
+  its full PartitionId (partition group + id). Each physical tenant registers its own partitions, so
+  this map accumulates across all tenants. Stays null until the first registration so that an
+  install status update before any partition is known fails fast. */
+  private volatile Map<PartitionId, Boolean> partitionInstallStatus;
+  /* Guards against logging "broker is ready" more than once. Only touched on the actor thread. */
+  private boolean readyLogged = false;
   private volatile boolean brokerStarted = false;
   private final HealthMonitor healthMonitor;
 
@@ -110,15 +113,24 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   }
 
   public void registerBootstrapPartitions(final Collection<PartitionMetadata> partitions) {
-    partitionInstallStatus =
-        partitions.stream().collect(Collectors.toMap(PartitionMetadata::id, p -> false));
+    // Called once per physical tenant during startup, so accumulate rather than replace: each call
+    // adds the tenant's partitions without dropping the ones registered by previous tenants.
+    if (partitionInstallStatus == null) {
+      partitionInstallStatus = new ConcurrentHashMap<>();
+    }
     partitions.forEach(
-        metadata ->
-            healthMonitor.monitorComponent(ZeebePartition.componentName(metadata.id().number())));
+        metadata -> {
+          partitionInstallStatus.putIfAbsent(metadata.id(), false);
+          healthMonitor.monitorComponent(ZeebePartition.componentName(metadata.id().number()));
+        });
   }
 
   public boolean isBrokerReady() {
-    return brokerStarted && allPartitionsInstalled;
+    // Ready once every registered partition (across all physical tenants) has been installed.
+    // Computed live from the map so that partitions registered by a later physical tenant still
+    // gate readiness even if an earlier tenant's partitions were already installed.
+    final var status = partitionInstallStatus;
+    return brokerStarted && status != null && !status.containsValue(false);
   }
 
   public String componentName() {
@@ -147,13 +159,10 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   private ActorFuture<Void> updateBrokerReadyStatus(final PartitionId partitionId) {
     return actor.call(
         () -> {
-          if (!allPartitionsInstalled) {
-            partitionInstallStatus.put(partitionId, true);
-            allPartitionsInstalled = !partitionInstallStatus.containsValue(false);
-
-            if (allPartitionsInstalled) {
-              LOG.info("All partitions are installed. Broker is ready!");
-            }
+          partitionInstallStatus.put(partitionId, true);
+          if (!readyLogged && !partitionInstallStatus.containsValue(false)) {
+            readyLogged = true;
+            LOG.info("All partitions are installed. Broker is ready!");
           }
         });
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -201,12 +201,12 @@ public class PartitionStartupAndTransitionContextImpl
 
   @Override
   public void notifyListenersOfBecameRaftLeader(final long newTerm) {
-    partitionRaftListeners.forEach(l -> l.onBecameRaftLeader(getPartitionId(), newTerm));
+    partitionRaftListeners.forEach(l -> l.onBecameRaftLeader(partitionId(), newTerm));
   }
 
   @Override
   public void notifyListenersOfBecameRaftFollower(final long newTerm) {
-    partitionRaftListeners.forEach(l -> l.onBecameRaftFollower(getPartitionId(), newTerm));
+    partitionRaftListeners.forEach(l -> l.onBecameRaftFollower(partitionId(), newTerm));
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
+import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.SnapshotReplicationListener;
@@ -86,7 +87,7 @@ public final class ZeebePartition extends Actor
     actorName = buildActorName("ZeebePartition", partitionId);
     transitionContext.setComponentHealthMonitor(
         new CriticalComponentsHealthMonitor(
-            componentName(partitionId),
+            componentName(context.partitionId()),
             actor,
             transitionContext.getComponentTreeListener(),
             Optional.of(transitionContext.brokerHealthCheckService().componentName()),
@@ -101,8 +102,8 @@ public final class ZeebePartition extends Actor
             transitionContext.getPartitionId());
   }
 
-  public static String componentName(final int partitionId) {
-    return String.format("Partition-%s", partitionId);
+  public static String componentName(final PartitionId partitionId) {
+    return String.format("Partition-%s-%d", partitionId.group(), partitionId.number());
   }
 
   public PartitionAdminAccess getAdminAccess() {
@@ -210,7 +211,7 @@ public final class ZeebePartition extends Actor
 
   @Override
   public String componentName() {
-    return String.format("Partition-%d", getPartitionId());
+    return componentName(context.partitionId());
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -7,24 +7,35 @@
  */
 package io.camunda.zeebe.broker.system.monitoring;
 
+import static io.camunda.zeebe.protocol.Protocol.DEFAULT_PARTITION_GROUP_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
-import io.camunda.zeebe.protocol.Protocol;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import org.junit.Test;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class BrokerHealthCheckServiceTest {
 
+  private static final String SECOND_PHYSICAL_TENANT = "tenant-2";
+
   private final MemberId member = MemberId.from("member-1");
+
+  @RegisterExtension
+  private final ControlledActorSchedulerExtension scheduler =
+      new ControlledActorSchedulerExtension();
 
   @Test
   public void shouldNotBeReadyHealthyOrStartedBeforePartitionManagerIsRegistered() {
     // given
-    final var healthCheckService =
-        new BrokerHealthCheckService(member, new HealthTreeMetrics(new SimpleMeterRegistry()));
+    final var healthCheckService = newHealthCheckService();
 
     // when
 
@@ -44,15 +55,83 @@ public class BrokerHealthCheckServiceTest {
   @Test
   public void shouldThrowIllegalStateExceptionIfStatusIsUpdatedBeforePartitionsAreKnown() {
     // given
-    final var healthCheckService =
-        new BrokerHealthCheckService(member, new HealthTreeMetrics(new SimpleMeterRegistry()));
+    final var healthCheckService = newHealthCheckService();
 
     // when + then
-
-    final var partitionId = new PartitionId(Protocol.DEFAULT_PARTITION_GROUP_NAME, 0);
+    final var partitionId = new PartitionId(DEFAULT_PARTITION_GROUP_NAME, 0);
     assertThatThrownBy(() -> healthCheckService.onBecameRaftFollower(partitionId, 0))
         .isInstanceOf(IllegalStateException.class);
     assertThatThrownBy(() -> healthCheckService.onBecameRaftLeader(partitionId, 0))
         .isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void shouldNotBeReadyUntilPartitionsFromAllPhysicalTenantsAreInstalled() {
+    // given a broker started with one partition in each of two physical tenants. Each physical
+    // tenant registers its own partitions, mirroring how PartitionManagerImpl#start does it.
+    final var healthCheckService = newStartedHealthCheckService();
+    healthCheckService.registerBootstrapPartitions(
+        List.of(partition(DEFAULT_PARTITION_GROUP_NAME, 1)));
+    healthCheckService.registerBootstrapPartitions(List.of(partition(SECOND_PHYSICAL_TENANT, 1)));
+    scheduler.workUntilDone();
+
+    // when only the second tenant's partition is installed
+    healthCheckService.onBecameRaftLeader(new PartitionId(SECOND_PHYSICAL_TENANT, 1), 1);
+    scheduler.workUntilDone();
+
+    // then the broker is not ready: the default tenant's partition is still missing
+    assertThat(healthCheckService.isBrokerReady()).isFalse();
+
+    // when the default tenant's partition is installed too
+    healthCheckService.onBecameRaftFollower(new PartitionId(DEFAULT_PARTITION_GROUP_NAME, 1), 1);
+    scheduler.workUntilDone();
+
+    // then the broker is ready, because every physical tenant's partition is installed
+    assertThat(healthCheckService.isBrokerReady()).isTrue();
+  }
+
+  @Test
+  public void shouldStayUnreadyWhenAPhysicalTenantRegistersAfterAnotherFinishedInstalling() {
+    // given a broker where the default tenant registers and fully installs its partition before a
+    // second physical tenant comes up. This is the ordering that a naive "all installed" latch gets
+    // wrong: it would freeze on the first completion.
+    final var healthCheckService = newStartedHealthCheckService();
+    healthCheckService.registerBootstrapPartitions(
+        List.of(partition(DEFAULT_PARTITION_GROUP_NAME, 1)));
+    scheduler.workUntilDone();
+    healthCheckService.onBecameRaftLeader(new PartitionId(DEFAULT_PARTITION_GROUP_NAME, 1), 1);
+    scheduler.workUntilDone();
+
+    // when a second physical tenant registers its not-yet-installed partition
+    healthCheckService.registerBootstrapPartitions(List.of(partition(SECOND_PHYSICAL_TENANT, 1)));
+    scheduler.workUntilDone();
+
+    // then the broker is no longer ready: it must wait for the new tenant's partition
+    assertThat(healthCheckService.isBrokerReady()).isFalse();
+
+    // when the second tenant's partition is installed
+    healthCheckService.onBecameRaftLeader(new PartitionId(SECOND_PHYSICAL_TENANT, 1), 1);
+    scheduler.workUntilDone();
+
+    // then the broker is ready again
+    assertThat(healthCheckService.isBrokerReady()).isTrue();
+  }
+
+  private BrokerHealthCheckService newHealthCheckService() {
+    return new BrokerHealthCheckService(member, new HealthTreeMetrics(new SimpleMeterRegistry()));
+  }
+
+  private BrokerHealthCheckService newStartedHealthCheckService() {
+    final var healthCheckService = newHealthCheckService();
+    scheduler.submitActor(healthCheckService);
+    healthCheckService.setBrokerStarted();
+    scheduler.workUntilDone();
+    return healthCheckService;
+  }
+
+  private static PartitionMetadata partition(final String partitionGroup, final int partitionId) {
+    final var owner = MemberId.from("member-1");
+    return new PartitionMetadata(
+        new PartitionId(partitionGroup, partitionId), Set.of(owner), Map.of(owner, 1), 1, owner);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -35,7 +35,7 @@ public class BrokerHealthCheckServiceTest {
   @Test
   public void shouldNotBeReadyHealthyOrStartedBeforePartitionManagerIsRegistered() {
     // given
-    final var healthCheckService = newHealthCheckService();
+    final var healthCheckService = newHealthCheckService(DEFAULT_PARTITION_GROUP_NAME);
 
     // when
 
@@ -55,7 +55,7 @@ public class BrokerHealthCheckServiceTest {
   @Test
   public void shouldThrowIllegalStateExceptionIfStatusIsUpdatedBeforePartitionsAreKnown() {
     // given
-    final var healthCheckService = newHealthCheckService();
+    final var healthCheckService = newHealthCheckService(DEFAULT_PARTITION_GROUP_NAME);
 
     // when + then
     final var partitionId = new PartitionId(DEFAULT_PARTITION_GROUP_NAME, 0);
@@ -69,10 +69,12 @@ public class BrokerHealthCheckServiceTest {
   public void shouldNotBeReadyUntilPartitionsFromAllPhysicalTenantsAreInstalled() {
     // given a broker started with one partition in each of two physical tenants. Each physical
     // tenant registers its own partitions, mirroring how PartitionManagerImpl#start does it.
-    final var healthCheckService = newStartedHealthCheckService();
+    final var healthCheckService =
+        newStartedHealthCheckService(DEFAULT_PARTITION_GROUP_NAME, SECOND_PHYSICAL_TENANT);
     healthCheckService.registerBootstrapPartitions(
-        List.of(partition(DEFAULT_PARTITION_GROUP_NAME, 1)));
-    healthCheckService.registerBootstrapPartitions(List.of(partition(SECOND_PHYSICAL_TENANT, 1)));
+        DEFAULT_PARTITION_GROUP_NAME, List.of(partition(DEFAULT_PARTITION_GROUP_NAME, 1)));
+    healthCheckService.registerBootstrapPartitions(
+        SECOND_PHYSICAL_TENANT, List.of(partition(SECOND_PHYSICAL_TENANT, 1)));
     scheduler.workUntilDone();
 
     // when only the second tenant's partition is installed
@@ -95,15 +97,17 @@ public class BrokerHealthCheckServiceTest {
     // given a broker where the default tenant registers and fully installs its partition before a
     // second physical tenant comes up. This is the ordering that a naive "all installed" latch gets
     // wrong: it would freeze on the first completion.
-    final var healthCheckService = newStartedHealthCheckService();
+    final var healthCheckService =
+        newStartedHealthCheckService(DEFAULT_PARTITION_GROUP_NAME, SECOND_PHYSICAL_TENANT);
     healthCheckService.registerBootstrapPartitions(
-        List.of(partition(DEFAULT_PARTITION_GROUP_NAME, 1)));
+        DEFAULT_PARTITION_GROUP_NAME, List.of(partition(DEFAULT_PARTITION_GROUP_NAME, 1)));
     scheduler.workUntilDone();
     healthCheckService.onBecameRaftLeader(new PartitionId(DEFAULT_PARTITION_GROUP_NAME, 1), 1);
     scheduler.workUntilDone();
 
     // when a second physical tenant registers its not-yet-installed partition
-    healthCheckService.registerBootstrapPartitions(List.of(partition(SECOND_PHYSICAL_TENANT, 1)));
+    healthCheckService.registerBootstrapPartitions(
+        SECOND_PHYSICAL_TENANT, List.of(partition(SECOND_PHYSICAL_TENANT, 1)));
     scheduler.workUntilDone();
 
     // then the broker is no longer ready: it must wait for the new tenant's partition
@@ -117,12 +121,58 @@ public class BrokerHealthCheckServiceTest {
     assertThat(healthCheckService.isBrokerReady()).isTrue();
   }
 
-  private BrokerHealthCheckService newHealthCheckService() {
-    return new BrokerHealthCheckService(member, new HealthTreeMetrics(new SimpleMeterRegistry()));
+  @Test
+  public void shouldNotBeReadyWhileAnExpectedPhysicalTenantNeverRegistered() {
+    // given a broker configured with two physical tenants, but only the default tenant comes up and
+    // installs its partition; the second tenant never registers (e.g. its startup stalled).
+    final var healthCheckService =
+        newStartedHealthCheckService(DEFAULT_PARTITION_GROUP_NAME, SECOND_PHYSICAL_TENANT);
+    healthCheckService.registerBootstrapPartitions(
+        DEFAULT_PARTITION_GROUP_NAME, List.of(partition(DEFAULT_PARTITION_GROUP_NAME, 1)));
+    healthCheckService.onBecameRaftLeader(new PartitionId(DEFAULT_PARTITION_GROUP_NAME, 1), 1);
+    scheduler.workUntilDone();
+
+    // when + then the broker must not report ready: a configured tenant is entirely unaccounted
+    // for, so an "all known partitions installed" check alone would falsely pass.
+    assertThat(healthCheckService.isBrokerReady()).isFalse();
+
+    // when the missing tenant finally registers and installs its partition
+    healthCheckService.registerBootstrapPartitions(
+        SECOND_PHYSICAL_TENANT, List.of(partition(SECOND_PHYSICAL_TENANT, 1)));
+    healthCheckService.onBecameRaftLeader(new PartitionId(SECOND_PHYSICAL_TENANT, 1), 1);
+    scheduler.workUntilDone();
+
+    // then the broker becomes ready
+    assertThat(healthCheckService.isBrokerReady()).isTrue();
   }
 
-  private BrokerHealthCheckService newStartedHealthCheckService() {
-    final var healthCheckService = newHealthCheckService();
+  @Test
+  public void shouldBeReadyWhenAnExpectedPhysicalTenantHasNoLocalPartitions() {
+    // given a broker with two physical tenants where the second tenant has no partitions on this
+    // node, so it registers an empty set
+    final var healthCheckService =
+        newStartedHealthCheckService(DEFAULT_PARTITION_GROUP_NAME, SECOND_PHYSICAL_TENANT);
+    healthCheckService.registerBootstrapPartitions(
+        DEFAULT_PARTITION_GROUP_NAME, List.of(partition(DEFAULT_PARTITION_GROUP_NAME, 1)));
+    healthCheckService.registerBootstrapPartitions(SECOND_PHYSICAL_TENANT, List.of());
+    scheduler.workUntilDone();
+
+    // when the default tenant's only partition is installed
+    healthCheckService.onBecameRaftLeader(new PartitionId(DEFAULT_PARTITION_GROUP_NAME, 1), 1);
+    scheduler.workUntilDone();
+
+    // then the broker is ready: the second tenant started and simply had nothing to install
+    assertThat(healthCheckService.isBrokerReady()).isTrue();
+  }
+
+  private BrokerHealthCheckService newHealthCheckService(final String... expectedPhysicalTenants) {
+    return new BrokerHealthCheckService(
+        member, new HealthTreeMetrics(new SimpleMeterRegistry()), Set.of(expectedPhysicalTenants));
+  }
+
+  private BrokerHealthCheckService newStartedHealthCheckService(
+      final String... expectedPhysicalTenants) {
+    final var healthCheckService = newHealthCheckService(expectedPhysicalTenants);
     scheduler.submitActor(healthCheckService);
     healthCheckService.setBrokerStarted();
     scheduler.workUntilDone();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -15,10 +15,13 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import io.camunda.zeebe.test.util.logging.RecordingAppender;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Logger;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -163,6 +166,68 @@ public class BrokerHealthCheckServiceTest {
 
     // then the broker is ready: the second tenant started and simply had nothing to install
     assertThat(healthCheckService.isBrokerReady()).isTrue();
+  }
+
+  @Test
+  public void shouldNotLogBrokerReadyWhileAnExpectedPhysicalTenantNeverRegistered() {
+    // given a broker with two physical tenants where only the default tenant registers and fully
+    // installs its partition; "all known partitions installed" is true but the broker is not ready
+    final var recorder = new RecordingAppender();
+    final var logger = (Logger) LogManager.getLogger("io.camunda.zeebe.broker.system");
+    recorder.start();
+    logger.addAppender(recorder);
+    try {
+      final var healthCheckService =
+          newStartedHealthCheckService(DEFAULT_PARTITION_GROUP_NAME, SECOND_PHYSICAL_TENANT);
+      healthCheckService.registerBootstrapPartitions(
+          DEFAULT_PARTITION_GROUP_NAME, List.of(partition(DEFAULT_PARTITION_GROUP_NAME, 1)));
+      scheduler.workUntilDone();
+
+      // when the default tenant's only partition is installed
+      healthCheckService.onBecameRaftLeader(new PartitionId(DEFAULT_PARTITION_GROUP_NAME, 1), 1);
+      scheduler.workUntilDone();
+
+      // then the broker must not announce readiness: a configured tenant has not registered yet
+      assertThat(healthCheckService.isBrokerReady()).isFalse();
+      assertThat(recorder.getAppendedEvents())
+          .noneSatisfy(
+              event -> assertThat(event.getMessage().getFormattedMessage()).contains("ready"));
+    } finally {
+      logger.removeAppender(recorder);
+      recorder.stop();
+    }
+  }
+
+  @Test
+  public void shouldLogBrokerReadyOnceWhenEveryPhysicalTenantIsInstalled() {
+    // given a broker with two physical tenants
+    final var recorder = new RecordingAppender();
+    final var logger = (Logger) LogManager.getLogger("io.camunda.zeebe.broker.system");
+    recorder.start();
+    logger.addAppender(recorder);
+    try {
+      final var healthCheckService =
+          newStartedHealthCheckService(DEFAULT_PARTITION_GROUP_NAME, SECOND_PHYSICAL_TENANT);
+      healthCheckService.registerBootstrapPartitions(
+          DEFAULT_PARTITION_GROUP_NAME, List.of(partition(DEFAULT_PARTITION_GROUP_NAME, 1)));
+      healthCheckService.registerBootstrapPartitions(
+          SECOND_PHYSICAL_TENANT, List.of(partition(SECOND_PHYSICAL_TENANT, 1)));
+      scheduler.workUntilDone();
+
+      // when every tenant's partition is installed
+      healthCheckService.onBecameRaftLeader(new PartitionId(DEFAULT_PARTITION_GROUP_NAME, 1), 1);
+      healthCheckService.onBecameRaftLeader(new PartitionId(SECOND_PHYSICAL_TENANT, 1), 1);
+      scheduler.workUntilDone();
+
+      // then the broker logs that it is ready exactly once
+      assertThat(healthCheckService.isBrokerReady()).isTrue();
+      assertThat(recorder.getAppendedEvents())
+          .filteredOn(event -> event.getMessage().getFormattedMessage().contains("Broker is ready"))
+          .hasSize(1);
+    } finally {
+      logger.removeAppender(recorder);
+      recorder.stop();
+    }
   }
 
   private BrokerHealthCheckService newHealthCheckService(final String... expectedPhysicalTenants) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.camunda.zeebe.protocol.Protocol;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 
@@ -47,9 +49,10 @@ public class BrokerHealthCheckServiceTest {
 
     // when + then
 
-    assertThatThrownBy(() -> healthCheckService.onBecameRaftFollower(0, 0))
+    final var partitionId = new PartitionId(Protocol.DEFAULT_PARTITION_GROUP_NAME, 0);
+    assertThatThrownBy(() -> healthCheckService.onBecameRaftFollower(partitionId, 0))
         .isInstanceOf(IllegalStateException.class);
-    assertThatThrownBy(() -> healthCheckService.onBecameRaftLeader(0, 0))
+    assertThatThrownBy(() -> healthCheckService.onBecameRaftLeader(partitionId, 0))
         .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -30,6 +30,7 @@ import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionTransitionImpl;
 import io.camunda.zeebe.broker.system.partitions.impl.RecoverablePartitionTransitionException;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.health.CriticalComponentsHealthMonitor;
@@ -71,7 +72,8 @@ public class ZeebePartitionTest {
     transition.updateTransitionContext(ctx);
 
     raft = mock(RaftPartition.class);
-    when(raft.id()).thenReturn(new PartitionId("", 0));
+    final var partitionId = new PartitionId(Protocol.DEFAULT_PARTITION_GROUP_NAME, 0);
+    when(raft.id()).thenReturn(partitionId);
     when(raft.getRole()).thenReturn(Role.INACTIVE);
     when(raft.getServer()).thenReturn(mock(RaftPartitionServer.class));
 
@@ -80,6 +82,7 @@ public class ZeebePartitionTest {
     when(ctx.getPartitionAdminControl()).thenReturn(mock(PartitionAdminControl.class));
     when(ctx.getRaftPartition()).thenReturn(raft);
     when(ctx.getPartitionContext()).thenReturn(ctx);
+    when(ctx.partitionId()).thenReturn(partitionId);
     when(ctx.getComponentHealthMonitor()).thenReturn(healthMonitor);
     when(ctx.createTransitionContext()).thenReturn(ctx);
     final BrokerHealthCheckService brokerCheckMock = mock();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/BrokerAdminServiceEndpointTest.java
@@ -44,7 +44,7 @@ public class BrokerAdminServiceEndpointTest {
   private static final ObjectMapper MAPPER =
       new ObjectMapper().registerModule(new Jdk8Module()).registerModule(new JavaTimeModule());
   private static final Duration ENDPOINT_TIMEOUT = Duration.ofSeconds(60);
-  private static final String PARTITION_HEALTH_ID = "Partition-1";
+  private static final String PARTITION_HEALTH_ID = "Partition-default-1";
   private static final List<String> EXPECTED_HEALTH_CHILDREN =
       List.of(
           "SnapshotDirector-1",


### PR DESCRIPTION
Makes the broker readiness/health check account for every physical tenant rather than only the default one.

Previously `BrokerHealthCheckService` tracked a single set of bootstrap partitions keyed by partition id, and only the default partition group was registered. With physical tenants this meant non-default tenants' partitions were invisible to the health check, so the broker could report itself ready before they were installed.

This PR:
- keys the install-status map by the full `PartitionId` (partition group + id) so partitions from different tenants no longer collide;
- registers bootstrap partitions for all partition groups, accumulating across tenants instead of overwriting on each registration;
- computes readiness live from the map so a tenant that registers after another has already finished installing still gates readiness;
- only reports ready once every configured physical tenant has registered and all of their partitions are installed, so a tenant that never started cannot be silently ignored.

For a default-only cluster the behavior is unchanged, so no backport is needed.

Stacked on #55746; review/merge that first. Part of the physical-tenants work tracked by #55118.
