### PR TITLE
feat: add scoped conversation history to agent details

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/ConversationToggles.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/ConversationToggles.tsx
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {QuerySortOrder} from '@camunda/camunda-api-zod-schemas/8.10';
+import {Button, ButtonSet} from '@carbon/react';
+import {
+  Filter,
+  FilterRemove,
+  SortAscending,
+  SortDescending,
+} from '@carbon/react/icons';
+
+type ConversationTogglesProps = {
+  sortOrder: QuerySortOrder;
+  canBeScoped: boolean;
+  isScoped: boolean;
+  onToggleSortOrder: () => void;
+  onToggleScope: () => void;
+};
+
+const ConversationToggles: React.FC<ConversationTogglesProps> = (props) => (
+  <ButtonSet>
+    <Button
+      kind="ghost"
+      size="xs"
+      renderIcon={props.sortOrder === 'desc' ? SortDescending : SortAscending}
+      onClick={props.onToggleSortOrder}
+    >
+      {props.sortOrder === 'desc' ? 'Most recent first' : 'Oldest first'}
+    </Button>
+    {props.canBeScoped && (
+      <Button
+        kind="ghost"
+        size="xs"
+        renderIcon={props.isScoped ? Filter : FilterRemove}
+        onClick={props.onToggleScope}
+      >
+        {props.isScoped ? 'Scoped conversation' : 'Whole conversation'}
+      </Button>
+    )}
+  </ButtonSet>
+);
+
+export {ConversationToggles};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -51,6 +51,8 @@ describe('<ConversationHistory />', () => {
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
         isVisible
+        selectedElementInstanceKey={null}
+        hasMultipleActivations={false}
       />,
       {wrapper: createWrapper()},
     );
@@ -68,6 +70,8 @@ describe('<ConversationHistory />', () => {
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
         isVisible
+        selectedElementInstanceKey={null}
+        hasMultipleActivations={false}
       />,
       {wrapper: createWrapper()},
     );
@@ -89,6 +93,8 @@ describe('<ConversationHistory />', () => {
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
         isVisible
+        selectedElementInstanceKey={null}
+        hasMultipleActivations={false}
       />,
       {wrapper: createWrapper()},
     );
@@ -128,6 +134,8 @@ describe('<ConversationHistory />', () => {
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
         isVisible
+        selectedElementInstanceKey={null}
+        hasMultipleActivations={false}
       />,
       {wrapper: createWrapper()},
     );
@@ -178,6 +186,8 @@ describe('<ConversationHistory />', () => {
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
         isVisible
+        selectedElementInstanceKey={null}
+        hasMultipleActivations={false}
       />,
       {wrapper: createWrapper()},
     );
@@ -222,6 +232,8 @@ describe('<ConversationHistory />', () => {
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
         isVisible
+        selectedElementInstanceKey={null}
+        hasMultipleActivations={false}
       />,
       {wrapper: createWrapper()},
     );
@@ -282,6 +294,8 @@ describe('<ConversationHistory />', () => {
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
         isVisible
+        selectedElementInstanceKey={null}
+        hasMultipleActivations={false}
       />,
       {wrapper: createWrapper()},
     );
@@ -359,6 +373,8 @@ describe('<ConversationHistory />', () => {
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
         isVisible
+        selectedElementInstanceKey={null}
+        hasMultipleActivations={false}
       />,
       {wrapper: createWrapper()},
     );
@@ -407,6 +423,8 @@ describe('<ConversationHistory />', () => {
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
         isVisible
+        selectedElementInstanceKey={null}
+        hasMultipleActivations={false}
       />,
       {wrapper: createWrapper()},
     );
@@ -451,6 +469,8 @@ describe('<ConversationHistory />', () => {
         agentInstanceKey={AGENT_INSTANCE_KEY}
         enablePeriodicRefetch={false}
         isVisible
+        selectedElementInstanceKey={null}
+        hasMultipleActivations={false}
       />,
       {wrapper: createWrapper()},
     );
@@ -477,5 +497,73 @@ describe('<ConversationHistory />', () => {
     expect(
       messageNoMetrics.queryByTestId('message-duration-metric'),
     ).not.toBeInTheDocument();
+  });
+
+  it('should only show a scope hint when the agent was activated multiple times', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([mockAgentInstanceHistoryItem({role: 'ASSISTANT'})]),
+    );
+
+    const {rerender} = render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+        isVisible
+        selectedElementInstanceKey="111"
+        hasMultipleActivations={false}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    expect(
+      screen.queryByText(
+        'History is scoped to the selected AI agent activation. Other element instances contain more conversation messages.',
+      ),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+        isVisible
+        selectedElementInstanceKey="111"
+        hasMultipleActivations={true}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        'History is scoped to the selected AI agent activation. Other element instances contain more conversation messages.',
+      ),
+    ).toBeVisible();
+  });
+
+  it('should show a scoped empty hint when the agent was activated multiple times', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+        isVisible
+        selectedElementInstanceKey="111"
+        hasMultipleActivations
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    expect(
+      screen.getByText(
+        'No conversation with the agent instance for this activation found.',
+      ),
+    ).toBeVisible();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -26,7 +26,7 @@ import {mockServer} from 'modules/mock-server/node';
 import {http} from 'msw';
 import {
   endpoints,
-  type QueryAgentInstancesRequestBody,
+  type QueryAgentInstanceHistoryRequestBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
 const AGENT_INSTANCE_KEY = '2251799813851828';
@@ -576,7 +576,8 @@ describe('<ConversationHistory />', () => {
           agentInstanceKey: AGENT_INSTANCE_KEY,
         }),
         async ({request}) => {
-          const req = (await request.json()) as QueryAgentInstancesRequestBody;
+          const req =
+            (await request.json()) as QueryAgentInstanceHistoryRequestBody;
           filter = req.filter;
           return Response.json(searchResult([item]));
         },

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -9,6 +9,7 @@
 import {
   render,
   screen,
+  waitFor,
   waitForElementToBeRemoved,
   within,
 } from 'modules/testing-library';
@@ -23,7 +24,10 @@ import {mockAgentInstanceHistoryItem} from 'modules/mocks/mockAgentInstanceHisto
 import {Paths} from 'modules/Routes';
 import {mockServer} from 'modules/mock-server/node';
 import {http} from 'msw';
-import {endpoints} from '@camunda/camunda-api-zod-schemas/8.10';
+import {
+  endpoints,
+  type QueryAgentInstancesRequestBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 
 const AGENT_INSTANCE_KEY = '2251799813851828';
 
@@ -52,7 +56,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={[]}
       />,
       {wrapper: createWrapper()},
     );
@@ -71,7 +75,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={[]}
       />,
       {wrapper: createWrapper()},
     );
@@ -94,7 +98,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={[]}
       />,
       {wrapper: createWrapper()},
     );
@@ -135,7 +139,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={[]}
       />,
       {wrapper: createWrapper()},
     );
@@ -187,7 +191,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={[]}
       />,
       {wrapper: createWrapper()},
     );
@@ -233,7 +237,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={[]}
       />,
       {wrapper: createWrapper()},
     );
@@ -251,15 +255,14 @@ describe('<ConversationHistory />', () => {
     );
 
     await user.click(sortButton);
-    await waitForElementToBeRemoved(
-      screen.queryByTestId('conversation-history-skeleton'),
-    );
 
     expect(screen.getByRole('button', {name: 'Oldest first'})).toBeVisible();
-    expect(query).toEqual(
-      expect.objectContaining({
-        sort: [{field: 'producedAt', order: 'asc'}],
-      }),
+    await waitFor(() =>
+      expect(query).toEqual(
+        expect.objectContaining({
+          sort: [{field: 'producedAt', order: 'asc'}],
+        }),
+      ),
     );
   });
 
@@ -295,7 +298,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={[]}
       />,
       {wrapper: createWrapper()},
     );
@@ -374,7 +377,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={[]}
       />,
       {wrapper: createWrapper()},
     );
@@ -424,7 +427,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={[]}
       />,
       {wrapper: createWrapper()},
     );
@@ -470,7 +473,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={[]}
       />,
       {wrapper: createWrapper()},
     );
@@ -499,7 +502,10 @@ describe('<ConversationHistory />', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should only show a scope hint when the agent was activated multiple times', async () => {
+  it('should only show a scope toggle when the agent was activated multiple times', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([mockAgentInstanceHistoryItem({role: 'ASSISTANT'})]),
+    );
     mockSearchAgentInstanceHistory().withSuccess(
       searchResult([mockAgentInstanceHistoryItem({role: 'ASSISTANT'})]),
     );
@@ -510,7 +516,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey="111"
-        hasMultipleActivations={false}
+        agentsElementInstanceKeys={['111']}
       />,
       {wrapper: createWrapper()},
     );
@@ -520,9 +526,7 @@ describe('<ConversationHistory />', () => {
     );
 
     expect(
-      screen.queryByText(
-        'History is scoped to the selected AI agent activation. Other element instances contain more conversation messages.',
-      ),
+      screen.queryByRole('button', {name: 'Scoped conversation'}),
     ).not.toBeInTheDocument();
 
     rerender(
@@ -531,14 +535,12 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey="111"
-        hasMultipleActivations={true}
+        agentsElementInstanceKeys={['111', '222']}
       />,
     );
 
     expect(
-      screen.getByText(
-        'History is scoped to the selected AI agent activation. Other element instances contain more conversation messages.',
-      ),
+      screen.getByRole('button', {name: 'Scoped conversation'}),
     ).toBeVisible();
   });
 
@@ -551,7 +553,7 @@ describe('<ConversationHistory />', () => {
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey="111"
-        hasMultipleActivations
+        agentsElementInstanceKeys={['111', '222']}
       />,
       {wrapper: createWrapper()},
     );
@@ -561,9 +563,58 @@ describe('<ConversationHistory />', () => {
     );
 
     expect(
-      screen.getByText(
-        'No conversation with the agent instance for this activation found.',
-      ),
+      screen.getByText('No scoped conversation with the agent instance found.'),
     ).toBeVisible();
+  });
+
+  it('should toggle between scoped and whole conversation history', async () => {
+    let filter: unknown;
+    const item = mockAgentInstanceHistoryItem();
+    mockServer.use(
+      http.post(
+        endpoints.queryAgentInstanceHistory.getUrl({
+          agentInstanceKey: AGENT_INSTANCE_KEY,
+        }),
+        async ({request}) => {
+          const req = (await request.json()) as QueryAgentInstancesRequestBody;
+          filter = req.filter;
+          return Response.json(searchResult([item]));
+        },
+      ),
+    );
+
+    const {user} = render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        enablePeriodicRefetch={false}
+        isVisible
+        selectedElementInstanceKey="111"
+        agentsElementInstanceKeys={['111', '222']}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    const scopeButton = screen.getByRole('button', {
+      name: 'Scoped conversation',
+    });
+    expect(scopeButton).toBeVisible();
+    expect(filter).toEqual(
+      expect.objectContaining({elementInstanceKey: '111'}),
+    );
+
+    await user.click(scopeButton);
+
+    expect(
+      screen.getByRole('button', {name: 'Whole conversation'}),
+    ).toBeVisible();
+    await waitFor(() =>
+      expect(filter).not.toEqual(
+        expect.objectContaining({elementInstanceKey: '111'}),
+      ),
+    );
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -7,15 +7,20 @@
  */
 
 import {useState} from 'react';
-import {Button, SkeletonText} from '@carbon/react';
-import {SortAscending, SortDescending} from '@carbon/react/icons';
+import {Button, ButtonSet, SkeletonText} from '@carbon/react';
+import {
+  Filter,
+  FilterRemove,
+  SortAscending,
+  SortDescending,
+} from '@carbon/react/icons';
 import type {QuerySortOrder} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
 import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
 import {
   ConversationContainer,
-  HistoryControls,
+  Messages,
   StatusHint,
   ShowMoreButton,
 } from './styled';
@@ -23,31 +28,41 @@ import {flattenPaginatedPages} from 'modules/queries/flattenPaginatedPages';
 
 type ConversationHistoryProps = {
   agentInstanceKey: string;
-  hasMultipleActivations: boolean;
   isVisible: boolean;
   enablePeriodicRefetch: boolean;
   selectedElementInstanceKey: string | null;
+  agentsElementInstanceKeys: string[];
 };
 
 const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   agentInstanceKey,
-  hasMultipleActivations,
   isVisible,
   enablePeriodicRefetch,
   selectedElementInstanceKey,
+  agentsElementInstanceKeys,
 }) => {
-  const showScopedHint =
-    hasMultipleActivations && selectedElementInstanceKey !== null;
+  const canBeScoped =
+    agentsElementInstanceKeys.length > 1 && selectedElementInstanceKey !== null;
+
   const [sortOrder, setSortOrder] = useState<QuerySortOrder>('desc');
+  const [isScoped, setIsScoped] = useState(true);
+
   const {selectElement} = useProcessInstanceElementSelectActions();
-  const {data, status, hasNextPage, fetchNextPage, isFetchingNextPage} =
-    useAgentInstanceHistory(agentInstanceKey, {
-      enabled: isVisible,
-      enablePeriodicRefetch,
-      sortOrder,
-      elementInstanceKey: selectedElementInstanceKey ?? undefined,
-      select: flattenPaginatedPages,
-    });
+  const {
+    data,
+    status,
+    isPlaceholderData,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useAgentInstanceHistory(agentInstanceKey, {
+    enabled: isVisible,
+    enablePeriodicRefetch,
+    sortOrder,
+    elementInstanceKey:
+      canBeScoped && isScoped ? selectedElementInstanceKey : null,
+    select: flattenPaginatedPages,
+  });
 
   if (status === 'pending') {
     return (
@@ -61,51 +76,42 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
     return <StatusHint>Failed to load conversation history.</StatusHint>;
   }
 
-  if (data.items.length === 0) {
-    return (
-      <StatusHint>
-        {showScopedHint
-          ? 'No conversation with the agent instance for this activation found.'
-          : 'No conversation with this agent instance found.'}
-      </StatusHint>
-    );
-  }
-
   return (
     <ConversationContainer>
-      <HistoryControls>
-        <Button
-          kind="ghost"
-          size="xs"
-          renderIcon={sortOrder === 'desc' ? SortDescending : SortAscending}
-          onClick={() =>
-            setSortOrder((prev) => (prev === 'desc' ? 'asc' : 'desc'))
-          }
-        >
-          {sortOrder === 'desc' ? 'Most recent first' : 'Oldest first'}
-        </Button>
-        {showScopedHint && (
+      <ConversationToggles
+        sortOrder={sortOrder}
+        canBeScoped={canBeScoped}
+        isScoped={isScoped}
+        onToggleSortOrder={() =>
+          setSortOrder((prev) => (prev === 'desc' ? 'asc' : 'desc'))
+        }
+        onToggleScope={() => setIsScoped((prev) => !prev)}
+      />
+      <Messages data-dimmed={isPlaceholderData}>
+        {data.items.length === 0 ? (
           <StatusHint>
-            History is scoped to the selected AI agent activation. Other element
-            instances contain more conversation messages.
+            {canBeScoped && isScoped
+              ? 'No scoped conversation with the agent instance found.'
+              : 'No conversation with this agent instance found.'}
           </StatusHint>
+        ) : (
+          data.items.map((item) => (
+            <ConversationMessage
+              key={item.historyItemKey}
+              historyItemKey={item.historyItemKey}
+              actor={item.role}
+              content={item.content}
+              toolCalls={item.toolCalls}
+              metrics={item.metrics}
+              onToolCallClick={(toolCall) => {
+                if (toolCall.elementId !== null) {
+                  selectElement({elementId: toolCall.elementId});
+                }
+              }}
+            />
+          ))
         )}
-      </HistoryControls>
-      {data.items.map((item) => (
-        <ConversationMessage
-          key={item.historyItemKey}
-          historyItemKey={item.historyItemKey}
-          actor={item.role}
-          content={item.content}
-          toolCalls={item.toolCalls}
-          metrics={item.metrics}
-          onToolCallClick={(toolCall) => {
-            if (toolCall.elementId !== null) {
-              selectElement({elementId: toolCall.elementId});
-            }
-          }}
-        />
-      ))}
+      </Messages>
       {isFetchingNextPage && <SkeletonText paragraph lineCount={2} />}
       {!isFetchingNextPage && hasNextPage && (
         <ShowMoreButton kind="ghost" size="sm" onClick={() => fetchNextPage()}>
@@ -115,5 +121,36 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
     </ConversationContainer>
   );
 };
+
+type ConersationTogglesProps = {
+  sortOrder: QuerySortOrder;
+  canBeScoped: boolean;
+  isScoped: boolean;
+  onToggleSortOrder: () => void;
+  onToggleScope: () => void;
+};
+
+const ConversationToggles: React.FC<ConersationTogglesProps> = (props) => (
+  <ButtonSet>
+    <Button
+      kind="ghost"
+      size="xs"
+      renderIcon={props.sortOrder === 'desc' ? SortDescending : SortAscending}
+      onClick={props.onToggleSortOrder}
+    >
+      {props.sortOrder === 'desc' ? 'Most recent first' : 'Oldest first'}
+    </Button>
+    {props.canBeScoped && (
+      <Button
+        kind="ghost"
+        size="xs"
+        renderIcon={props.isScoped ? Filter : FilterRemove}
+        onClick={props.onToggleScope}
+      >
+        {props.isScoped ? 'Scoped conversation' : 'Whole conversation'}
+      </Button>
+    )}
+  </ButtonSet>
+);
 
 export {ConversationHistory};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -13,20 +13,31 @@ import type {QuerySortOrder} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
 import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
-import {ConversationContainer, StatusHint, ShowMoreButton} from './styled';
+import {
+  ConversationContainer,
+  HistoryControls,
+  StatusHint,
+  ShowMoreButton,
+} from './styled';
 import {flattenPaginatedPages} from 'modules/queries/flattenPaginatedPages';
 
 type ConversationHistoryProps = {
   agentInstanceKey: string;
+  hasMultipleActivations: boolean;
   isVisible: boolean;
   enablePeriodicRefetch: boolean;
+  selectedElementInstanceKey: string | null;
 };
 
 const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   agentInstanceKey,
+  hasMultipleActivations,
   isVisible,
   enablePeriodicRefetch,
+  selectedElementInstanceKey,
 }) => {
+  const showScopedHint =
+    hasMultipleActivations && selectedElementInstanceKey !== null;
   const [sortOrder, setSortOrder] = useState<QuerySortOrder>('desc');
   const {selectElement} = useProcessInstanceElementSelectActions();
   const {data, status, hasNextPage, fetchNextPage, isFetchingNextPage} =
@@ -34,6 +45,7 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
       enabled: isVisible,
       enablePeriodicRefetch,
       sortOrder,
+      elementInstanceKey: selectedElementInstanceKey ?? undefined,
       select: flattenPaginatedPages,
     });
 
@@ -51,22 +63,34 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
 
   if (data.items.length === 0) {
     return (
-      <StatusHint>No conversation with this agent instance found.</StatusHint>
+      <StatusHint>
+        {showScopedHint
+          ? 'No conversation with the agent instance for this activation found.'
+          : 'No conversation with this agent instance found.'}
+      </StatusHint>
     );
   }
 
   return (
     <ConversationContainer>
-      <Button
-        kind="ghost"
-        size="xs"
-        renderIcon={sortOrder === 'desc' ? SortDescending : SortAscending}
-        onClick={() =>
-          setSortOrder((prev) => (prev === 'desc' ? 'asc' : 'desc'))
-        }
-      >
-        {sortOrder === 'desc' ? 'Most recent first' : 'Oldest first'}
-      </Button>
+      <HistoryControls>
+        <Button
+          kind="ghost"
+          size="xs"
+          renderIcon={sortOrder === 'desc' ? SortDescending : SortAscending}
+          onClick={() =>
+            setSortOrder((prev) => (prev === 'desc' ? 'asc' : 'desc'))
+          }
+        >
+          {sortOrder === 'desc' ? 'Most recent first' : 'Oldest first'}
+        </Button>
+        {showScopedHint && (
+          <StatusHint>
+            History is scoped to the selected AI agent activation. Other element
+            instances contain more conversation messages.
+          </StatusHint>
+        )}
+      </HistoryControls>
       {data.items.map((item) => (
         <ConversationMessage
           key={item.historyItemKey}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -122,7 +122,7 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   );
 };
 
-type ConersationTogglesProps = {
+type ConversationTogglesProps = {
   sortOrder: QuerySortOrder;
   canBeScoped: boolean;
   isScoped: boolean;
@@ -130,7 +130,7 @@ type ConersationTogglesProps = {
   onToggleScope: () => void;
 };
 
-const ConversationToggles: React.FC<ConersationTogglesProps> = (props) => (
+const ConversationToggles: React.FC<ConversationTogglesProps> = (props) => (
   <ButtonSet>
     <Button
       kind="ghost"

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -7,17 +7,12 @@
  */
 
 import {useState} from 'react';
-import {Button, ButtonSet, SkeletonText} from '@carbon/react';
-import {
-  Filter,
-  FilterRemove,
-  SortAscending,
-  SortDescending,
-} from '@carbon/react/icons';
+import {SkeletonText} from '@carbon/react';
 import type {QuerySortOrder} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
 import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
+import {ConversationToggles} from './ConversationToggles';
 import {
   ConversationContainer,
   Messages,
@@ -121,36 +116,5 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
     </ConversationContainer>
   );
 };
-
-type ConversationTogglesProps = {
-  sortOrder: QuerySortOrder;
-  canBeScoped: boolean;
-  isScoped: boolean;
-  onToggleSortOrder: () => void;
-  onToggleScope: () => void;
-};
-
-const ConversationToggles: React.FC<ConversationTogglesProps> = (props) => (
-  <ButtonSet>
-    <Button
-      kind="ghost"
-      size="xs"
-      renderIcon={props.sortOrder === 'desc' ? SortDescending : SortAscending}
-      onClick={props.onToggleSortOrder}
-    >
-      {props.sortOrder === 'desc' ? 'Most recent first' : 'Oldest first'}
-    </Button>
-    {props.canBeScoped && (
-      <Button
-        kind="ghost"
-        size="xs"
-        renderIcon={props.isScoped ? Filter : FilterRemove}
-        onClick={props.onToggleScope}
-      >
-        {props.isScoped ? 'Scoped conversation' : 'Whole conversation'}
-      </Button>
-    )}
-  </ButtonSet>
-);
 
 export {ConversationHistory};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
@@ -13,6 +13,22 @@ const ConversationContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: var(--cds-spacing-04);
+
+  .cds--btn-set > .cds--btn {
+    inline-size: auto;
+  }
+`;
+
+const Messages = styled.div`
+  display: flex;
+  flex-direction: inherit;
+  gap: inherit;
+  transition: opacity 150ms ease;
+
+  &[data-dimmed='true'] {
+    opacity: 0.5;
+    pointer-events: none;
+  }
 `;
 
 const StatusHint = styled.span`
@@ -20,6 +36,7 @@ const StatusHint = styled.span`
   font-weight: var(--cds-body-compact-01-font-weight);
   line-height: var(--cds-body-compact-01-line-height);
   letter-spacing: var(--cds-body-compact-01-letter-spacing);
+  text-align: center;
   color: var(--cds-text-secondary);
 `;
 
@@ -27,11 +44,4 @@ const ShowMoreButton = styled(Button)`
   align-self: center;
 `;
 
-const HistoryControls = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: var(--cds-spacing-03);
-`;
-
-export {ConversationContainer, StatusHint, ShowMoreButton, HistoryControls};
+export {ConversationContainer, Messages, StatusHint, ShowMoreButton};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
@@ -27,4 +27,11 @@ const ShowMoreButton = styled(Button)`
   align-self: center;
 `;
 
-export {ConversationContainer, StatusHint, ShowMoreButton};
+const HistoryControls = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+`;
+
+export {ConversationContainer, StatusHint, ShowMoreButton, HistoryControls};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -281,6 +281,7 @@ describe('<AgentDetails />', () => {
         })}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.test.tsx
@@ -52,6 +52,7 @@ describe('<AgentDetails />', () => {
         agentInstance={agentInstance}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );
@@ -69,6 +70,7 @@ describe('<AgentDetails />', () => {
         agentInstance={{...agentInstance, status: 'THINKING'}}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );
@@ -85,6 +87,7 @@ describe('<AgentDetails />', () => {
         agentInstance={{...agentInstance, status: 'IDLE'}}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );
@@ -99,6 +102,7 @@ describe('<AgentDetails />', () => {
         agentInstance={{...agentInstance, status: 'COMPLETED'}}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );
@@ -115,6 +119,7 @@ describe('<AgentDetails />', () => {
         agentInstance={{...agentInstance, status: 'INITIALIZING'}}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );
@@ -131,6 +136,7 @@ describe('<AgentDetails />', () => {
         agentInstance={{...agentInstance, status: 'TOOL_DISCOVERY'}}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );
@@ -147,6 +153,7 @@ describe('<AgentDetails />', () => {
         agentInstance={undefined}
         isLoading={true}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
     );
 
@@ -160,6 +167,7 @@ describe('<AgentDetails />', () => {
         agentInstance={undefined}
         isLoading={false}
         isError={true}
+        selectedElementInstanceKey={null}
       />,
     );
 
@@ -179,6 +187,7 @@ describe('<AgentDetails />', () => {
         agentInstance={agentInstance}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );
@@ -205,6 +214,7 @@ describe('<AgentDetails />', () => {
         agentInstance={agentInstance}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );
@@ -246,6 +256,7 @@ describe('<AgentDetails />', () => {
         agentInstance={agentInstance}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );
@@ -290,6 +301,7 @@ describe('<AgentDetails />', () => {
         agentInstance={agentInstance}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );
@@ -322,6 +334,7 @@ describe('<AgentDetails />', () => {
         agentInstance={agentInstance}
         isLoading={false}
         isError={false}
+        selectedElementInstanceKey={null}
       />,
       {wrapper: createWrapper()},
     );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -109,7 +109,6 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
   const statusLabel =
     STATUS_LABELS[agentInstance.status] ?? agentInstance.status;
   const {metrics, limits, definition} = agentInstance;
-  const hasMultipleActivations = agentInstance.elementInstanceKeys.length > 1;
 
   return (
     <AgentDetailsContainer
@@ -187,7 +186,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
             isVisible={isConversationHistoryOpen}
             enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
             selectedElementInstanceKey={selectedElementInstanceKey}
-            hasMultipleActivations={hasMultipleActivations}
+            agentsElementInstanceKeys={agentInstance.elementInstanceKeys}
           />
         </AccordionItem>
         <AccordionItem

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -68,12 +68,14 @@ function StatusIcon({status}: {status: AgentInstanceStatus}) {
 }
 
 type AgentDetailsProps = {
+  selectedElementInstanceKey: string | null;
   agentInstance: AgentInstance | undefined;
   isLoading: boolean;
   isError: boolean;
 };
 
 const AgentDetails: React.FC<AgentDetailsProps> = ({
+  selectedElementInstanceKey,
   agentInstance,
   isLoading,
   isError,
@@ -107,6 +109,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
   const statusLabel =
     STATUS_LABELS[agentInstance.status] ?? agentInstance.status;
   const {metrics, limits, definition} = agentInstance;
+  const hasMultipleActivations = agentInstance.elementInstanceKeys.length > 1;
 
   return (
     <AgentDetailsContainer
@@ -183,6 +186,8 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
             agentInstanceKey={agentInstance.agentInstanceKey}
             isVisible={isConversationHistoryOpen}
             enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
+            selectedElementInstanceKey={selectedElementInstanceKey}
+            hasMultipleActivations={hasMultipleActivations}
           />
         </AccordionItem>
         <AccordionItem

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -531,6 +531,7 @@ const DetailsTab: React.FC = () => {
           agentInstance={agentInstance}
           isLoading={isAgentLoading}
           isError={isAgentError}
+          selectedElementInstanceKey={elementInstanceKey}
         />
       )}
     </Container>

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
@@ -21,6 +21,7 @@ type QueryOptions<T> = {
   enabled?: boolean;
   enablePeriodicRefetch?: boolean;
   sortOrder?: QuerySortOrder;
+  elementInstanceKey?: string;
   select?: (result: InfiniteData<QueryAgentInstanceHistoryResponseBody>) => T;
 };
 
@@ -32,7 +33,10 @@ const useAgentInstanceHistory = <
 ) => {
   const historyPayload: QueryAgentInstanceHistoryRequestBody = {
     sort: [{field: 'producedAt', order: options?.sortOrder ?? 'desc'}],
-    filter: {commitStatus: 'COMMITTED'},
+    filter: {
+      commitStatus: 'COMMITTED',
+      elementInstanceKey: options?.elementInstanceKey,
+    },
   };
 
   return useInfiniteQuery({

--- a/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
+++ b/operate/client/src/modules/queries/agentInstances/useAgentInstanceHistory.ts
@@ -6,7 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useInfiniteQuery, type InfiniteData} from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  type InfiniteData,
+} from '@tanstack/react-query';
 import type {
   QuerySortOrder,
   QueryAgentInstanceHistoryRequestBody,
@@ -21,7 +25,7 @@ type QueryOptions<T> = {
   enabled?: boolean;
   enablePeriodicRefetch?: boolean;
   sortOrder?: QuerySortOrder;
-  elementInstanceKey?: string;
+  elementInstanceKey?: string | null;
   select?: (result: InfiniteData<QueryAgentInstanceHistoryResponseBody>) => T;
 };
 
@@ -35,7 +39,7 @@ const useAgentInstanceHistory = <
     sort: [{field: 'producedAt', order: options?.sortOrder ?? 'desc'}],
     filter: {
       commitStatus: 'COMMITTED',
-      elementInstanceKey: options?.elementInstanceKey,
+      elementInstanceKey: options?.elementInstanceKey ?? undefined,
     },
   };
 
@@ -48,6 +52,7 @@ const useAgentInstanceHistory = <
     select: options?.select,
     staleTime: 5000,
     refetchInterval: options?.enablePeriodicRefetch ? 5000 : undefined,
+    placeholderData: keepPreviousData,
     queryFn: async ({pageParam, signal}) => {
       const {response, error} = await searchAgentInstanceHistory(
         agentInstanceKey,


### PR DESCRIPTION
## Description

This PR scopes the conversation history in agent details to the selected element instance. The scoping is **only applied if** an single element instance is selected **and** the agent instance has been activated multiple times (has multiple element instances). This whole "selection might be null" logic aims to be future proof if we decide/manage to show the agent details without having a single element instance selected.

When the conversation history can be scoped, users see a toggle next to sorting toggle. By default it is toggled to "Scoped conversation" and can be toggled to "Whole conversation". The logic should be robust and gracefully get activated if single-activation agent conversation is viewed and another activation starts in the background. The "Scoped conversation" simply will become visible and the conversation stays as is.

For an improved user experience, I upgraded the loading logic a bit. It now keeps the previous data as placeholder data around, and adapts the "dimmed list" approach already introduced in the variables tab.

> [!NOTE]
> Demo of the feature: https://camunda.slack.com/archives/C0AH08C7UA2/p1782399629606489?thread_ts=1782391739.627599&cid=C0AH08C7UA2

## Related issues

closes #55912
