### PR TITLE
feat: add upgrade plan factory for 8.7.24 -> 8.7.25 and mergeback

### DIFF
--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.24</version>
+    <version>8.7.25-SNAPSHOT</version>
     <relativePath>../optimize/pom.xml</relativePath>
   </parent>
 

--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.24-SNAPSHOT</version>
+    <version>8.7.24</version>
     <relativePath>../optimize/pom.xml</relativePath>
   </parent>
 

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.24</version>
+    <version>8.7.25-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-backend</artifactId>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.24-SNAPSHOT</version>
+    <version>8.7.24</version>
   </parent>
 
   <artifactId>optimize-backend</artifactId>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.24-SNAPSHOT</version>
+    <version>8.7.24</version>
   </parent>
 
   <artifactId>client</artifactId>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.24</version>
+    <version>8.7.25-SNAPSHOT</version>
   </parent>
 
   <artifactId>client</artifactId>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>io.camunda.optimize</groupId>
   <artifactId>optimize-parent</artifactId>
-  <version>8.7.24</version>
+  <version>8.7.25-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Optimize Parent</name>
 
@@ -839,7 +839,7 @@
     <developerConnection>
       scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda.git
     </developerConnection>
-    <tag>8.7.24-optimize</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <issueManagement>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>io.camunda.optimize</groupId>
   <artifactId>optimize-parent</artifactId>
-  <version>8.7.24-SNAPSHOT</version>
+  <version>8.7.24</version>
   <packaging>pom</packaging>
   <name>Optimize Parent</name>
 
@@ -839,7 +839,7 @@
     <developerConnection>
       scm:git:https://${env.GITHUB_TOKEN_USR}:${env.GITHUB_TOKEN_PSW}@github.com/camunda/camunda.git
     </developerConnection>
-    <tag>HEAD</tag>
+    <tag>8.7.24-optimize</tag>
   </scm>
 
   <issueManagement>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.24-SNAPSHOT</version>
+    <version>8.7.24</version>
   </parent>
 
   <artifactId>upgrade-optimize</artifactId>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>optimize-parent</artifactId>
-    <version>8.7.24</version>
+    <version>8.7.25-SNAPSHOT</version>
   </parent>
 
   <artifactId>upgrade-optimize</artifactId>

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade8724To8725PlanFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/plan/factories/Upgrade8724To8725PlanFactory.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.upgrade.plan.factories;
+
+import io.camunda.optimize.upgrade.plan.UpgradeExecutionDependencies;
+import io.camunda.optimize.upgrade.plan.UpgradePlan;
+import io.camunda.optimize.upgrade.plan.UpgradePlanBuilder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Upgrade8724To8725PlanFactory implements UpgradePlanFactory {
+
+  @Override
+  public UpgradePlan createUpgradePlan(final UpgradeExecutionDependencies dependencies) {
+    return UpgradePlanBuilder.createUpgradePlan().fromVersion("8.7.24").toVersion("8.7.25").build();
+  }
+}

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>util</artifactId>
-    <version>8.7.24</version>
+    <version>8.7.25-SNAPSHOT</version>
   </parent>
 
   <artifactId>optimize-commons</artifactId>

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>io.camunda.optimize</groupId>
     <artifactId>util</artifactId>
-    <version>8.7.24-SNAPSHOT</version>
+    <version>8.7.24</version>
   </parent>
 
   <artifactId>optimize-commons</artifactId>

--- a/optimize/util/pom.xml
+++ b/optimize/util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.optimize</groupId>
         <artifactId>optimize-parent</artifactId>
-        <version>8.7.24</version>
+        <version>8.7.25-SNAPSHOT</version>
     </parent>
 
     <artifactId>util</artifactId>

--- a/optimize/util/pom.xml
+++ b/optimize/util/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.camunda.optimize</groupId>
         <artifactId>optimize-parent</artifactId>
-        <version>8.7.24-SNAPSHOT</version>
+        <version>8.7.24</version>
     </parent>
 
     <artifactId>util</artifactId>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
