### PR TITLE
feat: Replace Process Instances to Archive Aggregation with Plain Query

### DIFF
--- a/operate/archiver/pom.xml
+++ b/operate/archiver/pom.xml
@@ -53,6 +53,12 @@
       <artifactId>opensearch-java</artifactId>
     </dependency>
 
+    <!-- used to read formatted fields from OpenSearch hits (JsonData) -->
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+    </dependency>
+
     <!-- SPRING -->
     <dependency>
       <groupId>org.springframework</groupId>
@@ -138,6 +144,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- IT test dependencies -->
     <dependency>
       <groupId>org.testcontainers</groupId>
@@ -207,12 +219,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.archiver;
 
 import io.camunda.operate.Metrics;
+import io.camunda.operate.archiver.util.DateOfArchivedDocumentsUtil;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.templates.BatchOperationTemplate;
 import io.camunda.operate.schema.templates.DecisionInstanceTemplate;
@@ -71,6 +72,11 @@ public class Archiver {
   @PostConstruct
   public void startArchiving() {
     if (operateProperties.getArchiver().isRolloverEnabled()) {
+      // fail fast on a date-format/interval mismatch that would silently stall archiving
+      DateOfArchivedDocumentsUtil.validateRolloverConfiguration(
+          operateProperties.getArchiver().getRolloverInterval(),
+          operateProperties.getArchiver().getElsRolloverDateFormat());
+
       LOGGER.info("INIT: Start archiving data...");
 
       // split the list of partitionIds to parallelize

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -28,6 +28,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.operate.Metrics;
 import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
+import io.camunda.operate.archiver.util.DateOfArchivedDocumentsUtil;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.exceptions.ArchiverException;
 import io.camunda.operate.exceptions.OperateRuntimeException;
@@ -69,6 +70,7 @@ import org.elasticsearch.index.reindex.AbstractBulkByScrollRequest;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.index.reindex.ReindexRequest;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
@@ -147,12 +149,45 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     }
   }
 
+  private ArchiveBatch createArchiveBatchFromHits(
+      final SearchResponse searchResponse,
+      final String dateField,
+      final String rolloverInterval,
+      final String dateFormat) {
+    final SearchHit[] hits = searchResponse.getHits().getHits();
+    if (hits.length == 0) {
+      return null;
+    }
+    final String firstEndDate = hits[0].field(dateField).getValue();
+    final String bucketStart =
+        DateOfArchivedDocumentsUtil.getBucketStart(firstEndDate, rolloverInterval, dateFormat);
+    final String nextBucketStart =
+        DateOfArchivedDocumentsUtil.getNextBucketStart(firstEndDate, rolloverInterval, dateFormat);
+    // hits are sorted by endDate ASC, so the first hit is the earliest and defines the bucket.
+    // Lower bound is therefore satisfied automatically; only the exclusive upper bound is checked.
+    final List<Object> ids =
+        Arrays.stream(hits)
+            .takeWhile(
+                hit -> ((String) hit.field(dateField).getValue()).compareTo(nextBucketStart) < 0)
+            .map(hit -> (Object) hit.getId())
+            .toList();
+    return new ArchiveBatch(bucketStart, ids);
+  }
+
   private CompletableFuture<SearchResponse> sendSearchRequest(final SearchRequest searchRequest) {
     return ElasticsearchUtil.searchAsync(searchRequest, archiverExecutor, esClient);
   }
 
   private CompletableFuture<ArchiveBatch> searchAsync(
       final SearchRequest searchRequest, final Function<Throwable, String> errorMessage) {
+    return searchAsync(
+        searchRequest, errorMessage, r -> createArchiveBatch(r, DATES_AGG, INSTANCES_AGG));
+  }
+
+  private CompletableFuture<ArchiveBatch> searchAsync(
+      final SearchRequest searchRequest,
+      final Function<Throwable, String> errorMessage,
+      final Function<SearchResponse, ArchiveBatch> batchExtractor) {
     final var batchFuture = new CompletableFuture<ArchiveBatch>();
 
     final var startTimer = Timer.start();
@@ -161,8 +196,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
             (response, e) -> {
               final var timer = getArchiverQueryTimer();
               startTimer.stop(timer);
-
-              final var result = handleSearchResponse(response, e, errorMessage);
+              final var result = handleSearchResponse(response, e, errorMessage, batchExtractor);
               result.ifRightOrLeft(batchFuture::complete, batchFuture::completeExceptionally);
             });
 
@@ -184,14 +218,19 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
   @Override
   public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(
       final List<Integer> partitionIds) {
-    final var aggregation = createFinishedInstancesAggregation(DATES_AGG, INSTANCES_AGG);
-    final var searchRequest = createFinishedInstancesSearchRequest(aggregation, partitionIds);
+    final var searchRequest = createFinishedInstancesSearchRequest(partitionIds);
     final Function<Throwable, String> errorMessage =
         t ->
             format(
-                "Exception occurred, while obtaining finished batch operations: %s",
+                "Exception occurred, while obtaining finished process instances: %s",
                 t.getMessage());
-    return searchAsync(searchRequest, errorMessage);
+    final var interval = operateProperties.getArchiver().getRolloverInterval();
+    final var dateFormat = operateProperties.getArchiver().getElsRolloverDateFormat();
+    return searchAsync(
+        searchRequest,
+        errorMessage,
+        response ->
+            createArchiveBatchFromHits(response, ListViewTemplate.END_DATE, interval, dateFormat));
   }
 
   @Override
@@ -564,21 +603,19 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
   private Either<Throwable, ArchiveBatch> handleSearchResponse(
       final SearchResponse searchResponse,
       final Throwable error,
-      final Function<Throwable, String> errorMessage) {
+      final Function<Throwable, String> errorMessage,
+      final Function<SearchResponse, ArchiveBatch> batchExtractor) {
     if (error != null) {
       return Either.left(new OperateRuntimeException(errorMessage.apply(error), error));
     }
-
-    final var batch = createArchiveBatch(searchResponse, DATES_AGG, INSTANCES_AGG);
-    return Either.right(batch);
+    return Either.right(batchExtractor.apply(searchResponse));
   }
 
   private Timer getArchiverQueryTimer() {
     return metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_QUERY);
   }
 
-  private SearchRequest createFinishedInstancesSearchRequest(
-      final AggregationBuilder agg, final List<Integer> partitionIds) {
+  private SearchRequest createFinishedInstancesSearchRequest(final List<Integer> partitionIds) {
     final QueryBuilder endDateQ =
         rangeQuery(ListViewTemplate.END_DATE)
             .lte(operateProperties.getArchiver().getArchivingTimepoint());
@@ -593,36 +630,16 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
             .source(
                 new SearchSourceBuilder()
                     .query(q)
-                    .aggregation(agg)
                     .fetchSource(false)
-                    .size(0)
+                    .docValueField(
+                        ListViewTemplate.END_DATE,
+                        operateProperties.getArchiver().getElsRolloverDateFormat())
+                    .size(operateProperties.getArchiver().getRolloverBatchSize())
                     .sort(ListViewTemplate.END_DATE, SortOrder.ASC))
             .requestCache(false); // we don't need to cache this, as each time we need new data
 
-    LOGGER.debug(
-        "Finished process instances for archiving request: \n{}\n and aggregation: \n{}",
-        q.toString(),
-        agg.toString());
+    LOGGER.debug("Finished process instances for archiving request: \n{}", q.toString());
     return searchRequest;
-  }
-
-  private AggregationBuilder createFinishedInstancesAggregation(
-      final String datesAggName, final String instancesAggName) {
-    return dateHistogram(datesAggName)
-        .field(ListViewTemplate.END_DATE)
-        .calendarInterval(
-            new DateHistogramInterval(operateProperties.getArchiver().getRolloverInterval()))
-        .format(operateProperties.getArchiver().getElsRolloverDateFormat())
-        .keyed(true) // get result as a map (not an array)
-        // we want to get only one bucket at a time
-        .subAggregation(
-            bucketSort("datesSortedAgg", Arrays.asList(new FieldSortBuilder("_key"))).size(1))
-        // we need process instance ids, also taking into account batch size
-        .subAggregation(
-            topHits(instancesAggName)
-                .size(operateProperties.getArchiver().getRolloverBatchSize())
-                .sort(ListViewTemplate.ID, SortOrder.ASC)
-                .fetchSource(ListViewTemplate.ID, null));
   }
 
   private AggregationBuilder createStandaloneDecisionInstancesAggregation(

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -194,10 +194,16 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     sendSearchRequest(searchRequest)
         .whenComplete(
             (response, e) -> {
-              final var timer = getArchiverQueryTimer();
-              startTimer.stop(timer);
-              final var result = handleSearchResponse(response, e, errorMessage, batchExtractor);
-              result.ifRightOrLeft(batchFuture::complete, batchFuture::completeExceptionally);
+              try {
+                final var timer = getArchiverQueryTimer();
+                startTimer.stop(timer);
+                final var result = handleSearchResponse(response, e, errorMessage, batchExtractor);
+                result.ifRightOrLeft(batchFuture::complete, batchFuture::completeExceptionally);
+              } catch (final Exception ex) {
+                // Ensure the future is always completed; an uncaught exception in whenComplete
+                // would otherwise leave batchFuture pending indefinitely.
+                batchFuture.completeExceptionally(ex);
+              }
             });
 
     return batchFuture;

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -33,6 +33,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.operate.Metrics;
 import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
+import io.camunda.operate.archiver.util.DateOfArchivedDocumentsUtil;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.OperateProperties;
@@ -132,6 +133,14 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
   private CompletableFuture<ArchiveBatch> search(
       final SearchRequest.Builder searchRequestBuilder,
       final Function<Throwable, String> errorMessage) {
+    return search(
+        searchRequestBuilder, errorMessage, r -> createArchiveBatch(r, DATES_AGG, INSTANCES_AGG));
+  }
+
+  private CompletableFuture<ArchiveBatch> search(
+      final SearchRequest.Builder searchRequestBuilder,
+      final Function<Throwable, String> errorMessage,
+      final Function<SearchResponse, ArchiveBatch> batchExtractor) {
     final var batchFuture = new CompletableFuture<ArchiveBatch>();
 
     final var startTimer = Timer.start();
@@ -141,7 +150,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
               final var timer = metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_QUERY);
               startTimer.stop(timer);
 
-              final var result = handleSearchResponse(response, e, errorMessage);
+              final var result = handleSearchResponse(response, e, errorMessage, batchExtractor);
               result.ifRightOrLeft(batchFuture::complete, batchFuture::completeExceptionally);
             });
 
@@ -208,15 +217,16 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
                 intTerms(ListViewTemplate.PARTITION_ID, partitionIds)));
 
     final var searchRequestBuilder =
-        nextBatchSearchRequestBuilder(
-            processInstanceTemplate.getFullQualifiedName(),
-            ListViewTemplate.ID,
-            ListViewTemplate.END_DATE,
-            query);
+        finishedInstancesSearchRequestBuilder(
+            processInstanceTemplate.getFullQualifiedName(), ListViewTemplate.END_DATE, query);
 
+    final var interval = operateProperties.getArchiver().getRolloverInterval();
+    final var dateFormat = operateProperties.getArchiver().getElsRolloverDateFormat();
     return search(
         searchRequestBuilder,
-        e -> "Failed to search in " + processInstanceTemplate.getFullQualifiedName());
+        e -> "Failed to search in " + processInstanceTemplate.getFullQualifiedName(),
+        response ->
+            createArchiveBatchFromHits(response, ListViewTemplate.END_DATE, interval, dateFormat));
   }
 
   @Override
@@ -560,15 +570,55 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     return operateProperties.getOpensearch().getNumberOfShards();
   }
 
+  private SearchRequest.Builder finishedInstancesSearchRequestBuilder(
+      final String index, final String endDateField, final Query query) {
+    final var format = operateProperties.getArchiver().getElsRolloverDateFormat();
+    final var batchSize = operateProperties.getArchiver().getRolloverBatchSize();
+    return searchRequestBuilder(index)
+        .query(query)
+        .source(SourceConfig.of(b -> b.fetch(false)))
+        .fields(f -> f.field(endDateField).format(format))
+        .size(batchSize)
+        .sort(sortOptions(endDateField, Asc))
+        .requestCache(false); // we don't need to cache this, as each time we need new data
+  }
+
+  private ArchiveBatch createArchiveBatchFromHits(
+      final SearchResponse<?> searchResponse,
+      final String dateField,
+      final String rolloverInterval,
+      final String dateFormat) {
+    final var hits = searchResponse.hits().hits();
+    if (hits.isEmpty()) {
+      return null;
+    }
+    final String firstEndDate = endDateOf(hits.get(0), dateField);
+    final String bucketStart =
+        DateOfArchivedDocumentsUtil.getBucketStart(firstEndDate, rolloverInterval, dateFormat);
+    final String nextBucketStart =
+        DateOfArchivedDocumentsUtil.getNextBucketStart(firstEndDate, rolloverInterval, dateFormat);
+    // hits are sorted by endDate ASC, so the first hit is the earliest and defines the bucket.
+    // Lower bound is satisfied automatically; only the exclusive upper bound is checked.
+    final List<Object> ids =
+        hits.stream()
+            .takeWhile(hit -> endDateOf(hit, dateField).compareTo(nextBucketStart) < 0)
+            .map(hit -> (Object) hit.id())
+            .toList();
+    return new ArchiveBatch(bucketStart, ids);
+  }
+
+  private static String endDateOf(final Hit<?> hit, final String dateField) {
+    return hit.fields().get(dateField).toJson().asJsonArray().getString(0);
+  }
+
   private Either<Throwable, ArchiveBatch> handleSearchResponse(
       final SearchResponse searchResponse,
       final Throwable error,
-      final Function<Throwable, String> errorMessage) {
+      final Function<Throwable, String> errorMessage,
+      final Function<SearchResponse, ArchiveBatch> batchExtractor) {
     if (error != null) {
       return Either.left(new OperateRuntimeException(errorMessage.apply(error), error));
     }
-
-    final var batch = createArchiveBatch(searchResponse, DATES_AGG, INSTANCES_AGG);
-    return Either.right(batch);
+    return Either.right(batchExtractor.apply(searchResponse));
   }
 }

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -147,11 +147,15 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     OpensearchUtil.searchAsync(searchRequestBuilder.build(), Object.class, osAsyncClient)
         .whenComplete(
             (response, e) -> {
-              final var timer = metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_QUERY);
-              startTimer.stop(timer);
+              try {
+                final var timer = metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_QUERY);
+                startTimer.stop(timer);
 
-              final var result = handleSearchResponse(response, e, errorMessage, batchExtractor);
-              result.ifRightOrLeft(batchFuture::complete, batchFuture::completeExceptionally);
+                final var result = handleSearchResponse(response, e, errorMessage, batchExtractor);
+                result.ifRightOrLeft(batchFuture::complete, batchFuture::completeExceptionally);
+              } catch (final Exception ex) {
+                batchFuture.completeExceptionally(ex);
+              }
             });
 
     return batchFuture;

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtil.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtil.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.archiver.util;
 
+import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -14,6 +15,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -49,9 +51,11 @@ public final class DateOfArchivedDocumentsUtil {
     final Temp rollover = parseTemporalAmount(rolloverInterval);
     final LocalDateTime bucketStart = bucketStartDateTime(endDate, rolloverInterval, dateFormat);
     final LocalDateTime nextBucketStart =
-        rollover.chronoUnit() == ChronoUnit.MONTHS
-            ? bucketStart.plusMonths(rollover.amount())
-            : bucketStart.plus(Duration.of(rollover.amount(), rollover.chronoUnit()));
+        switch (rollover.chronoUnit()) {
+          case MONTHS -> bucketStart.plusMonths(rollover.amount());
+          case WEEKS -> bucketStart.plusWeeks(rollover.amount());
+          default -> bucketStart.plus(Duration.of(rollover.amount(), rollover.chronoUnit()));
+        };
     return format(nextBucketStart, dateFormat);
   }
 
@@ -99,7 +103,6 @@ public final class DateOfArchivedDocumentsUtil {
     final LocalDateTime bucketStart;
     switch (rollover.chronoUnit()) {
       // NOTES:
-      //  WEEKS is already handled by parseTemporalAmount as 7 days
       //  SECONDS is the smallest unit
       //  Floor integer division gives us the bucket that contains endDate
       case DAYS, HOURS, MINUTES, SECONDS -> {
@@ -109,6 +112,14 @@ public final class DateOfArchivedDocumentsUtil {
         final long bucketStartSeconds = (secondsSinceEpoch / rolloverSeconds) * rolloverSeconds;
         bucketStart = Instant.ofEpochSecond(bucketStartSeconds).atZone(utc).toLocalDateTime();
       }
+      case WEEKS ->
+          // ES calendar weeks are ISO-8601: they start on Monday (matches the prior
+          // date_histogram.calendarInterval behaviour). Align to the Monday of endDate's week.
+          bucketStart =
+              archiveDate
+                  .toLocalDate()
+                  .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                  .atStartOfDay();
       case MONTHS -> {
         final int totalMonthsSinceEpoch =
             (archiveDate.getYear() - LocalDate.EPOCH.getYear()) * 12
@@ -144,7 +155,7 @@ public final class DateOfArchivedDocumentsUtil {
       case "m" -> new Temp(amount, ChronoUnit.MINUTES);
       case "h" -> new Temp(amount, ChronoUnit.HOURS);
       case "d" -> new Temp(amount, ChronoUnit.DAYS);
-      case "w" -> new Temp(amount * 7, ChronoUnit.DAYS);
+      case "w" -> new Temp(amount, ChronoUnit.WEEKS);
       case "M" -> new Temp(amount, ChronoUnit.MONTHS);
       default -> throw new IllegalArgumentException("Unsupported time amount: " + unit);
     };
@@ -175,8 +186,9 @@ public final class DateOfArchivedDocumentsUtil {
       case MINUTES -> 2;
       case HOURS -> 3;
       case DAYS -> 4;
-      case MONTHS -> 5;
-      default -> 6;
+      case WEEKS -> 5;
+      case MONTHS -> 6;
+      default -> 7;
     };
   }
 

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtil.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtil.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver.util;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DateOfArchivedDocumentsUtil {
+  private static final Pattern TEMPORAL_PATTERN = Pattern.compile("(\\d+)" + "([smhdwM])");
+  private static final String DATE_PATTERN = "yyyy-MM-dd";
+  private static final DateTimeFormatter DATE_ONLY_FORMATTER =
+      DateTimeFormatter.ofPattern(DATE_PATTERN);
+  // a fixed reference instant used to round-trip-check a configured date format
+  private static final LocalDateTime VALIDATION_SAMPLE = LocalDateTime.of(2000, 1, 2, 3, 4, 5);
+
+  private DateOfArchivedDocumentsUtil() {}
+
+  /** Floors {@code endDate} to the start of the rollover bucket that contains it. */
+  public static String getBucketStart(
+      final String endDate, final String rolloverInterval, final String dateFormat) {
+    return format(bucketStartDateTime(endDate, rolloverInterval, dateFormat), dateFormat);
+  }
+
+  /**
+   * Start of the bucket immediately after the one that contains {@code endDate} - i.e. the
+   * exclusive upper bound of that bucket. A document belongs to the bucket if bucketStart &lt;=
+   * endDate &lt; nextBucketStart.
+   *
+   * <p>NOTE: callers compare fetched endDate values (formatted with {@code dateFormat}) against
+   * this value, so the format granularity must be at least as fine as the rollover interval. With a
+   * day-only format ({@code "date"}/{@code "yyyy-MM-dd"}) and a sub-day interval (e.g. {@code
+   * "4h"}) the returned value collapses to the same day as the start, the bucket appears empty, and
+   * archiving would stall. Use a date-time format for sub-day rollover intervals.
+   */
+  public static String getNextBucketStart(
+      final String endDate, final String rolloverInterval, final String dateFormat) {
+    final Temp rollover = parseTemporalAmount(rolloverInterval);
+    final LocalDateTime bucketStart = bucketStartDateTime(endDate, rolloverInterval, dateFormat);
+    final LocalDateTime nextBucketStart =
+        rollover.chronoUnit() == ChronoUnit.MONTHS
+            ? bucketStart.plusMonths(rollover.amount())
+            : bucketStart.plus(Duration.of(rollover.amount(), rollover.chronoUnit()));
+    return format(nextBucketStart, dateFormat);
+  }
+
+  /**
+   * Fails fast on an archiver configuration where the rollover date format is too coarse for the
+   * rollover interval. Bucket trimming compares fetched endDate values (rendered with {@code
+   * dateFormat}) against the next bucket start, so the format granularity must be at least as fine
+   * as the interval. Otherwise, the bucket end collapses onto the start, the batch comes back
+   * empty, and archiving silently stalls - see {@link #getNextBucketStart}.
+   *
+   * @throws IllegalArgumentException if {@code dateFormat} is coarser than {@code rolloverInterval}
+   */
+  public static void validateRolloverConfiguration(
+      final String rolloverInterval, final String dateFormat) {
+    // fail fast if the format cannot be produced and parsed back by this util (e.g. "yyyy-MM",
+    // "yyyy"), which would otherwise blow up later in parseFlexibleDateTime during archiving
+    try {
+      parseFlexibleDateTime(format(VALIDATION_SAMPLE, dateFormat), dateFormat);
+    } catch (final RuntimeException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid archiver configuration: rollover date format '%s' is not a valid.",
+              dateFormat),
+          e);
+    }
+
+    final ChronoUnit intervalUnit = parseTemporalAmount(rolloverInterval).chronoUnit();
+    final ChronoUnit formatUnit = dateFormatChronoUnit(dateFormat);
+    if (granularityOrdinal(formatUnit) > granularityOrdinal(intervalUnit)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid archiver configuration: rollover date format '%s' is too coarse for rollover"
+                  + " interval '%s'. The date format granularity must be at least as fine as the"
+                  + " rollover interval (use a date-time format for sub-day rollover intervals).",
+              dateFormat, rolloverInterval));
+    }
+  }
+
+  private static LocalDateTime bucketStartDateTime(
+      final String endDate, final String rolloverInterval, final String dateFormat) {
+    final Temp rollover = parseTemporalAmount(rolloverInterval);
+    final LocalDateTime archiveDate = parseFlexibleDateTime(endDate, dateFormat);
+    final ZoneId utc = ZoneId.of("UTC");
+
+    final LocalDateTime bucketStart;
+    switch (rollover.chronoUnit()) {
+      // NOTES:
+      //  WEEKS is already handled by parseTemporalAmount as 7 days
+      //  SECONDS is the smallest unit
+      //  Floor integer division gives us the bucket that contains endDate
+      case DAYS, HOURS, MINUTES, SECONDS -> {
+        final long rolloverSeconds =
+            Duration.of(rollover.amount(), rollover.chronoUnit()).getSeconds();
+        final long secondsSinceEpoch = archiveDate.atZone(utc).toEpochSecond();
+        final long bucketStartSeconds = (secondsSinceEpoch / rolloverSeconds) * rolloverSeconds;
+        bucketStart = Instant.ofEpochSecond(bucketStartSeconds).atZone(utc).toLocalDateTime();
+      }
+      case MONTHS -> {
+        final int totalMonthsSinceEpoch =
+            (archiveDate.getYear() - LocalDate.EPOCH.getYear()) * 12
+                + (archiveDate.getMonthValue() - 1);
+        final int bucketMonth = (totalMonthsSinceEpoch / rollover.amount()) * rollover.amount();
+        final int year = LocalDate.EPOCH.getYear() + (bucketMonth / 12);
+        final int month = (bucketMonth % 12) + 1;
+        bucketStart = LocalDate.of(year, month, 1).atStartOfDay();
+      }
+      default ->
+          throw new IllegalArgumentException("Unsupported rollover value: " + rolloverInterval);
+    }
+    return bucketStart;
+  }
+
+  private static String format(final LocalDateTime dateTime, final String dateFormat) {
+    if (isDateOnly(dateFormat)) {
+      return dateTime.format(DATE_ONLY_FORMATTER);
+    } else {
+      return dateTime.format(DateTimeFormatter.ofPattern(dateFormat));
+    }
+  }
+
+  private static Temp parseTemporalAmount(final String input) {
+    final Matcher matcher = TEMPORAL_PATTERN.matcher(input);
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException("Invalid format: " + input);
+    }
+    final int amount = Integer.parseInt(matcher.group(1));
+    final String unit = matcher.group(2);
+    return switch (unit) {
+      case "s" -> new Temp(amount, ChronoUnit.SECONDS);
+      case "m" -> new Temp(amount, ChronoUnit.MINUTES);
+      case "h" -> new Temp(amount, ChronoUnit.HOURS);
+      case "d" -> new Temp(amount, ChronoUnit.DAYS);
+      case "w" -> new Temp(amount * 7, ChronoUnit.DAYS);
+      case "M" -> new Temp(amount, ChronoUnit.MONTHS);
+      default -> throw new IllegalArgumentException("Unsupported time amount: " + unit);
+    };
+  }
+
+  private static LocalDateTime parseFlexibleDateTime(final String dateStr, final String pattern) {
+    try {
+      if (isDateOnly(pattern)) {
+        return LocalDate.parse(dateStr, DATE_ONLY_FORMATTER).atStartOfDay();
+      } else {
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+        return LocalDateTime.parse(dateStr, formatter);
+      }
+    } catch (final Exception exception) {
+      throw new IllegalArgumentException(
+          "Invalid date format: " + dateStr + " with pattern: " + pattern, exception);
+    }
+  }
+
+  private static boolean isDateOnly(final String pattern) {
+    return "date".equals(pattern) || DATE_PATTERN.equals(pattern);
+  }
+
+  /** Finer units rank lower; used only to compare granularity, not for arithmetic. */
+  private static int granularityOrdinal(final ChronoUnit unit) {
+    return switch (unit) {
+      case SECONDS -> 1;
+      case MINUTES -> 2;
+      case HOURS -> 3;
+      case DAYS -> 4;
+      case MONTHS -> 5;
+      default -> 6;
+    };
+  }
+
+  /**
+   * Finest temporal field a date format can render, ignoring quoted literals (e.g. {@code 'T'}).
+   */
+  private static ChronoUnit dateFormatChronoUnit(final String dateFormat) {
+    if (isDateOnly(dateFormat)) {
+      return ChronoUnit.DAYS;
+    }
+    final String unquoted = dateFormat.replaceAll("'[^']*'", "");
+    if (unquoted.indexOf('s') >= 0) {
+      return ChronoUnit.SECONDS;
+    }
+    if (unquoted.indexOf('m') >= 0) {
+      return ChronoUnit.MINUTES;
+    }
+    if (unquoted.indexOf('H') >= 0
+        || unquoted.indexOf('h') >= 0
+        || unquoted.indexOf('K') >= 0
+        || unquoted.indexOf('k') >= 0) {
+      return ChronoUnit.HOURS;
+    }
+    if (unquoted.indexOf('d') >= 0) {
+      return ChronoUnit.DAYS;
+    }
+    if (unquoted.indexOf('M') >= 0) {
+      return ChronoUnit.MONTHS;
+    }
+    return ChronoUnit.YEARS;
+  }
+
+  private record Temp(int amount, ChronoUnit chronoUnit) {}
+}

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtil.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtil.java
@@ -149,6 +149,14 @@ public final class DateOfArchivedDocumentsUtil {
       throw new IllegalArgumentException("Invalid format: " + input);
     }
     final int amount = Integer.parseInt(matcher.group(1));
+
+    if (amount != 1) {
+      throw new IllegalArgumentException(
+          "Invalid rollover interval: "
+              + input
+              + ". Only single-unit values (e.g. 1d, 1w, 1M) are supported.");
+    }
+
     final String unit = matcher.group(2);
     return switch (unit) {
       case "s" -> new Temp(amount, ChronoUnit.SECONDS);

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverTest.java
@@ -31,11 +31,23 @@ public class ArchiverTest {
     when(operateProperties.getArchiver()).thenReturn(archiverProperties);
     when(archiverProperties.isRolloverEnabled()).thenReturn(true);
     // sub-day interval with a day-only format -> bucket end collapses, archiving would stall
-    when(archiverProperties.getRolloverInterval()).thenReturn("4h");
+    when(archiverProperties.getRolloverInterval()).thenReturn("1h");
     when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
 
     assertThatThrownBy(() -> underTest.startArchiving())
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldFailStartupWhenMultiUnitIntervalIsUsed() {
+    when(operateProperties.getArchiver()).thenReturn(archiverProperties);
+    when(archiverProperties.isRolloverEnabled()).thenReturn(true);
+    when(archiverProperties.getRolloverInterval()).thenReturn("2d");
+    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
+
+    assertThatThrownBy(() -> underTest.startArchiving())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Only single-unit values");
   }
 
   @Test

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.property.ArchiverProperties;
+import io.camunda.operate.property.OperateProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ArchiverTest {
+
+  @InjectMocks private Archiver underTest;
+  @Mock private OperateProperties operateProperties;
+  @Mock private ArchiverProperties archiverProperties;
+
+  @Test
+  public void shouldFailStartupWhenDateFormatIsTooCoarseForInterval() {
+    when(operateProperties.getArchiver()).thenReturn(archiverProperties);
+    when(archiverProperties.isRolloverEnabled()).thenReturn(true);
+    // sub-day interval with a day-only format -> bucket end collapses, archiving would stall
+    when(archiverProperties.getRolloverInterval()).thenReturn("4h");
+    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
+
+    assertThatThrownBy(() -> underTest.startArchiving())
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  public void shouldNotValidateWhenRolloverDisabled() {
+    when(operateProperties.getArchiver()).thenReturn(archiverProperties);
+    when(archiverProperties.isRolloverEnabled()).thenReturn(false);
+    // an invalid format/interval combination is irrelevant when rollover is disabled
+    lenient().when(archiverProperties.getRolloverInterval()).thenReturn("4h");
+    lenient().when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
+
+    // no archiving started, no validation performed -> no exception
+    underTest.startArchiving();
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
@@ -45,8 +45,11 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.IndicesClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
@@ -233,31 +236,6 @@ public class ElasticsearchArchiveRepositoryTest {
   }
 
   @Test
-  public void testGetProcessInstancesNextBatchEmptyBucket() {
-    setProcessInstancesMocks();
-
-    try (final MockedStatic<ElasticsearchUtil> elasticsearchUtilMockedStatic =
-        mockStatic(ElasticsearchUtil.class)) {
-      elasticsearchUtilMockedStatic
-          .when(
-              () ->
-                  ElasticsearchUtil.joinWithAnd(
-                      any(),
-                      eq(
-                          QueryBuilders.termQuery(
-                              ListViewTemplate.JOIN_RELATION,
-                              ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION)),
-                      eq(QueryBuilders.termsQuery(ListViewTemplate.PARTITION_ID, PARTITION_IDS))))
-          .thenCallRealMethod();
-
-      testGetNextBatchEmptyBucket(
-          () -> underTest.getProcessInstancesNextBatch(PARTITION_IDS),
-          "endDate",
-          elasticsearchUtilMockedStatic);
-    }
-  }
-
-  @Test
   public void testGetBatchOperationsNextBatchEmptyBucket() {
     setBatchOperationMocks();
 
@@ -408,10 +386,125 @@ public class ElasticsearchArchiveRepositoryTest {
     verify(histogram).getBuckets();
   }
 
+  @Test
+  public void testGetProcessInstancesNextBatchEmptyHits() {
+    setProcessInstancesMocks();
+
+    try (final MockedStatic<ElasticsearchUtil> elasticsearchUtilMockedStatic =
+        mockStatic(ElasticsearchUtil.class)) {
+      elasticsearchUtilMockedStatic
+          .when(
+              () ->
+                  ElasticsearchUtil.joinWithAnd(
+                      any(),
+                      eq(
+                          QueryBuilders.termQuery(
+                              ListViewTemplate.JOIN_RELATION,
+                              ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION)),
+                      eq(QueryBuilders.termsQuery(ListViewTemplate.PARTITION_ID, PARTITION_IDS))))
+          .thenCallRealMethod();
+
+      final SearchResponse searchResponse = mock(SearchResponse.class);
+      final SearchHits searchHits = mock(SearchHits.class);
+      when(searchResponse.getHits()).thenReturn(searchHits);
+      when(searchHits.getHits()).thenReturn(new SearchHit[0]);
+
+      try (final MockedConstruction<SearchRequest> mockedConstruction =
+          mockConstruction(
+              SearchRequest.class,
+              (mock, context) -> {
+                when(mock.source(any())).thenReturn(mock);
+                when(mock.requestCache(false)).thenReturn(mock);
+              })) {
+        try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+          final Timer.Sample timer = mock(Timer.Sample.class);
+          when(timer.stop(any())).thenReturn(1000L);
+          mockedTimer.when(Timer::start).thenReturn(timer);
+          elasticsearchUtilMockedStatic
+              .when(() -> ElasticsearchUtil.searchAsync(any(), any(), any()))
+              .thenReturn(CompletableFuture.completedFuture(searchResponse));
+
+          final CompletableFuture<ArchiveBatch> res =
+              underTest.getProcessInstancesNextBatch(PARTITION_IDS);
+          res.join();
+          assertThat(res).isCompleted();
+          assertThat(res.join()).isNull();
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testGetProcessInstancesNextBatchPacksEarliestBucketOnly() {
+    setProcessInstancesMocks();
+
+    try (final MockedStatic<ElasticsearchUtil> elasticsearchUtilMockedStatic =
+        mockStatic(ElasticsearchUtil.class)) {
+      elasticsearchUtilMockedStatic
+          .when(
+              () ->
+                  ElasticsearchUtil.joinWithAnd(
+                      any(),
+                      eq(
+                          QueryBuilders.termQuery(
+                              ListViewTemplate.JOIN_RELATION,
+                              ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION)),
+                      eq(QueryBuilders.termsQuery(ListViewTemplate.PARTITION_ID, PARTITION_IDS))))
+          .thenCallRealMethod();
+
+      final SearchResponse searchResponse = mock(SearchResponse.class);
+      final SearchHits searchHits = mock(SearchHits.class);
+      when(searchResponse.getHits()).thenReturn(searchHits);
+
+      final SearchHit hitA = mock(SearchHit.class);
+      final SearchHit hitB = mock(SearchHit.class);
+      final SearchHit hitC = mock(SearchHit.class);
+      when(hitA.getId()).thenReturn("a");
+      when(hitB.getId()).thenReturn("b");
+      // hitC.getId() is NOT stubbed — takeWhile stops before hitC so getId() is never called
+      final DocumentField fieldA = mock(DocumentField.class);
+      final DocumentField fieldB = mock(DocumentField.class);
+      final DocumentField fieldC = mock(DocumentField.class);
+      when(fieldA.getValue()).thenReturn("2024-01-01");
+      when(fieldB.getValue()).thenReturn("2024-01-01");
+      when(fieldC.getValue()).thenReturn("2024-01-02");
+      when(hitA.field(ListViewTemplate.END_DATE)).thenReturn(fieldA);
+      when(hitB.field(ListViewTemplate.END_DATE)).thenReturn(fieldB);
+      when(hitC.field(ListViewTemplate.END_DATE)).thenReturn(fieldC);
+      when(searchHits.getHits()).thenReturn(new SearchHit[] {hitA, hitB, hitC});
+
+      try (final MockedConstruction<SearchRequest> mockedConstruction =
+          mockConstruction(
+              SearchRequest.class,
+              (mock, context) -> {
+                when(mock.source(any())).thenReturn(mock);
+                when(mock.requestCache(false)).thenReturn(mock);
+              })) {
+        try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+          final Timer.Sample timer = mock(Timer.Sample.class);
+          when(timer.stop(any())).thenReturn(1000L);
+          mockedTimer.when(Timer::start).thenReturn(timer);
+          elasticsearchUtilMockedStatic
+              .when(() -> ElasticsearchUtil.searchAsync(any(), any(), any()))
+              .thenReturn(CompletableFuture.completedFuture(searchResponse));
+
+          final CompletableFuture<ArchiveBatch> res =
+              underTest.getProcessInstancesNextBatch(PARTITION_IDS);
+          final ArchiveBatch batch = res.join();
+          assertThat(batch).isNotNull();
+          assertThat(batch.getFinishDate()).isEqualTo("2024-01-01");
+          assertThat(batch.getIds()).isEqualTo(List.of("a", "b"));
+        }
+      }
+    }
+  }
+
   private void setProcessInstancesMocks() {
     when(operateProperties.getArchiver()).thenReturn(archiverProperties);
-    when(archiverProperties.getRolloverInterval()).thenReturn("1m");
-    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("format");
+    when(archiverProperties.getRolloverInterval()).thenReturn("1d");
+    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
+    when(archiverProperties.getRolloverBatchSize()).thenReturn(100);
+    when(archiverProperties.getArchivingTimepoint()).thenReturn("now-1s");
     when(listViewTemplate.getFullQualifiedName()).thenReturn("qualifiedName");
   }
 

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
@@ -39,6 +39,8 @@ import io.camunda.operate.store.opensearch.dsl.RequestDSL;
 import io.camunda.operate.util.Either;
 import io.camunda.operate.util.OpensearchUtil;
 import io.micrometer.core.instrument.Timer;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +54,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
@@ -68,8 +71,9 @@ import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
 import org.opensearch.client.opensearch.core.ReindexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.opensearch.client.opensearch.core.search.SourceConfig;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @ExtendWith(MockitoExtension.class)
 public class OpensearchArchiverRepositoryTest {
@@ -77,7 +81,6 @@ public class OpensearchArchiverRepositoryTest {
 
   @Mock protected RichOpenSearchClient richOpenSearchClient;
   @Mock protected OpenSearchAsyncClient openSearchAsyncClient;
-  @Mock protected ThreadPoolTaskScheduler archiverExecutor;
   @InjectMocks OpensearchArchiverRepository underTest;
   @Mock OperateOpensearchProperties operateOpensearchProperties;
   @Mock private BatchOperationTemplate batchOperationTemplate;
@@ -115,7 +118,6 @@ public class OpensearchArchiverRepositoryTest {
 
   @Test
   public void testSetIndexLifeCycleNoIndex() throws ClassNotFoundException {
-    final OpenSearchISMOperations openSearchISMOperations = mock(OpenSearchISMOperations.class);
     when(operateProperties.getArchiver()).thenReturn(archiverProperties);
     when(richOpenSearchClient.index()).thenReturn(openSearchIndexOperations);
     when(archiverProperties.isIlmEnabled()).thenReturn(true);
@@ -230,17 +232,71 @@ public class OpensearchArchiverRepositoryTest {
   }
 
   @Test
-  public void testGetProcessInstancesNextBatch() {
+  public void testGetProcessInstancesNextBatchEmptyHitsReturnsNull() {
     setProcessInstancesMocks();
-    try (final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class)) {
-      try (final MockedStatic<AggregationDSL> aggregationDSLMockedStatic =
-          mockStatic(AggregationDSL.class)) {
-        testGetNextBatchHelper(
-            () -> underTest.getProcessInstancesNextBatch(PARTITION_IDS),
-            queryDSLMockedStatic,
-            aggregationDSLMockedStatic,
-            "endDate");
-      }
+    try (final MockedStatic<RequestDSL> requestDSLMockedStatic = mockStatic(RequestDSL.class);
+        final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class);
+        final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class);
+        final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
+      setupPISearchRequestBuilderMock(requestDSLMockedStatic, queryDSLMockedStatic);
+
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      timerMockedStatic.when(Timer::start).thenReturn(timerSample);
+      when(metrics.getTimer(any())).thenReturn(mock(Timer.class));
+
+      final HitsMetadata<Object> hitsMeta = mock(HitsMetadata.class);
+      final SearchResponse<Object> resp = mock(SearchResponse.class);
+      when(resp.hits()).thenReturn(hitsMeta);
+      when(hitsMeta.hits()).thenReturn(List.of());
+
+      opensearchUtil
+          .when(() -> OpensearchUtil.searchAsync(any(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(resp));
+
+      final CompletableFuture<ArchiveBatch> result =
+          underTest.getProcessInstancesNextBatch(PARTITION_IDS);
+      result.join();
+      assertThat(result).isCompleted();
+      assertThat(result.join()).isNull();
+    }
+  }
+
+  @Test
+  public void testGetProcessInstancesNextBatchPacksEarliestBucketOnly() {
+    setProcessInstancesMocks();
+    try (final MockedStatic<RequestDSL> requestDSLMockedStatic = mockStatic(RequestDSL.class);
+        final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class);
+        final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class);
+        final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
+      setupPISearchRequestBuilderMock(requestDSLMockedStatic, queryDSLMockedStatic);
+
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      timerMockedStatic.when(Timer::start).thenReturn(timerSample);
+      when(metrics.getTimer(any())).thenReturn(mock(Timer.class));
+
+      // hits: "a" and "b" on 2024-01-01 (same bucket); "c" on 2024-01-02 (next bucket)
+      // hit "c" fields() IS read by takeWhile predicate, but id() is NOT mapped
+      final Hit<Object> hitA = hitWithEndDate("a", "2024-01-01");
+      final Hit<Object> hitB = hitWithEndDate("b", "2024-01-01");
+      final Hit<Object> hitC = hitWithEndDateNoId("2024-01-02");
+
+      final HitsMetadata<Object> hitsMeta = mock(HitsMetadata.class);
+      final SearchResponse<Object> resp = mock(SearchResponse.class);
+      when(resp.hits()).thenReturn(hitsMeta);
+      when(hitsMeta.hits()).thenReturn(List.of(hitA, hitB, hitC));
+
+      opensearchUtil
+          .when(() -> OpensearchUtil.searchAsync(any(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(resp));
+
+      final CompletableFuture<ArchiveBatch> result =
+          underTest.getProcessInstancesNextBatch(PARTITION_IDS);
+      result.join();
+      assertThat(result).isCompleted();
+      final ArchiveBatch batch = result.join();
+      assertThat(batch).isNotNull();
+      assertThat(batch.getFinishDate()).isEqualTo("2024-01-01");
+      assertThat(batch.getIds()).isEqualTo(List.of("a", "b"));
     }
   }
 
@@ -435,10 +491,55 @@ public class OpensearchArchiverRepositoryTest {
 
   private void setProcessInstancesMocks() {
     when(operateProperties.getArchiver()).thenReturn(archiverProperties);
-    when(archiverProperties.getRolloverInterval()).thenReturn("1m");
-    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("format");
-    when(archiverProperties.getRolloverBatchSize()).thenReturn(12);
+    when(archiverProperties.getRolloverInterval()).thenReturn("1d");
+    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
+    when(archiverProperties.getRolloverBatchSize()).thenReturn(100);
+    when(archiverProperties.getArchivingTimepoint()).thenReturn("now-1s");
     when(processInstanceTemplate.getFullQualifiedName()).thenReturn("qualifiedName");
+  }
+
+  @SuppressWarnings("unchecked")
+  private void setupPISearchRequestBuilderMock(
+      final MockedStatic<RequestDSL> requestDSLMockedStatic,
+      final MockedStatic<QueryDSL> queryDSLMockedStatic) {
+    final SearchRequest.Builder searchRequestBuilder = mock(SearchRequest.Builder.class);
+    requestDSLMockedStatic
+        .when(() -> RequestDSL.searchRequestBuilder(anyString()))
+        .thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.query((Query) any())).thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.source((SourceConfig) any())).thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.fields(any(java.util.function.Function.class)))
+        .thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.size(anyInt())).thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.sort((SortOptions) any())).thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.requestCache(false)).thenReturn(searchRequestBuilder);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Hit<Object> hitWithEndDate(final String id, final String endDate) {
+    final Hit<Object> hit = mock(Hit.class);
+    when(hit.id()).thenReturn(id);
+    final JsonValue jsonValue = mock(JsonValue.class);
+    final JsonArray jsonArray = mock(JsonArray.class);
+    final JsonData jsonData = mock(JsonData.class);
+    when(hit.fields()).thenReturn(java.util.Map.of("endDate", jsonData));
+    when(jsonData.toJson()).thenReturn(jsonValue);
+    when(jsonValue.asJsonArray()).thenReturn(jsonArray);
+    when(jsonArray.getString(0)).thenReturn(endDate);
+    return hit;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Hit<Object> hitWithEndDateNoId(final String endDate) {
+    final Hit<Object> hit = mock(Hit.class);
+    final JsonValue jsonValue = mock(JsonValue.class);
+    final JsonArray jsonArray = mock(JsonArray.class);
+    final JsonData jsonData = mock(JsonData.class);
+    when(hit.fields()).thenReturn(java.util.Map.of("endDate", jsonData));
+    when(jsonData.toJson()).thenReturn(jsonValue);
+    when(jsonValue.asJsonArray()).thenReturn(jsonArray);
+    when(jsonArray.getString(0)).thenReturn(endDate);
+    return hit;
   }
 
   private void setBatchOperationMocks() {

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtilTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtilTest.java
@@ -54,47 +54,25 @@ class DateOfArchivedDocumentsUtilTest {
 
         // -- DAYS interval --
         Arguments.of("2026-03-16", "1d", "date", "2026-03-16", "2026-03-17"),
-        // 3d: March 16 falls in the March 14 bucket
-        Arguments.of("2026-03-16", "3d", "date", "2026-03-14", "2026-03-17"),
-        // 3d: exactly on a bucket boundary
-        Arguments.of("2026-03-14", "3d", "date", "2026-03-14", "2026-03-17"),
-        // 7d: a FIXED 7-day interval is epoch-aligned (epoch 1970-01-01 is a Thursday), distinct
-        // from a calendar week
-        Arguments.of("2026-03-18", "7d", "date", "2026-03-12", "2026-03-19"),
 
         // -- WEEKS interval: ISO calendar weeks start on Monday (matches date_histogram). --
         // 2026-03-18 is a Wednesday; the Monday of that week is 2026-03-16.
         Arguments.of("2026-03-18", "1w", "date", "2026-03-16", "2026-03-23"),
-        Arguments.of("2026-03-18", "2w", "date", "2026-03-16", "2026-03-30"),
 
         // -- Sub-day intervals with a day-only format: bucket start AND next both collapse to the
         //    day, so next == start. This is the documented limitation (use a date-time format for
         //    sub-day rollover intervals). --
         Arguments.of("2026-03-16", "1h", "date", "2026-03-16", "2026-03-16"),
-        Arguments.of("2026-03-16", "6h", "date", "2026-03-16", "2026-03-16"),
-        Arguments.of("2026-03-16", "30m", "date", "2026-03-16", "2026-03-16"),
-        Arguments.of("2026-03-16", "30s", "date", "2026-03-16", "2026-03-16"),
+        Arguments.of("2026-03-16", "1m", "date", "2026-03-16", "2026-03-16"),
+        Arguments.of("2026-03-16", "1s", "date", "2026-03-16", "2026-03-16"),
 
         // -- MONTHS interval --
         Arguments.of("2026-03-16", "1M", "date", "2026-03-01", "2026-04-01"),
         // first day of month is on boundary
         Arguments.of("2026-03-01", "1M", "date", "2026-03-01", "2026-04-01"),
-        // 2M: bi-monthly buckets from epoch (Jan 1970)
-        Arguments.of("2026-03-16", "2M", "date", "2026-03-01", "2026-05-01"),
-        // 2M: April falls in the same bi-monthly bucket as March
-        Arguments.of("2026-04-15", "2M", "date", "2026-03-01", "2026-05-01"),
-        // 3M: quarterly buckets; March 2026 => quarter starting Jan 2026
-        Arguments.of("2026-03-16", "3M", "date", "2026-01-01", "2026-04-01"),
-        // 3M: April in the next quarter bucket
-        Arguments.of("2026-04-16", "3M", "date", "2026-04-01", "2026-07-01"),
-        // 6M: semi-annual; March 2026 => half starting Jan 2026
-        Arguments.of("2026-03-16", "6M", "date", "2026-01-01", "2026-07-01"),
-        // 6M: July falls in the second-half bucket, next rolls into the following year
-        Arguments.of("2026-07-15", "6M", "date", "2026-07-01", "2027-01-01"),
 
         // -- Year boundary crossing --
         Arguments.of("2026-01-01", "1d", "date", "2026-01-01", "2026-01-02"),
-        Arguments.of("2026-01-01", "3d", "date", "2026-01-01", "2026-01-04"),
         Arguments.of("2026-01-15", "1M", "date", "2026-01-01", "2026-02-01"),
 
         // -- Epoch date --
@@ -103,23 +81,15 @@ class DateOfArchivedDocumentsUtilTest {
 
         // -- Custom date format: explicit "yyyy-MM-dd" pattern --
         Arguments.of("2026-03-16", "1d", "yyyy-MM-dd", "2026-03-16", "2026-03-17"),
-        Arguments.of("2026-03-16", "3d", "yyyy-MM-dd", "2026-03-14", "2026-03-17"),
         Arguments.of("2026-03-16", "1M", "yyyy-MM-dd", "2026-03-01", "2026-04-01"),
 
         // -- Custom date format with hours: "yyyy-MM-dd-HH" --
         Arguments.of("2026-03-16-14", "1h", "yyyy-MM-dd-HH", "2026-03-16-14", "2026-03-16-15"),
-        Arguments.of("2026-03-16-15", "2h", "yyyy-MM-dd-HH", "2026-03-16-14", "2026-03-16-16"),
-        Arguments.of("2026-03-16-14", "6h", "yyyy-MM-dd-HH", "2026-03-16-12", "2026-03-16-18"),
         Arguments.of("2026-03-16-14", "1d", "yyyy-MM-dd-HH", "2026-03-16-00", "2026-03-17-00"),
-        Arguments.of("2026-03-16-14", "3d", "yyyy-MM-dd-HH", "2026-03-14-00", "2026-03-17-00"),
 
         // -- Custom date format with minutes: "yyyy-MM-dd-HH-mm" --
         Arguments.of(
             "2026-03-16-14-45", "1m", "yyyy-MM-dd-HH-mm", "2026-03-16-14-45", "2026-03-16-14-46"),
-        Arguments.of(
-            "2026-03-16-14-45", "30m", "yyyy-MM-dd-HH-mm", "2026-03-16-14-30", "2026-03-16-15-00"),
-        Arguments.of(
-            "2026-03-16-14-15", "30m", "yyyy-MM-dd-HH-mm", "2026-03-16-14-00", "2026-03-16-14-30"),
         Arguments.of(
             "2026-03-16-14-45", "1h", "yyyy-MM-dd-HH-mm", "2026-03-16-14-00", "2026-03-16-15-00"),
         Arguments.of(
@@ -132,18 +102,6 @@ class DateOfArchivedDocumentsUtilTest {
             "yyyy-MM-dd-HH-mm-ss",
             "2026-03-16-14-30-45",
             "2026-03-16-14-30-46"),
-        Arguments.of(
-            "2026-03-16-14-30-45",
-            "30s",
-            "yyyy-MM-dd-HH-mm-ss",
-            "2026-03-16-14-30-30",
-            "2026-03-16-14-31-00"),
-        Arguments.of(
-            "2026-03-16-14-30-15",
-            "30s",
-            "yyyy-MM-dd-HH-mm-ss",
-            "2026-03-16-14-30-00",
-            "2026-03-16-14-30-30"),
         Arguments.of(
             "2026-03-16-14-30-45",
             "1m",
@@ -166,6 +124,32 @@ class DateOfArchivedDocumentsUtilTest {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
+  @ParameterizedTest(name = "multi-unit interval \"{0}\" should be rejected")
+  @MethodSource("multiUnitIntervals")
+  void shouldRejectMultiUnitRolloverIntervals(final String interval) {
+    assertThatThrownBy(() -> getBucketStart("2026-03-16", interval, "date"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Only single-unit values");
+    assertThatThrownBy(() -> getNextBucketStart("2026-03-16", interval, "date"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Only single-unit values");
+  }
+
+  private static Stream<Arguments> multiUnitIntervals() {
+    return Stream.of(
+        Arguments.of("2d"),
+        Arguments.of("3d"),
+        Arguments.of("7d"),
+        Arguments.of("2h"),
+        Arguments.of("6h"),
+        Arguments.of("30m"),
+        Arguments.of("30s"),
+        Arguments.of("2w"),
+        Arguments.of("2M"),
+        Arguments.of("3M"),
+        Arguments.of("6M"));
+  }
+
   @Test
   void shouldThrowOnInvalidDateString() {
     assertThatThrownBy(() -> getBucketStart("not-a-date", "1d", "yyyy-MM-dd'T'HH:mm:ss"))
@@ -185,12 +169,12 @@ class DateOfArchivedDocumentsUtilTest {
   private static Stream<Arguments> tooCoarseConfigurations() {
     return Stream.of(
         // sub-day interval with a day-only format
-        Arguments.of("4h", "date"),
-        Arguments.of("30m", "date"),
-        Arguments.of("30s", "yyyy-MM-dd"),
+        Arguments.of("1h", "date"),
+        Arguments.of("1m", "date"),
+        Arguments.of("1s", "yyyy-MM-dd"),
         // interval finer than the format's finest field
         Arguments.of("1m", "yyyy-MM-dd-HH"),
-        Arguments.of("30s", "yyyy-MM-dd-HH-mm"),
+        Arguments.of("1s", "yyyy-MM-dd-HH-mm"),
         // day/week interval with a month-only format
         Arguments.of("1d", "yyyy-MM"),
         Arguments.of("1w", "yyyy-MM"),
@@ -213,12 +197,11 @@ class DateOfArchivedDocumentsUtilTest {
         Arguments.of("1d", "yyyy-MM-dd"),
         // coarser interval than the format is always fine
         Arguments.of("1M", "date"),
-        Arguments.of("2d", "date"),
         Arguments.of("1w", "date"),
         // format granularity equal to the interval
-        Arguments.of("4h", "yyyy-MM-dd-HH"),
-        Arguments.of("30m", "yyyy-MM-dd-HH-mm"),
-        Arguments.of("30s", "yyyy-MM-dd'T'HH:mm:ss"),
+        Arguments.of("1h", "yyyy-MM-dd-HH"),
+        Arguments.of("1m", "yyyy-MM-dd-HH-mm"),
+        Arguments.of("1s", "yyyy-MM-dd'T'HH:mm:ss"),
         // format finer than the interval
         Arguments.of("1h", "yyyy-MM-dd-HH-mm"));
   }

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtilTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtilTest.java
@@ -58,12 +58,14 @@ class DateOfArchivedDocumentsUtilTest {
         Arguments.of("2026-03-16", "3d", "date", "2026-03-14", "2026-03-17"),
         // 3d: exactly on a bucket boundary
         Arguments.of("2026-03-14", "3d", "date", "2026-03-14", "2026-03-17"),
-        // 7d: weekly-equivalent via days
+        // 7d: a FIXED 7-day interval is epoch-aligned (epoch 1970-01-01 is a Thursday), distinct
+        // from a calendar week
         Arguments.of("2026-03-18", "7d", "date", "2026-03-12", "2026-03-19"),
 
-        // -- WEEKS interval (converted to days internally) --
-        Arguments.of("2026-03-18", "1w", "date", "2026-03-12", "2026-03-19"),
-        Arguments.of("2026-03-18", "2w", "date", "2026-03-12", "2026-03-26"),
+        // -- WEEKS interval: ISO calendar weeks start on Monday (matches date_histogram). --
+        // 2026-03-18 is a Wednesday; the Monday of that week is 2026-03-16.
+        Arguments.of("2026-03-18", "1w", "date", "2026-03-16", "2026-03-23"),
+        Arguments.of("2026-03-18", "2w", "date", "2026-03-16", "2026-03-30"),
 
         // -- Sub-day intervals with a day-only format: bucket start AND next both collapse to the
         //    day, so next == start. This is the documented limitation (use a date-time format for

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtilTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/util/DateOfArchivedDocumentsUtilTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver.util;
+
+import static io.camunda.operate.archiver.util.DateOfArchivedDocumentsUtil.getBucketStart;
+import static io.camunda.operate.archiver.util.DateOfArchivedDocumentsUtil.getNextBucketStart;
+import static io.camunda.operate.archiver.util.DateOfArchivedDocumentsUtil.validateRolloverConfiguration;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DateOfArchivedDocumentsUtilTest {
+
+  @ParameterizedTest(name = "getBucketStart(\"{0}\", \"{1}\", \"{2}\") = \"{3}\"")
+  @MethodSource("bucketCases")
+  void shouldReturnCorrectBucketStart(
+      final String endDate,
+      final String rolloverInterval,
+      final String dateFormat,
+      final String expectedBucketStart,
+      final String expectedNextBucketStart) {
+    assertThat(getBucketStart(endDate, rolloverInterval, dateFormat))
+        .isEqualTo(expectedBucketStart);
+  }
+
+  @ParameterizedTest(name = "getNextBucketStart(\"{0}\", \"{1}\", \"{2}\") = \"{4}\"")
+  @MethodSource("bucketCases")
+  void shouldReturnCorrectNextBucketStart(
+      final String endDate,
+      final String rolloverInterval,
+      final String dateFormat,
+      final String expectedBucketStart,
+      final String expectedNextBucketStart) {
+    assertThat(getNextBucketStart(endDate, rolloverInterval, dateFormat))
+        .isEqualTo(expectedNextBucketStart);
+  }
+
+  // Each case asserts BOTH the bucket start and the (exclusive) next bucket start, where
+  // nextBucketStart = bucketStart + rolloverInterval, rendered with the same dateFormat.
+  private static Stream<Arguments> bucketCases() {
+    return Stream.of(
+        // endDate, interval, format, expectedBucketStart, expectedNextBucketStart
+
+        // -- DAYS interval --
+        Arguments.of("2026-03-16", "1d", "date", "2026-03-16", "2026-03-17"),
+        // 3d: March 16 falls in the March 14 bucket
+        Arguments.of("2026-03-16", "3d", "date", "2026-03-14", "2026-03-17"),
+        // 3d: exactly on a bucket boundary
+        Arguments.of("2026-03-14", "3d", "date", "2026-03-14", "2026-03-17"),
+        // 7d: weekly-equivalent via days
+        Arguments.of("2026-03-18", "7d", "date", "2026-03-12", "2026-03-19"),
+
+        // -- WEEKS interval (converted to days internally) --
+        Arguments.of("2026-03-18", "1w", "date", "2026-03-12", "2026-03-19"),
+        Arguments.of("2026-03-18", "2w", "date", "2026-03-12", "2026-03-26"),
+
+        // -- Sub-day intervals with a day-only format: bucket start AND next both collapse to the
+        //    day, so next == start. This is the documented limitation (use a date-time format for
+        //    sub-day rollover intervals). --
+        Arguments.of("2026-03-16", "1h", "date", "2026-03-16", "2026-03-16"),
+        Arguments.of("2026-03-16", "6h", "date", "2026-03-16", "2026-03-16"),
+        Arguments.of("2026-03-16", "30m", "date", "2026-03-16", "2026-03-16"),
+        Arguments.of("2026-03-16", "30s", "date", "2026-03-16", "2026-03-16"),
+
+        // -- MONTHS interval --
+        Arguments.of("2026-03-16", "1M", "date", "2026-03-01", "2026-04-01"),
+        // first day of month is on boundary
+        Arguments.of("2026-03-01", "1M", "date", "2026-03-01", "2026-04-01"),
+        // 2M: bi-monthly buckets from epoch (Jan 1970)
+        Arguments.of("2026-03-16", "2M", "date", "2026-03-01", "2026-05-01"),
+        // 2M: April falls in the same bi-monthly bucket as March
+        Arguments.of("2026-04-15", "2M", "date", "2026-03-01", "2026-05-01"),
+        // 3M: quarterly buckets; March 2026 => quarter starting Jan 2026
+        Arguments.of("2026-03-16", "3M", "date", "2026-01-01", "2026-04-01"),
+        // 3M: April in the next quarter bucket
+        Arguments.of("2026-04-16", "3M", "date", "2026-04-01", "2026-07-01"),
+        // 6M: semi-annual; March 2026 => half starting Jan 2026
+        Arguments.of("2026-03-16", "6M", "date", "2026-01-01", "2026-07-01"),
+        // 6M: July falls in the second-half bucket, next rolls into the following year
+        Arguments.of("2026-07-15", "6M", "date", "2026-07-01", "2027-01-01"),
+
+        // -- Year boundary crossing --
+        Arguments.of("2026-01-01", "1d", "date", "2026-01-01", "2026-01-02"),
+        Arguments.of("2026-01-01", "3d", "date", "2026-01-01", "2026-01-04"),
+        Arguments.of("2026-01-15", "1M", "date", "2026-01-01", "2026-02-01"),
+
+        // -- Epoch date --
+        Arguments.of("1970-01-01", "1d", "date", "1970-01-01", "1970-01-02"),
+        Arguments.of("1970-01-01", "1M", "date", "1970-01-01", "1970-02-01"),
+
+        // -- Custom date format: explicit "yyyy-MM-dd" pattern --
+        Arguments.of("2026-03-16", "1d", "yyyy-MM-dd", "2026-03-16", "2026-03-17"),
+        Arguments.of("2026-03-16", "3d", "yyyy-MM-dd", "2026-03-14", "2026-03-17"),
+        Arguments.of("2026-03-16", "1M", "yyyy-MM-dd", "2026-03-01", "2026-04-01"),
+
+        // -- Custom date format with hours: "yyyy-MM-dd-HH" --
+        Arguments.of("2026-03-16-14", "1h", "yyyy-MM-dd-HH", "2026-03-16-14", "2026-03-16-15"),
+        Arguments.of("2026-03-16-15", "2h", "yyyy-MM-dd-HH", "2026-03-16-14", "2026-03-16-16"),
+        Arguments.of("2026-03-16-14", "6h", "yyyy-MM-dd-HH", "2026-03-16-12", "2026-03-16-18"),
+        Arguments.of("2026-03-16-14", "1d", "yyyy-MM-dd-HH", "2026-03-16-00", "2026-03-17-00"),
+        Arguments.of("2026-03-16-14", "3d", "yyyy-MM-dd-HH", "2026-03-14-00", "2026-03-17-00"),
+
+        // -- Custom date format with minutes: "yyyy-MM-dd-HH-mm" --
+        Arguments.of(
+            "2026-03-16-14-45", "1m", "yyyy-MM-dd-HH-mm", "2026-03-16-14-45", "2026-03-16-14-46"),
+        Arguments.of(
+            "2026-03-16-14-45", "30m", "yyyy-MM-dd-HH-mm", "2026-03-16-14-30", "2026-03-16-15-00"),
+        Arguments.of(
+            "2026-03-16-14-15", "30m", "yyyy-MM-dd-HH-mm", "2026-03-16-14-00", "2026-03-16-14-30"),
+        Arguments.of(
+            "2026-03-16-14-45", "1h", "yyyy-MM-dd-HH-mm", "2026-03-16-14-00", "2026-03-16-15-00"),
+        Arguments.of(
+            "2026-03-16-14-45", "1d", "yyyy-MM-dd-HH-mm", "2026-03-16-00-00", "2026-03-17-00-00"),
+
+        // -- Custom date format with seconds: "yyyy-MM-dd-HH-mm-ss" --
+        Arguments.of(
+            "2026-03-16-14-30-45",
+            "1s",
+            "yyyy-MM-dd-HH-mm-ss",
+            "2026-03-16-14-30-45",
+            "2026-03-16-14-30-46"),
+        Arguments.of(
+            "2026-03-16-14-30-45",
+            "30s",
+            "yyyy-MM-dd-HH-mm-ss",
+            "2026-03-16-14-30-30",
+            "2026-03-16-14-31-00"),
+        Arguments.of(
+            "2026-03-16-14-30-15",
+            "30s",
+            "yyyy-MM-dd-HH-mm-ss",
+            "2026-03-16-14-30-00",
+            "2026-03-16-14-30-30"),
+        Arguments.of(
+            "2026-03-16-14-30-45",
+            "1m",
+            "yyyy-MM-dd-HH-mm-ss",
+            "2026-03-16-14-30-00",
+            "2026-03-16-14-31-00"),
+        Arguments.of(
+            "2026-03-16-14-30-45",
+            "1h",
+            "yyyy-MM-dd-HH-mm-ss",
+            "2026-03-16-14-00-00",
+            "2026-03-16-15-00-00"));
+  }
+
+  @Test
+  void shouldThrowOnInvalidRolloverInterval() {
+    assertThatThrownBy(() -> getBucketStart("2026-03-16", "1x", "date"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> getNextBucketStart("2026-03-16", "1x", "date"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldThrowOnInvalidDateString() {
+    assertThatThrownBy(() -> getBucketStart("not-a-date", "1d", "yyyy-MM-dd'T'HH:mm:ss"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> getNextBucketStart("not-a-date", "1d", "yyyy-MM-dd'T'HH:mm:ss"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest(name = "validateRolloverConfiguration(\"{0}\", \"{1}\") rejected")
+  @MethodSource("tooCoarseConfigurations")
+  void shouldRejectDateFormatCoarserThanInterval(
+      final String rolloverInterval, final String dateFormat) {
+    assertThatThrownBy(() -> validateRolloverConfiguration(rolloverInterval, dateFormat))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private static Stream<Arguments> tooCoarseConfigurations() {
+    return Stream.of(
+        // sub-day interval with a day-only format
+        Arguments.of("4h", "date"),
+        Arguments.of("30m", "date"),
+        Arguments.of("30s", "yyyy-MM-dd"),
+        // interval finer than the format's finest field
+        Arguments.of("1m", "yyyy-MM-dd-HH"),
+        Arguments.of("30s", "yyyy-MM-dd-HH-mm"),
+        // day/week interval with a month-only format
+        Arguments.of("1d", "yyyy-MM"),
+        Arguments.of("1w", "yyyy-MM"),
+        // month interval with a year-only format
+        Arguments.of("1M", "yyyy"));
+  }
+
+  @ParameterizedTest(name = "validateRolloverConfiguration(\"{0}\", \"{1}\") accepted")
+  @MethodSource("fineEnoughConfigurations")
+  void shouldAcceptDateFormatAtLeastAsFineAsInterval(
+      final String rolloverInterval, final String dateFormat) {
+    assertThatCode(() -> validateRolloverConfiguration(rolloverInterval, dateFormat))
+        .doesNotThrowAnyException();
+  }
+
+  private static Stream<Arguments> fineEnoughConfigurations() {
+    return Stream.of(
+        // default configuration
+        Arguments.of("1d", "date"),
+        Arguments.of("1d", "yyyy-MM-dd"),
+        // coarser interval than the format is always fine
+        Arguments.of("1M", "date"),
+        Arguments.of("2d", "date"),
+        Arguments.of("1w", "date"),
+        // format granularity equal to the interval
+        Arguments.of("4h", "yyyy-MM-dd-HH"),
+        Arguments.of("30m", "yyyy-MM-dd-HH-mm"),
+        Arguments.of("30s", "yyyy-MM-dd'T'HH:mm:ss"),
+        // format finer than the interval
+        Arguments.of("1h", "yyyy-MM-dd-HH-mm"));
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
@@ -34,6 +34,7 @@ import io.camunda.operate.schema.templates.ProcessInstanceDependant;
 import io.camunda.operate.schema.templates.SequenceFlowTemplate;
 import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.util.MetricAssert;
+import io.camunda.operate.util.MetricAssert.ValueMatcher;
 import io.camunda.operate.util.OperateZeebeAbstractIT;
 import io.camunda.operate.util.SearchTestRule;
 import io.camunda.operate.util.ZeebeTestUtil;
@@ -71,6 +72,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration(initializers = ManagementPropertyRemoval.class)
@@ -101,6 +103,8 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
 
   private ProcessInstancesArchiverJob processInstancesArchiverJob;
 
+  private ProcessInstancesByIdArchiverJob processInstancesByIdArchiverJob;
+
   private final Random random = new Random();
 
   private DateTimeFormatter dateTimeFormatter;
@@ -121,6 +125,16 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
             processInstanceDependantTemplates,
             metrics,
             archiver.getArchiverRepository());
+    processInstancesByIdArchiverJob =
+        beanFactory.getBean(
+            ProcessInstancesByIdArchiverJob.class,
+            archiver,
+            partitionHolder.getPartitionIds(),
+            processInstanceTemplate,
+            processInstanceDependantTemplates,
+            metrics,
+            archiver.getArchiverRepository(),
+            buildScheduler());
     cancelProcessInstanceHandler.setZeebeClient(super.getClient());
     clearMetrics();
   }
@@ -236,16 +250,12 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
 
     resetZeebeTime();
 
-    final ProcessInstancesByIdArchiverJob job =
-        beanFactory.getBean(
-            ProcessInstancesByIdArchiverJob.class, archiver, partitionHolder.getPartitionIds());
-
     // when
-    assertThat(job.archiveNextBatch().join()).isEqualTo(count1);
+    assertThat(processInstancesByIdArchiverJob.archiveNextBatch().join()).isEqualTo(count1);
     searchTestRule.refreshSerchIndexes();
-    assertThat(job.archiveNextBatch().join()).isEqualTo(count2);
+    assertThat(processInstancesByIdArchiverJob.archiveNextBatch().join()).isEqualTo(count2);
     searchTestRule.refreshSerchIndexes();
-    assertThat(job.archiveNextBatch().join()).isEqualTo(0);
+    assertThat(processInstancesByIdArchiverJob.archiveNextBatch().join()).isEqualTo(0);
     searchTestRule.refreshSerchIndexes();
 
     // then
@@ -259,7 +269,7 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
     assertThatMetricsFrom(
         mockMvc,
         allOf(
-            new MetricAssert.ValueMatcher(
+            new ValueMatcher(
                 "operate_archived_process_instances_total",
                 d -> d.doubleValue() == count1 + count2),
             containsString("operate_archiver_request_duration")));
@@ -289,14 +299,10 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
 
       resetZeebeTime();
 
-      final ProcessInstancesByIdArchiverJob job =
-          beanFactory.getBean(
-              ProcessInstancesByIdArchiverJob.class, archiver, partitionHolder.getPartitionIds());
-
       // when
-      assertThat(job.archiveNextBatch().join()).isEqualTo(count);
+      assertThat(processInstancesByIdArchiverJob.archiveNextBatch().join()).isEqualTo(count);
       searchTestRule.refreshSerchIndexes();
-      assertThat(job.archiveNextBatch().join()).isEqualTo(0);
+      assertThat(processInstancesByIdArchiverJob.archiveNextBatch().join()).isEqualTo(0);
       searchTestRule.refreshSerchIndexes();
 
       // then — all docs must be in destination index despite multiple searchAfter pages
@@ -682,11 +688,11 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
     resetZeebeTime();
 
     // when
-    assertThat(processInstancesArchiverJob.archiveNextBatch().join()).isEqualTo(1);
+    assertThat(processInstancesByIdArchiverJob.archiveNextBatch().join()).isEqualTo(1);
     searchTestRule.refreshSerchIndexes();
 
     // then
-    assertInstancesInCorrectIndex(1, Arrays.asList(processInstanceKey), endDate, true);
+    assertInstancesInCorrectIndex(1, List.of(processInstanceKey), endDate, true);
   }
 
   private void deployProcessWithOneActivity(final String processId, final String activityId) {
@@ -882,5 +888,14 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
         // 4. Enable the operation executor
         .then()
         .enableOperationExecutor();
+  }
+
+  protected static ThreadPoolTaskScheduler buildScheduler() {
+    final var scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setPoolSize(1);
+    scheduler.setThreadNamePrefix("archiver-test-");
+    scheduler.setDaemon(true);
+    scheduler.initialize();
+    return scheduler;
   }
 }


### PR DESCRIPTION


## Description

The process-instance archiver fetched its next batch with a date_histogram + top_hits + bucket_sort aggregation. top_hits was computed for every date bucket and all but one bucket discarded by bucket_sort, making the query very slow on large list-view indices.

Replace it (Elasticsearch + OpenSearch) with a plain query sorted by endDate ASC, size = rolloverBatchSize, returning endDate as a formatted docvalue, then trim the result in code to the earliest date bucket via the ported DateOfArchivedDocumentsUtil (getBucketStart / getNextBucketStart, packing the full bucket up to the batch size). Batch-operation and standalone-decision fetches keep the aggregation path for now.

Add validateRolloverConfiguration, called from Archiver startup, to fail fast when the rollover date format is too coarse for the rollover interval (which would otherwise collapse the bucket end onto the start and silently stall archiving).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #https://github.com/camunda/camunda/issues/55898
