### PR TITLE
fix: resolve peer addresses as absolute names to avoid cold-start DNS hang

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -415,6 +415,17 @@ public final class NettyMessagingService implements ManagedMessagingService {
                               new BiDnsQueryLifecycleObserverFactory(
                                   ignored -> metrics,
                                   new LoggingDnsQueryLifeCycleObserverFactory()))
+                          // The addresses we resolve (initial contact points, advertised hosts) are
+                          // fully-qualified names. With the default ndots taken from resolv.conf
+                          // (typically ndots:5 in Kubernetes), a name with fewer dots is tried with
+                          // every search domain appended *before* the bare name. A single slow or
+                          // unresponsive search-domain query can then exceed the caller's timeout
+                          // (e.g. the 2s SWIM probe timeout) so the resolvable bare name is never
+                          // queried, and a broker can hang permanently waiting to discover a peer
+                          // whose name only became resolvable after startup. Forcing ndots=0 makes
+                          // the bare (absolute) name be tried first; search domains remain as a
+                          // fallback for short names. See camunda/camunda#55038.
+                          .ndots(0)
                           .socketChannelType(clientChannelClass)
                           .channelType(clientDataGramChannelClass));
               timeoutExecutor =


### PR DESCRIPTION
## Description

Fixes the permanent cold-start hang from #55038. Single PR for the fix; the change is one line and can be back/forward-ported to the other affected line (8.8) as needed.

On a cold multi-region start, a broker whose cross-region peers are not yet DNS-resolvable hangs **permanently** in `BrokerStartupProcess` at the cluster-topology step: 9600 never binds, quorum never forms, and only a pod restart recovers it.

### Root cause

`BrokerStartupProcess` blocks until the cluster-topology initializer can sync with a peer — a deliberate safety property (a coordinator that can't see its peers must not fabricate a topology). The real problem is that the peer is never *discovered*, because of how its address is resolved.

On 8.7/8.8 the `initialContactPoints` flow into `BootstrapDiscoveryProvider`, whose addresses are only ever resolved **inline during a SWIM probe**, via Netty's `DnsNameResolver`. That resolver takes `ndots` from `resolv.conf` (`ndots:5` in Kubernetes), so a fully-qualified name with fewer dots (e.g. `zeebe.camunda.svc.clusterset.local`, 4 dots) is tried with **every search domain appended before the bare name**. When a search-domain query is slow or unanswered, it exceeds the **2s SWIM probe timeout**, so the resolvable bare name is never queried within the budget — and the peer is never discovered, even after its name becomes resolvable.

(Confirmed with the reporter against the production ROSA + Submariner environments: `resolv.conf` has `ndots:5` and a search domain that doesn't answer promptly for the `clusterset.local` names.)

### Fix

Force `ndots=0` on the messaging DNS resolver so the **bare (absolute) name is the first query**; search domains remain as a fallback for short names. One line, shared by broker and gateway. It also speeds up the common case (FQDN/IP addresses) by skipping the search-domain round-trips, with no regression for short names.

This is the minimal equivalent, for the `BootstrapDiscoveryProvider` path, of what main/8.9+ already get from the switch to `DynamicDiscoveryProvider` (JVM-resolver-based discovery that resolves off the probe path).

### Validation

Reproduced the exact permanent-hang condition on a single Kind cluster with `camunda/zeebe:8.7.29` (clusterset names `NXDOMAIN` at start, plus a slow/unanswered search domain present), then made the clusterset names resolvable:

- **Stock 8.7.29** — stayed `0/1 Running` permanently; Netty only ever queried search-expanded names, never the bare name.
- **8.7.29 + this patch** — correctly waited while peers were unresolvable, then **recovered to `1/1` within ~20s** of the names becoming resolvable (slow search domain still present). DNS logs show the bare name queried first.

### Scope

- Targets **stable/8.7**; the identical one-liner applies to **8.8** (same `BootstrapDiscoveryProvider` / Netty resolver path) and can be back/forward-ported.
- **main / 8.9 / 8.10 do not need this** — already fixed via `DynamicDiscoveryProvider`.
- Deadline mismatch (2s probe vs 5s Netty query) verified benign: the probe timeout does not cancel the in-flight resolution, and successful resolutions are cached/reused across probes (~once per TTL), so no deadline-coupling change is needed.

Relates to #55038
