### PR TITLE
feat: add archive-by-ID for Operate archiver (8.7 backport)

### DIFF
--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -70,7 +70,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: ./mvnw -f operate/qa/integration-tests verify -P operateItStage1 -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw verify -pl operate/archiver,operate/qa/integration-tests -P operateItStage1 -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Integration Tests
       runner-type: gcp-core-32-default
 

--- a/operate/archiver/pom.xml
+++ b/operate/archiver/pom.xml
@@ -87,6 +87,11 @@
     <!-- OTHERS -->
 
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
     </dependency>

--- a/operate/archiver/pom.xml
+++ b/operate/archiver/pom.xml
@@ -107,6 +107,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/operate/archiver/pom.xml
+++ b/operate/archiver/pom.xml
@@ -200,6 +200,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiveByIdTaskSupplier.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiveByIdTaskSupplier.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import io.camunda.operate.Metrics;
+import io.camunda.operate.property.ArchiverProperties;
+import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import org.elasticsearch.ElasticsearchException;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.slf4j.Logger;
+
+public class ArchiveByIdTaskSupplier<T> {
+
+  private static final int MINIMUM_BATCH_SIZE = 50;
+  private static final double BATCH_SIZE_REDUCTION_FACTOR = 0.5;
+  private static final List<Class<? extends Throwable>> RETRYABLE_EXCEPTIONS =
+      List.of(
+          SocketTimeoutException.class,
+          ElasticsearchException.class,
+          OpenSearchException.class,
+          BatchCountMismatchException.class);
+
+  private final String sourceIdx;
+  private final String destinationIdx;
+  private final BiFunction<List<T>, Integer, CompletableFuture<ArchiveDocIdsBatch<T>>> idsSupplier;
+  private final Reindexer reindexer;
+  private final Deleter deleter;
+  private final Executor executor;
+  private final ArchiverProperties archiverProperties;
+  private final Metrics metrics;
+  private final Logger logger;
+
+  private final AtomicReference<ArchiveDocIdsBatch<T>> lastSearchResponse =
+      new AtomicReference<>(null);
+  private final AtomicBoolean finished = new AtomicBoolean(false);
+  private final AtomicInteger retryCount = new AtomicInteger(0);
+  private final AtomicInteger batchSize;
+  private final AtomicLong totalArchived = new AtomicLong(0);
+  private final AtomicLong totalTimeTakenMs = new AtomicLong(0);
+
+  public ArchiveByIdTaskSupplier(
+      final String sourceIdx,
+      final String destinationIdx,
+      final BiFunction<List<T>, Integer, CompletableFuture<ArchiveDocIdsBatch<T>>> idsSupplier,
+      final Reindexer reindexer,
+      final Deleter deleter,
+      final Executor executor,
+      final ArchiverProperties archiverProperties,
+      final Metrics metrics,
+      final Logger logger) {
+    this.sourceIdx = sourceIdx;
+    this.destinationIdx = destinationIdx;
+    this.idsSupplier = idsSupplier;
+    this.reindexer = reindexer;
+    this.deleter = deleter;
+    this.executor = executor;
+    this.archiverProperties = archiverProperties;
+    this.metrics = metrics;
+    this.logger = logger;
+    batchSize = new AtomicInteger(archiverProperties.getArchiveByIdBatchSize());
+  }
+
+  public boolean isComplete() {
+    return finished.get();
+  }
+
+  public long getTotalArchived() {
+    return totalArchived.get();
+  }
+
+  public long getTotalTimeTakenMs() {
+    return totalTimeTakenMs.get();
+  }
+
+  public CompletableFuture<Long> moveNextBatch() {
+    final long startMs = System.currentTimeMillis();
+    return idsSupplier
+        .apply(getLastSearchPosition(), batchSize.get())
+        .thenComposeAsync(
+            batch -> {
+              if (batch.isEmpty()) {
+                finished.set(true);
+                return CompletableFuture.completedFuture(0L);
+              }
+              return reindex(batch)
+                  .thenCompose(reindexedCount -> delete(batch))
+                  .thenApply(
+                      deletedCount -> {
+                        lastSearchResponse.set(batch);
+                        totalArchived.accumulateAndGet(deletedCount, Long::sum);
+                        retryCount.set(0);
+                        return deletedCount;
+                      })
+                  .exceptionallyCompose(
+                      ex -> {
+                        if (isRetryableError(ex)
+                            && retryCount.incrementAndGet()
+                                <= archiverProperties.getArchiveByIdMaxRetryAttempts()) {
+                          metrics.recordCounts(
+                              Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+                          adjustBatchSize(ex);
+
+                          logger.trace(
+                              "Encountered retryable error when archiving docs from '{}' to '{}', "
+                                  + "retrying the batch (attempt {}/{}). Next batch size {}. Error: {}",
+                              sourceIdx,
+                              destinationIdx,
+                              retryCount.get(),
+                              archiverProperties.getArchiveByIdMaxRetryAttempts(),
+                              batchSize.get(),
+                              ex.getMessage());
+                          final int delayMs =
+                              archiverProperties.getArchiveByIdRetryDelayMs() * retryCount.get();
+                          return CompletableFuture.supplyAsync(
+                              () -> 0L,
+                              CompletableFuture.delayedExecutor(
+                                  delayMs, TimeUnit.MILLISECONDS, executor));
+                        }
+                        retryCount.set(0);
+                        throw ex instanceof final RuntimeException re
+                            ? re
+                            : new RuntimeException(ex);
+                      });
+            },
+            executor)
+        .whenCompleteAsync(
+            (val, err) ->
+                totalTimeTakenMs.accumulateAndGet(System.currentTimeMillis() - startMs, Long::sum),
+            executor);
+  }
+
+  private List<T> getLastSearchPosition() {
+    final ArchiveDocIdsBatch<T> last = lastSearchResponse.get();
+    return last == null ? List.of() : last.searchAfter();
+  }
+
+  private void adjustBatchSize(final Throwable ex) {
+    if (batchSize.get() <= MINIMUM_BATCH_SIZE) {
+      return;
+    }
+
+    if (shouldReduceBatchSize(ex)) {
+      batchSize.set(
+          (int) Math.max(MINIMUM_BATCH_SIZE, batchSize.get() * BATCH_SIZE_REDUCTION_FACTOR));
+    }
+  }
+
+  private CompletableFuture<Long> reindex(final ArchiveDocIdsBatch<T> batch) {
+    return reindexer
+        .apply(sourceIdx, destinationIdx, batch.documents())
+        .thenApply(
+            reindexCount ->
+                validateProcessedCount("reindex", reindexCount, batch.documents().size()));
+  }
+
+  private CompletableFuture<Long> delete(final ArchiveDocIdsBatch<T> batch) {
+    return deleter
+        .apply(sourceIdx, batch.documents())
+        .thenApply(
+            deleteCount ->
+                validateProcessedCount("delete", deleteCount, batch.documents().size()));
+  }
+
+  private long validateProcessedCount(
+      final String operation, final long processedCount, final int expectedCount) {
+    if (processedCount != expectedCount) {
+      throw new BatchCountMismatchException(
+          operation,
+          String.format(
+              "The '%s' operation for a batch when archiving %s processed %d docs, however was "
+                  + "expecting %d docs",
+              operation, sourceIdx, processedCount, expectedCount));
+    }
+    return processedCount;
+  }
+
+  private boolean shouldReduceBatchSize(final Throwable thr) {
+    return matchesThrowableOrCause(thr, SocketTimeoutException.class);
+  }
+
+  private boolean isRetryableError(final Throwable thr) {
+    return RETRYABLE_EXCEPTIONS.stream().anyMatch(clazz -> matchesThrowableOrCause(thr, clazz));
+  }
+
+  private boolean matchesThrowableOrCause(
+      final Throwable thr, final Class<? extends Throwable> throwableClass) {
+    return thr != null
+        && (throwableClass.isInstance(thr) || throwableClass.isInstance(thr.getCause()));
+  }
+
+  public record ArchiveDocIdsBatch<T>(List<IdWithRouting> documents, List<T> searchAfter) {
+
+    static <T> ArchiveDocIdsBatch<T> empty() {
+      return new ArchiveDocIdsBatch<>(List.of(), List.of());
+    }
+
+    static <T> ArchiveDocIdsBatch<T> from(
+        final List<IdWithRouting> documents, final List<T> searchAfter) {
+      return new ArchiveDocIdsBatch<>(documents, searchAfter);
+    }
+
+    boolean isEmpty() {
+      return documents.isEmpty();
+    }
+  }
+
+  public record IdWithRouting(String id, String routing) {
+    public static IdWithRouting of(final String id) {
+      return new IdWithRouting(id, null);
+    }
+  }
+
+  /**
+   * Thrown when the number of documents processed by a reindex or delete operation does not match
+   * the expected count. This is caught to allow retrying the same batch on the next invocation.
+   */
+  static class BatchCountMismatchException extends RuntimeException {
+    final String operation;
+
+    BatchCountMismatchException(final String operation, final String message) {
+      super(message);
+      this.operation = operation;
+    }
+  }
+
+  @FunctionalInterface
+  public interface Reindexer {
+    CompletableFuture<Long> apply(
+        String sourceIndexName, String destinationIndexName, List<IdWithRouting> docs);
+  }
+
+  @FunctionalInterface
+  public interface Deleter {
+    CompletableFuture<Long> apply(String sourceIndexName, List<IdWithRouting> docs);
+  }
+}

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiveByIdTaskSupplier.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiveByIdTaskSupplier.java
@@ -110,8 +110,7 @@ public class ArchiveByIdTaskSupplier<T> {
                         if (isRetryableError(ex)
                             && retryCount.incrementAndGet()
                                 <= archiverProperties.getArchiveByIdMaxRetryAttempts()) {
-                          metrics.recordCounts(
-                              Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+                          metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
                           adjustBatchSize(ex);
 
                           logger.trace(
@@ -171,8 +170,7 @@ public class ArchiveByIdTaskSupplier<T> {
     return deleter
         .apply(sourceIdx, batch.documents())
         .thenApply(
-            deleteCount ->
-                validateProcessedCount("delete", deleteCount, batch.documents().size()));
+            deleteCount -> validateProcessedCount("delete", deleteCount, batch.documents().size()));
   }
 
   private long validateProcessedCount(

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
@@ -97,7 +97,14 @@ public class Archiver {
           final AbstractArchiverJob processInstancesArchiverJob =
               archiveById
                   ? beanFactory.getBean(
-                      ProcessInstancesByIdArchiverJob.class, this, partitionIdsSubset)
+                      ProcessInstancesByIdArchiverJob.class,
+                      this,
+                      partitionIdsSubset,
+                      processInstanceTemplate,
+                      processInstanceDependants,
+                      metrics,
+                      archiverRepository,
+                      archiverExecutor)
                   : beanFactory.getBean(
                       ProcessInstancesArchiverJob.class,
                       this,

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
@@ -84,19 +84,27 @@ public class Archiver {
             partitionIds.size());
       }
 
+      final boolean archiveById = operateProperties.getArchiver().isArchiveByIdEnabled();
+      if (archiveById) {
+        LOGGER.info("Archive-by-ID mode enabled (opt-in).");
+      }
+
       for (int i = 0; i < threadsCount; i++) {
         final List<Integer> partitionIdsSubset =
             CollectionUtil.splitAndGetSublist(partitionIds, threadsCount, i);
         if (!partitionIdsSubset.isEmpty()) {
-          final var processInstancesArchiverJob =
-              beanFactory.getBean(
-                  ProcessInstancesArchiverJob.class,
-                  this,
-                  partitionIdsSubset,
-                  processInstanceTemplate,
-                  processInstanceDependants,
-                  metrics,
-                  archiverRepository);
+          final AbstractArchiverJob processInstancesArchiverJob =
+              archiveById
+                  ? beanFactory.getBean(
+                      ProcessInstancesByIdArchiverJob.class, this, partitionIdsSubset)
+                  : beanFactory.getBean(
+                      ProcessInstancesArchiverJob.class,
+                      this,
+                      partitionIdsSubset,
+                      processInstanceTemplate,
+                      processInstanceDependants,
+                      metrics,
+                      archiverRepository);
           archiverExecutor.execute(processInstancesArchiverJob);
 
           final var standaloneDecisionArchiverJob =

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
@@ -89,9 +89,10 @@ public class Archiver {
         LOGGER.info("Archive-by-ID mode enabled (opt-in).");
       }
 
-      for (int i = 0; i < threadsCount; i++) {
+      final int effectiveThreadsCount = Math.min(threadsCount, partitionIds.size());
+      for (int i = 0; i < effectiveThreadsCount; i++) {
         final List<Integer> partitionIdsSubset =
-            CollectionUtil.splitAndGetSublist(partitionIds, threadsCount, i);
+            CollectionUtil.splitAndGetSublist(partitionIds, effectiveThreadsCount, i);
         if (!partitionIdsSubset.isEmpty()) {
           final AbstractArchiverJob processInstancesArchiverJob =
               archiveById

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiverRepository.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.archiver;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public interface ArchiverRepository {
@@ -16,6 +17,13 @@ public interface ArchiverRepository {
   CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(List<Integer> partitionIds);
 
   CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch(List<Integer> partitionIds);
+
+  CompletableFuture<Void> moveDocumentsById(
+      String sourceIndexName,
+      String destinationIndexName,
+      Map<String, List<Object>> keysByField,
+      Map<String, String> inclusionFilters,
+      Map<String, String> exclusionFilters);
 
   void setIndexLifeCycle(final String destinationIndexName);
 

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiverRepository.java
@@ -10,6 +10,7 @@ package io.camunda.operate.archiver;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 
 public interface ArchiverRepository {
   CompletableFuture<ArchiveBatch> getBatchOperationNextBatch();
@@ -23,7 +24,8 @@ public interface ArchiverRepository {
       String destinationIndexName,
       Map<String, List<Object>> keysByField,
       Map<String, String> inclusionFilters,
-      Map<String, String> exclusionFilters);
+      Map<String, String> exclusionFilters,
+      Executor executor);
 
   void setIndexLifeCycle(final String destinationIndexName);
 

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/AsyncRepeatUntil.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/AsyncRepeatUntil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+// Use to repeatedly call an async task until a condition is met.
+// NB avoiding using closures for this as with all the callbacks it can
+// easily lead to memory leaks if not used carefully. By using an explicit class
+// we can ensure that the state is properly cleaned up after completion.
+final class AsyncRepeatUntil<T> {
+  private final CompletableFuture<Void> finalFuture = new CompletableFuture<>();
+  private final Supplier<CompletableFuture<T>> asyncTask;
+  private final Predicate<T> until;
+
+  private AsyncRepeatUntil(
+      final Supplier<CompletableFuture<T>> asyncTask, final Predicate<T> until) {
+    this.asyncTask = asyncTask;
+    this.until = until;
+  }
+
+  private void next() {
+    try {
+      asyncTask
+          .get()
+          .thenAcceptAsync(this::completeOrNext)
+          .exceptionally(this::completeExceptionally);
+    } catch (final Throwable err) {
+      completeExceptionally(err);
+    }
+  }
+
+  private void completeOrNext(final T result) {
+    try {
+      if (until.test(result)) {
+        finalFuture.complete(null);
+      } else {
+        next();
+      }
+    } catch (final Throwable err) {
+      completeExceptionally(err);
+    }
+  }
+
+  private Void completeExceptionally(final Throwable err) {
+    finalFuture.completeExceptionally(err);
+    return null;
+  }
+
+  static <T> CompletableFuture<Void> repeatUntil(
+      final Supplier<CompletableFuture<T>> asyncTask, final Predicate<T> until) {
+    final var repeat = new AsyncRepeatUntil<>(asyncTask, until);
+
+    repeat.next();
+
+    return repeat.finalFuture;
+  }
+}

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -24,7 +24,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHist
 import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.bucketSort;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.operate.Metrics;

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -239,15 +239,17 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
             executor)
         .whenComplete(
             (ignored, error) -> {
+              final var totalArchived = supplier.getTotalArchived();
               indexTimer.stop(
-                  metrics.getTimer(
-                      Metrics.TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_INDEX, "source", sourceIndexName));
+                  metrics.getHistogram(
+                      Metrics.TIMER_NAME_ARCHIVER_INDEX_DURATION, "source", sourceIndexName));
+              metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, totalArchived);
               if (error != null) {
                 LOGGER.warn(
                     "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
                     sourceIndexName,
                     destinationIndexName,
-                    supplier.getTotalArchived(),
+                    totalArchived,
                     supplier.getTotalTimeTakenMs() / 1000,
                     error.getMessage(),
                     error);
@@ -256,7 +258,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                     "Successfully completed archiving {} to the {} index, moved {} docs in {}s",
                     sourceIndexName,
                     destinationIndexName,
-                    supplier.getTotalArchived(),
+                    totalArchived,
                     supplier.getTotalTimeTakenMs() / 1000);
               }
             });
@@ -393,7 +395,8 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
   }
 
   private Timer getArchiverDocIdsBatchQueryTimer() {
-    return metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_DOC_IDS_QUERY);
+    return metrics.getHistogram(
+        Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE, "search");
   }
 
   private CompletableFuture<Long> reindexDocumentsById(
@@ -419,7 +422,10 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         .whenCompleteAsync(
             (total, error) -> {
               metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
-              timer.stop(getArchiverReindexQueryTimer());
+              timer.stop(
+                  metrics.getHistogram(
+                      Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE,
+                      "reindex"));
             },
             executor);
   }
@@ -459,7 +465,10 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         .whenCompleteAsync(
             (deleted, error) -> {
               metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
-              timer.stop(getArchiverDeleteQueryTimer());
+              timer.stop(
+                  metrics.getHistogram(
+                      Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE,
+                      "delete"));
             },
             executor);
   }

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -376,6 +376,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
 
     final var searchSource =
         new SearchSourceBuilder()
+            .trackTotalHits(false)
             .query(constantScoreQuery(boolQ))
             .sort("id", SortOrder.ASC)
             .size(batchSize)

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -243,7 +243,11 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
               indexTimer.stop(
                   metrics.getHistogram(
                       Metrics.TIMER_NAME_ARCHIVER_INDEX_DURATION, "source", sourceIndexName));
-              metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, totalArchived);
+              metrics.recordCounts(
+                  Metrics.COUNTER_NAME_ARCHIVER_INDEX_DOCS,
+                  totalArchived,
+                  "source",
+                  sourceIndexName);
               if (error != null) {
                 LOGGER.warn(
                     "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
@@ -421,7 +425,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
             executor)
         .whenCompleteAsync(
             (total, error) -> {
-              metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
+              if (total != null) {
+                metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
+              }
               timer.stop(
                   metrics.getHistogram(
                       Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION,
@@ -465,7 +471,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         .thenApplyAsync(response -> getDeletedDocCount(sourceIndexName, response), executor)
         .whenCompleteAsync(
             (deleted, error) -> {
-              metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
+              if (deleted != null) {
+                metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
+              }
               timer.stop(
                   metrics.getHistogram(
                       Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION,

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
@@ -205,7 +206,8 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
       final String destinationIndexName,
       final Map<String, List<Object>> keysByField,
       final Map<String, String> inclusionFilters,
-      final Map<String, String> exclusionFilters) {
+      final Map<String, String> exclusionFilters,
+      final Executor executor) {
     final var supplier =
         new ArchiveByIdTaskSupplier<>(
             sourceIndexName,
@@ -217,22 +219,24 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                     inclusionFilters,
                     exclusionFilters,
                     size,
-                    searchAfter),
-            this::reindexDocumentsById,
-            this::deleteDocumentsById,
-            archiverExecutor.getScheduledExecutor(),
+                    searchAfter,
+                    executor),
+            (src, dst, docs) -> reindexDocumentsById(src, dst, docs, executor),
+            (src, docs) -> deleteDocumentsById(src, docs, executor),
+            executor,
             operateProperties.getArchiver(),
             metrics,
             LOGGER);
     final var indexTimer = Timer.start();
     return AsyncRepeatUntil.repeatUntil(supplier::moveNextBatch, count -> supplier.isComplete())
-        .thenCompose(
+        .thenComposeAsync(
             ignored -> {
               if (supplier.getTotalArchived() > 0L) {
                 setIndexLifeCycle(destinationIndexName);
               }
               return CompletableFuture.<Void>completedFuture(null);
-            })
+            },
+            executor)
         .whenComplete(
             (ignored, error) -> {
               indexTimer.stop(
@@ -347,7 +351,8 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
           final Map<String, String> inclusionFilters,
           final Map<String, String> exclusionFilters,
           final int batchSize,
-          final List<Object> searchAfter) {
+          final List<Object> searchAfter,
+          final Executor executor) {
     final var boolQ = boolQuery();
     keysByField.forEach((field, vals) -> boolQ.filter(termsQuery(field, vals)));
     inclusionFilters.forEach((field, val) -> boolQ.filter(termQuery(field, val)));
@@ -372,8 +377,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         searchSource.query());
 
     final var timer = Timer.start();
-    return ElasticsearchUtil.searchAsync(searchRequest, archiverExecutor, esClient)
-        .whenComplete((ignored, error) -> timer.stop(getArchiverDocIdsBatchQueryTimer()))
+    return ElasticsearchUtil.searchAsync(searchRequest, executor, esClient)
+        .whenCompleteAsync(
+            (ignored, error) -> timer.stop(getArchiverDocIdsBatchQueryTimer()), executor)
         .thenApply(
             response -> {
               final var hits = response.getHits().getHits();
@@ -393,7 +399,8 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
   private CompletableFuture<Long> reindexDocumentsById(
       final String sourceIndexName,
       final String destinationIndexName,
-      final List<IdWithRouting> docs) {
+      final List<IdWithRouting> docs,
+      final Executor executor) {
     final var docIds = docs.stream().map(IdWithRouting::id).toArray(String[]::new);
     final var reindexRequest =
         createReindexRequestWithDefaults()
@@ -403,16 +410,18 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
 
     final var timer = Timer.start();
     return ElasticsearchUtil.reindexAsync(archiverExecutor, reindexRequest, esClient)
-        .thenApply(
+        .thenApplyAsync(
             response -> {
               validateReindexResponse(sourceIndexName, response);
               return getReindexedDocumentsCount(response);
-            })
-        .whenComplete(
+            },
+            executor)
+        .whenCompleteAsync(
             (total, error) -> {
               metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
               timer.stop(getArchiverReindexQueryTimer());
-            });
+            },
+            executor);
   }
 
   private static void validateReindexResponse(
@@ -433,7 +442,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
   }
 
   private CompletableFuture<Long> deleteDocumentsById(
-      final String sourceIndexName, final List<IdWithRouting> docs) {
+      final String sourceIndexName, final List<IdWithRouting> docs, final Executor executor) {
     final var bulkRequest = new BulkRequest();
     docs.forEach(
         doc ->
@@ -446,12 +455,13 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         RequestOptions.DEFAULT,
         ActionListener.wrap(future::complete, future::completeExceptionally));
     return future
-        .thenApply(response -> getDeletedDocCount(sourceIndexName, response))
-        .whenComplete(
+        .thenApplyAsync(response -> getDeletedDocCount(sourceIndexName, response), executor)
+        .whenCompleteAsync(
             (deleted, error) -> {
               metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
               timer.stop(getArchiverDeleteQueryTimer());
-            });
+            },
+            executor);
   }
 
   private long getDeletedDocCount(final String sourceIndex, final BulkResponse response) {

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -54,6 +54,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
@@ -369,7 +370,8 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
             .query(constantScoreQuery(boolQ))
             .sort("id", SortOrder.ASC)
             .size(batchSize)
-            .fetchSource(false);
+            .fetchSource(false)
+            .storedField("_routing");
     if (!searchAfter.isEmpty()) {
       searchSource.searchAfter(searchAfter.toArray());
     }
@@ -393,7 +395,13 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                 return ArchiveByIdTaskSupplier.ArchiveDocIdsBatch.empty();
               }
               return ArchiveByIdTaskSupplier.ArchiveDocIdsBatch.from(
-                  Arrays.stream(hits).map(h -> IdWithRouting.of(h.getId())).toList(),
+                  Arrays.stream(hits)
+                      .map(
+                          h -> {
+                            final DocumentField rf = h.field("_routing");
+                            return new IdWithRouting(h.getId(), rf != null ? rf.getValue() : null);
+                          })
+                      .toList(),
                   Arrays.asList(hits[hits.length - 1].getSortValues()));
             });
   }

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -12,7 +12,10 @@ import static io.camunda.operate.archiver.AbstractArchiverJob.INSTANCES_AGG;
 import static io.camunda.operate.schema.SchemaManager.INDEX_LIFECYCLE_NAME;
 import static io.camunda.operate.schema.SchemaManager.OPERATE_DELETE_ARCHIVED_INDICES;
 import static java.lang.String.format;
+import static org.elasticsearch.action.DocWriteResponse.Result.DELETED;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
+import static org.elasticsearch.index.query.QueryBuilders.idsQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
@@ -22,6 +25,7 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.bucketSort;
 
 import io.camunda.operate.Metrics;
+import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.exceptions.ArchiverException;
 import io.camunda.operate.exceptions.OperateRuntimeException;
@@ -35,9 +39,15 @@ import io.micrometer.core.instrument.Timer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
@@ -190,6 +200,65 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
   }
 
   @Override
+  public CompletableFuture<Void> moveDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<Object>> keysByField,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters) {
+    final var supplier =
+        new ArchiveByIdTaskSupplier<>(
+            sourceIndexName,
+            destinationIndexName,
+            (searchAfter, size) ->
+                getArchiveDocIdsBatch(
+                    sourceIndexName,
+                    keysByField,
+                    inclusionFilters,
+                    exclusionFilters,
+                    size,
+                    searchAfter),
+            this::reindexDocumentsById,
+            this::deleteDocumentsById,
+            archiverExecutor.getScheduledExecutor(),
+            operateProperties.getArchiver(),
+            metrics,
+            LOGGER);
+    final var indexTimer = Timer.start();
+    return AsyncRepeatUntil.repeatUntil(supplier::moveNextBatch, count -> supplier.isComplete())
+        .thenCompose(
+            ignored -> {
+              if (supplier.getTotalArchived() > 0L) {
+                setIndexLifeCycle(destinationIndexName);
+              }
+              return CompletableFuture.<Void>completedFuture(null);
+            })
+        .whenComplete(
+            (ignored, error) -> {
+              indexTimer.stop(
+                  metrics.getTimer(
+                      Metrics.TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_INDEX, "source", sourceIndexName));
+              if (error != null) {
+                LOGGER.warn(
+                    "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
+                    sourceIndexName,
+                    destinationIndexName,
+                    supplier.getTotalArchived(),
+                    supplier.getTotalTimeTakenMs() / 1000,
+                    error.getMessage(),
+                    error);
+              } else {
+                LOGGER.debug(
+                    "Successfully completed archiving {} to the {} index, moved {} docs in {}s",
+                    sourceIndexName,
+                    destinationIndexName,
+                    supplier.getTotalArchived(),
+                    supplier.getTotalTimeTakenMs() / 1000);
+              }
+            });
+  }
+
+  @Override
   public void setIndexLifeCycle(final String destinationIndexName) {
     try {
       if (operateProperties.getArchiver().isIlmEnabled()
@@ -269,6 +338,135 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
               return null;
             });
     return reindexFuture;
+  }
+
+  private CompletableFuture<ArchiveByIdTaskSupplier.ArchiveDocIdsBatch<Object>>
+      getArchiveDocIdsBatch(
+          final String sourceIndexName,
+          final Map<String, List<Object>> keysByField,
+          final Map<String, String> inclusionFilters,
+          final Map<String, String> exclusionFilters,
+          final int batchSize,
+          final List<Object> searchAfter) {
+    final var boolQ = boolQuery();
+    keysByField.forEach((field, vals) -> boolQ.filter(termsQuery(field, vals)));
+    inclusionFilters.forEach((field, val) -> boolQ.filter(termQuery(field, val)));
+    exclusionFilters.forEach((field, val) -> boolQ.mustNot(termQuery(field, val)));
+
+    final var searchSource =
+        new SearchSourceBuilder()
+            .query(constantScoreQuery(boolQ))
+            .sort("id", SortOrder.ASC)
+            .size(batchSize)
+            .fetchSource(false);
+    if (!searchAfter.isEmpty()) {
+      searchSource.searchAfter(searchAfter.toArray());
+    }
+
+    final SearchRequest searchRequest =
+        new SearchRequest(sourceIndexName).source(searchSource).requestCache(false);
+
+    LOGGER.trace(
+        "Getting archive doc IDs batch from index '{}' with query '{}'",
+        sourceIndexName,
+        searchSource.query());
+
+    final var timer = Timer.start();
+    return ElasticsearchUtil.searchAsync(searchRequest, archiverExecutor, esClient)
+        .whenComplete((ignored, error) -> timer.stop(getArchiverDocIdsBatchQueryTimer()))
+        .thenApply(
+            response -> {
+              final var hits = response.getHits().getHits();
+              if (hits.length == 0) {
+                return ArchiveByIdTaskSupplier.ArchiveDocIdsBatch.empty();
+              }
+              return ArchiveByIdTaskSupplier.ArchiveDocIdsBatch.from(
+                  Arrays.stream(hits).map(h -> IdWithRouting.of(h.getId())).toList(),
+                  Arrays.asList(hits[hits.length - 1].getSortValues()));
+            });
+  }
+
+  private Timer getArchiverDocIdsBatchQueryTimer() {
+    return metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_DOC_IDS_QUERY);
+  }
+
+  private CompletableFuture<Long> reindexDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final List<IdWithRouting> docs) {
+    final var docIds = docs.stream().map(IdWithRouting::id).toArray(String[]::new);
+    final var reindexRequest =
+        createReindexRequestWithDefaults()
+            .setSourceIndices(sourceIndexName)
+            .setDestIndex(destinationIndexName)
+            .setSourceQuery(idsQuery().addIds(docIds));
+
+    final var timer = Timer.start();
+    return ElasticsearchUtil.reindexAsync(archiverExecutor, reindexRequest, esClient)
+        .thenApply(
+            response -> {
+              validateReindexResponse(sourceIndexName, response);
+              return getReindexedDocumentsCount(response);
+            })
+        .whenComplete(
+            (total, error) -> {
+              metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
+              timer.stop(getArchiverReindexQueryTimer());
+            });
+  }
+
+  private static void validateReindexResponse(
+      final String sourceIndex, final BulkByScrollResponse response) {
+    if (response.isTimedOut()) {
+      throw new IllegalStateException("Reindex request from %s timed out".formatted(sourceIndex));
+    }
+    final var failures = response.getBulkFailures().size() + response.getSearchFailures().size();
+    if (failures > 0) {
+      throw new IllegalStateException(
+          "Reindex request from %s index completed with %d failures"
+              .formatted(sourceIndex, failures));
+    }
+  }
+
+  private static long getReindexedDocumentsCount(final BulkByScrollResponse response) {
+    return response.getCreated() + response.getUpdated();
+  }
+
+  private CompletableFuture<Long> deleteDocumentsById(
+      final String sourceIndexName, final List<IdWithRouting> docs) {
+    final var bulkRequest = new BulkRequest();
+    docs.forEach(
+        doc ->
+            bulkRequest.add(new DeleteRequest(sourceIndexName, doc.id()).routing(doc.routing())));
+
+    final var future = new CompletableFuture<BulkResponse>();
+    final var timer = Timer.start();
+    esClient.bulkAsync(
+        bulkRequest,
+        RequestOptions.DEFAULT,
+        ActionListener.wrap(future::complete, future::completeExceptionally));
+    return future
+        .thenApply(response -> getDeletedDocCount(sourceIndexName, response))
+        .whenComplete(
+            (deleted, error) -> {
+              metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
+              timer.stop(getArchiverDeleteQueryTimer());
+            });
+  }
+
+  private long getDeletedDocCount(final String sourceIndex, final BulkResponse response) {
+    if (response.hasFailures()) {
+      final long errorCount =
+          Arrays.stream(response.getItems()).filter(BulkItemResponse::isFailed).count();
+      throw new IllegalStateException(
+          "Deleting reindexed documents from %s index completed with %d failures"
+              .formatted(sourceIndex, errorCount));
+    }
+
+    // only count DELETE bulk operation where result was `deleted`
+    return Arrays.stream(response.getItems())
+        .filter(i -> DELETED.equals(i.getResponse().getResult()))
+        .count();
   }
 
   private SearchRequest createFinishedBatchOperationsSearchRequest(final AggregationBuilder agg) {

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -424,7 +424,8 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
               metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
               timer.stop(
                   metrics.getHistogram(
-                      Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE,
+                      Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION,
+                      Metrics.TAG_KEY_TYPE,
                       "reindex"));
             },
             executor);
@@ -467,7 +468,8 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
               metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
               timer.stop(
                   metrics.getHistogram(
-                      Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE,
+                      Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION,
+                      Metrics.TAG_KEY_TYPE,
                       "delete"));
             },
             executor);

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -24,6 +24,9 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHist
 import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.bucketSort;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.operate.Metrics;
 import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.operate.conditions.ElasticsearchCondition;
@@ -42,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
@@ -116,6 +120,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     this.batchOperationTemplate = batchOperationTemplate;
     this.decisionInstanceTemplate = decisionInstanceTemplate;
   }
+
+  private final Cache<String, Boolean> ilmApplied =
+      Caffeine.newBuilder().maximumSize(200).expireAfterWrite(1, TimeUnit.HOURS).build();
 
   private ArchiveBatch createArchiveBatch(
       final SearchResponse searchResponse,
@@ -232,9 +239,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     return AsyncRepeatUntil.repeatUntil(supplier::moveNextBatch, count -> supplier.isComplete())
         .thenComposeAsync(
             ignored -> {
-              if (supplier.getTotalArchived() > 0L) {
-                setIndexLifeCycle(destinationIndexName);
-              }
+              setIndexLifeCycle(destinationIndexName);
               return CompletableFuture.<Void>completedFuture(null);
             },
             executor)
@@ -271,6 +276,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
 
   @Override
   public void setIndexLifeCycle(final String destinationIndexName) {
+    if (ilmApplied.getIfPresent(destinationIndexName) != null) {
+      return;
+    }
     try {
       if (operateProperties.getArchiver().isIlmEnabled()
           && esClient
@@ -285,6 +293,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                             .put(INDEX_LIFECYCLE_NAME, OPERATE_DELETE_ARCHIVED_INDICES)
                             .build()),
                 RequestOptions.DEFAULT);
+        ilmApplied.put(destinationIndexName, Boolean.TRUE);
       }
     } catch (final Exception e) {
       LOGGER.warn(
@@ -370,8 +379,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
             .query(constantScoreQuery(boolQ))
             .sort("id", SortOrder.ASC)
             .size(batchSize)
-            .fetchSource(false)
-            .storedField("_routing");
+            .fetchSource(false);
     if (!searchAfter.isEmpty()) {
       searchSource.searchAfter(searchAfter.toArray());
     }
@@ -398,7 +406,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                   Arrays.stream(hits)
                       .map(
                           h -> {
-                            final DocumentField rf = h.field("_routing");
+                            final DocumentField rf = h.getMetadataFields().get("_routing");
                             return new IdWithRouting(h.getId(), rf != null ? rf.getValue() : null);
                           })
                       .toList(),
@@ -462,7 +470,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     return response.getCreated() + response.getUpdated();
   }
 
-  private CompletableFuture<Long> deleteDocumentsById(
+  CompletableFuture<Long> deleteDocumentsById(
       final String sourceIndexName, final List<IdWithRouting> docs, final Executor executor) {
     final var bulkRequest = new BulkRequest();
     docs.forEach(

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -102,6 +102,9 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
   private final ListViewTemplate processInstanceTemplate;
   private final DecisionInstanceTemplate decisionInstanceTemplate;
 
+  private final Cache<String, Boolean> ilmApplied =
+      Caffeine.newBuilder().maximumSize(200).expireAfterWrite(1, TimeUnit.HOURS).build();
+
   @Autowired
   public ElasticsearchArchiverRepository(
       @Qualifier("archiverThreadPoolExecutor") final ThreadPoolTaskScheduler archiverExecutor,
@@ -119,9 +122,6 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     this.batchOperationTemplate = batchOperationTemplate;
     this.decisionInstanceTemplate = decisionInstanceTemplate;
   }
-
-  private final Cache<String, Boolean> ilmApplied =
-      Caffeine.newBuilder().maximumSize(200).expireAfterWrite(1, TimeUnit.HOURS).build();
 
   private ArchiveBatch createArchiveBatch(
       final SearchResponse searchResponse,

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -275,15 +275,17 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
             executor)
         .whenComplete(
             (ignored, error) -> {
+              final var totalArchived = supplier.getTotalArchived();
               indexTimer.stop(
-                  metrics.getTimer(
-                      Metrics.TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_INDEX, "source", sourceIndexName));
+                  metrics.getHistogram(
+                      Metrics.TIMER_NAME_ARCHIVER_INDEX_DURATION, "source", sourceIndexName));
+              metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, totalArchived);
               if (error != null) {
                 LOGGER.warn(
                     "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
                     sourceIndexName,
                     destinationIndexName,
-                    supplier.getTotalArchived(),
+                    totalArchived,
                     supplier.getTotalTimeTakenMs() / 1000,
                     error.getMessage(),
                     error);
@@ -292,7 +294,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
                     "Successfully completed archiving {} to the {} index, moved {} docs in {}s",
                     sourceIndexName,
                     destinationIndexName,
-                    supplier.getTotalArchived(),
+                    totalArchived,
                     supplier.getTotalTimeTakenMs() / 1000);
               }
             });
@@ -422,7 +424,9 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
         .whenCompleteAsync(
             (ignored, error) ->
                 timer.stop(
-                    metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_DOC_IDS_QUERY)),
+                    metrics.getHistogram(
+                        Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE,
+                        "search")),
             executor)
         .thenApply(
             response -> {
@@ -460,7 +464,10 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
         .whenCompleteAsync(
             (total, error) -> {
               metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
-              timer.stop(metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_REINDEX_QUERY));
+              timer.stop(
+                  metrics.getHistogram(
+                      Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE,
+                      "reindex"));
             },
             executor);
   }
@@ -503,7 +510,10 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
           .whenCompleteAsync(
               (deleted, error) -> {
                 metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
-                timer.stop(metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_DELETE_QUERY));
+                timer.stop(
+                    metrics.getHistogram(
+                        Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE,
+                        "delete"));
               },
               executor);
     } catch (final IOException e) {

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -48,6 +48,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.Conflicts;
@@ -241,7 +242,8 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
       final String destinationIndexName,
       final Map<String, List<Object>> keysByField,
       final Map<String, String> inclusionFilters,
-      final Map<String, String> exclusionFilters) {
+      final Map<String, String> exclusionFilters,
+      final Executor executor) {
     final var supplier =
         new ArchiveByIdTaskSupplier<String>(
             sourceIndexName,
@@ -253,22 +255,24 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
                     inclusionFilters,
                     exclusionFilters,
                     size,
-                    searchAfter),
-            this::reindexDocumentsById,
-            this::deleteDocumentsById,
-            archiverExecutor.getScheduledExecutor(),
+                    searchAfter,
+                    executor),
+            (src, dst, docs) -> reindexDocumentsById(src, dst, docs, executor),
+            (src, docs) -> deleteDocumentsById(src, docs, executor),
+            executor,
             operateProperties.getArchiver(),
             metrics,
             LOGGER);
     final var indexTimer = Timer.start();
     return AsyncRepeatUntil.repeatUntil(supplier::moveNextBatch, count -> supplier.isComplete())
-        .thenCompose(
+        .thenComposeAsync(
             ignored -> {
               if (supplier.getTotalArchived() > 0L) {
                 setIndexLifeCycle(destinationIndexName);
               }
               return CompletableFuture.<Void>completedFuture(null);
-            })
+            },
+            executor)
         .whenComplete(
             (ignored, error) -> {
               indexTimer.stop(
@@ -382,7 +386,8 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
           final Map<String, String> inclusionFilters,
           final Map<String, String> exclusionFilters,
           final int batchSize,
-          final List<String> searchAfter) {
+          final List<String> searchAfter,
+          final Executor executor) {
     final List<Query> filterClauses = new ArrayList<>();
     keysByField.forEach(
         (field, vals) ->
@@ -414,10 +419,11 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
 
     final var timer = Timer.start();
     return OpensearchUtil.searchAsync(requestBuilder.build(), Object.class, osAsyncClient)
-        .whenComplete(
+        .whenCompleteAsync(
             (ignored, error) ->
                 timer.stop(
-                    metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_DOC_IDS_QUERY)))
+                    metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_DOC_IDS_QUERY)),
+            executor)
         .thenApply(
             response -> {
               final List<Hit<Object>> hits = response.hits().hits();
@@ -433,7 +439,8 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
   private CompletableFuture<Long> reindexDocumentsById(
       final String sourceIndexName,
       final String destinationIndexName,
-      final List<IdWithRouting> docs) {
+      final List<IdWithRouting> docs,
+      final Executor executor) {
     final var docIds = docs.stream().map(IdWithRouting::id).toList();
     final var reindexRequest =
         reindexRequestBuilder(sourceIndexName, ids(docIds), destinationIndexName)
@@ -444,16 +451,18 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
 
     final var timer = Timer.start();
     return OpensearchUtil.reindexAsync(reindexRequest, osAsyncClient)
-        .thenApply(
+        .thenApplyAsync(
             response -> {
               validateReindexResponse(sourceIndexName, response);
               return getReindexedDocumentsCount(response);
-            })
-        .whenComplete(
+            },
+            executor)
+        .whenCompleteAsync(
             (total, error) -> {
               metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
               timer.stop(metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_REINDEX_QUERY));
-            });
+            },
+            executor);
   }
 
   private static void validateReindexResponse(
@@ -476,7 +485,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
   }
 
   private CompletableFuture<Long> deleteDocumentsById(
-      final String sourceIndexName, final List<IdWithRouting> docs) {
+      final String sourceIndexName, final List<IdWithRouting> docs, final Executor executor) {
     final var bulkRequestBuilder = new BulkRequest.Builder();
     docs.forEach(
         doc ->
@@ -490,12 +499,13 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     try {
       return osAsyncClient
           .bulk(bulkRequestBuilder.build())
-          .thenApply(response -> getDeletedDocCount(sourceIndexName, response))
-          .whenComplete(
+          .thenApplyAsync(response -> getDeletedDocCount(sourceIndexName, response), executor)
+          .whenCompleteAsync(
               (deleted, error) -> {
                 metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
                 timer.stop(metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_DELETE_QUERY));
-              });
+              },
+              executor);
     } catch (final IOException e) {
       throw new OperateRuntimeException(e);
     }

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -70,6 +70,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -29,6 +29,8 @@ import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBu
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.time;
 import static org.opensearch.client.opensearch._types.SortOrder.Asc;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.operate.Metrics;
 import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.operate.conditions.OpensearchCondition;
@@ -49,6 +51,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.Conflicts;
@@ -103,6 +106,9 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     this.decisionInstanceTemplate = decisionInstanceTemplate;
     this.archiverExecutor = archiverExecutor;
   }
+
+  private final Cache<String, Boolean> ilmApplied =
+      Caffeine.newBuilder().maximumSize(200).expireAfterWrite(1, TimeUnit.HOURS).build();
 
   private <R> ArchiveBatch createArchiveBatch(
       final SearchResponse<R> searchResponse,
@@ -266,9 +272,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     return AsyncRepeatUntil.repeatUntil(supplier::moveNextBatch, count -> supplier.isComplete())
         .thenComposeAsync(
             ignored -> {
-              if (supplier.getTotalArchived() > 0L) {
-                setIndexLifeCycle(destinationIndexName);
-              }
+              setIndexLifeCycle(destinationIndexName);
               return CompletableFuture.<Void>completedFuture(null);
             },
             executor)
@@ -305,12 +309,16 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
 
   @Override
   public void setIndexLifeCycle(final String destinationIndexName) {
+    if (ilmApplied.getIfPresent(destinationIndexName) != null) {
+      return;
+    }
     try {
       if (operateProperties.getArchiver().isIlmEnabled()
           && richOpenSearchClient.index().indexExists(destinationIndexName)) {
         richOpenSearchClient
             .ism()
             .addPolicyToIndex(destinationIndexName, OPERATE_DELETE_ARCHIVED_INDICES);
+        ilmApplied.put(destinationIndexName, Boolean.TRUE);
       }
     } catch (final Exception e) {
       LOGGER.warn(
@@ -498,7 +506,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
         Objects.requireNonNullElse(response.updated(), 0L));
   }
 
-  private CompletableFuture<Long> deleteDocumentsById(
+  CompletableFuture<Long> deleteDocumentsById(
       final String sourceIndexName, final List<IdWithRouting> docs, final Executor executor) {
     final var bulkRequestBuilder = new BulkRequest.Builder();
     docs.forEach(

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -17,6 +17,7 @@ import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.topHitsAggr
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.withSubaggregations;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.and;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.constantScore;
+import static io.camunda.operate.store.opensearch.dsl.QueryDSL.ids;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.intTerms;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.lte;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.sortOptions;
@@ -29,6 +30,7 @@ import static io.camunda.operate.store.opensearch.dsl.RequestDSL.time;
 import static org.opensearch.client.opensearch._types.SortOrder.Asc;
 
 import io.camunda.operate.Metrics;
+import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.OperateProperties;
@@ -40,22 +42,31 @@ import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.util.Either;
 import io.camunda.operate.util.OpensearchUtil;
 import io.micrometer.core.instrument.Timer;
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.ReindexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.SourceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)
@@ -71,6 +82,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
   private final ListViewTemplate processInstanceTemplate;
   private final BatchOperationTemplate batchOperationTemplate;
   private final DecisionInstanceTemplate decisionInstanceTemplate;
+  private final ThreadPoolTaskScheduler archiverExecutor;
 
   @Autowired
   public OpensearchArchiverRepository(
@@ -80,7 +92,8 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
       final Metrics metrics,
       final ListViewTemplate processInstanceTemplate,
       final BatchOperationTemplate batchOperationTemplate,
-      final DecisionInstanceTemplate decisionInstanceTemplate) {
+      final DecisionInstanceTemplate decisionInstanceTemplate,
+      @Qualifier("archiverThreadPoolExecutor") final ThreadPoolTaskScheduler archiverExecutor) {
     this.richOpenSearchClient = richOpenSearchClient;
     this.osAsyncClient = osAsyncClient;
     this.operateProperties = operateProperties;
@@ -88,6 +101,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     this.processInstanceTemplate = processInstanceTemplate;
     this.batchOperationTemplate = batchOperationTemplate;
     this.decisionInstanceTemplate = decisionInstanceTemplate;
+    this.archiverExecutor = archiverExecutor;
   }
 
   private <R> ArchiveBatch createArchiveBatch(
@@ -222,6 +236,65 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
   }
 
   @Override
+  public CompletableFuture<Void> moveDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<Object>> keysByField,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters) {
+    final var supplier =
+        new ArchiveByIdTaskSupplier<String>(
+            sourceIndexName,
+            destinationIndexName,
+            (searchAfter, size) ->
+                getArchiveDocIdsBatch(
+                    sourceIndexName,
+                    keysByField,
+                    inclusionFilters,
+                    exclusionFilters,
+                    size,
+                    searchAfter),
+            this::reindexDocumentsById,
+            this::deleteDocumentsById,
+            archiverExecutor.getScheduledExecutor(),
+            operateProperties.getArchiver(),
+            metrics,
+            LOGGER);
+    final var indexTimer = Timer.start();
+    return AsyncRepeatUntil.repeatUntil(supplier::moveNextBatch, count -> supplier.isComplete())
+        .thenCompose(
+            ignored -> {
+              if (supplier.getTotalArchived() > 0L) {
+                setIndexLifeCycle(destinationIndexName);
+              }
+              return CompletableFuture.<Void>completedFuture(null);
+            })
+        .whenComplete(
+            (ignored, error) -> {
+              indexTimer.stop(
+                  metrics.getTimer(
+                      Metrics.TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_INDEX, "source", sourceIndexName));
+              if (error != null) {
+                LOGGER.warn(
+                    "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
+                    sourceIndexName,
+                    destinationIndexName,
+                    supplier.getTotalArchived(),
+                    supplier.getTotalTimeTakenMs() / 1000,
+                    error.getMessage(),
+                    error);
+              } else {
+                LOGGER.debug(
+                    "Successfully completed archiving {} to the {} index, moved {} docs in {}s",
+                    sourceIndexName,
+                    destinationIndexName,
+                    supplier.getTotalArchived(),
+                    supplier.getTotalTimeTakenMs() / 1000);
+              }
+            });
+  }
+
+  @Override
   public void setIndexLifeCycle(final String destinationIndexName) {
     try {
       if (operateProperties.getArchiver().isIlmEnabled()
@@ -300,6 +373,145 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
               result.ifRightOrLeft(reindexFuture::complete, reindexFuture::completeExceptionally);
             });
     return reindexFuture.thenApply(ok -> null);
+  }
+
+  private CompletableFuture<ArchiveByIdTaskSupplier.ArchiveDocIdsBatch<String>>
+      getArchiveDocIdsBatch(
+          final String sourceIndexName,
+          final Map<String, List<Object>> keysByField,
+          final Map<String, String> inclusionFilters,
+          final Map<String, String> exclusionFilters,
+          final int batchSize,
+          final List<String> searchAfter) {
+    final List<Query> filterClauses = new ArrayList<>();
+    keysByField.forEach(
+        (field, vals) ->
+            filterClauses.add(stringTerms(field, vals.stream().map(Object::toString).toList())));
+    inclusionFilters.forEach((field, val) -> filterClauses.add(term(field, val)));
+
+    final List<Query> mustNotClauses =
+        exclusionFilters.entrySet().stream().map(e -> term(e.getKey(), e.getValue())).toList();
+
+    final Query finalQuery =
+        constantScore(Query.of(q -> q.bool(b -> b.filter(filterClauses).mustNot(mustNotClauses))));
+
+    final SearchRequest.Builder requestBuilder =
+        searchRequestBuilder(sourceIndexName)
+            .query(finalQuery)
+            .sort(sortOptions("id", Asc))
+            .size(batchSize)
+            .source(SourceConfig.of(s -> s.fetch(false)))
+            .requestCache(false);
+
+    if (!searchAfter.isEmpty()) {
+      requestBuilder.searchAfter(searchAfter);
+    }
+
+    LOGGER.trace(
+        "Getting archive doc IDs batch from index '{}' with query '{}'",
+        sourceIndexName,
+        finalQuery);
+
+    final var timer = Timer.start();
+    return OpensearchUtil.searchAsync(requestBuilder.build(), Object.class, osAsyncClient)
+        .whenComplete(
+            (ignored, error) ->
+                timer.stop(
+                    metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_DOC_IDS_QUERY)))
+        .thenApply(
+            response -> {
+              final List<Hit<Object>> hits = response.hits().hits();
+              if (hits.isEmpty()) {
+                return ArchiveByIdTaskSupplier.ArchiveDocIdsBatch.empty();
+              }
+              return ArchiveByIdTaskSupplier.ArchiveDocIdsBatch.from(
+                  hits.stream().map(h -> new IdWithRouting(h.id(), h.routing())).toList(),
+                  hits.getLast().sort());
+            });
+  }
+
+  private CompletableFuture<Long> reindexDocumentsById(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final List<IdWithRouting> docs) {
+    final var docIds = docs.stream().map(IdWithRouting::id).toList();
+    final var reindexRequest =
+        reindexRequestBuilder(sourceIndexName, ids(docIds), destinationIndexName)
+            .scroll(time(OpenSearchDocumentOperations.INTERNAL_SCROLL_KEEP_ALIVE_MS))
+            .slices(getAutoSlices())
+            .conflicts(Conflicts.Proceed)
+            .build();
+
+    final var timer = Timer.start();
+    return OpensearchUtil.reindexAsync(reindexRequest, osAsyncClient)
+        .thenApply(
+            response -> {
+              validateReindexResponse(sourceIndexName, response);
+              return getReindexedDocumentsCount(response);
+            })
+        .whenComplete(
+            (total, error) -> {
+              metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
+              timer.stop(metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_REINDEX_QUERY));
+            });
+  }
+
+  private static void validateReindexResponse(
+      final String sourceIndex, final ReindexResponse response) {
+    if (Boolean.TRUE.equals(response.timedOut())) {
+      throw new IllegalStateException("Reindex request from %s timed out".formatted(sourceIndex));
+    }
+    final var failures = response.failures();
+    if (!failures.isEmpty()) {
+      throw new IllegalStateException(
+          "Reindex request from %s index completed with %d failures"
+              .formatted(sourceIndex, failures.size()));
+    }
+  }
+
+  private static long getReindexedDocumentsCount(final ReindexResponse response) {
+    return Math.addExact(
+        Objects.requireNonNullElse(response.created(), 0L),
+        Objects.requireNonNullElse(response.updated(), 0L));
+  }
+
+  private CompletableFuture<Long> deleteDocumentsById(
+      final String sourceIndexName, final List<IdWithRouting> docs) {
+    final var bulkRequestBuilder = new BulkRequest.Builder();
+    docs.forEach(
+        doc ->
+            bulkRequestBuilder.operations(
+                BulkOperation.of(
+                    op ->
+                        op.delete(
+                            d -> d.index(sourceIndexName).id(doc.id()).routing(doc.routing())))));
+
+    final var timer = Timer.start();
+    try {
+      return osAsyncClient
+          .bulk(bulkRequestBuilder.build())
+          .thenApply(response -> getDeletedDocCount(sourceIndexName, response))
+          .whenComplete(
+              (deleted, error) -> {
+                metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
+                timer.stop(metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_DELETE_QUERY));
+              });
+    } catch (final IOException e) {
+      throw new OperateRuntimeException(e);
+    }
+  }
+
+  private long getDeletedDocCount(final String sourceIndex, final BulkResponse response) {
+    if (response.errors()) {
+      final long errorCount =
+          response.items().stream().filter(item -> item.error() != null).count();
+      throw new IllegalStateException(
+          "Deleting reindexed documents from %s index completed with %d failures"
+              .formatted(sourceIndex, errorCount));
+    }
+
+    // only count DELETE bulk operation where result was `deleted`
+    return response.items().stream().filter(i -> "deleted".equals(i.result())).count();
   }
 
   private long getAutoSlices() {

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -88,6 +88,9 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
   private final DecisionInstanceTemplate decisionInstanceTemplate;
   private final ThreadPoolTaskScheduler archiverExecutor;
 
+  private final Cache<String, Boolean> ilmApplied =
+      Caffeine.newBuilder().maximumSize(200).expireAfterWrite(1, TimeUnit.HOURS).build();
+
   @Autowired
   public OpensearchArchiverRepository(
       final RichOpenSearchClient richOpenSearchClient,
@@ -107,9 +110,6 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     this.decisionInstanceTemplate = decisionInstanceTemplate;
     this.archiverExecutor = archiverExecutor;
   }
-
-  private final Cache<String, Boolean> ilmApplied =
-      Caffeine.newBuilder().maximumSize(200).expireAfterWrite(1, TimeUnit.HOURS).build();
 
   private <R> ArchiveBatch createArchiveBatch(
       final SearchResponse<R> searchResponse,

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -279,7 +279,11 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
               indexTimer.stop(
                   metrics.getHistogram(
                       Metrics.TIMER_NAME_ARCHIVER_INDEX_DURATION, "source", sourceIndexName));
-              metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, totalArchived);
+              metrics.recordCounts(
+                  Metrics.COUNTER_NAME_ARCHIVER_INDEX_DOCS,
+                  totalArchived,
+                  "source",
+                  sourceIndexName);
               if (error != null) {
                 LOGGER.warn(
                     "Failed archiving {} to the {} index, moved {} docs so far in {}s, error={}",
@@ -464,7 +468,9 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
             executor)
         .whenCompleteAsync(
             (total, error) -> {
-              metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
+              if (total != null) {
+                metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
+              }
               timer.stop(
                   metrics.getHistogram(
                       Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION,
@@ -511,7 +517,9 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
           .thenApplyAsync(response -> getDeletedDocCount(sourceIndexName, response), executor)
           .whenCompleteAsync(
               (deleted, error) -> {
-                metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
+                if (deleted != null) {
+                  metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
+                }
                 timer.stop(
                     metrics.getHistogram(
                         Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION,

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -415,6 +415,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
 
     final SearchRequest.Builder requestBuilder =
         searchRequestBuilder(sourceIndexName)
+            .trackTotalHits(t -> t.enabled(false))
             .query(finalQuery)
             .sort(sortOptions("id", Asc))
             .size(batchSize)

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -425,7 +425,8 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
             (ignored, error) ->
                 timer.stop(
                     metrics.getHistogram(
-                        Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE,
+                        Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION,
+                        Metrics.TAG_KEY_TYPE,
                         "search")),
             executor)
         .thenApply(
@@ -466,7 +467,8 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
               metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_REINDEXED_DOCS, total);
               timer.stop(
                   metrics.getHistogram(
-                      Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE,
+                      Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION,
+                      Metrics.TAG_KEY_TYPE,
                       "reindex"));
             },
             executor);
@@ -512,7 +514,8 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
                 metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVER_DELETED_DOCS, deleted);
                 timer.stop(
                     metrics.getHistogram(
-                        Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION, Metrics.TAG_KEY_TYPE,
+                        Metrics.TIMER_NAME_ARCHIVER_REQUEST_DURATION,
+                        Metrics.TAG_KEY_TYPE,
                         "delete"));
               },
               executor);

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -67,7 +67,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
 
 @Conditional(OpensearchCondition.class)

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
@@ -33,20 +33,28 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
 
   private final List<Integer> partitionIds;
   private final Archiver archiver;
+  private final ListViewTemplate processInstanceTemplate;
+  private final List<ProcessInstanceDependant> processInstanceDependantTemplates;
+  private final Metrics metrics;
+  private final ArchiverRepository archiverRepository;
+  private final ThreadPoolTaskScheduler executor;
 
   @Autowired
-  @Qualifier("archiverThreadPoolExecutor")
-  private ThreadPoolTaskScheduler executor;
-
-  @Autowired private ListViewTemplate processInstanceTemplate;
-  @Autowired private List<ProcessInstanceDependant> processInstanceDependantTemplates;
-  @Autowired private Metrics metrics;
-  @Autowired private ArchiverRepository archiverRepository;
-
   public ProcessInstancesByIdArchiverJob(
-      final Archiver archiver, final List<Integer> partitionIds) {
+      final Archiver archiver,
+      final List<Integer> partitionIds,
+      final ListViewTemplate processInstanceTemplate,
+      final List<ProcessInstanceDependant> processInstanceDependantTemplates,
+      final Metrics metrics,
+      final ArchiverRepository archiverRepository,
+      @Qualifier("archiverThreadPoolExecutor") final ThreadPoolTaskScheduler executor) {
     this.archiver = archiver;
     this.partitionIds = partitionIds;
+    this.processInstanceTemplate = processInstanceTemplate;
+    this.processInstanceDependantTemplates = processInstanceDependantTemplates;
+    this.metrics = metrics;
+    this.archiverRepository = archiverRepository;
+    this.executor = executor;
   }
 
   @Override
@@ -104,6 +112,11 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
             executor);
   }
 
+  @Override
+  public CompletableFuture<ArchiveBatch> getNextBatch() {
+    return archiverRepository.getProcessInstancesNextBatch(partitionIds);
+  }
+
   private CompletableFuture<Void> archiveProcessDependants(
       final ArchiveBatch archiveBatch,
       final String listViewDest,
@@ -152,10 +165,5 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
         inclusionFilters,
         exclusionFilters,
         executor);
-  }
-
-  @Override
-  public CompletableFuture<ArchiveBatch> getNextBatch() {
-    return archiverRepository.getProcessInstancesNextBatch(partitionIds);
   }
 }

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
+
+import io.camunda.operate.Metrics;
+import io.camunda.operate.schema.templates.ListViewTemplate;
+import io.camunda.operate.schema.templates.ProcessInstanceDependant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(SCOPE_PROTOTYPE)
+public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ProcessInstancesByIdArchiverJob.class);
+
+  private final List<Integer> partitionIds;
+  private final Archiver archiver;
+
+  @Autowired private ListViewTemplate processInstanceTemplate;
+  @Autowired private List<ProcessInstanceDependant> processInstanceDependantTemplates;
+  @Autowired private Metrics metrics;
+  @Autowired private ArchiverRepository archiverRepository;
+
+  public ProcessInstancesByIdArchiverJob(
+      final Archiver archiver, final List<Integer> partitionIds) {
+    this.archiver = archiver;
+    this.partitionIds = partitionIds;
+  }
+
+  @Override
+  public CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
+    if (archiveBatch == null) {
+      LOGGER.debug("Nothing to archive");
+      return CompletableFuture.completedFuture(0);
+    }
+
+    LOGGER.debug("Following process instances are found for archiving: {}", archiveBatch);
+
+    final String finishDate = archiveBatch.getFinishDate();
+    final List<Object> keys = archiveBatch.getIds();
+
+    final String listViewDest =
+        archiver.getDestinationIndexName(
+            processInstanceTemplate.getFullQualifiedName(), finishDate);
+    final Map<String, List<Object>> piKeyFilter =
+        Map.of(ListViewTemplate.PROCESS_INSTANCE_KEY, keys);
+
+    // 1. First archive docs from dependent indices and `joinRelation={variable OR activity}`
+    // from operate-list-view index
+    // 2. Then archive all docs except `joinRelation=processInstance` from operate-list-view index
+    // 3. Then archive all `joinRelation=processInstance` docs from operate-list-view index
+    return archiveProcessDependants(archiveBatch, listViewDest, piKeyFilter)
+        // Phase 2: list-view excluding processInstance join (catch-all for any other joins)
+        .thenCompose(
+            v ->
+                archive(
+                    processInstanceTemplate.getFullQualifiedName(),
+                    listViewDest,
+                    piKeyFilter,
+                    Map.of(),
+                    Map.of(
+                        ListViewTemplate.JOIN_RELATION,
+                        ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION)))
+        // Phase 3: list-view processInstance join only (must be last to avoid dangling data)
+        .thenCompose(
+            v ->
+                archive(
+                    processInstanceTemplate.getFullQualifiedName(),
+                    listViewDest,
+                    piKeyFilter,
+                    Map.of(
+                        ListViewTemplate.JOIN_RELATION,
+                        ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION),
+                    Map.of()))
+        .thenApply(
+            v -> {
+              metrics.recordCounts(Metrics.COUNTER_NAME_PROCESS_INSTANCES_ARCHIVED, keys.size());
+              return keys.size();
+            });
+  }
+
+  private CompletableFuture<Void> archiveProcessDependants(
+      final ArchiveBatch archiveBatch,
+      final String listViewDest,
+      final Map<String, List<Object>> piKeyFilter) {
+    final String finishDate = archiveBatch.getFinishDate();
+    final List<Object> keys = archiveBatch.getIds();
+
+    // archive dependent indices and list-view variables + activities in parallel
+    final var futures = new ArrayList<CompletableFuture<Void>>();
+    for (final ProcessInstanceDependant template : processInstanceDependantTemplates) {
+      futures.add(
+          archive(
+              template.getFullQualifiedName(),
+              archiver.getDestinationIndexName(template.getFullQualifiedName(), finishDate),
+              Map.of(ProcessInstanceDependant.PROCESS_INSTANCE_KEY, keys),
+              Map.of(),
+              Map.of()));
+    }
+    futures.add(
+        archive(
+            processInstanceTemplate.getFullQualifiedName(),
+            listViewDest,
+            piKeyFilter,
+            Map.of(ListViewTemplate.JOIN_RELATION, ListViewTemplate.VARIABLES_JOIN_RELATION),
+            Map.of()));
+    futures.add(
+        archive(
+            processInstanceTemplate.getFullQualifiedName(),
+            listViewDest,
+            piKeyFilter,
+            Map.of(ListViewTemplate.JOIN_RELATION, ListViewTemplate.ACTIVITIES_JOIN_RELATION),
+            Map.of()));
+    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
+  }
+
+  private CompletableFuture<Void> archive(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final Map<String, List<Object>> keysByField,
+      final Map<String, String> inclusionFilters,
+      final Map<String, String> exclusionFilters) {
+    return archiverRepository.moveDocumentsById(
+        sourceIndexName, destinationIndexName, keysByField, inclusionFilters, exclusionFilters);
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getNextBatch() {
+    return archiverRepository.getProcessInstancesNextBatch(partitionIds);
+  }
+}

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
@@ -16,10 +16,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -31,6 +34,10 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
 
   private final List<Integer> partitionIds;
   private final Archiver archiver;
+
+  @Autowired
+  @Qualifier("archiverThreadPoolExecutor")
+  private ThreadPoolTaskScheduler executor;
 
   @Autowired private ListViewTemplate processInstanceTemplate;
   @Autowired private List<ProcessInstanceDependant> processInstanceDependantTemplates;
@@ -67,7 +74,7 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
     // 3. Then archive all `joinRelation=processInstance` docs from operate-list-view index
     return archiveProcessDependants(archiveBatch, listViewDest, piKeyFilter)
         // Phase 2: list-view excluding processInstance join (catch-all for any other joins)
-        .thenCompose(
+        .thenComposeAsync(
             v ->
                 archive(
                     processInstanceTemplate.getFullQualifiedName(),
@@ -76,9 +83,10 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
                     Map.of(),
                     Map.of(
                         ListViewTemplate.JOIN_RELATION,
-                        ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION)))
+                        ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION)),
+            executor)
         // Phase 3: list-view processInstance join only (must be last to avoid dangling data)
-        .thenCompose(
+        .thenComposeAsync(
             v ->
                 archive(
                     processInstanceTemplate.getFullQualifiedName(),
@@ -87,12 +95,14 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
                     Map.of(
                         ListViewTemplate.JOIN_RELATION,
                         ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION),
-                    Map.of()))
-        .thenApply(
+                    Map.of()),
+            executor)
+        .thenApplyAsync(
             v -> {
               metrics.recordCounts(Metrics.COUNTER_NAME_PROCESS_INSTANCES_ARCHIVED, keys.size());
               return keys.size();
-            });
+            },
+            executor);
   }
 
   private CompletableFuture<Void> archiveProcessDependants(
@@ -137,7 +147,12 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
       final Map<String, String> inclusionFilters,
       final Map<String, String> exclusionFilters) {
     return archiverRepository.moveDocumentsById(
-        sourceIndexName, destinationIndexName, keysByField, inclusionFilters, exclusionFilters);
+        sourceIndexName,
+        destinationIndexName,
+        keysByField,
+        inclusionFilters,
+        exclusionFilters,
+        executor);
   }
 
   @Override

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -102,7 +102,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT extends ArchiverJobIT
             for (int i = 0; i < batchSize; i++) {
               instances.add(processInstanceForListViewEntity("2020-01-01T00:00:00+00:00"));
             }
-            instances.add(processInstanceForListViewEntity("2020-01-01T00:00:10+00:00"));
+            instances.add(processInstanceForListViewEntity("2020-01-02T00:00:00+00:00"));
 
             for (final var pi : instances) {
               store(listViewTemplate, pi);
@@ -301,6 +301,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT extends ArchiverJobIT
   protected IncidentEntity incidentEntity(final ProcessInstanceForListViewEntity parent) {
     final var entity = create(IncidentEntity::new);
     entity.setProcessInstanceKey(parent.getKey());
+    entity.setErrorMessage("test error message");
     return entity;
   }
 

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -102,7 +102,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT extends ArchiverJobIT
             for (int i = 0; i < batchSize; i++) {
               instances.add(processInstanceForListViewEntity("2020-01-01T00:00:00+00:00"));
             }
-            instances.add(processInstanceForListViewEntity("2020-01-02T00:00:00+00:00"));
+            instances.add(processInstanceForListViewEntity("2020-01-01T00:00:10+00:00"));
 
             for (final var pi : instances) {
               store(listViewTemplate, pi);

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiveByIdTaskSupplierTest.java
@@ -36,8 +36,7 @@ import org.slf4j.LoggerFactory;
 
 class ArchiveByIdTaskSupplierTest {
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(ArchiveByIdTaskSupplierTest.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ArchiveByIdTaskSupplierTest.class);
   private static final Executor DIRECT_EXECUTOR = Runnable::run;
   private final Metrics metrics = mock(Metrics.class);
 
@@ -106,8 +105,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             (searchAfter, size) ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(
-                        List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> CompletableFuture.failedFuture(retryableError),
             (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
             DIRECT_EXECUTOR,
@@ -139,8 +137,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             (searchAfter, size) ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(
-                        List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> CompletableFuture.failedFuture(nonRetryableError),
             (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
             DIRECT_EXECUTOR,
@@ -186,8 +183,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             (searchAfter, size) ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(
-                        List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> {
               final var call = reindexCallCount.incrementAndGet();
               if (call == 1 || call == 3 || call == 4 || call == 5 || call == 6) {
@@ -383,8 +379,7 @@ class ArchiveByIdTaskSupplierTest {
             "destination-idx",
             (searchAfter, size) ->
                 CompletableFuture.completedFuture(
-                    ArchiveDocIdsBatch.from(
-                        List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+                    ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> CompletableFuture.failedFuture(retryableError),
             (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
             java.util.concurrent.Executors.newSingleThreadScheduledExecutor(),

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiveByIdTaskSupplierTest.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.operate.Metrics;
+import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.ArchiveDocIdsBatch;
+import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.BatchCountMismatchException;
+import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
+import io.camunda.operate.property.ArchiverProperties;
+import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.elasticsearch.ElasticsearchException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ArchiveByIdTaskSupplierTest {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ArchiveByIdTaskSupplierTest.class);
+  private static final Executor DIRECT_EXECUTOR = Runnable::run;
+  private final Metrics metrics = mock(Metrics.class);
+
+  static Stream<Throwable> retryableErrors() {
+    return Stream.of(
+        new CompletionException(mock(SocketTimeoutException.class)),
+        new CompletionException(mock(ElasticsearchException.class)),
+        new CompletionException(mock(OpenSearchException.class)),
+        new CompletionException(mock(BatchCountMismatchException.class)),
+        mock(SocketTimeoutException.class),
+        mock(ElasticsearchException.class),
+        mock(OpenSearchException.class),
+        mock(BatchCountMismatchException.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("retryableErrors")
+  void shouldRetryOnRetryableError(final Throwable retryableError) {
+    // given
+    final var reindexCallCount = new AtomicInteger(0);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(
+                        List.of(IdWithRouting.of("doc1"), IdWithRouting.of("doc2")),
+                        List.of("after1"))),
+            (source, dest, ids) -> {
+              if (reindexCallCount.incrementAndGet() <= 2) {
+                return CompletableFuture.failedFuture(retryableError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            archiverPropertiesWithMaxRetry(3),
+            metrics,
+            LOGGER);
+
+    // when - first call fails, returns 0 (retry scheduled)
+    final var firstResult = taskSupplier.moveNextBatch().join();
+    assertThat(firstResult).isEqualTo(0L);
+    verify(metrics, times(1)).recordCounts(Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+
+    // when - second call fails, returns 0 (retry scheduled)
+    final var secondResult = taskSupplier.moveNextBatch().join();
+    assertThat(secondResult).isEqualTo(0L);
+    verify(metrics, times(2)).recordCounts(Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+
+    // when - third call succeeds
+    final var thirdResult = taskSupplier.moveNextBatch().join();
+    assertThat(thirdResult).isEqualTo(2L);
+  }
+
+  @Test
+  void shouldThrowWhenMaxRetriesExceeded() {
+    // given - maxRetryCount of 1, so only 1 retry is allowed
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(
+                        List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+            (source, dest, ids) -> CompletableFuture.failedFuture(retryableError),
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            archiverPropertiesWithMaxRetry(1),
+            metrics,
+            LOGGER);
+
+    // when - first call retries (retryCount becomes 1, which is <= maxRetryCount 1)
+    final var firstResult = taskSupplier.moveNextBatch().join();
+    assertThat(firstResult).isEqualTo(0L);
+    verify(metrics, times(1)).recordCounts(Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+
+    // when - second call exceeds max retries (retryCount becomes 2, which is NOT <= 1)
+    final var future = taskSupplier.moveNextBatch();
+
+    // then - should throw
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(SocketTimeoutException.class);
+  }
+
+  @Test
+  void shouldThrowImmediatelyOnNonRetryableError() {
+    final var nonRetryableError = new CompletionException(new RuntimeException("non-retryable"));
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(
+                        List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+            (source, dest, ids) -> CompletableFuture.failedFuture(nonRetryableError),
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            archiverPropertiesWithMaxRetry(3),
+            metrics,
+            LOGGER);
+
+    assertThatThrownBy(() -> taskSupplier.moveNextBatch().join())
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(RuntimeException.class);
+    verify(metrics, times(0)).recordCounts(Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+  }
+
+  @Test
+  void shouldReturnZeroWhenBatchIsEmpty() {
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) -> CompletableFuture.completedFuture(ArchiveDocIdsBatch.empty()),
+            (source, dest, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            archiverPropertiesWithMaxRetry(3),
+            metrics,
+            LOGGER);
+
+    final var result = taskSupplier.moveNextBatch().join();
+    assertThat(result).isEqualTo(0L);
+    assertThat(taskSupplier.isComplete()).isTrue();
+  }
+
+  @Test
+  void shouldResetRetryCountAfterSuccessfulBatch() {
+    // given - maxRetryAttempts=2 means 2 retries allowed before throwing on the 3rd failure.
+    // reindex calls 1, 3, 4, 5, 6 fail; calls 2, 7 succeed.
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+    final var reindexCallCount = new AtomicInteger(0);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(
+                        List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+            (source, dest, ids) -> {
+              final var call = reindexCallCount.incrementAndGet();
+              if (call == 1 || call == 3 || call == 4 || call == 5 || call == 6) {
+                return CompletableFuture.failedFuture(retryableError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            archiverPropertiesWithMaxRetry(2),
+            metrics,
+            LOGGER);
+
+    // call 1 fails (retryCount=1, <= 2) — retry
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    verify(metrics, times(1)).recordCounts(Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+
+    // call 2 succeeds — retryCount resets to 0
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+
+    // call 3 fails (retryCount=1, <= 2) — retry
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    verify(metrics, times(2)).recordCounts(Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+
+    // call 4 fails (retryCount=2, <= 2) — retry
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    verify(metrics, times(3)).recordCounts(Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+
+    // call 5 fails (retryCount=3, NOT <= maxRetryAttempts 2) — throws and resets retryCount
+    assertThatThrownBy(() -> taskSupplier.moveNextBatch().join())
+        .isInstanceOf(CompletionException.class)
+        .hasCauseInstanceOf(SocketTimeoutException.class);
+
+    // call 6 fails again (retryCount=1, <= 2 since it was reset) — retry
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    verify(metrics, times(4)).recordCounts(Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+
+    // call 7 succeeds
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(taskSupplier.getTotalArchived()).isEqualTo(2L);
+  }
+
+  @Test
+  void shouldReduceReindexBatchSizeAfterEachSocketTimeoutRetry() {
+    // given - maxRetryAttempts=3. Reindex fails on calls 1, 2; succeeds on others.
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+    final var reindexCallCount = new AtomicInteger(0);
+    final var observedBatchSize = new AtomicInteger(0);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) -> {
+              observedBatchSize.set(size);
+              return CompletableFuture.completedFuture(
+                  ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1")));
+            },
+            (source, dest, ids) -> {
+              if (Set.of(1, 2).contains(reindexCallCount.incrementAndGet())) {
+                return CompletableFuture.failedFuture(retryableError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            archiverPropertiesWithMaxRetry(3),
+            metrics,
+            LOGGER);
+
+    // attempt 1 fails, full batch size used
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(observedBatchSize.get()).isEqualTo(1200);
+
+    // attempt 2 fails, batch size was halved
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(observedBatchSize.get()).isEqualTo(600);
+
+    // attempt 3 succeeds, batch size was halved again
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(observedBatchSize.get()).isEqualTo(300);
+
+    // attempt 4 successful, batch size is kept
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(observedBatchSize.get()).isEqualTo(300);
+  }
+
+  @Test
+  void shouldNotReduceBatchSizeBelowMinimum() {
+    // given - starting batch size of 100 so it hits the floor at 50 after one halving
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+    final var reindexCallCount = new AtomicInteger(0);
+    final var observedBatchSize = new AtomicInteger(0);
+
+    final var archiverProperties = new ArchiverProperties();
+    archiverProperties.setArchiveByIdBatchSize(100);
+    archiverProperties.setArchiveByIdMaxRetryAttempts(10);
+    archiverProperties.setArchiveByIdRetryDelayMs(0);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) -> {
+              observedBatchSize.set(size);
+              return CompletableFuture.completedFuture(
+                  ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1")));
+            },
+            (source, dest, ids) -> {
+              if (reindexCallCount.incrementAndGet() <= 3) {
+                return CompletableFuture.failedFuture(retryableError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            archiverProperties,
+            metrics,
+            LOGGER);
+
+    // attempt 1 fails: 100 used, reduction gives 50
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(observedBatchSize.get()).isEqualTo(100);
+
+    // attempt 2 fails: 50 used, reduction stays at 50 (floor)
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(observedBatchSize.get()).isEqualTo(50);
+
+    // attempt 3 fails: still 50 (floor enforced)
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(observedBatchSize.get()).isEqualTo(50);
+
+    // attempt 4 succeeds: still 50
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(observedBatchSize.get()).isEqualTo(50);
+  }
+
+  @Test
+  void shouldNotReduceBatchSizeForNonSocketTimeoutRetryableError() {
+    // given - retryable error that is NOT a SocketTimeoutException
+    final var batchMismatchError =
+        new CompletionException(new BatchCountMismatchException("reindex", "count mismatch"));
+    final var reindexCallCount = new AtomicInteger(0);
+    final var observedBatchSize = new AtomicInteger(0);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) -> {
+              observedBatchSize.set(size);
+              return CompletableFuture.completedFuture(
+                  ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1")));
+            },
+            (source, dest, ids) -> {
+              if (reindexCallCount.incrementAndGet() <= 2) {
+                return CompletableFuture.failedFuture(batchMismatchError);
+              }
+              return CompletableFuture.completedFuture((long) ids.size());
+            },
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            DIRECT_EXECUTOR,
+            archiverPropertiesWithMaxRetry(3),
+            metrics,
+            LOGGER);
+
+    // attempt 1 fails with non-SocketTimeout error
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(observedBatchSize.get()).isEqualTo(1200);
+
+    // attempt 2 fails: batch size unchanged
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(0L);
+    assertThat(observedBatchSize.get()).isEqualTo(1200);
+
+    // attempt 3 succeeds: batch size still unchanged
+    assertThat(taskSupplier.moveNextBatch().join()).isEqualTo(1L);
+    assertThat(observedBatchSize.get()).isEqualTo(1200);
+  }
+
+  @Test
+  void shouldDelayBeforeRetryingRetryableError() {
+    // given
+    final var retryableError = new CompletionException(new SocketTimeoutException("timeout"));
+
+    final var archiverProperties = new ArchiverProperties();
+    archiverProperties.setArchiveByIdBatchSize(1200);
+    archiverProperties.setArchiveByIdMaxRetryAttempts(3);
+    archiverProperties.setArchiveByIdRetryDelayMs(100);
+
+    final var taskSupplier =
+        new ArchiveByIdTaskSupplier<>(
+            "source-idx",
+            "destination-idx",
+            (searchAfter, size) ->
+                CompletableFuture.completedFuture(
+                    ArchiveDocIdsBatch.from(
+                        List.of(IdWithRouting.of("doc1")), List.of("after1"))),
+            (source, dest, ids) -> CompletableFuture.failedFuture(retryableError),
+            (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
+            java.util.concurrent.Executors.newSingleThreadScheduledExecutor(),
+            archiverProperties,
+            metrics,
+            LOGGER);
+
+    final var startMs = System.currentTimeMillis();
+    taskSupplier.moveNextBatch().join(); // retryCount = 1, delay = 100ms * 1
+    final var elapsed = System.currentTimeMillis() - startMs;
+
+    assertThat(elapsed).isGreaterThanOrEqualTo(100L);
+    verify(metrics, times(1)).recordCounts(Metrics.COUNTER_NAME_ARCHIVER_BATCH_RETRIES, 1);
+  }
+
+  private static ArchiverProperties archiverPropertiesWithMaxRetry(final int maxRetryCount) {
+    final var archiverProperties = new ArchiverProperties();
+    archiverProperties.setArchiveByIdMaxRetryAttempts(maxRetryCount);
+    archiverProperties.setArchiveByIdRetryDelayMs(0);
+    archiverProperties.setArchiveByIdBatchSize(1200);
+    return archiverProperties;
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiveByIdTaskSupplierTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiveByIdTaskSupplierTest.java
@@ -382,7 +382,7 @@ class ArchiveByIdTaskSupplierTest {
                     ArchiveDocIdsBatch.from(List.of(IdWithRouting.of("doc1")), List.of("after1"))),
             (source, dest, ids) -> CompletableFuture.failedFuture(retryableError),
             (source, ids) -> CompletableFuture.completedFuture((long) ids.size()),
-            java.util.concurrent.Executors.newSingleThreadScheduledExecutor(),
+            DIRECT_EXECUTOR,
             archiverProperties,
             metrics,
             LOGGER);

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverJobIT.java
@@ -20,13 +20,15 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.operate.Metrics;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.conditions.DatabaseType;
+import io.camunda.operate.connect.CustomOffsetDateTimeSerializer;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.entities.OperateEntity;
 import io.camunda.operate.property.ArchiverProperties;
 import io.camunda.operate.property.OperateElasticsearchProperties;
 import io.camunda.operate.property.OperateOpensearchProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.SchemaManager;
-import io.camunda.operate.schema.indices.IndexDescriptor;
+import io.camunda.operate.schema.indices.AbstractIndexDescriptor;
 import io.camunda.operate.schema.templates.AbstractTemplateDescriptor;
 import io.camunda.operate.schema.templates.BatchOperationTemplate;
 import io.camunda.operate.schema.templates.DecisionInstanceTemplate;
@@ -36,6 +38,8 @@ import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -93,7 +97,7 @@ public abstract class ArchiverJobIT {
   @Autowired private BatchOperationTemplate batchOperationTemplate;
   @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
   @Autowired private List<TemplateDescriptor> allTemplateDescriptors;
-  @Autowired private List<IndexDescriptor> allIndexDescriptors;
+  @Autowired private List<AbstractIndexDescriptor> allIndexDescriptors;
   private ElasticsearchSearchClientAdapter esAdapter;
   private OpensearchSearchClientAdapter osAdapter;
 
@@ -309,8 +313,13 @@ public abstract class ArchiverJobIT {
 
     @Bean
     ObjectMapper objectMapper() {
+      final var javaTimeModule = new JavaTimeModule();
+      final var formatter =
+          DateTimeFormatter.ofPattern(OperateDateTimeFormatter.DATE_FORMAT_DEFAULT);
+      javaTimeModule.addSerializer(
+          OffsetDateTime.class, new CustomOffsetDateTimeSerializer(formatter));
       return new ObjectMapper()
-          .registerModule(new JavaTimeModule())
+          .registerModule(javaTimeModule)
           .registerModule(new Jdk8Module())
           .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
           .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverJobIT.java
@@ -263,10 +263,11 @@ public abstract class ArchiverJobIT {
         metrics,
         processInstanceTemplate,
         batchOperationTemplate,
-        decisionInstanceTemplate);
+        decisionInstanceTemplate,
+        buildScheduler());
   }
 
-  private static ThreadPoolTaskScheduler buildScheduler() {
+  protected static ThreadPoolTaskScheduler buildScheduler() {
     final var scheduler = new ThreadPoolTaskScheduler();
     scheduler.setPoolSize(1);
     scheduler.setThreadNamePrefix("archiver-test-");

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverJobIT.java
@@ -69,7 +69,7 @@ public abstract class ArchiverJobIT {
 
   protected static final int PARTITION_ID = 1;
   protected static final List<Integer> PARTITION_IDS = List.of(PARTITION_ID);
-  protected static final AtomicLong ID_GENERATOR = new AtomicLong(0);
+  protected static final AtomicLong ID_GENERATOR = new AtomicLong(100);
   protected static final String INDEX_PREFIX = "test-archiver";
   protected static final Duration ARCHIVE_TIMEOUT = Duration.ofSeconds(30);
 

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/AsyncRepeatUntilTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/AsyncRepeatUntilTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+class AsyncRepeatUntilTest {
+
+  @Test
+  void shouldCompleteWhenTaskCompletes() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(() -> CompletableFuture.completedFuture(1), result -> true);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(2));
+    // ensure no exceptions are thrown
+    future.join();
+  }
+
+  @Test
+  void shouldNotCompleteWhenTaskDoesNotComplete() {
+    // given
+    // when
+    final var future = AsyncRepeatUntil.repeatUntil(CompletableFuture::new, result -> true);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenTasksFailsAsync() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            // task fails in an async manner
+            () -> CompletableFuture.failedFuture(new RuntimeException("future failed")),
+            result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("future failed");
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenTasksFailsSync() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> {
+              // task fails, but in a non-async way
+              throw new RuntimeException("task failed");
+            },
+            result -> true);
+
+    // then
+    assertThat(future.isDone()).isTrue();
+    assertThat(future.isCompletedExceptionally()).isTrue();
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("task failed");
+  }
+
+  @Test
+  void shouldCompleteExceptionallyWhenUntilFails() {
+    // given
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> CompletableFuture.completedFuture(1),
+            result -> {
+              throw new RuntimeException("until failed");
+            });
+
+    // then
+    assertThat(future).failsWithin(Duration.ofSeconds(2));
+    assertThatThrownBy(future::join)
+        .isInstanceOf(CompletionException.class)
+        .cause()
+        .hasMessageContaining("until failed");
+  }
+
+  @Test
+  void shouldCompleteWhenConditionMet() {
+    // given
+    final var counter = new AtomicInteger();
+
+    // when
+    final var future =
+        AsyncRepeatUntil.repeatUntil(
+            () -> CompletableFuture.completedFuture(counter.getAndIncrement()),
+            result -> result >= 5);
+
+    future.join();
+
+    // then
+    assertThat(counter.get()).isEqualTo(6);
+  }
+
+  @Test
+  void shouldRunTasksSerially() {
+    // given
+    final CompletableFuture<Integer> future1 = new CompletableFuture<>();
+    final CompletableFuture<Integer> future2 = new CompletableFuture<>();
+
+    final Supplier<CompletableFuture<Integer>> taskSupplier = mock(Supplier.class);
+
+    when(taskSupplier.get()).thenReturn(future1).thenReturn(future2);
+
+    // when
+    final var future = AsyncRepeatUntil.repeatUntil(taskSupplier, result -> result >= 2);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+    verify(taskSupplier).get();
+
+    // when
+    // complete the first task, which should trigger the second task to be called
+    future1.complete(1);
+
+    // then
+    assertThat(future.isDone()).isFalse();
+    Awaitility.await().untilAsserted(() -> verify(taskSupplier, times(2)).get());
+
+    // when
+    // complete the second task, which should complete the future
+    future2.complete(2);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofSeconds(2));
+    verify(taskSupplier, times(2)).get();
+
+    future.join();
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
@@ -21,6 +22,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.Metrics;
+import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.operate.property.ArchiverProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.templates.BatchOperationTemplate;
@@ -33,6 +35,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.IndicesClient;
@@ -51,6 +57,7 @@ import org.elasticsearch.search.aggregations.metrics.TopHitsAggregationBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
@@ -246,6 +253,45 @@ public class ElasticsearchArchiveRepositoryTest {
           "evaluationDate",
           elasticsearchUtilMockedStatic);
     }
+  }
+
+  @Test
+  void shouldPassRoutingToBulkDeleteRequest() {
+    // given
+    final var docs =
+        List.of(
+            new IdWithRouting("child-doc", "99"), // child doc routed by PI key
+            new IdWithRouting("pi-doc", null)); // PI doc has no custom routing
+
+    final ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+
+    try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      final Timer.Sample timer = mock(Timer.Sample.class);
+      mockedTimer.when(Timer::start).thenReturn(timer);
+
+      final BulkResponse bulkResponse = mock(BulkResponse.class);
+      when(bulkResponse.hasFailures()).thenReturn(false);
+      when(bulkResponse.getItems()).thenReturn(new BulkItemResponse[0]);
+
+      doAnswer(
+              invocation -> {
+                final ActionListener<BulkResponse> listener = invocation.getArgument(2);
+                listener.onResponse(bulkResponse);
+                return null;
+              })
+          .when(esClient)
+          .bulkAsync(bulkCaptor.capture(), any(), any());
+
+      // when
+      underTest.deleteDocumentsById("source-index", docs, Runnable::run).join();
+    }
+
+    // then — routing is forwarded exactly as supplied
+    final var requests = bulkCaptor.getValue().requests();
+    assertThat(requests.get(0).id()).isEqualTo("child-doc");
+    assertThat(requests.get(0).routing()).isEqualTo("99");
+    assertThat(requests.get(1).id()).isEqualTo("pi-doc");
+    assertThat(requests.get(1).routing()).isNull();
   }
 
   public void testGetNextBatchEmptyBucket(

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchSearchClientAdapter.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchSearchClientAdapter.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.SchemaManager;
 import io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager;
-import io.camunda.operate.schema.indices.IndexDescriptor;
+import io.camunda.operate.schema.indices.AbstractIndexDescriptor;
 import io.camunda.operate.schema.templates.TemplateDescriptor;
 import io.camunda.operate.store.elasticsearch.RetryElasticsearchClient;
 import java.io.IOException;
@@ -107,7 +107,7 @@ class ElasticsearchSearchClientAdapter
   SchemaManager buildSchemaManager(
       final OperateProperties props,
       final List<TemplateDescriptor> templates,
-      final List<IndexDescriptor> indices) {
+      final List<AbstractIndexDescriptor> indices) {
     final var retryClient = new RetryElasticsearchClient();
     ReflectionTestUtils.setField(retryClient, "esClient", client);
     final var manager = new ElasticsearchSchemaManager();

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.when;
 import static org.opensearch.client.opensearch._types.SortOrder.Asc;
 
 import io.camunda.operate.Metrics;
+import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
 import io.camunda.operate.exceptions.ArchiverException;
 import io.camunda.operate.property.ArchiverProperties;
 import io.camunda.operate.property.OperateOpensearchProperties;
@@ -46,6 +47,7 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -60,6 +62,8 @@ import org.opensearch.client.opensearch._types.aggregations.DateHistogramAggrega
 import org.opensearch.client.opensearch._types.aggregations.DateHistogramAggregation;
 import org.opensearch.client.opensearch._types.aggregations.TopHitsAggregation;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
 import org.opensearch.client.opensearch.core.ReindexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
@@ -268,6 +272,37 @@ public class OpensearchArchiverRepositoryTest {
             "evaluationDate");
       }
     }
+  }
+
+  @Test
+  void shouldPassRoutingToBulkDeleteRequest() throws Exception {
+    // given
+    final var docs =
+        List.of(
+            new IdWithRouting("child-doc", "99"), // child doc routed by PI key
+            new IdWithRouting("pi-doc", null)); // PI doc has no custom routing
+
+    final ArgumentCaptor<BulkRequest> bulkCaptor = ArgumentCaptor.forClass(BulkRequest.class);
+    final BulkResponse bulkResponse = mock(BulkResponse.class);
+    when(bulkResponse.errors()).thenReturn(false);
+    when(bulkResponse.items()).thenReturn(List.of());
+    when(openSearchAsyncClient.bulk(bulkCaptor.capture()))
+        .thenReturn(CompletableFuture.completedFuture(bulkResponse));
+
+    try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+      final Timer.Sample timer = mock(Timer.Sample.class);
+      mockedTimer.when(Timer::start).thenReturn(timer);
+
+      // when
+      underTest.deleteDocumentsById("source-index", docs, Runnable::run).join();
+    }
+
+    // then — routing is forwarded exactly as supplied
+    final var ops = bulkCaptor.getValue().operations();
+    assertThat(ops.get(0).delete().id()).isEqualTo("child-doc");
+    assertThat(ops.get(0).delete().routing()).isEqualTo("99");
+    assertThat(ops.get(1).delete().id()).isEqualTo("pi-doc");
+    assertThat(ops.get(1).delete().routing()).isNull();
   }
 
   public void testGetNextBatchHelper(

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchSearchClientAdapter.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchSearchClientAdapter.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.opensearch.ExtendedOpenSearchClient;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.SchemaManager;
-import io.camunda.operate.schema.indices.IndexDescriptor;
+import io.camunda.operate.schema.indices.AbstractIndexDescriptor;
 import io.camunda.operate.schema.opensearch.OpensearchSchemaManager;
 import io.camunda.operate.schema.templates.TemplateDescriptor;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
@@ -87,7 +87,7 @@ class OpensearchSearchClientAdapter
   }
 
   @Override
-  public void deleteIndices(final String pattern) throws IOException {
+  public void deleteIndices(final String pattern) {
     try {
       client.indices().delete(r -> r.index(List.of(pattern)).ignoreUnavailable(true));
     } catch (final Exception ignored) {
@@ -98,15 +98,11 @@ class OpensearchSearchClientAdapter
   SchemaManager buildSchemaManager(
       final OperateProperties props,
       final List<TemplateDescriptor> templates,
-      final List<IndexDescriptor> indices) {
+      final List<AbstractIndexDescriptor> indices) {
     final var richClient =
         new RichOpenSearchClient(
             null, client, new OpenSearchAsyncClient(client._transport()), objectMapper);
     return new OpensearchSchemaManager(
-        props,
-        richClient,
-        new ArrayList<>(templates),
-        new ArrayList<IndexDescriptor>(indices),
-        objectMapper);
+        props, richClient, new ArrayList<>(templates), new ArrayList<>(indices), objectMapper);
   }
 }

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJobIT.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import java.util.List;
+
+public class ProcessInstancesByIdArchiverJobIT extends AbstractProcessInstanceArchiverJobIT {
+
+  @Override
+  protected ArchiverJob createArchiveJob(final List<Integer> partitionIds) {
+    return new ProcessInstancesByIdArchiverJob(
+        getArchiver(),
+        partitionIds,
+        getListViewTemplate(),
+        getDependantTemplates(),
+        getMetrics(),
+        getArchiverRepository(),
+        buildScheduler());
+  }
+}

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -62,6 +62,7 @@ public class Metrics {
   public static final String COUNTER_NAME_ARCHIVER_BATCH_RETRIES = "archiver.batch.retries";
   public static final String COUNTER_NAME_ARCHIVER_REINDEXED_DOCS = "archiver.reindexed.docs";
   public static final String COUNTER_NAME_ARCHIVER_DELETED_DOCS = "archiver.deleted.docs";
+  public static final String COUNTER_NAME_ARCHIVER_INDEX_DOCS = "archiver.index.docs";
 
   // Gauges:
   public static final String GAUGE_IMPORT_QUEUE_SIZE = OPERATE_NAMESPACE + "import.queue.size";

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -40,6 +40,10 @@ public class Metrics {
       OPERATE_NAMESPACE + "archiver.reindex.query";
   public static final String TIMER_NAME_ARCHIVER_DELETE_QUERY =
       OPERATE_NAMESPACE + "archiver.delete.query";
+  public static final String TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_DOC_IDS_QUERY =
+      OPERATE_NAMESPACE + "archiver.archive.by.id.doc.ids.query";
+  public static final String TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_INDEX =
+      OPERATE_NAMESPACE + "archiver.archive.by.id.index";
   public static final String TIMER_NAME_IMPORT_FNI_TREE_PATH_CACHE_ACCESS =
       OPERATE_NAMESPACE + "import.fni.tree.path.cache.access";
   // Counters:
@@ -55,6 +59,9 @@ public class Metrics {
       "import.fni.tree.path.cache.result";
   public static final String COUNTER_NAME_REINDEX_FAILURES = "archival.reindex.failures";
   public static final String COUNTER_NAME_DELETE_FAILURES = "archival.delete.failures";
+  public static final String COUNTER_NAME_ARCHIVER_BATCH_RETRIES = "archiver.batch.retries";
+  public static final String COUNTER_NAME_ARCHIVER_REINDEXED_DOCS = "archiver.reindexed.docs";
+  public static final String COUNTER_NAME_ARCHIVER_DELETED_DOCS = "archiver.deleted.docs";
 
   // Gauges:
   public static final String GAUGE_IMPORT_QUEUE_SIZE = OPERATE_NAMESPACE + "import.queue.size";

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -40,10 +40,10 @@ public class Metrics {
       OPERATE_NAMESPACE + "archiver.reindex.query";
   public static final String TIMER_NAME_ARCHIVER_DELETE_QUERY =
       OPERATE_NAMESPACE + "archiver.delete.query";
-  public static final String TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_DOC_IDS_QUERY =
-      OPERATE_NAMESPACE + "archiver.archive.by.id.doc.ids.query";
-  public static final String TIMER_NAME_ARCHIVER_ARCHIVE_BY_ID_INDEX =
-      OPERATE_NAMESPACE + "archiver.archive.by.id.index";
+  public static final String TIMER_NAME_ARCHIVER_REQUEST_DURATION =
+      OPERATE_NAMESPACE + "archiver.request.duration";
+  public static final String TIMER_NAME_ARCHIVER_INDEX_DURATION =
+      OPERATE_NAMESPACE + "archiver.index.duration";
   public static final String TIMER_NAME_IMPORT_FNI_TREE_PATH_CACHE_ACCESS =
       OPERATE_NAMESPACE + "import.fni.tree.path.cache.access";
   // Counters:

--- a/operate/common/src/main/java/io/camunda/operate/property/ArchiverProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ArchiverProperties.java
@@ -9,8 +9,6 @@ package io.camunda.operate.property;
 
 public class ArchiverProperties {
 
-  public static final int DEFAULT_ROLLOVER_BATCH_SIZE = 100;
-  public static final int DEFAULT_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE = 500;
   private static final int DEFAULT_ARCHIVER_THREADS_COUNT = 1;
 
   private boolean rolloverEnabled = true;
@@ -35,7 +33,7 @@ public class ArchiverProperties {
    */
   private String rolloverInterval = "1d";
 
-  private Integer rolloverBatchSize;
+  private int rolloverBatchSize = 100;
 
   private String waitPeriodBeforeArchiving = "1h";
 
@@ -140,14 +138,6 @@ public class ArchiverProperties {
   }
 
   public int getRolloverBatchSize() {
-    if (rolloverBatchSize == null) {
-      if (archiveByIdEnabled) {
-        rolloverBatchSize = DEFAULT_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE;
-      } else {
-        rolloverBatchSize = DEFAULT_ROLLOVER_BATCH_SIZE;
-      }
-    }
-
     return rolloverBatchSize;
   }
 

--- a/operate/common/src/main/java/io/camunda/operate/property/ArchiverProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ArchiverProperties.java
@@ -9,6 +9,8 @@ package io.camunda.operate.property;
 
 public class ArchiverProperties {
 
+  public static final int DEFAULT_ROLLOVER_BATCH_SIZE = 100;
+  public static final int DEFAULT_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE = 500;
   private static final int DEFAULT_ARCHIVER_THREADS_COUNT = 1;
 
   private boolean rolloverEnabled = true;
@@ -33,7 +35,7 @@ public class ArchiverProperties {
    */
   private String rolloverInterval = "1d";
 
-  private int rolloverBatchSize = 100;
+  private Integer rolloverBatchSize;
 
   private String waitPeriodBeforeArchiving = "1h";
 
@@ -49,11 +51,51 @@ public class ArchiverProperties {
    */
   private int delayBetweenRuns = 2000;
 
+  private boolean archiveByIdEnabled = false;
+
+  private int archiveByIdBatchSize = 500;
+
+  private int archiveByIdMaxRetryAttempts = 3;
+
+  private int archiveByIdRetryDelayMs = 1000;
+
+  public boolean isArchiveByIdEnabled() {
+    return archiveByIdEnabled;
+  }
+
+  public void setArchiveByIdEnabled(final boolean archiveByIdEnabled) {
+    this.archiveByIdEnabled = archiveByIdEnabled;
+  }
+
+  public int getArchiveByIdBatchSize() {
+    return archiveByIdBatchSize;
+  }
+
+  public void setArchiveByIdBatchSize(final int archiveByIdBatchSize) {
+    this.archiveByIdBatchSize = archiveByIdBatchSize;
+  }
+
+  public int getArchiveByIdMaxRetryAttempts() {
+    return archiveByIdMaxRetryAttempts;
+  }
+
+  public void setArchiveByIdMaxRetryAttempts(final int archiveByIdMaxRetryAttempts) {
+    this.archiveByIdMaxRetryAttempts = archiveByIdMaxRetryAttempts;
+  }
+
+  public int getArchiveByIdRetryDelayMs() {
+    return archiveByIdRetryDelayMs;
+  }
+
+  public void setArchiveByIdRetryDelayMs(final int archiveByIdRetryDelayMs) {
+    this.archiveByIdRetryDelayMs = archiveByIdRetryDelayMs;
+  }
+
   public String getIlmMinAgeForDeleteArchivedIndices() {
     return ilmMinAgeForDeleteArchivedIndices;
   }
 
-  public void setIlmMinAgeForDeleteArchivedIndices(String ilmMinAgeForDeleteArchivedIndices) {
+  public void setIlmMinAgeForDeleteArchivedIndices(final String ilmMinAgeForDeleteArchivedIndices) {
     this.ilmMinAgeForDeleteArchivedIndices = ilmMinAgeForDeleteArchivedIndices;
   }
 
@@ -61,7 +103,7 @@ public class ArchiverProperties {
     return ilmEnabled;
   }
 
-  public void setIlmEnabled(boolean ilmEnabled) {
+  public void setIlmEnabled(final boolean ilmEnabled) {
     this.ilmEnabled = ilmEnabled;
   }
 
@@ -69,7 +111,7 @@ public class ArchiverProperties {
     return rolloverEnabled;
   }
 
-  public void setRolloverEnabled(boolean rolloverEnabled) {
+  public void setRolloverEnabled(final boolean rolloverEnabled) {
     this.rolloverEnabled = rolloverEnabled;
   }
 
@@ -77,7 +119,7 @@ public class ArchiverProperties {
     return rolloverDateFormat;
   }
 
-  public void setRolloverDateFormat(String rolloverDateFormat) {
+  public void setRolloverDateFormat(final String rolloverDateFormat) {
     this.rolloverDateFormat = rolloverDateFormat;
   }
 
@@ -85,7 +127,7 @@ public class ArchiverProperties {
     return elsRolloverDateFormat;
   }
 
-  public void setElsRolloverDateFormat(String elsRolloverDateFormat) {
+  public void setElsRolloverDateFormat(final String elsRolloverDateFormat) {
     this.elsRolloverDateFormat = elsRolloverDateFormat;
   }
 
@@ -93,15 +135,23 @@ public class ArchiverProperties {
     return rolloverInterval;
   }
 
-  public void setRolloverInterval(String rolloverInterval) {
+  public void setRolloverInterval(final String rolloverInterval) {
     this.rolloverInterval = rolloverInterval;
   }
 
   public int getRolloverBatchSize() {
+    if (rolloverBatchSize == null) {
+      if (archiveByIdEnabled) {
+        rolloverBatchSize = DEFAULT_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE;
+      } else {
+        rolloverBatchSize = DEFAULT_ROLLOVER_BATCH_SIZE;
+      }
+    }
+
     return rolloverBatchSize;
   }
 
-  public void setRolloverBatchSize(int rolloverBatchSize) {
+  public void setRolloverBatchSize(final int rolloverBatchSize) {
     this.rolloverBatchSize = rolloverBatchSize;
   }
 
@@ -109,7 +159,7 @@ public class ArchiverProperties {
     return threadsCount;
   }
 
-  public void setThreadsCount(int threadsCount) {
+  public void setThreadsCount(final int threadsCount) {
     this.threadsCount = threadsCount;
   }
 
@@ -117,7 +167,7 @@ public class ArchiverProperties {
     return waitPeriodBeforeArchiving;
   }
 
-  public void setWaitPeriodBeforeArchiving(String waitPeriodBeforeArchiving) {
+  public void setWaitPeriodBeforeArchiving(final String waitPeriodBeforeArchiving) {
     this.waitPeriodBeforeArchiving = waitPeriodBeforeArchiving;
   }
 
@@ -129,7 +179,7 @@ public class ArchiverProperties {
     return delayBetweenRuns;
   }
 
-  public void setDelayBetweenRuns(int delayBetweenRuns) {
+  public void setDelayBetweenRuns(final int delayBetweenRuns) {
     this.delayBetweenRuns = delayBetweenRuns;
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/util/CollectionUtil.java
+++ b/operate/common/src/main/java/io/camunda/operate/util/CollectionUtil.java
@@ -29,23 +29,25 @@ import java.util.stream.Stream;
 
 public abstract class CollectionUtil {
 
-  public static <K, V> V getOrDefaultForNullValue(Map<K, V> map, K key, V defaultValue) {
+  public static <K, V> V getOrDefaultForNullValue(
+      final Map<K, V> map, final K key, final V defaultValue) {
     final V value = map.get(key);
     return value == null ? defaultValue : value;
   }
 
-  public static <K, T> T getOrDefaultFromMap(Map<K, T> map, K key, T defaultValue) {
+  public static <K, T> T getOrDefaultFromMap(
+      final Map<K, T> map, final K key, final T defaultValue) {
     return key == null ? defaultValue : map.getOrDefault(key, defaultValue);
   }
 
-  public static <T> T firstOrDefault(List<T> list, T defaultValue) {
+  public static <T> T firstOrDefault(final List<T> list, final T defaultValue) {
     return list.isEmpty() ? defaultValue : list.get(0);
   }
 
   @SafeVarargs
-  public static <T> List<T> throwAwayNullElements(T... array) {
+  public static <T> List<T> throwAwayNullElements(final T... array) {
     final List<T> listOfNotNulls = new ArrayList<>();
-    for (T o : array) {
+    for (final T o : array) {
       if (o != null) {
         listOfNotNulls.add(o);
       }
@@ -53,28 +55,29 @@ public abstract class CollectionUtil {
     return listOfNotNulls;
   }
 
-  public static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
+  public static <T> Predicate<T> distinctByKey(final Function<? super T, ?> keyExtractor) {
     final Set<Object> seen = ConcurrentHashMap.newKeySet();
     return t -> seen.add(keyExtractor.apply(t));
   }
 
-  public static <T> List<T> emptyListWhenNull(List<T> aList) {
+  public static <T> List<T> emptyListWhenNull(final List<T> aList) {
     return aList == null ? Collections.emptyList() : aList;
   }
 
-  public static <T> List<T> withoutNulls(Collection<T> aCollection) {
+  public static <T> List<T> withoutNulls(final Collection<T> aCollection) {
     if (aCollection != null) {
       return filter(aCollection, Objects::nonNull);
     }
     return Collections.emptyList();
   }
 
-  public static <T, S> Map<T, List<S>> addToMap(Map<T, List<S>> map, T key, S value) {
+  public static <T, S> Map<T, List<S>> addToMap(
+      final Map<T, List<S>> map, final T key, final S value) {
     map.computeIfAbsent(key, k -> new ArrayList<S>()).add(value);
     return map;
   }
 
-  public static Map<String, Object> asMap(Object... keyValuePairs) {
+  public static Map<String, Object> asMap(final Object... keyValuePairs) {
     if (keyValuePairs == null || keyValuePairs.length % 2 != 0) {
       throw new OperateRuntimeException("keyValuePairs should not be null and has a even length.");
     }
@@ -85,49 +88,51 @@ public abstract class CollectionUtil {
     return result;
   }
 
-  public static <S, T> List<T> map(Collection<S> sourceList, Function<? super S, T> mapper) {
+  public static <S, T> List<T> map(
+      final Collection<S> sourceList, final Function<? super S, T> mapper) {
     return map(sourceList.stream(), mapper);
   }
 
-  public static <S, T> List<T> map(S[] sourceArray, Function<S, T> mapper) {
+  public static <S, T> List<T> map(final S[] sourceArray, final Function<S, T> mapper) {
     return map(Arrays.stream(sourceArray).parallel(), mapper);
   }
 
-  public static <S, T> List<T> map(Stream<S> sequenceStream, Function<? super S, T> mapper) {
+  public static <S, T> List<T> map(
+      final Stream<S> sequenceStream, final Function<? super S, T> mapper) {
     return sequenceStream.map(mapper).collect(Collectors.toList());
   }
 
-  public static <T> List<T> filter(Collection<T> collection, Predicate<T> predicate) {
+  public static <T> List<T> filter(final Collection<T> collection, final Predicate<T> predicate) {
     return filter(collection.stream(), predicate);
   }
 
-  public static <T> List<T> filter(Stream<T> filterStream, Predicate<T> predicate) {
+  public static <T> List<T> filter(final Stream<T> filterStream, final Predicate<T> predicate) {
     return filterStream.filter(predicate).collect(Collectors.toList());
   }
 
-  public static List<String> toSafeListOfStrings(Collection<?> aCollection) {
+  public static List<String> toSafeListOfStrings(final Collection<?> aCollection) {
     return map(withoutNulls(aCollection), Object::toString);
   }
 
-  public static String[] toSafeArrayOfStrings(Collection<?> aCollection) {
+  public static String[] toSafeArrayOfStrings(final Collection<?> aCollection) {
     return toSafeListOfStrings(aCollection).toArray(new String[] {});
   }
 
-  public static List<String> toSafeListOfStrings(Object... objects) {
+  public static List<String> toSafeListOfStrings(final Object... objects) {
     return toSafeListOfStrings(Arrays.asList(objects));
   }
 
-  public static List<Long> toSafeListOfLongs(Collection<String> aCollection) {
+  public static List<Long> toSafeListOfLongs(final Collection<String> aCollection) {
     return map(withoutNulls(aCollection), STRING_TO_LONG);
   }
 
-  public static <T> void addNotNull(Collection<T> collection, T object) {
+  public static <T> void addNotNull(final Collection<T> collection, final T object) {
     if (collection != null && object != null) {
       collection.add(object);
     }
   }
 
-  public static List<Integer> fromTo(int from, int to) {
+  public static List<Integer> fromTo(final int from, final int to) {
     final List<Integer> result = new ArrayList<>();
     for (int i = from; i <= to; i++) {
       result.add(i);
@@ -135,15 +140,15 @@ public abstract class CollectionUtil {
     return result;
   }
 
-  public static boolean isNotEmpty(Collection<?> aCollection) {
+  public static boolean isNotEmpty(final Collection<?> aCollection) {
     return aCollection != null && !aCollection.isEmpty();
   }
 
-  public static boolean isEmpty(Collection<?> aCollection) {
+  public static boolean isEmpty(final Collection<?> aCollection) {
     return aCollection == null || aCollection.isEmpty();
   }
 
-  public static boolean isEmpty(Object... objects) {
+  public static boolean isEmpty(final Object... objects) {
     return objects == null || objects.length == 0;
   }
 
@@ -154,28 +159,32 @@ public abstract class CollectionUtil {
    * @param <E>
    * @return
    */
-  public static <E> List<E> splitAndGetSublist(List<E> list, int subsetCount, int subsetId) {
+  public static <E> List<E> splitAndGetSublist(
+      final List<E> list, final int subsetCount, final int subsetId) {
     if (subsetId >= subsetCount) {
       return new ArrayList<>();
     }
     final Integer size = list.size();
     final int bucketSize = (int) Math.round((double) size / (double) subsetCount);
     final int start = bucketSize * subsetId;
+    if (start >= size) {
+      return new ArrayList<>();
+    }
     final int end;
     if (subsetId == subsetCount - 1) {
       end = size;
     } else {
-      end = start + bucketSize;
+      end = Math.min(start + bucketSize, size);
     }
     return new ArrayList<>(list.subList(start, end));
   }
 
-  public static <T> T chooseOne(List<T> items) {
+  public static <T> T chooseOne(final List<T> items) {
     return items.get(new Random().nextInt(items.size()));
   }
 
-  public static <T> boolean allElementsAreOfType(Class clazz, T... array) {
-    for (T element : array) {
+  public static <T> boolean allElementsAreOfType(final Class clazz, final T... array) {
+    for (final T element : array) {
       if (!clazz.isInstance(element)) {
         return false;
       }
@@ -183,14 +192,14 @@ public abstract class CollectionUtil {
     return true;
   }
 
-  public static long countNonNullObjects(Object... objects) {
+  public static long countNonNullObjects(final Object... objects) {
     return Arrays.stream(objects).filter(Objects::nonNull).count();
   }
 
   public static <T> List<T> reversedView(final List<T> list) {
     return new AbstractList<T>() {
       @Override
-      public T get(int index) {
+      public T get(final int index) {
         return list.get(list.size() - 1 - index);
       }
 

--- a/operate/common/src/main/java/io/camunda/operate/util/CollectionUtil.java
+++ b/operate/common/src/main/java/io/camunda/operate/util/CollectionUtil.java
@@ -164,19 +164,13 @@ public abstract class CollectionUtil {
     if (subsetId >= subsetCount) {
       return new ArrayList<>();
     }
-    final Integer size = list.size();
-    final int bucketSize = (int) Math.round((double) size / (double) subsetCount);
+    final int size = list.size();
+    final int bucketSize = (int) Math.ceil((double) size / (double) subsetCount);
     final int start = bucketSize * subsetId;
     if (start >= size) {
       return new ArrayList<>();
     }
-    final int end;
-    if (subsetId == subsetCount - 1) {
-      end = size;
-    } else {
-      end = Math.min(start + bucketSize, size);
-    }
-    return new ArrayList<>(list.subList(start, end));
+    return new ArrayList<>(list.subList(start, Math.min(start + bucketSize, size)));
   }
 
   public static <T> T chooseOne(final List<T> items) {

--- a/operate/common/src/test/java/io/camunda/operate/util/CollectionUtilTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/util/CollectionUtilTest.java
@@ -79,5 +79,11 @@ public class CollectionUtilTest {
 
     partitions = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8);
     assertThat(CollectionUtil.splitAndGetSublist(partitions, 3, 4)).isEmpty();
+
+    // threadsCount > partitions.size(): excess threads must return empty (not throw IOOB)
+    assertThat(CollectionUtil.splitAndGetSublist(List.of(1, 2), 4, 2)).isEmpty();
+    assertThat(CollectionUtil.splitAndGetSublist(List.of(1, 2), 4, 3)).isEmpty();
+    assertThat(CollectionUtil.splitAndGetSublist(List.of(1, 2, 3), 5, 3)).isEmpty();
+    assertThat(CollectionUtil.splitAndGetSublist(List.of(1, 2, 3), 5, 4)).isEmpty();
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
@@ -18,6 +18,7 @@ import io.camunda.operate.Metrics;
 import io.camunda.operate.archiver.Archiver;
 import io.camunda.operate.archiver.BatchOperationArchiverJob;
 import io.camunda.operate.archiver.ProcessInstancesArchiverJob;
+import io.camunda.operate.archiver.ProcessInstancesByIdArchiverJob;
 import io.camunda.operate.archiver.StandaloneDecisionArchiverJob;
 import io.camunda.operate.entities.BatchOperationEntity;
 import io.camunda.operate.entities.OperationType;
@@ -203,6 +204,111 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
             containsString("operate_archiver_query"),
             containsString("operate_archiver_reindex_query"),
             containsString("operate_archiver_delete_query")));
+  }
+
+  @Test
+  public void shouldArchiveProcessInstancesById() throws ArchiverException, IOException {
+    // given
+    final Instant currentTime = pinZeebeTime();
+
+    offsetZeebeTime(Duration.ofDays(-4));
+    final String processId = "demoProcess";
+    final String activityId = "task1";
+    deployProcessWithOneActivity(processId, activityId);
+
+    final int count1 = random.nextInt(6) + 5;
+    final List<Long> ids1 =
+        startInstances(processId, count1, currentTime.minus(3, ChronoUnit.DAYS));
+    createOperations(ids1);
+    final Instant endDate1 = currentTime.minus(2, ChronoUnit.DAYS);
+    finishInstances(count1, endDate1, activityId);
+    searchTestRule.processAllRecordsAndWait(processInstancesAreFinishedCheck, ids1);
+
+    final int count2 = random.nextInt(6) + 5;
+    final List<Long> ids2 = startInstances(processId, count2, endDate1);
+    createOperations(ids2);
+    final Instant endDate2 = currentTime.minus(1, ChronoUnit.DAYS);
+    finishInstances(count2, endDate2, activityId);
+    searchTestRule.processAllRecordsAndWait(processInstancesAreFinishedCheck, ids2);
+
+    final int count3 = random.nextInt(6) + 5;
+    final List<Long> ids3 = startInstances(processId, count3, endDate2);
+
+    resetZeebeTime();
+
+    final ProcessInstancesByIdArchiverJob job =
+        beanFactory.getBean(
+            ProcessInstancesByIdArchiverJob.class, archiver, partitionHolder.getPartitionIds());
+
+    // when
+    assertThat(job.archiveNextBatch().join()).isEqualTo(count1);
+    searchTestRule.refreshSerchIndexes();
+    assertThat(job.archiveNextBatch().join()).isEqualTo(count2);
+    searchTestRule.refreshSerchIndexes();
+    assertThat(job.archiveNextBatch().join()).isEqualTo(0);
+    searchTestRule.refreshSerchIndexes();
+
+    // then
+    assertInstancesInCorrectIndex(count1, ids1, endDate1, true);
+    assertInstancesInCorrectIndex(count2, ids2, endDate2, true);
+    assertInstancesInCorrectIndex(count3, ids3, null, true);
+    assertAllInstancesInAlias(count1 + count2 + count3);
+
+    assertThatMetricsFrom(
+        mockMvc,
+        allOf(
+            new MetricAssert.ValueMatcher(
+                "operate_archived_process_instances_total",
+                d -> d.doubleValue() == count1 + count2),
+            containsString("operate_archiver_request_duration")));
+  }
+
+  @Test
+  public void shouldArchiveProcessInstancesByIdWithSmallBatchSize()
+      throws ArchiverException, IOException {
+    // given — batch size of 1 forces a separate searchAfter page per document inside
+    // moveDocumentsById, exercising the pagination loop in ArchiveByIdTaskSupplier
+    operateProperties.getArchiver().setArchiveByIdBatchSize(1);
+    try {
+      final Instant currentTime = pinZeebeTime();
+
+      offsetZeebeTime(Duration.ofDays(-4));
+      final String processId = "demoProcess";
+      final String activityId = "task1";
+      deployProcessWithOneActivity(processId, activityId);
+
+      final int count = random.nextInt(3) + 3;
+      final List<Long> ids =
+          startInstances(processId, count, currentTime.minus(3, ChronoUnit.DAYS));
+      createOperations(ids);
+      final Instant endDate = currentTime.minus(2, ChronoUnit.DAYS);
+      finishInstances(count, endDate, activityId);
+      searchTestRule.processAllRecordsAndWait(processInstancesAreFinishedCheck, ids);
+
+      resetZeebeTime();
+
+      final ProcessInstancesByIdArchiverJob job =
+          beanFactory.getBean(
+              ProcessInstancesByIdArchiverJob.class, archiver, partitionHolder.getPartitionIds());
+
+      // when
+      assertThat(job.archiveNextBatch().join()).isEqualTo(count);
+      searchTestRule.refreshSerchIndexes();
+      assertThat(job.archiveNextBatch().join()).isEqualTo(0);
+      searchTestRule.refreshSerchIndexes();
+
+      // then — all docs must be in destination index despite multiple searchAfter pages
+      assertInstancesInCorrectIndex(count, ids, endDate, true);
+      assertAllInstancesInAlias(count);
+      // pagination proof: with batchSize=1 the PI template alone requires count+1 search calls,
+      // so the total search histogram count must exceed count
+      assertThatMetricsFrom(
+          mockMvc,
+          new MetricAssert.ValueMatcher(
+              "operate_archiver_request_duration_seconds_count", d -> d > count, "type", "search"));
+    } finally {
+      operateProperties.getArchiver().setArchiveByIdBatchSize(500);
+    }
   }
 
   protected void createOperations(final List<Long> ids1) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
@@ -133,7 +133,7 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  public void testArchivingProcessInstances() throws ArchiverException, IOException {
+  public void testArchivingProcessInstances() throws IOException {
 
     final Instant currentTime = pinZeebeTime();
 
@@ -207,7 +207,7 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  public void shouldArchiveProcessInstancesById() throws ArchiverException, IOException {
+  public void shouldArchiveProcessInstancesById() throws IOException {
     // given
     final Instant currentTime = pinZeebeTime();
 
@@ -253,6 +253,8 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
     assertInstancesInCorrectIndex(count2, ids2, endDate2, true);
     assertInstancesInCorrectIndex(count3, ids3, null, true);
     assertAllInstancesInAlias(count1 + count2 + count3);
+    assertRemovedFromSourceIndices(ids1);
+    assertRemovedFromSourceIndices(ids2);
 
     assertThatMetricsFrom(
         mockMvc,
@@ -318,6 +320,27 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
         new CreateBatchOperationRequestDto(
             query, OperationType.CANCEL_PROCESS_INSTANCE); // the type does not matter
     batchOperationWriter.scheduleBatchOperation(batchOperationRequest);
+  }
+
+  private void assertRemovedFromSourceIndices(final List<Long> ids) throws IOException {
+    final List<ProcessInstanceForListViewEntity> remaining =
+        testSearchRepository.getProcessInstances(
+            processInstanceTemplate.getFullQualifiedName(), ids);
+    assertThat(remaining).as("archived PIs must be removed from source list-view index").isEmpty();
+
+    for (final ProcessInstanceDependant template : processInstanceDependantTemplates) {
+      final List<Long> remainingIds =
+          testSearchRepository.searchIds(
+              template.getFullQualifiedName(),
+              ProcessInstanceDependant.PROCESS_INSTANCE_KEY,
+              ids,
+              ids.size() * 100);
+      assertThat(remainingIds)
+          .as(
+              "archived dependants must be removed from source index %s",
+              template.getFullQualifiedName())
+          .isEmpty();
+    }
   }
 
   private void assertAllInstancesInAlias(final int count) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/MetricAssert.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/MetricAssert.java
@@ -58,6 +58,9 @@ public class MetricAssert {
      */
     public ValueMatcher(
         final String metricName, final Predicate<Double> valueMatcher, final String... tags) {
+      if (tags.length % 2 != 0) {
+        throw new IllegalArgumentException("tags must be provided as alternating key/value pairs");
+      }
       this.metricName = metricName.toLowerCase();
       this.valueMatcher = valueMatcher;
       this.tags = tags;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/MetricAssert.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/MetricAssert.java
@@ -32,11 +32,12 @@ public class MetricAssert {
   //    }
   //  }
 
-  public static void assertThatMetricsFrom(MockMvc mockMvc, Matcher<? super String> matcher) {
+  public static void assertThatMetricsFrom(
+      final MockMvc mockMvc, final Matcher<? super String> matcher) {
     final MockHttpServletRequestBuilder request = get("/actuator/prometheus");
     try {
       mockMvc.perform(request).andExpect(status().isOk()).andExpect(content().string(matcher));
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new RuntimeException("Exception while asserting:" + e.getMessage(), e);
     }
   }
@@ -45,14 +46,25 @@ public class MetricAssert {
 
     private final String metricName;
     private final Predicate<Double> valueMatcher;
+    private final String[] tags;
 
-    public ValueMatcher(String metricName, Predicate<Double> valueMatcher) {
+    public ValueMatcher(final String metricName, final Predicate<Double> valueMatcher) {
+      this(metricName, valueMatcher, new String[0]);
+    }
+
+    /**
+     * @param tags alternating key/value pairs, e.g. {@code "type", "search"} — each pair is matched
+     *     as {@code key="value"} in the Prometheus line
+     */
+    public ValueMatcher(
+        final String metricName, final Predicate<Double> valueMatcher, final String... tags) {
       this.metricName = metricName.toLowerCase();
       this.valueMatcher = valueMatcher;
+      this.tags = tags;
     }
 
     @Override
-    public boolean matches(Object o) {
+    public boolean matches(final Object o) {
       final Double metricValue = getMetricValue(o);
       if (metricValue != null) {
         return valueMatcher.test(metricValue);
@@ -60,7 +72,7 @@ public class MetricAssert {
       return false;
     }
 
-    public Double getMetricValue(Object o) {
+    public Double getMetricValue(final Object o) {
       final Optional<String> metricString = getMetricString(o);
       if (metricString.isPresent()) {
         final String[] oneMetric = metricString.get().split(" ");
@@ -71,15 +83,25 @@ public class MetricAssert {
       return null;
     }
 
-    public Optional<String> getMetricString(Object o) {
+    public Optional<String> getMetricString(final Object o) {
       final String s = (String) o;
       final String[] strings = s.split("\\n");
       return Arrays.stream(strings)
           .filter(str -> str.toLowerCase().contains(metricName) && !str.startsWith("#"))
+          .filter(this::allTagsPresent)
           .findFirst();
     }
 
+    private boolean allTagsPresent(final String line) {
+      for (int i = 0; i + 1 < tags.length; i += 2) {
+        if (!line.contains(tags[i] + "=\"" + tags[i + 1] + "\"")) {
+          return false;
+        }
+      }
+      return true;
+    }
+
     @Override
-    public void describeTo(Description description) {}
+    public void describeTo(final Description description) {}
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Backports, manually, the archive-by-ID code path from 8.8+ to Operate 8.7 as an opt-in feature behind `CAMUNDA_OPERATE_ARCHIVER_ARCHIVE_BY_ID` (default: `false`, existing behavior unchanged). Only the most important code is backported. It also resolves two bugs around partition assignment to archiver threads.

To discover the batched it still uses the same mechanism as the existing archiver, i.e., using a date-histogram + topHits aggregation. This will be improved in a separate PR.

Note that this PR only concerns the Operate. Tasklist will be kept on its existing archiver.

**Changes:**

- `ArchiverProperties`: adds `archiveById` flag and `archiveByIdBatchSize` (default 500)
- `ProcessInstancesByIdArchiverJob`: new prototype-scoped job driving the new code path
- `ElasticsearchArchiverRepository` / `OpensearchArchiverRepository`: `moveDocumentsById` with
  searchAfter pagination; emits `archiver.request.duration` histogram tagged
  `type=search/reindex/delete` and counts archived docs via `archiver.reindexed.docs`
- `CollectionUtil.splitAndGetSublist`: fixes `Math.round` → `Math.ceil` (rounds to 0 when
  `threadsCount > 2 × partitions.size()`)
- `Archiver`: caps thread loop to `min(threadsCount, partitions.size())`
- `MetricAssert.ValueMatcher`: extended with tag-pair constructor for Prometheus line filtering
- Tests: `AsyncRepeatUntilTest` (backported), `ArchiverZeebeIT` (archive-by-ID correctness +
  pagination proof)


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54452 
