### PR TITLE
feat: add OAuth and context headers to app-integrations exporter [backport 8.9]

### DIFF
--- a/zeebe/exporters/app-integrations-exporter/README.md
+++ b/zeebe/exporters/app-integrations-exporter/README.md
@@ -130,14 +130,17 @@ which cluster/org a batch of events originates from. Each header is sent indepen
 **only when its source value is available** — there is no dependency on the deployment model
 (SaaS vs Self-Managed) or the configured authentication mechanism.
 
-|     Header     |                              Source                               |                   Sent when                    |
-|----------------|-------------------------------------------------------------------|------------------------------------------------|
-| `X-Org-Id`     | `CAMUNDA_CLOUD_ORGANIZATION_ID` environment variable (set in SaaS) | present, non-blank and not the `null` sentinel |
-| `X-Cluster-Id` | `clusterId` config option                                         | the configured value is non-blank              |
+|     Header     |                                  Source                                   |                   Sent when                    |
+|----------------|---------------------------------------------------------------------------|------------------------------------------------|
+| `X-Org-Id`     | `CAMUNDA_CLOUD_ORGANIZATION_ID` environment variable (set in SaaS)        | present, non-blank and not the `null` sentinel |
+| `X-Cluster-Id` | `clusterId` config option (preferred), else the `ZEEBE_BROKER_CLUSTER_CLUSTERID` environment variable | the chosen value is non-blank                  |
 
 Notes:
-- In SaaS the org id is provided by the environment; no extra configuration is required.
-- In Self-Managed setups, set the `clusterId` config option to identify the cluster.
+- In SaaS the org id and cluster id are provided by the environment
+(`CAMUNDA_CLOUD_ORGANIZATION_ID` / `ZEEBE_BROKER_CLUSTER_CLUSTERID`); no extra configuration is
+required.
+- The configured `clusterId` takes precedence over the environment-provided cluster id, so a
+Self-Managed operator value wins when both are present.
 
 ## Metrics
 

--- a/zeebe/exporters/app-integrations-exporter/README.md
+++ b/zeebe/exporters/app-integrations-exporter/README.md
@@ -55,6 +55,7 @@ ZEEBE_BROKER_EXPORTERS_APPINTEXPORTER_CLASSNAME=io.camunda.exporter.appint.AppIn
 Additional configuration options:
 - `url` (string, required): The endpoint URL of the App Integration Backend.
 - `apiKey` (string, optional): API key for authentication with the backend.
+- `clusterId` (string, optional): Identifier of the cluster, sent to the backend via the `X-Cluster-Id` header (see [Context headers](#context-headers)). Intended for Self-Managed setups; expected to be unique per cluster configuration.
 - `continueOnError` (boolean, optional): Whether to continue processing events on error (default: true).
 - `maxRetries` (integer, optional): Maximum number of retry attempts for failed requests (default: 2).
 - `retryDelayMs` (duration, optional): Delay between retry attempts (default: 1500).
@@ -65,8 +66,10 @@ Additional configuration options:
 
 ### Authentication
 
-The exporter supports different authentication mechanisms.
-Currently, it supports API key authentication as well as no authentication (if the backend does not require it).
+The exporter supports different authentication mechanisms: OAuth 2.0 (client credentials),
+API key, and no authentication (if the backend does not require it). At most one mechanism may be
+configured: setting both `oauth` and `apiKey` is rejected at startup. When `oauth` is set it is
+used; otherwise an `apiKey` (when set) is used; otherwise requests are sent without authentication.
 
 #### Example of API key authentication:
 
@@ -75,6 +78,86 @@ You can provide the API key via the `apiKey` configuration property. The exporte
 ```
 x-api-key: myAPIKey
 ```
+
+#### Example of OAuth 2.0 authentication:
+
+For backends protected by an OAuth 2.0 authorization server, configure the `oauth` block. The
+exporter performs a [client-credentials grant](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4)
+against the configured `authorizationServerUrl`, caches the resulting access token in memory, and
+proactively rotates it on a background thread ahead of expiry. Each export request then carries the
+token in the `Authorization` header:
+
+```
+Authorization: Bearer <access-token>
+```
+
+```yaml
+zeebe:
+  broker:
+    exporters:
+      app-integrations:
+        className: io.camunda.exporter.appint.AppIntegrationsExporter
+        args:
+          url: "http://app-integration-backend:8080/events"
+          oauth:
+            clientId: "my-client-id"
+            clientSecret: "my-client-secret"
+            authorizationServerUrl: "https://auth.example.com/oauth/token"
+            audience: "app-integration-backend"
+```
+
+OAuth configuration keys (nested under `oauth`):
+
+|           Key            |  Type   | Required |                                      Description                                      |
+|--------------------------|---------|----------|---------------------------------------------------------------------------------------|
+| `clientId`               | string  | yes      | OAuth client identifier sent as `client_id` in the token request.                     |
+| `clientSecret`           | string  | yes      | OAuth client secret sent as `client_secret` in the token request.                     |
+| `authorizationServerUrl` | string  | yes      | Token endpoint URL of the authorization server (the client-credentials grant target). |
+| `audience`               | string  | no       | Sent as `audience` in the token request when set; omitted otherwise.                  |
+| `scope`                  | string  | no       | Sent as `scope` in the token request when set; omitted otherwise.                     |
+| `resource`               | string  | no       | Sent as `resource` in the token request when set; omitted otherwise.                  |
+| `connectTimeoutMs`       | integer | no       | Connect timeout for the token request, in milliseconds (default: 5000).               |
+| `readTimeoutMs`          | integer | no       | Read (socket) timeout for the token request, in milliseconds (default: 5000).         |
+
+The `connectTimeoutMs` / `readTimeoutMs` defaults ensure the token fetch — which runs synchronously
+on the export dispatch thread on a cache miss — always has a bounded ceiling, so enabling OAuth
+without explicit timeouts cannot stall exporting against an unresponsive token endpoint.
+
+## Context headers
+
+On every request the exporter attaches context-identification headers so the backend can tell
+which cluster/org a batch of events originates from. Each header is sent independently,
+**only when its source value is available** — there is no dependency on the deployment model
+(SaaS vs Self-Managed) or the configured authentication mechanism.
+
+|     Header     |                              Source                               |                   Sent when                    |
+|----------------|-------------------------------------------------------------------|------------------------------------------------|
+| `X-Org-Id`     | `CAMUNDA_CLOUD_ORGANIZATION_ID` environment variable (set in SaaS) | present, non-blank and not the `null` sentinel |
+| `X-Cluster-Id` | `clusterId` config option                                         | the configured value is non-blank              |
+
+Notes:
+- In SaaS the org id is provided by the environment; no extra configuration is required.
+- In Self-Managed setups, set the `clusterId` config option to identify the cluster.
+
+## Metrics
+
+The exporter publishes Micrometer metrics under the `zeebe.app.integrations.exporter` namespace.
+The `MeterRegistry` handed to the exporter is already partition scoped, so the metrics below carry
+no partition tag. In addition, the broker emits the standard per-exporter metrics (exporting
+latency, last exported position, exporter state, per-value-type event counters) for this exporter
+like for every other exporter.
+
+|                          Metric                          |         Type         |      Tags      |                           Description                           |
+|----------------------------------------------------------|----------------------|----------------|-----------------------------------------------------------------|
+| `zeebe.app.integrations.exporter.token.fetch.failed`     | counter              | —              | Failures while fetching a new OAuth token (non-timeout errors). |
+| `zeebe.app.integrations.exporter.timeout`                | counter              | `phase=token`  | Timeout reached while acquiring an OAuth token.                 |
+| `zeebe.app.integrations.exporter.timeout`                | counter              | `phase=export` | Timeout reached while exporting a batch.                        |
+| `zeebe.app.integrations.exporter.export.unauthorized`    | counter              | —              | `401 Unauthorized` responses received while exporting.          |
+| `zeebe.app.integrations.exporter.export.failed`          | counter              | —              | Failed batch export attempts.                                   |
+| `zeebe.app.integrations.exporter.records.exported`       | counter              | —              | Events successfully exported to the backend.                    |
+| `zeebe.app.integrations.exporter.batch.size`             | distribution summary | —              | Number of events per exported batch.                            |
+| `zeebe.app.integrations.exporter.flush.duration.seconds` | timer                | —              | Duration of exporting a batch to the backend.                   |
+| `zeebe.app.integrations.exporter.batches.in.flight`      | gauge                | —              | Number of batches currently being exported.                     |
 
 ## Development
 

--- a/zeebe/exporters/app-integrations-exporter/README.md
+++ b/zeebe/exporters/app-integrations-exporter/README.md
@@ -130,9 +130,9 @@ which cluster/org a batch of events originates from. Each header is sent indepen
 **only when its source value is available** — there is no dependency on the deployment model
 (SaaS vs Self-Managed) or the configured authentication mechanism.
 
-|     Header     |                                  Source                                   |                   Sent when                    |
-|----------------|---------------------------------------------------------------------------|------------------------------------------------|
-| `X-Org-Id`     | `CAMUNDA_CLOUD_ORGANIZATION_ID` environment variable (set in SaaS)        | present, non-blank and not the `null` sentinel |
+|     Header     |                                                Source                                                 |                   Sent when                    |
+|----------------|-------------------------------------------------------------------------------------------------------|------------------------------------------------|
+| `X-Org-Id`     | `CAMUNDA_CLOUD_ORGANIZATION_ID` environment variable (set in SaaS)                                    | present, non-blank and not the `null` sentinel |
 | `X-Cluster-Id` | `clusterId` config option (preferred), else the `ZEEBE_BROKER_CLUSTER_CLUSTERID` environment variable | the chosen value is non-blank                  |
 
 Notes:

--- a/zeebe/exporters/app-integrations-exporter/pom.xml
+++ b/zeebe/exporters/app-integrations-exporter/pom.xml
@@ -53,6 +53,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/AppIntegrationsExporter.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/AppIntegrationsExporter.java
@@ -46,7 +46,9 @@ public class AppIntegrationsExporter implements Exporter {
   public void configure(final Context context) {
     config = context.getConfiguration().instantiate(Config.class);
     deploymentContext =
-        new DeploymentContext(environment.apply(DeploymentContext.ORGANIZATION_ID_ENV_VAR));
+        new DeploymentContext(
+            environment.apply(DeploymentContext.ORGANIZATION_ID_ENV_VAR),
+            environment.apply(DeploymentContext.CLUSTER_ID_ENV_VAR));
     metrics = new AppIntegrationsExporterMetrics(context.getMeterRegistry());
   }
 

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/AppIntegrationsExporter.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/AppIntegrationsExporter.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.appint;
 
 import io.camunda.exporter.appint.config.Config;
 import io.camunda.exporter.appint.event.Event;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
 import io.camunda.exporter.appint.subscription.Subscription;
 import io.camunda.exporter.appint.subscription.SubscriptionFactory;
 import io.camunda.zeebe.exporter.api.Exporter;
@@ -16,6 +17,7 @@ import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import java.time.Duration;
+import java.util.function.UnaryOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,19 +26,36 @@ public class AppIntegrationsExporter implements Exporter {
 
   private final Logger log = LoggerFactory.getLogger(getClass().getPackageName());
 
+  private final UnaryOperator<String> environment;
+
   private Subscription<Event> subscription;
   private Controller controller;
   private Config config;
+  private DeploymentContext deploymentContext;
+  private AppIntegrationsExporterMetrics metrics;
+
+  public AppIntegrationsExporter() {
+    this(System::getenv);
+  }
+
+  AppIntegrationsExporter(final UnaryOperator<String> environment) {
+    this.environment = environment;
+  }
 
   @Override
   public void configure(final Context context) {
     config = context.getConfiguration().instantiate(Config.class);
+    deploymentContext =
+        new DeploymentContext(environment.apply(DeploymentContext.ORGANIZATION_ID_ENV_VAR));
+    metrics = new AppIntegrationsExporterMetrics(context.getMeterRegistry());
   }
 
   @Override
   public void open(final Controller controller) {
     this.controller = controller;
-    subscription = SubscriptionFactory.createDefault(config, this::updateExportPosition);
+    subscription =
+        SubscriptionFactory.createDefault(
+            config, deploymentContext, this::updateExportPosition, metrics);
     scheduleDelayedFlush();
   }
 

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/DeploymentContext.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/DeploymentContext.java
@@ -16,10 +16,19 @@ package io.camunda.exporter.appint;
  *
  * @param orgId the organization id (SaaS), read from the {@value #ORGANIZATION_ID_ENV_VAR}
  *     environment variable; {@code null} when not set.
+ * @param clusterId the cluster id (SaaS), read from the {@value #CLUSTER_ID_ENV_VAR} environment
+ *     variable; {@code null}/empty when not set.
  */
-public record DeploymentContext(String orgId) {
+public record DeploymentContext(String orgId, String clusterId) {
 
   public static final String ORGANIZATION_ID_ENV_VAR = "CAMUNDA_CLOUD_ORGANIZATION_ID";
 
-  public static final DeploymentContext EMPTY = new DeploymentContext(null);
+  /**
+   * Environment variable carrying the broker cluster id. Mirrors the fallback used by the exporter
+   * {@code Context#getClusterId()} on newer brokers, so SaaS deployments emit the cluster id even
+   * though the 8.9 exporter {@code Context} does not expose it natively.
+   */
+  public static final String CLUSTER_ID_ENV_VAR = "ZEEBE_BROKER_CLUSTER_CLUSTERID";
+
+  public static final DeploymentContext EMPTY = new DeploymentContext(null, null);
 }

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/DeploymentContext.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/DeploymentContext.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint;
+
+/**
+ * Immutable carrier for the deployment-level identifiers captured from the exporter {@link
+ * io.camunda.zeebe.exporter.api.context.Context} (and the environment) at configuration time.
+ *
+ * <p>These are forwarded to the App Integration Backend as context headers. Any field may be {@code
+ * null} when the corresponding value is not available; consumers decide which headers to emit.
+ *
+ * @param orgId the organization id (SaaS), read from the {@value #ORGANIZATION_ID_ENV_VAR}
+ *     environment variable; {@code null} when not set.
+ */
+public record DeploymentContext(String orgId) {
+
+  public static final String ORGANIZATION_ID_ENV_VAR = "CAMUNDA_CLOUD_ORGANIZATION_ID";
+
+  public static final DeploymentContext EMPTY = new DeploymentContext(null);
+}

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/config/Config.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/config/Config.java
@@ -12,6 +12,12 @@ public class Config {
   // Connection settings
   private String url;
   private String apiKey;
+  private OAuthConfig oauth;
+
+  // Context settings
+  // Operator-supplied cluster identifier. In Self-Managed setups this is expected to be unique
+  // per cluster/physical-tenant configuration. Sent to the backend via the X-Cluster-Id header.
+  private String clusterId;
 
   // Error handling settings
   private boolean continueOnError = true;
@@ -39,6 +45,24 @@ public class Config {
 
   public Config setApiKey(final String apiKey) {
     this.apiKey = apiKey;
+    return this;
+  }
+
+  public OAuthConfig getOauth() {
+    return oauth;
+  }
+
+  public Config setOauth(final OAuthConfig oauth) {
+    this.oauth = oauth;
+    return this;
+  }
+
+  public String getClusterId() {
+    return clusterId;
+  }
+
+  public Config setClusterId(final String clusterId) {
+    this.clusterId = clusterId;
     return this;
   }
 

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/config/ConfigValidator.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/config/ConfigValidator.java
@@ -16,5 +16,26 @@ public class ConfigValidator {
     if (config.getUrl() == null || config.getUrl().isBlank()) {
       throw new IllegalArgumentException("Url cannot be null or blank.");
     }
+    validateAuthentication(config);
+  }
+
+  private static void validateAuthentication(final Config config) {
+    final OAuthConfig oauth = config.getOauth();
+    if (oauth == null) {
+      return;
+    }
+    if (config.getApiKey() != null && !config.getApiKey().isBlank()) {
+      throw new IllegalArgumentException(
+          "Both apiKey and oauth authentication are configured; only one may be set.");
+    }
+    if (oauth.getClientId() == null || oauth.getClientId().isBlank()) {
+      throw new IllegalArgumentException("OAuth clientId cannot be null or blank.");
+    }
+    if (oauth.getClientSecret() == null || oauth.getClientSecret().isBlank()) {
+      throw new IllegalArgumentException("OAuth clientSecret cannot be null or blank.");
+    }
+    if (oauth.getAuthorizationServerUrl() == null || oauth.getAuthorizationServerUrl().isBlank()) {
+      throw new IllegalArgumentException("OAuth authorizationServerUrl cannot be null or blank.");
+    }
   }
 }

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/config/OAuthConfig.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/config/OAuthConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.config;
+
+public class OAuthConfig {
+
+  private String clientId;
+  private String clientSecret;
+  private String audience;
+  private String scope;
+  private String resource;
+  private String authorizationServerUrl;
+  private Long connectTimeoutMs;
+  private Long readTimeoutMs;
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  public OAuthConfig setClientId(final String clientId) {
+    this.clientId = clientId;
+    return this;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public OAuthConfig setClientSecret(final String clientSecret) {
+    this.clientSecret = clientSecret;
+    return this;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  public OAuthConfig setAudience(final String audience) {
+    this.audience = audience;
+    return this;
+  }
+
+  public String getScope() {
+    return scope;
+  }
+
+  public OAuthConfig setScope(final String scope) {
+    this.scope = scope;
+    return this;
+  }
+
+  public String getResource() {
+    return resource;
+  }
+
+  public OAuthConfig setResource(final String resource) {
+    this.resource = resource;
+    return this;
+  }
+
+  public String getAuthorizationServerUrl() {
+    return authorizationServerUrl;
+  }
+
+  public OAuthConfig setAuthorizationServerUrl(final String authorizationServerUrl) {
+    this.authorizationServerUrl = authorizationServerUrl;
+    return this;
+  }
+
+  public Long getConnectTimeoutMs() {
+    return connectTimeoutMs;
+  }
+
+  public OAuthConfig setConnectTimeoutMs(final Long connectTimeoutMs) {
+    this.connectTimeoutMs = connectTimeoutMs;
+    return this;
+  }
+
+  public Long getReadTimeoutMs() {
+    return readTimeoutMs;
+  }
+
+  public OAuthConfig setReadTimeoutMs(final Long readTimeoutMs) {
+    this.readTimeoutMs = readTimeoutMs;
+    return this;
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/dispatch/DispatcherImpl.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/dispatch/DispatcherImpl.java
@@ -40,11 +40,20 @@ public class DispatcherImpl implements Dispatcher {
   public void dispatch(final Runnable job) {
     try {
       semaphore.acquire();
-      metrics.incrementBatchesInFlight();
-      log.trace("Dispatching job {}", job);
-      executorService.execute(() -> executeJob(job));
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
+    }
+    metrics.incrementBatchesInFlight();
+    log.trace("Dispatching job {}", job);
+    try {
+      executorService.execute(() -> executeJob(job));
+    } catch (final RuntimeException e) {
+      // Submission failed (e.g. RejectedExecutionException once the executor is shutting down);
+      // release the permit and gauge reserved for this job so they are not leaked.
+      metrics.decrementBatchesInFlight();
+      semaphore.release();
+      throw e;
     }
   }
 
@@ -79,6 +88,7 @@ public class DispatcherImpl implements Dispatcher {
       executorService.shutdown();
       executorService.awaitTermination(10, java.util.concurrent.TimeUnit.SECONDS);
     } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
   }

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/dispatch/DispatcherImpl.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/dispatch/DispatcherImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.appint.dispatch;
 
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -27,9 +28,11 @@ public class DispatcherImpl implements Dispatcher {
   private final ExecutorService executorService = Executors.newSingleThreadExecutor();
   private final Semaphore semaphore;
   private final int maxJobsInFlight;
+  private final AppIntegrationsExporterMetrics metrics;
 
-  public DispatcherImpl(final int maxJobsInFlight) {
+  public DispatcherImpl(final int maxJobsInFlight, final AppIntegrationsExporterMetrics metrics) {
     this.maxJobsInFlight = maxJobsInFlight;
+    this.metrics = metrics;
     semaphore = new Semaphore(maxJobsInFlight);
   }
 
@@ -37,6 +40,7 @@ public class DispatcherImpl implements Dispatcher {
   public void dispatch(final Runnable job) {
     try {
       semaphore.acquire();
+      metrics.incrementBatchesInFlight();
       log.trace("Dispatching job {}", job);
       executorService.execute(() -> executeJob(job));
     } catch (final InterruptedException e) {
@@ -61,6 +65,7 @@ public class DispatcherImpl implements Dispatcher {
       try {
         job.run();
         success = true;
+        metrics.decrementBatchesInFlight();
         semaphore.release();
       } catch (final Exception e) {
         log.debug("Failed to run the job. Restarting.", e);

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/metrics/AppIntegrationsExporterMetrics.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/metrics/AppIntegrationsExporterMetrics.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.metrics;
+
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+
+/**
+ * Holds the App Integrations Exporter specific Micrometer metrics.
+ *
+ * <p>The {@link MeterRegistry} handed to an exporter is already partition scoped, so no partition
+ * tag is added here (consistent with the Elasticsearch / OpenSearch exporters). Standard
+ * per-exporter metrics (exporting latency, last exported position, ...) are emitted by the broker
+ * for every exporter and are therefore not duplicated here.
+ */
+public class AppIntegrationsExporterMetrics {
+
+  private static final String NAMESPACE = "zeebe.app.integrations.exporter";
+  private static final String PHASE_TAG = "phase";
+
+  private final Timer flushDuration;
+  private final DistributionSummary batchSize;
+  private final StatefulGauge batchesInFlight;
+  private final Counter recordsExported;
+  private final Counter exportFailed;
+  private final Counter exportUnauthorized;
+  private final Counter tokenFetchFailed;
+  private final Counter exportTimeout;
+  private final Counter tokenTimeout;
+
+  public AppIntegrationsExporterMetrics(final MeterRegistry registry) {
+    flushDuration =
+        Timer.builder(meterName("flush.duration.seconds"))
+            .description("Duration of exporting a batch of events to the backend")
+            .publishPercentileHistogram()
+            .minimumExpectedValue(Duration.ofMillis(10))
+            .register(registry);
+
+    batchSize =
+        DistributionSummary.builder(meterName("batch.size"))
+            .description("Number of events exported per batch")
+            .serviceLevelObjectives(1, 10, 50, 100, 500)
+            .register(registry);
+
+    batchesInFlight =
+        StatefulGauge.builder(meterName("batches.in.flight"))
+            .description("Number of batches currently being exported")
+            .register(registry);
+
+    recordsExported =
+        Counter.builder(meterName("records.exported"))
+            .description("Number of events successfully exported to the backend")
+            .register(registry);
+
+    exportFailed =
+        Counter.builder(meterName("export.failed"))
+            .description("Number of failed batch export attempts")
+            .register(registry);
+
+    exportUnauthorized =
+        Counter.builder(meterName("export.unauthorized"))
+            .description("Number of 401 Unauthorized responses received while exporting")
+            .register(registry);
+
+    tokenFetchFailed =
+        Counter.builder(meterName("token.fetch.failed"))
+            .description("Number of failures while fetching a new OAuth token")
+            .register(registry);
+
+    exportTimeout =
+        Counter.builder(meterName("timeout"))
+            .description("Number of timeouts reached while acquiring a token or exporting")
+            .tag(PHASE_TAG, Phase.EXPORT.tagValue)
+            .register(registry);
+
+    tokenTimeout =
+        Counter.builder(meterName("timeout"))
+            .description("Number of timeouts reached while acquiring a token or exporting")
+            .tag(PHASE_TAG, Phase.TOKEN.tagValue)
+            .register(registry);
+  }
+
+  /**
+   * @return an instance backed by a throwaway {@link SimpleMeterRegistry}, for components
+   *     constructed without an exporter {@link MeterRegistry} (e.g. in unit tests).
+   */
+  public static AppIntegrationsExporterMetrics disabled() {
+    return new AppIntegrationsExporterMetrics(new SimpleMeterRegistry());
+  }
+
+  /** Measures the duration of a batch export. */
+  public void measureFlushDuration(final Runnable flushFunction) {
+    flushDuration.record(flushFunction);
+  }
+
+  public void recordBatchSize(final int size) {
+    batchSize.record(size);
+  }
+
+  public void recordExported(final int count) {
+    recordsExported.increment(count);
+  }
+
+  public void recordExportFailed() {
+    exportFailed.increment();
+  }
+
+  public void recordUnauthorized() {
+    exportUnauthorized.increment();
+  }
+
+  public void recordTokenFetchFailed() {
+    tokenFetchFailed.increment();
+  }
+
+  public void recordTimeout(final Phase phase) {
+    final Counter counter = phase == Phase.TOKEN ? tokenTimeout : exportTimeout;
+    counter.increment();
+  }
+
+  public void incrementBatchesInFlight() {
+    batchesInFlight.increment();
+  }
+
+  public void decrementBatchesInFlight() {
+    batchesInFlight.decrement();
+  }
+
+  private static String meterName(final String name) {
+    return NAMESPACE + "." + name;
+  }
+
+  /** The phase during which a timeout was reached. */
+  public enum Phase {
+    TOKEN("token"),
+    EXPORT("export");
+
+    private final String tagValue;
+
+    Phase(final String tagValue) {
+      this.tagValue = tagValue;
+    }
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/subscription/Subscription.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/subscription/Subscription.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.appint.config.BatchConfig;
 import io.camunda.exporter.appint.dispatch.Dispatcher;
 import io.camunda.exporter.appint.dispatch.DispatcherImpl;
 import io.camunda.exporter.appint.mapper.RecordMapper;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
 import io.camunda.exporter.appint.transport.Transport;
 import io.camunda.zeebe.protocol.record.Record;
 import java.util.concurrent.locks.ReentrantLock;
@@ -35,7 +36,8 @@ public class Subscription<T> {
       final Transport<T> transport,
       final RecordMapper<T> mapper,
       final BatchConfig batchConfig,
-      final Consumer<Long> positionConsumer) {
+      final Consumer<Long> positionConsumer,
+      final AppIntegrationsExporterMetrics metrics) {
     this.transport = transport;
     this.mapper = mapper;
     this.batchConfig = batchConfig;
@@ -44,7 +46,7 @@ public class Subscription<T> {
       log.warn(
           "Subscription is configured to continue on error. This may lead to data loss if errors occur during export.");
     }
-    dispatcher = new DispatcherImpl(batchConfig.maxBatchesInFlight());
+    dispatcher = new DispatcherImpl(batchConfig.maxBatchesInFlight(), metrics);
     currentBatch = new Batch<>(batchConfig.batchSize(), batchConfig.batchIntervalMs());
   }
 

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/subscription/SubscriptionFactory.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/subscription/SubscriptionFactory.java
@@ -7,21 +7,30 @@
  */
 package io.camunda.exporter.appint.subscription;
 
-import static io.camunda.exporter.appint.transport.Authentication.*;
+import static io.camunda.exporter.appint.transport.Authentication.None;
+import static java.util.Optional.ofNullable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.exporter.appint.DeploymentContext;
 import io.camunda.exporter.appint.config.BatchConfig;
 import io.camunda.exporter.appint.config.Config;
 import io.camunda.exporter.appint.config.ConfigValidator;
+import io.camunda.exporter.appint.config.OAuthConfig;
 import io.camunda.exporter.appint.event.Event;
 import io.camunda.exporter.appint.mapper.SupportedRecordsMapper;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
+import io.camunda.exporter.appint.transport.Authentication;
 import io.camunda.exporter.appint.transport.Authentication.ApiKey;
+import io.camunda.exporter.appint.transport.Authentication.OAuthCredentialsProvider;
+import io.camunda.exporter.appint.transport.ContextHeaders;
+import io.camunda.exporter.appint.transport.DefaultOAuthCredentialsProvider;
 import io.camunda.exporter.appint.transport.HttpTransportConfig;
 import io.camunda.exporter.appint.transport.HttpTransportImpl;
 import io.camunda.exporter.appint.transport.JsonMapper;
+import java.time.Duration;
 import java.util.function.Consumer;
 
 public class SubscriptionFactory {
@@ -42,21 +51,37 @@ public class SubscriptionFactory {
   }
 
   public static Subscription<Event> createDefault(
-      final Config config, final Consumer<Long> positionConsumer) {
+      final Config config,
+      final Consumer<Long> positionConsumer,
+      final AppIntegrationsExporterMetrics metrics) {
+    return createDefault(config, DeploymentContext.EMPTY, positionConsumer, metrics);
+  }
+
+  public static Subscription<Event> createDefault(
+      final Config config,
+      final DeploymentContext deploymentContext,
+      final Consumer<Long> positionConsumer,
+      final AppIntegrationsExporterMetrics metrics) {
     ConfigValidator.validate(config);
-    final var auth =
-        switch (config.getApiKey()) {
-          case null -> None.INSTANCE;
-          default -> new ApiKey(config.getApiKey());
-        };
+    final Authentication auth;
+    if (config.getOauth() != null) {
+      auth = new Authentication.OAuth(buildOAuthProvider(config.getOauth(), metrics));
+    } else if (config.getApiKey() != null && !config.getApiKey().isBlank()) {
+      auth = new ApiKey(config.getApiKey());
+    } else {
+      auth = None.INSTANCE;
+    }
+    final var contextHeaders =
+        ContextHeaders.resolve(config.getClusterId(), deploymentContext.orgId());
     final var httpTransportConfig =
         new HttpTransportConfig(
             config.getUrl(),
             auth,
             config.getMaxRetries(),
             config.getRetryDelayMs(),
-            config.getRequestTimeoutMs());
-    final var transport = new HttpTransportImpl(createJsonMapper(), httpTransportConfig);
+            config.getRequestTimeoutMs(),
+            contextHeaders);
+    final var transport = new HttpTransportImpl(createJsonMapper(), httpTransportConfig, metrics);
     final var mapper = new SupportedRecordsMapper();
     final var batchConfig =
         new BatchConfig(
@@ -64,6 +89,24 @@ public class SubscriptionFactory {
             config.getBatchSize(),
             config.getBatchIntervalMs(),
             config.isContinueOnError());
-    return new Subscription<>(transport, mapper, batchConfig, positionConsumer);
+    return new Subscription<>(transport, mapper, batchConfig, positionConsumer, metrics);
+  }
+
+  private static OAuthCredentialsProvider buildOAuthProvider(
+      final OAuthConfig cfg, final AppIntegrationsExporterMetrics metrics) {
+    final Duration connectTimeout =
+        ofNullable(cfg.getConnectTimeoutMs()).map(Duration::ofMillis).orElse(null);
+    final Duration readTimeout =
+        ofNullable(cfg.getReadTimeoutMs()).map(Duration::ofMillis).orElse(null);
+    return new DefaultOAuthCredentialsProvider(
+        cfg.getAuthorizationServerUrl(),
+        cfg.getClientId(),
+        cfg.getClientSecret(),
+        cfg.getAudience(),
+        cfg.getScope(),
+        cfg.getResource(),
+        connectTimeout,
+        readTimeout,
+        metrics);
   }
 }

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/subscription/SubscriptionFactory.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/subscription/SubscriptionFactory.java
@@ -72,7 +72,8 @@ public class SubscriptionFactory {
       auth = None.INSTANCE;
     }
     final var contextHeaders =
-        ContextHeaders.resolve(config.getClusterId(), deploymentContext.orgId());
+        ContextHeaders.resolve(
+            config.getClusterId(), deploymentContext.clusterId(), deploymentContext.orgId());
     final var httpTransportConfig =
         new HttpTransportConfig(
             config.getUrl(),

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/Authentication.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/Authentication.java
@@ -9,8 +9,11 @@ package io.camunda.exporter.appint.transport;
 
 import io.camunda.exporter.appint.transport.Authentication.ApiKey;
 import io.camunda.exporter.appint.transport.Authentication.None;
+import io.camunda.exporter.appint.transport.Authentication.OAuth;
+import java.io.IOException;
+import java.util.function.BiConsumer;
 
-public sealed interface Authentication permits ApiKey, None {
+public sealed interface Authentication permits ApiKey, None, OAuth {
 
   final class None implements Authentication {
     public static final None INSTANCE = new None();
@@ -20,5 +23,34 @@ public sealed interface Authentication permits ApiKey, None {
 
   record ApiKey(String apiKey) implements Authentication {
     public static final String HEADER_NAME = "X-API-KEY";
+  }
+
+  record OAuth(OAuthCredentialsProvider credentialsProvider) implements Authentication {}
+
+  /**
+   * Provides OAuth credentials as request headers. Implementations must be thread-safe.
+   *
+   * <p>This is an exporter-local abstraction so the exporter does not depend on the camunda-client
+   * library.
+   */
+  @FunctionalInterface
+  interface OAuthCredentialsProvider {
+
+    /**
+     * Applies the credentials by emitting one or more headers via the given consumer.
+     *
+     * @param headerConsumer accepts (headerName, headerValue) pairs
+     * @throws IOException if obtaining credentials fails (e.g. token endpoint is unreachable)
+     */
+    void applyCredentials(BiConsumer<String, String> headerConsumer) throws IOException;
+
+    /**
+     * Marks the current credentials as invalid (e.g. after a {@code 401}) so the next {@link
+     * #applyCredentials} call obtains fresh credentials. No-op by default.
+     */
+    default void invalidate() {}
+
+    /** Releases any background resources (e.g. a token-refresh thread). No-op by default. */
+    default void close() {}
   }
 }

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/ContextHeaders.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/ContextHeaders.java
@@ -29,11 +29,13 @@ public record ContextHeaders(String orgId, String clusterId) {
   /**
    * Resolves the headers from their possible sources.
    *
-   * @param clusterId the operator-supplied cluster id (exporter config).
+   * @param configClusterId the operator-supplied cluster id (exporter config); takes precedence.
+   * @param envClusterId the cluster id read from the environment (SaaS).
    * @param orgId the organization id read from the environment.
    */
-  public static ContextHeaders resolve(final String clusterId, final String orgId) {
-    return new ContextHeaders(normalizeOrgId(orgId), blankToNull(clusterId));
+  public static ContextHeaders resolve(
+      final String configClusterId, final String envClusterId, final String orgId) {
+    return new ContextHeaders(normalizeOrgId(orgId), firstNonBlank(configClusterId, envClusterId));
   }
 
   /** Emits each resolved header via the given consumer, skipping any blank value. */
@@ -53,8 +55,11 @@ public record ContextHeaders(String orgId, String clusterId) {
     return orgId;
   }
 
-  private static String blankToNull(final String value) {
-    return isPresent(value) ? value : null;
+  private static String firstNonBlank(final String preferred, final String fallback) {
+    if (isPresent(preferred)) {
+      return preferred;
+    }
+    return isPresent(fallback) ? fallback : null;
   }
 
   private static boolean isPresent(final String value) {

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/ContextHeaders.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/ContextHeaders.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.transport;
+
+import java.util.function.BiConsumer;
+
+/**
+ * Resolved context-identification headers attached to every export request so the backend can tell
+ * which cluster/org a batch originates from.
+ *
+ * <p>Each value is sourced independently and a header is only emitted when its value is available;
+ * there is no dependency on the deployment model (SaaS vs Self-Managed) or the authentication
+ * mechanism.
+ */
+public record ContextHeaders(String orgId, String clusterId) {
+
+  public static final String X_ORG_ID = "X-Org-Id";
+  public static final String X_CLUSTER_ID = "X-Cluster-Id";
+  public static final ContextHeaders EMPTY = new ContextHeaders(null, null);
+
+  /** Sentinel some SaaS environments use to indicate the organization id is unset. */
+  private static final String ORG_ID_UNSET_SENTINEL = "null";
+
+  /**
+   * Resolves the headers from their possible sources.
+   *
+   * @param clusterId the operator-supplied cluster id (exporter config).
+   * @param orgId the organization id read from the environment.
+   */
+  public static ContextHeaders resolve(final String clusterId, final String orgId) {
+    return new ContextHeaders(normalizeOrgId(orgId), blankToNull(clusterId));
+  }
+
+  /** Emits each resolved header via the given consumer, skipping any blank value. */
+  public void applyTo(final BiConsumer<String, String> headerConsumer) {
+    if (isPresent(orgId)) {
+      headerConsumer.accept(X_ORG_ID, orgId);
+    }
+    if (isPresent(clusterId)) {
+      headerConsumer.accept(X_CLUSTER_ID, clusterId);
+    }
+  }
+
+  private static String normalizeOrgId(final String orgId) {
+    if (!isPresent(orgId) || ORG_ID_UNSET_SENTINEL.equals(orgId)) {
+      return null;
+    }
+    return orgId;
+  }
+
+  private static String blankToNull(final String value) {
+    return isPresent(value) ? value : null;
+  }
+
+  private static boolean isPresent(final String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProvider.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProvider.java
@@ -77,18 +77,6 @@ public final class DefaultOAuthCredentialsProvider implements OAuthCredentialsPr
 
   static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(5);
 
-  /**
-   * Returns {@code configured} only when it is a positive duration; otherwise falls back to {@code
-   * fallback}. A non-positive value (null, zero or negative) would otherwise reach Apache
-   * HttpClient as a {@code 0}ms timeout, which it treats as <em>infinite</em> and would defeat the
-   * bounded token-fetch safety.
-   */
-  private static Duration boundedTimeout(final Duration configured, final Duration fallback) {
-    return configured != null && !configured.isZero() && !configured.isNegative()
-        ? configured
-        : fallback;
-  }
-
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   private final Logger log = LoggerFactory.getLogger(getClass().getPackageName());
@@ -145,6 +133,18 @@ public final class DefaultOAuthCredentialsProvider implements OAuthCredentialsPr
     // Run the initial fetch off-thread so construction never blocks or throws on a token-endpoint
     // failure.
     scheduler.schedule(this::refreshTokenTask, 0, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Returns {@code configured} only when it is a positive duration; otherwise falls back to {@code
+   * fallback}. A non-positive value (null, zero or negative) would otherwise reach Apache
+   * HttpClient as a {@code 0}ms timeout, which it treats as <em>infinite</em> and would defeat the
+   * bounded token-fetch safety.
+   */
+  private static Duration boundedTimeout(final Duration configured, final Duration fallback) {
+    return configured != null && !configured.isZero() && !configured.isNegative()
+        ? configured
+        : fallback;
   }
 
   @Override

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProvider.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProvider.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.transport;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics.Phase;
+import io.camunda.exporter.appint.transport.Authentication.OAuthCredentialsProvider;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A self-contained OAuth 2.0 client-credentials grant provider.
+ *
+ * <p>Fetches an access token from the configured authorization server and caches it in memory. A
+ * single daemon background thread keeps the token valid ahead of time by proactively rotating it
+ * once less than {@link #REFRESH_MARGIN} of its lifetime remains, so request threads almost always
+ * hit a warm cache. A synchronous fetch is retained as a safety net (e.g. immediately after an
+ * {@link #invalidate()} or before the first background fetch completes).
+ *
+ * <p>It is intentionally minimal and has no dependency on the camunda-client library.
+ */
+public final class DefaultOAuthCredentialsProvider implements OAuthCredentialsProvider {
+
+  static final String AUTHORIZATION_HEADER = "Authorization";
+  static final String CONTENT_TYPE_FORM = "application/x-www-form-urlencoded";
+
+  /** Token is safe to attach to an outgoing request while at least this margin remains. */
+  static final Duration USABLE_SAFETY_MARGIN = Duration.ofSeconds(30);
+
+  /** Proactively rotate the token once less than this much of its lifetime remains. */
+  static final Duration REFRESH_MARGIN = Duration.ofSeconds(60);
+
+  /** Backoff before retrying a failed background token fetch. */
+  static final Duration MIN_REFRESH_RETRY_BACKOFF = Duration.ofSeconds(5);
+
+  /** Assumed token lifetime when the response does not report a positive {@code expires_in}. */
+  static final Duration DEFAULT_LIFETIME = Duration.ofMinutes(5);
+
+  /**
+   * Fallback connect/read timeouts applied when none are configured. Without these, Apache
+   * HttpClient defaults both to {@code 0} (infinite), so a hung token endpoint that accepts the
+   * connection but never responds would block the synchronous {@link #obtainToken()} fetch — which
+   * runs on the single export dispatcher thread — indefinitely and stall exporting for that
+   * partition. A bounded default keeps enabling OAuth without explicit timeouts safe.
+   */
+  static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
+
+  static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(5);
+
+  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+  private final Logger log = LoggerFactory.getLogger(getClass().getPackageName());
+
+  private final String authorizationServerUrl;
+  private final String clientId;
+  private final String clientSecret;
+  private final String audience;
+  private final String scope;
+  private final String resource;
+  private final Duration connectTimeout;
+  private final Duration readTimeout;
+
+  private final Object tokenLock = new Object();
+  private volatile CachedToken cachedToken;
+
+  private final CloseableHttpClient httpClient;
+  private final ScheduledExecutorService scheduler;
+  private final AppIntegrationsExporterMetrics metrics;
+  private volatile boolean closed;
+
+  public DefaultOAuthCredentialsProvider(
+      final String authorizationServerUrl,
+      final String clientId,
+      final String clientSecret,
+      final String audience,
+      final String scope,
+      final String resource,
+      final Duration connectTimeout,
+      final Duration readTimeout,
+      final AppIntegrationsExporterMetrics metrics) {
+    this.authorizationServerUrl =
+        Objects.requireNonNull(authorizationServerUrl, "authorizationServerUrl");
+    this.clientId = Objects.requireNonNull(clientId, "clientId");
+    this.clientSecret = Objects.requireNonNull(clientSecret, "clientSecret");
+    this.audience = audience;
+    this.scope = scope;
+    this.resource = resource;
+    this.connectTimeout = connectTimeout != null ? connectTimeout : DEFAULT_CONNECT_TIMEOUT;
+    this.readTimeout = readTimeout != null ? readTimeout : DEFAULT_READ_TIMEOUT;
+    this.metrics = metrics;
+
+    // Build the shared client once; it is thread-safe and reused by both the background refresher
+    // thread and any synchronous fetch, avoiding per-request connection and TLS setup.
+    httpClient = HttpClientBuilder.create().build();
+
+    scheduler =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              final Thread t = new Thread(r, "app-integrations-oauth-token-refresher");
+              t.setDaemon(true);
+              return t;
+            });
+    // Run the initial fetch off-thread so construction never blocks or throws on a token-endpoint
+    // failure.
+    scheduler.schedule(this::refreshTokenTask, 0, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public void applyCredentials(final BiConsumer<String, String> headerConsumer) throws IOException {
+    final CachedToken token = obtainToken();
+    headerConsumer.accept(AUTHORIZATION_HEADER, token.tokenType + " " + token.accessToken);
+  }
+
+  @Override
+  public void invalidate() {
+    synchronized (tokenLock) {
+      cachedToken = null;
+    }
+    // Rotate immediately in the background as well, so the token is valid even with no in-flight
+    // request. The synchronous applyCredentials path also covers the retry.
+    if (!closed) {
+      try {
+        scheduler.execute(this::refreshTokenTask);
+      } catch (final RejectedExecutionException ignored) {
+        // closed concurrently; ignore
+      }
+    }
+  }
+
+  @Override
+  public void close() {
+    closed = true;
+    scheduler.shutdownNow();
+    try {
+      scheduler.awaitTermination(5, TimeUnit.SECONDS);
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    try {
+      httpClient.close();
+    } catch (final IOException e) {
+      log.debug("Failed to close OAuth token http client", e);
+    }
+  }
+
+  private CachedToken obtainToken() throws IOException {
+    final CachedToken current = cachedToken;
+    if (current != null && current.isUsable()) {
+      return current;
+    }
+    synchronized (tokenLock) {
+      if (cachedToken != null && cachedToken.isUsable()) {
+        return cachedToken;
+      }
+      cachedToken = fetchToken();
+      return cachedToken;
+    }
+  }
+
+  /** Runs on the refresher thread; fetches the token when needed and self-reschedules. */
+  private void refreshTokenTask() {
+    if (closed) {
+      return;
+    }
+    Duration nextDelay;
+    try {
+      synchronized (tokenLock) {
+        if (cachedToken == null || cachedToken.needsProactiveRefresh()) {
+          cachedToken = fetchToken();
+        }
+        nextDelay = cachedToken.untilRefresh();
+      }
+      // Never schedule a tight loop if clock math underflows.
+      if (nextDelay.isZero()) {
+        nextDelay = MIN_REFRESH_RETRY_BACKOFF;
+      }
+    } catch (final Exception e) {
+      log.warn("Failed to proactively refresh OAuth token; will retry.", e);
+      nextDelay = MIN_REFRESH_RETRY_BACKOFF;
+    }
+    scheduleNext(nextDelay);
+  }
+
+  private void scheduleNext(final Duration delay) {
+    if (closed) {
+      return;
+    }
+    try {
+      scheduler.schedule(this::refreshTokenTask, delay.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (final RejectedExecutionException ignored) {
+      // scheduler shut down concurrently with close(); nothing to do
+    }
+  }
+
+  private CachedToken fetchToken() throws IOException {
+    try {
+      return doFetchToken();
+    } catch (final SocketTimeoutException | ConnectTimeoutException e) {
+      metrics.recordTimeout(Phase.TOKEN);
+      throw e;
+    } catch (final IOException e) {
+      metrics.recordTokenFetchFailed();
+      throw e;
+    }
+  }
+
+  private CachedToken doFetchToken() throws IOException {
+    final HttpPost post = new HttpPost(authorizationServerUrl);
+    post.setHeader("Content-Type", CONTENT_TYPE_FORM);
+    post.setHeader("Accept", "application/json");
+    post.setEntity(new StringEntity(buildFormBody(), StandardCharsets.UTF_8));
+
+    final RequestConfig requestConfig =
+        RequestConfig.custom()
+            .setConnectTimeout(Math.toIntExact(connectTimeout.toMillis()))
+            .setSocketTimeout(Math.toIntExact(readTimeout.toMillis()))
+            .build();
+    post.setConfig(requestConfig);
+
+    try (final CloseableHttpResponse response = httpClient.execute(post)) {
+      final int statusCode = response.getStatusLine().getStatusCode();
+      final String body =
+          response.getEntity() != null ? EntityUtils.toString(response.getEntity()) : "";
+      if (statusCode < 200 || statusCode >= 300) {
+        throw new IOException(
+            "Failed to fetch OAuth token: HTTP "
+                + statusCode
+                + " "
+                + response.getStatusLine().getReasonPhrase()
+                + " - "
+                + body);
+      }
+      final TokenResponse parsed = JSON_MAPPER.readValue(body, TokenResponse.class);
+      if (parsed.accessToken == null || parsed.accessToken.isBlank()) {
+        throw new IOException("OAuth token response did not contain an access_token");
+      }
+      final String tokenType = parsed.tokenType != null ? parsed.tokenType : "Bearer";
+      final Instant expiresAt =
+          parsed.expiresInSeconds > 0
+              ? Instant.now().plusSeconds(parsed.expiresInSeconds)
+              : Instant.now().plus(DEFAULT_LIFETIME);
+      return new CachedToken(parsed.accessToken, tokenType, expiresAt);
+    }
+  }
+
+  private String buildFormBody() {
+    final Map<String, String> params = new LinkedHashMap<>();
+    params.put("grant_type", "client_credentials");
+    params.put("client_id", clientId);
+    params.put("client_secret", clientSecret);
+    if (audience != null && !audience.isBlank()) {
+      params.put("audience", audience);
+    }
+    if (scope != null && !scope.isBlank()) {
+      params.put("scope", scope);
+    }
+    if (resource != null && !resource.isBlank()) {
+      params.put("resource", resource);
+    }
+    final StringBuilder sb = new StringBuilder();
+    boolean first = true;
+    for (final Map.Entry<String, String> e : params.entrySet()) {
+      if (!first) {
+        sb.append('&');
+      }
+      first = false;
+      sb.append(URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8))
+          .append('=')
+          .append(URLEncoder.encode(e.getValue(), StandardCharsets.UTF_8));
+    }
+    return sb.toString();
+  }
+
+  private static final class CachedToken {
+    private final String accessToken;
+    private final String tokenType;
+    private final Instant expiresAt;
+
+    CachedToken(final String accessToken, final String tokenType, final Instant expiresAt) {
+      this.accessToken = accessToken;
+      this.tokenType = tokenType;
+      this.expiresAt = expiresAt;
+    }
+
+    /** Whether the token is safe to attach to an outgoing request right now. */
+    boolean isUsable() {
+      return Instant.now().isBefore(expiresAt.minus(USABLE_SAFETY_MARGIN));
+    }
+
+    /** The instant at which the proactive rotation should happen. */
+    Instant refreshAt() {
+      return expiresAt.minus(REFRESH_MARGIN);
+    }
+
+    boolean needsProactiveRefresh() {
+      return !Instant.now().isBefore(refreshAt());
+    }
+
+    /** Delay until the next proactive refresh, clamped to {@code >= 0}. */
+    Duration untilRefresh() {
+      final Duration d = Duration.between(Instant.now(), refreshAt());
+      return d.isNegative() ? Duration.ZERO : d;
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static final class TokenResponse {
+    @JsonProperty("access_token")
+    String accessToken;
+
+    @JsonProperty("token_type")
+    String tokenType;
+
+    @JsonProperty("expires_in")
+    long expiresInSeconds;
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProvider.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProvider.java
@@ -77,6 +77,18 @@ public final class DefaultOAuthCredentialsProvider implements OAuthCredentialsPr
 
   static final Duration DEFAULT_READ_TIMEOUT = Duration.ofSeconds(5);
 
+  /**
+   * Returns {@code configured} only when it is a positive duration; otherwise falls back to {@code
+   * fallback}. A non-positive value (null, zero or negative) would otherwise reach Apache
+   * HttpClient as a {@code 0}ms timeout, which it treats as <em>infinite</em> and would defeat the
+   * bounded token-fetch safety.
+   */
+  private static Duration boundedTimeout(final Duration configured, final Duration fallback) {
+    return configured != null && !configured.isZero() && !configured.isNegative()
+        ? configured
+        : fallback;
+  }
+
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   private final Logger log = LoggerFactory.getLogger(getClass().getPackageName());
@@ -115,8 +127,8 @@ public final class DefaultOAuthCredentialsProvider implements OAuthCredentialsPr
     this.audience = audience;
     this.scope = scope;
     this.resource = resource;
-    this.connectTimeout = connectTimeout != null ? connectTimeout : DEFAULT_CONNECT_TIMEOUT;
-    this.readTimeout = readTimeout != null ? readTimeout : DEFAULT_READ_TIMEOUT;
+    this.connectTimeout = boundedTimeout(connectTimeout, DEFAULT_CONNECT_TIMEOUT);
+    this.readTimeout = boundedTimeout(readTimeout, DEFAULT_READ_TIMEOUT);
     this.metrics = metrics;
 
     // Build the shared client once; it is thread-safe and reused by both the background refresher

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/HttpTransportConfig.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/HttpTransportConfig.java
@@ -12,4 +12,15 @@ public record HttpTransportConfig(
     Authentication authentication,
     int maxRetries,
     long retryDelayMs,
-    long requestTimeoutMs) {}
+    long requestTimeoutMs,
+    ContextHeaders contextHeaders) {
+
+  public HttpTransportConfig(
+      final String url,
+      final Authentication authentication,
+      final int maxRetries,
+      final long retryDelayMs,
+      final long requestTimeoutMs) {
+    this(url, authentication, maxRetries, retryDelayMs, requestTimeoutMs, ContextHeaders.EMPTY);
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/HttpTransportImpl.java
+++ b/zeebe/exporters/app-integrations-exporter/src/main/java/io/camunda/exporter/appint/transport/HttpTransportImpl.java
@@ -12,10 +12,14 @@ import dev.failsafe.RetryPolicy;
 import dev.failsafe.Timeout;
 import dev.failsafe.TimeoutExceededException;
 import io.camunda.exporter.appint.event.Event;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics.Phase;
 import io.camunda.exporter.appint.transport.Authentication.ApiKey;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
@@ -38,15 +42,21 @@ public class HttpTransportImpl implements Transport<Event> {
   private final CloseableHttpClient httpClient;
   private final String url;
   private final Authentication authentication;
+  private final ContextHeaders contextHeaders;
   private final Timeout<Object> timeout;
   private final RetryPolicy<Object> retryPolicy;
+  private final AppIntegrationsExporterMetrics metrics;
 
   public HttpTransportImpl(
-      final JsonMapper jsonMapper, final HttpTransportConfig httpTransportConfig) {
+      final JsonMapper jsonMapper,
+      final HttpTransportConfig httpTransportConfig,
+      final AppIntegrationsExporterMetrics metrics) {
     this.jsonMapper = jsonMapper;
+    this.metrics = metrics;
 
     url = httpTransportConfig.url();
     authentication = httpTransportConfig.authentication();
+    contextHeaders = httpTransportConfig.contextHeaders();
 
     retryPolicy =
         RetryPolicy.builder()
@@ -66,19 +76,43 @@ public class HttpTransportImpl implements Transport<Event> {
   @Override
   public void send(final List<Event> events) {
     log.debug("Posting records to url: {}", url);
+    metrics.recordBatchSize(events.size());
     final var json = jsonMapper.toJson(new BatchRequest(events));
-    sendPostRequest(url, json);
+    try {
+      metrics.measureFlushDuration(() -> sendPostRequest(url, json));
+    } catch (final RuntimeException e) {
+      metrics.recordExportFailed();
+      throw e;
+    }
+    metrics.recordExported(events.size());
   }
 
   private void sendPostRequest(final String url, final String json) {
-    final HttpPost httpPost = new HttpPost(url);
-    switch (authentication) {
-      case final ApiKey apiKeyAuth -> httpPost.setHeader(ApiKey.HEADER_NAME, apiKeyAuth.apiKey());
-      case final Authentication.None ignored ->
-          log.warn("No authentication provided for HTTP transport");
+    final StringEntity entity = createJsonEntity(json);
+    // Build the HttpPost (and re-apply auth) inside the retry loop so that transient failures
+    // when obtaining credentials (e.g. OAuth token endpoint blips) are retried as well.
+    post(
+        () -> {
+          final HttpPost httpPost = new HttpPost(url);
+          switch (authentication) {
+            case final ApiKey apiKeyAuth ->
+                httpPost.setHeader(ApiKey.HEADER_NAME, apiKeyAuth.apiKey());
+            case final Authentication.OAuth oauth -> applyOAuth(httpPost, oauth);
+            case final Authentication.None ignored ->
+                log.warn("No authentication provided for HTTP transport");
+          }
+          contextHeaders.applyTo(httpPost::setHeader);
+          httpPost.setEntity(entity);
+          return httpPost;
+        });
+  }
+
+  private void applyOAuth(final HttpPost httpPost, final Authentication.OAuth oauth) {
+    try {
+      oauth.credentialsProvider().applyCredentials(httpPost::setHeader);
+    } catch (final IOException e) {
+      throw new TransportException("Failed to obtain OAuth credentials", e);
     }
-    httpPost.setEntity(createJsonEntity(json));
-    post(httpPost);
   }
 
   private StringEntity createJsonEntity(final String json) {
@@ -88,16 +122,26 @@ public class HttpTransportImpl implements Transport<Event> {
     return entity;
   }
 
-  private void post(final HttpPost httpPost) {
+  private void post(final Supplier<HttpPost> httpPostSupplier) {
+    final AtomicReference<HttpPost> currentRequest = new AtomicReference<>();
     Failsafe.with(timeout)
         .compose(retryPolicy)
         .onFailure(
             event -> {
               if (event.getException() instanceof TimeoutExceededException) {
-                abortRequest(httpPost);
+                metrics.recordTimeout(Phase.EXPORT);
+                final HttpPost inFlight = currentRequest.get();
+                if (inFlight != null) {
+                  abortRequest(inFlight);
+                }
               }
             })
-        .run(() -> executeRequest(httpPost));
+        .run(
+            () -> {
+              final HttpPost httpPost = httpPostSupplier.get();
+              currentRequest.set(httpPost);
+              executeRequest(httpPost);
+            });
   }
 
   private void executeRequest(final HttpPost httpPost) {
@@ -114,6 +158,12 @@ public class HttpTransportImpl implements Transport<Event> {
     final String responseReason = response.getStatusLine().getReasonPhrase();
     if (statusCode >= 200 && statusCode < 300) {
       log.debug("Successfully posted records to: {}", responseReason);
+    } else if (statusCode == 401 && authentication instanceof final Authentication.OAuth oauth) {
+      log.debug("Received 401; invalidating OAuth token and retrying with a fresh token");
+      metrics.recordUnauthorized();
+      oauth.credentialsProvider().invalidate();
+      throw new TransportException(
+          "Unauthorized (401); OAuth token invalidated, retrying with a fresh token");
     } else {
       log.debug("Failed posting records. Status: {} reason: {}", statusCode, responseReason);
       throw new TransportException(
@@ -134,6 +184,9 @@ public class HttpTransportImpl implements Transport<Event> {
 
   @Override
   public void close() {
+    if (authentication instanceof final Authentication.OAuth oauth) {
+      oauth.credentialsProvider().close();
+    }
     try {
       httpClient.close();
     } catch (final Exception e) {

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/AppIntegrationsExporterContextHeadersIT.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/AppIntegrationsExporterContextHeadersIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.exporter.appint.config.Config;
+import io.camunda.exporter.appint.transport.ContextHeaders;
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+final class AppIntegrationsExporterContextHeadersIT {
+
+  @RegisterExtension
+  public static WireMockExtension wireMock =
+      WireMockExtension.extensionOptions().options(wireMockConfig().dynamicPort()).build();
+
+  private final ProtocolFactory factory = new ProtocolFactory(b -> b.withAuthorizations(Map.of()));
+  private final ExporterTestController controller = new ExporterTestController();
+  private AppIntegrationsExporter exporter;
+  private String url;
+
+  @BeforeEach
+  public void setUp() {
+    url = "http://localhost:" + wireMock.getPort();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    if (exporter != null) {
+      exporter.close();
+    }
+  }
+
+  @Test
+  void shouldSendContextHeadersCapturedFromConfigAndEnvironment() {
+    // given — org id from the environment and cluster id from the exporter config
+    wireMock.stubFor(post("/").willReturn(ok()));
+    final UnaryOperator<String> env =
+        name -> DeploymentContext.ORGANIZATION_ID_ENV_VAR.equals(name) ? "org-from-env" : null;
+    final ExporterTestContext context = new ExporterTestContext();
+    final Config config =
+        new Config()
+            .setUrl(url)
+            .setApiKey("test-key")
+            .setClusterId("cluster-from-config")
+            .setBatchSize(1);
+    context.setConfiguration(new ExporterTestConfiguration<>("test", config));
+
+    exporter = new AppIntegrationsExporter(env);
+    exporter.configure(context);
+    exporter.open(controller);
+
+    // when
+    exporter.export(generateUserTaskRecord());
+    Awaitility.await().until(() -> exporter.getSubscription().hasNoActiveBatch());
+
+    // then
+    wireMock.verify(
+        exactly(1),
+        postRequestedFor(urlEqualTo("/"))
+            .withHeader(ContextHeaders.X_ORG_ID, equalTo("org-from-env"))
+            .withHeader(ContextHeaders.X_CLUSTER_ID, equalTo("cluster-from-config")));
+  }
+
+  private Record<UserTaskRecordValue> generateUserTaskRecord() {
+    return factory.generateRecord(
+        ValueType.USER_TASK, r -> r.withPosition(1L).withIntent(UserTaskIntent.CREATED));
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/AppIntegrationsExporterContextHeadersIT.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/AppIntegrationsExporterContextHeadersIT.java
@@ -58,18 +58,18 @@ final class AppIntegrationsExporterContextHeadersIT {
   }
 
   @Test
-  void shouldSendContextHeadersCapturedFromConfigAndEnvironment() {
-    // given — org id from the environment and cluster id from the exporter config
+  void shouldSendContextHeadersCapturedFromEnvironment() {
+    // given — org id and cluster id both come from the environment (SaaS deployment)
     wireMock.stubFor(post("/").willReturn(ok()));
     final UnaryOperator<String> env =
-        name -> DeploymentContext.ORGANIZATION_ID_ENV_VAR.equals(name) ? "org-from-env" : null;
+        name ->
+            switch (name) {
+              case DeploymentContext.ORGANIZATION_ID_ENV_VAR -> "org-from-env";
+              case DeploymentContext.CLUSTER_ID_ENV_VAR -> "cluster-from-env";
+              default -> null;
+            };
     final ExporterTestContext context = new ExporterTestContext();
-    final Config config =
-        new Config()
-            .setUrl(url)
-            .setApiKey("test-key")
-            .setClusterId("cluster-from-config")
-            .setBatchSize(1);
+    final Config config = new Config().setUrl(url).setApiKey("test-key").setBatchSize(1);
     context.setConfiguration(new ExporterTestConfiguration<>("test", config));
 
     exporter = new AppIntegrationsExporter(env);
@@ -85,7 +85,7 @@ final class AppIntegrationsExporterContextHeadersIT {
         exactly(1),
         postRequestedFor(urlEqualTo("/"))
             .withHeader(ContextHeaders.X_ORG_ID, equalTo("org-from-env"))
-            .withHeader(ContextHeaders.X_CLUSTER_ID, equalTo("cluster-from-config")));
+            .withHeader(ContextHeaders.X_CLUSTER_ID, equalTo("cluster-from-env")));
   }
 
   private Record<UserTaskRecordValue> generateUserTaskRecord() {

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/config/ConfigTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/config/ConfigTest.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.appint.config;
 
 import static io.camunda.exporter.appint.config.ConfigValidator.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
@@ -23,5 +24,15 @@ public class ConfigTest {
     final Config invalidConfig1 = new Config().setUrl("");
     org.junit.jupiter.api.Assertions.assertThrows(
         IllegalArgumentException.class, () -> validate(invalidConfig1));
+  }
+
+  @Test
+  void shouldExposeClusterId() {
+    // given
+    final Config config = new Config().setUrl("http://example.com").setClusterId("my-cluster");
+
+    // when / then — clusterId is optional and does not affect validation
+    validate(config);
+    assertThat(config.getClusterId()).isEqualTo("my-cluster");
   }
 }

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/config/ConfigValidatorTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/config/ConfigValidatorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.config;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ConfigValidatorTest {
+
+  private static OAuthConfig validOAuthConfig() {
+    return new OAuthConfig()
+        .setClientId("client-id")
+        .setClientSecret("client-secret")
+        .setAuthorizationServerUrl("https://auth.example.com/oauth/token");
+  }
+
+  private static Config validBaseConfig() {
+    return new Config().setUrl("http://example.com");
+  }
+
+  @Test
+  void shouldRejectOAuthMissingClientId() {
+    // given
+    final Config config = validBaseConfig().setOauth(validOAuthConfig().setClientId(null));
+
+    // when / then
+    assertThatThrownBy(() -> ConfigValidator.validate(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("clientId");
+  }
+
+  @Test
+  void shouldRejectOAuthMissingClientSecret() {
+    // given
+    final Config config = validBaseConfig().setOauth(validOAuthConfig().setClientSecret(""));
+
+    // when / then
+    assertThatThrownBy(() -> ConfigValidator.validate(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("clientSecret");
+  }
+
+  @Test
+  void shouldRejectOAuthMissingAuthorizationServerUrl() {
+    // given
+    final Config config =
+        validBaseConfig().setOauth(validOAuthConfig().setAuthorizationServerUrl(null));
+
+    // when / then
+    assertThatThrownBy(() -> ConfigValidator.validate(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("authorizationServerUrl");
+  }
+
+  @Test
+  void shouldRejectBothApiKeyAndOAuthConfigured() {
+    // given
+    final Config config = validBaseConfig().setApiKey("key").setOauth(validOAuthConfig());
+
+    // when / then
+    assertThatThrownBy(() -> ConfigValidator.validate(config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("only one");
+  }
+
+  @Test
+  void shouldAcceptValidOAuthConfig() {
+    // given
+    final Config config = validBaseConfig().setOauth(validOAuthConfig());
+
+    // when / then
+    assertThatCode(() -> ConfigValidator.validate(config)).doesNotThrowAnyException();
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/dispatch/DispatcherTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/dispatch/DispatcherTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.appint.dispatch;
 
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ public class DispatcherTest {
     // given
     final ArgumentCaptor<Long> positionUpdaterCaptor = ArgumentCaptor.captor();
     final Consumer<Long> positionUpdater = Mockito.mock();
-    final var dispatcher = new DispatcherImpl(1);
+    final var dispatcher = new DispatcherImpl(1, AppIntegrationsExporterMetrics.disabled());
     final var atomicBoolean = new java.util.concurrent.atomic.AtomicBoolean(true);
 
     // when

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/metrics/AppIntegrationsExporterMetricsTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/metrics/AppIntegrationsExporterMetricsTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics.Phase;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class AppIntegrationsExporterMetricsTest {
+
+  private static final String NAMESPACE = "zeebe.app.integrations.exporter";
+
+  private SimpleMeterRegistry registry;
+  private AppIntegrationsExporterMetrics metrics;
+
+  @BeforeEach
+  void setUp() {
+    registry = new SimpleMeterRegistry();
+    metrics = new AppIntegrationsExporterMetrics(registry);
+  }
+
+  @Test
+  void shouldRecordTokenFetchFailed() {
+    // when
+    metrics.recordTokenFetchFailed();
+    metrics.recordTokenFetchFailed();
+
+    // then
+    assertThat(counter(NAMESPACE + ".token.fetch.failed")).isEqualTo(2.0);
+  }
+
+  @Test
+  void shouldRecordExportFailed() {
+    // when
+    metrics.recordExportFailed();
+
+    // then
+    assertThat(counter(NAMESPACE + ".export.failed")).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldRecordUnauthorized() {
+    // when
+    metrics.recordUnauthorized();
+
+    // then
+    assertThat(counter(NAMESPACE + ".export.unauthorized")).isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldRecordTimeoutPerPhase() {
+    // when
+    metrics.recordTimeout(Phase.TOKEN);
+    metrics.recordTimeout(Phase.EXPORT);
+    metrics.recordTimeout(Phase.EXPORT);
+
+    // then
+    assertThat(timeoutCounter("token")).isEqualTo(1.0);
+    assertThat(timeoutCounter("export")).isEqualTo(2.0);
+  }
+
+  @Test
+  void shouldRecordBatchSizeAndExportedRecords() {
+    // when
+    metrics.recordBatchSize(5);
+    metrics.recordExported(5);
+
+    // then
+    assertThat(registry.get(NAMESPACE + ".batch.size").summary().totalAmount()).isEqualTo(5.0);
+    assertThat(counter(NAMESPACE + ".records.exported")).isEqualTo(5.0);
+  }
+
+  @Test
+  void shouldMeasureFlushDuration() {
+    // when
+    metrics.measureFlushDuration(() -> {});
+
+    // then
+    assertThat(registry.get(NAMESPACE + ".flush.duration.seconds").timer().count()).isEqualTo(1L);
+  }
+
+  @Test
+  void shouldTrackBatchesInFlight() {
+    // when
+    metrics.incrementBatchesInFlight();
+    metrics.incrementBatchesInFlight();
+    metrics.decrementBatchesInFlight();
+
+    // then
+    assertThat(registry.get(NAMESPACE + ".batches.in.flight").gauge().value()).isEqualTo(1.0);
+  }
+
+  private double counter(final String name) {
+    return registry.get(name).counter().count();
+  }
+
+  private double timeoutCounter(final String phase) {
+    return registry.get(NAMESPACE + ".timeout").tag("phase", phase).counter().count();
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/subscription/SubscriptionFactoryAuthTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/subscription/SubscriptionFactoryAuthTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.exporter.appint.config.Config;
+import io.camunda.exporter.appint.config.OAuthConfig;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
+import io.camunda.exporter.appint.transport.Authentication;
+import io.camunda.exporter.appint.transport.HttpTransportImpl;
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionFactoryAuthTest {
+
+  @Test
+  void shouldBuildOAuthAuthenticationWhenOAuthConfigured() throws Exception {
+    // given
+    final Config config =
+        new Config()
+            .setUrl("http://example.com")
+            .setOauth(
+                new OAuthConfig()
+                    .setClientId("id")
+                    .setClientSecret("secret")
+                    .setAuthorizationServerUrl("https://auth.example.com/oauth/token"));
+
+    // when
+    final var subscription =
+        SubscriptionFactory.createDefault(
+            config, position -> {}, AppIntegrationsExporterMetrics.disabled());
+
+    // then
+    final Authentication auth = extractAuthentication(subscription);
+    assertThat(auth).isInstanceOf(Authentication.OAuth.class);
+    // closing must also stop the provider's token-refresher thread without throwing
+    assertThatCode(subscription::close).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldFallBackToApiKeyWhenOnlyApiKeyConfigured() throws Exception {
+    // given
+    final Config config = new Config().setUrl("http://example.com").setApiKey("key");
+
+    // when
+    final var subscription =
+        SubscriptionFactory.createDefault(
+            config, position -> {}, AppIntegrationsExporterMetrics.disabled());
+
+    // then
+    final Authentication auth = extractAuthentication(subscription);
+    assertThat(auth).isInstanceOf(Authentication.ApiKey.class);
+    assertThat(((Authentication.ApiKey) auth).apiKey()).isEqualTo("key");
+    subscription.close();
+  }
+
+  @Test
+  void shouldUseNoneWhenApiKeyIsBlank() throws Exception {
+    // given
+    final Config config = new Config().setUrl("http://example.com").setApiKey("   ");
+
+    // when
+    final var subscription =
+        SubscriptionFactory.createDefault(
+            config, position -> {}, AppIntegrationsExporterMetrics.disabled());
+
+    // then
+    final Authentication auth = extractAuthentication(subscription);
+    assertThat(auth).isInstanceOf(Authentication.None.class);
+    subscription.close();
+  }
+
+  @Test
+  void shouldUseNoneWhenNeitherConfigured() throws Exception {
+    // given
+    final Config config = new Config().setUrl("http://example.com");
+
+    // when
+    final var subscription =
+        SubscriptionFactory.createDefault(
+            config, position -> {}, AppIntegrationsExporterMetrics.disabled());
+
+    // then
+    final Authentication auth = extractAuthentication(subscription);
+    assertThat(auth).isInstanceOf(Authentication.None.class);
+    subscription.close();
+  }
+
+  private static Authentication extractAuthentication(final Subscription<?> subscription)
+      throws Exception {
+    final Field transportField = Subscription.class.getDeclaredField("transport");
+    transportField.setAccessible(true);
+    final HttpTransportImpl transport = (HttpTransportImpl) transportField.get(subscription);
+    final Field authField = HttpTransportImpl.class.getDeclaredField("authentication");
+    authField.setAccessible(true);
+    return (Authentication) authField.get(transport);
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/subscription/SubscriptionFactoryContextHeadersTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/subscription/SubscriptionFactoryContextHeadersTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.subscription;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.appint.DeploymentContext;
+import io.camunda.exporter.appint.config.Config;
+import io.camunda.exporter.appint.config.OAuthConfig;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
+import io.camunda.exporter.appint.transport.ContextHeaders;
+import io.camunda.exporter.appint.transport.HttpTransportImpl;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionFactoryContextHeadersTest {
+
+  @Test
+  void shouldResolveHeadersIndependentlyOfAuth() throws Exception {
+    // given — OAuth auth plus org from the deployment context and cluster id from config
+    final Config config =
+        new Config()
+            .setUrl("http://example.com")
+            .setClusterId("cluster-config")
+            .setOauth(
+                new OAuthConfig()
+                    .setClientId("id")
+                    .setClientSecret("secret")
+                    .setAuthorizationServerUrl("https://auth.example.com/oauth/token"));
+    final var deploymentContext = new DeploymentContext("org-123");
+
+    // when
+    final var subscription =
+        SubscriptionFactory.createDefault(
+            config, deploymentContext, position -> {}, AppIntegrationsExporterMetrics.disabled());
+
+    // then
+    assertThat(extractHeaders(subscription))
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                ContextHeaders.X_ORG_ID, "org-123",
+                ContextHeaders.X_CLUSTER_ID, "cluster-config"));
+    subscription.close();
+  }
+
+  @Test
+  void shouldUseConfiguredClusterId() throws Exception {
+    // given — Self-Managed style: operator clusterId, api key auth, no org id
+    final Config config =
+        new Config().setUrl("http://example.com").setApiKey("key").setClusterId("sm-cluster");
+    final var deploymentContext = new DeploymentContext(null);
+
+    // when
+    final var subscription =
+        SubscriptionFactory.createDefault(
+            config, deploymentContext, position -> {}, AppIntegrationsExporterMetrics.disabled());
+
+    // then
+    assertThat(extractHeaders(subscription))
+        .containsExactlyInAnyOrderEntriesOf(Map.of(ContextHeaders.X_CLUSTER_ID, "sm-cluster"));
+    subscription.close();
+  }
+
+  @Test
+  void shouldEmitNoHeadersWhenNothingAvailable() throws Exception {
+    // given
+    final Config config = new Config().setUrl("http://example.com");
+
+    // when
+    final var subscription =
+        SubscriptionFactory.createDefault(
+            config,
+            DeploymentContext.EMPTY,
+            position -> {},
+            AppIntegrationsExporterMetrics.disabled());
+
+    // then
+    assertThat(extractHeaders(subscription)).isEmpty();
+    subscription.close();
+  }
+
+  private static Map<String, String> extractHeaders(final Subscription<?> subscription)
+      throws Exception {
+    final Field transportField = Subscription.class.getDeclaredField("transport");
+    transportField.setAccessible(true);
+    final HttpTransportImpl transport = (HttpTransportImpl) transportField.get(subscription);
+    final Field headersField = HttpTransportImpl.class.getDeclaredField("contextHeaders");
+    headersField.setAccessible(true);
+    final ContextHeaders headers = (ContextHeaders) headersField.get(transport);
+    final Map<String, String> collected = new LinkedHashMap<>();
+    headers.applyTo(collected::put);
+    return collected;
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/subscription/SubscriptionFactoryContextHeadersTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/subscription/SubscriptionFactoryContextHeadersTest.java
@@ -24,17 +24,16 @@ class SubscriptionFactoryContextHeadersTest {
 
   @Test
   void shouldResolveHeadersIndependentlyOfAuth() throws Exception {
-    // given — OAuth auth plus org from the deployment context and cluster id from config
+    // given — OAuth auth plus org and cluster id from the deployment context (SaaS environment)
     final Config config =
         new Config()
             .setUrl("http://example.com")
-            .setClusterId("cluster-config")
             .setOauth(
                 new OAuthConfig()
                     .setClientId("id")
                     .setClientSecret("secret")
                     .setAuthorizationServerUrl("https://auth.example.com/oauth/token"));
-    final var deploymentContext = new DeploymentContext("org-123");
+    final var deploymentContext = new DeploymentContext("org-123", "cluster-env");
 
     // when
     final var subscription =
@@ -46,16 +45,16 @@ class SubscriptionFactoryContextHeadersTest {
         .containsExactlyInAnyOrderEntriesOf(
             Map.of(
                 ContextHeaders.X_ORG_ID, "org-123",
-                ContextHeaders.X_CLUSTER_ID, "cluster-config"));
+                ContextHeaders.X_CLUSTER_ID, "cluster-env"));
     subscription.close();
   }
 
   @Test
-  void shouldUseConfiguredClusterId() throws Exception {
-    // given — Self-Managed style: operator clusterId, api key auth, no org id
+  void shouldPreferConfiguredClusterIdOverEnvironment() throws Exception {
+    // given — Self-Managed style: operator clusterId overrides the environment-provided one
     final Config config =
         new Config().setUrl("http://example.com").setApiKey("key").setClusterId("sm-cluster");
-    final var deploymentContext = new DeploymentContext(null);
+    final var deploymentContext = new DeploymentContext(null, "cluster-env");
 
     // when
     final var subscription =

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/subscription/SubscriptionTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/subscription/SubscriptionTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.appint.config.BatchConfig;
 import io.camunda.exporter.appint.mapper.RecordMapper;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
 import io.camunda.exporter.appint.transport.Transport;
 import io.camunda.zeebe.protocol.record.Record;
 import java.util.List;
@@ -52,7 +53,13 @@ public class SubscriptionTest {
     mapper = mock(RecordMapper.class);
     positionConsumer = mock(Consumer.class);
     batchConfig = new BatchConfig(MAX_BATCHES_IN_FLIGHT, BATCH_SIZE, BATCH_INTERVAL_MS, false);
-    subscription = new Subscription<>(transport, mapper, batchConfig, positionConsumer);
+    subscription =
+        new Subscription<>(
+            transport,
+            mapper,
+            batchConfig,
+            positionConsumer,
+            AppIntegrationsExporterMetrics.disabled());
 
     // Default behavior for mapper to support all test records and return a non-null value
     // This can be overridden in specific tests as needed
@@ -246,7 +253,13 @@ public class SubscriptionTest {
   void shouldRetryBatchOnTransportFailureWhenContinueOnErrorDisabled() {
     // given
     batchConfig = new BatchConfig(MAX_BATCHES_IN_FLIGHT, 1, BATCH_INTERVAL_MS, false);
-    subscription = new Subscription<>(transport, mapper, batchConfig, positionConsumer);
+    subscription =
+        new Subscription<>(
+            transport,
+            mapper,
+            batchConfig,
+            positionConsumer,
+            AppIntegrationsExporterMetrics.disabled());
     final var counter = new AtomicInteger(0);
     doAnswer(
             i -> {
@@ -271,7 +284,13 @@ public class SubscriptionTest {
   void shouldContinueOnTransportFailureWhenContinueOnErrorEnabled() {
     // given
     batchConfig = new BatchConfig(MAX_BATCHES_IN_FLIGHT, 1, BATCH_INTERVAL_MS, true);
-    subscription = new Subscription<>(transport, mapper, batchConfig, positionConsumer);
+    subscription =
+        new Subscription<>(
+            transport,
+            mapper,
+            batchConfig,
+            positionConsumer,
+            AppIntegrationsExporterMetrics.disabled());
 
     doThrow(new RuntimeException("Transport error")).when(transport).send(anyList());
 

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/ContextHeadersTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/ContextHeadersTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.transport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ContextHeadersTest {
+
+  @Test
+  void shouldResolveAllHeadersWhenEverythingAvailable() {
+    // given / when
+    final var headers = ContextHeaders.resolve("cluster-config", "org-123");
+
+    // then
+    assertThat(collect(headers))
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                ContextHeaders.X_ORG_ID, "org-123",
+                ContextHeaders.X_CLUSTER_ID, "cluster-config"));
+  }
+
+  @Test
+  void shouldResolveClusterIdFromConfig() {
+    // given / when
+    final var headers = ContextHeaders.resolve("cluster-config", null);
+
+    // then
+    assertThat(collect(headers)).containsEntry(ContextHeaders.X_CLUSTER_ID, "cluster-config");
+  }
+
+  @Test
+  void shouldOmitClusterIdWhenBlank() {
+    // given / when
+    final var headers = ContextHeaders.resolve("  ", "org-123");
+
+    // then
+    assertThat(collect(headers)).doesNotContainKey(ContextHeaders.X_CLUSTER_ID);
+  }
+
+  @Test
+  void shouldOmitOrgIdWhenBlank() {
+    // given / when
+    final var headers = ContextHeaders.resolve("cluster", "   ");
+
+    // then
+    assertThat(collect(headers)).doesNotContainKey(ContextHeaders.X_ORG_ID);
+  }
+
+  @Test
+  void shouldOmitOrgIdWhenNullSentinel() {
+    // given / when
+    final var headers = ContextHeaders.resolve("cluster", "null");
+
+    // then
+    assertThat(collect(headers)).doesNotContainKey(ContextHeaders.X_ORG_ID);
+  }
+
+  @Test
+  void shouldEmitNoHeadersWhenNothingAvailable() {
+    // given / when
+    final var headers = ContextHeaders.resolve("  ", null);
+
+    // then
+    assertThat(collect(headers)).isEmpty();
+  }
+
+  @Test
+  void emptyShouldEmitNoHeaders() {
+    // given / when / then
+    assertThat(collect(ContextHeaders.EMPTY)).isEmpty();
+  }
+
+  private static Map<String, String> collect(final ContextHeaders headers) {
+    final Map<String, String> collected = new LinkedHashMap<>();
+    headers.applyTo(collected::put);
+    return collected;
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/ContextHeadersTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/ContextHeadersTest.java
@@ -18,38 +18,38 @@ class ContextHeadersTest {
   @Test
   void shouldResolveAllHeadersWhenEverythingAvailable() {
     // given / when
-    final var headers = ContextHeaders.resolve("cluster-config", "org-123");
+    final var headers = ContextHeaders.resolve(null, "cluster-env", "org-123");
 
     // then
     assertThat(collect(headers))
         .containsExactlyInAnyOrderEntriesOf(
             Map.of(
                 ContextHeaders.X_ORG_ID, "org-123",
-                ContextHeaders.X_CLUSTER_ID, "cluster-config"));
+                ContextHeaders.X_CLUSTER_ID, "cluster-env"));
   }
 
   @Test
-  void shouldResolveClusterIdFromConfig() {
+  void shouldPreferConfiguredClusterIdOverEnvClusterId() {
     // given / when
-    final var headers = ContextHeaders.resolve("cluster-config", null);
+    final var headers = ContextHeaders.resolve("cluster-config", "cluster-env", null);
 
     // then
     assertThat(collect(headers)).containsEntry(ContextHeaders.X_CLUSTER_ID, "cluster-config");
   }
 
   @Test
-  void shouldOmitClusterIdWhenBlank() {
+  void shouldFallBackToEnvClusterIdWhenConfiguredIsBlank() {
     // given / when
-    final var headers = ContextHeaders.resolve("  ", "org-123");
+    final var headers = ContextHeaders.resolve("  ", "cluster-env", null);
 
     // then
-    assertThat(collect(headers)).doesNotContainKey(ContextHeaders.X_CLUSTER_ID);
+    assertThat(collect(headers)).containsEntry(ContextHeaders.X_CLUSTER_ID, "cluster-env");
   }
 
   @Test
   void shouldOmitOrgIdWhenBlank() {
     // given / when
-    final var headers = ContextHeaders.resolve("cluster", "   ");
+    final var headers = ContextHeaders.resolve("cluster", null, "   ");
 
     // then
     assertThat(collect(headers)).doesNotContainKey(ContextHeaders.X_ORG_ID);
@@ -58,7 +58,7 @@ class ContextHeadersTest {
   @Test
   void shouldOmitOrgIdWhenNullSentinel() {
     // given / when
-    final var headers = ContextHeaders.resolve("cluster", "null");
+    final var headers = ContextHeaders.resolve("cluster", null, "null");
 
     // then
     assertThat(collect(headers)).doesNotContainKey(ContextHeaders.X_ORG_ID);
@@ -67,7 +67,7 @@ class ContextHeadersTest {
   @Test
   void shouldEmitNoHeadersWhenNothingAvailable() {
     // given / when
-    final var headers = ContextHeaders.resolve("  ", null);
+    final var headers = ContextHeaders.resolve("  ", "", null);
 
     // then
     assertThat(collect(headers)).isEmpty();

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProviderTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProviderTest.java
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -288,6 +289,30 @@ class DefaultOAuthCredentialsProviderTest {
         .isInstanceOf(IOException.class)
         .hasMessageContaining("HTTP 400")
         .hasMessageContaining("invalid_client");
+  }
+
+  @Test
+  void shouldFallBackToDefaultTimeoutsWhenNullOrNonPositive() throws Exception {
+    // given — null, zero and negative timeouts must not reach HttpClient as 0ms (infinite)
+    for (final Duration invalid : new Duration[] {null, Duration.ZERO, Duration.ofMillis(-1)}) {
+      // when
+      provider = newProvider(invalid, invalid);
+
+      // then — both timeouts fall back to the bounded defaults
+      assertThat(timeoutField("connectTimeout"))
+          .isEqualTo(DefaultOAuthCredentialsProvider.DEFAULT_CONNECT_TIMEOUT);
+      assertThat(timeoutField("readTimeout"))
+          .isEqualTo(DefaultOAuthCredentialsProvider.DEFAULT_READ_TIMEOUT);
+
+      provider.close();
+      provider = null;
+    }
+  }
+
+  private Duration timeoutField(final String name) throws Exception {
+    final Field field = DefaultOAuthCredentialsProvider.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return (Duration) field.get(provider);
   }
 
   private DefaultOAuthCredentialsProvider newProvider() {

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProviderTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProviderTest.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.transport;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class DefaultOAuthCredentialsProviderTest {
+
+  @RegisterExtension
+  public static WireMockExtension wireMock =
+      WireMockExtension.extensionOptions().options(wireMockConfig().dynamicPort()).build();
+
+  private static final String TOKEN_PATH = "/oauth/token";
+
+  private DefaultOAuthCredentialsProvider provider;
+  private SimpleMeterRegistry registry;
+
+  @AfterEach
+  void tearDown() {
+    if (provider != null) {
+      provider.close();
+      provider = null;
+    }
+  }
+
+  @Test
+  void shouldFetchTokenInBackgroundOnStart() throws IOException {
+    // given
+    wireMock.stubFor(post(TOKEN_PATH).willReturn(tokenResponse("tok-A", 3600)));
+
+    // when
+    provider = newProvider();
+
+    // then — the background thread fetches the token without any applyCredentials call
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tokenRequestCount()).isGreaterThanOrEqualTo(1));
+
+    // and a subsequent applyCredentials attaches the warm token without another fetch
+    final int fetchesBefore = tokenRequestCount();
+    assertThat(applyAndCaptureAuthorization()).isEqualTo("Bearer tok-A");
+    assertThat(tokenRequestCount()).isEqualTo(fetchesBefore);
+  }
+
+  @Test
+  void shouldProactivelyRotateBeforeTheSixtySecondMargin() throws IOException {
+    // given — first token expires just past the 60s refresh margin so rotation happens quickly
+    wireMock.stubFor(
+        post(TOKEN_PATH)
+            .inScenario("rotation")
+            .whenScenarioStateIs(STARTED)
+            .willReturn(tokenResponse("tok-1", 61))
+            .willSetStateTo("rotated"));
+    wireMock.stubFor(
+        post(TOKEN_PATH)
+            .inScenario("rotation")
+            .whenScenarioStateIs("rotated")
+            .willReturn(tokenResponse("tok-2", 3600)));
+
+    // when
+    provider = newProvider();
+
+    // then — a second token request happens before expiry and the cached bearer changes
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(() -> assertThat(tokenRequestCount()).isGreaterThanOrEqualTo(2));
+    assertThat(applyAndCaptureAuthorization()).isEqualTo("Bearer tok-2");
+  }
+
+  @Test
+  void shouldRefetchAfterInvalidate() throws IOException {
+    // given
+    wireMock.stubFor(
+        post(TOKEN_PATH)
+            .inScenario("invalidate")
+            .whenScenarioStateIs(STARTED)
+            .willReturn(tokenResponse("tok-1", 3600))
+            .willSetStateTo("second"));
+    wireMock.stubFor(
+        post(TOKEN_PATH)
+            .inScenario("invalidate")
+            .whenScenarioStateIs("second")
+            .willReturn(tokenResponse("tok-2", 3600)));
+    provider = newProvider();
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tokenRequestCount()).isGreaterThanOrEqualTo(1));
+
+    // when
+    provider.invalidate();
+
+    // then — a fresh token is fetched and applied
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tokenRequestCount()).isGreaterThanOrEqualTo(2));
+    assertThat(applyAndCaptureAuthorization()).isEqualTo("Bearer tok-2");
+  }
+
+  @Test
+  void shouldStopRefresherThreadOnClose() {
+    // given — a short-lived token that would keep rotating roughly every second
+    wireMock.stubFor(post(TOKEN_PATH).willReturn(tokenResponse("tok-A", 61)));
+    provider = newProvider();
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tokenRequestCount()).isGreaterThanOrEqualTo(1));
+
+    // when
+    provider.close();
+    provider = null; // already closed
+    final int countAtClose = tokenRequestCount();
+
+    // then — no further token requests arrive after close
+    await()
+        .during(Duration.ofSeconds(2))
+        .atMost(Duration.ofSeconds(4))
+        .untilAsserted(() -> assertThat(tokenRequestCount()).isEqualTo(countAtClose));
+  }
+
+  @Test
+  void shouldFallBackToSynchronousFetchBeforeBackgroundWarmup() throws IOException {
+    // given
+    wireMock.stubFor(post(TOKEN_PATH).willReturn(tokenResponse("tok-A", 3600)));
+    provider = newProvider();
+
+    // when — the very first applyCredentials may run before the background fetch completes
+    final String authorization = applyAndCaptureAuthorization();
+
+    // then — it still yields a valid bearer header via the synchronous fallback
+    assertThat(authorization).isEqualTo("Bearer tok-A");
+  }
+
+  @Test
+  void shouldKeepRetryingBackgroundRefreshWhenTokenEndpointFails() {
+    // given — the token endpoint fails once, then succeeds
+    wireMock.stubFor(
+        post(TOKEN_PATH)
+            .inScenario("retry")
+            .whenScenarioStateIs(STARTED)
+            .willReturn(aResponse().withStatus(500))
+            .willSetStateTo("recovered"));
+    wireMock.stubFor(
+        post(TOKEN_PATH)
+            .inScenario("retry")
+            .whenScenarioStateIs("recovered")
+            .willReturn(tokenResponse("tok-A", 3600)));
+
+    // when — construction must not throw despite the initial failure
+    provider = newProvider();
+
+    // then — the provider eventually serves a valid token
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(applyAndCaptureAuthorization()).isEqualTo("Bearer tok-A"));
+
+    // and the initial failure was recorded
+    assertThat(registry.get("zeebe.app.integrations.exporter.token.fetch.failed").counter().count())
+        .isGreaterThanOrEqualTo(1.0);
+  }
+
+  @Test
+  void shouldReuseHttpClientAcrossTokenFetches() throws IOException {
+    // given
+    wireMock.stubFor(post(TOKEN_PATH).willReturn(tokenResponse("tok-A", 3600)));
+    provider = newProvider();
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(tokenRequestCount()).isGreaterThanOrEqualTo(1));
+
+    // when — drive several fetches through the single shared client
+    for (int i = 0; i < 3; i++) {
+      provider.invalidate();
+      final int expected = i + 2;
+      await()
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(() -> assertThat(tokenRequestCount()).isGreaterThanOrEqualTo(expected));
+    }
+
+    // then — the provider keeps serving a valid token without per-call client teardown
+    assertThat(applyAndCaptureAuthorization()).isEqualTo("Bearer tok-A");
+  }
+
+  @Test
+  void shouldRecordTokenTimeoutMetricWhenTokenEndpointStalls() {
+    // given — the endpoint accepts the connection but never responds within the read timeout
+    wireMock.stubFor(
+        post(TOKEN_PATH).willReturn(tokenResponse("tok-A", 3600).withFixedDelay(2000)));
+
+    // when — a provider with a short read timeout fetches in the background
+    provider = newProvider(Duration.ofSeconds(5), Duration.ofMillis(200));
+
+    // then — the token-phase timeout metric is recorded
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        registry
+                            .get("zeebe.app.integrations.exporter.timeout")
+                            .tag("phase", "token")
+                            .counter()
+                            .count())
+                    .isGreaterThanOrEqualTo(1.0));
+  }
+
+  @Test
+  void shouldApplyTokenWhenResponseOmitsExpiresIn() throws IOException {
+    // given — a token response without an expires_in field falls back to the default lifetime
+    wireMock.stubFor(
+        post(TOKEN_PATH)
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"access_token\":\"tok-A\",\"token_type\":\"Bearer\"}")));
+
+    // when
+    provider = newProvider();
+
+    // then — the token is treated as valid (for DEFAULT_LIFETIME) and attached
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(applyAndCaptureAuthorization()).isEqualTo("Bearer tok-A"));
+  }
+
+  @Test
+  void shouldDefaultTokenTypeToBearerWhenOmitted() throws IOException {
+    // given — a token response without a token_type field
+    wireMock.stubFor(
+        post(TOKEN_PATH)
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"access_token\":\"tok-A\",\"expires_in\":3600}")));
+
+    // when
+    provider = newProvider();
+
+    // then — the Authorization header falls back to the Bearer scheme
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .ignoreExceptions()
+        .untilAsserted(() -> assertThat(applyAndCaptureAuthorization()).isEqualTo("Bearer tok-A"));
+  }
+
+  @Test
+  void shouldPropagateErrorBodyOnNon2xxResponse() {
+    // given — the token endpoint returns a 4xx with a descriptive error body
+    wireMock.stubFor(
+        post(TOKEN_PATH)
+            .willReturn(
+                aResponse()
+                    .withStatus(400)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"error\":\"invalid_client\"}")));
+    provider = newProvider();
+
+    // when / then — a synchronous fetch surfaces the status and the error body
+    assertThatThrownBy(this::applyAndCaptureAuthorization)
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("HTTP 400")
+        .hasMessageContaining("invalid_client");
+  }
+
+  private DefaultOAuthCredentialsProvider newProvider() {
+    return newProvider(Duration.ofSeconds(5), Duration.ofSeconds(5));
+  }
+
+  private DefaultOAuthCredentialsProvider newProvider(
+      final Duration connectTimeout, final Duration readTimeout) {
+    registry = new SimpleMeterRegistry();
+    return new DefaultOAuthCredentialsProvider(
+        wireMock.baseUrl() + TOKEN_PATH,
+        "client-id",
+        "client-secret",
+        null,
+        null,
+        null,
+        connectTimeout,
+        readTimeout,
+        new AppIntegrationsExporterMetrics(registry));
+  }
+
+  private String applyAndCaptureAuthorization() throws IOException {
+    final Map<String, String> headers = new HashMap<>();
+    provider.applyCredentials(headers::put);
+    return headers.get(DefaultOAuthCredentialsProvider.AUTHORIZATION_HEADER);
+  }
+
+  private int tokenRequestCount() {
+    return wireMock.findAll(postRequestedFor(urlEqualTo(TOKEN_PATH))).size();
+  }
+
+  private static ResponseDefinitionBuilder tokenResponse(
+      final String accessToken, final long expiresInSeconds) {
+    return aResponse()
+        .withStatus(200)
+        .withHeader("Content-Type", "application/json")
+        .withBody(
+            "{\"access_token\":\""
+                + accessToken
+                + "\",\"token_type\":\"Bearer\",\"expires_in\":"
+                + expiresInSeconds
+                + "}");
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportOAuth401Test.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportOAuth401Test.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.transport;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
+import io.camunda.exporter.appint.subscription.SubscriptionFactory;
+import io.camunda.exporter.appint.transport.Authentication.ApiKey;
+import io.camunda.exporter.appint.transport.Authentication.OAuth;
+import io.camunda.exporter.appint.transport.Authentication.OAuthCredentialsProvider;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class HttpTransportOAuth401Test {
+
+  @RegisterExtension
+  public static WireMockExtension wireMock =
+      WireMockExtension.extensionOptions().options(wireMockConfig().dynamicPort()).build();
+
+  @Test
+  void shouldInvalidateAndRetryOnUnauthorized() {
+    // given — the backend rejects the stale token with 401, then accepts the fresh one
+    final String url = "http://localhost:" + wireMock.getPort();
+    wireMock.stubFor(
+        post("/")
+            .inScenario("unauthorized")
+            .whenScenarioStateIs(STARTED)
+            .willReturn(aResponse().withStatus(401))
+            .willSetStateTo("authorized"));
+    wireMock.stubFor(
+        post("/").inScenario("unauthorized").whenScenarioStateIs("authorized").willReturn(ok()));
+
+    final RotatingProvider provider = new RotatingProvider();
+    final var httpConfig = new HttpTransportConfig(url, new OAuth(provider), 2, 50, 5000);
+    final var registry = new SimpleMeterRegistry();
+    final var transport =
+        new HttpTransportImpl(
+            SubscriptionFactory.createJsonMapper(),
+            httpConfig,
+            new AppIntegrationsExporterMetrics(registry));
+
+    // when
+    transport.send(new ArrayList<>());
+
+    // then — the token was invalidated once and the retry carried the fresh token
+    assertThat(provider.invalidations.get()).isEqualTo(1);
+    assertThat(
+            registry.get("zeebe.app.integrations.exporter.export.unauthorized").counter().count())
+        .isEqualTo(1.0);
+    wireMock.verify(
+        exactly(1),
+        postRequestedFor(urlEqualTo("/")).withHeader("Authorization", equalTo("Bearer stale")));
+    wireMock.verify(
+        exactly(1),
+        postRequestedFor(urlEqualTo("/")).withHeader("Authorization", equalTo("Bearer fresh")));
+  }
+
+  @Test
+  void shouldNotInvalidateNonOauth401() {
+    // given — a 401 with non-OAuth auth is treated as a generic failure (no token invalidation);
+    // without OAuth there is nothing to refresh, so it is retried like any other error response
+    final String url = "http://localhost:" + wireMock.getPort();
+    wireMock.stubFor(post("/").willReturn(aResponse().withStatus(401)));
+    final var httpConfig = new HttpTransportConfig(url, new ApiKey("test-key"), 2, 50, 5000);
+    final var transport =
+        new HttpTransportImpl(
+            SubscriptionFactory.createJsonMapper(),
+            httpConfig,
+            AppIntegrationsExporterMetrics.disabled());
+
+    // when / then
+    assertThatCode(() -> transport.send(new ArrayList<>())).isInstanceOf(TransportException.class);
+    wireMock.verify(
+        exactly(3),
+        postRequestedFor(urlEqualTo("/")).withHeader(ApiKey.HEADER_NAME, equalTo("test-key")));
+  }
+
+  /**
+   * Returns {@code Bearer stale} until {@link #invalidate()} is called, then {@code Bearer fresh}.
+   */
+  private static final class RotatingProvider implements OAuthCredentialsProvider {
+    private final AtomicInteger invalidations = new AtomicInteger();
+    private volatile boolean invalidated;
+
+    @Override
+    public void applyCredentials(final BiConsumer<String, String> headerConsumer) {
+      headerConsumer.accept("Authorization", invalidated ? "Bearer fresh" : "Bearer stale");
+    }
+
+    @Override
+    public void invalidate() {
+      invalidations.incrementAndGet();
+      invalidated = true;
+    }
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportOAuthTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportOAuthTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.transport;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
+import io.camunda.exporter.appint.subscription.SubscriptionFactory;
+import io.camunda.exporter.appint.transport.Authentication.OAuth;
+import io.camunda.exporter.appint.transport.Authentication.OAuthCredentialsProvider;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class HttpTransportOAuthTest {
+
+  @RegisterExtension
+  public static WireMockExtension wireMock =
+      WireMockExtension.extensionOptions().options(wireMockConfig().dynamicPort()).build();
+
+  @Test
+  void shouldSetAuthorizationHeaderFromOAuthProvider() {
+    // given
+    final String url = "http://localhost:" + wireMock.getPort();
+    wireMock.stubFor(post("/").willReturn(ok()));
+    final OAuthCredentialsProvider provider =
+        headerConsumer -> headerConsumer.accept("Authorization", "Bearer test-token");
+    final var httpConfig = new HttpTransportConfig(url, new OAuth(provider), 2, 50, 5000);
+    final var transport =
+        new HttpTransportImpl(
+            SubscriptionFactory.createJsonMapper(),
+            httpConfig,
+            AppIntegrationsExporterMetrics.disabled());
+
+    // when
+    transport.send(new ArrayList<>());
+
+    // then
+    wireMock.verify(
+        exactly(1),
+        postRequestedFor(urlEqualTo("/"))
+            .withHeader("Authorization", equalTo("Bearer test-token")));
+  }
+
+  @Test
+  void shouldRetryWhenOAuthProviderThrows() {
+    // given
+    final String url = "http://localhost:" + wireMock.getPort();
+    wireMock.stubFor(post("/").willReturn(ok()));
+    final AtomicInteger calls = new AtomicInteger();
+    final OAuthCredentialsProvider flakyProvider =
+        headerConsumer -> {
+          if (calls.getAndIncrement() == 0) {
+            throw new IOException("transient");
+          }
+          headerConsumer.accept("Authorization", "Bearer late-token");
+        };
+    final var httpConfig = new HttpTransportConfig(url, new OAuth(flakyProvider), 2, 50, 5000);
+    final var transport =
+        new HttpTransportImpl(
+            SubscriptionFactory.createJsonMapper(),
+            httpConfig,
+            AppIntegrationsExporterMetrics.disabled());
+
+    // when
+    transport.send(new ArrayList<>());
+
+    // then
+    Assertions.assertThat(calls.get()).isGreaterThanOrEqualTo(2);
+    wireMock.verify(
+        exactly(1),
+        postRequestedFor(urlEqualTo("/"))
+            .withHeader("Authorization", equalTo("Bearer late-token")));
+  }
+}

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import dev.failsafe.TimeoutExceededException;
 import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
 import io.camunda.exporter.appint.subscription.SubscriptionFactory;
 import io.camunda.exporter.appint.transport.Authentication.ApiKey;
@@ -161,7 +162,7 @@ public class HttpTransportTest {
 
     // when
     Assertions.assertThatCode(() -> transport.send(new ArrayList<>()))
-        .isInstanceOf(Throwable.class);
+        .isInstanceOf(TimeoutExceededException.class);
 
     // then
     assertThat(timeoutCounter("export")).isEqualTo(1.0);

--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/HttpTransportTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.appint.transport;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.exporter.appint.metrics.AppIntegrationsExporterMetrics;
+import io.camunda.exporter.appint.subscription.SubscriptionFactory;
+import io.camunda.exporter.appint.transport.Authentication.ApiKey;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.ArrayList;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class HttpTransportTest {
+
+  @RegisterExtension
+  public static WireMockExtension wireMock =
+      WireMockExtension.extensionOptions().options(wireMockConfig().dynamicPort()).build();
+
+  private String url;
+  private Transport transport;
+  private SimpleMeterRegistry registry;
+
+  @BeforeEach
+  public void beforeAll() {
+    url = "http://localhost:" + wireMock.getPort();
+    final var httpConfig = new HttpTransportConfig(url, new ApiKey("test-key"), 2, 50, 5000);
+    final var jsonMapper = SubscriptionFactory.createJsonMapper();
+    registry = new SimpleMeterRegistry();
+    transport =
+        new HttpTransportImpl(jsonMapper, httpConfig, new AppIntegrationsExporterMetrics(registry));
+  }
+
+  @Test
+  public void testForStatusCode2XX() {
+    wireMock.stubFor(post("/").willReturn(ok()));
+
+    transport.send(new ArrayList<>());
+
+    wireMock.verify(
+        exactly(1),
+        postRequestedFor(urlEqualTo("/")).withHeader(ApiKey.HEADER_NAME, equalTo("test-key")));
+    assertThat(counter("zeebe.app.integrations.exporter.export.failed")).isZero();
+  }
+
+  @Test
+  public void testRetryForStatusCode3XX() {
+    wireMock.stubFor(
+        post("/").willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(302)));
+
+    Assertions.assertThatCode(() -> transport.send(new ArrayList<>()))
+        .isInstanceOf(TransportException.class);
+
+    wireMock.verify(
+        exactly(3),
+        postRequestedFor(urlEqualTo("/")).withHeader(ApiKey.HEADER_NAME, equalTo("test-key")));
+  }
+
+  @Test
+  public void testRetryForStatusCode5XX() {
+    wireMock.stubFor(
+        post("/").willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(500)));
+
+    Assertions.assertThatCode(() -> transport.send(new ArrayList<>()))
+        .isInstanceOf(TransportException.class);
+
+    wireMock.verify(
+        exactly(3),
+        postRequestedFor(urlEqualTo("/")).withHeader(ApiKey.HEADER_NAME, equalTo("test-key")));
+  }
+
+  @Test
+  public void shouldSendContextHeaders() {
+    // given
+    final var contextHeaders = new ContextHeaders("org-1", "cluster-1");
+    final var httpConfig =
+        new HttpTransportConfig(url, new ApiKey("test-key"), 2, 50, 5000, contextHeaders);
+    transport =
+        new HttpTransportImpl(
+            SubscriptionFactory.createJsonMapper(),
+            httpConfig,
+            new AppIntegrationsExporterMetrics(registry));
+    wireMock.stubFor(post("/").willReturn(ok()));
+
+    // when
+    transport.send(new ArrayList<>());
+
+    // then
+    wireMock.verify(
+        exactly(1),
+        postRequestedFor(urlEqualTo("/"))
+            .withHeader(ContextHeaders.X_ORG_ID, equalTo("org-1"))
+            .withHeader(ContextHeaders.X_CLUSTER_ID, equalTo("cluster-1")));
+  }
+
+  @Test
+  public void shouldSendContextHeadersOnEveryRetry() {
+    // given
+    final var contextHeaders = new ContextHeaders(null, "cluster-1");
+    final var httpConfig =
+        new HttpTransportConfig(url, new ApiKey("test-key"), 2, 50, 5000, contextHeaders);
+    transport =
+        new HttpTransportImpl(
+            SubscriptionFactory.createJsonMapper(),
+            httpConfig,
+            new AppIntegrationsExporterMetrics(registry));
+    wireMock.stubFor(
+        post("/").willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(500)));
+
+    // when
+    Assertions.assertThatCode(() -> transport.send(new ArrayList<>()))
+        .isInstanceOf(TransportException.class);
+
+    // then
+    wireMock.verify(
+        exactly(3),
+        postRequestedFor(urlEqualTo("/"))
+            .withHeader(ContextHeaders.X_CLUSTER_ID, equalTo("cluster-1")));
+  }
+
+  @Test
+  public void shouldRecordExportFailedWhenSendFails() {
+    // given
+    wireMock.stubFor(
+        post("/").willReturn(ResponseDefinitionBuilder.responseDefinition().withStatus(500)));
+
+    // when
+    Assertions.assertThatCode(() -> transport.send(new ArrayList<>()))
+        .isInstanceOf(TransportException.class);
+
+    // then
+    assertThat(counter("zeebe.app.integrations.exporter.export.failed")).isEqualTo(1.0);
+  }
+
+  @Test
+  public void shouldRecordExportTimeoutWhenRequestTimesOut() {
+    // given
+    final var httpConfig = new HttpTransportConfig(url, new ApiKey("test-key"), 2, 50, 500);
+    final var jsonMapper = SubscriptionFactory.createJsonMapper();
+    transport =
+        new HttpTransportImpl(jsonMapper, httpConfig, new AppIntegrationsExporterMetrics(registry));
+    wireMock.stubFor(post("/").willReturn(aResponse().withFixedDelay(2000).withStatus(200)));
+
+    // when
+    Assertions.assertThatCode(() -> transport.send(new ArrayList<>()))
+        .isInstanceOf(Throwable.class);
+
+    // then
+    assertThat(timeoutCounter("export")).isEqualTo(1.0);
+  }
+
+  private double counter(final String name) {
+    return registry.get(name).counter().count();
+  }
+
+  private double timeoutCounter(final String phase) {
+    return registry
+        .get("zeebe.app.integrations.exporter.timeout")
+        .tag("phase", phase)
+        .counter()
+        .count();
+  }
+}


### PR DESCRIPTION
## Description

Backport of #51785 to `stable/8.9`.

Adds to the App Integrations exporter:
- **OAuth client-credentials authentication** (`DefaultOAuthCredentialsProvider`, `OAuthConfig`) with bounded connect/read timeouts on the token fetch.
- **401 handling**: on an OAuth `401`, the cached token is invalidated and the request retried with a fresh token.
- **Micrometer metrics** under `zeebe.app.integrations.exporter` (batch size, flush duration, exported/failed counts, timeouts, unauthorized).
- **Context-identification headers**: `X-Org-Id` and `X-Cluster-Id`, attached to every request and re-applied on each retry.

## 8.9 adaptations

The original change relied on broker `Context` APIs that **do not exist on 8.9**, so they were adapted:

- **Physical tenant removed.** `Context.getPhysicalTenantId()` is absent on `stable/8.9`, so the `X-Physical-Tenant-Id` header and `DeploymentContext.physicalTenantId` are dropped.
- **Cluster id sourced from the environment.** `Context.getClusterId()` is also absent on 8.9. Since the newer broker's `Context.getClusterId()` falls back to the `ZEEBE_BROKER_CLUSTER_CLUSTERID` environment variable (see `feat: add clusterId to Exporter Context API`), the exporter now reads that env var directly — exactly analogous to how the org id is read from `CAMUNDA_CLOUD_ORGANIZATION_ID`. This keeps the `X-Cluster-Id` header working in **SaaS**. The `clusterId` config option still takes precedence so Self-Managed operators can override it.
- **401 retry behavior.** 8.9 has no `TransportClientException` / 4xx-no-retry special-casing (a main-only change, not part of this feature), so the OAuth 401-invalidation branch is layered on top of 8.9's existing generic error handling. A non-OAuth `401` is retried as a generic failure. Tests were adapted accordingly.

## Testing

Module build is green: 77 unit tests + 8 integration tests pass. Formatting (spotless + license) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)