### PR TITLE
fix: inherit root OIDC provider fields when a PT overlay partially overrides a named provider

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAuthenticationConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAuthenticationConfigurations.java
@@ -32,13 +32,13 @@ import org.springframework.core.env.Environment;
  * provider id so that Binder applies the PT delta on top of a fully-populated root object.
  */
 @NullMarked
-public final class PhysicalTenantOidcProviderConfigurations {
+public final class PhysicalTenantAuthenticationConfigurations {
 
   private static final String ROOT_PREFIX = Camunda.PREFIX + ".security.authentication";
   private static final String PT_PREFIX_TEMPLATE =
       Camunda.PREFIX + ".physical-tenants.%s.security.authentication";
 
-  private PhysicalTenantOidcProviderConfigurations() {}
+  private PhysicalTenantAuthenticationConfigurations() {}
 
   public static AuthenticationConfiguration forPhysicalTenant(
       final String tenantId, final Environment environment) {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderConfigurations.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration.physicaltenants;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
 import java.util.LinkedHashMap;
@@ -33,9 +34,9 @@ import org.springframework.core.env.Environment;
 @NullMarked
 public final class PhysicalTenantOidcProviderConfigurations {
 
-  private static final String ROOT_PREFIX = "camunda.security.authentication";
+  private static final String ROOT_PREFIX = Camunda.PREFIX + ".security.authentication";
   private static final String PT_PREFIX_TEMPLATE =
-      "camunda.physical-tenants.%s.security.authentication";
+      Camunda.PREFIX + ".physical-tenants.%s.security.authentication";
 
   private PhysicalTenantOidcProviderConfigurations() {}
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderConfigurations.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
+
+/**
+ * Resolves a per-tenant {@link AuthenticationConfiguration} by overlaying {@code
+ * camunda.physical-tenants.<id>.security.authentication.*} on top of the root {@code
+ * camunda.security.authentication.*} config.
+ *
+ * <p>Uses a snapshot-then-rebind strategy to avoid Spring's {@link Binder} replacing entire map
+ * entries on partial field overrides. When a tenant overrides only some fields of a named OIDC
+ * provider (e.g. {@code client-id}, {@code client-secret}, {@code audiences}), {@link Binder} would
+ * replace the whole map entry with a fresh {@link OidcConfiguration} built only from the
+ * PT-specific keys, silently losing root fields like {@code issuer-uri}, {@code username-claim},
+ * and {@code redirect-uri}. This class avoids that by snapshotting the root POJOs first, running
+ * the PT overlay, then re-binding the PT overlay keys onto the pristine root POJO for any shared
+ * provider id so that Binder applies the PT delta on top of a fully-populated root object.
+ */
+@NullMarked
+public final class PhysicalTenantOidcProviderConfigurations {
+
+  private static final String ROOT_PREFIX = "camunda.security.authentication";
+  private static final String PT_PREFIX_TEMPLATE =
+      "camunda.physical-tenants.%s.security.authentication";
+
+  private PhysicalTenantOidcProviderConfigurations() {}
+
+  public static AuthenticationConfiguration forPhysicalTenant(
+      final String tenantId, final Environment environment) {
+    final Binder binder = Binder.get(environment);
+
+    final AuthenticationConfiguration auth =
+        binder
+            .bind(ROOT_PREFIX, Bindable.of(AuthenticationConfiguration.class))
+            .orElseGet(AuthenticationConfiguration::new);
+
+    // snapshot pristine root provider POJOs before the PT overlay mutates them
+    final Map<String, OidcConfiguration> rootOidc =
+        new LinkedHashMap<>(auth.getProviders().getOidc());
+
+    final String ptPrefix = PT_PREFIX_TEMPLATE.formatted(tenantId);
+    binder.bind(ptPrefix, Bindable.ofInstance(auth));
+
+    mergeSharedProviders(auth, rootOidc, binder, ptPrefix);
+
+    return auth;
+  }
+
+  /**
+   * Re-binds the PT overlay onto the pristine root POJOs for any provider id that existed in both
+   * root and PT configs. Without this step a tenant that overrides only some fields of a shared
+   * provider would lose all other root-level fields because Spring's {@link Binder} replaces the
+   * entire map entry on the first matching key.
+   */
+  private static void mergeSharedProviders(
+      final AuthenticationConfiguration auth,
+      final Map<String, OidcConfiguration> rootOidc,
+      final Binder binder,
+      final String ptPrefix) {
+    rootOidc.forEach(
+        (providerId, rootProvider) -> {
+          if (auth.getProviders().getOidc().containsKey(providerId)) {
+            binder.bind(
+                ptPrefix + ".providers.oidc." + providerId, Bindable.ofInstance(rootProvider));
+            auth.getProviders().getOidc().put(providerId, rootProvider);
+          }
+        });
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderConfigurations.java
@@ -71,12 +71,16 @@ public final class PhysicalTenantOidcProviderConfigurations {
       final Map<String, OidcConfiguration> rootOidc,
       final Binder binder,
       final String ptPrefix) {
+    final Map<String, OidcConfiguration> resolvedOidc = auth.getProviders().getOidc();
     rootOidc.forEach(
         (providerId, rootProvider) -> {
-          if (auth.getProviders().getOidc().containsKey(providerId)) {
+          if (resolvedOidc.containsKey(providerId)) {
+            // Apply the PT delta onto the pristine root POJO, then swap it back in for the
+            // Binder-created entry that holds only the PT-specified fields. Both steps are
+            // required: the bind layers the override, the put restores the merged result.
             binder.bind(
                 ptPrefix + ".providers.oidc." + providerId, Bindable.ofInstance(rootProvider));
-            auth.getProviders().getOidc().put(providerId, rootProvider);
+            resolvedOidc.put(providerId, rootProvider);
           }
         });
   }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -96,6 +96,11 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
       binder.bind(Camunda.PREFIX, Bindable.ofInstance(physicalTenant));
       binder.bind(
           PHYSICAL_TENANTS_PREFIX + "." + physicalTenantId, Bindable.ofInstance(physicalTenant));
+      physicalTenant
+          .getSecurity()
+          .setAuthentication(
+              PhysicalTenantOidcProviderConfigurations.forPhysicalTenant(
+                  physicalTenantId, environment));
       resolvedPhysicalTenants.put(physicalTenantId, physicalTenant);
     }
     if (!resolvedPhysicalTenants.containsKey(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)) {

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -96,6 +96,9 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
       binder.bind(Camunda.PREFIX, Bindable.ofInstance(physicalTenant));
       binder.bind(
           PHYSICAL_TENANTS_PREFIX + "." + physicalTenantId, Bindable.ofInstance(physicalTenant));
+      // The two binds above leave security.authentication with the MapBinder defect for named OIDC
+      // providers (a partial PT override drops the entry's root fields). Recompute it with the
+      // merge-aware resolver, which binds an isolated per-tenant copy and overlays the PT delta.
       physicalTenant
           .getSecurity()
           .setAuthentication(

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -102,7 +102,7 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
       physicalTenant
           .getSecurity()
           .setAuthentication(
-              PhysicalTenantOidcProviderConfigurations.forPhysicalTenant(
+              PhysicalTenantAuthenticationConfigurations.forPhysicalTenant(
                   physicalTenantId, environment));
       resolvedPhysicalTenants.put(physicalTenantId, physicalTenant);
     }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
@@ -51,7 +51,7 @@ class PhysicalTenantOidcProviderOverlayTest {
 
     // when
     final AuthenticationConfiguration auth =
-        PhysicalTenantOidcProviderConfigurations.forPhysicalTenant("tenanta", environment);
+        PhysicalTenantAuthenticationConfigurations.forPhysicalTenant("tenanta", environment);
 
     // then all root fields survive unchanged
     final var provider = auth.getProviders().getOidc().get("tenanta");
@@ -90,7 +90,7 @@ class PhysicalTenantOidcProviderOverlayTest {
 
     // when
     final AuthenticationConfiguration auth =
-        PhysicalTenantOidcProviderConfigurations.forPhysicalTenant("tenanta", environment);
+        PhysicalTenantAuthenticationConfigurations.forPhysicalTenant("tenanta", environment);
 
     // then root fields are preserved despite the PT overlay
     final var provider = auth.getProviders().getOidc().get("tenanta");
@@ -123,7 +123,7 @@ class PhysicalTenantOidcProviderOverlayTest {
 
     // when
     final AuthenticationConfiguration auth =
-        PhysicalTenantOidcProviderConfigurations.forPhysicalTenant("tenanta", environment);
+        PhysicalTenantAuthenticationConfigurations.forPhysicalTenant("tenanta", environment);
 
     // then both root and PT-private providers are present
     assertThat(auth.getProviders().getOidc()).containsKey("sharedprovider");
@@ -148,7 +148,7 @@ class PhysicalTenantOidcProviderOverlayTest {
 
     // when
     final AuthenticationConfiguration auth =
-        PhysicalTenantOidcProviderConfigurations.forPhysicalTenant("tenanta", environment);
+        PhysicalTenantAuthenticationConfigurations.forPhysicalTenant("tenanta", environment);
 
     // then the flat slot survives
     assertThat(auth.getOidc().getIssuerUri()).isEqualTo("http://localhost:8081/realms/default");

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+class PhysicalTenantOidcProviderOverlayTest {
+
+  private MockEnvironment environment;
+
+  @BeforeEach
+  void setUp() {
+    environment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(environment);
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  @Test
+  void shouldInheritRootProviderWhenTenantHasNoOverride() {
+    // given
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.security.authentication.providers.oidc.tenanta.issuer-uri",
+                    "http://localhost:8082/realms/tenanta",
+                    "camunda.security.authentication.providers.oidc.tenanta.username-claim",
+                    "preferred_username",
+                    "camunda.security.authentication.providers.oidc.tenanta.client-id",
+                    "root-client")));
+
+    // when
+    final AuthenticationConfiguration auth =
+        PhysicalTenantOidcProviderConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then all root fields survive unchanged
+    final var provider = auth.getProviders().getOidc().get("tenanta");
+    assertThat(provider.getIssuerUri()).isEqualTo("http://localhost:8082/realms/tenanta");
+    assertThat(provider.getUsernameClaim()).isEqualTo("preferred_username");
+    assertThat(provider.getClientId()).isEqualTo("root-client");
+  }
+
+  @Test
+  void shouldOverrideOnlyTheFieldsTenantSets() {
+    // given root declares a full tenanta provider; the PT overlay overrides only
+    // client-id/secret/audiences — omitting issuer-uri, username-claim, client-id-claim,
+    // and redirect-uri. Without the snapshot-then-rebind strategy those root fields would be lost.
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.security.authentication.providers.oidc.tenanta.issuer-uri",
+                    "http://localhost:8082/realms/tenanta",
+                    "camunda.security.authentication.providers.oidc.tenanta.username-claim",
+                    "preferred_username",
+                    "camunda.security.authentication.providers.oidc.tenanta.client-id-claim",
+                    "client_id",
+                    "camunda.security.authentication.providers.oidc.tenanta.redirect-uri",
+                    "{baseUrl}/sso-callback",
+                    "camunda.security.authentication.providers.oidc.tenanta.client-id",
+                    "root-client",
+                    "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.tenanta.client-id",
+                    "pt-tenanta-client",
+                    "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.tenanta.client-secret",
+                    "tenanta-secret",
+                    "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.tenanta.audiences[0]",
+                    "pt-tenanta-aud")));
+
+    // when
+    final AuthenticationConfiguration auth =
+        PhysicalTenantOidcProviderConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then root fields are preserved despite the PT overlay
+    final var provider = auth.getProviders().getOidc().get("tenanta");
+    assertThat(provider.getIssuerUri()).isEqualTo("http://localhost:8082/realms/tenanta");
+    assertThat(provider.getUsernameClaim()).isEqualTo("preferred_username");
+    assertThat(provider.getClientIdClaim()).isEqualTo("client_id");
+    assertThat(provider.getRedirectUri()).isEqualTo("{baseUrl}/sso-callback");
+
+    // and the PT override fields win
+    assertThat(provider.getClientId()).isEqualTo("pt-tenanta-client");
+    assertThat(provider.getClientSecret()).isEqualTo("tenanta-secret");
+    assertThat(provider.getAudiences()).containsExactly("pt-tenanta-aud");
+  }
+
+  @Test
+  void shouldAddTenantPrivateProviderNotInRoot() {
+    // given root declares "sharedprovider"; tenant adds a new "privateprovider" not in root
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.security.authentication.providers.oidc.sharedprovider.issuer-uri",
+                    "http://localhost:8081/realms/default",
+                    "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.privateprovider.issuer-uri",
+                    "http://localhost:8082/realms/private",
+                    "camunda.physical-tenants.tenanta.security.authentication.providers.oidc.privateprovider.client-id",
+                    "private-client")));
+
+    // when
+    final AuthenticationConfiguration auth =
+        PhysicalTenantOidcProviderConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then both root and PT-private providers are present
+    assertThat(auth.getProviders().getOidc()).containsKey("sharedprovider");
+    assertThat(auth.getProviders().getOidc()).containsKey("privateprovider");
+    assertThat(auth.getProviders().getOidc().get("privateprovider").getClientId())
+        .isEqualTo("private-client");
+  }
+
+  @Test
+  void shouldPreserveRootFlatOidcSlotUnchanged() {
+    // given root sets the flat oidc slot (not a named provider)
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.security.authentication.oidc.issuer-uri",
+                    "http://localhost:8081/realms/default",
+                    "camunda.security.authentication.oidc.username-claim",
+                    "preferred_username")));
+
+    // when
+    final AuthenticationConfiguration auth =
+        PhysicalTenantOidcProviderConfigurations.forPhysicalTenant("tenanta", environment);
+
+    // then the flat slot survives
+    assertThat(auth.getOidc().getIssuerUri()).isEqualTo("http://localhost:8081/realms/default");
+    assertThat(auth.getOidc().getUsernameClaim()).isEqualTo("preferred_username");
+  }
+}


### PR DESCRIPTION
## Summary

When a physical tenant's YAML overlay overrides only a **subset** of a named OIDC provider's fields
(e.g. `client-id`, `client-secret`, `audiences`) Spring Boot's `MapBinder` replaces the entire
`Map<String, OidcConfiguration>` entry with a fresh object built only from the PT-specific keys.
Fields present in the root provider — `issuer-uri`, `username-claim`, `client-id-claim`,
`redirect-uri` — are silently lost, because `OidcProvidersConfiguration.setOidc()` replaces the
whole map.

This was latent before CSL alpha35 but immediately visible afterwards: `ScopedJwtDecoderFactory`
now calls `flatten(authConfig)` which copies the per-PT provider map as-is into a flat map, and
`createFromProviderMap` throws:

```
Cannot build ClientRegistration 'tenanta':
set issuer-uri or all three endpoint URIs (authorizationUri, tokenUri, jwkSetUri)
```

**Fix:** Introduces `PhysicalTenantOidcProviderConfigurations`, a dedicated utility class
following the same **snapshot-then-rebind** pattern used by `PhysicalTenantDocumentConfigurations`
(#55765). It binds the root authentication config, snapshots the root provider POJOs, applies the
PT overlay, then re-binds the PT overlay keys *onto the pristine root POJO* for each shared
provider id — so Spring's `Binder` applies the PT delta on top of a fully-populated root object
rather than replacing the whole entry. `PhysicalTenantResolver` delegates to it with
`physicalTenant.getSecurity().setAuthentication(PhysicalTenantOidcProviderConfigurations.forPhysicalTenant(...))`.

## Test plan

- New `PhysicalTenantOidcProviderOverlayTest` covers:
  - root provider inherited unchanged when tenant has no override
  - partial PT overlay: only the overridden fields change, root fields survive
  - tenant-private provider not in root is added alongside inherited ones
  - flat `oidc` slot (not a named provider) is preserved unchanged
- Full `configuration` module test suite: 924 unit + 27 IT, all green.

Follow-up on https://github.com/camunda/camunda/pull/55863 which otherwise caused failures during engine setup in OIDC auth mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
