### PR TITLE
add physicalTenantId to @MultiDbTest for local testing convenience

### DIFF
--- a/qa/archunit-tests/src/test/java/io/camunda/it/MultiDbTestArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/MultiDbTestArchTest.java
@@ -38,4 +38,24 @@ final class MultiDbTestArchTest {
               """
           @MultiDbTest should not specify explicit databases; that's only for local testing \
           purposes, please remove it before checking the code in""");
+
+  /**
+   * This test ensures that PRs cannot be merged if you have committed a {@link MultiDbTest} with an
+   * explicit physical tenant ID. Specifying a physical tenant ID is only intended for local testing
+   * purposes, but should not be part of the code base.
+   */
+  @ArchTest
+  static final ArchRule FORBID_MULTI_DB_SPECIFIED_PHYSICAL_TENANT =
+      classes()
+          .that()
+          .areAnnotatedWith(MultiDbTest.class)
+          .should()
+          .beAnnotatedWith(
+              DescribedPredicate.describe(
+                  "@MultiDbTest(physicalTenantId = ...)",
+                  annotation -> !annotation.hasExplicitlyDeclaredProperty("physicalTenantId")))
+          .as(
+              """
+          @MultiDbTest should not specify an explicit physicalTenantId; that's only for local \
+          testing purposes, please remove it before checking the code in""");
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -388,6 +388,13 @@ public class CamundaMultiDBExtension
 
     final var databaseType = getDatabaseType(context);
     physicalTenantId = getPhysicalTenant();
+    if (physicalTenantId == null) {
+      physicalTenantId =
+          AnnotationSupport.findAnnotation(testClass, MultiDbTest.class)
+              .map(MultiDbTest::physicalTenantId)
+              .filter(id -> !id.isBlank())
+              .orElse(null);
+    }
     if (physicalTenantId != null && !databaseType.storageType().isRdbms()) {
       throw new IllegalStateException(
           "Physical-tenant mode (%s) is only supported on RDBMS storage; got %s."

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
@@ -105,4 +105,15 @@ public @interface MultiDbTest {
    *     database type as defined in the test configuration.
    */
   DatabaseType value() default DatabaseType.LOCAL;
+
+  /**
+   * Setting this is only for local testing purposes; setting the property {@link
+   * CamundaMultiDBExtension#TEST_INTEGRATION_PHYSICAL_TENANT} will override this. This is NOT a way
+   * to gate which tests run under a physical tenant; for that, use JUnit's {@code @DisabledIf}
+   * matching on the property.
+   *
+   * @return the physical tenant ID to run the test with. Empty string (default) means no physical
+   *     tenant is used.
+   */
+  String physicalTenantId() default "";
 }


### PR DESCRIPTION
## Summary

- Adds `physicalTenantId()` attribute to `@MultiDbTest` so developers can run a test under a physical tenant locally via `@MultiDbTest(physicalTenantId = "tenanta")`, without having to pass `-Dtest.integration.camunda.physical-tenant=tenanta` on every Maven invocation.
- The system property (`test.integration.camunda.physical-tenant`) always wins; the annotation value is only consulted when the property is absent — CI behaviour is unchanged.
- Adds `FORBID_MULTI_DB_SPECIFIED_PHYSICAL_TENANT` ArchUnit rule to block any committed test that has an explicit `physicalTenantId`, mirroring the existing `FORBID_MULTI_DB_SPECIFIED_DB` guard for the database type.

Relates to #55350 / stacked on #55768.

## Test plan

- [ ] Annotate a test with `@MultiDbTest(physicalTenantId = "tenanta", value = DatabaseType.RDBMS_H2)` locally and confirm the extension boots under that tenant
- [ ] Confirm ArchUnit test fails when `physicalTenantId` is committed (set to non-default), passes when removed
- [ ] Confirm CI run is unaffected (property-driven path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)