### PR TITLE
propagate business ID from process instance to jobs

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -165,4 +165,15 @@ public interface ActivatedJob {
    *     pre-8.9 data)
    */
   Long getRootProcessInstanceKey();
+
+  /**
+   * The business ID of the owning process instance, inherited when the job was created.
+   *
+   * <p><b>Note:</b> This field is only available when using the REST API. When using the gRPC API,
+   * this method returns {@code null}.
+   *
+   * @return the business ID, or {@code null} if not available (gRPC API, jobs created before
+   *     version 8.10, or when the owning process instance has no business ID)
+   */
+  String getBusinessId();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/Job.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/Job.java
@@ -72,6 +72,16 @@ public interface Job {
    */
   Long getRootProcessInstanceKey();
 
+  /**
+   * Returns the business ID of the owning process instance, inherited when the job was created.
+   *
+   * <p><strong>Note:</strong> This field is {@code null} for jobs created before version 8.10 and
+   * when the owning process instance has no business ID.
+   *
+   * @return the business ID, or {@code null} when not set
+   */
+  String getBusinessId();
+
   String getElementId();
 
   Long getElementInstanceKey();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
@@ -59,6 +59,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final ListenerEventType listenerEventType;
   private final Set<String> tags;
   private final Long rootProcessInstanceKey;
+  private final String businessId;
 
   private Map<String, Object> variablesAsMap;
 
@@ -91,6 +92,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
     tags = Collections.unmodifiableSet(new HashSet<>(job.getTagsList()));
     // gRPC doesn't have rootProcessInstanceKey - return null
     rootProcessInstanceKey = null;
+    // gRPC doesn't have businessId - return null
+    businessId = null;
   }
 
   public ActivatedJobImpl(
@@ -132,6 +135,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
         job.getRootProcessInstanceKey() != null
             ? Long.parseLong(job.getRootProcessInstanceKey())
             : null;
+    businessId = job.getBusinessId();
   }
 
   @Override
@@ -267,6 +271,11 @@ public final class ActivatedJobImpl implements ActivatedJob {
   @Override
   public Long getRootProcessInstanceKey() {
     return rootProcessInstanceKey;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return businessId;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
@@ -92,8 +92,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
     tags = Collections.unmodifiableSet(new HashSet<>(job.getTagsList()));
     // gRPC doesn't have rootProcessInstanceKey - return null
     rootProcessInstanceKey = null;
-    // gRPC doesn't have businessId - return null
-    businessId = null;
+    // proto strings default to "" when unset; expose as null like the REST response
+    businessId = job.getBusinessId().isEmpty() ? null : job.getBusinessId();
   }
 
   public ActivatedJobImpl(

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/JobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/JobImpl.java
@@ -47,6 +47,7 @@ public class JobImpl implements Job {
   private final Long processDefinitionKey;
   private final Long processInstanceKey;
   private final Long rootProcessInstanceKey;
+  private final String businessId;
   private final String elementId;
   private final Long elementInstanceKey;
   private final String tenantId;
@@ -74,6 +75,7 @@ public class JobImpl implements Job {
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
     rootProcessInstanceKey = ParseUtil.parseLongOrNull(item.getRootProcessInstanceKey());
+    businessId = item.getBusinessId();
     elementId = item.getElementId();
     elementInstanceKey = ParseUtil.parseLongOrNull(item.getElementInstanceKey());
     tenantId = item.getTenantId();
@@ -179,6 +181,11 @@ public class JobImpl implements Job {
   @Override
   public Long getRootProcessInstanceKey() {
     return rootProcessInstanceKey;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return businessId;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
@@ -65,6 +65,7 @@ public final class ActivateJobsTest extends ClientTest {
             .setTenantId("test-tenant-1")
             .setKind(JobKind.BPMN_ELEMENT)
             .setListenerEventType(ListenerEventType.START)
+            .setBusinessId("order-123")
             .build();
 
     final ActivatedJob activatedJob2 =
@@ -132,6 +133,7 @@ public final class ActivateJobsTest extends ClientTest {
             EnumUtil.convert(
                 activatedJob1.getListenerEventType(),
                 io.camunda.client.api.search.enums.ListenerEventType.class));
+    assertThat(job.getBusinessId()).isEqualTo("order-123");
 
     job = response.getJobs().get(1);
     assertThat(job.getKey()).isEqualTo(activatedJob2.getKey());
@@ -160,6 +162,7 @@ public final class ActivateJobsTest extends ClientTest {
             EnumUtil.convert(
                 activatedJob2.getListenerEventType(),
                 io.camunda.client.api.search.enums.ListenerEventType.class));
+    assertThat(job.getBusinessId()).isNull();
 
     final ActivateJobsRequest request = gatewayService.getLastRequest();
     assertThat(request.getType()).isEqualTo("foo");

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -75,6 +75,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .kind(JobKindEnum.BPMN_ELEMENT)
             .listenerEventType(JobListenerEventTypeEnum.START)
             .rootProcessInstanceKey("321")
+            .businessId("business-1")
             .priority(15);
 
     final ActivatedJobResult activatedJob2 =
@@ -96,6 +97,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .kind(JobKindEnum.BPMN_ELEMENT)
             .listenerEventType(JobListenerEventTypeEnum.END)
             .rootProcessInstanceKey("444")
+            .businessId("business-2")
             .priority(-3);
 
     gatewayService.onActivateJobsRequest(
@@ -131,6 +133,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
         .isEqualTo(activatedJob1.getProcessInstanceKey());
     assertThat(String.valueOf(job.getRootProcessInstanceKey()))
         .isEqualTo(activatedJob1.getRootProcessInstanceKey());
+    assertThat(job.getBusinessId()).isEqualTo(activatedJob1.getBusinessId());
     assertThat(job.getCustomHeaders()).isEqualTo(activatedJob1.getCustomHeaders());
     assertThat(job.getWorker()).isEqualTo(activatedJob1.getWorker());
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
@@ -156,6 +159,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
         .isEqualTo(activatedJob2.getProcessDefinitionKey());
     assertThat(String.valueOf(job.getRootProcessInstanceKey()))
         .isEqualTo(activatedJob2.getRootProcessInstanceKey());
+    assertThat(job.getBusinessId()).isEqualTo(activatedJob2.getBusinessId());
     assertThat(String.valueOf(job.getProcessInstanceKey()))
         .isEqualTo(activatedJob2.getProcessInstanceKey());
     assertThat(job.getCustomHeaders()).isEqualTo(activatedJob2.getCustomHeaders());

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -439,6 +439,17 @@
     </addColumn>
   </changeSet>
 
+  <changeSet id="add_business_id_to_job" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}JOB" columnName="BUSINESS_ID"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}JOB">
+      <column name="BUSINESS_ID" type="NVARCHAR(${userCharColumnSize})"/>
+    </addColumn>
+  </changeSet>
+
   <changeSet id="create_agent_history_table" author="camunda">
     <preConditions onFail="MARK_RAN">
       <not>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/JobEntityMapper.java
@@ -39,6 +39,7 @@ public class JobEntityMapper {
         .processDefinitionKey(jobDbModel.processDefinitionKey())
         .processInstanceKey(jobDbModel.processInstanceKey())
         .rootProcessInstanceKey(jobDbModel.rootProcessInstanceKey())
+        .businessId(jobDbModel.businessId())
         .elementId(nullToEmpty(jobDbModel.elementId()))
         .elementInstanceKey(jobDbModel.elementInstanceKey())
         .tenantId(nullToEmpty(jobDbModel.tenantId()))

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
@@ -44,6 +44,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
   private Long processDefinitionKey;
   private Long processInstanceKey;
   private Long rootProcessInstanceKey;
+  private String businessId;
   private String elementId;
   private Long elementInstanceKey;
   private String tenantId;
@@ -76,6 +77,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
       final Long processDefinitionKey,
       final Long processInstanceKey,
       final Long rootProcessInstanceKey,
+      final String businessId,
       final String elementId,
       final Long elementInstanceKey,
       final String tenantId,
@@ -103,6 +105,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
     this.processDefinitionKey = processDefinitionKey;
     this.processInstanceKey = processInstanceKey;
     this.rootProcessInstanceKey = rootProcessInstanceKey;
+    this.businessId = businessId;
     this.elementId = elementId;
     this.elementInstanceKey = elementInstanceKey;
     this.tenantId = tenantId;
@@ -144,6 +147,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
         processDefinitionKey,
         processInstanceKey,
         rootProcessInstanceKey,
+        businessId,
         elementId,
         elementInstanceKey,
         tenantId,
@@ -330,6 +334,14 @@ public class JobDbModel implements Copyable<JobDbModel> {
     this.rootProcessInstanceKey = rootProcessInstanceKey;
   }
 
+  public String businessId() {
+    return businessId;
+  }
+
+  public void businessId(final String businessId) {
+    this.businessId = businessId;
+  }
+
   public String elementId() {
     return elementId;
   }
@@ -400,6 +412,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
         .processDefinitionKey(processDefinitionKey)
         .processInstanceKey(processInstanceKey)
         .rootProcessInstanceKey(rootProcessInstanceKey)
+        .businessId(businessId)
         .elementId(elementId)
         .elementInstanceKey(elementInstanceKey)
         .tenantId(tenantId)
@@ -430,6 +443,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
     private Long processDefinitionKey;
     private Long processInstanceKey;
     private Long rootProcessInstanceKey;
+    private String businessId;
     private String elementId;
     private Long elementInstanceKey;
     private String tenantId;
@@ -557,6 +571,11 @@ public class JobDbModel implements Copyable<JobDbModel> {
       return this;
     }
 
+    public Builder businessId(final String businessId) {
+      this.businessId = businessId;
+      return this;
+    }
+
     public Builder partitionId(final int partitionId) {
       this.partitionId = partitionId;
       return this;
@@ -595,6 +614,7 @@ public class JobDbModel implements Copyable<JobDbModel> {
           processDefinitionKey,
           processInstanceKey,
           rootProcessInstanceKey,
+          businessId,
           elementId,
           elementInstanceKey,
           tenantId,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
@@ -110,6 +110,8 @@ public class JobWriter extends ProcessInstanceDependant implements RdbmsWriter {
               if (job.rootProcessInstanceKey() != null) {
                 b.rootProcessInstanceKey(job.rootProcessInstanceKey());
               }
+              // businessId is intentionally not updated: it is an immutable value inherited at
+              // job creation (written by the INSERT) and must never be changed by a later event.
               b.truncateErrorMessage(
                   vendorDatabaseProperties.errorMessageSize(),
                   vendorDatabaseProperties.charColumnMaxBytes());

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -32,6 +32,7 @@
         PARTITION_ID,
         PROCESS_INSTANCE_KEY,
         ROOT_PROCESS_INSTANCE_KEY,
+        BUSINESS_ID,
         ELEMENT_INSTANCE_KEY,
         PROCESS_DEFINITION_ID,
         PROCESS_DEFINITION_KEY,
@@ -236,6 +237,7 @@
     <result column="PARTITION_ID" property="partitionId" javaType="java.lang.Integer" />
     <result column="PROCESS_INSTANCE_KEY" property="processInstanceKey" javaType="java.lang.Long" />
     <result column="ROOT_PROCESS_INSTANCE_KEY" property="rootProcessInstanceKey" javaType="java.lang.Long" />
+    <result column="BUSINESS_ID" property="businessId" javaType="java.lang.String" />
     <result column="ELEMENT_INSTANCE_KEY" property="elementInstanceKey" javaType="java.lang.Long" />
     <result column="PROCESS_DEFINITION_ID" property="processDefinitionId" javaType="java.lang.String" />
     <result column="PROCESS_DEFINITION_KEY" property="processDefinitionKey" javaType="java.lang.Long" />

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -262,12 +262,12 @@
 
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.queue.BatchInsertDto">
-    INSERT INTO ${prefix}JOB (JOB_KEY, PARTITION_ID, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, ELEMENT_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY,
+    INSERT INTO ${prefix}JOB (JOB_KEY, PARTITION_ID, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, BUSINESS_ID, ELEMENT_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY,
     TENANT_ID, TYPE, WORKER, STATE, RETRIES, PRIORITY, ERROR_MESSAGE, ERROR_CODE, END_TIME, CUSTOM_HEADERS, KIND, ELEMENT_ID, IS_DENIED, DENIED_REASON, LISTENER_EVENT_TYPE,
     DEADLINE, HAS_FAILED_WITH_RETRIES_LEFT, CREATION_TIME, LAST_UPDATE_TIME)
     VALUES
     <foreach collection="dbModels" item="job" separator=",">
-      (#{job.jobKey}, #{job.partitionId}, #{job.processInstanceKey}, #{job.rootProcessInstanceKey}, #{job.elementInstanceKey}, #{job.processDefinitionId},
+      (#{job.jobKey}, #{job.partitionId}, #{job.processInstanceKey}, #{job.rootProcessInstanceKey}, #{job.businessId}, #{job.elementInstanceKey}, #{job.processDefinitionId},
       #{job.processDefinitionKey}, #{job.tenantId}, #{job.type}, #{job.worker}, #{job.state}, #{job.retries}, #{job.priority}, #{job.errorMessage}, #{job.errorCode}, #{job.endTime, jdbcType=TIMESTAMP}, #{job.serializedCustomHeaders}, #{job.kind}, #{job.elementId}, #{job.isDenied},
       #{job.deniedReason}, #{job.listenerEventType}, #{job.deadline, jdbcType=TIMESTAMP}, #{job.hasFailedWithRetriesLeft}, #{job.creationTime, jdbcType=TIMESTAMP}, #{job.lastUpdateTime, jdbcType=TIMESTAMP})
     </foreach>
@@ -276,10 +276,10 @@
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.queue.BatchInsertDto" databaseId="oracle">
     INSERT ALL
     <foreach collection="dbModels" item="job">
-      INTO ${prefix}JOB (JOB_KEY, PARTITION_ID, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, ELEMENT_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY,
+      INTO ${prefix}JOB (JOB_KEY, PARTITION_ID, PROCESS_INSTANCE_KEY, ROOT_PROCESS_INSTANCE_KEY, BUSINESS_ID, ELEMENT_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY,
       TENANT_ID, TYPE, WORKER, STATE, RETRIES, PRIORITY, ERROR_MESSAGE, ERROR_CODE, END_TIME, CUSTOM_HEADERS, KIND, ELEMENT_ID, IS_DENIED, DENIED_REASON, LISTENER_EVENT_TYPE,
       DEADLINE, HAS_FAILED_WITH_RETRIES_LEFT, CREATION_TIME, LAST_UPDATE_TIME)
-      VALUES (#{job.jobKey}, #{job.partitionId}, #{job.processInstanceKey}, #{job.rootProcessInstanceKey}, #{job.elementInstanceKey}, #{job.processDefinitionId},
+      VALUES (#{job.jobKey}, #{job.partitionId}, #{job.processInstanceKey}, #{job.rootProcessInstanceKey}, #{job.businessId}, #{job.elementInstanceKey}, #{job.processDefinitionId},
       #{job.processDefinitionKey}, #{job.tenantId}, #{job.type}, #{job.worker}, #{job.state}, #{job.retries}, #{job.priority}, #{job.errorMessage}, #{job.errorCode}, #{job.endTime, jdbcType=TIMESTAMP}, #{job.serializedCustomHeaders}, #{job.kind}, #{job.elementId}, #{job.isDenied},
       #{job.deniedReason}, #{job.listenerEventType}, #{job.deadline, jdbcType=TIMESTAMP}, #{job.hasFailedWithRetriesLeft}, #{job.creationTime, jdbcType=TIMESTAMP}, #{job.lastUpdateTime, jdbcType=TIMESTAMP})
     </foreach>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/JobEntityMapperTest.java
@@ -50,6 +50,7 @@ public class JobEntityMapperTest {
             .elementId("elementBpmnId")
             .elementInstanceKey(1L)
             .tenantId("tenantId")
+            .businessId("testBusinessId")
             .creationTime(OffsetDateTime.now())
             .lastUpdateTime(OffsetDateTime.now())
             .build();
@@ -127,6 +128,7 @@ public class JobEntityMapperTest {
         .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
     assertThat(entity.tenantId())
         .isEqualTo(""); // Oracle treats empty strings as NULL, mapper converts back to ""
+    assertThat(entity.businessId()).isNull();
     assertThat(entity.creationTime()).isNotNull();
     assertThat(entity.lastUpdateTime()).isNotNull();
   }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -233,6 +233,7 @@ public final class ResponseMapper {
             EnumUtil.convert(job.getJobListenerEventType(), JobListenerEventTypeEnum.class))
         .rootProcessInstanceKey(
             rootProcessInstanceKey > 0 ? keyToString(rootProcessInstanceKey) : null)
+        .businessId(emptyToNull(job.getBusinessId()))
         .tags(job.getTags())
         .userTask(toUserTaskProperties(job))
         .priority(job.getPriority())

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -923,6 +923,7 @@ public final class SearchQueryResponseMapper {
         .type(job.type())
         .worker(job.worker())
         .rootProcessInstanceKey(keyToStringOrNull(job.rootProcessInstanceKey()))
+        .businessId(job.businessId())
         .creationTime(formatDateOrNull(job.creationTime()))
         .deadline(formatDateOrNull(job.deadline()))
         .deniedReason(job.deniedReason())

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/ResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/ResponseMapperTest.java
@@ -123,6 +123,79 @@ class ResponseMapperTest {
     }
 
     @Test
+    void shouldMapActivatedJobWithBusinessId() {
+      // given
+      final JobRecord jobRecord =
+          new JobRecord()
+              .setJobKind(JobKind.BPMN_ELEMENT)
+              .setType("test-type")
+              .setBpmnProcessId("procId")
+              .setElementId("elementId")
+              .setProcessInstanceKey(456L)
+              .setProcessDefinitionVersion(1)
+              .setProcessDefinitionKey(123L)
+              .setElementInstanceKey(555L)
+              .setWorker("worker")
+              .setRetries(3)
+              .setDeadline(0L)
+              .setBusinessId("business-1")
+              .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+      final byte[] emptyVariables = MsgPackConverter.convertToMsgPack(Collections.emptyMap());
+      jobRecord.setVariables(new UnsafeBuffer(emptyVariables));
+
+      final JobBatchRecord batchRecord = buildJobBatchRecord(jobRecord);
+      final JobActivationResponse activationResponse =
+          new JobActivationResponse(123L, batchRecord, 1024 * 1024L);
+
+      // when
+      final var result = ResponseMapper.toActivateJobsResponse(activationResponse);
+
+      // then
+      final var jobs = result.getActivateJobsResponse().getJobs();
+      assertThat(jobs)
+          .singleElement()
+          .satisfies(job -> assertThat(job.getBusinessId()).isEqualTo("business-1"));
+    }
+
+    @Test
+    void shouldNotSetBusinessIdWhenEmptyForActivatedJob() {
+      // given - job whose owning instance has no business ID (empty string on the record)
+      final JobRecord jobRecord =
+          new JobRecord()
+              .setJobKind(JobKind.BPMN_ELEMENT)
+              .setType("test-type")
+              .setBpmnProcessId("procId")
+              .setElementId("elementId")
+              .setProcessInstanceKey(456L)
+              .setProcessDefinitionVersion(1)
+              .setProcessDefinitionKey(123L)
+              .setElementInstanceKey(555L)
+              .setWorker("worker")
+              .setRetries(3)
+              .setDeadline(0L)
+              // businessId defaults to an empty string when not set
+              .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+      final byte[] emptyVariables = MsgPackConverter.convertToMsgPack(Collections.emptyMap());
+      jobRecord.setVariables(new UnsafeBuffer(emptyVariables));
+
+      final JobBatchRecord batchRecord = buildJobBatchRecord(jobRecord);
+      final JobActivationResponse activationResponse =
+          new JobActivationResponse(123L, batchRecord, 1024 * 1024L);
+
+      // when
+      final var result = ResponseMapper.toActivateJobsResponse(activationResponse);
+
+      // then
+      final var jobs = result.getActivateJobsResponse().getJobs();
+      assertThat(jobs)
+          .singleElement()
+          // businessId should be null when the record carries an empty string
+          .satisfies(job -> assertThat(job.getBusinessId()).isNull());
+    }
+
+    @Test
     void shouldMapPriorityToActivatedJobResult() {
       // given
       final JobRecord jobRecord =
@@ -320,7 +393,8 @@ class ResponseMapperTest {
           .setRetries(jobRecord.getRetries())
           .setPriority(jobRecord.getPriority())
           .setDeadline(jobRecord.getDeadline())
-          .setTenantId(jobRecord.getTenantId());
+          .setTenantId(jobRecord.getTenantId())
+          .setBusinessId(jobRecord.getBusinessId());
 
       // Set variables as empty MsgPack map
       final byte[] emptyVariables = MsgPackConverter.convertToMsgPack(Collections.emptyMap());

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -458,6 +458,75 @@ class SearchQueryResponseMapperTest {
   }
 
   @Test
+  void shouldMapBusinessIdForJob() {
+    // given
+    final var entity =
+        new JobEntity.Builder()
+            .jobKey(123L)
+            .type("test-type")
+            .worker("test-worker")
+            .state(JobState.CREATED)
+            .kind(JobKind.BPMN_ELEMENT)
+            .listenerEventType(ListenerEventType.UNSPECIFIED)
+            .retries(3)
+            .isDenied(false)
+            .hasFailedWithRetriesLeft(false)
+            .processDefinitionId("processId")
+            .processDefinitionKey(456L)
+            .processInstanceKey(789L)
+            .rootProcessInstanceKey(999L)
+            .businessId("business-1")
+            .elementId("serviceTask1")
+            .elementInstanceKey(111L)
+            .tenantId("tenant")
+            .creationTime(OffsetDateTime.now())
+            .lastUpdateTime(OffsetDateTime.now())
+            .build();
+
+    // when
+    final var jobs =
+        SearchQueryResponseMapper.toJobSearchQueryResponse(
+            new SearchQueryResult<JobEntity>(1, false, List.of(entity), null, null));
+
+    // then
+    assertThat(jobs.getItems().getFirst().getBusinessId()).isEqualTo("business-1");
+  }
+
+  @Test
+  void shouldMapNullBusinessIdForJob() {
+    // given
+    final var entity =
+        new JobEntity.Builder()
+            .jobKey(123L)
+            .type("test-type")
+            .worker("test-worker")
+            .state(JobState.CREATED)
+            .kind(JobKind.BPMN_ELEMENT)
+            .listenerEventType(ListenerEventType.UNSPECIFIED)
+            .retries(1)
+            .hasFailedWithRetriesLeft(false)
+            .processDefinitionId("processId")
+            .processDefinitionKey(456L)
+            .processInstanceKey(789L)
+            .rootProcessInstanceKey(999L)
+            .businessId(null)
+            .elementId("serviceTask1")
+            .elementInstanceKey(111L)
+            .tenantId("tenant")
+            .creationTime(OffsetDateTime.now())
+            .lastUpdateTime(OffsetDateTime.now())
+            .build();
+
+    // when
+    final var jobs =
+        SearchQueryResponseMapper.toJobSearchQueryResponse(
+            new SearchQueryResult<JobEntity>(1, false, List.of(entity), null, null));
+
+    // then
+    assertThat(jobs.getItems().getFirst().getBusinessId()).isNull();
+  }
+
+  @Test
   void shouldMapRootProcessInstanceKeyForMessageSubscription() {
     // given
     final var entity =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobBusinessIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobBusinessIdIT.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstanceWithBusinessId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.response.Job;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage that a job inherits its owning process instance's {@code businessId} and that
+ * the value is returned across both backends from the two surfaces that expose it: the {@code
+ * /jobs/search} response and the {@code POST /jobs/activation} response.
+ *
+ * <p>Each test uses its own process/job type so the activation tests never steal another test's
+ * job.
+ */
+@MultiDbTest
+@CompatibilityTest
+public class JobBusinessIdIT {
+
+  private static CamundaClient client;
+
+  @Test
+  void shouldReturnBusinessIdOnActivatedJob() {
+    // given
+    final String jobType = deployServiceTaskProcess("activate");
+    final ProcessInstanceEvent processInstance =
+        startProcessInstanceWithBusinessId(client, "process-activate", "order-activate-1");
+    waitForJob(processInstance.getProcessInstanceKey());
+
+    // when
+    final ActivatedJob job =
+        client
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+
+    // then
+    assertThat(job.getBusinessId()).isEqualTo("order-activate-1");
+  }
+
+  @Test
+  void shouldReturnBusinessIdOnJobSearch() {
+    // given
+    deployServiceTaskProcess("search");
+    final ProcessInstanceEvent processInstance =
+        startProcessInstanceWithBusinessId(client, "process-search", "order-search-1");
+    waitForJob(processInstance.getProcessInstanceKey());
+
+    // when
+    final Job job =
+        client
+            .newJobSearchRequest()
+            .filter(f -> f.processInstanceKey(processInstance.getProcessInstanceKey()))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then
+    assertThat(job.getBusinessId()).isEqualTo("order-search-1");
+  }
+
+  @Test
+  void shouldReturnNullBusinessIdWhenInstanceHasNone() {
+    // given - a process instance started without a business ID
+    final String jobType = deployServiceTaskProcess("nobusinessid");
+    final ProcessInstanceEvent processInstance =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process-nobusinessid")
+            .latestVersion()
+            .execute();
+    waitForJob(processInstance.getProcessInstanceKey());
+
+    // when
+    final ActivatedJob activatedJob =
+        client
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+    final Job searchedJob =
+        client
+            .newJobSearchRequest()
+            .filter(f -> f.processInstanceKey(processInstance.getProcessInstanceKey()))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then - both surfaces report no business ID
+    assertThat(activatedJob.getBusinessId()).isNull();
+    assertThat(searchedJob.getBusinessId()).isNull();
+  }
+
+  private static String deployServiceTaskProcess(final String suffix) {
+    final String processId = "process-" + suffix;
+    final String jobType = "job-" + suffix;
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(client, model, processId + ".bpmn");
+    return jobType;
+  }
+
+  private static void waitForJob(final long processInstanceKey) {
+    Awaitility.await()
+        .ignoreExceptions()
+        .timeout(Duration.ofSeconds(30))
+        .until(
+            () ->
+                !client
+                    .newJobSearchRequest()
+                    .filter(f -> f.processInstanceKey(processInstanceKey))
+                    .send()
+                    .join()
+                    .items()
+                    .isEmpty());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/JobFixtures.java
@@ -29,6 +29,7 @@ public final class JobFixtures extends CommonFixtures {
             .processDefinitionId("job-" + generateRandomString(20))
             .processInstanceKey(nextKey())
             .rootProcessInstanceKey(nextKey())
+            .businessId("business-" + generateRandomString(20))
             .jobKey(nextKey())
             .state(randomEnum(JobState.class))
             .errorMessage("error-" + generateRandomString(20))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/job/JobIT.java
@@ -378,7 +378,7 @@ public class JobIT {
             .partitionId(original.partitionId())
             .lastUpdateTime(NOW)
             // intentionally omit: elementId, creationTime, errorMessage, errorCode, isDenied,
-            // deniedReason, deadline, endTime, rootProcessInstanceKey
+            // deniedReason, deadline, endTime, rootProcessInstanceKey, businessId
             .build();
     rdbmsWriters.getJobWriter().update(update);
     rdbmsWriters.flush();
@@ -395,6 +395,7 @@ public class JobIT {
     assertThat(stored.endTime())
         .isCloseTo(original.endTime(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
     assertThat(stored.rootProcessInstanceKey()).isEqualTo(original.rootProcessInstanceKey());
+    assertThat(stored.businessId()).isEqualTo(original.businessId());
     assertThat(stored.priority()).isEqualTo(original.priority());
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/JobEntityTransformer.java
@@ -39,6 +39,7 @@ public class JobEntityTransformer
         .processDefinitionKey(value.getProcessDefinitionKey())
         .processInstanceKey(value.getProcessInstanceKey())
         .rootProcessInstanceKey(value.getRootProcessInstanceKey())
+        .businessId(value.getBusinessId())
         .elementId(value.getFlowNodeId())
         .elementInstanceKey(value.getFlowNodeInstanceId())
         .tenantId(value.getTenantId())

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/JobEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/JobEntityTransformerTest.java
@@ -90,6 +90,24 @@ class JobEntityTransformerTest {
     assertThat(transformed.rootProcessInstanceKey()).isNull();
   }
 
+  @Test
+  void shouldMapBusinessId() {
+    when(entityValue.getBusinessId()).thenReturn("business-1");
+
+    final var transformed = transformer.apply(entityValue);
+
+    assertThat(transformed.businessId()).isEqualTo("business-1");
+  }
+
+  @Test
+  void shouldMapNullBusinessId() {
+    when(entityValue.getBusinessId()).thenReturn(null);
+
+    final var transformed = transformer.apply(entityValue);
+
+    assertThat(transformed.businessId()).isNull();
+  }
+
   @ParameterizedTest
   @EnumSource(ListenerEventType.class)
   void handlesAllListenerEventTypes(final ListenerEventType listenerEventType) {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/JobEntity.java
@@ -39,6 +39,7 @@ public record JobEntity(
     Long processDefinitionKey,
     Long processInstanceKey,
     @Nullable Long rootProcessInstanceKey,
+    @Nullable String businessId,
     String elementId,
     Long elementInstanceKey,
     String tenantId,
@@ -90,6 +91,7 @@ public record JobEntity(
     private @Nullable Long processDefinitionKey;
     private @Nullable Long processInstanceKey;
     private @Nullable Long rootProcessInstanceKey;
+    private @Nullable String businessId;
     private @Nullable String elementId;
     private @Nullable Long elementInstanceKey;
     private @Nullable String tenantId;
@@ -196,6 +198,11 @@ public record JobEntity(
       return this;
     }
 
+    public Builder businessId(final String businessId) {
+      this.businessId = businessId;
+      return this;
+    }
+
     public Builder elementId(final String elementId) {
       this.elementId = elementId;
       return this;
@@ -245,6 +252,7 @@ public record JobEntity(
           processDefinitionKey,
           processInstanceKey,
           rootProcessInstanceKey,
+          businessId,
           elementId,
           elementInstanceKey,
           tenantId,

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/JobEntity.java
@@ -43,6 +43,9 @@ public class JobEntity
   @SinceVersion(value = "8.9.0", requireDefault = false)
   private Long rootProcessInstanceKey;
 
+  @SinceVersion(value = "8.10.0", requireDefault = false)
+  private String businessId;
+
   @BeforeVersion880 private String tenantId;
   @BeforeVersion880 private String type;
   @BeforeVersion880 private String worker;
@@ -315,6 +318,15 @@ public class JobEntity
     return this;
   }
 
+  public String getBusinessId() {
+    return businessId;
+  }
+
+  public JobEntity setBusinessId(final String businessId) {
+    this.businessId = businessId;
+    return this;
+  }
+
   public Boolean isDenied() {
     return denied;
   }
@@ -363,7 +375,8 @@ public class JobEntity
         deniedReason,
         creationTime,
         lastUpdateTime,
-        rootProcessInstanceKey);
+        rootProcessInstanceKey,
+        businessId);
   }
 
   @Override
@@ -402,7 +415,8 @@ public class JobEntity
         && Objects.equals(deniedReason, jobEntity.deniedReason)
         && Objects.equals(creationTime, jobEntity.creationTime)
         && Objects.equals(lastUpdateTime, jobEntity.lastUpdateTime)
-        && Objects.equals(rootProcessInstanceKey, jobEntity.rootProcessInstanceKey);
+        && Objects.equals(rootProcessInstanceKey, jobEntity.rootProcessInstanceKey)
+        && Objects.equals(businessId, jobEntity.businessId);
   }
 
   @Override
@@ -468,6 +482,9 @@ public class JobEntity
         + lastUpdateTime
         + ", rootProcessInstanceKey="
         + rootProcessInstanceKey
+        + ", businessId='"
+        + businessId
+        + '\''
         + "} "
         + super.toString();
   }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
@@ -96,6 +96,9 @@
       },
       "rootProcessInstanceKey": {
         "type": "long"
+      },
+      "businessId": {
+        "type": "keyword"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
@@ -96,6 +96,9 @@
       },
       "rootProcessInstanceKey": {
         "type": "long"
+      },
+      "businessId": {
+        "type": "keyword"
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -597,7 +597,8 @@ public final class BpmnJobBehavior {
         .setTenantId(context.getTenantId())
         .setTags(getTagsFromProcessInstance(context))
         .setPriority(props.getPriority())
-        .setRootProcessInstanceKey(context.getRootProcessInstanceKey());
+        .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
+        .setBusinessId(getBusinessIdFromProcessInstance(context));
 
     final var jobKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CREATED, jobRecord);
@@ -619,6 +620,14 @@ public final class BpmnJobBehavior {
         stateBehavior.getElementInstance(context.getProcessInstanceKey()).getValue();
 
     return processInstance != null ? processInstance.getTags() : Collections.emptySet();
+  }
+
+  private String getBusinessIdFromProcessInstance(final BpmnElementContext context) {
+    final var elementInstance = stateBehavior.getElementInstance(context.getProcessInstanceKey());
+    if (elementInstance == null) {
+      return "";
+    }
+    return elementInstance.getValue().getBusinessId();
   }
 
   private DirectBuffer encodeHeaders(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBusinessIdTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class JobBusinessIdTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String CHILD_PROCESS_ID = "child-process";
+  private static final String JOB_TYPE = "task-type";
+  private static final String BUSINESS_ID = "order-123";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance processWithServiceTask() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance parentProcessWithCallActivity() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .callActivity("call", c -> c.zeebeProcessId(CHILD_PROCESS_ID))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance childProcessWithServiceTask() {
+    return Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+        .startEvent()
+        .serviceTask("child-task", t -> t.zeebeJobType(JOB_TYPE))
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  public void shouldInheritBusinessIdFromOwningProcessInstance() {
+    // given
+    ENGINE.deployment().withXmlResource(processWithServiceTask()).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withBusinessId(BUSINESS_ID).create();
+
+    // then
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(jobCreated.getValue()).hasBusinessId(BUSINESS_ID);
+  }
+
+  @Test
+  public void shouldInheritBusinessIdFromOwningChildProcessInstance() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource("parent.bpmn", parentProcessWithCallActivity())
+        .withXmlResource("child.bpmn", childProcessWithServiceTask())
+        .deploy();
+
+    // when
+    final long parentProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withBusinessId(BUSINESS_ID).create();
+
+    // then - the job is created in the child instance, which inherited the business ID
+    final Record<ProcessInstanceRecordValue> childProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentProcessInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(childProcessInstance.getKey())
+            .getFirst();
+
+    Assertions.assertThat(jobCreated.getValue()).hasBusinessId(BUSINESS_ID);
+  }
+
+  @Test
+  public void shouldHaveEmptyBusinessIdWhenProcessInstanceHasNone() {
+    // given
+    ENGINE.deployment().withXmlResource(processWithServiceTask()).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<JobRecordValue> jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(jobCreated.getValue()).hasBusinessId("");
+  }
+
+  @Test
+  public void shouldRetainBusinessIdWhenRetriesUpdated() {
+    // given
+    ENGINE.deployment().withXmlResource(processWithServiceTask()).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withBusinessId(BUSINESS_ID).create();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    ENGINE.job().withKey(jobKey).withRetries(5).updateRetries();
+
+    // then - the business ID survives a retries update
+    final Record<JobRecordValue> retriesUpdated =
+        RecordingExporter.jobRecords(JobIntent.RETRIES_UPDATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(retriesUpdated.getValue()).hasBusinessId(BUSINESS_ID);
+  }
+
+  @Test
+  public void shouldRetainBusinessIdWhenJobFails() {
+    // given
+    ENGINE.deployment().withXmlResource(processWithServiceTask()).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withBusinessId(BUSINESS_ID).create();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+    ENGINE.jobs().withType(JOB_TYPE).activate();
+
+    // when
+    ENGINE.job().withKey(jobKey).withRetries(2).fail();
+
+    // then - the business ID survives a non-CREATED (FAILED) state update
+    final Record<JobRecordValue> jobFailed =
+        RecordingExporter.jobRecords(JobIntent.FAILED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(jobFailed.getValue()).hasBusinessId(BUSINESS_ID);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -25,6 +25,7 @@ import static io.camunda.webapps.schema.descriptors.template.JobTemplate.RETRIES
 import static io.camunda.webapps.schema.descriptors.template.JobTemplate.TIME;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.JobEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -119,6 +120,11 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
     if (record.getIntent().equals(JobIntent.CREATED)) {
       entity.setCreationTime(recordTimestampAsOffsetDateTime);
       entity.setFlowNodeType(recordValue.getElementType().name());
+      // businessId is immutable and inherited at creation; never updated by later events
+      final String businessId = recordValue.getBusinessId();
+      if (!ExporterUtil.isEmpty(businessId)) {
+        entity.setBusinessId(businessId);
+      }
     }
     entity.setLastUpdateTime(recordTimestampAsOffsetDateTime);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -151,6 +151,7 @@ final class JobHandlerTest {
     final String elementId = "elementId";
     final String bpmnProcessId = "bpmnProcessId";
     final String tenantId = "tenantId";
+    final String businessId = "businessId";
     final String jobType = "jobType";
     final int retries = 3;
     final int priority = 77;
@@ -175,6 +176,7 @@ final class JobHandlerTest {
             .withWorker(jobWorker)
             .withCustomHeaders(Map.of("key", "val"))
             .withTenantId(tenantId)
+            .withBusinessId(businessId)
             .withErrorMessage(errorMessage)
             .withJobKind(jobKind)
             .withJobListenerEventType(jobListenerEventType)
@@ -227,6 +229,7 @@ final class JobHandlerTest {
     assertThat(entity.isDenied()).isEqualTo(null);
     assertThat(entity.getDeniedReason()).isEqualTo(null);
     assertThat(entity.getRootProcessInstanceKey()).isEqualTo(rootProcessInstanceKey);
+    assertThat(entity.getBusinessId()).isEqualTo(businessId);
   }
 
   @Test
@@ -254,6 +257,60 @@ final class JobHandlerTest {
 
     // then
     assertThat(entity.getRootProcessInstanceKey()).isNull();
+  }
+
+  @Test
+  void shouldNotSetBusinessIdWhenEmpty() {
+    // given
+    final long recordKey = 789;
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withBusinessId("")
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CREATED)
+                    .withKey(recordKey)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+    final var entity = new JobEntity().setId(String.valueOf(recordKey));
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getBusinessId()).isNull();
+  }
+
+  @Test
+  void shouldNotSetBusinessIdForNonCreatedIntent() {
+    // given
+    final long recordKey = 789;
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withBusinessId("order-123")
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.RETRIES_UPDATED)
+                    .withKey(recordKey)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+    final var entity = new JobEntity().setId(String.valueOf(recordKey));
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then - businessId is immutable and only set on CREATED
+    assertThat(entity.getBusinessId()).isNull();
   }
 
   @Test

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -179,7 +179,7 @@ final class BulkIndexRequest {
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
   private static final class CommandDistributionMixin {}
 
-  @JsonIgnoreProperties({PRIORITY_PROPERTY, ELEMENT_TYPE_PROPERTY})
+  @JsonIgnoreProperties({PRIORITY_PROPERTY, ELEMENT_TYPE_PROPERTY, BUSINESS_ID_PROPERTY})
   private static final class JobMixin {}
 
   /** Shared by record values that only need to strip {@code businessId} for previous versions. */

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
@@ -169,6 +169,9 @@
                 },
                 "rootProcessInstanceKey": {
                   "type": "long"
+                },
+                "businessId": {
+                  "type": "keyword"
                 }
               }
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-template.json
@@ -150,6 +150,9 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -452,6 +452,57 @@ final class BulkIndexRequestTest {
     }
 
     @Test
+    void shouldIndexJobRecordWithoutBusinessIdOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new JobRecord().setBusinessId("order-123")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("businessId"))
+          .describedAs(
+              "Expect that job records are NOT serialized with businessId on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithBusinessIdOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new JobRecord().setBusinessId("order-123")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("businessId"))
+          .describedAs("Expect that job records are serialized with businessId on current version")
+          .containsExactly("order-123");
+    }
+
+    @Test
     void shouldIndexUserTaskRecordWithoutBusinessIdOnPreviousVersion() {
       // given
       final var record =

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -179,7 +179,7 @@ final class BulkIndexRequest {
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
   private static final class CommandDistributionMixin {}
 
-  @JsonIgnoreProperties({PRIORITY_PROPERTY, ELEMENT_TYPE_PROPERTY})
+  @JsonIgnoreProperties({PRIORITY_PROPERTY, ELEMENT_TYPE_PROPERTY, BUSINESS_ID_PROPERTY})
   private static final class JobMixin {}
 
   /** Shared by record values that only need to strip {@code businessId} for previous versions. */

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
@@ -175,6 +175,9 @@
                 },
                 "rootProcessInstanceKey": {
                   "type": "long"
+                },
+                "businessId": {
+                  "type": "keyword"
                 }
               }
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-template.json
@@ -156,6 +156,9 @@
             },
             "rootProcessInstanceKey": {
               "type": "long"
+            },
+            "businessId": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -465,6 +465,57 @@ final class BulkIndexRequestTest {
     }
 
     @Test
+    void shouldIndexJobRecordWithoutBusinessIdOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new JobRecord().setBusinessId("order-123")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("businessId"))
+          .describedAs(
+              "Expect that job records are NOT serialized with businessId on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithBusinessIdOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new JobRecord().setBusinessId("order-123")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("businessId"))
+          .describedAs("Expect that job records are serialized with businessId on current version")
+          .containsExactly("order-123");
+    }
+
+    @Test
     void shouldIndexUserTaskRecordWithoutBusinessIdOnPreviousVersion() throws IOException {
       // given
       final var record =

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobExportHandler.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import java.time.Instant;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 
 public class JobExportHandler implements RdbmsExportHandler<JobRecordValue> {
 
@@ -72,6 +73,7 @@ public class JobExportHandler implements RdbmsExportHandler<JobRecordValue> {
             .partitionId(record.getPartitionId())
             .processInstanceKey(value.getProcessInstanceKey())
             .rootProcessInstanceKey(value.getRootProcessInstanceKey())
+            .businessId(StringUtils.defaultIfEmpty(value.getBusinessId(), null))
             .elementInstanceKey(value.getElementInstanceKey())
             .processDefinitionId(value.getBpmnProcessId())
             .processDefinitionKey(value.getProcessDefinitionKey())

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/JobExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/JobExportHandlerTest.java
@@ -207,4 +207,52 @@ class JobExportHandlerTest {
     verify(jobWriter).update(jobDbModelCaptor.capture());
     assertThat(jobDbModelCaptor.getValue().priority()).isEqualTo(99);
   }
+
+  @Test
+  void shouldSetBusinessId() {
+    // given
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withBusinessId("order-123")
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CREATED)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(jobWriter).create(jobDbModelCaptor.capture());
+    assertThat(jobDbModelCaptor.getValue().businessId()).isEqualTo("order-123");
+  }
+
+  @Test
+  void shouldNotSetBusinessIdWhenEmpty() {
+    // given
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .withBusinessId("")
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CREATED)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then - an empty business ID is stored as null rather than an empty string
+    verify(jobWriter).create(jobDbModelCaptor.capture());
+    assertThat(jobDbModelCaptor.getValue().businessId()).isNull();
+  }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -404,7 +404,8 @@ public final class ResponseMapper {
             .setListenerEventType(
                 EnumUtil.convert(
                     job.getJobListenerEventType(), ActivatedJob.ListenerEventType.class))
-            .addAllTags(job.getTags());
+            .addAllTags(job.getTags())
+            .setBusinessId(job.getBusinessId());
 
     if (job.getJobKind().equals(io.camunda.zeebe.protocol.record.value.JobKind.TASK_LISTENER)
         && !job.getCustomHeaders().isEmpty()) {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
@@ -188,6 +188,20 @@ class ResponseMapperTest {
       assertThat(result.getPriority()).isEqualTo(80);
     }
 
+    @Test
+    void shouldMapBusinessIdToActivatedJob() {
+      // given
+      final JobRecord jobRecord = mockJobRecord(JobKind.BPMN_ELEMENT, Map.of());
+      when(jobRecord.getBusinessId()).thenReturn("order-123");
+      final var activatedJob = mockActivatedJob(jobRecord);
+
+      // when
+      final var result = ResponseMapper.toActivatedJob(activatedJob);
+
+      // then
+      assertThat(result.getBusinessId()).isEqualTo("order-123");
+    }
+
     @ParameterizedTest
     @EnumSource(JobListenerEventType.class)
     void shouldMapActivatedJobWithListenerEventType(final JobListenerEventType listenerEventType) {
@@ -225,6 +239,7 @@ class ResponseMapperTest {
       when(jobRecord.getVariables()).thenReturn(Map.of());
       when(jobRecord.getTenantId()).thenReturn(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
       when(jobRecord.getLength()).thenReturn(1);
+      when(jobRecord.getBusinessId()).thenReturn("");
       return jobRecord;
     }
 

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -127,6 +127,8 @@ message ActivatedJob {
   repeated string tags = 18;
   // the priority of the job; higher values indicate higher priority
   int32 priority = 19;
+  // the business ID of the owning process instance; null when the instance has none
+  string businessId = 20;
 }
 
 message UserTaskProperties {

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -419,6 +419,7 @@ components:
         - kind
         - listenerEventType
         - rootProcessInstanceKey
+        - businessId
         - tags
         - userTask
         - priority
@@ -504,6 +505,14 @@ components:
           nullable: true
           allOf:
             - $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+        businessId:
+          description: |
+            The business ID of the owning process instance, inherited when the job was created.
+            This is `null` for jobs created before version 8.10 and for jobs whose owning process
+            instance has no business ID.
+          nullable: true
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/BusinessId'
         priority:
           description: >
             The priority of the job. Higher values indicate higher priority.
@@ -522,6 +531,8 @@ components:
         - propertyName: rootProcessInstanceKey
           addedInVersion: "8.9"
         - propertyName: priority
+          addedInVersion: "8.10"
+        - propertyName: businessId
           addedInVersion: "8.10"
 
     UserTaskProperties:

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -817,6 +817,7 @@ components:
         - type
         - worker
         - rootProcessInstanceKey
+        - businessId
         - creationTime
         - deadline
         - deniedReason
@@ -899,6 +900,14 @@ components:
           nullable: true
           allOf:
             - $ref: "keys.yaml#/components/schemas/ProcessInstanceKey"
+        businessId:
+          description: |
+            The business ID of the owning process instance, inherited when the job was created.
+            This is `null` for jobs created before version 8.10 and for jobs whose owning process
+            instance has no business ID.
+          nullable: true
+          allOf:
+            - $ref: "identifiers.yaml#/components/schemas/BusinessId"
         retries:
           description: The amount of retries left to this job.
           type: integer
@@ -939,6 +948,8 @@ components:
         - propertyName: lastUpdateTime
           addedInVersion: "8.9"
         - propertyName: priority
+          addedInVersion: "8.10"
+        - propertyName: businessId
           addedInVersion: "8.10"
 
     JobFailRequest:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -136,6 +136,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "kind": "BPMN_ELEMENT",
               "listenerEventType": "UNSPECIFIED",
               "rootProcessInstanceKey": null,
+              "businessId": null,
               "userTask": null,
               "priority": 80
             },
@@ -164,6 +165,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "kind": "BPMN_ELEMENT",
               "listenerEventType": "UNSPECIFIED",
               "rootProcessInstanceKey": null,
+              "businessId": null,
               "userTask": null,
               "priority": 80
             }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobQueryControllerTest.java
@@ -70,6 +70,7 @@ public class JobQueryControllerTest extends RestControllerTest {
                     "processDefinitionKey": "2",
                     "processInstanceKey": "3",
                     "rootProcessInstanceKey": "37",
+                    "businessId": "business-1",
                     "elementId": "elementId",
                     "elementInstanceKey": "4",
                     "tenantId": "<default>",
@@ -111,6 +112,7 @@ public class JobQueryControllerTest extends RestControllerTest {
                       .processDefinitionKey(2L)
                       .processInstanceKey(3L)
                       .rootProcessInstanceKey(37L)
+                      .businessId("business-1")
                       .elementId("elementId")
                       .elementInstanceKey(4L)
                       .tenantId("<default>")

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -89,6 +89,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringValue("isUserTaskMigration");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue PRIORITY_KEY = new StringValue(PRIORITY);
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
@@ -135,10 +136,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, EMPTY_STRING);
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
 
   public JobRecord() {
-    super(26);
+    super(27);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -165,7 +167,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(tagsProp)
         .declareProperty(isJobToUserTaskMigrationProp)
         .declareProperty(rootProcessInstanceKeyProp)
-        .declareProperty(priorityProp);
+        .declareProperty(priorityProp)
+        .declareProperty(businessIdProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -197,6 +200,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     setTags(record.getTags());
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
     priorityProp.setValue(record.getPriority());
+    businessIdProp.setValue(record.getBusinessIdBuffer());
   }
 
   public void wrap(final JobRecord record) {
@@ -400,6 +404,26 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   public JobRecord setRootProcessInstanceKey(final long rootProcessInstanceKey) {
     rootProcessInstanceKeyProp.setValue(rootProcessInstanceKey);
     return this;
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProp.getValue());
+  }
+
+  public JobRecord setBusinessId(final String businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  public JobRecord setBusinessId(final DirectBuffer businessId) {
+    businessIdProp.setValue(businessId);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBusinessIdBuffer() {
+    return businessIdProp.getValue();
   }
 
   public JobRecord setElementInstanceKey(final long elementInstanceKey) {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -886,6 +886,7 @@ final class JsonSerializableToJsonTest {
                       },
                       "retries": 3,
                       "priority": 0,
+                      "businessId": "",
                       "jobKind": "BPMN_ELEMENT",
                       "jobListenerEventType": "UNSPECIFIED",
                       "retryBackoff": 1002,
@@ -1054,7 +1055,8 @@ final class JsonSerializableToJsonTest {
                       .setTags(Set.of("tag1", "tag2"))
                       .setRootProcessInstanceKey(rootProcessInstanceKey)
                       .setIsJobToUserTaskMigration(true)
-                      .setPriority(42);
+                      .setPriority(42)
+                      .setBusinessId("biz-42");
 
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
               return record;
@@ -1075,6 +1077,7 @@ final class JsonSerializableToJsonTest {
                   },
                   "retries": 12,
                   "priority": 42,
+                  "businessId": "biz-42",
                   "jobKind": "BPMN_ELEMENT",
                   "jobListenerEventType": "UNSPECIFIED",
                   "retryBackoff": 1003,
@@ -1154,6 +1157,7 @@ final class JsonSerializableToJsonTest {
                   "worker": "",
                   "retries": -1,
                   "priority": 0,
+                  "businessId": "",
                   "jobKind": "BPMN_ELEMENT",
                   "jobListenerEventType": "UNSPECIFIED",
                   "retryBackoff": 0,
@@ -1218,6 +1222,7 @@ final class JsonSerializableToJsonTest {
                   "worker": "",
                   "retries": -1,
                   "priority": 0,
+                  "businessId": "",
                   "jobKind": "BPMN_ELEMENT",
                   "jobListenerEventType": "UNSPECIFIED",
                   "retryBackoff": 0,

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
@@ -78,6 +78,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringValue("isUserTaskMigration");
   private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
       new StringValue("rootProcessInstanceKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue PRIORITY_KEY = new StringValue(PRIORITY);
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
@@ -124,6 +125,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new BooleanProperty(IS_JOB_TO_USERTASK_MIGRATION_KEY, false);
   private final LongProperty rootProcessInstanceKeyProp =
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
+  private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, EMPTY_STRING);
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
 
   public JobRecord() {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -131,6 +131,16 @@ public interface JobRecordValue
   long getRootProcessInstanceKey();
 
   /**
+   * Returns the business ID inherited from the owning process instance, captured when the job is
+   * created within a process. Every job is created inside a process element, so the value is
+   * present whenever the owning instance carries a business ID.
+   *
+   * @return the business ID of the owning process instance, or an empty string when the owning
+   *     instance has no business ID (and for jobs created before 8.10)
+   */
+  String getBusinessId();
+
+  /**
    * @return the bpmn process id of the corresponding process definition
    */
   @Override


### PR DESCRIPTION
## Description

This PR adds end-to-end propagation of a process instance’s `businessId` into job records and surfaces it through REST/search APIs and the Java client, including persistence/index mappings so downstream tooling (Operate/Search) can store and return it consistently.

**Changes:**
- Extend the Zeebe job record model to carry `businessId` and populate it at job creation time in the engine.
- Persist/index `businessId` for jobs across RDBMS + Elasticsearch/OpenSearch exporters and webapp schema templates.
- Expose `businessId` on REST/OpenAPI responses and Java client response models, with unit/integration/E2E test updates.

## Related issues

closes #55685 