### PR TITLE
fix: don't wait for an orderly shutdown after fatal errors

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
@@ -57,7 +57,7 @@ public final class VirtualMachineErrorHandler
 
   private void tryLoggingThenExit(final Throwable cause) {
     tryLogging(cause);
-    System.exit(EXIT_CODE);
+    Runtime.getRuntime().halt(EXIT_CODE);
   }
 
   private void tryLogging(final Throwable e) {


### PR DESCRIPTION
The class of errors caught here make an orderly shutdown unreliable. OutOfMemory, StackOverflow and ClassCircularityError all leave us with a broken system where shutdown does not work reliably. Using halt instead of exit ensures that broken nodes get restarted reliably at least.

closes #50913
