### PR TITLE
Backport Archiver ITs to 8.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -899,7 +899,7 @@ jobs:
         with:
           token: ${{ github.token }}
           maven-args: >-
-            -pl bom,clients/java,clients/camunda-spring-boot-starter,zeebe/bpmn-model,zeebe/exporter-api,zeebe/gateway-protocol-impl,zeebe/protocol
+            -pl bom,clients/java,clients/camunda-spring-boot-3-starter,clients/camunda-spring-boot-4-starter,zeebe/bpmn-model,zeebe/exporter-api,zeebe/gateway-protocol-impl,zeebe/protocol
             -am
             -Dquickly
           correlator: submit-maven-snapshot-maven

--- a/dist/src/test/java/io/camunda/operate/OperateQualifiedBeansArchTest.java
+++ b/dist/src/test/java/io/camunda/operate/OperateQualifiedBeansArchTest.java
@@ -110,7 +110,8 @@ public class OperateQualifiedBeansArchTest {
                                         field.getAnnotationOfType(Qualifier.class).value())));
                   }
                 }
-              });
+              })
+          .allowEmptyShould(true);
 
   private static final String ZEEBE_OPENSEARCH_CLIENT_QUALIFIER = "zeebeOpensearchClient";
   private static final String OPEN_SEARCH_CLIENT_QUALIFIER = "openSearchClient";

--- a/operate/archiver/pom.xml
+++ b/operate/archiver/pom.xml
@@ -97,11 +97,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -164,6 +159,47 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch-x-content</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -181,6 +217,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <spring.profiles.active>test</spring.profiles.active>
+          </systemPropertyVariables>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/operate/archiver/pom.xml
+++ b/operate/archiver/pom.xml
@@ -133,6 +133,37 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- IT test dependencies -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-elasticsearch</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.opensearch</groupId>
+      <artifactId>opensearch-testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>
@@ -145,6 +176,19 @@
             <spring.profiles.active>test</spring.profiles.active>
           </systemPropertyVariables>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
@@ -28,17 +28,25 @@ public class Archiver {
   protected static final String INDEX_NAME_PATTERN = "%s%s";
   private static final Logger LOGGER = LoggerFactory.getLogger(Archiver.class);
 
-  @Autowired protected BeanFactory beanFactory;
-
-  @Autowired protected OperateProperties operateProperties;
-
-  @Autowired protected PartitionHolder partitionHolder;
+  protected final BeanFactory beanFactory;
+  protected final OperateProperties operateProperties;
+  protected final PartitionHolder partitionHolder;
+  protected final ThreadPoolTaskScheduler archiverExecutor;
+  protected final ArchiverRepository archiverRepository;
 
   @Autowired
-  @Qualifier("archiverThreadPoolExecutor")
-  protected ThreadPoolTaskScheduler archiverExecutor;
-
-  @Autowired protected ArchiverRepository archiverRepository;
+  public Archiver(
+      final BeanFactory beanFactory,
+      final OperateProperties operateProperties,
+      final PartitionHolder partitionHolder,
+      @Qualifier("archiverThreadPoolExecutor") final ThreadPoolTaskScheduler archiverExecutor,
+      final ArchiverRepository archiverRepository) {
+    this.beanFactory = beanFactory;
+    this.operateProperties = operateProperties;
+    this.partitionHolder = partitionHolder;
+    this.archiverExecutor = archiverExecutor;
+    this.archiverRepository = archiverRepository;
+  }
 
   @PostConstruct
   public void startArchiving() {

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/Archiver.java
@@ -7,7 +7,12 @@
  */
 package io.camunda.operate.archiver;
 
+import io.camunda.operate.Metrics;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.templates.BatchOperationTemplate;
+import io.camunda.operate.schema.templates.DecisionInstanceTemplate;
+import io.camunda.operate.schema.templates.ListViewTemplate;
+import io.camunda.operate.schema.templates.ProcessInstanceDependant;
 import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.zeebe.PartitionHolder;
 import jakarta.annotation.PostConstruct;
@@ -33,6 +38,11 @@ public class Archiver {
   protected final PartitionHolder partitionHolder;
   protected final ThreadPoolTaskScheduler archiverExecutor;
   protected final ArchiverRepository archiverRepository;
+  protected final ListViewTemplate processInstanceTemplate;
+  protected final List<ProcessInstanceDependant> processInstanceDependants;
+  protected final DecisionInstanceTemplate decisionInstanceTemplate;
+  protected final BatchOperationTemplate batchOperationTemplate;
+  protected final Metrics metrics;
 
   @Autowired
   public Archiver(
@@ -40,12 +50,22 @@ public class Archiver {
       final OperateProperties operateProperties,
       final PartitionHolder partitionHolder,
       @Qualifier("archiverThreadPoolExecutor") final ThreadPoolTaskScheduler archiverExecutor,
-      final ArchiverRepository archiverRepository) {
+      final ArchiverRepository archiverRepository,
+      final ListViewTemplate processInstanceTemplate,
+      final List<ProcessInstanceDependant> processInstanceDependants,
+      final DecisionInstanceTemplate decisionInstanceTemplate,
+      final BatchOperationTemplate batchOperationTemplate,
+      final Metrics metrics) {
     this.beanFactory = beanFactory;
     this.operateProperties = operateProperties;
     this.partitionHolder = partitionHolder;
     this.archiverExecutor = archiverExecutor;
     this.archiverRepository = archiverRepository;
+    this.processInstanceTemplate = processInstanceTemplate;
+    this.processInstanceDependants = processInstanceDependants;
+    this.decisionInstanceTemplate = decisionInstanceTemplate;
+    this.batchOperationTemplate = batchOperationTemplate;
+    this.metrics = metrics;
   }
 
   @PostConstruct
@@ -69,16 +89,34 @@ public class Archiver {
             CollectionUtil.splitAndGetSublist(partitionIds, threadsCount, i);
         if (!partitionIdsSubset.isEmpty()) {
           final var processInstancesArchiverJob =
-              beanFactory.getBean(ProcessInstancesArchiverJob.class, this, partitionIdsSubset);
+              beanFactory.getBean(
+                  ProcessInstancesArchiverJob.class,
+                  this,
+                  partitionIdsSubset,
+                  processInstanceTemplate,
+                  processInstanceDependants,
+                  metrics,
+                  archiverRepository);
           archiverExecutor.execute(processInstancesArchiverJob);
 
           final var standaloneDecisionArchiverJob =
-              beanFactory.getBean(StandaloneDecisionArchiverJob.class, this, partitionIdsSubset);
+              beanFactory.getBean(
+                  StandaloneDecisionArchiverJob.class,
+                  this,
+                  partitionIdsSubset,
+                  decisionInstanceTemplate,
+                  metrics,
+                  archiverRepository);
           archiverExecutor.execute(standaloneDecisionArchiverJob);
         }
         if (partitionIdsSubset.contains(1)) {
           final var batchOperationArchiverJob =
-              beanFactory.getBean(BatchOperationArchiverJob.class, this);
+              beanFactory.getBean(
+                  BatchOperationArchiverJob.class,
+                  this,
+                  batchOperationTemplate,
+                  metrics,
+                  archiverRepository);
           archiverExecutor.execute(batchOperationArchiverJob);
         }
       }
@@ -102,5 +140,9 @@ public class Archiver {
 
   public String getDestinationIndexName(final String sourceIndexName, final String finishDate) {
     return String.format(INDEX_NAME_PATTERN, sourceIndexName, finishDate);
+  }
+
+  public ArchiverRepository getArchiverRepository() {
+    return archiverRepository;
   }
 }

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/BatchOperationArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/BatchOperationArchiverJob.java
@@ -25,15 +25,20 @@ public class BatchOperationArchiverJob extends AbstractArchiverJob {
   private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationArchiverJob.class);
 
   private final Archiver archiver;
+  private final BatchOperationTemplate batchOperationTemplate;
+  private final Metrics metrics;
+  private final ArchiverRepository archiverRepository;
 
-  @Autowired private BatchOperationTemplate batchOperationTemplate;
-
-  @Autowired private Metrics metrics;
-
-  @Autowired private ArchiverRepository archiverRepository;
-
-  public BatchOperationArchiverJob(final Archiver archiver) {
+  @Autowired
+  public BatchOperationArchiverJob(
+      final Archiver archiver,
+      final BatchOperationTemplate batchOperationTemplate,
+      final Metrics metrics,
+      final ArchiverRepository archiverRepository) {
     this.archiver = archiver;
+    this.batchOperationTemplate = batchOperationTemplate;
+    this.metrics = metrics;
+    this.archiverRepository = archiverRepository;
   }
 
   @Override

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -21,7 +21,6 @@ import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHist
 import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
 import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.bucketSort;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.Metrics;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.exceptions.ArchiverException;
@@ -80,14 +79,13 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
       LoggerFactory.getLogger(ElasticsearchArchiverRepository.class);
   private static final int UPDATE_RETRY_COUNT = 3;
 
-  protected ThreadPoolTaskScheduler archiverExecutor;
-  private BatchOperationTemplate batchOperationTemplate;
-  private ListViewTemplate processInstanceTemplate;
-  private DecisionInstanceTemplate decisionInstanceTemplate;
-  private OperateProperties operateProperties;
-  private Metrics metrics;
-  private RestHighLevelClient esClient;
-  private ObjectMapper objectMapper;
+  private final ThreadPoolTaskScheduler archiverExecutor;
+  private final OperateProperties operateProperties;
+  private final Metrics metrics;
+  private final RestHighLevelClient esClient;
+  private final BatchOperationTemplate batchOperationTemplate;
+  private final ListViewTemplate processInstanceTemplate;
+  private final DecisionInstanceTemplate decisionInstanceTemplate;
 
   @Autowired
   public ElasticsearchArchiverRepository(
@@ -95,7 +93,6 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
       final OperateProperties operateProperties,
       final Metrics metrics,
       final RestHighLevelClient esClient,
-      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper,
       final ListViewTemplate processInstanceTemplate,
       final BatchOperationTemplate batchOperationTemplate,
       final DecisionInstanceTemplate decisionInstanceTemplate) {
@@ -103,7 +100,6 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     this.operateProperties = operateProperties;
     this.metrics = metrics;
     this.esClient = esClient;
-    this.objectMapper = objectMapper;
     this.processInstanceTemplate = processInstanceTemplate;
     this.batchOperationTemplate = batchOperationTemplate;
     this.decisionInstanceTemplate = decisionInstanceTemplate;

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -80,20 +80,34 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
       LoggerFactory.getLogger(ElasticsearchArchiverRepository.class);
   private static final int UPDATE_RETRY_COUNT = 3;
 
-  @Autowired
-  @Qualifier("archiverThreadPoolExecutor")
   protected ThreadPoolTaskScheduler archiverExecutor;
-
-  @Autowired private BatchOperationTemplate batchOperationTemplate;
-  @Autowired private ListViewTemplate processInstanceTemplate;
-  @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
-  @Autowired private OperateProperties operateProperties;
-  @Autowired private Metrics metrics;
-  @Autowired private RestHighLevelClient esClient;
+  private BatchOperationTemplate batchOperationTemplate;
+  private ListViewTemplate processInstanceTemplate;
+  private DecisionInstanceTemplate decisionInstanceTemplate;
+  private OperateProperties operateProperties;
+  private Metrics metrics;
+  private RestHighLevelClient esClient;
+  private ObjectMapper objectMapper;
 
   @Autowired
-  @Qualifier("operateObjectMapper")
-  private ObjectMapper objectMapper;
+  public ElasticsearchArchiverRepository(
+      @Qualifier("archiverThreadPoolExecutor") final ThreadPoolTaskScheduler archiverExecutor,
+      final OperateProperties operateProperties,
+      final Metrics metrics,
+      final RestHighLevelClient esClient,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper,
+      final ListViewTemplate processInstanceTemplate,
+      final BatchOperationTemplate batchOperationTemplate,
+      final DecisionInstanceTemplate decisionInstanceTemplate) {
+    this.archiverExecutor = archiverExecutor;
+    this.operateProperties = operateProperties;
+    this.metrics = metrics;
+    this.esClient = esClient;
+    this.objectMapper = objectMapper;
+    this.processInstanceTemplate = processInstanceTemplate;
+    this.batchOperationTemplate = batchOperationTemplate;
+    this.decisionInstanceTemplate = decisionInstanceTemplate;
+  }
 
   private ArchiveBatch createArchiveBatch(
       final SearchResponse searchResponse,

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -63,13 +63,14 @@ import org.springframework.stereotype.Component;
 public class OpensearchArchiverRepository implements ArchiverRepository {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchArchiverRepository.class);
-  protected RichOpenSearchClient richOpenSearchClient;
-  protected OpenSearchAsyncClient osAsyncClient;
-  private BatchOperationTemplate batchOperationTemplate;
-  private ListViewTemplate processInstanceTemplate;
-  private DecisionInstanceTemplate decisionInstanceTemplate;
-  private OperateProperties operateProperties;
-  private Metrics metrics;
+
+  private final RichOpenSearchClient richOpenSearchClient;
+  private final OpenSearchAsyncClient osAsyncClient;
+  private final OperateProperties operateProperties;
+  private final Metrics metrics;
+  private final ListViewTemplate processInstanceTemplate;
+  private final BatchOperationTemplate batchOperationTemplate;
+  private final DecisionInstanceTemplate decisionInstanceTemplate;
 
   @Autowired
   public OpensearchArchiverRepository(

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -63,17 +63,31 @@ import org.springframework.stereotype.Component;
 public class OpensearchArchiverRepository implements ArchiverRepository {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchArchiverRepository.class);
-  @Autowired protected RichOpenSearchClient richOpenSearchClient;
+  protected RichOpenSearchClient richOpenSearchClient;
+  protected OpenSearchAsyncClient osAsyncClient;
+  private BatchOperationTemplate batchOperationTemplate;
+  private ListViewTemplate processInstanceTemplate;
+  private DecisionInstanceTemplate decisionInstanceTemplate;
+  private OperateProperties operateProperties;
+  private Metrics metrics;
 
   @Autowired
-  @Qualifier("openSearchAsyncClient")
-  protected OpenSearchAsyncClient osAsyncClient;
-
-  @Autowired private BatchOperationTemplate batchOperationTemplate;
-  @Autowired private ListViewTemplate processInstanceTemplate;
-  @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
-  @Autowired private OperateProperties operateProperties;
-  @Autowired private Metrics metrics;
+  public OpensearchArchiverRepository(
+      final RichOpenSearchClient richOpenSearchClient,
+      @Qualifier("openSearchAsyncClient") final OpenSearchAsyncClient osAsyncClient,
+      final OperateProperties operateProperties,
+      final Metrics metrics,
+      final ListViewTemplate processInstanceTemplate,
+      final BatchOperationTemplate batchOperationTemplate,
+      final DecisionInstanceTemplate decisionInstanceTemplate) {
+    this.richOpenSearchClient = richOpenSearchClient;
+    this.osAsyncClient = osAsyncClient;
+    this.operateProperties = operateProperties;
+    this.metrics = metrics;
+    this.processInstanceTemplate = processInstanceTemplate;
+    this.batchOperationTemplate = batchOperationTemplate;
+    this.decisionInstanceTemplate = decisionInstanceTemplate;
+  }
 
   private <R> ArchiveBatch createArchiveBatch(
       final SearchResponse<R> searchResponse,

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesArchiverJob.java
@@ -27,20 +27,26 @@ public class ProcessInstancesArchiverJob extends AbstractArchiverJob {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstancesArchiverJob.class);
 
   private final List<Integer> partitionIds;
-
   private final Archiver archiver;
+  private final ListViewTemplate processInstanceTemplate;
+  private final List<ProcessInstanceDependant> processInstanceDependantTemplates;
+  private final Metrics metrics;
+  private final ArchiverRepository archiverRepository;
 
-  @Autowired private ListViewTemplate processInstanceTemplate;
-
-  @Autowired private List<ProcessInstanceDependant> processInstanceDependantTemplates;
-
-  @Autowired private Metrics metrics;
-
-  @Autowired private ArchiverRepository archiverRepository;
-
-  public ProcessInstancesArchiverJob(final Archiver archiver, final List<Integer> partitionIds) {
-    this.partitionIds = partitionIds;
+  @Autowired
+  public ProcessInstancesArchiverJob(
+      final Archiver archiver,
+      final List<Integer> partitionIds,
+      final ListViewTemplate processInstanceTemplate,
+      final List<ProcessInstanceDependant> processInstanceDependantTemplates,
+      final Metrics metrics,
+      final ArchiverRepository archiverRepository) {
     this.archiver = archiver;
+    this.partitionIds = partitionIds;
+    this.processInstanceTemplate = processInstanceTemplate;
+    this.processInstanceDependantTemplates = processInstanceDependantTemplates;
+    this.metrics = metrics;
+    this.archiverRepository = archiverRepository;
   }
 
   @Override

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/StandaloneDecisionArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/StandaloneDecisionArchiverJob.java
@@ -25,18 +25,24 @@ public class StandaloneDecisionArchiverJob extends AbstractArchiverJob {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StandaloneDecisionArchiverJob.class);
 
-  @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
-
-  @Autowired private Metrics metrics;
-
-  @Autowired private ArchiverRepository archiverRepository;
-
   private final Archiver archiver;
   private final List<Integer> partitionIds;
+  private final DecisionInstanceTemplate decisionInstanceTemplate;
+  private final Metrics metrics;
+  private final ArchiverRepository archiverRepository;
 
-  public StandaloneDecisionArchiverJob(final Archiver archiver, final List<Integer> partitionIds) {
+  @Autowired
+  public StandaloneDecisionArchiverJob(
+      final Archiver archiver,
+      final List<Integer> partitionIds,
+      final DecisionInstanceTemplate decisionInstanceTemplate,
+      final Metrics metrics,
+      final ArchiverRepository archiverRepository) {
     this.archiver = archiver;
     this.partitionIds = partitionIds;
+    this.decisionInstanceTemplate = decisionInstanceTemplate;
+    this.metrics = metrics;
+    this.archiverRepository = archiverRepository;
   }
 
   @Override

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -93,30 +93,33 @@ public abstract class AbstractProcessInstanceArchiverJobIT extends ArchiverJobIT
   @Test
   void shouldOnlyArchiveOneBatchAtATime() throws Exception {
     final int batchSize = 5;
+    final int previousBatchSize = operateProperties.getArchiver().getRolloverBatchSize();
     operateProperties.getArchiver().setRolloverBatchSize(batchSize);
-    withArchiverJob(
-        job -> {
-          final var instances = new ArrayList<ProcessInstanceForListViewEntity>();
-          for (int i = 0; i < batchSize; i++) {
-            instances.add(processInstanceForListViewEntity("2020-01-01T00:00:00+00:00"));
-          }
-          instances.add(processInstanceForListViewEntity("2020-01-01T00:00:10+00:00"));
+    try {
+      withArchiverJob(
+          job -> {
+            final var instances = new ArrayList<ProcessInstanceForListViewEntity>();
+            for (int i = 0; i < batchSize; i++) {
+              instances.add(processInstanceForListViewEntity("2020-01-01T00:00:00+00:00"));
+            }
+            instances.add(processInstanceForListViewEntity("2020-01-01T00:00:10+00:00"));
 
-          for (final var pi : instances) {
-            store(listViewTemplate, pi);
-          }
-          refresh();
+            for (final var pi : instances) {
+              store(listViewTemplate, pi);
+            }
+            refresh();
 
-          final var result = job.archiveNextBatch();
-          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(5);
+            final var result = job.archiveNextBatch();
+            assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(5);
 
-          for (int i = 0; i < batchSize; i++) {
-            verifyMoved(listViewTemplate, instances.get(i).getId(), "2020-01-01");
-          }
-          verifyNotMoved(listViewTemplate, instances.get(batchSize).getId());
-
-          operateProperties.getArchiver().setRolloverBatchSize(100);
-        });
+            for (int i = 0; i < batchSize; i++) {
+              verifyMoved(listViewTemplate, instances.get(i).getId(), "2020-01-01");
+            }
+            verifyNotMoved(listViewTemplate, instances.get(batchSize).getId());
+          });
+    } finally {
+      operateProperties.getArchiver().setRolloverBatchSize(previousBatchSize);
+    }
   }
 
   @Test

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.entities.EventEntity;
+import io.camunda.operate.entities.FlowNodeInstanceEntity;
+import io.camunda.operate.entities.IncidentEntity;
+import io.camunda.operate.entities.JobEntity;
+import io.camunda.operate.entities.OperateEntity;
+import io.camunda.operate.entities.OperationEntity;
+import io.camunda.operate.entities.SequenceFlowEntity;
+import io.camunda.operate.entities.UserTaskEntity;
+import io.camunda.operate.entities.VariableEntity;
+import io.camunda.operate.entities.dmn.DecisionInstanceEntity;
+import io.camunda.operate.entities.listview.FlowNodeInstanceForListViewEntity;
+import io.camunda.operate.entities.listview.ListViewJoinRelation;
+import io.camunda.operate.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.operate.entities.listview.VariableForListViewEntity;
+import io.camunda.operate.entities.post.PostImporterQueueEntity;
+import io.camunda.operate.schema.templates.AbstractTemplateDescriptor;
+import io.camunda.operate.schema.templates.DecisionInstanceTemplate;
+import io.camunda.operate.schema.templates.EventTemplate;
+import io.camunda.operate.schema.templates.FlowNodeInstanceTemplate;
+import io.camunda.operate.schema.templates.IncidentTemplate;
+import io.camunda.operate.schema.templates.JobTemplate;
+import io.camunda.operate.schema.templates.ListViewTemplate;
+import io.camunda.operate.schema.templates.OperationTemplate;
+import io.camunda.operate.schema.templates.PostImporterQueueTemplate;
+import io.camunda.operate.schema.templates.ProcessInstanceDependant;
+import io.camunda.operate.schema.templates.SequenceFlowTemplate;
+import io.camunda.operate.schema.templates.UserTaskTemplate;
+import io.camunda.operate.schema.templates.VariableTemplate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public abstract class AbstractProcessInstanceArchiverJobIT extends ArchiverJobIT {
+
+  @Autowired private ListViewTemplate listViewTemplate;
+  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
+  @Autowired private VariableTemplate variableTemplate;
+  @Autowired private IncidentTemplate incidentTemplate;
+  @Autowired private OperationTemplate operationTemplate;
+  @Autowired private SequenceFlowTemplate sequenceFlowTemplate;
+  @Autowired private JobTemplate jobTemplate;
+  @Autowired private EventTemplate eventTemplate;
+  @Autowired private PostImporterQueueTemplate postImporterQueueTemplate;
+  @Autowired private UserTaskTemplate userTaskTemplate;
+  @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
+
+  protected ListViewTemplate getListViewTemplate() {
+    return listViewTemplate;
+  }
+
+  protected List<ProcessInstanceDependant> getDependantTemplates() {
+    return List.of(
+        flowNodeInstanceTemplate,
+        variableTemplate,
+        incidentTemplate,
+        operationTemplate,
+        sequenceFlowTemplate,
+        jobTemplate,
+        eventTemplate,
+        postImporterQueueTemplate,
+        userTaskTemplate,
+        decisionInstanceTemplate);
+  }
+
+  @Test
+  void shouldArchiveLoneProcessInstance() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var pi = processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
+          store(listViewTemplate, pi);
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
+
+          verifyMoved(listViewTemplate, pi.getId(), "2020-01-01");
+        });
+  }
+
+  @Test
+  void shouldOnlyArchiveOneBatchAtATime() throws Exception {
+    final int batchSize = 5;
+    operateProperties.getArchiver().setRolloverBatchSize(batchSize);
+    withArchiverJob(
+        job -> {
+          final var instances = new ArrayList<ProcessInstanceForListViewEntity>();
+          for (int i = 0; i < batchSize; i++) {
+            instances.add(processInstanceForListViewEntity("2020-01-01T00:00:00+00:00"));
+          }
+          instances.add(processInstanceForListViewEntity("2020-01-01T00:00:10+00:00"));
+
+          for (final var pi : instances) {
+            store(listViewTemplate, pi);
+          }
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(5);
+
+          for (int i = 0; i < batchSize; i++) {
+            verifyMoved(listViewTemplate, instances.get(i).getId(), "2020-01-01");
+          }
+          verifyNotMoved(listViewTemplate, instances.get(batchSize).getId());
+
+          operateProperties.getArchiver().setRolloverBatchSize(100);
+        });
+  }
+
+  @Test
+  void shouldOnlyArchiveFinishedProcessInstances() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var finished = processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
+          final var unfinished = processInstanceForListViewEntity(null);
+
+          store(listViewTemplate, finished);
+          store(listViewTemplate, unfinished);
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
+
+          verifyMoved(listViewTemplate, finished.getId(), "2020-01-01");
+          verifyNotMoved(listViewTemplate, unfinished.getId());
+        });
+  }
+
+  @Test
+  void shouldOnlyArchiveProcessInstancesCompletedAfterAWhile() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var old = processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
+          final var notOldEnough = processInstanceForListViewEntity("2099-01-01T00:00:00+00:00");
+
+          store(listViewTemplate, old);
+          store(listViewTemplate, notOldEnough);
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
+
+          verifyMoved(listViewTemplate, old.getId(), "2020-01-01");
+          verifyNotMoved(listViewTemplate, notOldEnough.getId());
+        });
+  }
+
+  @Test
+  void shouldArchiveProcessInstanceAndDependentChildListViewEntities() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var pi = processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
+          final var fni = flowNodeInstanceForListViewEntity(pi);
+          final var variable = variableForListViewEntity(pi);
+
+          store(listViewTemplate, pi);
+          store(listViewTemplate, fni, String.valueOf(pi.getKey()));
+          store(listViewTemplate, variable, String.valueOf(pi.getKey()));
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
+
+          verifyMoved(listViewTemplate, pi.getId(), "2020-01-01");
+          verifyMoved(listViewTemplate, fni.getId(), String.valueOf(pi.getKey()), "2020-01-01");
+          verifyMoved(
+              listViewTemplate, variable.getId(), String.valueOf(pi.getKey()), "2020-01-01");
+        });
+  }
+
+  @Test
+  void shouldArchiveProcessInstanceAndProcessInstanceDependentEntities() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var pi = processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
+          store(listViewTemplate, pi);
+
+          final var dependants = getProcessInstanceDependentEntities(pi);
+          for (final var dep : dependants) {
+            for (final var entity : dep.entities()) {
+              store(dep.template(), entity);
+            }
+          }
+
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
+
+          verifyMoved(listViewTemplate, pi.getId(), "2020-01-01");
+          for (final var dep : dependants) {
+            for (final var entity : dep.entities()) {
+              verifyMoved(dep.template(), entity.getId(), "2020-01-01");
+            }
+          }
+        });
+  }
+
+  @Test
+  void shouldOnlyArchiveFinishedAndDependants() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var finishedPi = processInstanceForListViewEntity("2020-01-01T00:00:00+00:00");
+          final var finishedFni = flowNodeInstanceEntity(finishedPi);
+          store(listViewTemplate, finishedPi);
+          store(flowNodeInstanceTemplate, finishedFni);
+
+          final var unfinishedPi = processInstanceForListViewEntity(null);
+          final var unfinishedFni = flowNodeInstanceEntity(unfinishedPi);
+          store(listViewTemplate, unfinishedPi);
+          store(flowNodeInstanceTemplate, unfinishedFni);
+
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
+
+          verifyMoved(listViewTemplate, finishedPi.getId(), "2020-01-01");
+          verifyMoved(flowNodeInstanceTemplate, finishedFni.getId(), "2020-01-01");
+          verifyNotMoved(listViewTemplate, unfinishedPi.getId());
+          verifyNotMoved(flowNodeInstanceTemplate, unfinishedFni.getId());
+        });
+  }
+
+  private List<DependentEntities> getProcessInstanceDependentEntities(
+      final ProcessInstanceForListViewEntity pi) {
+    return List.of(
+        new DependentEntities(flowNodeInstanceTemplate, List.of(flowNodeInstanceEntity(pi))),
+        new DependentEntities(variableTemplate, List.of(variableEntity(pi))),
+        new DependentEntities(incidentTemplate, List.of(incidentEntity(pi))),
+        new DependentEntities(operationTemplate, List.of(operationEntity(pi))),
+        new DependentEntities(sequenceFlowTemplate, List.of(sequenceFlowEntity(pi))),
+        new DependentEntities(jobTemplate, List.of(jobEntity(pi))),
+        new DependentEntities(eventTemplate, List.of(eventEntity(pi))),
+        new DependentEntities(postImporterQueueTemplate, List.of(postImporterQueueEntity(pi))),
+        new DependentEntities(userTaskTemplate, List.of(userTaskEntity(pi))),
+        new DependentEntities(decisionInstanceTemplate, List.of(decisionInstanceEntity(pi))));
+  }
+
+  protected ProcessInstanceForListViewEntity processInstanceForListViewEntity(
+      final String endDate) {
+    final long id = ID_GENERATOR.incrementAndGet();
+    final var pi = new ProcessInstanceForListViewEntity();
+    pi.setId(String.valueOf(id));
+    pi.setKey(id);
+    pi.setPartitionId(PARTITION_ID);
+    if (endDate != null) {
+      pi.setEndDate(OffsetDateTime.parse(endDate));
+    }
+    return pi;
+  }
+
+  protected FlowNodeInstanceForListViewEntity flowNodeInstanceForListViewEntity(
+      final ProcessInstanceForListViewEntity parent) {
+    final var entity = create(FlowNodeInstanceForListViewEntity::new);
+    entity.setProcessInstanceKey(parent.getKey());
+    final var join = new ListViewJoinRelation(ListViewTemplate.ACTIVITIES_JOIN_RELATION);
+    join.setParent(parent.getKey());
+    entity.setJoinRelation(join);
+    return entity;
+  }
+
+  protected VariableForListViewEntity variableForListViewEntity(
+      final ProcessInstanceForListViewEntity parent) {
+    final var entity = create(VariableForListViewEntity::new);
+    entity.setProcessInstanceKey(parent.getKey());
+    final var join = new ListViewJoinRelation(ListViewTemplate.VARIABLES_JOIN_RELATION);
+    join.setParent(parent.getKey());
+    entity.setJoinRelation(join);
+    return entity;
+  }
+
+  protected FlowNodeInstanceEntity flowNodeInstanceEntity(
+      final ProcessInstanceForListViewEntity parent) {
+    final var entity = create(FlowNodeInstanceEntity::new);
+    entity.setProcessInstanceKey(parent.getKey());
+    return entity;
+  }
+
+  protected VariableEntity variableEntity(final ProcessInstanceForListViewEntity parent) {
+    final var entity = create(VariableEntity::new);
+    entity.setProcessInstanceKey(parent.getKey());
+    return entity;
+  }
+
+  protected IncidentEntity incidentEntity(final ProcessInstanceForListViewEntity parent) {
+    final var entity = create(IncidentEntity::new);
+    entity.setProcessInstanceKey(parent.getKey());
+    return entity;
+  }
+
+  protected OperationEntity operationEntity(final ProcessInstanceForListViewEntity parent) {
+    final var entity = new OperationEntity();
+    entity.setId(String.valueOf(ID_GENERATOR.incrementAndGet()));
+    entity.setProcessInstanceKey(parent.getKey());
+    return entity;
+  }
+
+  protected SequenceFlowEntity sequenceFlowEntity(final ProcessInstanceForListViewEntity parent) {
+    final var entity = new SequenceFlowEntity();
+    entity.setId(String.valueOf(ID_GENERATOR.incrementAndGet()));
+    entity.setProcessInstanceKey(parent.getKey());
+    return entity;
+  }
+
+  protected JobEntity jobEntity(final ProcessInstanceForListViewEntity parent) {
+    final var entity = create(JobEntity::new);
+    entity.setProcessInstanceKey(parent.getKey());
+    return entity;
+  }
+
+  protected EventEntity eventEntity(final ProcessInstanceForListViewEntity parent) {
+    final var entity = create(EventEntity::new);
+    entity.setProcessInstanceKey(parent.getKey());
+    return entity;
+  }
+
+  protected PostImporterQueueEntity postImporterQueueEntity(
+      final ProcessInstanceForListViewEntity parent) {
+    final var entity = new PostImporterQueueEntity();
+    entity.setId(String.valueOf(ID_GENERATOR.incrementAndGet()));
+    entity.setProcessInstanceKey(parent.getKey());
+    return entity;
+  }
+
+  protected UserTaskEntity userTaskEntity(final ProcessInstanceForListViewEntity parent) {
+    final var entity = create(UserTaskEntity::new);
+    entity.setProcessInstanceKey(parent.getKey());
+    return entity;
+  }
+
+  protected DecisionInstanceEntity decisionInstanceEntity(
+      final ProcessInstanceForListViewEntity parent) {
+    final var entity = create(DecisionInstanceEntity::new);
+    entity.setProcessInstanceKey(parent.getKey());
+    return entity;
+  }
+
+  record DependentEntities(
+      AbstractTemplateDescriptor template, List<? extends OperateEntity<?>> entities) {}
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverJobIT.java
@@ -106,12 +106,24 @@ public abstract class ArchiverJobIT {
       searchClient = osAdapter;
       archiverRepository = buildOpensearchArchiverRepository(osAdapter);
     } else {
+      ReflectionTestUtils.setField(DatabaseInfo.class, "current", DatabaseType.Elasticsearch);
       ELASTICSEARCH.start();
       esAdapter = new ElasticsearchSearchClientAdapter(ELASTICSEARCH, objectMapper);
       searchClient = esAdapter;
       archiverRepository = buildElasticsearchArchiverRepository(esAdapter);
     }
-    archiver = new Archiver(null, operateProperties, null, null, archiverRepository);
+    archiver =
+        new Archiver(
+            null,
+            operateProperties,
+            null,
+            null,
+            archiverRepository,
+            processInstanceTemplate,
+            List.of(),
+            decisionInstanceTemplate,
+            batchOperationTemplate,
+            metrics);
   }
 
   @AfterEach
@@ -232,7 +244,6 @@ public abstract class ArchiverJobIT {
         operateProperties,
         metrics,
         adapter.getClient(),
-        objectMapper,
         processInstanceTemplate,
         batchOperationTemplate,
         decisionInstanceTemplate);
@@ -259,6 +270,7 @@ public abstract class ArchiverJobIT {
     final var scheduler = new ThreadPoolTaskScheduler();
     scheduler.setPoolSize(1);
     scheduler.setThreadNamePrefix("archiver-test-");
+    scheduler.setDaemon(true);
     scheduler.initialize();
     return scheduler;
   }

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ArchiverJobIT.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.operate.Metrics;
+import io.camunda.operate.conditions.DatabaseInfo;
+import io.camunda.operate.conditions.DatabaseType;
+import io.camunda.operate.entities.OperateEntity;
+import io.camunda.operate.property.ArchiverProperties;
+import io.camunda.operate.property.OperateElasticsearchProperties;
+import io.camunda.operate.property.OperateOpensearchProperties;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.SchemaManager;
+import io.camunda.operate.schema.indices.IndexDescriptor;
+import io.camunda.operate.schema.templates.AbstractTemplateDescriptor;
+import io.camunda.operate.schema.templates.BatchOperationTemplate;
+import io.camunda.operate.schema.templates.DecisionInstanceTemplate;
+import io.camunda.operate.schema.templates.ListViewTemplate;
+import io.camunda.operate.schema.templates.TemplateDescriptor;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.testcontainers.OpenSearchContainer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = ArchiverJobIT.TestConfig.class)
+@TestInstance(Lifecycle.PER_CLASS)
+public abstract class ArchiverJobIT {
+
+  protected static final int PARTITION_ID = 1;
+  protected static final List<Integer> PARTITION_IDS = List.of(PARTITION_ID);
+  protected static final AtomicLong ID_GENERATOR = new AtomicLong(0);
+  protected static final String INDEX_PREFIX = "test-archiver";
+  protected static final Duration ARCHIVE_TIMEOUT = Duration.ofSeconds(30);
+
+  private static final String OPERATE_TEST_DB_PROPERTY = "OPERATE_TEST_DB";
+
+  private static final ElasticsearchContainer ELASTICSEARCH =
+      new ElasticsearchContainer(
+              "docker.elastic.co/elasticsearch/elasticsearch:"
+                  + RestHighLevelClient.class.getPackage().getImplementationVersion())
+          .withEnv("xpack.security.enabled", "false");
+
+  @SuppressWarnings("resource")
+  private static final OpenSearchContainer<?> OPENSEARCH =
+      new OpenSearchContainer<>("opensearchproject/opensearch:2.11.1")
+          .withEnv("DISABLE_SECURITY_PLUGIN", "true");
+
+  @Autowired protected OperateProperties operateProperties;
+  @Autowired protected ObjectMapper objectMapper;
+  protected SearchClientAdapter searchClient;
+  @Autowired private Metrics metrics;
+  private ArchiverRepository archiverRepository;
+  private Archiver archiver;
+
+  @Autowired private ListViewTemplate processInstanceTemplate;
+  @Autowired private BatchOperationTemplate batchOperationTemplate;
+  @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
+  @Autowired private List<TemplateDescriptor> allTemplateDescriptors;
+  @Autowired private List<IndexDescriptor> allIndexDescriptors;
+  private ElasticsearchSearchClientAdapter esAdapter;
+  private OpensearchSearchClientAdapter osAdapter;
+
+  @BeforeAll
+  void setupInfrastructure() throws Exception {
+    if (isOpensearch()) {
+      ReflectionTestUtils.setField(DatabaseInfo.class, "current", DatabaseType.Opensearch);
+      OPENSEARCH.start();
+      osAdapter = new OpensearchSearchClientAdapter(OPENSEARCH, objectMapper);
+      searchClient = osAdapter;
+      archiverRepository = buildOpensearchArchiverRepository(osAdapter);
+    } else {
+      ELASTICSEARCH.start();
+      esAdapter = new ElasticsearchSearchClientAdapter(ELASTICSEARCH, objectMapper);
+      searchClient = esAdapter;
+      archiverRepository = buildElasticsearchArchiverRepository(esAdapter);
+    }
+    archiver = new Archiver(null, operateProperties, null, null, archiverRepository);
+  }
+
+  @AfterEach
+  void cleanupIndices() throws IOException {
+    searchClient.deleteIndices(INDEX_PREFIX + "-*");
+  }
+
+  @Test
+  void shouldExecuteWithoutErrorsWhenNothingToArchive() throws Exception {
+    withArchiverJob(
+        job -> {
+          assertThat(job.archiveNextBatch()).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(0);
+        });
+  }
+
+  protected void withArchiverJob(final ArchiverJobConsumer consumer) throws Exception {
+    createSchema();
+    final var job = createArchiveJob(PARTITION_IDS);
+    consumer.accept(job);
+  }
+
+  protected abstract ArchiverJob createArchiveJob(List<Integer> partitionIds);
+
+  protected void createSchema() throws Exception {
+    buildSchemaManager().createSchema();
+  }
+
+  protected SchemaManager buildSchemaManager() {
+    if (osAdapter != null) {
+      return osAdapter.buildSchemaManager(
+          operateProperties, allTemplateDescriptors, allIndexDescriptors);
+    }
+    return esAdapter.buildSchemaManager(
+        operateProperties, allTemplateDescriptors, allIndexDescriptors);
+  }
+
+  protected Metrics getMetrics() {
+    return metrics;
+  }
+
+  protected ArchiverRepository getArchiverRepository() {
+    return archiverRepository;
+  }
+
+  protected Archiver getArchiver() {
+    return archiver;
+  }
+
+  protected <E extends OperateEntity<E>> E create(final Supplier<E> constructor) {
+    final long id = ID_GENERATOR.incrementAndGet();
+    final var entity = constructor.get();
+    entity.setId(String.valueOf(id));
+    return entity;
+  }
+
+  protected void store(final AbstractTemplateDescriptor template, final OperateEntity<?> entity)
+      throws IOException {
+    searchClient.index(entity.getId(), null, template.getFullQualifiedName(), entity);
+  }
+
+  protected void store(
+      final AbstractTemplateDescriptor template,
+      final OperateEntity<?> entity,
+      final String routing)
+      throws IOException {
+    searchClient.index(entity.getId(), routing, template.getFullQualifiedName(), entity);
+  }
+
+  protected void refresh() throws IOException {
+    searchClient.refresh();
+  }
+
+  protected void verifyMoved(
+      final AbstractTemplateDescriptor template, final String entityId, final String datedSuffix)
+      throws IOException {
+    verifyMoved(template, entityId, null, datedSuffix);
+  }
+
+  protected void verifyMoved(
+      final AbstractTemplateDescriptor template,
+      final String entityId,
+      final String routing,
+      final String datedSuffix)
+      throws IOException {
+    final String sourceIndex = template.getFullQualifiedName();
+    final String destIndex = sourceIndex + datedSuffix;
+
+    assertThat(searchClient.exists(entityId, routing, sourceIndex))
+        .describedAs("Expected %s to have been deleted from source index %s", entityId, sourceIndex)
+        .isFalse();
+    assertThat(searchClient.exists(entityId, routing, destIndex))
+        .describedAs("Expected %s to exist in dated index %s", entityId, destIndex)
+        .isTrue();
+  }
+
+  protected void verifyNotMoved(final AbstractTemplateDescriptor template, final String entityId)
+      throws IOException {
+    verifyNotMoved(template, entityId, null);
+  }
+
+  protected void verifyNotMoved(
+      final AbstractTemplateDescriptor template, final String entityId, final String routing)
+      throws IOException {
+    final String sourceIndex = template.getFullQualifiedName();
+    assertThat(searchClient.exists(entityId, routing, sourceIndex))
+        .describedAs("Expected %s to still be in source index %s", entityId, sourceIndex)
+        .isTrue();
+  }
+
+  private boolean isOpensearch() {
+    return "opensearch".equalsIgnoreCase(System.getProperty(OPERATE_TEST_DB_PROPERTY));
+  }
+
+  private ElasticsearchArchiverRepository buildElasticsearchArchiverRepository(
+      final ElasticsearchSearchClientAdapter adapter) {
+    return new ElasticsearchArchiverRepository(
+        buildScheduler(),
+        operateProperties,
+        metrics,
+        adapter.getClient(),
+        objectMapper,
+        processInstanceTemplate,
+        batchOperationTemplate,
+        decisionInstanceTemplate);
+  }
+
+  private OpensearchArchiverRepository buildOpensearchArchiverRepository(
+      final OpensearchSearchClientAdapter adapter) {
+    final var asyncClient = new OpenSearchAsyncClient(adapter.getClient()._transport());
+    // beanFactory is null: only used by RichOpenSearchClient.batch().doWithRetry(), which the
+    // archiver never calls — it uses osAsyncClient for searches and index() for existence checks.
+    final var richClient =
+        new RichOpenSearchClient(null, adapter.getClient(), asyncClient, objectMapper);
+    return new OpensearchArchiverRepository(
+        richClient,
+        asyncClient,
+        operateProperties,
+        metrics,
+        processInstanceTemplate,
+        batchOperationTemplate,
+        decisionInstanceTemplate);
+  }
+
+  private static ThreadPoolTaskScheduler buildScheduler() {
+    final var scheduler = new ThreadPoolTaskScheduler();
+    scheduler.setPoolSize(1);
+    scheduler.setThreadNamePrefix("archiver-test-");
+    scheduler.initialize();
+    return scheduler;
+  }
+
+  @Configuration
+  @ComponentScan({"io.camunda.operate.schema.templates", "io.camunda.operate.schema.indices"})
+  static class TestConfig {
+
+    @Bean
+    OperateProperties operateProperties() {
+      final var props = new OperateProperties();
+
+      final var esProps = new OperateElasticsearchProperties();
+      esProps.setIndexPrefix(INDEX_PREFIX);
+      props.setElasticsearch(esProps);
+
+      final var osProps = new OperateOpensearchProperties();
+      osProps.setIndexPrefix(INDEX_PREFIX);
+      props.setOpensearch(osProps);
+
+      final var archiverProps = new ArchiverProperties();
+      archiverProps.setRolloverInterval("1d");
+      archiverProps.setElsRolloverDateFormat("date");
+      archiverProps.setRolloverBatchSize(100);
+      archiverProps.setIlmEnabled(false);
+      props.setArchiver(archiverProps);
+
+      return props;
+    }
+
+    @Bean
+    Metrics metrics() {
+      return new Metrics(new SimpleMeterRegistry());
+    }
+
+    @Bean
+    ObjectMapper objectMapper() {
+      return new ObjectMapper()
+          .registerModule(new JavaTimeModule())
+          .registerModule(new Jdk8Module())
+          .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+          .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+          .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+          .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+          .enable(JsonParser.Feature.ALLOW_COMMENTS)
+          .setVisibility(PropertyAccessor.GETTER, Visibility.ANY)
+          .setVisibility(PropertyAccessor.IS_GETTER, Visibility.ANY)
+          .setVisibility(PropertyAccessor.SETTER, Visibility.ANY)
+          .setVisibility(PropertyAccessor.FIELD, Visibility.NONE)
+          .setVisibility(PropertyAccessor.CREATOR, Visibility.ANY);
+    }
+  }
+
+  @FunctionalInterface
+  protected interface ArchiverJobConsumer {
+    void accept(ArchiverJob job) throws Exception;
+  }
+
+  protected interface SearchClientAdapter<T> {
+    T getClient();
+
+    void index(String id, String routing, String indexName, Object entity) throws IOException;
+
+    boolean exists(String id, String routing, String indexName) throws IOException;
+
+    void refresh() throws IOException;
+
+    void deleteIndices(String pattern) throws IOException;
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/BatchOperationArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/BatchOperationArchiverJobIT.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.entities.BatchOperationEntity;
+import io.camunda.operate.schema.templates.BatchOperationTemplate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class BatchOperationArchiverJobIT extends ArchiverJobIT {
+
+  @Autowired private BatchOperationTemplate batchOperationTemplate;
+
+  @Override
+  protected ArchiverJob createArchiveJob(final List<Integer> partitionIds) {
+    return new BatchOperationArchiverJob(
+        getArchiver(), batchOperationTemplate, getMetrics(), getArchiverRepository());
+  }
+
+  @Test
+  void shouldArchiveBatchOperation() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var batchOp = batchOperationEntity("2020-01-01T00:00:00+00:00");
+          store(batchOperationTemplate, batchOp);
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
+
+          verifyMoved(batchOperationTemplate, batchOp.getId(), "2020-01-01");
+        });
+  }
+
+  @Test
+  void shouldNotArchiveRecentBatchOperation() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var batchOp = batchOperationEntity("2099-01-01T00:00:00+00:00");
+          store(batchOperationTemplate, batchOp);
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(0);
+
+          verifyNotMoved(batchOperationTemplate, batchOp.getId());
+        });
+  }
+
+  private BatchOperationEntity batchOperationEntity(final String endDate) {
+    final var entity = new BatchOperationEntity();
+    entity.setId(String.valueOf(ID_GENERATOR.incrementAndGet()));
+    entity.setEndDate(OffsetDateTime.parse(endDate));
+    return entity;
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchSearchClientAdapter.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchSearchClientAdapter.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.SchemaManager;
+import io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager;
+import io.camunda.operate.schema.indices.IndexDescriptor;
+import io.camunda.operate.schema.templates.TemplateDescriptor;
+import io.camunda.operate.store.elasticsearch.RetryElasticsearchClient;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.RestHighLevelClientBuilder;
+import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.xcontent.XContentType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+class ElasticsearchSearchClientAdapter
+    implements ArchiverJobIT.SearchClientAdapter<RestHighLevelClient> {
+
+  private final ObjectMapper objectMapper;
+  private final RestHighLevelClient client;
+
+  ElasticsearchSearchClientAdapter(
+      final ElasticsearchContainer container, final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+    client =
+        new RestHighLevelClientBuilder(
+                RestClient.builder(
+                        new HttpHost(container.getHost(), container.getMappedPort(9200), "http"))
+                    .build())
+            .setApiCompatibilityMode(true)
+            .build();
+  }
+
+  @Override
+  public RestHighLevelClient getClient() {
+    return client;
+  }
+
+  @Override
+  public void index(
+      final String id, final String routing, final String indexName, final Object entity)
+      throws IOException {
+    final var req =
+        new IndexRequest(indexName)
+            .id(id)
+            .source(objectMapper.writeValueAsBytes(entity), XContentType.JSON)
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE);
+    if (routing != null) {
+      req.routing(routing);
+    }
+    client.index(req, RequestOptions.DEFAULT);
+  }
+
+  @Override
+  public boolean exists(final String id, final String routing, final String indexName)
+      throws IOException {
+    final var req = new GetRequest(indexName, id);
+    if (routing != null) {
+      req.routing(routing);
+    }
+    return client.get(req, RequestOptions.DEFAULT).isExists();
+  }
+
+  @Override
+  public void refresh() throws IOException {
+    client.indices().refresh(new RefreshRequest(), RequestOptions.DEFAULT);
+  }
+
+  @Override
+  public void deleteIndices(final String pattern) throws IOException {
+    final var getResp =
+        client
+            .indices()
+            .get(
+                new GetIndexRequest(pattern).indicesOptions(IndicesOptions.lenientExpandOpen()),
+                RequestOptions.DEFAULT);
+    final String[] indices = getResp.getIndices();
+    if (indices != null && indices.length > 0) {
+      client
+          .indices()
+          .delete(
+              new DeleteIndexRequest(indices).indicesOptions(IndicesOptions.lenientExpandOpen()),
+              RequestOptions.DEFAULT);
+    }
+  }
+
+  SchemaManager buildSchemaManager(
+      final OperateProperties props,
+      final List<TemplateDescriptor> templates,
+      final List<IndexDescriptor> indices) {
+    final var retryClient = new RetryElasticsearchClient();
+    ReflectionTestUtils.setField(retryClient, "esClient", client);
+    final var manager = new ElasticsearchSchemaManager();
+    ReflectionTestUtils.setField(manager, "retryElasticsearchClient", retryClient);
+    ReflectionTestUtils.setField(manager, "operateProperties", props);
+    ReflectionTestUtils.setField(manager, "templateDescriptors", new ArrayList<>(templates));
+    ReflectionTestUtils.setField(manager, "indexDescriptors", new ArrayList<>(indices));
+    ReflectionTestUtils.setField(manager, "objectMapper", objectMapper);
+    return manager;
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchSearchClientAdapter.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchSearchClientAdapter.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.opensearch.ExtendedOpenSearchClient;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.SchemaManager;
+import io.camunda.operate.schema.indices.IndexDescriptor;
+import io.camunda.operate.schema.opensearch.OpensearchSchemaManager;
+import io.camunda.operate.schema.templates.TemplateDescriptor;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.hc.core5.http.HttpHost;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+import org.opensearch.testcontainers.OpenSearchContainer;
+
+class OpensearchSearchClientAdapter
+    implements ArchiverJobIT.SearchClientAdapter<ExtendedOpenSearchClient> {
+
+  private final ObjectMapper objectMapper;
+  private final OpenSearchClient client;
+  private final ExtendedOpenSearchClient extendedClient;
+
+  OpensearchSearchClientAdapter(
+      final OpenSearchContainer<?> container, final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+    final var host = new HttpHost("http", container.getHost(), container.getMappedPort(9200));
+    final var transport =
+        ApacheHttpClient5TransportBuilder.builder(host)
+            .setMapper(new JacksonJsonpMapper(objectMapper))
+            .build();
+    client = new OpenSearchClient(transport);
+    extendedClient = new ExtendedOpenSearchClient(transport);
+  }
+
+  @Override
+  public ExtendedOpenSearchClient getClient() {
+    return extendedClient;
+  }
+
+  @Override
+  public void index(
+      final String id, final String routing, final String indexName, final Object entity)
+      throws IOException {
+    client.index(
+        r -> {
+          final var req = r.index(indexName).id(id).document(entity).refresh(Refresh.True);
+          if (routing != null) {
+            req.routing(routing);
+          }
+          return req;
+        });
+  }
+
+  @Override
+  public boolean exists(final String id, final String routing, final String indexName)
+      throws IOException {
+    final var resp =
+        client.get(
+            r -> {
+              final var req = r.index(indexName).id(id);
+              if (routing != null) {
+                req.routing(routing);
+              }
+              return req;
+            },
+            Map.class);
+    return resp.found();
+  }
+
+  @Override
+  public void refresh() throws IOException {
+    client.indices().refresh(r -> r);
+  }
+
+  @Override
+  public void deleteIndices(final String pattern) throws IOException {
+    try {
+      client.indices().delete(r -> r.index(List.of(pattern)).ignoreUnavailable(true));
+    } catch (final Exception ignored) {
+      // no matching indices is fine
+    }
+  }
+
+  SchemaManager buildSchemaManager(
+      final OperateProperties props,
+      final List<TemplateDescriptor> templates,
+      final List<IndexDescriptor> indices) {
+    final var richClient =
+        new RichOpenSearchClient(
+            null, client, new OpenSearchAsyncClient(client._transport()), objectMapper);
+    return new OpensearchSchemaManager(
+        props,
+        richClient,
+        new ArrayList<>(templates),
+        new ArrayList<IndexDescriptor>(indices),
+        objectMapper);
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesArchiverJobIT.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import java.util.List;
+
+public class ProcessInstancesArchiverJobIT extends AbstractProcessInstanceArchiverJobIT {
+
+  @Override
+  protected ArchiverJob createArchiveJob(final List<Integer> partitionIds) {
+    return new ProcessInstancesArchiverJob(
+        getArchiver(),
+        partitionIds,
+        getListViewTemplate(),
+        getDependantTemplates(),
+        getMetrics(),
+        getArchiverRepository());
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/StandaloneDecisionArchiverJobIT.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/StandaloneDecisionArchiverJobIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.entities.dmn.DecisionInstanceEntity;
+import io.camunda.operate.schema.templates.DecisionInstanceTemplate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class StandaloneDecisionArchiverJobIT extends ArchiverJobIT {
+
+  @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
+
+  @Override
+  protected ArchiverJob createArchiveJob(final List<Integer> partitionIds) {
+    return new StandaloneDecisionArchiverJob(
+        getArchiver(),
+        partitionIds,
+        decisionInstanceTemplate,
+        getMetrics(),
+        getArchiverRepository());
+  }
+
+  @Test
+  void shouldArchiveStandaloneDecisionInstance() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var decision = decisionInstance("2020-01-01T00:00:00+00:00", -1L);
+          store(decisionInstanceTemplate, decision);
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
+
+          verifyMoved(decisionInstanceTemplate, decision.getId(), "2020-01-01");
+        });
+  }
+
+  @Test
+  void shouldNotArchiveDecisionInstanceBelongingToProcess() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var standalone = decisionInstance("2020-01-01T00:00:00+00:00", -1L);
+          final var processOwned = decisionInstance("2020-01-01T00:00:00+00:00", 12345L);
+          store(decisionInstanceTemplate, standalone);
+          store(decisionInstanceTemplate, processOwned);
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
+
+          verifyMoved(decisionInstanceTemplate, standalone.getId(), "2020-01-01");
+          verifyNotMoved(decisionInstanceTemplate, processOwned.getId());
+        });
+  }
+
+  @Test
+  void shouldNotArchiveRecentStandaloneDecision() throws Exception {
+    withArchiverJob(
+        job -> {
+          final var recent = decisionInstance("2099-01-01T00:00:00+00:00", -1L);
+          store(decisionInstanceTemplate, recent);
+          refresh();
+
+          final var result = job.archiveNextBatch();
+          assertThat(result).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(0);
+
+          verifyNotMoved(decisionInstanceTemplate, recent.getId());
+        });
+  }
+
+  private DecisionInstanceEntity decisionInstance(
+      final String evaluationDate, final long processInstanceKey) {
+    final var entity = create(DecisionInstanceEntity::new);
+    entity.setEvaluationDate(OffsetDateTime.parse(evaluationDate));
+    entity.setProcessInstanceKey(processInstanceKey);
+    entity.setPartitionId(PARTITION_ID);
+    return entity;
+  }
+}

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -13,8 +13,6 @@ import io.micrometer.core.instrument.Timer;
 import java.util.Queue;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -81,9 +79,13 @@ public class Metrics {
       TAG_VALUE_CORESTATISTICS = "corestatistics",
       TAG_VALUE_SUCCEEDED = "succeeded",
       TAG_VALUE_FAILED = "failed";
-  private static final Logger LOGGER = LoggerFactory.getLogger(Metrics.class);
-  private Timer importBatchTimer;
-  @Autowired private MeterRegistry registry;
+
+  private final MeterRegistry registry;
+
+  @Autowired
+  public Metrics(final MeterRegistry registry) {
+    this.registry = registry;
+  }
 
   /**
    * Record counts for given name and tags. Tags are further attributes that gives the possibility

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 
+import io.camunda.operate.Metrics;
 import io.camunda.operate.archiver.Archiver;
 import io.camunda.operate.archiver.BatchOperationArchiverJob;
 import io.camunda.operate.archiver.ProcessInstancesArchiverJob;
@@ -95,6 +96,8 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
 
   @Autowired private CancelProcessInstanceHandler cancelProcessInstanceHandler;
 
+  @Autowired private Metrics metrics;
+
   private ProcessInstancesArchiverJob processInstancesArchiverJob;
 
   private final Random random = new Random();
@@ -110,7 +113,13 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
             .withZone(ZoneId.systemDefault());
     processInstancesArchiverJob =
         beanFactory.getBean(
-            ProcessInstancesArchiverJob.class, archiver, partitionHolder.getPartitionIds());
+            ProcessInstancesArchiverJob.class,
+            archiver,
+            partitionHolder.getPartitionIds(),
+            processInstanceTemplate,
+            processInstanceDependantTemplates,
+            metrics,
+            archiver.getArchiverRepository());
     cancelProcessInstanceHandler.setZeebeClient(super.getClient());
     clearMetrics();
   }
@@ -365,7 +374,12 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
     // when
     final StandaloneDecisionArchiverJob standaloneDecisionArchiverJob =
         beanFactory.getBean(
-            StandaloneDecisionArchiverJob.class, archiver, partitionHolder.getPartitionIds());
+            StandaloneDecisionArchiverJob.class,
+            archiver,
+            partitionHolder.getPartitionIds(),
+            decisionInstanceTemplate,
+            metrics,
+            archiver.getArchiverRepository());
 
     assertThat(standaloneDecisionArchiverJob.archiveNextBatch().join()).isEqualTo(1);
     searchTestRule.refreshSerchIndexes();
@@ -423,7 +437,12 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
     // then
     final StandaloneDecisionArchiverJob standaloneDecisionArchiverJob =
         beanFactory.getBean(
-            StandaloneDecisionArchiverJob.class, archiver, partitionHolder.getPartitionIds());
+            StandaloneDecisionArchiverJob.class,
+            archiver,
+            partitionHolder.getPartitionIds(),
+            decisionInstanceTemplate,
+            metrics,
+            archiver.getArchiverRepository());
     assertThat(standaloneDecisionArchiverJob.archiveNextBatch().join())
         .isEqualTo(sourceDecisionInstanceEntities.size());
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/OneNodeArchiverZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/OneNodeArchiverZeebeIT.java
@@ -13,6 +13,7 @@ import static io.camunda.operate.schema.templates.ListViewTemplate.PROCESS_INSTA
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.Metrics;
 import io.camunda.operate.archiver.Archiver;
 import io.camunda.operate.archiver.ProcessInstancesArchiverJob;
 import io.camunda.operate.archiver.StandaloneDecisionArchiverJob;
@@ -70,7 +71,7 @@ public class OneNodeArchiverZeebeIT extends OperateZeebeAbstractIT {
 
   @Autowired private TestSearchRepository testSearchRepository;
 
-  @Autowired private ListViewTemplate listViewTemplate;
+  @Autowired private ListViewTemplate processInstanceTemplate;
 
   @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
 
@@ -83,6 +84,8 @@ public class OneNodeArchiverZeebeIT extends OperateZeebeAbstractIT {
   @Autowired private ListViewReader listViewReader;
 
   @Autowired private List<ProcessInstanceDependant> processInstanceDependantTemplates;
+
+  @Autowired private Metrics metrics;
 
   private final Random random = new Random();
 
@@ -101,10 +104,21 @@ public class OneNodeArchiverZeebeIT extends OperateZeebeAbstractIT {
             .withZone(ZoneId.systemDefault());
     processInstancesArchiverJob =
         beanFactory.getBean(
-            ProcessInstancesArchiverJob.class, archiver, partitionHolder.getPartitionIds());
+            ProcessInstancesArchiverJob.class,
+            archiver,
+            partitionHolder.getPartitionIds(),
+            processInstanceTemplate,
+            processInstanceDependantTemplates,
+            metrics,
+            archiver.getArchiverRepository());
     standaloneDecisionArchiverJob =
         beanFactory.getBean(
-            StandaloneDecisionArchiverJob.class, archiver, partitionHolder.getPartitionIds());
+            StandaloneDecisionArchiverJob.class,
+            archiver,
+            partitionHolder.getPartitionIds(),
+            decisionInstanceTemplate,
+            metrics,
+            archiver.getArchiverRepository());
   }
 
   @Test
@@ -247,7 +261,7 @@ public class OneNodeArchiverZeebeIT extends OperateZeebeAbstractIT {
       throws IOException {
     final String destinationIndexName =
         archiver.getDestinationIndexName(
-            listViewTemplate.getFullQualifiedName(), dateTimeFormatter.format(endDate));
+            processInstanceTemplate.getFullQualifiedName(), dateTimeFormatter.format(endDate));
     final List<ProcessInstanceForListViewEntity> processInstances =
         testSearchRepository.searchJoinRelation(
             destinationIndexName,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/FlowNodeMetadataZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/FlowNodeMetadataZeebeImportIT.java
@@ -14,6 +14,7 @@ import static io.camunda.operate.entities.FlowNodeType.SUB_PROCESS;
 import static io.camunda.operate.webapp.rest.ProcessInstanceRestService.PROCESS_INSTANCE_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.operate.Metrics;
 import io.camunda.operate.archiver.Archiver;
 import io.camunda.operate.archiver.ProcessInstancesArchiverJob;
 import io.camunda.operate.entities.ErrorType;
@@ -22,6 +23,8 @@ import io.camunda.operate.entities.EventType;
 import io.camunda.operate.entities.FlowNodeInstanceEntity;
 import io.camunda.operate.entities.FlowNodeType;
 import io.camunda.operate.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.operate.schema.templates.ListViewTemplate;
+import io.camunda.operate.schema.templates.ProcessInstanceDependant;
 import io.camunda.operate.util.OperateZeebeAbstractIT;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.reader.ListViewReader;
@@ -57,7 +60,13 @@ public class FlowNodeMetadataZeebeImportIT extends OperateZeebeAbstractIT {
 
   @Autowired private ListViewReader listViewReader;
 
+  @Autowired private ListViewTemplate processInstanceTemplate;
+
+  @Autowired private List<ProcessInstanceDependant> processInstanceDependantTemplates;
+
   @Autowired private Archiver archiver;
+
+  @Autowired private Metrics metrics;
 
   private ProcessInstancesArchiverJob archiverJob;
 
@@ -68,7 +77,13 @@ public class FlowNodeMetadataZeebeImportIT extends OperateZeebeAbstractIT {
     cancelProcessInstanceHandler.setZeebeClient(zeebeClient);
     archiverJob =
         beanFactory.getBean(
-            ProcessInstancesArchiverJob.class, archiver, partitionHolder.getPartitionIds());
+            ProcessInstancesArchiverJob.class,
+            archiver,
+            partitionHolder.getPartitionIds(),
+            processInstanceTemplate,
+            processInstanceDependantTemplates,
+            metrics,
+            archiver.getArchiverRepository());
   }
 
   /** Use cases 1.1 and 2.1. */


### PR DESCRIPTION


## Description

Backports the Operate archiver integration test infrastructure from 8.8+ to stable/8.7. 


Production changes to enable testing:
- Add @Autowired constructors to ElasticsearchArchiverRepository, OpensearchArchiverRepository, and ProcessInstancesArchiverJob
- Add no-arg refresh() to Metrics and expose it via SearchClientAdapter
- Add @Autowired constructor to Archiver

Adds ProcessInstancesArchiverJobIT covering archiving of process instances and all dependent entities against both Elasticsearch and OpenSearch via Testcontainers.

Similarly add BatchOperationArchiverJobIT & StandaloneDecisionArchiverJobIT to test respective functionality.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
