### PR TITLE
Fix missing CODEOWNERS entry for frontend-operate-migrator skill

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -216,6 +216,7 @@ mwnw*                       @camunda/monorepo-devops-team
 /.claude/skills/frontend-feature/          @camunda/core-features
 /.claude/skills/frontend-integration-test/ @camunda/core-features
 /.claude/skills/frontend-migrator/         @camunda/core-features
+/.claude/skills/frontend-operate-migrator/ @camunda/core-features
 /.claude/skills/frontend-unit-test/        @camunda/core-features
 /.claude/skills/operate-frontend/          @camunda/core-features
 /.claude/skills/tasklist-frontend/         @camunda/core-features

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -177,6 +177,7 @@
 /.claude/skills/frontend-feature/          @camunda/core-features
 /.claude/skills/frontend-integration-test/ @camunda/core-features
 /.claude/skills/frontend-migrator/         @camunda/core-features
+/.claude/skills/frontend-operate-migrator/ @camunda/core-features
 /.claude/skills/frontend-unit-test/        @camunda/core-features
 /.claude/skills/operate-frontend/          @camunda/core-features
 /.claude/skills/tasklist-frontend/         @camunda/core-features


### PR DESCRIPTION
## Summary

The `frontend-operate-migrator` skill was added without a matching `.codeowners` entry. After #55819 removed the `/.claude/skills/` catch-all, this left `.claude/skills/frontend-operate-migrator/SKILL.md` and `.claude/skills/frontend-operate-migrator/scripts/fidelity.mjs` unowned, causing `codeowners-cli unowned` to exit 1 on `main` and every open PR.

Adds `/.claude/skills/frontend-operate-migrator/ @camunda/core-features` to match the ownership pattern of sibling frontend skills.

Closes #55819 follow-up (see https://github.com/camunda/camunda/pull/55819#issuecomment-4810221148)

## Test plan

- [ ] `Lint / Codeowners` CI job passes on this PR