### PR TITLE
fix: release load tests for 8.8

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -457,9 +457,7 @@ jobs:
         with:
           ref: main
           sparse-checkout: |
-            load-tests/setup/stable-88
-            load-tests/setup/newLoadTest.sh
-            load-tests/setup/utils.sh
+            load-tests/
             .github/actions
       # camunda-platform-8.10 requires Helm CLI v4; runners ship v3.x.
       - name: Set up Helm


### PR DESCRIPTION
## Description

The repository became a more complicated, let's be less specifics about what we pull in from release tests.
https://github.com/camunda/camunda/actions/runs/28214550275

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://camunda.slack.com/archives/C0ANMGS3D4Y/p1782444040586319
