### PR TITLE
test: disable instable PT auth ITs

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -49,6 +50,7 @@ import org.junit.jupiter.api.Test;
  * have no ES/OS indices to authorize against.
  */
 @ZeebeIntegration
+@Disabled
 final class MultiPhysicalTenantAuthorizationIT extends MultiPhysicalTenantAuthorizationTestBase {
 
   @TestZeebe(autoStart = false)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -46,6 +47,7 @@ import org.junit.jupiter.api.Test;
  * have no ES/OS indices to authorize against.
  */
 @ZeebeIntegration
+@Disabled
 final class PhysicalTenantAuthorizationEnablementIT {
 
   private static final String TENANT_OFF = "tenantoff";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.Test;
  * have no ES/OS indices to read from.
  */
 @ZeebeIntegration
+@Disabled
 final class PhysicalTenantLogicalTenantScopingIT {
 
   private static final String TENANT_A = "tenanta";


### PR DESCRIPTION
## Description

Temporarily disable instable ITs, will be fixed with a follow-up issue is being created now and I'll link it.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
