### PR TITLE
perf: flatten WaitState keyset pagination to allow PG index pushdown

### DIFF
--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -126,6 +126,33 @@
     </if>
   </sql>
 
+  <!--
+    Keyset pagination as an AND-condition for use inside a <where> block.
+    Same logic as keySetPageFilter but without the leading WHERE keyword, so
+    the keyset predicate can be merged into the base-table WHERE clause. This
+    lets the database planner use the index for the keyset boundary without
+    materialising a derived table first.
+  -->
+  <sql id="keySetPageCondition">
+    <if test="page != null and page.keySetPagination != null and !page.keySetPagination.isEmpty()">
+      AND
+      <foreach collection="page.keySetPagination" item="keySet" open="(" separator=" OR "
+        close=")">
+        <foreach collection="keySet.entries" item="entry" open="(" separator=" AND "
+          close=")">
+          <choose>
+            <when test="entry.fieldValue != null">
+              ${entry.fieldName} ${entry.operator.symbol} #{entry.fieldValue}
+            </when>
+            <otherwise>
+              ${entry.fieldName} ${entry.operator.symbol}
+            </otherwise>
+          </choose>
+        </foreach>
+      </foreach>
+    </if>
+  </sql>
+
   <sql id="orderBy">
     <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">
       <foreach collection="sort.orderings" open="ORDER BY " separator=", " item="item">

--- a/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/WaitStateMapper.xml
@@ -46,7 +46,6 @@
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.WaitStateDbQuery"
     resultMap="io.camunda.db.rdbms.sql.WaitStateMapper.waitStateResultMap">
-    SELECT * FROM (
     SELECT
       WAIT_STATE_KEY,
       ROOT_PROCESS_INSTANCE_KEY,
@@ -60,63 +59,70 @@
       TENANT_ID,
       PARTITION_ID
     FROM ${prefix}WAIT_STATE
-    <include refid="io.camunda.db.rdbms.sql.WaitStateMapper.searchFilter"/>
-    ) t
-    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <where>
+      <include refid="io.camunda.db.rdbms.sql.WaitStateMapper.searchFilterConditions"/>
+      <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageCondition"/>
+    </where>
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
 
+  <!-- Bare conditions, no <where> tag — shared by count and search -->
+  <sql id="searchFilterConditions">
+    <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
+      AND PROCESS_DEFINITION_ID IN
+      <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator="," close=")">
+        #{resourceId}
+      </foreach>
+    </if>
+    <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+      AND TENANT_ID IN
+      <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+        #{tenantId}
+      </foreach>
+    </if>
+    <if test="filter.elementInstanceKeyOperations != null and !filter.elementInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.elementInstanceKeyOperations" item="operation">
+        AND ELEMENT_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.processInstanceKeyOperations" item="operation">
+        AND PROCESS_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.rootProcessInstanceKeyOperations != null and !filter.rootProcessInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.rootProcessInstanceKeyOperations" item="operation">
+        AND ROOT_PROCESS_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.elementIdOperations != null and !filter.elementIdOperations.isEmpty()">
+      <foreach collection="filter.elementIdOperations" item="operation">
+        AND ELEMENT_ID
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.elementTypeOperations != null and !filter.elementTypeOperations.isEmpty()">
+      <foreach collection="filter.elementTypeOperations" item="operation">
+        AND ELEMENT_TYPE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.waitStateTypeOperations != null and !filter.waitStateTypeOperations.isEmpty()">
+      <foreach collection="filter.waitStateTypeOperations" item="operation">
+        AND WAIT_STATE_TYPE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+  </sql>
+
+  <!-- Full WHERE clause for count — does NOT include keyset predicate -->
   <sql id="searchFilter">
     <where>
-      <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
-        AND PROCESS_DEFINITION_ID IN
-        <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator="," close=")">
-          #{resourceId}
-        </foreach>
-      </if>
-      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
-        AND TENANT_ID IN
-        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
-          #{tenantId}
-        </foreach>
-      </if>
-      <if test="filter.elementInstanceKeyOperations != null and !filter.elementInstanceKeyOperations.isEmpty()">
-        <foreach collection="filter.elementInstanceKeyOperations" item="operation">
-          AND ELEMENT_INSTANCE_KEY
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
-      <if test="filter.processInstanceKeyOperations != null and !filter.processInstanceKeyOperations.isEmpty()">
-        <foreach collection="filter.processInstanceKeyOperations" item="operation">
-          AND PROCESS_INSTANCE_KEY
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
-      <if test="filter.rootProcessInstanceKeyOperations != null and !filter.rootProcessInstanceKeyOperations.isEmpty()">
-        <foreach collection="filter.rootProcessInstanceKeyOperations" item="operation">
-          AND ROOT_PROCESS_INSTANCE_KEY
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
-      <if test="filter.elementIdOperations != null and !filter.elementIdOperations.isEmpty()">
-        <foreach collection="filter.elementIdOperations" item="operation">
-          AND ELEMENT_ID
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
-      <if test="filter.elementTypeOperations != null and !filter.elementTypeOperations.isEmpty()">
-        <foreach collection="filter.elementTypeOperations" item="operation">
-          AND ELEMENT_TYPE
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
-      <if test="filter.waitStateTypeOperations != null and !filter.waitStateTypeOperations.isEmpty()">
-        <foreach collection="filter.waitStateTypeOperations" item="operation">
-          AND WAIT_STATE_TYPE
-          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-        </foreach>
-      </if>
+      <include refid="io.camunda.db.rdbms.sql.WaitStateMapper.searchFilterConditions"/>
     </where>
   </sql>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/WaitStateFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/WaitStateFixtures.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.function.Function;
+
+public final class WaitStateFixtures extends CommonFixtures {
+
+  private WaitStateFixtures() {}
+
+  public static WaitStateDbModel createRandomized(
+      final Function<WaitStateDbModel.Builder, WaitStateDbModel.Builder> builderFunction) {
+    final var key = nextKey();
+    final var builder =
+        new WaitStateDbModel.Builder()
+            .waitStateKey(key)
+            .rootProcessInstanceKey(nextKey())
+            .processInstanceKey(nextKey())
+            .elementInstanceKey(nextKey())
+            .elementId("task-" + key)
+            .elementType(BpmnElementType.SERVICE_TASK.name())
+            .waitStateType("JOB")
+            .processDefinitionId("process-" + generateRandomString(10))
+            .details("{\"jobKey\":" + key + ",\"jobType\":\"payment\",\"retries\":3}")
+            .tenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .partitionId(0);
+    return builderFunction.apply(builder).build();
+  }
+
+  public static void createAndSaveRandomWaitStates(
+      final RdbmsWriters rdbmsWriters,
+      final Function<WaitStateDbModel.Builder, WaitStateDbModel.Builder> builderFunction) {
+    createAndSaveRandomWaitStates(rdbmsWriters, 20, builderFunction);
+  }
+
+  public static void createAndSaveRandomWaitStates(
+      final RdbmsWriters rdbmsWriters,
+      final int count,
+      final Function<WaitStateDbModel.Builder, WaitStateDbModel.Builder> builderFunction) {
+    for (int i = 0; i < count; i++) {
+      rdbmsWriters.getWaitStateWriter().create(createRandomized(builderFunction));
+    }
+    rdbmsWriters.flush();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateIT.java
@@ -8,13 +8,20 @@
 package io.camunda.it.rdbms.db.waitstate;
 
 import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.WaitStateFixtures.createAndSaveRandomWaitStates;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.WaitStateDbReader;
 import io.camunda.db.rdbms.write.RdbmsWriters;
 import io.camunda.db.rdbms.write.domain.WaitStateDbModel;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.filter.ElementInstanceWaitStateFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.ElementInstanceWaitStateQuery;
+import io.camunda.search.sort.WaitStateSort;
+import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.junit.jupiter.api.Tag;
@@ -69,6 +76,55 @@ public class WaitStateIT {
 
     // then
     assertThat(rdbmsService.getWaitStateReader().findOne(model.waitStateKey())).isEmpty();
+  }
+
+  @TestTemplate
+  public void shouldReturnCorrectResultsWithKeysetPagination(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
+    final var processInstanceKey = nextKey();
+    createAndSaveRandomWaitStates(
+        rdbmsWriters,
+        b -> b.processInstanceKey(processInstanceKey).rootProcessInstanceKey(nextKey()));
+
+    final WaitStateDbReader reader = rdbmsService.getWaitStateReader();
+    final var sort = WaitStateSort.of(s -> s.elementInstanceKey().asc());
+    final var filter =
+        new ElementInstanceWaitStateFilter.Builder()
+            .processInstanceKeys(processInstanceKey)
+            .build();
+
+    // when
+    final var allItems =
+        reader
+            .search(
+                new ElementInstanceWaitStateQuery(
+                    filter, sort, SearchQueryPage.of(b -> b.from(0).size(20))),
+                ResourceAccessChecks.disabled())
+            .items();
+
+    final var page1 =
+        reader.search(
+            new ElementInstanceWaitStateQuery(filter, sort, SearchQueryPage.of(b -> b.size(10))),
+            ResourceAccessChecks.disabled());
+
+    final var page2 =
+        reader.search(
+            new ElementInstanceWaitStateQuery(
+                filter, sort, SearchQueryPage.of(b -> b.size(10).after(page1.endCursor()))),
+            ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(allItems).hasSize(20);
+    assertThat(page1.items()).hasSize(10);
+    assertThat(page2.items()).hasSize(10);
+    assertThat(page1.items()).isEqualTo(allItems.subList(0, 10));
+    assertThat(page2.items()).isEqualTo(allItems.subList(10, 20));
+    // total() must be 20 on page 2 — not the post-cursor remainder.
+    // Guards against the keyset predicate leaking into the COUNT query.
+    assertThat(page2.total()).isEqualTo(20);
   }
 
   private static WaitStateDbModel createRandomized(final long waitStateKey) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/waitstate/WaitStateIT.java
@@ -85,9 +85,7 @@ public class WaitStateIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriters rdbmsWriters = rdbmsService.createWriter(PARTITION_ID);
     final var processInstanceKey = nextKey();
-    createAndSaveRandomWaitStates(
-        rdbmsWriters,
-        b -> b.processInstanceKey(processInstanceKey).rootProcessInstanceKey(nextKey()));
+    createAndSaveRandomWaitStates(rdbmsWriters, b -> b.processInstanceKey(processInstanceKey));
 
     final WaitStateDbReader reader = rdbmsService.getWaitStateReader();
     final var sort = WaitStateSort.of(s -> s.elementInstanceKey().asc());
@@ -122,8 +120,9 @@ public class WaitStateIT {
     assertThat(page2.items()).hasSize(10);
     assertThat(page1.items()).isEqualTo(allItems.subList(0, 10));
     assertThat(page2.items()).isEqualTo(allItems.subList(10, 20));
-    // total() must be 20 on page 2 — not the post-cursor remainder.
+    // total() must be 20 on both pages — not the post-cursor remainder.
     // Guards against the keyset predicate leaking into the COUNT query.
+    assertThat(page1.total()).isEqualTo(20);
     assertThat(page2.total()).isEqualTo(20);
   }
 


### PR DESCRIPTION
## Summary

- Removes the derived-table wrapper from `WaitStateMapper.search` so PostgreSQL can push the keyset predicate directly against the `WAIT_STATE` base-table index, restoring O(log n) page-2 latency.
- Extracts `searchFilterConditions` (bare AND-conditions) from the existing `searchFilter` fragment so the two queries (`count` and `search`) can share conditions without sharing the keyset predicate.
- Adds `keySetPageCondition` to `Commons.xml` — the same keyset logic as `keySetPageFilter` but using `AND` (no leading `WHERE`), safe for embedding inside a MyBatis `<where>` block.
- Adds a regression test that asserts `total()` on page 2 equals the full matching set (guarding against keyset leakage into the `COUNT` query).

## Background

Benchmark `c8-ws-bench-s3-pg-page2` (scenario 3, 300 PI/s, 5 s worker delay) confirmed 127× p50 latency degradation for `wait_state_page2` at ~8.5M WAIT_STATE rows (~10 h into a 24 h run), while `wait_state_all` stayed flat. The root cause is that PostgreSQL materialises the entire inner subquery before applying the keyset `WHERE` predicate on the outer query.

Closes #56068
Parent: #52037

## Test Plan

- [x] `db/rdbms` compiles clean (`./mvnw install -pl db/rdbms -Dquickly -T1C`)
- [x] `shouldReturnCorrectResultsWithKeysetPagination` in `WaitStateIT` covers page-1 + page-2 cursor traversal and asserts `total() == 20` on both pages
- [ ] CI RDBMS matrix (H2, PostgreSQL, MariaDB, MySQL, Oracle, MSSQL) via `WaitStateIT` + `WaitStateSortIT`
- [ ] Re-run `c8-ws-bench-s3-pg-page2` benchmark scenario against this branch to confirm regression is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)