### PR TITLE
Optimize process instance cleanup ITs

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -262,6 +262,7 @@ runs:
         java-code-change:
           - '**/src/main/**'
           - '**/src/test/**'
+          - '**/src/it/**'
 
         maven-change:
           - 'bom/**'

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
@@ -48,7 +48,7 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
   }
 
   @Test
-  public void testCleanupModeAll() {
+  public void shouldDeleteProcessInstanceWhenCleanupModeAll() {
     // given
     final var processDefinitionKey = KEY_GENERATOR.generate(10);
 
@@ -84,7 +84,7 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
   }
 
   @Test
-  public void testCleanupModeAllMultipleDefinitions() {
+  public void shouldDeleteProcessInstanceWhenCleanupModeAllWithMultipleDefinitions() {
     // given
     final var processDefinitionKey1 = KEY_GENERATOR.generate(10);
     final var processDefinitionKey2 = KEY_GENERATOR.generate(10);
@@ -128,7 +128,7 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
   }
 
   @Test
-  public void testCleanupModeAll_disabled() {
+  public void shouldNotDeleteProcessInstanceWhenCleanupModeAllDisabled() {
     // given
     final var processDefinitionKey = KEY_GENERATOR.generate(10);
 
@@ -152,7 +152,7 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
   }
 
   @Test
-  public void testCleanupModeAll_customBatchSize() {
+  public void shouldDeleteProcessInstanceWhenCleanupModeAllWithCustomBatchSize() {
     // given
     final var processDefinitionKey = KEY_GENERATOR.generate(10);
 
@@ -189,7 +189,7 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
   }
 
   @Test
-  public void testCleanupModeAll_specificKeyTtl() {
+  public void shouldNotDeleteProcessInstanceWhenCleanupModeAllAndSpecificKeyTtl() {
     // given
     final var processDefinitionKey1 = KEY_GENERATOR.generate(10);
     final var processDefinitionKey2 = KEY_GENERATOR.generate(10);
@@ -226,7 +226,7 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
   }
 
   @Test
-  public void testCleanupModeVariables() {
+  public void shouldRemoveVariablesWhenCleanupModeVariables() {
     // given
     final var processDefinitionKey = KEY_GENERATOR.generate(10);
     getProcessDataCleanupConfiguration().setCleanupMode(CleanupMode.VARIABLES);
@@ -260,7 +260,7 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
   }
 
   @Test
-  public void testCleanupModeVariables_specificKeyCleanupMode() {
+  public void shouldRemoveVariablesForSpecificKeyCleanupMode() {
     // given
     final var processDefinitionKey = KEY_GENERATOR.generate(10);
     getProcessDataCleanupConfiguration().setCleanupMode(CleanupMode.ALL);
@@ -290,7 +290,7 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
   }
 
   @Test
-  public void testCleanupOnSpecificKeyConfigWithNoMatchingProcessDefinitionLogsWarning() {
+  public void shouldLogNoMatchingProcessDefinitionWarning() {
     // given I have a key specific config
     final var processDefinitionKey = KEY_GENERATOR.generate(10);
     final String configuredKey = "myMistypedKey";

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.cleanup;
+
+import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessInstanceConstants;
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import io.camunda.optimize.service.security.util.LocalDateUtil;
+import io.camunda.optimize.service.util.configuration.cleanup.CleanupConfiguration;
+import io.camunda.optimize.service.util.configuration.cleanup.CleanupMode;
+import io.camunda.optimize.service.util.configuration.cleanup.ProcessCleanupConfiguration;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.apache.commons.text.RandomStringGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCCSMIT {
+  private static final RandomStringGenerator KEY_GENERATOR =
+      new RandomStringGenerator.Builder().withinRange('a', 'z').get();
+
+  @BeforeEach
+  public void enableProcessCleanup() {
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getCleanupServiceConfiguration()
+        .getProcessDataCleanupConfiguration()
+        .setEnabled(true);
+  }
+
+  @Test
+  public void testCleanupModeAll() {
+    // given
+    final var processDefinitionKey = KEY_GENERATOR.generate(10);
+
+    getProcessDataCleanupConfiguration().setCleanupMode(CleanupMode.ALL);
+
+    final var now = LocalDateUtil.getCurrentDateTime();
+    final var endDateForCleanup = getEndTimeLessThanGlobalTtl();
+
+    final List<ProcessInstanceDto> instancesToGetCleanedUp =
+        List.of(
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup));
+    final ProcessInstanceDto unaffectedProcessInstanceForSameDefinition =
+        processInstanceWithEndDate(processDefinitionKey, now);
+
+    final List<ProcessInstanceDto> allInstances =
+        ImmutableList.<ProcessInstanceDto>builder()
+            .addAll(instancesToGetCleanedUp)
+            .add(unaffectedProcessInstanceForSameDefinition)
+            .build();
+
+    persistProcessInstances(allInstances);
+
+    // when
+    embeddedOptimizeExtension.getCleanupScheduler().runCleanup();
+
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    assertNoProcessInstanceDataExists(instancesToGetCleanedUp);
+
+    assertProcessInstanceDataExists(List.of(unaffectedProcessInstanceForSameDefinition));
+  }
+
+  @Test
+  public void testCleanupModeAllMultipleDefinitions() {
+    // given
+    final var processDefinitionKey1 = KEY_GENERATOR.generate(10);
+    final var processDefinitionKey2 = KEY_GENERATOR.generate(10);
+
+    getProcessDataCleanupConfiguration().setCleanupMode(CleanupMode.ALL);
+
+    final var now = LocalDateUtil.getCurrentDateTime();
+    final var endDateForCleanup = getEndTimeLessThanGlobalTtl();
+
+    final List<ProcessInstanceDto> instancesToGetCleanedUp =
+        List.of(
+            processInstanceWithEndDate(processDefinitionKey1, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey1, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey1, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey1, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey2, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey2, endDateForCleanup));
+    final List<ProcessInstanceDto> unaffectedProcessInstances =
+        List.of(
+            processInstanceWithEndDate(processDefinitionKey1, now),
+            processInstanceWithEndDate(processDefinitionKey1, now),
+            processInstanceWithEndDate(processDefinitionKey1, now),
+            processInstanceWithEndDate(processDefinitionKey2, now));
+
+    final List<ProcessInstanceDto> allInstances =
+        ImmutableList.<ProcessInstanceDto>builder()
+            .addAll(instancesToGetCleanedUp)
+            .addAll(unaffectedProcessInstances)
+            .build();
+
+    persistProcessInstances(allInstances);
+
+    // when
+    embeddedOptimizeExtension.getCleanupScheduler().runCleanup();
+
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    assertNoProcessInstanceDataExists(instancesToGetCleanedUp);
+
+    assertProcessInstanceDataExists(unaffectedProcessInstances);
+  }
+
+  private void assertNoProcessInstanceDataExists(final List<ProcessInstanceDto> instances) {
+    final var ids = instances.stream().map(ProcessInstanceDto::getProcessInstanceId).toList();
+    final var instancesInDb = databaseIntegrationTestExtension.getProcessInstancesById(ids);
+    assertThat(instancesInDb).isEmpty();
+  }
+
+  private void assertProcessInstanceDataExists(final List<ProcessInstanceDto> instances) {
+    final var ids = instances.stream().map(ProcessInstanceDto::getProcessInstanceId).toList();
+    final var instancesInDb = databaseIntegrationTestExtension.getProcessInstancesById(ids);
+    assertThat(instancesInDb).containsAll(instances);
+  }
+
+  private CleanupConfiguration getCleanupConfiguration() {
+    return embeddedOptimizeExtension.getConfigurationService().getCleanupServiceConfiguration();
+  }
+
+  private ProcessCleanupConfiguration getProcessDataCleanupConfiguration() {
+    return getCleanupConfiguration().getProcessDataCleanupConfiguration();
+  }
+
+  private OffsetDateTime getEndTimeLessThanGlobalTtl() {
+    return LocalDateUtil.getCurrentDateTime()
+        .minus(getCleanupConfiguration().getTtl())
+        .minusSeconds(1);
+  }
+
+  private static ProcessInstanceDto processInstanceWithEndDate(
+      final String processDefinitionKey, final OffsetDateTime endDate) {
+    final OffsetDateTime startDate = endDate.minusHours(1);
+    final long duration = Duration.between(startDate, endDate).toMillis();
+    return ProcessInstanceDto.builder()
+        .processInstanceId(UUID.randomUUID().toString())
+        .processDefinitionKey(processDefinitionKey)
+        .processDefinitionVersion("1")
+        .processDefinitionId(processDefinitionKey + ":1:1")
+        .tenantId(ZEEBE_DEFAULT_TENANT_ID)
+        .state(ProcessInstanceConstants.COMPLETED_STATE)
+        .dataSource(new ZeebeDataSourceDto("test-source", 1))
+        .startDate(startDate)
+        .endDate(endDate)
+        .duration(duration)
+        .build();
+  }
+}

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
@@ -21,6 +21,7 @@ import io.camunda.optimize.service.util.configuration.cleanup.CleanupConfigurati
 import io.camunda.optimize.service.util.configuration.cleanup.CleanupMode;
 import io.camunda.optimize.service.util.configuration.cleanup.ProcessCleanupConfiguration;
 import io.camunda.optimize.service.util.configuration.cleanup.ProcessDefinitionCleanupConfiguration;
+import io.github.netmikey.logunit.api.LogCapturer;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -28,10 +29,14 @@ import java.util.UUID;
 import org.apache.commons.text.RandomStringGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCCSMIT {
   private static final RandomStringGenerator KEY_GENERATOR =
       new RandomStringGenerator.Builder().withinRange('a', 'z').get();
+
+  @RegisterExtension
+  LogCapturer cleanupServiceLogs = LogCapturer.create().captureForType(CleanupService.class);
 
   @BeforeEach
   public void enableProcessCleanup() {
@@ -282,6 +287,52 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
 
     // then
     assertVariablesEmptyInProcessInstances(instancesOfDefinitionWithVariableMode);
+  }
+
+  @Test
+  public void testCleanupOnSpecificKeyConfigWithNoMatchingProcessDefinitionLogsWarning() {
+    // given I have a key specific config
+    final var processDefinitionKey = KEY_GENERATOR.generate(10);
+    final String configuredKey = "myMistypedKey";
+
+    getProcessDataCleanupConfiguration().setCleanupMode(CleanupMode.VARIABLES);
+    getProcessDataCleanupConfiguration()
+        .getProcessDefinitionSpecificConfiguration()
+        .put(configuredKey, new ProcessDefinitionCleanupConfiguration(CleanupMode.VARIABLES));
+
+    // and deploy processes with different keys
+    final var now = LocalDateUtil.getCurrentDateTime();
+    final var endDateForCleanup = getEndTimeLessThanGlobalTtl();
+
+    final List<ProcessInstanceDto> instancesToGetCleanedUp =
+        List.of(
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup));
+    final ProcessInstanceDto unaffectedProcessInstanceForSameDefinition =
+        processInstanceWithEndDate(processDefinitionKey, now);
+
+    final List<ProcessInstanceDto> allInstances =
+        ImmutableList.<ProcessInstanceDto>builder()
+            .addAll(instancesToGetCleanedUp)
+            .add(unaffectedProcessInstanceForSameDefinition)
+            .build();
+
+    persistProcessInstances(allInstances);
+
+    // when
+    embeddedOptimizeExtension.getCleanupScheduler().runCleanup();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then data clear up has succeeded as expected
+    assertVariablesEmptyInProcessInstances(instancesToGetCleanedUp);
+
+    assertProcessInstanceDataExists(List.of(unaffectedProcessInstanceForSameDefinition));
+    // and the misconfigured process is logged
+    cleanupServiceLogs.assertContains(
+        String.format(
+            "History Cleanup Configuration contains definition keys for which there is no "
+                + "definition imported yet. The keys without a match in the database are: [%s]",
+            configuredKey));
   }
 
   private void assertNoProcessInstanceDataExists(final List<ProcessInstanceDto> instances) {

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.service.security.util.LocalDateUtil;
 import io.camunda.optimize.service.util.configuration.cleanup.CleanupConfiguration;
 import io.camunda.optimize.service.util.configuration.cleanup.CleanupMode;
 import io.camunda.optimize.service.util.configuration.cleanup.ProcessCleanupConfiguration;
+import io.camunda.optimize.service.util.configuration.cleanup.ProcessDefinitionCleanupConfiguration;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -112,13 +113,110 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
 
     // when
     embeddedOptimizeExtension.getCleanupScheduler().runCleanup();
-
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();
 
     // then
     assertNoProcessInstanceDataExists(instancesToGetCleanedUp);
 
     assertProcessInstanceDataExists(unaffectedProcessInstances);
+  }
+
+  @Test
+  public void testCleanupModeAll_disabled() {
+    // given
+    final var processDefinitionKey = KEY_GENERATOR.generate(10);
+
+    getProcessDataCleanupConfiguration().setEnabled(false);
+    getProcessDataCleanupConfiguration().setCleanupMode(CleanupMode.ALL);
+    final var endDateForCleanup = getEndTimeLessThanGlobalTtl();
+
+    final List<ProcessInstanceDto> instancesPastCleanupTTL =
+        List.of(
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup));
+
+    persistProcessInstances(instancesPastCleanupTTL);
+
+    // when
+    embeddedOptimizeExtension.getCleanupScheduler().runCleanup();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    assertProcessInstanceDataExists(instancesPastCleanupTTL);
+  }
+
+  @Test
+  public void testCleanupModeAll_customBatchSize() {
+    // given
+    final var processDefinitionKey = KEY_GENERATOR.generate(10);
+
+    getProcessDataCleanupConfiguration().setCleanupMode(CleanupMode.ALL);
+    getProcessDataCleanupConfiguration().setBatchSize(1);
+
+    final var now = LocalDateUtil.getCurrentDateTime();
+    final var endDateForCleanup = getEndTimeLessThanGlobalTtl();
+
+    final List<ProcessInstanceDto> instancesToGetCleanedUp =
+        List.of(
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup));
+    final ProcessInstanceDto unaffectedProcessInstanceForSameDefinition =
+        processInstanceWithEndDate(processDefinitionKey, now);
+
+    final List<ProcessInstanceDto> allInstances =
+        ImmutableList.<ProcessInstanceDto>builder()
+            .addAll(instancesToGetCleanedUp)
+            .add(unaffectedProcessInstanceForSameDefinition)
+            .build();
+
+    persistProcessInstances(allInstances);
+
+    // when
+    embeddedOptimizeExtension.getCleanupScheduler().runCleanup();
+
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    assertNoProcessInstanceDataExists(instancesToGetCleanedUp);
+
+    assertProcessInstanceDataExists(List.of(unaffectedProcessInstanceForSameDefinition));
+  }
+
+  @Test
+  public void testCleanupModeAll_specificKeyTtl() {
+    // given
+    final var processDefinitionKey1 = KEY_GENERATOR.generate(10);
+    final var processDefinitionKey2 = KEY_GENERATOR.generate(10);
+
+    getProcessDataCleanupConfiguration().setCleanupMode(CleanupMode.ALL);
+    configureHigherProcessSpecificTtl(processDefinitionKey2);
+
+    final var endDateForCleanup = getEndTimeLessThanGlobalTtl();
+    final List<ProcessInstanceDto> instancesToGetCleanedUp =
+        List.of(
+            processInstanceWithEndDate(processDefinitionKey1, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey1, endDateForCleanup));
+
+    final List<ProcessInstanceDto> instancesOfDefinitionWithHigherTtl =
+        List.of(
+            processInstanceWithEndDate(processDefinitionKey2, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey2, endDateForCleanup));
+
+    final List<ProcessInstanceDto> allInstances =
+        ImmutableList.<ProcessInstanceDto>builder()
+            .addAll(instancesToGetCleanedUp)
+            .addAll(instancesOfDefinitionWithHigherTtl)
+            .build();
+
+    persistProcessInstances(allInstances);
+
+    // when
+    embeddedOptimizeExtension.getCleanupScheduler().runCleanup();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    assertNoProcessInstanceDataExists(instancesToGetCleanedUp);
+    assertProcessInstanceDataExists(instancesOfDefinitionWithHigherTtl);
   }
 
   private void assertNoProcessInstanceDataExists(final List<ProcessInstanceDto> instances) {
@@ -139,6 +237,19 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
 
   private ProcessCleanupConfiguration getProcessDataCleanupConfiguration() {
     return getCleanupConfiguration().getProcessDataCleanupConfiguration();
+  }
+
+  private void configureHigherProcessSpecificTtl(final String processDefinitionKey) {
+    getCleanupConfiguration()
+        .getProcessDataCleanupConfiguration()
+        .getProcessDefinitionSpecificConfiguration()
+        .put(
+            processDefinitionKey,
+            ProcessDefinitionCleanupConfiguration.builder()
+                .cleanupMode(CleanupMode.ALL)
+                // higher ttl than default
+                .ttl(getCleanupConfiguration().getTtl().plusYears(5L))
+                .build());
   }
 
   private OffsetDateTime getEndTimeLessThanGlobalTtl() {

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/cleanup/EngineDataProcessCleanupServiceIT.java
@@ -15,6 +15,7 @@ import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
 import io.camunda.optimize.dto.optimize.ProcessInstanceConstants;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
+import io.camunda.optimize.dto.optimize.query.variable.SimpleProcessVariableDto;
 import io.camunda.optimize.service.security.util.LocalDateUtil;
 import io.camunda.optimize.service.util.configuration.cleanup.CleanupConfiguration;
 import io.camunda.optimize.service.util.configuration.cleanup.CleanupMode;
@@ -219,10 +220,81 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
     assertProcessInstanceDataExists(instancesOfDefinitionWithHigherTtl);
   }
 
+  @Test
+  public void testCleanupModeVariables() {
+    // given
+    final var processDefinitionKey = KEY_GENERATOR.generate(10);
+    getProcessDataCleanupConfiguration().setCleanupMode(CleanupMode.VARIABLES);
+
+    final var now = LocalDateUtil.getCurrentDateTime();
+    final var endDateForCleanup = getEndTimeLessThanGlobalTtl();
+
+    final List<ProcessInstanceDto> instancesToGetCleanedUp =
+        List.of(
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup));
+    final ProcessInstanceDto unaffectedProcessInstanceForSameDefinition =
+        processInstanceWithEndDate(processDefinitionKey, now);
+
+    final List<ProcessInstanceDto> allInstances =
+        ImmutableList.<ProcessInstanceDto>builder()
+            .addAll(instancesToGetCleanedUp)
+            .add(unaffectedProcessInstanceForSameDefinition)
+            .build();
+
+    persistProcessInstances(allInstances);
+
+    // when
+    embeddedOptimizeExtension.getCleanupScheduler().runCleanup();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    assertVariablesEmptyInProcessInstances(instancesToGetCleanedUp);
+
+    assertProcessInstanceDataExists(List.of(unaffectedProcessInstanceForSameDefinition));
+  }
+
+  @Test
+  public void testCleanupModeVariables_specificKeyCleanupMode() {
+    // given
+    final var processDefinitionKey = KEY_GENERATOR.generate(10);
+    getProcessDataCleanupConfiguration().setCleanupMode(CleanupMode.ALL);
+    getCleanupConfiguration()
+        .getProcessDataCleanupConfiguration()
+        .getProcessDefinitionSpecificConfiguration()
+        .put(
+            processDefinitionKey,
+            ProcessDefinitionCleanupConfiguration.builder()
+                .cleanupMode(CleanupMode.VARIABLES)
+                .build());
+
+    final var endDateForCleanup = getEndTimeLessThanGlobalTtl();
+    final List<ProcessInstanceDto> instancesOfDefinitionWithVariableMode =
+        List.of(
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup),
+            processInstanceWithEndDate(processDefinitionKey, endDateForCleanup));
+
+    persistProcessInstances(instancesOfDefinitionWithVariableMode);
+
+    // when
+    embeddedOptimizeExtension.getCleanupScheduler().runCleanup();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // then
+    assertVariablesEmptyInProcessInstances(instancesOfDefinitionWithVariableMode);
+  }
+
   private void assertNoProcessInstanceDataExists(final List<ProcessInstanceDto> instances) {
     final var ids = instances.stream().map(ProcessInstanceDto::getProcessInstanceId).toList();
     final var instancesInDb = databaseIntegrationTestExtension.getProcessInstancesById(ids);
     assertThat(instancesInDb).isEmpty();
+  }
+
+  private void assertVariablesEmptyInProcessInstances(final List<ProcessInstanceDto> instances) {
+    final var ids = instances.stream().map(ProcessInstanceDto::getProcessInstanceId).toList();
+    assertThat(databaseIntegrationTestExtension.getProcessInstancesById(ids))
+        .hasSameSizeAs(instances)
+        .allMatch(processInstanceDto -> processInstanceDto.getVariables().isEmpty());
   }
 
   private void assertProcessInstanceDataExists(final List<ProcessInstanceDto> instances) {
@@ -273,6 +345,13 @@ public class EngineDataProcessCleanupServiceIT extends AbstractBrokerlessZeebeCC
         .startDate(startDate)
         .endDate(endDate)
         .duration(duration)
+        .variables(
+            List.of(
+                SimpleProcessVariableDto.builder()
+                    .id("var1")
+                    .name("Variable1")
+                    .value(List.of("one"))
+                    .build()))
         .build();
   }
 }

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/DatabaseIntegrationTestExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/DatabaseIntegrationTestExtension.java
@@ -114,6 +114,10 @@ public class DatabaseIntegrationTestExtension implements BeforeEachCallback, Aft
     return getAllDocumentsOfIndexAs(PROCESS_INSTANCE_MULTI_ALIAS, ProcessInstanceDto.class);
   }
 
+  public List<ProcessInstanceDto> getProcessInstancesById(final List<String> instanceIds) {
+    return databaseTestService.getProcessInstancesById(instanceIds);
+  }
+
   public void deleteAllOptimizeData() {
     databaseTestService.deleteAllOptimizeData();
   }

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/EmbeddedOptimizeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/EmbeddedOptimizeExtension.java
@@ -19,6 +19,7 @@ import io.camunda.optimize.ApplicationContextProvider;
 import io.camunda.optimize.OptimizeRequestExecutor;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
 import io.camunda.optimize.service.alert.AlertService;
+import io.camunda.optimize.service.cleanup.CleanupScheduler;
 import io.camunda.optimize.service.db.DatabaseClient;
 import io.camunda.optimize.service.db.schema.DatabaseMetadataService;
 import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
@@ -208,6 +209,10 @@ public class EmbeddedOptimizeExtension
 
   public ImportSchedulerManagerService getImportSchedulerManager() {
     return getBean(ImportSchedulerManagerService.class);
+  }
+
+  public CleanupScheduler getCleanupScheduler() {
+    return getBean(CleanupScheduler.class);
   }
 
   public OptimizeRequestExecutor getRequestExecutor() {

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
@@ -222,6 +222,12 @@ public class ZeebeExtension implements BeforeAllCallback, AfterAllCallback {
 
   public long startProcessInstanceWithVariables(
       final String bpmnProcessId, final Map<String, Object> variables) {
+    return startProcessInstanceForProcessWithVariables(bpmnProcessId, variables)
+        .getProcessInstanceKey();
+  }
+
+  public ProcessInstanceEvent startProcessInstanceForProcessWithVariables(
+      final String bpmnProcessId, final Map<String, Object> variables) {
     final CreateProcessInstanceCommandStep1.CreateProcessInstanceCommandStep3
         createProcessInstanceCommandStep3 =
             camundaClient
@@ -229,9 +235,9 @@ public class ZeebeExtension implements BeforeAllCallback, AfterAllCallback {
                 .bpmnProcessId(bpmnProcessId)
                 .latestVersion()
                 .variables(variables);
-    final long key = createProcessInstanceCommandStep3.send().join().getProcessInstanceKey();
-    startedInstanceKeys.add(key);
-    return key;
+    final ProcessInstanceEvent event = createProcessInstanceCommandStep3.send().join();
+    startedInstanceKeys.add(event.getProcessInstanceKey());
+    return event;
   }
 
   public void startProcessInstanceWithSignal(final String signalName) {


### PR DESCRIPTION
## Description

This revives the ITs around process instance cleanup in Optimize.  Those tests were removed around 2 years ago (https://github.com/camunda/camunda/pull/19803) as they related to C7 only.  I've used those tests as inspiration for these new tests (similar tests and method names), but tweaked them a bit.

Doing this ahead of changing how the cleanup works to address an OOM issue.

## Related issues

refs #55734
