### PR TITLE
fix: Revert "fix: make hashmod_zone macos compatible"

### DIFF
--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-c"
+        topology.kubernetes.io/zone: "europe-west1-d"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-c"
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-8
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/identity/deployment.yaml
@@ -144,7 +144,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -201,7 +201,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -178,7 +178,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4-stable
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-c"
+        topology.kubernetes.io/zone: "europe-west1-d"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-c"
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/main/elasticsearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-8
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/identity/deployment.yaml
@@ -144,7 +144,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -201,7 +201,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -178,7 +178,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/main/max/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/max/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/max/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/max/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/none/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/none/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-b"
+        topology.kubernetes.io/zone: "europe-west1-c"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/main/none/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/none/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-b"
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/main/none/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/none/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/none/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/none/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/none/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/identity/deployment.yaml
@@ -134,7 +134,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/none/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/orchestration/statefulset.yaml
@@ -178,7 +178,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-b"
+        topology.kubernetes.io/zone: "europe-west1-c"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-b"
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/identity/deployment.yaml
@@ -144,7 +144,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -213,7 +213,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -178,7 +178,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4-stable
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-b"
+        topology.kubernetes.io/zone: "europe-west1-d"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-b"
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/main/opensearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/opensearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/identity/deployment.yaml
@@ -144,7 +144,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/deployment.yaml
@@ -213,7 +213,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -178,7 +178,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-d
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-d"
+        topology.kubernetes.io/zone: "europe-west1-c"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-d"
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-8
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/identity/deployment.yaml
@@ -144,7 +144,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/deployment.yaml
@@ -201,7 +201,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
@@ -180,7 +180,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-d"
+        topology.kubernetes.io/zone: "europe-west1-c"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-d"
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/deployment.yaml
@@ -139,7 +139,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/statefulset.yaml
@@ -180,7 +180,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4-stable
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-c"
+        topology.kubernetes.io/zone: "europe-west1-b"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-c"
+    topology.kubernetes.io/zone: "europe-west1-b"

--- a/load-tests/setup/test/golden/main/rdbms/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/deployment.yaml
@@ -119,7 +119,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/deployment.yaml
@@ -139,7 +139,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/statefulset.yaml
@@ -180,7 +180,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-c"
+        topology.kubernetes.io/zone: "europe-west1-d"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-c"
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-c"
+        topology.kubernetes.io/zone: "europe-west1-d"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-c"
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-8
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/deployment.yaml
@@ -118,7 +118,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/identity/deployment.yaml
@@ -140,7 +140,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -187,7 +187,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -176,7 +176,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4-stable
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/stable-88/max/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/max/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-b"
+        topology.kubernetes.io/zone: "europe-west1-c"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-b"
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-88/none/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/none/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/identity/deployment.yaml
@@ -130,7 +130,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/statefulset.yaml
@@ -176,7 +176,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-b"
+        topology.kubernetes.io/zone: "europe-west1-c"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-b"
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/deployment.yaml
@@ -118,7 +118,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/identity/deployment.yaml
@@ -140,7 +140,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -195,7 +195,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -176,7 +176,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4-stable
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-d"
+        topology.kubernetes.io/zone: "europe-west1-c"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-d"
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/deployment.yaml
@@ -118,7 +118,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/identity/deployment.yaml
@@ -140,7 +140,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/deployment.yaml
@@ -195,7 +195,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -176,7 +176,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/stable-88/realistic/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-88/realistic/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool
@@ -166,7 +166,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool
@@ -299,7 +299,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool
@@ -444,7 +444,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool
@@ -577,7 +577,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool
@@ -710,7 +710,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-b"
+        topology.kubernetes.io/zone: "europe-west1-d"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-b"
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-d"
+        topology.kubernetes.io/zone: "europe-west1-c"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-d"
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-8
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/deployment.yaml
@@ -118,7 +118,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/identity/deployment.yaml
@@ -138,7 +138,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -193,7 +193,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -177,7 +177,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4-stable
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-d"
+        topology.kubernetes.io/zone: "europe-west1-b"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-d"
+    topology.kubernetes.io/zone: "europe-west1-b"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-8
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/deployment.yaml
@@ -118,7 +118,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/identity/deployment.yaml
@@ -138,7 +138,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -193,7 +193,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -177,7 +177,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-b
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/stable-89/max/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/max/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-b"
+        topology.kubernetes.io/zone: "europe-west1-c"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-b"
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-8
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/deployment.yaml
@@ -118,7 +118,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/identity/deployment.yaml
@@ -138,7 +138,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/deployment.yaml
@@ -193,7 +193,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
@@ -179,7 +179,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-b
+        topology.kubernetes.io/zone: europe-west1-c
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-c"
+        topology.kubernetes.io/zone: "europe-west1-d"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-c"
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/deployment.yaml
@@ -118,7 +118,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/identity/deployment.yaml
@@ -133,7 +133,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/statefulset.yaml
@@ -179,7 +179,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4-stable
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-d
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/metrics-exporter.yaml
@@ -46,7 +46,7 @@ spec:
 
       # Node scheduling
       nodeSelector:
-        topology.kubernetes.io/zone: "europe-west1-d"
+        topology.kubernetes.io/zone: "europe-west1-c"
       tolerations:
       - effect: NoSchedule
         key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/namespace.yaml
@@ -10,4 +10,4 @@ metadata:
     deadline-date: TEST_DATE
     registry: harbor
   annotations:
-    topology.kubernetes.io/zone: "europe-west1-d"
+    topology.kubernetes.io/zone: "europe-west1-c"

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
           
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/deployment.yaml
@@ -118,7 +118,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/identity/deployment.yaml
@@ -133,7 +133,7 @@ spec:
       nodeSelector:
         
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       tolerations:
         
         - effect: NoSchedule

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/statefulset.yaml
@@ -179,7 +179,7 @@ spec:
           type: RuntimeDefault
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-d
+        topology.kubernetes.io/zone: europe-west1-c
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/load-tests/setup/test/golden/stable-89/realistic/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-tester/templates/starter.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/test/golden/stable-89/realistic/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-tester/templates/workers.yaml
@@ -24,7 +24,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool
@@ -166,7 +166,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool
@@ -299,7 +299,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool
@@ -444,7 +444,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool
@@ -577,7 +577,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool
@@ -710,7 +710,7 @@ spec:
         - name: harbor-registry
       nodeSelector:
         component: benchmark-n2-standard-4
-        topology.kubernetes.io/zone: europe-west1-c
+        topology.kubernetes.io/zone: europe-west1-b
       tolerations:
         - effect: NoSchedule
           key: nodepool

--- a/load-tests/setup/utils.sh
+++ b/load-tests/setup/utils.sh
@@ -53,29 +53,23 @@ compute_git_author() {
 
 # Pick a "random" zone, selected from the input value.
 function hashmod_zone() {
-  local input="${1?"Specify an initial value to compute the zone from"}"
+    local input="${1?"Specify an initial value to compute the zone from"}"
 
-  # We can get the list of zones with already created nodes with:
-  # kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io\/zone}{"\n"}{end}' | sort | uniq -c
-  local -a zones=(
-    europe-west1-b
-    europe-west1-c
-    europe-west1-d
-  )
-  local nb_zones=${#zones[@]}
+    # We can get the list of zones with already created nodes with:
+    # kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.topology\.kubernetes\.io\/zone}{"\n"}{end}' | sort | uniq -c
+    zones=(
+        europe-west1-b
+        europe-west1-c
+        europe-west1-d
+    )
+    nb_zones=${#zones[@]}
 
-  detect_os
-  local checksum
-  if [ "${GO_OS}" == "darwin" ]; then
-    checksum="$(printf '%s' "$input" | md5 -q | tr '[:lower:]' '[:upper:]')"
-  else
-    checksum="$(printf '%s' "$input" | md5sum | awk '{print $1}' | tr '[:lower:]' '[:upper:]')"
-  fi
+    # bc only accept hexadecimal with capitalized letters
+    checksum="$(echo "$input" | md5sum | cut -c 1-32 | tr "a-z" "A-Z")"
+    hashmod="$(echo "ibase=16; $checksum % $nb_zones" | bc)"
 
-  local hashmod
-  hashmod="$(echo "ibase=16; $checksum % $nb_zones" | bc)"
-
-  echo "${zones[$hashmod]}"
+    zone="${zones[$hashmod]}"
+    echo "$zone"
 }
 
 function get_existing_secret() {


### PR DESCRIPTION
## Description

This reverts commit 7a4f65a98107e6c2a708f6df338fbf38a793d021.

It changes the output of the function, which changes how pods are being scheduled to availability zones.

On existing deployments, since we are using zonal disks, if a pod tries to schedule on a different zone than the previous one, the disk can't be moved to the new zone and the pod will be pending forever.

After:
```shell
$ git checkout 7a4f65a^
Previous HEAD position was 7a4f65a9810 fix: make hashmod_zone macos compatible
HEAD is now at de0e1d0d1f5 refactor: move shared load-test utils into utils.sh

$ bash -c ". ./utils.sh; hashmod_zone c8-release-8-8-x"
europe-west1-c
```

Before:
```shell
$ git checkout 7a4f65a
Previous HEAD position was de0e1d0d1f5 refactor: move shared load-test utils into utils.sh
HEAD is now at 7a4f65a9810 fix: make hashmod_zone macos compatible

$ bash -c ". ./utils.sh; hashmod_zone c8-release-8-8-x"
europe-west1-d
```



## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://camunda.slack.com/archives/C0ANMGS3D4Y/p1782401033114889
* https://app.incident.io/camunda/incidents/6250