### PR TITLE
deps: update c8run versions to 8.8.29

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,10 +1,10 @@
 ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.8.28
+CAMUNDA_VERSION=8.8.29
 # docker images moved to a shortened tag, override compose with this value when using --docker
-CAMUNDA_DOCKER_VERSION=8.8.28
+CAMUNDA_DOCKER_VERSION=8.8.29
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.8.14
+CONNECTORS_VERSION=8.8.15
 # version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.8
 COMPOSE_EXTRACTED_FOLDER=docker-compose-8.8


### PR DESCRIPTION
## Summary

- Bumps `CAMUNDA_VERSION` and `CAMUNDA_DOCKER_VERSION` from `8.8.28` → `8.8.29`
- Bumps `CONNECTORS_VERSION` from `8.8.14` → `8.8.15`

Pre-requisite for the c8run 8.8.29 RC release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)