### PR TITLE
fix: purge secondary storage for every physical tenant

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
@@ -35,7 +35,8 @@ public class ClusterConfigurationManagerStep
             brokerStartupContext.getConcurrencyControl(),
             brokerStartupContext.getExporterRepository(),
             brokerStartupContext.getNodeIdProvider(),
-            brokerStartupContext.getMeterRegistry());
+            brokerStartupContext.getMeterRegistry(),
+            brokerStartupContext.getPhysicalTenantIds());
     final ClusterConfigurationService clusterConfigurationService =
         new DynamicClusterConfigurationService(clusterChangeExecutor);
     return clusterConfigurationService

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
@@ -33,16 +33,19 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
   private final ExporterRepository exporterRepository;
   private final NodeIdProvider nodeIdProvider;
   private final MeterRegistry meterRegistry;
+  private final PhysicalTenantIds physicalTenantIds;
 
   public ClusterChangeExecutorImpl(
       final ConcurrencyControl concurrencyControl,
       final ExporterRepository exporterRepository,
       final NodeIdProvider nodeIdProvider,
-      final MeterRegistry meterRegistry) {
+      final MeterRegistry meterRegistry,
+      final PhysicalTenantIds physicalTenantIds) {
     this.concurrencyControl = concurrencyControl;
     this.exporterRepository = exporterRepository;
     this.nodeIdProvider = Objects.requireNonNull(nodeIdProvider);
     this.meterRegistry = meterRegistry;
+    this.physicalTenantIds = Objects.requireNonNull(physicalTenantIds);
   }
 
   @Override
@@ -119,6 +122,14 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
   }
 
   private void purgeExporter(final String id, final ExporterDescriptor descriptor) {
+    // Each physical tenant has its own isolated secondary storage, so the exporter must be purged
+    // once per configured tenant. Without this, only the default tenant's data would be removed and
+    // purged entities would still surface in other tenants' stores.
+    physicalTenantIds.known().forEach(tenantId -> purgeExporter(id, descriptor, tenantId));
+  }
+
+  private void purgeExporter(
+      final String id, final ExporterDescriptor descriptor, final String physicalTenantId) {
     final Exporter exporter = descriptor.newInstance();
 
     final var exporterContext =
@@ -126,7 +137,7 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
             Loggers.getExporterLogger(descriptor.getId()),
             descriptor.getConfiguration(),
             1,
-            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+            physicalTenantId,
             "",
             exporterRepository.getLicenseKey(),
             meterRegistry,
@@ -135,12 +146,12 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
     try {
       exporter.configure(exporterContext);
       exporter.purge();
-      LOG.info("Purged history for {}", id);
+      LOG.info("Purged history for exporter {} and physical tenant {}", id, physicalTenantId);
       exporter.close();
     } catch (final Exception e) {
       throw new ExporterPurgeException(
-          "Failed to purge C8 data from exporter %s of type %s; operation will be retried."
-              .formatted(id, exporter.getClass()),
+          "Failed to purge C8 data from exporter %s of type %s for physical tenant %s; operation will be retried."
+              .formatted(id, exporter.getClass(), physicalTenantId),
           e);
     }
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImplTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
@@ -38,11 +39,14 @@ public class ClusterChangeExecutorImplTest {
 
   public static class AuditExporter implements Exporter {
     static final List<String> AUDITS = new ArrayList<>();
+    static final List<String> PURGED_TENANTS = new ArrayList<>();
     String exporterId;
+    String physicalTenantId;
 
     @Override
     public void configure(final Context context) throws Exception {
       exporterId = context.getConfiguration().getId();
+      physicalTenantId = context.getPhysicalTenantId();
       audit("configure");
     }
 
@@ -59,6 +63,7 @@ public class ClusterChangeExecutorImplTest {
     @Override
     public void purge() throws Exception {
       audit("purge");
+      PURGED_TENANTS.add(physicalTenantId);
       Exporter.super.purge();
     }
 
@@ -85,7 +90,8 @@ public class ClusterChangeExecutorImplTest {
               new TestConcurrencyControl(),
               repository,
               mock(NodeIdProvider.class),
-              new SimpleMeterRegistry());
+              new SimpleMeterRegistry(),
+              PhysicalTenantIds.DEFAULT);
 
       // when
       final Future<Void> result = executor.deleteHistory();
@@ -97,6 +103,35 @@ public class ClusterChangeExecutorImplTest {
           .containsSubsequence("configure-test-2", "purge-test-2", "close-test-2")
           .doesNotContainAnyElementsOf(
               Arrays.asList("open-test-1", "export-test-1", "open-test-2", "export-test-2"));
+    }
+
+    @Test
+    void shouldRunPurgeForEveryPhysicalTenant() {
+      // given
+      AuditExporter.PURGED_TENANTS.clear();
+      final ExporterRepository repository = new ExporterRepository();
+      try {
+        repository.validateAndAddExporterDescriptor("test-1", AuditExporter.class, null);
+      } catch (final ExporterLoadException e) {
+        Assertions.fail(e);
+      }
+
+      final PhysicalTenantIds physicalTenantIds = () -> Set.of("default", "tenantA", "tenantB");
+      final var executor =
+          new ClusterChangeExecutorImpl(
+              new TestConcurrencyControl(),
+              repository,
+              mock(NodeIdProvider.class),
+              new SimpleMeterRegistry(),
+              physicalTenantIds);
+
+      // when
+      final Future<Void> result = executor.deleteHistory();
+
+      // then
+      Assertions.assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      Assertions.assertThat(AuditExporter.PURGED_TENANTS)
+          .containsExactlyInAnyOrder("default", "tenantA", "tenantB");
     }
   }
 
@@ -110,7 +145,11 @@ public class ClusterChangeExecutorImplTest {
       when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
       final var executor =
           new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+              new TestConcurrencyControl(),
+              new ExporterRepository(),
+              nodeIdProvider,
+              null,
+              PhysicalTenantIds.DEFAULT);
 
       // when
       final var result =
@@ -129,7 +168,11 @@ public class ClusterChangeExecutorImplTest {
       when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
       final var executor =
           new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+              new TestConcurrencyControl(),
+              new ExporterRepository(),
+              nodeIdProvider,
+              null,
+              PhysicalTenantIds.DEFAULT);
 
       // when
       final var result = executor.preScaling(3, Set.of(MemberId.from("0"), MemberId.from("1")));
@@ -147,7 +190,11 @@ public class ClusterChangeExecutorImplTest {
           .thenReturn(CompletableFuture.failedFuture(new RuntimeException("scale failed")));
       final var executor =
           new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+              new TestConcurrencyControl(),
+              new ExporterRepository(),
+              nodeIdProvider,
+              null,
+              PhysicalTenantIds.DEFAULT);
 
       // when
       final var result =
@@ -173,7 +220,11 @@ public class ClusterChangeExecutorImplTest {
       when(nodeIdProvider.scale(anyInt())).thenReturn(CompletableFuture.completedFuture(null));
       final var executor =
           new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+              new TestConcurrencyControl(),
+              new ExporterRepository(),
+              nodeIdProvider,
+              null,
+              PhysicalTenantIds.DEFAULT);
 
       // when
       final var result =
@@ -192,7 +243,11 @@ public class ClusterChangeExecutorImplTest {
           .thenReturn(CompletableFuture.failedFuture(new RuntimeException("scale failed")));
       final var executor =
           new ClusterChangeExecutorImpl(
-              new TestConcurrencyControl(), new ExporterRepository(), nodeIdProvider, null);
+              new TestConcurrencyControl(),
+              new ExporterRepository(),
+              nodeIdProvider,
+              null,
+              PhysicalTenantIds.DEFAULT);
 
       // when
       final var result =


### PR DESCRIPTION
## Description

Cluster purge (and history deletion via `deleteHistory`) only cleared the **default** physical tenant's secondary storage. `ClusterChangeExecutorImpl.purgeExporter` built the `ExporterContext` with a hardcoded `PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID`, so an exporter scoped to any other physical tenant was never purged — the "purged" entities kept surfacing in tenant-scoped search.

### Fix

Fan the purge out over **every** configured physical tenant: iterate `PhysicalTenantIds.known()` and configure one exporter instance per tenant id.

- The exporter SPI is already per-physical-tenant — `RdbmsExporter.purge()` clears the store for the `physicalTenantId` it was configured with — so **no exporter changes are needed**.
- The only gap was the dispatcher hardcoding the default tenant. The tenant set is wired in from the broker startup context (`BrokerStartupContext.getPhysicalTenantIds()`) at the single construction site (`ClusterConfigurationManagerStep`).

### How this was found

Running `ClusterPurgeMultiDbIT` under physical-tenant mode (per #55350): the 4 methods that assert the secondary-store search returns empty after `ClusterActuator.purge()` all time out because the per-tenant RDBMS store is never cleared.

## Testing

- New unit test `ClusterChangeExecutorImplTest#shouldRunPurgeForEveryPhysicalTenant` asserts the purge fans out across all configured tenants (`default`, `tenantA`, `tenantB`).
- Existing `deleteHistory`/scaling tests updated for the new constructor parameter; all green.
- Full-repo `install -Dquickly` compiles.

End-to-end validation against `ClusterPurgeMultiDbIT` in physical-tenant mode depends on the test harness in #55768; the test's exclusion will be removed there once this merges.

Relates to #55350
