### PR TITLE
Temporarily disable GatewayAuthenticationNoneIT

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayAuthenticationNoneIT.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -50,6 +51,7 @@ import org.testcontainers.utility.DockerImageName;
  * even when the {@link Profile#CONSOLIDATED_AUTH} profile is active. In other words, users must be
  * able to override the security configuration with env vars.
  */
+@Disabled("Flaky in CI; see https://github.com/camunda/camunda/issues/56057")
 @Testcontainers
 @ZeebeIntegration
 public class GatewayAuthenticationNoneIT {


### PR DESCRIPTION
## Description

Temporarily disables `GatewayAuthenticationNoneIT` to stop CI bleeding while the root cause is investigated and a proper fix is prepared.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

https://github.com/camunda/camunda/issues/56057