### PR TITLE
fix: align pr-maven-snapshot correlator with push snapshot workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1685,7 +1685,7 @@ jobs:
             -pl bom,clients/java,clients/camunda-spring-boot-starter,zeebe/bpmn-model,zeebe/exporter-api,zeebe/gateway-protocol-impl,zeebe/protocol
             -am
             -Dquickly
-          correlator: ${{ github.job }}-maven
+          correlator: submit-maven-snapshot-maven
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Problem

The `pr-maven-snapshot` job in CI submits the Maven dependency snapshot with a different `correlator` than the push-triggered `maven-dependency-snapshot.yml` workflow:

| Job | Job key (`github.job`) | Correlator (`${{ github.job }}-maven`) |
|-----|------------------------|----------------------------------------|
| `maven-dependency-snapshot.yml` → `submit-maven-snapshot` | `submit-maven-snapshot` | `submit-maven-snapshot-maven` |
| `ci.yml` → `pr-maven-snapshot` | `pr-maven-snapshot` | `pr-maven-snapshot-maven` |

This mismatch causes every PR that changes any dep manifest (`pom.xml`, `package.json`, `package-lock.json`, `go.mod`, …) to see **all ~620 Maven transitive deps reported as `change_type: added`** by the Dependency Review API — even when the PR touches zero Java dep files.

## Root cause: Dependency Review API is correlator-keyed

The [GitHub Dependency Submission API](https://docs.github.com/en/rest/dependency-graph/dependency-submission) uses the `correlator` field as an upsert key:

> *"Only the latest submitted snapshot for a given combination of `job.correlator` and `detector.name` will be considered when calculating a repository's current dependencies."*

The [Dependency Review API](https://docs.github.com/en/rest/dependency-graph/dependency-review) (`GET /repos/{owner}/{repo}/dependency-graph/compare/{base}...{head}`) then compares dep graph entries **per matching correlator**. When the base SHA has correlator `submit-maven-snapshot-maven` and the head SHA has `pr-maven-snapshot-maven`, there is **no overlap** — the two snapshots are invisible to each other.

Note: GitHub's public docs describe the dep graph as a "union" of all submitted snapshots. The actual API behaviour is correlator-keyed, which differs from the documented description.

## Empirical proof

Comparing two commits where **both** have push-workflow snapshots (same correlator):

```
GET dependency-graph/compare/226df5d...3be3b0a   # same correlator both sides
→ [] (zero Maven changes)
```

Comparing a base with push-workflow snapshot vs head with PR-job snapshot (**different correlators**):

```
GET dependency-graph/compare/1ada603c...9c174f13  # cross-correlator
→ 620 Maven deps change_type=added, 0 removed
```

The only variable between the two calls is whether the correlators match.

## Impact

During the [GHSA-5JMJ-H7XM-6Q6V](https://github.com/advisories/GHSA-5jmj-h7xm-6q6v) advisory window (jackson-databind, published 2026-06-23), every PR that triggered `pr-maven-snapshot` had `jackson-databind@2.21.4` appear as a newly-added vulnerable dependency — including PRs that changed only JavaScript files and touched zero Java dep manifests. Confirmed false-positive on PR #55742 ("feat: port shared layout primitives into operate/shared"), which changed only `webapp/client/package.json` + `package-lock.json`.

## Fix

Hardcode the correlator in `pr-maven-snapshot` to match the push workflow's correlator:

```yaml
# before (job-key-derived, different per job name):
correlator: ${{ github.job }}-maven   # → pr-maven-snapshot-maven

# after (hardcoded to match push workflow):
correlator: submit-maven-snapshot-maven
```

This is a one-line change. No behavioural change for the snapshot submission itself — the correlator only affects how GitHub groups and matches snapshots at comparison time.

## Test / validation plan

- [x] Empirical comparison confirms same-correlator returns 0 Maven changes; cross-correlator returns 620 added
- [ ] After merge: re-run the compare for the FP PR's SHAs using the new correlator — should show 0 Maven changes
- [ ] Monitor gate telemetry for the first 48 h after this merges: `pr-vuln-check` blocking rate should drop from ~100% to ~0% for PRs that don't genuinely add new deps

## Related

- Vuln gate epic: #29729
- Confirmed FP PR: #55742
- Advisory: [GHSA-5JMJ-H7XM-6Q6V](https://github.com/advisories/GHSA-5jmj-h7xm-6q6v) (jackson-databind ≥ 2.19.0, < 2.21.5)
- [Dependency Submission API docs](https://docs.github.com/en/rest/dependency-graph/dependency-submission)
- [Dependency Review API docs](https://docs.github.com/en/rest/dependency-graph/dependency-review)
- [About the dependency graph](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-the-dependency-graph)
- [infra-global-github-actions#726](https://github.com/camunda/infra-global-github-actions/pull/726) — pre-existing dep filter (separate defence-in-depth, decision pending after this fix is validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)