### PR TITLE
refactor: use React namespace for type-only react imports

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Dashboard/ExpandableList.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Dashboard/ExpandableList.tsx
@@ -8,26 +8,25 @@
 
 import {DataTableSkeleton, InlineLoading} from '@carbon/react';
 import {useTranslation} from 'react-i18next';
-import type {ReactElement, ReactNode, UIEvent} from 'react';
 import SvgErrorRobot from '#/shared/svg/ErrorRobot';
 import {EmptyState} from '#/operate/components/EmptyState/EmptyState';
 import {PartiallyExpandableDataTable} from './PartiallyExpandableDataTable/PartiallyExpandableDataTable';
 import {ScrollableList, LoadingRow} from './styled';
 
-type Row = {id: string; [key: string]: ReactNode};
+type Row = {id: string; [key: string]: React.ReactNode};
 
 type Props = {
 	isPending: boolean;
 	isError: boolean;
-	emptyState?: ReactNode;
+	emptyState?: React.ReactNode;
 	listTestId: string;
 	dataTestId: string;
 	header: string;
 	rows: Row[];
-	expandedContents: Record<string, ReactElement<{tabIndex: number}>>;
+	expandedContents: Record<string, React.ReactElement<{tabIndex: number}>>;
 	isFetchingNextPage: boolean;
 	isFetchingPreviousPage: boolean;
-	onScroll: (event: UIEvent<HTMLDivElement>) => void;
+	onScroll: (event: React.UIEvent<HTMLDivElement>) => void;
 };
 
 const ExpandableList: React.FC<Props> = ({

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Dashboard/IncidentsByError/IncidentsByError.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Dashboard/IncidentsByError/IncidentsByError.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Suspense, useMemo, type ReactElement} from 'react';
+import {Suspense, useMemo} from 'react';
 import {useInfiniteQuery} from '@tanstack/react-query';
 import {InlineLoading} from '@carbon/react';
 import {useTranslation} from 'react-i18next';
@@ -78,7 +78,7 @@ const IncidentsByError: React.FC = () => {
 
 	const expandedContents = useMemo(
 		() =>
-			items.reduce<Record<string, ReactElement<{tabIndex: number}>>>((accumulator, item) => {
+			items.reduce<Record<string, React.ReactElement<{tabIndex: number}>>>((accumulator, item) => {
 				accumulator[String(item.errorHashCode)] = (
 					<ErrorBoundary
 						fallback={<ExpandedRowErrorFallback message={t('operate.dashboard.incidentDetailsFetchError')} />}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Dashboard/InstancesByProcess/InstancesByProcess.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Dashboard/InstancesByProcess/InstancesByProcess.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Suspense, useMemo, type ReactElement} from 'react';
+import {Suspense, useMemo} from 'react';
 import {useInfiniteQuery} from '@tanstack/react-query';
 import {InlineLoading} from '@carbon/react';
 import {useTranslation} from 'react-i18next';
@@ -84,7 +84,7 @@ const InstancesByProcess: React.FC = () => {
 
 	const expandedContents = useMemo(
 		() =>
-			items.reduce<Record<string, ReactElement<{tabIndex: number}>>>((accumulator, item) => {
+			items.reduce<Record<string, React.ReactElement<{tabIndex: number}>>>((accumulator, item) => {
 				if (item.hasMultipleVersions) {
 					accumulator[`${item.processDefinitionId}:${item.tenantId}`] = (
 						<ErrorBoundary

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Dashboard/useDashboardScrollPagination.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/pages/Dashboard/useDashboardScrollPagination.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useCallback, type UIEvent} from 'react';
+import {useCallback} from 'react';
 
 const ROW_HEIGHT = 64;
 
@@ -30,7 +30,7 @@ function useDashboardScrollPagination({
 	fetchPreviousPage,
 }: Params) {
 	return useCallback(
-		async (event: UIEvent<HTMLDivElement>) => {
+		async (event: React.UIEvent<HTMLDivElement>) => {
 			const target = event.currentTarget;
 			const atBottom = Math.floor(target.scrollHeight - target.clientHeight - target.scrollTop) <= 0;
 			const atTop = target.scrollTop === 0;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CollapsablePanel/CollapsablePanel.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/CollapsablePanel/CollapsablePanel.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {forwardRef, type ReactNode, type RefObject} from 'react';
+import {forwardRef} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Panel, Header, Collapsable, ExpandIcon, CollapseIcon, IconButton, Content} from './styled';
 import {Title as PanelTitle} from '../PanelTitle/styled';
@@ -18,11 +18,11 @@ type Props = {
 	isOverlay?: boolean;
 	onToggle: () => void;
 	isCollapsed: boolean;
-	children?: ReactNode;
-	footer?: ReactNode;
+	children?: React.ReactNode;
+	footer?: React.ReactNode;
 	maxWidth: number;
 	scrollable?: boolean;
-	collapsablePanelRef?: RefObject<HTMLElement | null>;
+	collapsablePanelRef?: React.RefObject<HTMLElement | null>;
 };
 
 const CollapsablePanel = forwardRef<HTMLDivElement, Props>(

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DiagramShell/DiagramShell.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/DiagramShell/DiagramShell.tsx
@@ -6,25 +6,24 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type ReactNode, type ComponentProps, type FC} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Loading} from '@carbon/react';
 import {Container, LoadingContainer, EmptyMessage, ErrorMessage} from './styled';
 import {EmptyMessage as BaseEmptyMessage} from '../EmptyMessage/EmptyMessage';
 
 type DefaultProps = {
-	children: ReactNode;
+	children: React.ReactNode;
 	status: 'error' | 'loading' | 'content' | 'forbidden';
 };
 
 type WithEmptyMessageProps = {
-	children: ReactNode;
+	children: React.ReactNode;
 	status: 'error' | 'empty' | 'loading' | 'content';
-	emptyMessage: ComponentProps<typeof BaseEmptyMessage>;
+	emptyMessage: React.ComponentProps<typeof BaseEmptyMessage>;
 	messagePosition?: 'top' | 'center';
 };
 
-const DiagramShell: FC<DefaultProps | WithEmptyMessageProps> = ({children, status, ...props}) => {
+const DiagramShell: React.FC<DefaultProps | WithEmptyMessageProps> = ({children, status, ...props}) => {
 	const {t} = useTranslation();
 	return (
 		<Container data-testid="diagram-body" tabIndex={0}>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/EmptyMessage/EmptyMessage.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/EmptyMessage/EmptyMessage.tsx
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type FC} from 'react';
 import {Message, AdditionalInfo, Stack} from './styled';
 
 type Props = {
@@ -14,7 +13,7 @@ type Props = {
 	additionalInfo?: string;
 };
 
-const EmptyMessage: FC<Props> = ({message, additionalInfo, ...props}) => {
+const EmptyMessage: React.FC<Props> = ({message, additionalInfo, ...props}) => {
 	return (
 		<Stack {...props} gap={3}>
 			<Message>{message}</Message>

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/ErrorMessage/ErrorMessage.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/ErrorMessage/ErrorMessage.tsx
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type FC} from 'react';
 import {useTranslation} from 'react-i18next';
 import {EmptyMessage} from '../EmptyMessage/EmptyMessage';
 
@@ -15,7 +14,7 @@ type Props = {
 	additionalInfo?: string;
 };
 
-const ErrorMessage: FC<Props> = (props) => {
+const ErrorMessage: React.FC<Props> = (props) => {
 	const {t} = useTranslation();
 	const defaultError = {
 		message: t('operate.shared.errorMessage.message'),

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/FiltersPanel/FiltersPanel.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/FiltersPanel/FiltersPanel.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useEffect, useState, type FC, type ReactNode} from 'react';
+import {useEffect, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {getStateLocally, storeStateLocally} from '#/shared/browser-storage/local-storage';
 import {CollapsablePanel} from '../CollapsablePanel/CollapsablePanel';
@@ -15,12 +15,12 @@ import {Footer} from './styled';
 
 type Props = {
 	localStorageKey: 'isFiltersCollapsed' | 'isDecisionsFiltersCollapsed' | 'isAuditLogsFiltersCollapsed';
-	children: ReactNode;
+	children: React.ReactNode;
 	onResetClick?: () => void;
 	isResetButtonDisabled: boolean;
 };
 
-const FiltersPanel: FC<Props> = ({children, localStorageKey, onResetClick, isResetButtonDisabled}) => {
+const FiltersPanel: React.FC<Props> = ({children, localStorageKey, onResetClick, isResetButtonDisabled}) => {
 	const {t} = useTranslation();
 	const storedState = getStateLocally('operate.panelStates')?.[localStorageKey];
 	const isCollapsed = typeof storedState === 'boolean' ? storedState : false;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Frame/Frame.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/Frame/Frame.tsx
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type FC, type ReactNode} from 'react';
 import {FrameContainer, FrameHeader} from './styled';
 
 type FrameProps = {
@@ -14,7 +13,7 @@ type FrameProps = {
 	isVisible?: boolean;
 };
 
-const Frame: FC<{frame?: FrameProps; children: ReactNode}> = ({frame, children}) => {
+const Frame: React.FC<{frame?: FrameProps; children: React.ReactNode}> = ({frame, children}) => {
 	if (frame === undefined) {
 		return <>{children}</>;
 	}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/PanelHeader/PanelHeader.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/PanelHeader/PanelHeader.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type ReactNode, forwardRef} from 'react';
+import {forwardRef} from 'react';
 import {useTranslation} from 'react-i18next';
 import {Header} from './styled';
 import {Title as PanelTitle} from '../PanelTitle/styled';
@@ -15,7 +15,7 @@ type Props = {
 	title?: string;
 	count?: number;
 	hasMoreTotalItems?: boolean;
-	children?: ReactNode;
+	children?: React.ReactNode;
 	className?: string;
 	hasTopBorder?: boolean;
 	size?: 'sm' | 'md';

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/StateIcon/StateIcon.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/StateIcon/StateIcon.tsx
@@ -6,7 +6,6 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {type ComponentProps, type FC} from 'react';
 import {WarningFilled, CheckmarkOutline, RadioButtonChecked} from './styled';
 import {type CarbonIconType, Error, UnknownFilled} from '@carbon/react/icons';
 import type {DecisionInstanceState, ProcessInstanceState} from '@camunda/camunda-api-zod-schemas/8.10';
@@ -24,10 +23,10 @@ const stateIconsMap = {
 
 type Props = {
 	state: ProcessInstanceState | DecisionInstanceState | 'INCIDENT';
-	size: ComponentProps<CarbonIconType>['size'];
+	size: React.ComponentProps<CarbonIconType>['size'];
 };
 
-const StateIcon: FC<Props> = ({state, ...props}) => {
+const StateIcon: React.FC<Props> = ({state, ...props}) => {
 	const TargetComponent = stateIconsMap[state];
 	return <TargetComponent data-testid={`${state}-icon`} {...props} />;
 };

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/LabelWithPopover.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/available-tasks/components/LabelWithPopover.tsx
@@ -7,14 +7,14 @@
  */
 
 import {Popover, PopoverContent} from '@carbon/react';
-import {type ReactNode, useCallback, useState} from 'react';
+import {useCallback, useState} from 'react';
 import {cn} from '#/shared/cn';
 import styles from './LabelWithPopover.module.scss';
 
 const LabelWithPopover: React.FC<{
 	title: string;
-	popoverContent: ReactNode;
-	children: ReactNode;
+	popoverContent: React.ReactNode;
+	children: React.ReactNode;
 	align: React.ComponentProps<typeof Popover>['align'];
 }> = ({title, popoverContent, children, align}) => {
 	const [popOverOpen, setPopOverOpen] = useState(false);


### PR DESCRIPTION
## Description

Drops type-only `react` imports in 13 files and references those types via the global `React` namespace instead, to stay consistent with the rest of the repo.

The generated svg files under `shared/svg/` are intentionally left as is, since svgr regenerates them with the named import.

## Checklist

- [x] Typecheck, ESLint, and Prettier pass

## Related issues

N/A