### PR TITLE
ci: make optimize e2e smoke non-blocking (temp workaround for INC-6264)

### DIFF
--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -516,6 +516,7 @@ jobs:
 
       - name: Run smoke tests
         working-directory: ./optimize/client
+        continue-on-error: true # temporary: flaky test, tracked in #55958
         run: yarn run e2e:ci:sm:smoke:headless
 
       - name: Upload logs


### PR DESCRIPTION
## Summary

Temporary workaround for [INC-6264](https://app.incident.io/camunda/incidents/6264) — the `CI: optimize-e2e-smoke` job is blocking merges due to flaky TestCafe selector timeouts on `CreateNewButton`.

This PR adds `continue-on-error: true` to the **Run smoke tests** step so CI failures in that step no longer block the merge queue, while keeping the test execution visible in logs and artifacts.

**This is not a fix** — it only prevents the flaky failure from blocking other teams. The root-cause fix (adding `--selector-timeout 40000` to match the assertion timeout) is tracked in #55958 and implemented in #55936.

## Root cause

`CreateNewButton` renders only after `api/identity/current/user` resolves asynchronously. The smoke run omits `--selector-timeout`, leaving TestCafe at its 10 s default — too short under CI load. The nightly run avoids this with `-c 3` (3 parallel browsers reducing per-browser load).

## Related issues

Relates to #55958 (do **not** close — the actual fix is pending in #55936)

## Incident

- Slack: [#inc-6264-unsuccessful-job-ci-optimize-e2e-smoke-on-main](https://camunda.slack.com/archives/C0BD05LLCLD)
- Incident.io: https://app.incident.io/camunda/incidents/6264

## Checklist

- [ ] Enable backports when necessary — this workaround should be backported to `stable/8.8` and `stable/8.9` since the incident affected those branches too.