### PR TITLE
Fix backwards.compat.version now using proper previous minor version

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -329,6 +329,11 @@ jobs:
           FILE=$(./mvnw -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout -P\!include-optimize)
           rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"
           git diff --quiet HEAD || git commit -am "build(project): update java compat versions"
+      - name: Debug Compat Version
+        if: ${{ inputs.dryRun }}
+        run: |
+          echo "=== Compat Version after Update Compat Version step ==="
+          ./mvnw -B help:evaluate -Dexpression=backwards.compat.version -q -DforceStdout -P\!include-optimize
       - name: Delete version-specific allowed API breaking changes
         run: |
           IFS=$'\n' readarray -t files <<< "$(find . -name 'ignored-changes.json')"

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -96,8 +96,18 @@ jobs:
     steps:
       - name: Output Inputs
         run: echo "${{ toJSON(github.event.inputs) }}"
-        # This step generates a GitHub App token to be used in Git operations as a workaround  for
-        # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
+      - name: Parse Release Version
+        run: |
+          if [[ "${RELEASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            echo "RELEASE_MAJOR=${BASH_REMATCH[1]}" >> "$GITHUB_ENV"
+            echo "RELEASE_MINOR=${BASH_REMATCH[2]}" >> "$GITHUB_ENV"
+            echo "RELEASE_PATCH=${BASH_REMATCH[3]}" >> "$GITHUB_ENV"
+            echo "IS_STABLE_VERSION=true" >> "$GITHUB_ENV"
+          else
+            echo "IS_STABLE_VERSION=false" >> "$GITHUB_ENV"
+          fi
+      # This step generates a GitHub App token to be used in Git operations as a workaround  for
+      # the known GitHub issue described in https://github.com/camunda/camunda/issues/28522
       - name: Generate GitHub token
         id: github-token
         uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
@@ -297,15 +307,26 @@ jobs:
           retention-days: 5
       - name: Update Compat Version
         run: |
-          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Skipping updating the compat version as ${RELEASE_VERSION} is not a stable version"
+          if [[ "$IS_STABLE_VERSION" != "true" ]]; then
+            echo "Skipping: ${RELEASE_VERSION} is not a stable version"
             exit 0
           fi
 
-          ./mvnw -B versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion="${RELEASE_VERSION}" -P\!include-optimize
+          if [[ "$RELEASE_PATCH" == "0" ]]; then
+            PREV_MINOR=$((RELEASE_MINOR - 1))
+            if [[ "$PREV_MINOR" -lt 0 ]]; then
+              echo "ERROR: Cannot compute previous minor for ${RELEASE_VERSION} (MINOR=0). Set the 'backwards.compat.version' property in parent/pom.xml to the last stable minor baseline (e.g. 8.X.0) before re-running."
+              exit 1
+            fi
+            COMPAT_VERSION="${RELEASE_MAJOR}.${PREV_MINOR}.0"
+            ./mvnw -B versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion="${COMPAT_VERSION}" -P\!include-optimize
+          else
+            echo "Patch release: backwards.compat.version not updated (stays at minor baseline)"
+          fi
+
           FILE=$(./mvnw -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout -P\!include-optimize)
           rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"
-          git commit -am "build(project): update java compat versions"
+          git diff --quiet HEAD || git commit -am "build(project): update java compat versions"
       - name: Delete version-specific allowed API breaking changes
         run: |
           IFS=$'\n' readarray -t files <<< "$(find . -name 'ignored-changes.json')"

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -99,10 +99,12 @@ jobs:
       - name: Parse Release Version
         run: |
           if [[ "${RELEASE_VERSION}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-            echo "RELEASE_MAJOR=${BASH_REMATCH[1]}" >> "$GITHUB_ENV"
-            echo "RELEASE_MINOR=${BASH_REMATCH[2]}" >> "$GITHUB_ENV"
-            echo "RELEASE_PATCH=${BASH_REMATCH[3]}" >> "$GITHUB_ENV"
-            echo "IS_STABLE_VERSION=true" >> "$GITHUB_ENV"
+            {
+              echo "RELEASE_MAJOR=${BASH_REMATCH[1]}"
+              echo "RELEASE_MINOR=${BASH_REMATCH[2]}"
+              echo "RELEASE_PATCH=${BASH_REMATCH[3]}"
+              echo "IS_STABLE_VERSION=true"
+            } >> "$GITHUB_ENV"
           else
             echo "IS_STABLE_VERSION=false" >> "$GITHUB_ENV"
           fi
@@ -315,7 +317,7 @@ jobs:
           if [[ "$RELEASE_PATCH" == "0" ]]; then
             PREV_MINOR=$((RELEASE_MINOR - 1))
             if [[ "$PREV_MINOR" -lt 0 ]]; then
-              echo "ERROR: Cannot compute previous minor for ${RELEASE_VERSION} (MINOR=0). Set the 'backwards.compat.version' property in parent/pom.xml to the last stable minor baseline (e.g. 8.X.0) before re-running."
+              echo "ERROR: Cannot compute previous minor for ${RELEASE_VERSION} (MINOR=0). Please set 'backwards.compat.version' in parent/pom.xml to the last stable release from the previous release line (e.g. 8.<minor>.<patch> for a 9.0.0 release), then re-run the workflow."
               exit 1
             fi
             COMPAT_VERSION="${RELEASE_MAJOR}.${PREV_MINOR}.0"


### PR DESCRIPTION
## Description
When a stable release was built, `backwards.compat.version` was set to the current release version (e.g. `8.9.10` → `8.9.10`), causing the backwards-compatibility CI to **compare a release against itself** and silently pass checks that should verify compatibility with the previous minor.

The bug was in the *Update Compat Version* step, which derived the compat target from `RELEASE_VERSION` without handling the minor vs. patch distinction.

### Fix
A new `Parse Release Version` step extracts `RELEASE_MAJOR`, `RELEASE_MINOR`, `RELEASE_PATCH`, and `IS_STABLE_VERSION` into `$GITHUB_ENV` via a single grouped redirect (SC2129-compliant). All later steps consume these instead of re-parsing.

*Update Compat Version* now branches on `RELEASE_PATCH`:

- **Minor release (PATCH == 0):** sets `backwards.compat.version` to `{MAJOR}.{PREV_MINOR}.0` — e.g. `8.9.0` → `8.8.0`
- **Patch release (PATCH > 0):** skips the update; the property stays at the minor baseline set when the minor was cut
- **Non-stable (alpha/snapshot):** skipped entirely

A *Debug Compat Version* step (dry-run only) logs the resolved value for verification.

> [!IMPORTANT]
> Patches never recompute the baseline — they only inherit whatever is committed. After this PR is merged and backported, each existing `stable/*` branch must be checked and corrected to the right baseline (`8.{minor-1}.0`), since branches that never ran the new minor-release path may still carry a wrong value. Branches that receive a future minor will self-heal automatically.

## Design decision: `.0` baseline, not latest patch
The target is `{major}.{prev-minor}.0`, **not the latest patch of the previous minor**. Patches are policy-guaranteed backwards-compatible, so testing against `.0` gives equivalent coverage without a git tag lookup. See [#51405 comment](https://github.com/camunda/camunda/issues/51405#issuecomment-4326471146).

**Edge case: MINOR == 0** — a major bump (e.g. `9.0.0`) yields `PREV_MINOR = -1`. The step exits with an explicit error instructing to set `backwards.compat.version` manually to the last stable release of the previous major before re-running.

### Testing
- Dry-run, releaseVersion=8.9.1 → property unchanged (stays at minor baseline)
https://github.com/camunda/camunda/actions/runs/28269160534/job/83762729369#step:17:52
- Dry-run, releaseVersion=8.10.0-alpha2 -> unchanged is not a stable branch 
https://github.com/camunda/camunda/actions/runs/28269042047/job/83762366856#step:17:49
- Dry-run, releaseVersion 8.10.0 -> set to previous version https://github.com/camunda/camunda/actions/runs/28269069590/job/83762451923#step:18:35
- Backport: applies to stable/8.7, stable/8.8, stable/8.9. The PATCH==0 path never fires on stable branches (patch-only), but keeping correct code there is consistent and future-safe. https://github.com/camunda/camunda/pull/56063#issuecomment-4832191686

## Checklist
- Enable backports when necessary (e.g. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- If this PR modifies the C8 Orchestration Cluster E2E Test Suite, the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Failures documented and confirmed not regressions.

## Related issues
Related to [#51405](https://github.com/camunda/camunda/issues/51405)