### PR TITLE
Fix/rdbms null job error metrics

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReader.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
@@ -251,8 +252,8 @@ public class JobMetricsBatchDbReader extends AbstractEntityReader<JobTypeStatist
             .map(
                 result ->
                     new JobErrorStatisticsEntity(
-                        result.errorCode(),
-                        result.errorMessage(),
+                        nullToEmpty(result.errorCode()),
+                        nullToEmpty(result.errorMessage()),
                         ofNullable(result.workers()).orElse(0)))
             .toList();
 

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -125,6 +125,47 @@
       </foreach>
     </if>
   </sql>
+  <!--
+    Oracle treats empty strings as NULL. When a cursor field value is '' (empty string),
+    comparison operators like = '' and > '' evaluate to UNKNOWN (NULL comparison), so no
+    rows would be returned.  Map empty-string cursor comparisons to their null-safe equivalents:
+      EQUALS ''  → IS NULL       (match the rows that contain NULL)
+      GREATER '' → IS NOT NULL   (in ASC NULLS FIRST, NULLs sort first; anything after them is non-NULL)
+    All other operators with '' fall through to the default behaviour (which yields no rows,
+    the correct result for e.g. LOWER '' in a NULLS FIRST ascending sort).
+  -->
+  <sql id="keySetPageFilter" databaseId="oracle">
+    <if test="page != null and page.keySetPagination != null and !page.keySetPagination.isEmpty()">
+      WHERE
+      <foreach collection="page.keySetPagination" item="keySet" open="(" separator=" OR "
+        close=")">
+        <foreach collection="keySet.entries" item="entry" open="(" separator=" AND "
+          close=")">
+          <choose>
+            <when test="entry.fieldValue != null and entry.fieldValue.toString().equals('')">
+              <choose>
+                <when test="entry.operator.name().equals('EQUALS')">
+                  ${entry.fieldName} IS NULL
+                </when>
+                <when test="entry.operator.name().equals('GREATER')">
+                  ${entry.fieldName} IS NOT NULL
+                </when>
+                <otherwise>
+                  ${entry.fieldName} ${entry.operator.symbol} #{entry.fieldValue}
+                </otherwise>
+              </choose>
+            </when>
+            <when test="entry.fieldValue != null">
+              ${entry.fieldName} ${entry.operator.symbol} #{entry.fieldValue}
+            </when>
+            <otherwise>
+              ${entry.fieldName} ${entry.operator.symbol}
+            </otherwise>
+          </choose>
+        </foreach>
+      </foreach>
+    </if>
+  </sql>
 
   <sql id="orderBy">
     <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/JobMetricsBatchDbReaderTest.java
@@ -915,6 +915,29 @@ class JobMetricsBatchDbReaderTest {
   }
 
   @Test
+  void shouldCoerceNullErrorCodeAndErrorMessageToEmptyString() {
+    // given — Oracle stores empty strings as NULL; the mapper returns null for both fields
+    final var dbResult = new JobErrorStatisticsDbResult(null, null, 2);
+    when(jobMetricsBatchMapper.jobErrorStatistics(any())).thenReturn(List.of(dbResult));
+
+    final var now = OffsetDateTime.now();
+    final var query =
+        JobErrorStatisticsQuery.of(
+            b -> b.filter(f -> f.from(now.minusDays(1)).to(now).jobType("some-task")));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    // when
+    final var result = jobMetricsBatchDbReader.getJobErrorStatistics(query, resourceAccessChecks);
+
+    // then — null must be coerced to "" so the OAS schema (required, non-nullable) is respected
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().errorCode()).isEqualTo("");
+    assertThat(result.items().getFirst().errorMessage()).isEqualTo("");
+    assertThat(result.items().getFirst().workers()).isEqualTo(2);
+  }
+
+  @Test
   void shouldReturnEmptyErrorStatisticsWhenMapperReturnsEmptyList() {
     // given
     when(jobMetricsBatchMapper.jobErrorStatistics(any())).thenReturn(List.of());


### PR DESCRIPTION
## Description

https://github.com/camunda/camunda/pull/54059 fixes an Oracle NULL/blank problem in 8.9, this merges the fix also to main:

> Fixes the Oracle 26ai null errorMessage/errorCode failure in the stable/8.9 nightly RDBMS run.
> 
> Root cause: Oracle treats empty strings as NULL. When a job fails without an explicit error code/message, Oracle 26ai stores NULL in those columns. JobMetricsBatchDbReader passed raw null through to the HTTP response, violating the OAS schema (errorMessage/errorCode are required non-nullable strings in POST /jobs/statistics/errors).
> 
> Fix: Wrap both fields with nullToEmpty() in JobMetricsBatchDbReader.getJobErrorStatistics(), matching the established pattern in FlowNodeInstanceEntityMapper, SequenceFlowEntityMapper, and other RDBMS mappers.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
