### PR TITLE
fix: remap old CamundaAuthentication FQN during session deserialization

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/identity/MigratingWebSessionAttributeConverter.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/MigratingWebSessionAttributeConverter.java
@@ -21,23 +21,13 @@ import org.springframework.core.serializer.support.DeserializingConverter;
 import org.springframework.core.serializer.support.SerializingConverter;
 
 /**
- * {@link WebSessionAttributeConverter} that handles deserialization of session attributes
- * serialized by older versions of the application, where class FQNs have since changed.
- *
- * <p>Specifically, {@code CamundaAuthentication} moved from the monorepo ({@code
- * io.camunda.security.auth}) to CSL ({@code io.camunda.security.api.model}). Sessions persisted
- * before this migration contain the old FQN in their serialized byte stream. The {@link
- * MigratingObjectInputStream} remaps these to the current class at read time, allowing existing
- * sessions to survive the upgrade without forcing users to re-authenticate.
+ * Deserializes session attributes persisted before the {@code io.camunda.security.auth ->
+ * io.camunda.security.api.model} CamundaAuthentication class migration.
  */
 final class MigratingWebSessionAttributeConverter implements WebSessionAttributeConverter {
 
-  // Old FQN baked into sessions serialized before the CSL migration.
-  // Safe to remove once all sessions from pre-migration deployments have naturally expired
-  // (bounded by the configured maxInactiveInterval). When removed, also delete:
-  //   - MigratingDeserializer, MigratingObjectInputStream (this file)
-  //   - dist/src/test/java/io/camunda/security/auth/CamundaAuthentication.java (test stub)
-  //   - the old-FQN test case in MigratingWebSessionAttributeConverterTest
+  // Pre-migration FQN -> current class; remove together with MigratingDeserializer,
+  // MigratingObjectInputStream, and the test stub once old sessions have naturally expired.
   private static final Map<String, Class<?>> CLASS_RENAMES =
       Map.of("io.camunda.security.auth.CamundaAuthentication", CamundaAuthentication.class);
 

--- a/dist/src/main/java/io/camunda/application/commons/identity/MigratingWebSessionAttributeConverter.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/MigratingWebSessionAttributeConverter.java
@@ -33,6 +33,11 @@ import org.springframework.core.serializer.support.SerializingConverter;
 final class MigratingWebSessionAttributeConverter implements WebSessionAttributeConverter {
 
   // Old FQN baked into sessions serialized before the CSL migration.
+  // Safe to remove once all sessions from pre-migration deployments have naturally expired
+  // (bounded by the configured maxInactiveInterval). When removed, also delete:
+  //   - MigratingDeserializer, MigratingObjectInputStream (this file)
+  //   - dist/src/test/java/io/camunda/security/auth/CamundaAuthentication.java (test stub)
+  //   - the old-FQN test case in MigratingWebSessionAttributeConverterTest
   private static final Map<String, Class<?>> CLASS_RENAMES =
       Map.of("io.camunda.security.auth.CamundaAuthentication", CamundaAuthentication.class);
 

--- a/dist/src/main/java/io/camunda/application/commons/identity/MigratingWebSessionAttributeConverter.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/MigratingWebSessionAttributeConverter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.identity;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.spring.session.WebSessionAttributeConverter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.util.Map;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.core.serializer.Deserializer;
+import org.springframework.core.serializer.support.DeserializingConverter;
+import org.springframework.core.serializer.support.SerializingConverter;
+
+/**
+ * {@link WebSessionAttributeConverter} that handles deserialization of session attributes
+ * serialized by older versions of the application, where class FQNs have since changed.
+ *
+ * <p>Specifically, {@code CamundaAuthentication} moved from the monorepo ({@code
+ * io.camunda.security.auth}) to CSL ({@code io.camunda.security.api.model}). Sessions persisted
+ * before this migration contain the old FQN in their serialized byte stream. The {@link
+ * MigratingObjectInputStream} remaps these to the current class at read time, allowing existing
+ * sessions to survive the upgrade without forcing users to re-authenticate.
+ */
+final class MigratingWebSessionAttributeConverter implements WebSessionAttributeConverter {
+
+  // Old FQN baked into sessions serialized before the CSL migration.
+  private static final Map<String, Class<?>> CLASS_RENAMES =
+      Map.of("io.camunda.security.auth.CamundaAuthentication", CamundaAuthentication.class);
+
+  private final GenericConversionService conversionService;
+
+  MigratingWebSessionAttributeConverter() {
+    conversionService = new GenericConversionService();
+    conversionService.addConverter(Object.class, byte[].class, new SerializingConverter());
+    conversionService.addConverter(
+        byte[].class, Object.class, new DeserializingConverter(new MigratingDeserializer()));
+  }
+
+  @Override
+  public Object deserialize(final byte[] value) {
+    return conversionService.convert(
+        value, TypeDescriptor.valueOf(byte[].class), TypeDescriptor.valueOf(Object.class));
+  }
+
+  @Override
+  public byte[] serialize(final Object value) {
+    return (byte[])
+        conversionService.convert(
+            value, TypeDescriptor.valueOf(Object.class), TypeDescriptor.valueOf(byte[].class));
+  }
+
+  private static final class MigratingDeserializer implements Deserializer<Object> {
+
+    @Override
+    public Object deserialize(final InputStream inputStream) throws IOException {
+      try (final var ois = new MigratingObjectInputStream(inputStream)) {
+        return ois.readObject();
+      } catch (final ClassNotFoundException e) {
+        throw new IOException("Failed to deserialize object type", e);
+      }
+    }
+  }
+
+  private static final class MigratingObjectInputStream extends ObjectInputStream {
+
+    MigratingObjectInputStream(final InputStream in) throws IOException {
+      super(in);
+    }
+
+    @Override
+    protected Class<?> resolveClass(final ObjectStreamClass desc)
+        throws IOException, ClassNotFoundException {
+      final Class<?> remapped = CLASS_RENAMES.get(desc.getName());
+      return remapped != null ? remapped : super.resolveClass(desc);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -60,6 +60,9 @@ public class WebSessionRepositoryConfiguration {
     this.connectConfiguration = connectConfiguration;
   }
 
+  // No @ConditionalOnMissingBean: the migration must always be active for this deployment.
+  // A duplicate WebSessionAttributeConverter bean would mean two configurations are fighting
+  // over session handling, which is a bug — failing loudly at startup is the correct behaviour.
   @Bean
   public WebSessionAttributeConverter webSessionAttributeConverter() {
     return new MigratingWebSessionAttributeConverter();

--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -60,9 +60,11 @@ public class WebSessionRepositoryConfiguration {
     this.connectConfiguration = connectConfiguration;
   }
 
-  // No @ConditionalOnMissingBean: the migration must always be active for this deployment.
-  // A duplicate WebSessionAttributeConverter bean would mean two configurations are fighting
-  // over session handling, which is a bug — failing loudly at startup is the correct behaviour.
+  // CSL's default webSessionAttributeConverter is @ConditionalOnMissingBean, so this
+  // unconditional host-side bean takes precedence — the migration is always active for
+  // this deployment. Omitting @ConditionalOnMissingBean here is intentional: a stale
+  // second WebSessionAttributeConverter definition would fail loudly at startup rather
+  // than silently winning the race.
   @Bean
   public WebSessionAttributeConverter webSessionAttributeConverter() {
     return new MigratingWebSessionAttributeConverter();

--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -19,6 +19,7 @@ import io.camunda.search.clients.tenant.PhysicalTenantScoped;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.security.core.port.out.SessionStorePort;
 import io.camunda.security.spring.annotation.ConditionalOnPersistentWebSessionEnabled;
+import io.camunda.security.spring.session.WebSessionAttributeConverter;
 import io.camunda.security.spring.session.WebSessionConfiguration;
 import io.camunda.security.spring.session.WebSessionRepository;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
@@ -57,6 +58,11 @@ public class WebSessionRepositoryConfiguration {
 
   public WebSessionRepositoryConfiguration(final ConnectConfiguration connectConfiguration) {
     this.connectConfiguration = connectConfiguration;
+  }
+
+  @Bean
+  public WebSessionAttributeConverter webSessionAttributeConverter() {
+    return new MigratingWebSessionAttributeConverter();
   }
 
   @Bean

--- a/dist/src/test/java/io/camunda/application/commons/identity/MigratingWebSessionAttributeConverterTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/MigratingWebSessionAttributeConverterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class MigratingWebSessionAttributeConverterTest {
+
+  private final MigratingWebSessionAttributeConverter converter =
+      new MigratingWebSessionAttributeConverter();
+
+  @Test
+  void shouldDeserializeSessionSerializedWithOldCamundaAuthenticationFqn() throws IOException {
+    // given — a payload serialized by the old monorepo class at io.camunda.security.auth
+    final var oldAuth =
+        new io.camunda.security.auth.CamundaAuthentication(
+            "alice",
+            null,
+            false,
+            List.of("group1"),
+            List.of("role1"),
+            List.of("tenant1"),
+            List.of(),
+            Map.of("claim", "value"));
+    final byte[] payload = serialize(oldAuth);
+
+    // when
+    final Object result = converter.deserialize(payload);
+
+    // then — result is the new CSL class, with all fields preserved
+    assertThat(result).isInstanceOf(CamundaAuthentication.class);
+    final var auth = (CamundaAuthentication) result;
+    assertThat(auth.authenticatedUsername()).isEqualTo("alice");
+    assertThat(auth.authenticatedClientId()).isNull();
+    assertThat(auth.anonymousUser()).isFalse();
+    assertThat(auth.authenticatedGroupIds()).containsExactly("group1");
+    assertThat(auth.authenticatedRoleIds()).containsExactly("role1");
+    assertThat(auth.authenticatedTenantIds()).containsExactly("tenant1");
+    assertThat(auth.authenticatedMappingRuleIds()).isEmpty();
+    assertThat(auth.claims()).containsEntry("claim", "value");
+  }
+
+  @Test
+  void shouldRoundTripCurrentCamundaAuthenticationUnchanged() {
+    // given — a session attribute serialized by the current CSL class (no migration needed)
+    final var auth =
+        CamundaAuthentication.of(
+            b -> b.user("bob").group("admins").tenant("default").claims(Map.of("sub", "bob")));
+    final byte[] payload = converter.serialize(auth);
+
+    // when
+    final Object result = converter.deserialize(payload);
+
+    // then
+    assertThat(result).isInstanceOf(CamundaAuthentication.class);
+    final var restored = (CamundaAuthentication) result;
+    assertThat(restored.authenticatedUsername()).isEqualTo("bob");
+    assertThat(restored.authenticatedGroupIds()).containsExactly("admins");
+    assertThat(restored.authenticatedTenantIds()).containsExactly("default");
+    assertThat(restored.claims()).containsEntry("sub", "bob");
+  }
+
+  private static byte[] serialize(final Object obj) throws IOException {
+    final var baos = new ByteArrayOutputStream();
+    try (final var oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(obj);
+    }
+    return baos.toByteArray();
+  }
+}

--- a/dist/src/test/java/io/camunda/security/auth/CamundaAuthentication.java
+++ b/dist/src/test/java/io/camunda/security/auth/CamundaAuthentication.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.auth;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Test-only stub at the old FQN used to produce byte[] payloads that simulate sessions serialized
+ * before the CamundaAuthentication class was migrated to CSL.
+ */
+public record CamundaAuthentication(
+    String authenticatedUsername,
+    String authenticatedClientId,
+    boolean anonymousUser,
+    List<String> authenticatedGroupIds,
+    List<String> authenticatedRoleIds,
+    List<String> authenticatedTenantIds,
+    List<String> authenticatedMappingRuleIds,
+    Map<String, Object> claims)
+    implements Serializable {}


### PR DESCRIPTION
## Summary

- Sessions persisted before the CSL migration have `io.camunda.security.auth.CamundaAuthentication` baked into their serialized byte streams via Java's default `Serializable` encoding
- After the class moved to `io.camunda.security.api.model.CamundaAuthentication` in CSL, `ObjectInputStream.resolveClass()` throws `ClassNotFoundException` on any existing session, breaking deserialization for all users who were logged in at upgrade time
- Introduces `MigratingWebSessionAttributeConverter` with a custom `ObjectInputStream` that remaps the old FQN to the current class at read time — existing sessions survive the upgrade without forcing re-authentication

## How it works

`MigratingWebSessionAttributeConverter` replaces CSL's default `SpringBasedWebSessionAttributeConverter` (via `@ConditionalOnMissingBean`) by overriding `ObjectInputStream.resolveClass()`:

```java
protected Class<?> resolveClass(ObjectStreamClass desc) throws ... {
    final Class<?> remapped = CLASS_RENAMES.get(desc.getName());
    return remapped != null ? remapped : super.resolveClass(desc);
}
```

Both the old and new classes are Java records with `serialVersionUID = 0L` (the record default, confirmed via `serialver`), so no UID mismatch occurs — only the FQN remap is needed.

## Test plan

- [ ] `MigratingWebSessionAttributeConverterTest#shouldDeserializeSessionSerializedWithOldCamundaAuthenticationFqn` — serializes a stub at the old FQN, deserializes via the converter, asserts the result is the new CSL class with all fields preserved
- [ ] `MigratingWebSessionAttributeConverterTest#shouldRoundTripCurrentCamundaAuthenticationUnchanged` — verifies sessions written by the current CSL class are unaffected

Closes https://github.com/camunda/camunda/issues/55964

🤖 Generated with [Claude Code](https://claude.com/claude-code)