### PR TITLE
deps: update c8run versions to 8.9.11

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,4 +1,4 @@
 # this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.9.9
+CAMUNDA_VERSION=8.9.11
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.9.5
+CONNECTORS_VERSION=8.9.6


### PR DESCRIPTION
## Summary

- Bumps `CAMUNDA_VERSION` from `8.9.9` → `8.9.11`
- Bumps `CONNECTORS_VERSION` from `8.9.5` → `8.9.6`

Pre-requisite for the c8run 8.9.11 RC release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)