### PR TITLE
Fix GatewayAuthenticationNoneIT flake by authenticating Docker Hub pulls in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1104,6 +1104,7 @@ jobs:
           test_owner: "${{ matrix.owner }}"
       - uses: ./.github/actions/setup-build
         with:
+          dockerhub-readonly: true
           maven-cache-key-modifier: it-${{ matrix.group }}
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/gateway/GatewayAuthenticationNoneIT.java
@@ -32,7 +32,6 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,7 +50,6 @@ import org.testcontainers.utility.DockerImageName;
  * even when the {@link Profile#CONSOLIDATED_AUTH} profile is active. In other words, users must be
  * able to override the security configuration with env vars.
  */
-@Disabled("Flaky in CI; see https://github.com/camunda/camunda/issues/56057")
 @Testcontainers
 @ZeebeIntegration
 public class GatewayAuthenticationNoneIT {


### PR DESCRIPTION
## Description

Fixes the `GatewayAuthenticationNoneIT` flake by adding `dockerhub-readonly: true` to the `integration-tests` job in `ci.yml`, and re-enables the test.

Without this flag, `docker.io` image pulls in the `integration-tests` job run anonymously and share the Docker Hub rate limit with all other anonymous pulls on the same GitHub-managed runner IP. When the IP is already rate-limited (e.g. from concurrent `ubuntu:noble` pulls in a sibling step), the `camunda/identity` pull stalls silently for 2 minutes until Testcontainers' Awaitility window expires.

With `dockerhub-readonly: true`, `setup-build` fetches a read-only CI account from Vault and runs `docker login`, so all `docker.io` pulls are authenticated and not subject to anonymous rate limits.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Closes #56057