### PR TITLE
fix: resolve peer addresses as absolute names to avoid cold-start DNS hang

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -435,6 +435,17 @@ public final class NettyMessagingService implements ManagedMessagingService {
                               new BiDnsQueryLifecycleObserverFactory(
                                   ignored -> metrics,
                                   new LoggingDnsQueryLifeCycleObserverFactory()))
+                          // The addresses we resolve (initial contact points, advertised hosts) are
+                          // fully-qualified names. With the default ndots taken from resolv.conf
+                          // (typically ndots:5 in Kubernetes), a name with fewer dots is tried with
+                          // every search domain appended *before* the bare name. A single slow or
+                          // unresponsive search-domain query can then exceed the caller's timeout
+                          // (e.g. the 2s SWIM probe timeout) so the resolvable bare name is never
+                          // queried, and a broker can hang permanently waiting to discover a peer
+                          // whose name only became resolvable after startup. Forcing ndots=0 makes
+                          // the bare (absolute) name be tried first; search domains remain as a
+                          // fallback for short names. See camunda/camunda#55038.
+                          .ndots(0)
                           .socketChannelType(clientChannelClass)
                           .channelType(clientDataGramChannelClass));
               timeoutExecutor =


### PR DESCRIPTION
## Description

Fixes the permanent cold-start hang from #55038 on the **8.8** line. Byte-identical to the 8.7 PR #55961.

On a cold multi-region start, a broker whose cross-region peers are not yet DNS-resolvable hangs **permanently** in `BrokerStartupProcess` at the cluster-topology step: 9600 never binds, quorum never forms, and only a pod restart recovers it.

### Root cause

`BrokerStartupProcess` blocks until the cluster-topology initializer can sync with a peer — a deliberate safety property (a coordinator that can't see its peers must not fabricate a topology). The real problem is that the peer is never *discovered*, because of how its address is resolved.

On 8.7/8.8 the `initialContactPoints` flow into `BootstrapDiscoveryProvider`, whose addresses are only ever resolved **inline during a SWIM probe**, via Netty's `DnsNameResolver`. That resolver takes `ndots` from `resolv.conf` (`ndots:5` in Kubernetes), so a fully-qualified name with fewer dots (e.g. `zeebe.camunda.svc.clusterset.local`, 4 dots) is tried with **every search domain appended before the bare name**. When a search-domain query is slow or unanswered, it exceeds the **2s SWIM probe timeout**, so the resolvable bare name is never queried within the budget — and the peer is never discovered, even after its name becomes resolvable.

(Confirmed with the reporter against the production ROSA + Submariner environments: `resolv.conf` has `ndots:5` and a search domain that doesn't answer promptly for the `clusterset.local` names.)

### Fix

Force `ndots=0` on the messaging DNS resolver so the **bare (absolute) name is the first query**; search domains remain as a fallback for short names. One line, shared by broker and gateway. It also speeds up the common case (FQDN/IP addresses) by skipping the search-domain round-trips, with no regression for short names.

This is the minimal equivalent, for the `BootstrapDiscoveryProvider` path, of what main/8.9+ already get from the switch to `DynamicDiscoveryProvider`. **main and 8.9/8.10 do not need this change.**

### Validation

End-to-end Kind validation was run on the 8.7 PR (#55961) against `camunda/zeebe:8.7.29`: reproduced the exact permanent-hang condition (clusterset names `NXDOMAIN` at start + a slow/unanswered search domain), then made the names resolvable — stock stayed `0/1` permanently, patched recovered to `1/1` within ~20s. The change here is identical and the `BootstrapDiscoveryProvider` / Netty resolver path is the same on 8.8, so it was not separately re-run.

### Scope

- This PR: **8.8**.
- 8.7 PR: #55961.
- main / 8.9 / 8.10: already fixed via `DynamicDiscoveryProvider`; no change needed.

Relates to #55038
