### PR TITLE
ci: fix C8Run RC and public release workflows

### DIFF
--- a/.github/actions/sign-and-notarize/sign_and_notarize.sh
+++ b/.github/actions/sign-and-notarize/sign_and_notarize.sh
@@ -245,7 +245,8 @@ done < <(find "$C8RUN_DIR" -name "*.app" -type d -print0)
 while IFS= read -r -d '' candidate; do
   # skip files inside .app bundles (covered by --deep above)
   [[ "$candidate" == *.app/* ]] && continue
-  file -b "$candidate" | grep -q "Mach-O" || continue
+  macho_type="$(file -b "$candidate")"
+  echo "$macho_type" | grep -q "Mach-O" || continue
 
   # 2. Valid signature
   if codesign --verify --strict "$candidate" 2>/dev/null; then
@@ -255,7 +256,12 @@ while IFS= read -r -d '' candidate; do
     verify_errors=$((verify_errors + 1))
   fi
 
-  # 3. JRE path → must carry all three JVM entitlements
+  # 3. JRE executables → assert all three JVM entitlements are present.
+  #    codesign embeds entitlements only into Mach-O executables, not dylibs or
+  #    bundles; the JVM's JIT capability comes from the launching executable
+  #    (jre/bin/java), so the runtime dylibs (libjvm.dylib, ...) neither carry
+  #    nor need them. Skip non-executables to avoid false verification failures.
+  echo "$macho_type" | grep -q "executable" || continue
   for jre_dir in "${JRE_DIR_NAMES[@]}"; do
     if [[ "$candidate" == */"$jre_dir"/* ]]; then
       entitlements_out="$(codesign -d --entitlements - "$candidate" 2>/dev/null)"

--- a/.github/workflows/c8run-release-public.yaml
+++ b/.github/workflows/c8run-release-public.yaml
@@ -75,8 +75,17 @@ jobs:
             secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD;
             secret/data/common/jenkins/downloads-camunda-cloud_google_sa_key DOWNLOAD_CENTER_GCLOUD_KEY_BYTES | GCP_CREDENTIALS_NAME;
 
-      - name: Setup oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+      - name: Install regctl CLI
+        env:
+          REGCTL_VERSION: "0.11.5"
+          REGCTL_SHA256: "c93aa7638749f5aaac1a8e01787321889c78f0101809bb2880343478d0ba0467"
+        run: |
+          workdir="$(mktemp -d)"; cd "$workdir"
+          curl -fsSL -o regctl "https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/regctl-linux-amd64"
+          echo "${REGCTL_SHA256}  regctl" | sha256sum -c -
+          chmod +x regctl
+          sudo mv regctl /usr/local/bin/regctl
+          regctl version
 
       - name: Guard - Camunda apps release must exist
         if: ${{ !inputs.dryRun }}
@@ -94,12 +103,15 @@ jobs:
         env:
           HARBOR_REGISTRY_USER: ${{ steps.secrets.outputs.HARBOR_REGISTRY_USER }}
           HARBOR_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.HARBOR_REGISTRY_PASSWORD }}
-          RC_REF: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
+          RC_PREFIX: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
         run: |
           mkdir -p artifacts
           echo "${HARBOR_REGISTRY_PASSWORD}" | \
-            oras login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --password-stdin
-          oras pull "${RC_REF}" --output artifacts
+            regctl registry login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --pass-stdin
+          # The RC build stages one tag per OS in parallel; pull each into the same dir.
+          for os in linux-x86_64 darwin-aarch64 darwin-x86_64 windows-x86_64; do
+            regctl artifact get "${RC_PREFIX}-${os}" --output artifacts
+          done
           echo "Pulled RC artifacts (notarized bytes, unchanged):"
           ls -la artifacts
           echo "Artifact checksums (post-pull; must match the RC build's pre-push checksums):"
@@ -165,24 +177,10 @@ jobs:
           echo "Download Center own (minor):  c8run/${MINOR}/  <- artifacts/camunda8-run-${MINOR}-*"
           echo "Download Center apps version: c8run/${CAMUNDA_VERSION}/  <- artifacts/camunda8-run-${CAMUNDA_VERSION}-*"
 
-      # On a dry run ARCHIVE_TAG carries a -dryrun suffix, so this retags the isolated dryrun artifact
-      # rather than a public version — it intentionally runs in both modes and needs no dryRun guard.
-      - name: Harbor - Tag promoted version (archival)
-        env:
-          HARBOR_REGISTRY_USER: ${{ steps.secrets.outputs.HARBOR_REGISTRY_USER }}
-          HARBOR_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.HARBOR_REGISTRY_PASSWORD }}
-          RC_REF: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
-          ARCHIVE_TAG: ${{ inputs.camundaVersion }}${{ inputs.dryRun && '-dryrun' || '' }}
-        run: |
-          echo "${HARBOR_REGISTRY_PASSWORD}" | \
-            oras login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --password-stdin
-          oras tag "${RC_REF}" "${ARCHIVE_TAG}"
-
       - name: Release summary
         env:
           MINOR: ${{ steps.vars.outputs.minor }}
           DRY_RUN: ${{ inputs.dryRun }}
-          ARCHIVE_TAG: ${{ inputs.camundaVersion }}${{ inputs.dryRun && '-dryrun' || '' }}
           CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
           REPO: ${{ github.repository }}
         run: |
@@ -190,9 +188,9 @@ jobs:
             if [ "${DRY_RUN}" = "true" ]; then
               echo "🧪 C8Run public promote (DRY RUN) 🧪"
               echo "- Version: \`${CAMUNDA_VERSION}\` (minor \`${MINOR}\`)"
-              echo "- Pulled & re-hashed the isolated \`${CAMUNDA_VERSION}-rc-dryrun\` tag — see the pull step for checksums."
+              echo "- Pulled & re-hashed the isolated \`${CAMUNDA_VERSION}-rc-dryrun-<os>\` tags — see the pull step for checksums."
               echo "- Public publishes (GitHub release + Download Center) were logged, not executed."
-              echo "- Delete the dryrun tags when done: \`oras manifest delete .../${RC_REPOSITORY}:${ARCHIVE_TAG}\` and \`...:${CAMUNDA_VERSION}-rc-dryrun\`"
+              echo "- No Harbor tags were written; the pulled \`${CAMUNDA_VERSION}-rc-dryrun-<os>\` tags are residue from the RC dry run (delete with \`regctl tag rm\`)."
             else
               echo "⭐ C8Run public release complete ⭐"
               echo "- Version: \`${CAMUNDA_VERSION}\` (minor \`${MINOR}\`)"
@@ -211,3 +209,73 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  # Merge the c8run/.env bump PR that the RC workflow opened, mirroring the Helm chart's public
+  # release. A non-merge is a branch-sync gap, not a release failure (the artifacts are already
+  # published), so this job never fails the run; it warns and leaves the PR for a manual merge.
+  merge-env-pr:
+    name: Merge c8run/.env bump PR
+    needs: promote
+    if: ${{ !inputs.dryRun }}
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@1c317c29f01f213c82f601e971ac4d6d449071d2 # main
+        with:
+          github-app-id-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+
+      - name: Find PR and enable auto-merge
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          ACTIONS_TOKEN: ${{ github.token }}
+          CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
+          REPO: ${{ github.repository }}
+        run: |
+          pr_branch="c8run-release-${CAMUNDA_VERSION}"
+          pr_number="$(gh pr list --repo "${REPO}" --state open --head "${pr_branch}" --json number --jq '.[0].number // empty')"
+          if [ -z "${pr_number}" ]; then
+            echo "::notice::No open c8run/.env bump PR for ${pr_branch} (already merged, or the RC bump was a no-op). Nothing to merge."
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+          # Approve as the Actions identity, which differs from the app that authored the PR.
+          GH_TOKEN="${ACTIONS_TOKEN}" gh pr review "${pr_number}" --repo "${REPO}" --approve \
+            || echo "::warning::Could not approve PR #${pr_number}; relying on the merge queue / a human review."
+          # Enable auto-merge with the app token; the default Actions token cannot trigger the queue.
+          gh pr merge "${pr_number}" --repo "${REPO}" --auto --squash
+
+      - name: Shepherd PR through the merge queue
+        id: merge-queue
+        if: ${{ steps.find-pr.outputs.pr_number != '' }}
+        continue-on-error: true
+        uses: camunda/infra-global-github-actions/ensure-pr-passes-merge-queue@1c317c29f01f213c82f601e971ac4d6d449071d2 # main
+        with:
+          pr-number: ${{ steps.find-pr.outputs.pr_number }}
+          app-token: ${{ steps.github-token.outputs.token }}
+          repository-owner: ${{ github.repository_owner }}
+          repository-name: ${{ github.event.repository.name }}
+          timeout-minutes: "90"
+          max-evictions: "3"
+
+      - name: Warn if PR did not merge
+        if: ${{ steps.find-pr.outputs.pr_number != '' && steps.merge-queue.outputs.result != 'merged' }}
+        env:
+          PR_NUMBER: ${{ steps.find-pr.outputs.pr_number }}
+          RESULT: ${{ steps.merge-queue.outputs.result }}
+        run: |
+          echo "::warning::c8run/.env bump PR #${PR_NUMBER} did not merge (merge-queue result: ${RESULT:-unknown}). Merge it manually so the release branch records the published versions."

--- a/.github/workflows/c8run-release-rc.yaml
+++ b/.github/workflows/c8run-release-rc.yaml
@@ -171,6 +171,8 @@ jobs:
             secret/data/products/distribution/ci APPLE_DEVELOPER_PASSWORD;
             secret/data/products/distribution/ci APPLE_TEAM_ID;
             secret/data/products/distribution/ci APPLE_COMMON_NAME;
+            secret/data/products/distribution/ci HARBOR_REGISTRY_USER;
+            secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD;
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -265,13 +267,77 @@ jobs:
         run: |
           mv ./c8run/tmp/c8run_complete.zip ./c8run/"$C8RUN_NAME_ARTIFACT"
 
-      - name: Upload RC artifact for staging
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: ${{ matrix.os.id }}
-          path: ${{ matrix.os.workingDir }}/${{ env.C8RUN_NAME_ARTIFACT }}
-          if-no-files-found: error
-          retention-days: 7
+      - name: Install regctl CLI
+        env:
+          REGCTL_VERSION: "0.11.5"
+          REGCTL_SHA_LINUX_AMD64: "c93aa7638749f5aaac1a8e01787321889c78f0101809bb2880343478d0ba0467"
+          REGCTL_SHA_DARWIN_ARM64: "f4d536d64d0c3cc1db7400902175a1c314675991d22e87e15c319501a2676d3f"
+          REGCTL_SHA_DARWIN_AMD64: "c132fdddda68b9c7584ac19f3b40cd17f71916c2bca8182270ebe65b55198a12"
+          REGCTL_SHA_WINDOWS_AMD64: "9b83975d464e4ee5a9f899a3ead26072ed67e9a8ed0f582897bfad8141b45938"
+        run: |
+          case "${RUNNER_OS}_${RUNNER_ARCH}" in
+            Linux_X64)   asset="regctl-linux-amd64";       sha="${REGCTL_SHA_LINUX_AMD64}" ;;
+            macOS_ARM64) asset="regctl-darwin-arm64";      sha="${REGCTL_SHA_DARWIN_ARM64}" ;;
+            macOS_X64)   asset="regctl-darwin-amd64";      sha="${REGCTL_SHA_DARWIN_AMD64}" ;;
+            Windows_X64) asset="regctl-windows-amd64.exe"; sha="${REGCTL_SHA_WINDOWS_AMD64}" ;;
+            *) echo "::error::unsupported runner ${RUNNER_OS}_${RUNNER_ARCH}"; exit 1 ;;
+          esac
+          dir="${HOME}/regctl-bin"; mkdir -p "${dir}"
+          out="${dir}/regctl"; [ "${RUNNER_OS}" = "Windows" ] && out="${dir}/regctl.exe"
+          curl -fsSL -o "${out}" "https://github.com/regclient/regclient/releases/download/v${REGCTL_VERSION}/${asset}"
+          actual="$(openssl dgst -sha256 "${out}" | awk '{print $NF}')"
+          if [ "${actual}" != "${sha}" ]; then
+            echo "::error::regctl checksum mismatch: got ${actual}, want ${sha}"; exit 1
+          fi
+          chmod +x "${out}"
+          echo "REGCTL=${out}" >> "$GITHUB_ENV"
+          "${out}" version
+
+      # Push this OS's artifact straight to its own per-OS Harbor tag (no GHA staging hop, no gather):
+      # the four runners stage concurrently, each uploading once.
+      - name: Push RC artifact to Harbor
+        working-directory: ${{ matrix.os.workingDir }}
+        env:
+          HARBOR_REGISTRY_USER: ${{ steps.secrets.outputs.HARBOR_REGISTRY_USER }}
+          HARBOR_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.HARBOR_REGISTRY_PASSWORD }}
+          ARTIFACT: ${{ env.C8RUN_NAME_ARTIFACT }}
+          ARTIFACT_SUFFIX: ${{ matrix.os.artifactFileSuffix }}
+          RC_BASE: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
+        run: |
+          if [ ! -f "${ARTIFACT}" ]; then
+            echo "::error::Built artifact ${ARTIFACT} not found in $(pwd)."
+            exit 1
+          fi
+          os_tag="${ARTIFACT_SUFFIX%%.*}"
+          case "${ARTIFACT_SUFFIX}" in
+            *.tar.gz) media_type="application/gzip" ;;
+            *.zip)    media_type="application/zip" ;;
+            *)        media_type="application/octet-stream" ;;
+          esac
+          rc_ref="${RC_BASE}-${os_tag}"
+          echo "Staging ${ARTIFACT} -> ${rc_ref}"
+          echo "Checksum (pre-push; compare against the public promote):"
+          openssl dgst -sha256 "${ARTIFACT}"
+
+          echo "${HARBOR_REGISTRY_PASSWORD}" | \
+            "${REGCTL}" registry login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --pass-stdin
+          # Upload in 320 MiB chunks (a monolithic PUT of the ~780 MB artifact overruns Harbor's
+          # ~60s per-request gateway timeout; 320 MiB measured ~33s/chunk at peak throughput).
+          "${REGCTL}" registry set "${HARBOR_REGISTRY_HOST}" --blob-chunk 335544320
+
+          attempt=1
+          until "${REGCTL}" artifact put --artifact-type application/vnd.camunda.c8run.v1 --file-title \
+            -f "${ARTIFACT}" -m "${media_type}" "${rc_ref}"; do
+            if [ "${attempt}" -ge 3 ]; then
+              echo "::error::regctl artifact put failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "::warning::regctl artifact put failed (attempt ${attempt}); re-authenticating and retrying..."
+            echo "${HARBOR_REGISTRY_PASSWORD}" | \
+              "${REGCTL}" registry login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --pass-stdin || true
+            attempt=$((attempt + 1))
+            sleep 30
+          done
 
       - name: Observe build status
         if: always()
@@ -284,106 +350,38 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  stage-rc:
-    name: Stage RC to Harbor
+  rc-summary:
+    name: RC summary
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
     permissions:
       contents: read
     steps:
-      - name: Checkout observe-build-status action
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          sparse-checkout: .github/actions/observe-build-status
-          sparse-checkout-cone-mode: false
-
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/distribution/ci HARBOR_REGISTRY_USER;
-            secret/data/products/distribution/ci HARBOR_REGISTRY_PASSWORD;
-
-      - name: Setup oras
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
-
-      - name: Download built RC artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: rc-artifacts
-          merge-multiple: true
-
-      - name: Push RC artifacts to Harbor
-        working-directory: rc-artifacts
-        env:
-          HARBOR_REGISTRY_USER: ${{ steps.secrets.outputs.HARBOR_REGISTRY_USER }}
-          HARBOR_REGISTRY_PASSWORD: ${{ steps.secrets.outputs.HARBOR_REGISTRY_PASSWORD }}
-          RC_REF: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
-        run: |
-          echo "Staging artifacts:"
-          ls -la
-          echo "Artifact checksums (pre-push; compare against the public promote):"
-          sha256sum ./* || true
-          mapfile -t files < <(find . -maxdepth 1 -type f -printf '%P\n')
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "::error::No RC artifacts found to push."
-            exit 1
-          fi
-
-          echo "${HARBOR_REGISTRY_PASSWORD}" | \
-            oras login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --password-stdin
-
-          # Retry oras push for transient Harbor 401s.
-          attempt=1
-          until oras push "${RC_REF}" "${files[@]}"; do
-            if [ "${attempt}" -ge 3 ]; then
-              echo "::error::oras push failed after ${attempt} attempts"
-              exit 1
-            fi
-            echo "::warning::oras push failed (attempt ${attempt}); re-authenticating and retrying..."
-            echo "${HARBOR_REGISTRY_PASSWORD}" | \
-              oras login "${HARBOR_REGISTRY_HOST}" -u "${HARBOR_REGISTRY_USER}" --password-stdin || true
-            attempt=$((attempt + 1))
-            sleep 30
-          done
-
       - name: Release summary
         env:
-          RC_REF: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
           DRY_RUN: ${{ inputs.dryRun }}
           BRANCH: ${{ inputs.branch }}
           CAMUNDA_VERSION: ${{ inputs.camundaVersion }}
           CONNECTORS_VERSION: ${{ inputs.connectorsVersion }}
+          RC_PREFIX: ${{ env.HARBOR_REGISTRY_HOST }}/${{ env.HARBOR_REGISTRY_PROJECT }}/${{ env.RC_REPOSITORY }}:${{ inputs.camundaVersion }}${{ inputs.dryRun && '-rc-dryrun' || '-rc' }}
         run: |
           {
             if [ "${DRY_RUN}" = "true" ]; then
               echo "🧪 C8Run RC staged to Harbor (DRY RUN) 🧪"
               echo "- The .env bump PR was skipped."
-              echo "- Delete this tag when done: \`oras manifest delete ${RC_REF}\`"
+              echo "- Delete the dryrun tags when done: \`regctl tag rm ${RC_PREFIX}-<os>\` for each OS."
             else
               echo "⭐ C8Run RC staged to Harbor ⭐"
             fi
             echo "- Branch: \`${BRANCH}\`"
             echo "- Version: \`${CAMUNDA_VERSION}\`"
             echo "- Connectors: \`${CONNECTORS_VERSION}\`"
-            echo "- RC artifact: \`${RC_REF}\`"
+            echo "- RC artifacts (one tag per OS):"
+            for os in linux-x86_64 darwin-aarch64 darwin-x86_64 windows-x86_64; do
+              echo "  - \`${RC_PREFIX}-${os}\`"
+            done
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   # Persist exactly what was built: open (do not merge) a c8run/.env bump PR against the release
   # branch. This replaces the manual "Version Bump" runbook step. The PR is merged after QA sign-off
@@ -392,8 +390,9 @@ jobs:
   # backport.yml) so the PR triggers CI and can clear the main ruleset + merge queue.
   open-env-pr:
     name: Open c8run/.env bump PR
-    needs: stage-rc
+    needs: build
     if: ${{ !inputs.dryRun }}
+    continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions: {}

--- a/.github/workflows/c8run-release-rc.yaml
+++ b/.github/workflows/c8run-release-rc.yaml
@@ -85,11 +85,13 @@ jobs:
           unzip -o -q docker-compose.zip -d dc
           dc_camunda="$(grep -E '^CAMUNDA_VERSION=' dc/.env | head -1 | cut -d= -f2-)"
           echo "docker-compose-${compose_tag} pins CAMUNDA_VERSION=${dc_camunda}; target is ${CAMUNDA_VERSION}"
-          if [ "${dc_camunda}" != "${CAMUNDA_VERSION}" ]; then
-            echo "::error::Rolling docker-compose-${compose_tag} pins ${dc_camunda} but the target is ${CAMUNDA_VERSION}. Compose is not ready — refresh it upstream (Renovate / release train) before building C8Run."
+          # sort -V picks the lower version; if that is the compose pin (and the two differ), compose is behind target.
+          lower="$(printf '%s\n%s\n' "${dc_camunda}" "${CAMUNDA_VERSION}" | sort -V | head -1)"
+          if [ "${dc_camunda}" != "${CAMUNDA_VERSION}" ] && [ "${lower}" = "${dc_camunda}" ]; then
+            echo "::error::Rolling docker-compose-${compose_tag} pins ${dc_camunda}, which is behind the target ${CAMUNDA_VERSION}. Compose is stale — refresh it upstream (Renovate / release train) before building C8Run."
             exit 1
           fi
-          echo "Docker Compose is at target. Proceeding."
+          echo "Docker Compose is at or ahead of the target (pins ${dc_camunda}, target ${CAMUNDA_VERSION}). Proceeding."
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

The build-once→promote C8Run release workflows could not run: the RC workflow
`startup_failure`d on the non-allowlisted `setup-oras` action, plus further
transport/signing defects. This makes them operational:

- Install `regctl` via pinned curl (replaces the non-allowlisted oras action).
- Sign-and-notarize: assert JRE JIT entitlements on Mach-O executables, not dylibs
  (the dylib over-assertion failed notarization).
- Stage each OS artifact straight to its own `c8run:<version>-rc-<os>` Harbor tag via
  regctl 320 MiB chunked upload — avoids Harbor's ~60s monolithic-PUT gateway timeout
  and the single-manifest serial bottleneck (no GHA artifact hop, no gather job).
- Public promote pulls the four per-OS tags, publishes byte-identical to the GitHub
  release + Download Center, and merges the `.env` bump PR through the merge queue
  (mirrors the Helm chart public release). Removed the unconsumed archival Harbor
  retag; the `.env`-PR open is non-gating so a flaky PR open never fails the run.

Validated end-to-end via dry runs (RC build+sign+push across all four OSes; public
pull + byte-identity proof).

## Checklist

- [ ] Enable backports when necessary.
- [ ] If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run.

## Related issues

Relates to camunda/camunda-distributions#319 (automate) and
camunda/camunda-distributions#320 (release-train BPMN, camunda/camunda-release#123).
