### PR TITLE
feat: add OpenSearch 3.7 support

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -30,6 +30,7 @@ opensearch:
   os3:
     - "3.5.0"
     - "3.6.0"
+    - "3.7.0"
 
 # ── RDBMS databases ─────────────────────────────────────────────────────────────
 # Each entry is a Docker image tag representing one supported major version.

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/BackupReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/BackupReaderOS.java
@@ -34,7 +34,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.opensearch.client.opensearch._types.OpenSearchException;
-import org.opensearch.client.opensearch._types.ShardFailure;
+import org.opensearch.client.opensearch._types.ShardSearchFailure;
 import org.opensearch.client.opensearch.snapshot.GetRepositoryRequest;
 import org.opensearch.client.opensearch.snapshot.GetSnapshotRequest;
 import org.opensearch.client.opensearch.snapshot.GetSnapshotResponse;
@@ -120,7 +120,7 @@ public class BackupReaderOS extends AbstractBackupReader {
   private static SnapshotInfoDto toSnapshotInfoDto(final SnapshotInfo snapshotInfo) {
     final long startTimeMillis = snapshotInfo.startTimeInMillis();
     final List<String> shardFailures =
-        snapshotInfo.shards().failures().stream().map(ShardFailure::toString).toList();
+        snapshotInfo.shards().failures().stream().map(ShardSearchFailure::toString).toList();
     return new SnapshotInfoDto(
         snapshotInfo.snapshot(),
         SnapshotState.valueOf(snapshotInfo.state()),

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/client/sync/OpenSearchDocumentOperations.java
@@ -36,7 +36,7 @@ import org.opensearch.client.opensearch._types.ErrorCause;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch._types.Script;
-import org.opensearch.client.opensearch._types.ShardFailure;
+import org.opensearch.client.opensearch._types.ShardSearchFailure;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.BulkRequest;
@@ -111,14 +111,10 @@ public class OpenSearchDocumentOperations extends OpenSearchRetryOperation {
     }
   }
 
-  private String formatShardFailure(final ShardFailure failure) {
+  private String formatShardFailure(final ShardSearchFailure failure) {
     return String.format(
-        "ShardFailure[index=%s, shard=%s, status=%s, node=%s, reason=%s]",
-        failure.index(),
-        failure.shard(),
-        failure.status(),
-        failure.node(),
-        formatErrorCause(failure.reason()));
+        "ShardSearchFailure[index=%s, shard=%s, node=%s, reason=%s]",
+        failure.index(), failure.shard(), failure.node(), formatErrorCause(failure.reason()));
   }
 
   private String formatErrorCause(final ErrorCause errorCause) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -91,7 +91,7 @@
     <version.objenesis>3.5</version.objenesis>
     <version.opentelemetry>1.62.0</version.opentelemetry>
     <version.opensearch.client>2.17.0</version.opensearch.client>
-    <version.opensearch-java>3.5.0</version.opensearch-java>
+    <version.opensearch-java>3.7.0</version.opensearch-java>
     <!-- renovate: datasource=docker depName=opensearchproject/opensearch -->
     <version.opensearch.container>2.19.5</version.opensearch.container>
     <version.opensearch.testcontainers>4.1.0</version.opensearch.testcontainers>


### PR DESCRIPTION
## Description

OpenSearch 3.7.0 has been released. This adds it to our test matrix and bumps the Java client to match.

Note:
- Small API change in the [search shard response](https://github.com/opensearch-project/opensearch-java/blob/33ce2e1a150d6b189d8b6ec53994512945b4e18d/java-client/src/generated/java/org/opensearch/client/opensearch/_types/ShardSearchFailure.java)
- We keep support for 3.5 for now, even though we normally only support minimum two minor versions, because it's the latest managed AWS version and we want customers with managed OS to be able to run against an officially supported version

Closes #53827