### PR TITLE
ci: skip helm integration deploy when no image tag was built

### DIFF
--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -583,6 +583,11 @@ jobs:
   helm-deploy:
     name: Helm chart Integration Tests
     needs: [build-and-push, format-identifier]
+    # build-and-push is continue-on-error on merge_group, so this job still runs
+    # if the image build failed. Skip when no image tag was produced — otherwise
+    # the deploy runs with an empty orchestration.image.tag and fails with a
+    # cryptic Helm YAML error instead of surfacing the real build failure.
+    if: needs.build-and-push.outputs.image-tag != ''
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
@@ -694,6 +699,10 @@ jobs:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest
     needs: [build-and-push, format-identifier]
+    # Skip when build-and-push produced no image tag (it is continue-on-error on
+    # merge_group); without a tag the dispatched SaaS run gets an empty
+    # zeebeVersion.
+    if: needs.build-and-push.outputs.image-tag != ''
     timeout-minutes: 35
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -588,6 +588,11 @@ jobs:
   helm-deploy:
     name: Helm chart Integration Tests
     needs: [build-and-push, format-identifier]
+    # build-and-push is continue-on-error on merge_group, so this job still runs
+    # if the image build failed. Skip when no image tag was produced — otherwise
+    # the deploy runs with an empty orchestration.image.tag and fails with a
+    # cryptic Helm YAML error instead of surfacing the real build failure.
+    if: needs.build-and-push.outputs.image-tag != ''
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
@@ -761,6 +766,10 @@ jobs:
     name: Trigger SaaS E2E tests
     runs-on: ubuntu-latest
     needs: [build-and-push, format-identifier]
+    # Skip when build-and-push produced no image tag (it is continue-on-error on
+    # merge_group); without a tag the dispatched SaaS run gets an empty
+    # zeebeVersion.
+    if: needs.build-and-push.outputs.image-tag != ''
     timeout-minutes: 35
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -592,7 +592,10 @@ jobs:
     # if the image build failed. Skip when no image tag was produced — otherwise
     # the deploy runs with an empty orchestration.image.tag and fails with a
     # cryptic Helm YAML error instead of surfacing the real build failure.
-    if: needs.build-and-push.outputs.image-tag != ''
+    # success() keeps the implicit needs-succeeded gate that a custom `if` would
+    # otherwise drop (on merge_group build-and-push is continue-on-error, so it
+    # still reports success and only the empty-tag check applies there).
+    if: success() && needs.build-and-push.outputs.image-tag != ''
     uses: camunda/camunda-platform-helm/.github/workflows/test-integration-template.yaml@main
     secrets: inherit
     with:
@@ -768,8 +771,9 @@ jobs:
     needs: [build-and-push, format-identifier]
     # Skip when build-and-push produced no image tag (it is continue-on-error on
     # merge_group); without a tag the dispatched SaaS run gets an empty
-    # zeebeVersion.
-    if: needs.build-and-push.outputs.image-tag != ''
+    # zeebeVersion. success() keeps the implicit needs-succeeded gate that a
+    # custom `if` would otherwise drop.
+    if: success() && needs.build-and-push.outputs.image-tag != ''
     timeout-minutes: 35
     continue-on-error: ${{ github.event_name == 'merge_group' }}
     permissions: { }


### PR DESCRIPTION
## Description

A `stable/8.9` merge-queue run failed the Helm integration check with a cryptic error:

```
YAML parse error on camunda-platform/templates/orchestration/statefulset.yaml:
yaml: line 49: mapping values are not allowed in this context
```

**Root cause:** in that run, `build-and-push` failed at the **"Get Maven project version"** step, so `set-image-tag` was skipped and `build-and-push.outputs.image-tag` was empty. Because `build-and-push` is `continue-on-error` on `merge_group`, the downstream `helm-deploy` and `trigger-saas-e2e` jobs still ran — `helm-deploy` deployed with an empty `orchestration.image.tag`, which rendered an invalid `image:` line and produced the misleading YAML error instead of surfacing the real build failure.

The image tag is already wired correctly (`tag: ${{ needs.build-and-push.outputs.image-tag }}`); the gap is that nothing guards against that value being empty.

## What's in this PR?

Gate both image-consuming jobs on a non-empty tag:

```yaml
if: needs.build-and-push.outputs.image-tag != ''
```

- `helm-deploy` — skips the Helm deploy/E2E when no image was built.
- `trigger-saas-e2e` — avoids dispatching a SaaS run with an empty `zeebeVersion`.

On `merge_group` the build failure remains non-blocking (AlwaysGreen semantics unchanged); we simply no longer fire a deploy against a non-existent image. The build failure itself is still surfaced via the existing AlwaysGreen failure-context steps.

## Related

- Failing run: https://github.com/camunda/camunda/actions/runs/28229119075/job/83629073810
- Defense-in-depth on the Helm side (clearer error if a tag-less image is ever rendered): camunda/camunda-platform-helm#6462 and camunda/camunda-platform-helm#6464

## Backport

Targets `main`; should be backported to `stable/8.9` (and other active stable branches that carry this workflow), where the same gap exists.


Fixes https://github.com/camunda/camunda/issues/58921