### PR TITLE
fix: separate load-test flags

### DIFF
--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -54,6 +54,9 @@ platform_values := -f camunda-platform-values-defaults.yaml
 helm_chart_load_test_setup := charts/load-test-setup
 load_test_setup_values := -f load-test-setup-values.yaml
 additional_load_test_setup_configuration ?=
+# Makefile-side load-test-setup flags. Separate from `additional_load_test_setup_configuration`,
+# which CI sets on the make command line and would suppress `+=` here.
+_load_test_setup_flags :=
 
 # The Docker image tag for the load test metrics exporter
 metrics_exporter_image_tag := latest
@@ -91,23 +94,23 @@ platform_values_stable := $(platform_values) -f values-stable.yaml
 ifeq ($(secondary_storage),elasticsearch)
 	install_es_prom_exporter := true
 	es_prom_exporter_es_uri := http://elastic:9200
-	additional_load_test_setup_configuration += --set metricsExporter.database.url=http://elastic:9200
+	_load_test_setup_flags += --set metricsExporter.database.url=http://elastic:9200
 else ifeq ($(secondary_storage),opensearch)
 	install_es_prom_exporter := true
 	es_prom_exporter_es_uri := http://opensearch:9200
-	additional_load_test_setup_configuration += --set metricsExporter.database.url=http://opensearch:9200
+	_load_test_setup_flags += --set metricsExporter.database.url=http://opensearch:9200
 else ifeq ($(enable_optimize),true)
 	# Here, the secondary storage is either none or a RDBMS database.
 	# Elasticsearch is always used in this case as the backend for Optimize.
 	install_es_prom_exporter := true
 	es_prom_exporter_es_uri := http://elastic:9200
-	additional_load_test_setup_configuration += --set metricsExporter.database.url=http://elastic:9200
+	_load_test_setup_flags += --set metricsExporter.database.url=http://elastic:9200
 else
 	install_es_prom_exporter := false
 endif
 
 ifeq ($(chaos),true)
-	additional_load_test_setup_configuration += --set chaosKiller.enabled=true
+	_load_test_setup_flags += --set chaosKiller.enabled=true
 endif
 
 .PHONY: all
@@ -245,7 +248,9 @@ install-load-test-setup: create-namespace
 		--reset-then-reuse-values \
 		--render-subchart-notes \
 		--take-ownership --create-namespace \
-		$(load_test_setup_values) $(additional_load_test_setup_configuration)
+		$(load_test_setup_values) \
+		$(_load_test_setup_flags) \
+		$(additional_load_test_setup_configuration)
 
 # Install/upgrade load test helm chart
 .PHONY: install-load-test
@@ -284,6 +289,7 @@ template-load-test-setup:
 	helm template load-test-setup $(helm_chart_load_test_setup) \
 		--namespace $(namespace) \
 		$(load_test_setup_values) \
+		$(_load_test_setup_flags) \
 		$(additional_load_test_setup_configuration) \
 		--output-dir $(template_output_dir)
 

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -3,7 +3,9 @@ package golden
 
 import (
 	"flag"
+	"os/exec"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -162,6 +164,32 @@ func TestGoldenFiles(t *testing.T) {
 			renderAndAssert(t, s.Version, s.Name, "load-test-setup", ns, "template-load-test-setup", "")
 		})
 	}
+}
+
+func TestInstallLoadTestSetupKeepsMakefileFlagsWhenAdditionalConfigurationIsProvided(t *testing.T) {
+	ns := Scaffold(t, "main", "c8-golden-setup-flags", "postgresql", "true")
+	defer ns.Cleanup()
+
+	cmd := exec.Command(
+		"make",
+		"-n",
+		"install-load-test-setup",
+		"chaos=true",
+		"additional_load_test_setup_configuration=--set metricsExporter.image.tag=test-tag",
+	)
+	cmd.Dir = ns.Dir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "make dry-run failed:\n%s", string(out))
+
+	helmCommand := string(out)
+	require.Contains(t, helmCommand, "--set metricsExporter.database.url=http://elastic:9200")
+	require.Contains(t, helmCommand, "--set chaosKiller.enabled=true")
+	require.Contains(t, helmCommand, "--set metricsExporter.image.tag=test-tag")
+	require.Less(
+		t,
+		strings.Index(helmCommand, "--set chaosKiller.enabled=true"),
+		strings.Index(helmCommand, "--set metricsExporter.image.tag=test-tag"),
+	)
 }
 
 // renderAndAssert renders a chart via the scaffolded Makefile's make target and


### PR DESCRIPTION
## Description

* Introduced a new variable, `_load_test_setup_flags`, to store Makefile-side Helm flags separately from `additional_load_test_setup_configuration`, preventing command-line overrides from suppressing default flags.
* Updated all relevant Makefile logic to append flags (e.g., `--set metricsExporter.database.url=...`, `--set chaosKiller.enabled=true`) to `_load_test_setup_flags` instead of `additional_load_test_setup_configuration`.
* Updated `install-load-test-setup` and `template-load-test-setup` targets to include both `_load_test_setup_flags` and `additional_load_test_setup_configuration` when invoking Helm, ensuring both sets of flags are applied. [[1]](diffhunk://#diff-3ded45cac5d76b3b79606f6bbc1716868617b772d7166ceed026474bf1fb7956L248-R253) [[2]](diffhunk://#diff-3ded45cac5d76b3b79606f6bbc1716868617b772d7166ceed026474bf1fb7956R292)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
