### PR TITLE
fix: delete stale legacy task doc on job-worker to Zeebe migration cancel

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usertask/TaskEntity.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.webapps.schema.entities.usertask;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
 import io.camunda.webapps.schema.entities.BeforeVersion880;
@@ -151,6 +152,9 @@ public class TaskEntity extends AbstractExporterEntity<TaskEntity>
   @SinceVersion(value = "8.10.0", requireDefault = false)
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private String businessId;
+
+  // transient flag: signals flush() to issue a delete instead of an upsert; never written to index
+  @JsonIgnore private boolean markedForDeletion;
 
   public TaskEntity() {}
 
@@ -459,6 +463,15 @@ public class TaskEntity extends AbstractExporterEntity<TaskEntity>
 
   public TaskEntity setBusinessId(final String businessId) {
     this.businessId = businessId;
+    return this;
+  }
+
+  public boolean isMarkedForDeletion() {
+    return markedForDeletion;
+  }
+
+  public TaskEntity setMarkedForDeletion(final boolean markedForDeletion) {
+    this.markedForDeletion = markedForDeletion;
     return this;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -85,9 +85,18 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
 
   @Override
   public boolean handlesRecord(final Record<JobRecordValue> record) {
-    return SUPPORTED_INTENTS.contains(record.getIntent())
-        && record.getValue().getType().equals(Protocol.USER_TASK_JOB_TYPE)
-        && !record.getValue().isJobToUserTaskMigration();
+    if (!(record.getIntent() instanceof final JobIntent intent)
+        || !SUPPORTED_INTENTS.contains(intent)) {
+      return false;
+    }
+    if (!record.getValue().getType().equals(Protocol.USER_TASK_JOB_TYPE)) {
+      return false;
+    }
+    if (!record.getValue().isJobToUserTaskMigration()) {
+      return true;
+    }
+    return record.getIntent().equals(JobIntent.CANCELED)
+        && refersToPreviousVersionRecord(record.getKey());
   }
 
   @Override
@@ -112,14 +121,21 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
     entity.setKey(record.getKey());
     switch (record.getIntent()) {
       case JobIntent.CREATED -> createTaskEntity(entity, record);
-      case JobIntent.COMPLETED, JobIntent.CANCELED ->
+      case JobIntent.COMPLETED ->
           entity
-              .setState(
-                  record.getIntent().equals(JobIntent.COMPLETED)
-                      ? TaskState.COMPLETED
-                      : TaskState.CANCELED)
+              .setState(TaskState.COMPLETED)
               .setCompletionTime(
                   ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+      case JobIntent.CANCELED -> {
+        if (record.getValue().isJobToUserTaskMigration()) {
+          entity.setState(null);
+        } else {
+          entity
+              .setState(TaskState.CANCELED)
+              .setCompletionTime(
+                  ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+        }
+      }
       case JobIntent.MIGRATED ->
           entity
               .setFlowNodeBpmnId(record.getValue().getElementId())
@@ -156,11 +172,17 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
 
   @Override
   public void flush(final TaskEntity entity, final BatchRequest batchRequest) {
+    final boolean previousVersionRecord = refersToPreviousVersionRecord(entity.getKey());
+
+    if (entity.getState() == null && previousVersionRecord) {
+      final var jobKey = String.valueOf(entity.getKey());
+      batchRequest.deleteWithRouting(indexName, jobKey, jobKey);
+      return;
+    }
+
     final var updateFields = getUpdatedFields(entity);
     final var taskEntityId = entity.getId();
     final var processInstanceKey = entity.getProcessInstanceId();
-
-    final boolean previousVersionRecord = refersToPreviousVersionRecord(entity.getKey());
 
     batchRequest.upsertWithRouting(
         indexName,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -128,7 +128,8 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
                   ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
       case JobIntent.CANCELED -> {
         if (record.getValue().isJobToUserTaskMigration()) {
-          entity.setState(null);
+          // stale legacy job-worker task doc; flush() will delete it instead of upserting
+          entity.setMarkedForDeletion(true);
         } else {
           entity
               .setState(TaskState.CANCELED)
@@ -174,7 +175,7 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
   public void flush(final TaskEntity entity, final BatchRequest batchRequest) {
     final boolean previousVersionRecord = refersToPreviousVersionRecord(entity.getKey());
 
-    if (entity.getState() == null && previousVersionRecord) {
+    if (entity.isMarkedForDeletion() && previousVersionRecord) {
       final var jobKey = String.valueOf(entity.getKey());
       batchRequest.deleteWithRouting(indexName, jobKey, jobKey);
       return;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterBulkConsistencyIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterBulkConsistencyIT.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -318,6 +319,116 @@ final class ExporterBulkConsistencyIT {
 
   private static long userTaskElementKey(final int i) {
     return processInstanceKey(i) + 4;
+  }
+
+  /**
+   * Verifies that a migration-cancel for a legacy job-worker task doc produces a delete (not an
+   * upsert) at all bulk-flush sizes, leaving no task document in the index. Two exporter runs
+   * simulate two engine sessions: the first creates the legacy doc; the second sets a new
+   * firstUserTaskKey watermark and then cancels the legacy job via migration.
+   */
+  @TestTemplate
+  void shouldDeleteLegacyJobWorkerTaskDocOnMigrationCancel(
+      final ExporterConfiguration baseConfig, final SearchClientAdapter clientAdapter)
+      throws IOException {
+    // given
+    final var legacyJobKey = 9_000_001L;
+    final var currentJobKey = 9_000_002L;
+    final var legacyProcessInstanceKey = 9_000_100L;
+    final var currentProcessInstanceKey = 9_000_200L;
+    final var legacyTaskId = String.valueOf(legacyJobKey);
+
+    // phase 1: current-version CREATED sets the watermark; legacy CREATED is then below it
+    final var phase1Records =
+        List.of(
+            buildJobCreatedRecord(currentJobKey, currentProcessInstanceKey),
+            buildJobCreatedRecord(legacyJobKey, legacyProcessInstanceKey));
+    // phase 2: fresh exporter — re-establish watermark, then cancel the legacy doc
+    final var phase2Records =
+        List.of(
+            buildJobCreatedRecord(currentJobKey, currentProcessInstanceKey),
+            buildJobMigrationCancelRecord(legacyJobKey, legacyProcessInstanceKey));
+
+    final var testBulkSizes = List.of(1, 2, 5, 20);
+
+    // when — reference run (bulk 500)
+    final var referenceConfig = configWithBulkSize(baseConfig, 500, "ref-del");
+    createSchemas(referenceConfig);
+    runExporter(phase1Records, referenceConfig);
+    runExporter(phase2Records, referenceConfig);
+    clientAdapter.refresh();
+
+    final var isEs = ConnectionTypes.isElasticSearch(referenceConfig.getConnect().getType());
+    final var taskIndex =
+        new TaskTemplate(referenceConfig.getConnect().getIndexPrefix(), isEs)
+            .getFullQualifiedName();
+    assertThat(clientAdapter.searchByIds(taskIndex, List.of(legacyTaskId), TaskEntity.class))
+        .as("legacy task doc must be absent after migration-cancel (reference)")
+        .isEmpty();
+
+    // then — identical result at every test bulk size
+    createSchemas(configWithBulkSize(baseConfig, 500, "work-del"));
+    for (final int bulkSize : testBulkSizes) {
+      final var config = configWithBulkSize(baseConfig, bulkSize, "work-del");
+      clientAdapter.deleteAllDocuments(config.getConnect().getIndexPrefix());
+      clientAdapter.refresh();
+      runExporter(phase1Records, config);
+      runExporter(phase2Records, config);
+      clientAdapter.refresh();
+      final var isEsWork = ConnectionTypes.isElasticSearch(config.getConnect().getType());
+      final var taskIndexWork =
+          new TaskTemplate(config.getConnect().getIndexPrefix(), isEsWork).getFullQualifiedName();
+      assertThat(clientAdapter.searchByIds(taskIndexWork, List.of(legacyTaskId), TaskEntity.class))
+          .as("legacy task doc must be absent at bulk size %d", bulkSize)
+          .isEmpty();
+    }
+  }
+
+  private Record<?> buildJobCreatedRecord(final long jobKey, final long processInstanceKey) {
+    return factory.generateRecord(
+        ValueType.JOB,
+        r ->
+            r.withKey(jobKey)
+                .withBrokerVersion(VersionUtil.getVersion())
+                .withTimestamp(System.currentTimeMillis())
+                .withPartitionId(PARTITION_ID)
+                .withIntent(JobIntent.CREATED)
+                .withValue(
+                    ImmutableJobRecordValue.builder()
+                        .from(factory.generateObject(ImmutableJobRecordValue.class))
+                        .withType(Protocol.USER_TASK_JOB_TYPE)
+                        .withElementInstanceKey(jobKey)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withRootProcessInstanceKey(processInstanceKey)
+                        .withRetries(0)
+                        .withDeadline(System.currentTimeMillis() + 60_000L)
+                        .withTenantId(TENANT_ID)
+                        .withJobToUserTaskMigration(false)
+                        .build()));
+  }
+
+  private Record<?> buildJobMigrationCancelRecord(
+      final long jobKey, final long processInstanceKey) {
+    return factory.generateRecord(
+        ValueType.JOB,
+        r ->
+            r.withKey(jobKey)
+                .withBrokerVersion(VersionUtil.getVersion())
+                .withTimestamp(System.currentTimeMillis())
+                .withPartitionId(PARTITION_ID)
+                .withIntent(JobIntent.CANCELED)
+                .withValue(
+                    ImmutableJobRecordValue.builder()
+                        .from(factory.generateObject(ImmutableJobRecordValue.class))
+                        .withType(Protocol.USER_TASK_JOB_TYPE)
+                        .withElementInstanceKey(jobKey)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withRootProcessInstanceKey(processInstanceKey)
+                        .withRetries(0)
+                        .withDeadline(System.currentTimeMillis() + 60_000L)
+                        .withTenantId(TENANT_ID)
+                        .withJobToUserTaskMigration(true)
+                        .build()));
   }
 
   private List<Record<?>> buildRecordsForInstance(final int i) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -100,8 +101,8 @@ public class UserTaskJobBasedHandlerTest {
   }
 
   @Test
-  void shouldNotHandleUserTaskMigrationRecord() {
-    // given
+  void shouldNotHandleNonCanceledMigrationRecord() {
+    // given: migration=true records that are NOT CANCELED must never be handled
     final JobRecordValue jobRecordValue =
         ImmutableJobRecordValue.builder()
             .from(factory.generateObject(JobRecordValue.class))
@@ -109,14 +110,80 @@ public class UserTaskJobBasedHandlerTest {
             .withJobToUserTaskMigration(true)
             .build();
 
-    SUPPORTED_INTENTS.forEach(
-        intent -> {
-          final Record<JobRecordValue> jobRecord =
-              factory.generateRecord(
-                  ValueType.JOB, r -> r.withIntent(intent).withValue(jobRecordValue));
-          // when - then
-          assertThat(underTest.handlesRecord(jobRecord)).isFalse();
-        });
+    SUPPORTED_INTENTS.stream()
+        .filter(intent -> !intent.equals(JobIntent.CANCELED))
+        .forEach(
+            intent -> {
+              final Record<JobRecordValue> jobRecord =
+                  factory.generateRecord(
+                      ValueType.JOB, r -> r.withIntent(intent).withValue(jobRecordValue));
+              assertThat(underTest.handlesRecord(jobRecord)).isFalse();
+            });
+  }
+
+  @Test
+  void shouldHandleRecordForMigrationCancelWithLegacyKey() {
+    // given: CANCELED + migration=true + key below watermark → true (stale-doc delete)
+    final long firstUserTaskKey = 100;
+    final long legacyJobKey = 90;
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.JOB_WORKER, firstUserTaskKey);
+
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(true)
+            .build();
+
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r -> r.withIntent(JobIntent.CANCELED).withKey(legacyJobKey).withValue(value));
+
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleRecordForMigrationCancelWithCurrentVersionKey() {
+    // given: CANCELED + migration=true + key above watermark → false (current-version, no delete)
+    final long firstUserTaskKey = 100;
+    final long currentJobKey = 110;
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.JOB_WORKER, firstUserTaskKey);
+
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(true)
+            .build();
+
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r -> r.withIntent(JobIntent.CANCELED).withKey(currentJobKey).withValue(value));
+
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void shouldHandleRecordForMigrationCancelWhenWatermarkUnset() {
+    // given: CANCELED + migration=true + watermark=-1 → any key treated as legacy → true
+    // (watermark reset to -1 in @BeforeEach)
+    final long anyJobKey = 12345;
+
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(true)
+            .build();
+
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r -> r.withIntent(JobIntent.CANCELED).withKey(anyJobKey).withValue(value));
+
+    assertThat(underTest.handlesRecord(record)).isTrue();
   }
 
   @Test
@@ -263,6 +330,7 @@ public class UserTaskJobBasedHandlerTest {
         new TaskEntity()
             .setId(String.valueOf(recordKey))
             .setKey(recordKey)
+            .setState(TaskState.CREATED)
             .setProcessInstanceId(String.valueOf(processInstanceKey))
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceKey));
     final BatchRequest mockRequest = mock(BatchRequest.class);
@@ -272,6 +340,7 @@ public class UserTaskJobBasedHandlerTest {
 
     // then
     final Map<String, Object> updateFieldsMap = new HashMap<>();
+    updateFieldsMap.put(TaskTemplate.STATE, TaskState.CREATED);
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
@@ -441,6 +510,7 @@ public class UserTaskJobBasedHandlerTest {
         ImmutableJobRecordValue.builder()
             .from(factory.generateObject(JobRecordValue.class))
             .withProcessInstanceKey(processInstanceKey)
+            .withJobToUserTaskMigration(false)
             .build();
 
     final Record<JobRecordValue> jobRecord =
@@ -799,6 +869,186 @@ public class UserTaskJobBasedHandlerTest {
 
     // then
     assertThat(taskEntity.getState()).isEqualTo(TaskState.CREATED);
+  }
+
+  @Test
+  void shouldDeleteLegacyDocumentOnMigrationCancelForPreviousVersionRecord() {
+    // given
+    final long firstUserTaskKey = 100;
+    final long legacyJobKey = 90; // below watermark → legacy doc _id = jobKey
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.JOB_WORKER, firstUserTaskKey);
+
+    final JobRecordValue migrationCancelValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(true)
+            .build();
+
+    final Record<JobRecordValue> migrationCancelRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CANCELED)
+                    .withKey(legacyJobKey)
+                    .withValue(migrationCancelValue));
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when: process the migration cancel through the handler
+    assertThat(underTest.handlesRecord(migrationCancelRecord)).isTrue();
+    final var ids = underTest.generateIds(migrationCancelRecord);
+    ids.forEach(
+        id -> {
+          final var entity = underTest.createNewEntity(id);
+          underTest.updateEntity(migrationCancelRecord, entity);
+          underTest.flush(entity, mockRequest);
+        });
+
+    // then — the stale legacy task doc (keyed by jobKey) must be deleted; no upsert should occur
+    verify(mockRequest, times(1))
+        .deleteWithRouting(indexName, String.valueOf(legacyJobKey), String.valueOf(legacyJobKey));
+    verify(mockRequest, never())
+        .upsertWithRouting(
+            org.mockito.ArgumentMatchers.eq(indexName),
+            org.mockito.ArgumentMatchers.eq(String.valueOf(legacyJobKey)),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.eq(String.valueOf(legacyJobKey)));
+  }
+
+  @Test
+  void shouldDeleteLegacyDocumentOnMigrationCancelEvenWhenCreatedInSameBatch() {
+    // given: simulates a batch containing both JOB.CREATED and JOB.CANCELED+migration for the
+    // same legacy job key — the CANCELED must still issue a delete, not an upsert
+    final long firstUserTaskKey = 100;
+    final long legacyJobKey = 90;
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.JOB_WORKER, firstUserTaskKey);
+
+    final JobRecordValue createdValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(false)
+            .build();
+
+    final Record<JobRecordValue> createdRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r -> r.withIntent(JobIntent.CREATED).withKey(legacyJobKey).withValue(createdValue));
+
+    final JobRecordValue migrationCancelValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(true)
+            .build();
+
+    final Record<JobRecordValue> migrationCancelRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CANCELED)
+                    .withKey(legacyJobKey)
+                    .withValue(migrationCancelValue));
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+    final TaskEntity sharedEntity = underTest.createNewEntity(String.valueOf(legacyJobKey));
+
+    // simulate same-batch processing: CREATED first, then CANCELED+migration on the same entity
+    underTest.updateEntity(createdRecord, sharedEntity);
+    underTest.updateEntity(migrationCancelRecord, sharedEntity);
+    underTest.flush(sharedEntity, mockRequest);
+
+    // then — the migration-cancel must clear the state so the delete path is taken
+    assertThat(sharedEntity.getState()).isNull();
+    verify(mockRequest, times(1))
+        .deleteWithRouting(indexName, String.valueOf(legacyJobKey), String.valueOf(legacyJobKey));
+    verify(mockRequest, never())
+        .upsertWithRouting(
+            org.mockito.ArgumentMatchers.eq(indexName),
+            org.mockito.ArgumentMatchers.eq(String.valueOf(legacyJobKey)),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.eq(String.valueOf(legacyJobKey)));
+  }
+
+  @Test
+  void shouldNotDeleteDocumentOnMigrationCancelForCurrentVersionRecord() {
+    // given: jobKey above watermark → current-version scheme (_id = elementInstanceKey)
+    final long firstUserTaskKey = 100;
+    final long currentJobKey =
+        110; // above watermark → current-version doc _id = elementInstanceKey
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.JOB_WORKER, firstUserTaskKey);
+
+    final JobRecordValue migrationCancelValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(true)
+            .build();
+
+    final Record<JobRecordValue> migrationCancelRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CANCELED)
+                    .withKey(currentJobKey)
+                    .withValue(migrationCancelValue));
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when: current-version migration cancel — handlesRecord returns false, nothing dispatched
+    assertThat(underTest.handlesRecord(migrationCancelRecord)).isFalse();
+  }
+
+  @Test
+  void shouldNotDeleteDocumentOnNonMigrationCancel() {
+    // given: a normal (non-migration) JOB CANCELED — must never trigger a delete
+    final long firstUserTaskKey = 100;
+    final long legacyJobKey = 90; // below watermark, but NOT a migration cancel
+    exporterMetadata.setFirstUserTaskKey(TaskImplementation.JOB_WORKER, firstUserTaskKey);
+
+    final JobRecordValue normalCancelValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .withJobToUserTaskMigration(false)
+            .build();
+
+    final Record<JobRecordValue> normalCancelRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CANCELED)
+                    .withKey(legacyJobKey)
+                    .withValue(normalCancelValue));
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when: non-migration cancel is handled normally (state update, not delete)
+    assertThat(underTest.handlesRecord(normalCancelRecord)).isTrue();
+    final var ids = underTest.generateIds(normalCancelRecord);
+    ids.forEach(
+        id -> {
+          final var entity = underTest.createNewEntity(id);
+          underTest.updateEntity(normalCancelRecord, entity);
+          underTest.flush(entity, mockRequest);
+        });
+
+    // then — normal cancel issues an upsert (state update), never a delete
+    verify(mockRequest, never())
+        .deleteWithRouting(
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any());
+    verify(mockRequest, times(1))
+        .upsertWithRouting(
+            org.mockito.ArgumentMatchers.eq(indexName),
+            org.mockito.ArgumentMatchers.eq(String.valueOf(legacyJobKey)),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.any(),
+            org.mockito.ArgumentMatchers.eq(String.valueOf(legacyJobKey)));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -960,8 +960,8 @@ public class UserTaskJobBasedHandlerTest {
     underTest.updateEntity(migrationCancelRecord, sharedEntity);
     underTest.flush(sharedEntity, mockRequest);
 
-    // then — the migration-cancel must clear the state so the delete path is taken
-    assertThat(sharedEntity.getState()).isNull();
+    // then — the migration-cancel must mark the entity for deletion so the delete path is taken
+    assertThat(sharedEntity.isMarkedForDeletion()).isTrue();
     verify(mockRequest, times(1))
         .deleteWithRouting(indexName, String.valueOf(legacyJobKey), String.valueOf(legacyJobKey));
     verify(mockRequest, never())


### PR DESCRIPTION
## Description

Fixes duplicate user task documents in the Tasklist `task` index when migrating from a job-worker user task to a Zeebe user task. The camunda-exporter was assigning different document IDs (`_id = jobKey` vs `_id = elementInstanceKey`) to the legacy and new task documents due to independent per-implementation watermarks, causing both to coexist. The fix adds a delete-only path in `UserTaskJobBasedHandler` that removes stale legacy documents when their migration-cancel records arrive, guarded by `refersToPreviousVersionRecord` to prevent deleting the live document in 8.8-native migrations where IDs already converged.

## Checklist

<!--- Please delete options that are not relevant. -->

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54316
