### PR TITLE
fix: resolve peer addresses as absolute DNS names (ndots=0)

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -433,6 +433,17 @@ public final class NettyMessagingService implements ManagedMessagingService {
                               new BiDnsQueryLifecycleObserverFactory(
                                   ignored -> metrics,
                                   new LoggingDnsQueryLifeCycleObserverFactory()))
+                          // The addresses we resolve (initial contact points, advertised hosts) are
+                          // fully-qualified names. With the default ndots taken from resolv.conf
+                          // (typically ndots:5 in Kubernetes), a name with fewer dots is tried with
+                          // every search domain appended *before* the bare name. A single slow or
+                          // unresponsive search-domain query can then exceed the caller's timeout
+                          // (e.g. the 2s SWIM probe timeout) so the resolvable bare name is never
+                          // queried, and a broker can hang permanently waiting to discover a peer
+                          // whose name only became resolvable after startup. Forcing ndots=0 makes
+                          // the bare (absolute) name be tried first; search domains remain as a
+                          // fallback for short names. See camunda/camunda#55038.
+                          .ndots(0)
                           .socketChannelType(clientChannelClass)
                           .channelType(clientDataGramChannelClass));
               timeoutExecutor =


### PR DESCRIPTION
## Description

Set `ndots=0` on the messaging DNS resolver so the cluster's peer addresses (initial contact points, advertised hosts) are resolved as **absolute names**. Applies to all lines; backported to 8.7/8.8/8.9.

### Why

Netty's `DnsNameResolver` otherwise takes `ndots` from `resolv.conf` (`ndots:5` in Kubernetes), so a fully-qualified name with fewer dots (e.g. `zeebe.camunda.svc.clusterset.local`, 4 dots) is tried with **every search domain appended before the bare name**. That's slower in the common case, and on **8.7/8.8** it causes the permanent cold-start hang in #55038:

- `BrokerStartupProcess` blocks until the cluster-topology initializer can sync with a peer — a deliberate safety property.
- On 8.7/8.8 the contact points flow into `BootstrapDiscoveryProvider`, whose addresses are only ever resolved **inline during a SWIM probe**, via this Netty resolver.
- When a search-domain query is slow/unanswered, it exceeds the **2s SWIM probe timeout**, so the resolvable bare name is never queried within the budget and the peer is never discovered — even after its name becomes resolvable. Only a pod restart recovers it.

(Confirmed with the reporter against production ROSA + Submariner: `resolv.conf` has `ndots:5` and a search domain that doesn't answer promptly for the `clusterset.local` names.)

`ndots=0` makes the bare (absolute) name the **first** query; search domains remain as a fallback for short names.

### Scope across lines

- **8.7 / 8.8** — fixes the permanent hang (`BootstrapDiscoveryProvider` path). Backport labels applied.
- **8.9 / main** — resolve contact points off the probe path via `DynamicDiscoveryProvider`, so they do **not** hang; they still benefit from the same change (faster FQDN resolution, no search-domain round-trips) and it keeps behaviour consistent. 8.9 backport label applied.

### Validation

Reproduced the exact permanent-hang condition on a single Kind cluster with `camunda/zeebe:8.7.29` (clusterset names `NXDOMAIN` at start + a slow/unanswered search domain present), then made the names resolvable:

- **Stock 8.7.29** — stayed `0/1 Running` permanently; Netty only ever queried search-expanded names, never the bare name.
- **8.7.29 + this patch** — correctly waited while peers were unresolvable, then **recovered to `1/1` within ~20s** once the names resolved (slow search domain still present); DNS logs show the bare name queried first.

The change is one line on the shared `NettyMessagingService` resolver (broker + gateway), identical on every line.

### Notes

- Deadline mismatch (2s probe vs 5s Netty query) verified benign: the probe timeout doesn't cancel the in-flight resolution, and successful resolutions are cached/reused across probes (~once per TTL), so no deadline-coupling change is needed.

Relates to #55038
