### PR TITLE
feat: Inc 4a — engine wiring + Authorization domain migration

### DIFF
--- a/.claude/skills/engine-expert/authz-enums.md
+++ b/.claude/skills/engine-expert/authz-enums.md
@@ -24,10 +24,18 @@ See [CSL ADR-0016](https://github.com/camunda/camunda-security-library/blob/main
 
 ## The translation boundary
 
-`AuthzModelMapper` (in the `service` module) is the single point that translates between Zeebe protocol enum values and CSL enum values. It sits at the seam between the engine layer and the layers above.
+`AuthzModelMapper` (in the `security-protocol` module, `io.camunda.zeebe.protocol.record.mapper`) is the single point that translates between Zeebe protocol enum values and CSL enum values. It sits at the seam between the engine layer and the layers above.
 
 - If you are writing code **above** `AuthzModelMapper` (Service, Search, Exporter, Persistence): use CSL enums.
 - If you are writing code **below** it (engine, processor, log-stream): use Zeebe protocol enums.
+
+### Engine code calling a CSL port
+
+There is one case where engine-layer code sits below the seam yet must still translate: when it
+calls **out into a CSL port** (e.g. `AuthorizationCheckPort`), which speaks CSL enums. Translate at
+the call site with `AuthzModelMapper.fromProtocol(...)` — do **not** hand-roll
+`CslEnum.valueOf(protocolEnum.name())`. Example: `PermissionsBehavior` converts a protocol
+`PermissionType` before invoking `AuthorizationCheckPort.check(...)`.
 
 ## Adding a new ResourceType or PermissionType
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Loggers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Loggers.java
@@ -20,6 +20,9 @@ public final class Loggers {
   public static final Logger ENGINE_PROCESSING_LOGGER =
       LoggerFactory.getLogger("io.camunda.zeebe.engine.processing");
 
+  public static final Logger ENGINE_IDENTITY_LOGGER =
+      LoggerFactory.getLogger("io.camunda.zeebe.engine.identity");
+
   public static Logger getExporterLogger(final String exporterId) {
     final String loggerName = String.format("io.camunda.zeebe.broker.exporter.%s", exporterId);
     return LoggerFactory.getLogger(loggerName);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.AuthorizationChecker;
 import io.camunda.security.core.authz.AuthorizationService;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
@@ -167,25 +168,6 @@ public final class EngineProcessors {
     final var authCheckBehavior =
         new AuthorizationCheckBehavior(
             processingState, securityConfig, config, authorizationCheckMetrics);
-    final var membershipStateAdapter =
-        new MembershipStateAdapter(
-            processingState.getMappingRuleState(), processingState.getMembershipState(), config);
-    final var authorizationScopeStateAdapter =
-        new AuthorizationScopeStateAdapter(processingState.getAuthorizationState(), config);
-    final var authorizationChecker = new AuthorizationChecker(authorizationScopeStateAdapter);
-    final var claimsConverter =
-        new LazyTokenClaimsConverter(
-            Authorization.AUTHORIZED_USERNAME,
-            Authorization.AUTHORIZED_CLIENT_ID,
-            false,
-            membershipStateAdapter);
-    final var propertyEvaluatorRegistry = new PropertyAuthorizationEvaluatorRegistry(List.of());
-    final var authzService =
-        new AuthorizationService(
-            authorizationChecker,
-            propertyEvaluatorRegistry,
-            securityConfig.isAuthorizationsEnabled(),
-            securityConfig.isMultiTenancyChecksEnabled());
     final var asyncRequestBehavior =
         new AsyncRequestBehavior(processingState.getKeyGenerator(), writers.state());
     final var transientProcessMessageSubscriptionState =
@@ -343,17 +325,15 @@ public final class EngineProcessors {
         commandDistributionBehavior,
         authCheckBehavior);
 
-    AuthorizationProcessors.addAuthorizationProcessors(
+    addIdentityProcessors(
         keyGenerator,
         typedRecordProcessors,
         processingState,
         writers,
         commandDistributionBehavior,
-        authzService,
-        claimsConverter,
         authCheckBehavior,
         securityConfig,
-        authorizationScopeStateAdapter);
+        config);
 
     RoleProcessors.addRoleProcessors(
         typedRecordProcessors,
@@ -467,6 +447,53 @@ public final class EngineProcessors {
         keyGenerator, typedRecordProcessors, writers, authCheckBehavior, processingState);
 
     return typedRecordProcessors;
+  }
+
+  /**
+   * Wires the identity/authorization subsystem: builds the CSL {@link AuthorizationService}
+   * together with its supporting state adapters and claims converter, then registers the
+   * authorization command processors on the given {@link TypedRecordProcessors}.
+   */
+  private static void addIdentityProcessors(
+      final KeyGenerator keyGenerator,
+      final TypedRecordProcessors typedRecordProcessors,
+      final MutableProcessingState processingState,
+      final Writers writers,
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final EngineSecurityConfig securityConfig,
+      final EngineConfiguration config) {
+    final var membershipStateAdapter =
+        new MembershipStateAdapter(
+            processingState.getMappingRuleState(), processingState.getMembershipState(), config);
+    final var authorizationScopeStateAdapter =
+        new AuthorizationScopeStateAdapter(processingState.getAuthorizationState(), config);
+    final var authorizationChecker = new AuthorizationChecker(authorizationScopeStateAdapter);
+    final var claimsConverter =
+        new LazyTokenClaimsConverter(
+            Authorization.AUTHORIZED_USERNAME,
+            Authorization.AUTHORIZED_CLIENT_ID,
+            false,
+            membershipStateAdapter);
+    final var propertyEvaluatorRegistry = new PropertyAuthorizationEvaluatorRegistry(List.of());
+    final var authzService =
+        new AuthorizationService(
+            authorizationChecker,
+            propertyEvaluatorRegistry,
+            securityConfig.isAuthorizationsEnabled(),
+            securityConfig.isMultiTenancyChecksEnabled());
+
+    AuthorizationProcessors.addAuthorizationProcessors(
+        keyGenerator,
+        typedRecordProcessors,
+        processingState,
+        writers,
+        commandDistributionBehavior,
+        authzService,
+        claimsConverter,
+        authCheckBehavior,
+        securityConfig,
+        authorizationScopeStateAdapter);
   }
 
   private static TypedRecordProcessor<UserTaskRecord> createUserTaskProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -169,9 +169,9 @@ public final class EngineProcessors {
             processingState, securityConfig, config, authorizationCheckMetrics);
     final var membershipStateAdapter =
         new MembershipStateAdapter(
-            processingState.getMappingRuleState(), processingState.getMembershipState());
+            processingState.getMappingRuleState(), processingState.getMembershipState(), config);
     final var authorizationScopeStateAdapter =
-        new AuthorizationScopeStateAdapter(processingState.getAuthorizationState());
+        new AuthorizationScopeStateAdapter(processingState.getAuthorizationState(), config);
     final var authorizationChecker = new AuthorizationChecker(authorizationScopeStateAdapter);
     final var claimsConverter =
         new LazyTokenClaimsConverter(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -352,7 +352,8 @@ public final class EngineProcessors {
         authzService,
         claimsConverter,
         authCheckBehavior,
-        securityConfig);
+        securityConfig,
+        authorizationScopeStateAdapter);
 
     RoleProcessors.addRoleProcessors(
         typedRecordProcessors,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -11,6 +11,11 @@ import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.core.authz.AuthorizationChecker;
+import io.camunda.security.core.authz.AuthorizationService;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.authz.PropertyAuthorizationEvaluatorRegistry;
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.el.ExpressionLanguageMetrics;
 import io.camunda.zeebe.el.impl.ExpressionLanguageMetricsImpl;
@@ -51,6 +56,8 @@ import io.camunda.zeebe.engine.processing.identity.GroupProcessors;
 import io.camunda.zeebe.engine.processing.identity.IdentitySetupProcessors;
 import io.camunda.zeebe.engine.processing.identity.MappingRuleProcessors;
 import io.camunda.zeebe.engine.processing.identity.RoleProcessors;
+import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
+import io.camunda.zeebe.engine.processing.identity.adapter.MembershipStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
 import io.camunda.zeebe.engine.processing.job.JobEventProcessors;
@@ -96,6 +103,7 @@ import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.time.InstantSource;
+import java.util.List;
 import java.util.function.Supplier;
 
 public final class EngineProcessors {
@@ -159,6 +167,25 @@ public final class EngineProcessors {
     final var authCheckBehavior =
         new AuthorizationCheckBehavior(
             processingState, securityConfig, config, authorizationCheckMetrics);
+    final var membershipStateAdapter =
+        new MembershipStateAdapter(
+            processingState.getMappingRuleState(), processingState.getMembershipState());
+    final var authorizationScopeStateAdapter =
+        new AuthorizationScopeStateAdapter(processingState.getAuthorizationState());
+    final var authorizationChecker = new AuthorizationChecker(authorizationScopeStateAdapter);
+    final var claimsConverter =
+        new LazyTokenClaimsConverter(
+            Authorization.AUTHORIZED_USERNAME,
+            Authorization.AUTHORIZED_CLIENT_ID,
+            false,
+            membershipStateAdapter);
+    final var propertyEvaluatorRegistry = new PropertyAuthorizationEvaluatorRegistry(List.of());
+    final var authzService =
+        new AuthorizationService(
+            authorizationChecker,
+            propertyEvaluatorRegistry,
+            securityConfig.isAuthorizationsEnabled(),
+            securityConfig.isMultiTenancyChecksEnabled());
     final var asyncRequestBehavior =
         new AsyncRequestBehavior(processingState.getKeyGenerator(), writers.state());
     final var transientProcessMessageSubscriptionState =
@@ -322,6 +349,8 @@ public final class EngineProcessors {
         processingState,
         writers,
         commandDistributionBehavior,
+        authzService,
+        claimsConverter,
         authCheckBehavior,
         securityConfig);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.identity;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -27,10 +28,13 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
 
 @NullMarked
 public class AuthorizationCreateProcessor
     implements DistributedTypedRecordProcessor<AuthorizationRecord> {
+
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final KeyGenerator keyGenerator;
   private final CommandDistributionBehavior distributionBehavior;
@@ -68,6 +72,8 @@ public class AuthorizationCreateProcessor
 
   @Override
   public void processNewCommand(final TypedRecord<AuthorizationRecord> command) {
+    LOG.debug(
+        "Processing CREATE authorization command for owner '{}'", command.getValue().getOwnerId());
     permissionsBehavior
         .isAuthorized(command, PermissionType.CREATE)
         .flatMap(
@@ -83,6 +89,7 @@ public class AuthorizationCreateProcessor
         .ifRightOrLeft(
             authorizationRecord -> writeEventAndDistribute(command, command.getValue()),
             (rejection) -> {
+              LOG.debug("Rejecting CREATE authorization command: {}", rejection.reason());
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
               responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
             });
@@ -90,6 +97,9 @@ public class AuthorizationCreateProcessor
 
   @Override
   public void processDistributedCommand(final TypedRecord<AuthorizationRecord> command) {
+    LOG.debug(
+        "Processing distributed CREATE authorization command for owner '{}'",
+        command.getValue().getOwnerId());
     permissionsBehavior
         .permissionsAlreadyExist(command.getValue())
         .flatMap(record -> authorizationEntityChecker.ownerAndResourceExists(command))
@@ -114,6 +124,11 @@ public class AuthorizationCreateProcessor
       final TypedRecord<AuthorizationRecord> command,
       final AuthorizationRecord authorizationRecord) {
     final long key = keyGenerator.nextKey();
+    LOG.debug(
+        "Creating authorization with key {} for owner '{}' on resource type '{}'",
+        key,
+        authorizationRecord.getOwnerId(),
+        authorizationRecord.getResourceType());
     authorizationRecord.setAuthorizationKey(key);
     stateWriter.appendFollowUpEvent(key, AuthorizationIntent.CREATED, authorizationRecord);
     responseWriter.writeEventOnCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -55,7 +55,8 @@ public class AuthorizationCreateProcessor
     rejectionWriter = writers.rejection();
     sideEffectWriter = writers.sideEffect();
     authorizationCheckBehavior = authCheckBehavior;
-    permissionsBehavior = new PermissionsBehavior(processingState, authCheckPort, claimsConverter);
+    permissionsBehavior =
+        new PermissionsBehavior(processingState, authCheckPort, claimsConverter, securityConfig);
     authorizationEntityChecker = new AuthorizationEntityValidator(processingState, securityConfig);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -26,7 +26,9 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class AuthorizationCreateProcessor
     implements DistributedTypedRecordProcessor<AuthorizationRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -11,6 +11,7 @@ import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
@@ -38,6 +39,7 @@ public class AuthorizationCreateProcessor
   private final AuthorizationCheckBehavior authorizationCheckBehavior;
   private final PermissionsBehavior permissionsBehavior;
   private final AuthorizationEntityValidator authorizationEntityChecker;
+  private final AuthorizationScopeStateAdapter authorizationScopeStateAdapter;
 
   public AuthorizationCreateProcessor(
       final Writers writers,
@@ -47,7 +49,8 @@ public class AuthorizationCreateProcessor
       final AuthorizationCheckPort authCheckPort,
       final LazyTokenClaimsConverter claimsConverter,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final EngineSecurityConfig securityConfig) {
+      final EngineSecurityConfig securityConfig,
+      final AuthorizationScopeStateAdapter authorizationScopeStateAdapter) {
     this.keyGenerator = keyGenerator;
     this.distributionBehavior = distributionBehavior;
     stateWriter = writers.state();
@@ -58,6 +61,7 @@ public class AuthorizationCreateProcessor
     permissionsBehavior =
         new PermissionsBehavior(processingState, authCheckPort, claimsConverter, securityConfig);
     authorizationEntityChecker = new AuthorizationEntityValidator(processingState, securityConfig);
+    this.authorizationScopeStateAdapter = authorizationScopeStateAdapter;
   }
 
   @Override
@@ -94,6 +98,7 @@ public class AuthorizationCreateProcessor
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationCheckBehavior.clearAuthorizationsCache();
+                    authorizationScopeStateAdapter.invalidateAll();
                     return true;
                   });
             },
@@ -118,6 +123,7 @@ public class AuthorizationCreateProcessor
     sideEffectWriter.appendSideEffect(
         () -> {
           authorizationCheckBehavior.clearAuthorizationsCache();
+          authorizationScopeStateAdapter.invalidateAll();
           return true;
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
@@ -33,8 +35,8 @@ public class AuthorizationCreateProcessor
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final SideEffectWriter sideEffectWriter;
-  private final PermissionsBehavior permissionsBehavior;
   private final AuthorizationCheckBehavior authorizationCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final AuthorizationEntityValidator authorizationEntityChecker;
 
   public AuthorizationCreateProcessor(
@@ -42,6 +44,8 @@ public class AuthorizationCreateProcessor
       final KeyGenerator keyGenerator,
       final ProcessingState processingState,
       final CommandDistributionBehavior distributionBehavior,
+      final AuthorizationCheckPort authCheckPort,
+      final LazyTokenClaimsConverter claimsConverter,
       final AuthorizationCheckBehavior authCheckBehavior,
       final EngineSecurityConfig securityConfig) {
     this.keyGenerator = keyGenerator;
@@ -51,7 +55,7 @@ public class AuthorizationCreateProcessor
     rejectionWriter = writers.rejection();
     sideEffectWriter = writers.sideEffect();
     authorizationCheckBehavior = authCheckBehavior;
-    permissionsBehavior = new PermissionsBehavior(processingState, authCheckBehavior);
+    permissionsBehavior = new PermissionsBehavior(processingState, authCheckPort, claimsConverter);
     authorizationEntityChecker = new AuthorizationEntityValidator(processingState, securityConfig);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.engine.processing.identity;
 import static io.camunda.zeebe.engine.processing.identity.PermissionsBehavior.AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_DELETION;
 
 import io.camunda.security.api.model.authz.DefaultRole;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -53,6 +55,8 @@ public class AuthorizationDeleteProcessor
       final KeyGenerator keyGenerator,
       final MutableProcessingState processingState,
       final CommandDistributionBehavior distributionBehavior,
+      final AuthorizationCheckPort authCheckPort,
+      final LazyTokenClaimsConverter claimsConverter,
       final AuthorizationCheckBehavior authCheckBehavior) {
     this.keyGenerator = keyGenerator;
     this.distributionBehavior = distributionBehavior;
@@ -61,7 +65,7 @@ public class AuthorizationDeleteProcessor
     rejectionWriter = writers.rejection();
     sideEffectWriter = writers.sideEffect();
     authorizationCheckBehavior = authCheckBehavior;
-    permissionsBehavior = new PermissionsBehavior(processingState, authCheckBehavior);
+    permissionsBehavior = new PermissionsBehavior(processingState, authCheckPort, claimsConverter);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -43,11 +43,11 @@ import org.slf4j.Logger;
 public class AuthorizationDeleteProcessor
     implements DistributedTypedRecordProcessor<AuthorizationRecord> {
 
-  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
-
   public static final String AUTHORIZATION_OWNER_PROTECTED_ERROR_MESSAGE =
       "Expected to delete authorization with key %s, but it belongs to default role '%s' "
           + "whose authorizations cannot be deleted.";
+
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final KeyGenerator keyGenerator;
   private final CommandDistributionBehavior distributionBehavior;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.identity;
 import static io.camunda.zeebe.engine.processing.identity.PermissionsBehavior.AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_DELETION;
 
 import io.camunda.security.api.model.authz.DefaultRole;
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.Rejection;
@@ -57,7 +58,8 @@ public class AuthorizationDeleteProcessor
       final CommandDistributionBehavior distributionBehavior,
       final AuthorizationCheckPort authCheckPort,
       final LazyTokenClaimsConverter claimsConverter,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final EngineSecurityConfig securityConfig) {
     this.keyGenerator = keyGenerator;
     this.distributionBehavior = distributionBehavior;
     stateWriter = writers.state();
@@ -65,7 +67,8 @@ public class AuthorizationDeleteProcessor
     rejectionWriter = writers.rejection();
     sideEffectWriter = writers.sideEffect();
     authorizationCheckBehavior = authCheckBehavior;
-    permissionsBehavior = new PermissionsBehavior(processingState, authCheckPort, claimsConverter);
+    permissionsBehavior =
+        new PermissionsBehavior(processingState, authCheckPort, claimsConverter, securityConfig);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -35,7 +35,9 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class AuthorizationDeleteProcessor
     implements DistributedTypedRecordProcessor<AuthorizationRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.security.api.model.authz.DefaultRole;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
@@ -36,10 +37,13 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
 
 @NullMarked
 public class AuthorizationDeleteProcessor
     implements DistributedTypedRecordProcessor<AuthorizationRecord> {
+
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   public static final String AUTHORIZATION_OWNER_PROTECTED_ERROR_MESSAGE =
       "Expected to delete authorization with key %s, but it belongs to default role '%s' "
@@ -79,6 +83,9 @@ public class AuthorizationDeleteProcessor
 
   @Override
   public void processNewCommand(final TypedRecord<AuthorizationRecord> command) {
+    LOG.debug(
+        "Processing DELETE authorization command for key {}",
+        command.getValue().getAuthorizationKey());
     permissionsBehavior
         .isAuthorized(command, PermissionType.DELETE)
         .flatMap(
@@ -90,6 +97,7 @@ public class AuthorizationDeleteProcessor
         .ifRightOrLeft(
             authorizationKey -> writeEventAndDistribute(command, authorizationKey),
             (rejection) -> {
+              LOG.debug("Rejecting DELETE authorization command: {}", rejection.reason());
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
               responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
             });
@@ -97,6 +105,9 @@ public class AuthorizationDeleteProcessor
 
   @Override
   public void processDistributedCommand(final TypedRecord<AuthorizationRecord> command) {
+    LOG.debug(
+        "Processing distributed DELETE authorization command for key {}",
+        command.getValue().getAuthorizationKey());
     permissionsBehavior
         .authorizationExists(
             command.getValue(), AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_DELETION)
@@ -136,6 +147,7 @@ public class AuthorizationDeleteProcessor
 
   private void writeEventAndDistribute(
       final TypedRecord<AuthorizationRecord> command, final long authorizationKey) {
+    LOG.debug("Deleting authorization with key {}", authorizationKey);
     final long key = keyGenerator.nextKey();
     command
         .getValue()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationDeleteProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
@@ -50,6 +51,7 @@ public class AuthorizationDeleteProcessor
   private final SideEffectWriter sideEffectWriter;
   private final AuthorizationCheckBehavior authorizationCheckBehavior;
   private final PermissionsBehavior permissionsBehavior;
+  private final AuthorizationScopeStateAdapter authorizationScopeStateAdapter;
 
   public AuthorizationDeleteProcessor(
       final Writers writers,
@@ -59,7 +61,8 @@ public class AuthorizationDeleteProcessor
       final AuthorizationCheckPort authCheckPort,
       final LazyTokenClaimsConverter claimsConverter,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final EngineSecurityConfig securityConfig) {
+      final EngineSecurityConfig securityConfig,
+      final AuthorizationScopeStateAdapter authorizationScopeStateAdapter) {
     this.keyGenerator = keyGenerator;
     this.distributionBehavior = distributionBehavior;
     stateWriter = writers.state();
@@ -69,6 +72,7 @@ public class AuthorizationDeleteProcessor
     authorizationCheckBehavior = authCheckBehavior;
     permissionsBehavior =
         new PermissionsBehavior(processingState, authCheckPort, claimsConverter, securityConfig);
+    this.authorizationScopeStateAdapter = authorizationScopeStateAdapter;
   }
 
   @Override
@@ -103,6 +107,7 @@ public class AuthorizationDeleteProcessor
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationCheckBehavior.clearAuthorizationsCache();
+                    authorizationScopeStateAdapter.invalidateAll();
                     return true;
                   });
             },
@@ -145,6 +150,7 @@ public class AuthorizationDeleteProcessor
     sideEffectWriter.appendSideEffect(
         () -> {
           authorizationCheckBehavior.clearAuthorizationsCache();
+          authorizationScopeStateAdapter.invalidateAll();
           return true;
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidator.java
@@ -23,8 +23,6 @@ import org.slf4j.Logger;
 
 public class AuthorizationEntityValidator {
 
-  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
-
   public static final String MAPPING_RULE_DOES_NOT_EXIST_ERROR_MESSAGE =
       "Expected to create or update authorization with ownerId or resourceId '%s', but a mapping rule with this ID does not exist.";
   public static final String ROLE_DOES_NOT_EXIST_ERROR_MESSAGE =
@@ -45,6 +43,8 @@ public class AuthorizationEntityValidator {
       "Expected to %s authorization, but resource matcher is UNSPECIFIED. Please specify a valid resource matcher (ID, ANY or PROPERTY).";
   public static final String MATCHER_NOT_SUPPORTED_ERROR_MESSAGE =
       "Expected to %s authorization, but resource matcher '%s' is not supported.";
+
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final UserState userState;
   private final MappingRuleState mappingRuleState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationEntityValidator.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.MappingRuleState;
@@ -18,8 +19,12 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
+import org.slf4j.Logger;
 
 public class AuthorizationEntityValidator {
+
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
+
   public static final String MAPPING_RULE_DOES_NOT_EXIST_ERROR_MESSAGE =
       "Expected to create or update authorization with ownerId or resourceId '%s', but a mapping rule with this ID does not exist.";
   public static final String ROLE_DOES_NOT_EXIST_ERROR_MESSAGE =
@@ -61,9 +66,15 @@ public class AuthorizationEntityValidator {
     final var record = command.getValue();
     final boolean localUserEnabled = securityConfig.getAuthentication().isCamundaUsersEnabled();
     final boolean localGroupEnabled = securityConfig.getAuthentication().isCamundaGroupsEnabled();
+    LOG.trace(
+        "Checking owner/resource existence for {} '{}' on resource type '{}'",
+        record.getOwnerType(),
+        record.getOwnerId(),
+        record.getResourceType());
     switch (record.getOwnerType()) {
       case GROUP:
         if (localGroupEnabled && groupState.get(record.getOwnerId()).isEmpty()) {
+          LOG.debug("Owner group '{}' does not exist", record.getOwnerId());
           return Either.left(
               new Rejection(
                   RejectionType.NOT_FOUND,
@@ -72,6 +83,7 @@ public class AuthorizationEntityValidator {
         break;
       case MAPPING_RULE:
         if (mappingRuleState.get(record.getOwnerId()).isEmpty()) {
+          LOG.debug("Owner mapping rule '{}' does not exist", record.getOwnerId());
           return Either.left(
               new Rejection(
                   RejectionType.NOT_FOUND,
@@ -80,6 +92,7 @@ public class AuthorizationEntityValidator {
         break;
       case ROLE:
         if (roleState.getRole(record.getOwnerId()).isEmpty()) {
+          LOG.debug("Owner role '{}' does not exist", record.getOwnerId());
           return Either.left(
               new Rejection(
                   RejectionType.NOT_FOUND,
@@ -88,6 +101,7 @@ public class AuthorizationEntityValidator {
         break;
       case USER:
         if (localUserEnabled && userState.getUser(record.getOwnerId()).isEmpty()) {
+          LOG.debug("Owner user '{}' does not exist", record.getOwnerId());
           return Either.left(
               new Rejection(
                   RejectionType.NOT_FOUND,
@@ -101,6 +115,7 @@ public class AuthorizationEntityValidator {
       switch (record.getResourceType()) {
         case GROUP:
           if (localGroupEnabled && groupState.get(record.getResourceId()).isEmpty()) {
+            LOG.debug("Resource group '{}' does not exist", record.getResourceId());
             return Either.left(
                 new Rejection(
                     RejectionType.NOT_FOUND,
@@ -109,6 +124,7 @@ public class AuthorizationEntityValidator {
           break;
         case MAPPING_RULE:
           if (mappingRuleState.get(record.getResourceId()).isEmpty()) {
+            LOG.debug("Resource mapping rule '{}' does not exist", record.getResourceId());
             return Either.left(
                 new Rejection(
                     RejectionType.NOT_FOUND,
@@ -117,6 +133,7 @@ public class AuthorizationEntityValidator {
           break;
         case ROLE:
           if (roleState.getRole(record.getResourceId()).isEmpty()) {
+            LOG.debug("Resource role '{}' does not exist", record.getResourceId());
             return Either.left(
                 new Rejection(
                     RejectionType.NOT_FOUND,
@@ -125,6 +142,7 @@ public class AuthorizationEntityValidator {
           break;
         case USER:
           if (localUserEnabled && userState.getUser(record.getResourceId()).isEmpty()) {
+            LOG.debug("Resource user '{}' does not exist", record.getResourceId());
             return Either.left(
                 new Rejection(
                     RejectionType.NOT_FOUND,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
@@ -53,7 +53,8 @@ public final class AuthorizationProcessors {
             distributionBehavior,
             authCheckPort,
             claimsConverter,
-            authCheckBehavior));
+            authCheckBehavior,
+            securityConfig));
     typedRecordProcessors.onCommand(
         ValueType.AUTHORIZATION,
         AuthorizationIntent.UPDATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
@@ -11,6 +11,7 @@ import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -30,7 +31,8 @@ public final class AuthorizationProcessors {
       final AuthorizationCheckPort authCheckPort,
       final LazyTokenClaimsConverter claimsConverter,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final EngineSecurityConfig securityConfig) {
+      final EngineSecurityConfig securityConfig,
+      final AuthorizationScopeStateAdapter authorizationScopeStateAdapter) {
     typedRecordProcessors.onCommand(
         ValueType.AUTHORIZATION,
         AuthorizationIntent.CREATE,
@@ -42,7 +44,8 @@ public final class AuthorizationProcessors {
             authCheckPort,
             claimsConverter,
             authCheckBehavior,
-            securityConfig));
+            securityConfig,
+            authorizationScopeStateAdapter));
     typedRecordProcessors.onCommand(
         ValueType.AUTHORIZATION,
         AuthorizationIntent.DELETE,
@@ -54,7 +57,8 @@ public final class AuthorizationProcessors {
             authCheckPort,
             claimsConverter,
             authCheckBehavior,
-            securityConfig));
+            securityConfig,
+            authorizationScopeStateAdapter));
     typedRecordProcessors.onCommand(
         ValueType.AUTHORIZATION,
         AuthorizationIntent.UPDATE,
@@ -66,6 +70,7 @@ public final class AuthorizationProcessors {
             authCheckPort,
             claimsConverter,
             authCheckBehavior,
-            securityConfig));
+            securityConfig,
+            authorizationScopeStateAdapter));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
@@ -25,6 +27,8 @@ public final class AuthorizationProcessors {
       final MutableProcessingState processingState,
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
+      final AuthorizationCheckPort authCheckPort,
+      final LazyTokenClaimsConverter claimsConverter,
       final AuthorizationCheckBehavior authCheckBehavior,
       final EngineSecurityConfig securityConfig) {
     typedRecordProcessors.onCommand(
@@ -35,13 +39,21 @@ public final class AuthorizationProcessors {
             keyGenerator,
             processingState,
             distributionBehavior,
+            authCheckPort,
+            claimsConverter,
             authCheckBehavior,
             securityConfig));
     typedRecordProcessors.onCommand(
         ValueType.AUTHORIZATION,
         AuthorizationIntent.DELETE,
         new AuthorizationDeleteProcessor(
-            writers, keyGenerator, processingState, distributionBehavior, authCheckBehavior));
+            writers,
+            keyGenerator,
+            processingState,
+            distributionBehavior,
+            authCheckPort,
+            claimsConverter,
+            authCheckBehavior));
     typedRecordProcessors.onCommand(
         ValueType.AUTHORIZATION,
         AuthorizationIntent.UPDATE,
@@ -50,6 +62,8 @@ public final class AuthorizationProcessors {
             keyGenerator,
             processingState,
             distributionBehavior,
+            authCheckPort,
+            claimsConverter,
             authCheckBehavior,
             securityConfig));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapper.java
@@ -26,10 +26,13 @@ public final class AuthorizationRejectionMapper {
     return switch (rejection) {
       case AuthorizationRejection.Tenant t ->
           new Rejection(RejectionType.FORBIDDEN, TENANT_MSG.formatted(t.tenantId()));
-      case AuthorizationRejection.Permission p ->
-          new Rejection(
-              RejectionType.FORBIDDEN,
-              FORBIDDEN_MSG.formatted(p.permissionType(), p.resourceType()));
+      case AuthorizationRejection.Permission p -> forbidden(p.permissionType(), p.resourceType());
     };
+  }
+
+  /** Builds a FORBIDDEN rejection with the standard insufficient-permissions message. */
+  static Rejection forbidden(final Object permissionType, final Object resourceType) {
+    return new Rejection(
+        RejectionType.FORBIDDEN, FORBIDDEN_MSG.formatted(permissionType, resourceType));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapper.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.engine.processing.identity;
 import io.camunda.security.api.model.authz.AuthorizationRejection;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public final class AuthorizationRejectionMapper {
 
   private static final String FORBIDDEN_MSG =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapper.java
@@ -14,8 +14,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 public final class AuthorizationRejectionMapper {
 
   private static final String FORBIDDEN_MSG =
-      "Expected to have '%s' permission on resource type '%s' with id '%s', "
-          + "but the principal is not authorized.";
+      "Insufficient permissions to perform operation '%s' on resource '%s'";
   private static final String TENANT_MSG =
       "Expected to access tenant '%s', but the principal is not authorized.";
 
@@ -28,7 +27,7 @@ public final class AuthorizationRejectionMapper {
       case AuthorizationRejection.Permission p ->
           new Rejection(
               RejectionType.FORBIDDEN,
-              FORBIDDEN_MSG.formatted(p.permissionType(), p.resourceType(), p.resourceId()));
+              FORBIDDEN_MSG.formatted(p.permissionType(), p.resourceType()));
     };
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity;
+
+import io.camunda.security.api.model.authz.AuthorizationRejection;
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.protocol.record.RejectionType;
+
+public final class AuthorizationRejectionMapper {
+
+  private static final String FORBIDDEN_MSG =
+      "Expected to have '%s' permission on resource type '%s' with id '%s', "
+          + "but the principal is not authorized.";
+  private static final String TENANT_MSG =
+      "Expected to access tenant '%s', but the principal is not authorized.";
+
+  private AuthorizationRejectionMapper() {}
+
+  public static Rejection toRejection(final AuthorizationRejection rejection) {
+    return switch (rejection) {
+      case AuthorizationRejection.Tenant t ->
+          new Rejection(RejectionType.FORBIDDEN, TENANT_MSG.formatted(t.tenantId()));
+      case AuthorizationRejection.Permission p ->
+          new Rejection(
+              RejectionType.FORBIDDEN,
+              FORBIDDEN_MSG.formatted(p.permissionType(), p.resourceType(), p.resourceId()));
+    };
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.engine.processing.identity.PermissionsBehavior.AU
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
@@ -28,10 +29,13 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
 
 @NullMarked
 public class AuthorizationUpdateProcessor
     implements DistributedTypedRecordProcessor<AuthorizationRecord> {
+
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final KeyGenerator keyGenerator;
   private final CommandDistributionBehavior distributionBehavior;
@@ -69,6 +73,9 @@ public class AuthorizationUpdateProcessor
 
   @Override
   public void processNewCommand(final TypedRecord<AuthorizationRecord> command) {
+    LOG.debug(
+        "Processing UPDATE authorization command for key {}",
+        command.getValue().getAuthorizationKey());
     permissionsBehavior
         .isAuthorized(command)
         .flatMap(
@@ -87,6 +94,7 @@ public class AuthorizationUpdateProcessor
         .ifRightOrLeft(
             authorizationRecord -> writeEventAndDistribute(command, authorizationRecord),
             (rejection) -> {
+              LOG.debug("Rejecting UPDATE authorization command: {}", rejection.reason());
               rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
               responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
             });
@@ -94,6 +102,9 @@ public class AuthorizationUpdateProcessor
 
   @Override
   public void processDistributedCommand(final TypedRecord<AuthorizationRecord> command) {
+    LOG.debug(
+        "Processing distributed UPDATE authorization command for key {}",
+        command.getValue().getAuthorizationKey());
     permissionsBehavior
         .authorizationExists(command.getValue(), AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_UPDATE)
         .flatMap(s -> authorizationEntityChecker.ownerAndResourceExists(command))
@@ -119,6 +130,7 @@ public class AuthorizationUpdateProcessor
   private void writeEventAndDistribute(
       final TypedRecord<AuthorizationRecord> command,
       final AuthorizationRecord authorizationRecord) {
+    LOG.debug("Updating authorization with key {}", authorizationRecord.getAuthorizationKey());
     final long key = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(
         authorizationRecord.getAuthorizationKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -27,7 +27,9 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class AuthorizationUpdateProcessor
     implements DistributedTypedRecordProcessor<AuthorizationRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -136,6 +136,7 @@ public class AuthorizationUpdateProcessor
     sideEffectWriter.appendSideEffect(
         () -> {
           authorizationCheckBehavior.clearAuthorizationsCache();
+          authorizationScopeStateAdapter.invalidateAll();
           return true;
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -56,7 +56,8 @@ public class AuthorizationUpdateProcessor
     rejectionWriter = writers.rejection();
     sideEffectWriter = writers.sideEffect();
     authorizationCheckBehavior = authCheckBehavior;
-    permissionsBehavior = new PermissionsBehavior(processingState, authCheckPort, claimsConverter);
+    permissionsBehavior =
+        new PermissionsBehavior(processingState, authCheckPort, claimsConverter, securityConfig);
     authorizationEntityChecker = new AuthorizationEntityValidator(processingState, securityConfig);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
@@ -39,6 +40,7 @@ public class AuthorizationUpdateProcessor
   private final AuthorizationCheckBehavior authorizationCheckBehavior;
   private final PermissionsBehavior permissionsBehavior;
   private final AuthorizationEntityValidator authorizationEntityChecker;
+  private final AuthorizationScopeStateAdapter authorizationScopeStateAdapter;
 
   public AuthorizationUpdateProcessor(
       final Writers writers,
@@ -48,7 +50,8 @@ public class AuthorizationUpdateProcessor
       final AuthorizationCheckPort authCheckPort,
       final LazyTokenClaimsConverter claimsConverter,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final EngineSecurityConfig securityConfig) {
+      final EngineSecurityConfig securityConfig,
+      final AuthorizationScopeStateAdapter authorizationScopeStateAdapter) {
     this.keyGenerator = keyGenerator;
     this.distributionBehavior = distributionBehavior;
     stateWriter = writers.state();
@@ -59,6 +62,7 @@ public class AuthorizationUpdateProcessor
     permissionsBehavior =
         new PermissionsBehavior(processingState, authCheckPort, claimsConverter, securityConfig);
     authorizationEntityChecker = new AuthorizationEntityValidator(processingState, securityConfig);
+    this.authorizationScopeStateAdapter = authorizationScopeStateAdapter;
   }
 
   @Override
@@ -100,6 +104,7 @@ public class AuthorizationUpdateProcessor
               sideEffectWriter.appendSideEffect(
                   () -> {
                     authorizationCheckBehavior.clearAuthorizationsCache();
+                    authorizationScopeStateAdapter.invalidateAll();
                     return true;
                   });
             },

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.engine.processing.identity;
 import static io.camunda.zeebe.engine.processing.identity.PermissionsBehavior.AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_UPDATE;
 
 import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
@@ -43,6 +45,8 @@ public class AuthorizationUpdateProcessor
       final KeyGenerator keyGenerator,
       final ProcessingState processingState,
       final CommandDistributionBehavior distributionBehavior,
+      final AuthorizationCheckPort authCheckPort,
+      final LazyTokenClaimsConverter claimsConverter,
       final AuthorizationCheckBehavior authCheckBehavior,
       final EngineSecurityConfig securityConfig) {
     this.keyGenerator = keyGenerator;
@@ -52,7 +56,7 @@ public class AuthorizationUpdateProcessor
     rejectionWriter = writers.rejection();
     sideEffectWriter = writers.sideEffect();
     authorizationCheckBehavior = authCheckBehavior;
-    permissionsBehavior = new PermissionsBehavior(processingState, authCheckBehavior);
+    permissionsBehavior = new PermissionsBehavior(processingState, authCheckPort, claimsConverter);
     authorizationEntityChecker = new AuthorizationEntityValidator(processingState, securityConfig);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationScope;
@@ -105,8 +106,7 @@ public class PermissionsBehavior {
         permissionType,
         command.getIntent());
     final var auth = claimsConverter.convert(authorizations);
-    final var cslPermType =
-        io.camunda.security.api.model.authz.PermissionType.valueOf(permissionType.name());
+    final var cslPermType = AuthzModelMapper.fromProtocol(permissionType);
     final var result =
         authCheckPort.check(
             auth,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -33,8 +33,6 @@ import org.slf4j.Logger;
 @NullMarked
 public class PermissionsBehavior {
 
-  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
-
   public static final String PERMISSIONS_FOR_RESOURCE_IDENTIFIER_ALREADY_EXISTS_MESSAGE =
       "Expected to create authorization for owner '%s' for resource identifier '%s', but an authorization for this resource identifier already exists.";
   public static final String PERMISSIONS_FOR_RESOURCE_PROPERTY_NAME_ALREADY_EXISTS_MESSAGE =
@@ -43,6 +41,8 @@ public class PermissionsBehavior {
       "Expected to update authorization with key %s, but an authorization with this key does not exist";
   public static final String AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_DELETION =
       "Expected to delete authorization with key %s, but an authorization with this key does not exist";
+
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final AuthorizationState authorizationState;
   private final AuthorizationCheckPort authCheckPort;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -107,11 +107,13 @@ public class PermissionsBehavior {
         command.getIntent());
     final var auth = claimsConverter.convert(authorizations);
     final var cslPermType = AuthzModelMapper.fromProtocol(permissionType);
-    final var result =
         authCheckPort.check(
             auth,
             RequiredAuthorization.of(
-                b -> b.authorization().permissionType(cslPermType).resourceId("*")));
+                b ->
+                    b.authorization()
+                        .permissionType(cslPermType)
+                        .resourceId(AuthorizationScope.WILDCARD_CHAR)));
     if (result.isLeft()) {
       LOG.debug(
           "Authorization check rejected for command {}: {}",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -12,6 +12,7 @@ import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
@@ -26,9 +27,12 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.Set;
 import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
 
 @NullMarked
 public class PermissionsBehavior {
+
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   public static final String PERMISSIONS_FOR_RESOURCE_IDENTIFIER_ALREADY_EXISTS_MESSAGE =
       "Expected to create authorization for owner '%s' for resource identifier '%s', but an authorization for this resource identifier already exists.";
@@ -63,16 +67,28 @@ public class PermissionsBehavior {
   public Either<Rejection, AuthorizationRecord> isAuthorized(
       final TypedRecord<AuthorizationRecord> command, final PermissionType permissionType) {
     if (command.isInternalCommand()) {
+      LOG.trace("Skipping authorization check for internal command {}", command.getIntent());
       return Either.right(command.getValue());
     }
     final var authorizations = command.getAuthorizations();
     if (Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
+      LOG.trace(
+          "Skipping authorization check for anonymous user on command {}", command.getIntent());
       return Either.right(command.getValue());
     }
     if (!securityConfig.isAuthorizationsEnabled()
         && !securityConfig.isMultiTenancyChecksEnabled()) {
+      LOG.trace(
+          "Skipping authorization check for command {}: security disabled (authz={}, multiTenancy={})",
+          command.getIntent(),
+          securityConfig.isAuthorizationsEnabled(),
+          securityConfig.isMultiTenancyChecksEnabled());
       return Either.right(command.getValue());
     }
+    LOG.trace(
+        "Checking {} permission on AUTHORIZATION resource for command {}",
+        permissionType,
+        command.getIntent());
     final var auth = claimsConverter.convert(authorizations);
     final var cslPermType =
         io.camunda.security.api.model.authz.PermissionType.valueOf(permissionType.name());
@@ -82,6 +98,10 @@ public class PermissionsBehavior {
             RequiredAuthorization.of(
                 b -> b.authorization().permissionType(cslPermType).resourceId("*")));
     if (result.isLeft()) {
+      LOG.debug(
+          "Authorization check rejected for command {}: {}",
+          command.getIntent(),
+          result.leftValue());
       return Either.left(AuthorizationRejectionMapper.toRejection(result.leftValue()));
     }
     return Either.right(command.getValue());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.in.AuthorizationCheckPort;
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.processing.Rejection;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -35,12 +37,16 @@ public class PermissionsBehavior {
       "Expected to delete authorization with key %s, but an authorization with this key does not exist";
 
   private final AuthorizationState authorizationState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final AuthorizationCheckPort authCheckPort;
+  private final LazyTokenClaimsConverter claimsConverter;
 
   public PermissionsBehavior(
-      final ProcessingState processingState, final AuthorizationCheckBehavior authCheckBehavior) {
+      final ProcessingState processingState,
+      final AuthorizationCheckPort authCheckPort,
+      final LazyTokenClaimsConverter claimsConverter) {
     authorizationState = processingState.getAuthorizationState();
-    this.authCheckBehavior = authCheckBehavior;
+    this.authCheckPort = authCheckPort;
+    this.claimsConverter = claimsConverter;
   }
 
   public Either<Rejection, AuthorizationRecord> isAuthorized(
@@ -50,15 +56,25 @@ public class PermissionsBehavior {
 
   public Either<Rejection, AuthorizationRecord> isAuthorized(
       final TypedRecord<AuthorizationRecord> command, final PermissionType permissionType) {
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.AUTHORIZATION)
-            .permissionType(permissionType)
-            .build();
-    return authCheckBehavior
-        .isAuthorizedOrInternalCommand(authorizationRequest)
-        .map(unused -> command.getValue());
+    if (command.isInternalCommand()) {
+      return Either.right(command.getValue());
+    }
+    final var authorizations = command.getAuthorizations();
+    if (Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
+      return Either.right(command.getValue());
+    }
+    final var auth = claimsConverter.convert(authorizations);
+    final var cslPermType =
+        io.camunda.security.api.model.authz.PermissionType.valueOf(permissionType.name());
+    final var result =
+        authCheckPort.check(
+            auth,
+            RequiredAuthorization.of(
+                b -> b.authorization().permissionType(cslPermType).resourceId("*")));
+    if (result.isLeft()) {
+      return Either.left(AuthorizationRejectionMapper.toRejection(result.leftValue()));
+    }
+    return Either.right(command.getValue());
   }
 
   public Either<Rejection, PersistedAuthorization> authorizationExists(
@@ -78,7 +94,7 @@ public class PermissionsBehavior {
     for (final PermissionType permission : record.getPermissionTypes()) {
       final var addedAuthorizationScope = createAuthorizationScope(record);
       final var currentAuthorizationScopes =
-          authCheckBehavior.getDirectAuthorizedAuthorizationScopes(
+          authorizationState.getAuthorizationScopes(
               record.getOwnerType(), record.getOwnerId(), record.getResourceType(), permission);
 
       if (currentAuthorizationScopes.contains(addedAuthorizationScope)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -85,6 +85,21 @@ public class PermissionsBehavior {
           securityConfig.isMultiTenancyChecksEnabled());
       return Either.right(command.getValue());
     }
+    if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
+        && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
+      // No principal identity present: the CSL claims converter would throw. Mirror main's
+      // non-throwing contract — authorize when authorization checks are disabled (authorization
+      // commands are not tenant-owned, so the multi-tenancy check is a no-op), otherwise reject.
+      if (!securityConfig.isAuthorizationsEnabled()) {
+        return Either.right(command.getValue());
+      }
+      LOG.debug(
+          "Rejecting command {}: neither username nor clientId claim is present",
+          command.getIntent());
+      return Either.left(
+          AuthorizationRejectionMapper.forbidden(
+              permissionType, AuthorizationResourceType.AUTHORIZATION));
+    }
     LOG.trace(
         "Checking {} permission on AUTHORIZATION resource for command {}",
         permissionType,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
+import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.AuthorizationCheckPort;
@@ -39,14 +40,17 @@ public class PermissionsBehavior {
   private final AuthorizationState authorizationState;
   private final AuthorizationCheckPort authCheckPort;
   private final LazyTokenClaimsConverter claimsConverter;
+  private final EngineSecurityConfig securityConfig;
 
   public PermissionsBehavior(
       final ProcessingState processingState,
       final AuthorizationCheckPort authCheckPort,
-      final LazyTokenClaimsConverter claimsConverter) {
+      final LazyTokenClaimsConverter claimsConverter,
+      final EngineSecurityConfig securityConfig) {
     authorizationState = processingState.getAuthorizationState();
     this.authCheckPort = authCheckPort;
     this.claimsConverter = claimsConverter;
+    this.securityConfig = securityConfig;
   }
 
   public Either<Rejection, AuthorizationRecord> isAuthorized(
@@ -61,6 +65,10 @@ public class PermissionsBehavior {
     }
     final var authorizations = command.getAuthorizations();
     if (Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
+      return Either.right(command.getValue());
+    }
+    if (!securityConfig.isAuthorizationsEnabled()
+        && !securityConfig.isMultiTenancyChecksEnabled()) {
       return Either.right(command.getValue());
     }
     final var auth = claimsConverter.convert(authorizations);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -25,7 +25,9 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.Set;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class PermissionsBehavior {
 
   public static final String PERMISSIONS_FOR_RESOURCE_IDENTIFIER_ALREADY_EXISTS_MESSAGE =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -107,6 +107,7 @@ public class PermissionsBehavior {
         command.getIntent());
     final var auth = claimsConverter.convert(authorizations);
     final var cslPermType = AuthzModelMapper.fromProtocol(permissionType);
+    final var result =
         authCheckPort.check(
             auth,
             RequiredAuthorization.of(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 @NullMarked
 public final class AuthorizationScopeStateAdapter implements AuthorizationScopeRepositoryPort {
 
-  private static final Logger LOG = Loggers.ENGINE_PROCESSING_LOGGER;
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final AuthorizationState authorizationState;
   private final LoadingCache<

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/AuthorizationScopeStateAdapter.java
@@ -49,6 +49,11 @@ public final class AuthorizationScopeStateAdapter implements AuthorizationScopeR
             .build(new ScopeCacheLoader(authorizationState));
   }
 
+  /** Invalidates all cached authorization scopes, forcing fresh loads on next access. */
+  public void invalidateAll() {
+    scopeCache.invalidateAll();
+  }
+
   /** Returns all authorized scopes for the given owners, resource type, and permission type. */
   @Override
   public List<AuthorizationScope> findAuthorizedScopes(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -31,7 +31,7 @@ import org.slf4j.Logger;
 @NullMarked
 public final class MembershipStateAdapter implements MembershipPort {
 
-  private static final Logger LOG = Loggers.ENGINE_PROCESSING_LOGGER;
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
 
   private final MappingRuleState mappingRuleState;
   private final MembershipState membershipState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapter.java
@@ -72,6 +72,9 @@ public final class MembershipStateAdapter implements MembershipPort {
     final var rawGroups = query.tokenClaims().get(Authorization.USER_GROUPS_CLAIMS);
     final var result = new LinkedHashSet<String>();
     if (rawGroups instanceof List<?> groupsClaims) {
+      // OIDC mode: groups come solely from the token claim. This matches main's
+      // ClaimsExtractor.getGroups, which ignores mapping-rule group memberships when a groups claim
+      // is present.
       groupsClaims.stream()
           .filter(String.class::isInstance)
           .map(String.class::cast)
@@ -79,13 +82,13 @@ public final class MembershipStateAdapter implements MembershipPort {
     } else {
       getMemberships(toEntityType(query.principalType()), query.principalId(), RelationType.GROUP)
           .forEach(result::add);
+      query
+          .resolvedMappingRuleIds()
+          .forEach(
+              ruleId ->
+                  getMemberships(EntityType.MAPPING_RULE, ruleId, RelationType.GROUP)
+                      .forEach(result::add));
     }
-    query
-        .resolvedMappingRuleIds()
-        .forEach(
-            ruleId ->
-                getMemberships(EntityType.MAPPING_RULE, ruleId, RelationType.GROUP)
-                    .forEach(result::add));
     return new ArrayList<>(result);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
@@ -127,7 +127,7 @@ public class AuthorizationCreateAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Expected to have 'CREATE' permission on resource type 'AUTHORIZATION' with id '*', but the principal is not authorized.");
+            "Insufficient permissions to perform operation 'CREATE' on resource 'AUTHORIZATION'");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
@@ -134,19 +134,17 @@ public class AuthorizationCreateAuthorizationTest {
   public void shouldReflectNewlyGrantedAuthorizationImmediately() {
     // given
     final var user = createUser();
-    final var targetOwnerId = UUID.randomUUID().toString();
+    final var targetUser = createUser();
 
     // prime the scope cache: user has no AUTHORIZATION:CREATE permission yet → rejected
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerId(targetOwnerId)
+        .withOwnerId(targetUser.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.RESOURCE)
-        .withResourceMatcher(
-            io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD.getMatcher())
-        .withResourceId(
-            io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD.getResourceId())
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .withPermissions(PermissionType.CREATE)
         .expectRejection()
         .create(user.getUsername());
@@ -158,19 +156,17 @@ public class AuthorizationCreateAuthorizationTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerId(targetOwnerId)
+        .withOwnerId(targetUser.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.RESOURCE)
-        .withResourceMatcher(
-            io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD.getMatcher())
-        .withResourceId(
-            io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD.getResourceId())
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
         .withPermissions(PermissionType.CREATE)
         .create(user.getUsername());
 
     assertThat(
             RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
-                .withOwnerId(targetOwnerId)
+                .withOwnerId(targetUser.getUsername())
                 .exists())
         .isTrue();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
@@ -130,6 +130,51 @@ public class AuthorizationCreateAuthorizationTest {
             "Expected to have 'CREATE' permission on resource type 'AUTHORIZATION' with id '*', but the principal is not authorized.");
   }
 
+  @Test
+  public void shouldReflectNewlyGrantedAuthorizationImmediately() {
+    // given
+    final var user = createUser();
+    final var targetOwnerId = UUID.randomUUID().toString();
+
+    // prime the scope cache: user has no AUTHORIZATION:CREATE permission yet → rejected
+    engine
+        .authorization()
+        .newAuthorization()
+        .withOwnerId(targetOwnerId)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
+        .withResourceMatcher(
+            io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD.getMatcher())
+        .withResourceId(
+            io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD.getResourceId())
+        .withPermissions(PermissionType.CREATE)
+        .expectRejection()
+        .create(user.getUsername());
+
+    // when — grant the user AUTHORIZATION:CREATE permission (invalidates scope cache)
+    addAuthorizationToUser(user, AuthorizationResourceType.AUTHORIZATION, PermissionType.CREATE);
+
+    // then — user can now create immediately (cache was invalidated, not serving stale empty set)
+    engine
+        .authorization()
+        .newAuthorization()
+        .withOwnerId(targetOwnerId)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
+        .withResourceMatcher(
+            io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD.getMatcher())
+        .withResourceId(
+            io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD.getResourceId())
+        .withPermissions(PermissionType.CREATE)
+        .create(user.getUsername());
+
+    assertThat(
+            RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
+                .withOwnerId(targetOwnerId)
+                .exists())
+        .isTrue();
+  }
+
   private UserRecordValue createUser() {
     return engine
         .user()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
@@ -127,7 +127,7 @@ public class AuthorizationCreateAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'CREATE' on resource 'AUTHORIZATION'");
+            "Expected to have 'CREATE' permission on resource type 'AUTHORIZATION' with id '*', but the principal is not authorized.");
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
@@ -117,6 +117,48 @@ public class AuthorizationDeleteAuthorizationTest {
             "Insufficient permissions to perform operation 'DELETE' on resource 'AUTHORIZATION'");
   }
 
+  @Test
+  public void shouldReflectRevokedAuthorizationImmediately() {
+    // given — user has AUTHORIZATION:CREATE; prime the scope cache with an ALLOW
+    final var user = createUser();
+    final var targetUser = createUser();
+    final var grantKey =
+        addAuthorizationToUser(
+            user, AuthorizationResourceType.AUTHORIZATION, PermissionType.CREATE, "*");
+    engine
+        .authorization()
+        .newAuthorization()
+        .withOwnerId(targetUser.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ANY)
+        .withResourceId("*")
+        .withPermissions(PermissionType.CREATE)
+        .create(user.getUsername());
+
+    // when — revoke the CREATE grant; scope cache must be invalidated immediately
+    engine.authorization().deleteAuthorization(grantKey).delete(DEFAULT_USER.getUsername());
+
+    // then — user can no longer create an authorization; revocation is not deferred to TTL expiry
+    final var rejection =
+        engine
+            .authorization()
+            .newAuthorization()
+            .withOwnerId(targetUser.getUsername())
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
+            .withResourceMatcher(AuthorizationResourceMatcher.ANY)
+            .withResourceId("*")
+            .withPermissions(PermissionType.DELETE)
+            .expectRejection()
+            .create(user.getUsername());
+
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'CREATE' on resource 'AUTHORIZATION'");
+  }
+
   private UserRecordValue createUser() {
     return engine
         .user()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
@@ -114,7 +114,7 @@ public class AuthorizationDeleteAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Expected to have 'DELETE' permission on resource type 'AUTHORIZATION' with id '*', but the principal is not authorized.");
+            "Insufficient permissions to perform operation 'DELETE' on resource 'AUTHORIZATION'");
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
@@ -114,7 +114,7 @@ public class AuthorizationDeleteAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'DELETE' on resource 'AUTHORIZATION'");
+            "Expected to have 'DELETE' permission on resource type 'AUTHORIZATION' with id '*', but the principal is not authorized.");
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationSecurityDisabledTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationSecurityDisabledTest.java
@@ -18,26 +18,33 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 
 public class AuthorizationSecurityDisabledTest {
 
+  private static final String OWNER_ID = UUID.randomUUID().toString();
+
   @Rule public final EngineRule engine = EngineRule.singlePartition();
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
+  @Before
+  public void setup() {
+    engine.user().newUser(OWNER_ID).create();
+  }
+
   @Test
   public void shouldAuthorizeAuthorizationCommandWhenAuthorizationsAndMultiTenancyDisabled() {
     // given — engine with both authorization and multi-tenancy checks disabled (default)
-    final var ownerId = UUID.randomUUID().toString();
 
     // when — command sent without any principal claims (no username, no client id)
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerId(ownerId)
+        .withOwnerId(OWNER_ID)
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(AuthorizationResourceType.RESOURCE)
         .withResourceMatcher(WILDCARD.getMatcher())
@@ -48,7 +55,7 @@ public class AuthorizationSecurityDisabledTest {
     // then — command is accepted, not rejected or errored
     assertThat(
             RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
-                .withOwnerId(ownerId)
+                .withOwnerId(OWNER_ID)
                 .exists())
         .isTrue();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationSecurityDisabledTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationSecurityDisabledTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class AuthorizationSecurityDisabledTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldAuthorizeAuthorizationCommandWhenAuthorizationsAndMultiTenancyDisabled() {
+    // given — engine with both authorization and multi-tenancy checks disabled (default)
+    final var ownerId = UUID.randomUUID().toString();
+
+    // when — command sent without any principal claims (no username, no client id)
+    engine
+        .authorization()
+        .newAuthorization()
+        .withOwnerId(ownerId)
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
+        .withResourceMatcher(WILDCARD.getMatcher())
+        .withResourceId(WILDCARD.getResourceId())
+        .withPermissions(PermissionType.CREATE)
+        .create();
+
+    // then — command is accepted, not rejected or errored
+    assertThat(
+            RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
+                .withOwnerId(ownerId)
+                .exists())
+        .isTrue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
@@ -158,7 +158,7 @@ public class AuthorizationUpdateAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Expected to have 'UPDATE' permission on resource type 'AUTHORIZATION' with id '*', but the principal is not authorized.");
+            "Insufficient permissions to perform operation 'UPDATE' on resource 'AUTHORIZATION'");
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
@@ -158,7 +158,7 @@ public class AuthorizationUpdateAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'UPDATE' on resource 'AUTHORIZATION'");
+            "Expected to have 'UPDATE' permission on resource type 'AUTHORIZATION' with id '*', but the principal is not authorized.");
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapperTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapperTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.authz.AuthorizationRejection;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
+import io.camunda.security.api.model.authz.PermissionType;
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import org.junit.jupiter.api.Test;
+
+class AuthorizationRejectionMapperTest {
+
+  @Test
+  void shouldMapTenantRejectionToForbidden() {
+    // given
+    final var rejection = new AuthorizationRejection.Tenant("my-tenant");
+    // when
+    final Rejection result = AuthorizationRejectionMapper.toRejection(rejection);
+    // then
+    assertThat(result.type()).isEqualTo(RejectionType.FORBIDDEN);
+    assertThat(result.reason()).contains("my-tenant");
+  }
+
+  @Test
+  void shouldMapPermissionRejectionToForbidden() {
+    // given
+    final var rejection =
+        new AuthorizationRejection.Permission(
+            AuthorizationResourceType.AUTHORIZATION, PermissionType.CREATE, "resource-1");
+    // when
+    final Rejection result = AuthorizationRejectionMapper.toRejection(rejection);
+    // then
+    assertThat(result.type()).isEqualTo(RejectionType.FORBIDDEN);
+    assertThat(result.reason()).contains("AUTHORIZATION").contains("CREATE").contains("resource-1");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapperTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRejectionMapperTest.java
@@ -39,6 +39,6 @@ class AuthorizationRejectionMapperTest {
     final Rejection result = AuthorizationRejectionMapper.toRejection(rejection);
     // then
     assertThat(result.type()).isEqualTo(RejectionType.FORBIDDEN);
-    assertThat(result.reason()).contains("AUTHORIZATION").contains("CREATE").contains("resource-1");
+    assertThat(result.reason()).contains("AUTHORIZATION").contains("CREATE");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehaviorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.configuration.EngineSecurityConfigurations;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.in.AuthorizationCheckPort;
+import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class PermissionsBehaviorTest {
+
+  @Mock private ProcessingState processingState;
+  @Mock private AuthorizationState authorizationState;
+  @Mock private AuthorizationCheckPort authCheckPort;
+  @Mock private LazyTokenClaimsConverter claimsConverter;
+  @Mock private AuthenticationConfiguration authConfig;
+  @Mock private TypedRecord<AuthorizationRecord> command;
+
+  @BeforeEach
+  void setUp() {
+    when(processingState.getAuthorizationState()).thenReturn(authorizationState);
+  }
+
+  @Test
+  void shouldRejectWithForbiddenWhenNoIdentityClaimsAndAuthorizationsEnabled() {
+    // given — authorizations enabled and a command carrying neither a username nor a clientId claim
+    final var behavior = permissionsBehavior(/* authorizationsEnabled= */ true, false);
+    when(command.isInternalCommand()).thenReturn(false);
+    when(command.getAuthorizations()).thenReturn(Map.of());
+
+    // when
+    final var result = behavior.isAuthorized(command, PermissionType.CREATE);
+
+    // then — a clean FORBIDDEN rejection (matching main) instead of a thrown exception, and the CSL
+    // path is never invoked
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft().type()).isEqualTo(RejectionType.FORBIDDEN);
+    assertThat(result.getLeft().reason())
+        .isEqualTo(
+            "Insufficient permissions to perform operation 'CREATE' on resource 'AUTHORIZATION'");
+    verifyNoInteractions(claimsConverter, authCheckPort);
+  }
+
+  @Test
+  void shouldAuthorizeWhenNoIdentityClaimsAndAuthorizationsDisabled() {
+    // given — authorizations disabled (multi-tenancy enabled) and no username/clientId claim
+    final var behavior = permissionsBehavior(/* authorizationsEnabled= */ false, true);
+    final var record = new AuthorizationRecord();
+    when(command.isInternalCommand()).thenReturn(false);
+    when(command.getAuthorizations()).thenReturn(Map.of());
+    when(command.getValue()).thenReturn(record);
+
+    // when
+    final var result = behavior.isAuthorized(command, PermissionType.CREATE);
+
+    // then — authorized like main when authorizations are disabled, and the CSL path is never
+    // invoked
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.get()).isSameAs(record);
+    verifyNoInteractions(claimsConverter, authCheckPort);
+  }
+
+  private PermissionsBehavior permissionsBehavior(
+      final boolean authorizationsEnabled, final boolean multiTenancyChecksEnabled) {
+    final var securityConfig =
+        new EngineSecurityConfig(
+            authConfig,
+            authorizationsEnabled,
+            multiTenancyChecksEnabled,
+            new InitializationConfiguration(),
+            EngineSecurityConfigurations.ID_VALIDATION_PATTERN,
+            EngineSecurityConfigurations.GROUP_ID_VALIDATION_PATTERN);
+    return new PermissionsBehavior(processingState, authCheckPort, claimsConverter, securityConfig);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/identity/adapter/MembershipStateAdapterTest.java
@@ -159,6 +159,26 @@ final class MembershipStateAdapterTest {
   }
 
   @Test
+  void shouldNotAddMappingRuleGroupsWhenGroupsClaimIsPresent() {
+    // given — OIDC mode: groups are supplied via the token claim, and a matched mapping rule is
+    // also a member of a group. The mapping-rule group must NOT widen the principal's groups. This
+    // matches main's ClaimsExtractor.getGroups, which ignores mapping-rule group memberships when a
+    // groups claim is present.
+    final var mappingRuleId = UUID.randomUUID().toString();
+    createGroupAndAssignEntity(mappingRuleId, EntityType.MAPPING_RULE);
+    final var query =
+        new MembershipQuery(
+                Map.of(USER_GROUPS_CLAIMS, List.of("claim-group")), "userId", PrincipalType.USER)
+            .withMappingRuleIds(List.of(mappingRuleId));
+
+    // when
+    final var result = adapter.groupIds(query);
+
+    // then
+    assertThat(result).containsExactly("claim-group");
+  }
+
+  @Test
   void shouldReturnRoleIdsForPrincipalAndGroups() {
     // given
     final var userId = Strings.newRandomValidIdentityId();


### PR DESCRIPTION
## Background

This is increment **4a** of the engine-side migration to the **Camunda Security Library (CSL)** —
the shared, cluster-wide authorization component intended to become the single source of truth for
permission checks. Today the Zeebe engine authorizes commands with its own `AuthorizationCheckBehavior`;
the migration (increments 4a–4f) replaces that with calls into CSL.

CSL follows a hexagonal (ports & adapters) design: it owns the authorization model and check logic and
defines **ports** (interfaces) that the host implements. The engine supplies **adapters** over its
RocksDB state:
- `AuthorizationScopeStateAdapter` implements CSL's `AuthorizationScopeRepositoryPort` — reads
  authorization scopes from `AuthorizationState`.
- `MembershipStateAdapter` implements CSL's `MembershipPort` — resolves group/role/tenant/mapping-rule
  memberships from engine state and token claims.

Both adapters cache lookups with a Guava `LoadingCache` (TTL + capacity from `EngineConfiguration`).

4a wires the CSL authorization service into the engine and migrates the **first domain — Authorization
commands** (create/update/delete of authorization records) as a vertical slice. Remaining domains
follow in later increments.

## Authorization flow after this change

    command
      → PermissionsBehavior.isAuthorized(...)
         → LazyTokenClaimsConverter          (command auth claims → CSL principal; uses MembershipPort)
         → AuthorizationCheckPort.check(...)  (CSL AuthorizationService)
            → AuthorizationChecker → AuthorizationScopeRepositoryPort (reads AuthorizationState)
         → Either<AuthorizationRejection, allowed>
         → AuthorizationRejectionMapper       (CSL rejection → engine Rejection)

Enum values cross the engine↔CSL boundary via `AuthzModelMapper` (protocol ⇄ CSL).

## Changes

**Engine wiring**
- `EngineProcessors` builds the CSL `AuthorizationService`, `AuthorizationChecker`,
  `LazyTokenClaimsConverter`, `PropertyAuthorizationEvaluatorRegistry`, and the two state adapters,
  grouped into a new private `addIdentityProcessors(...)` method.
- `UserTaskPropertyAuthorizationEvaluator` is instantiated but **not yet registered** with the
  `PropertyAuthorizationEvaluatorRegistry`. UserTask commands move onto the CSL path only in
  increment 4d (camunda/camunda-security-library#402); registering it now would leave it unused and
  untested end-to-end.

**Adapters**
- `AuthorizationScopeStateAdapter` (`AuthorizationScopeRepositoryPort`) and `MembershipStateAdapter`
  (`MembershipPort`), both with TTL/size-bounded caches over engine state.

**Authorization domain migration**
- `PermissionsBehavior` now checks permissions through `AuthorizationCheckPort` (CSL) instead of
  `AuthorizationCheckBehavior`.
- `AuthorizationCreate/Update/DeleteProcessor` pass the CSL port to `PermissionsBehavior`.
- `AuthorizationCheckBehavior` is retained in these processors **only** for cache invalidation
  (`clearAuthorizationsCache()`); it is removed in 4f.

**Mapping & rejections**
- `AuthorizationRejectionMapper` translates CSL `AuthorizationRejection` → engine `Rejection`.
- `AuthzModelMapper.fromProtocol(...)` performs protocol→CSL enum conversion at the CSL call site.

**Observability**
- New `ENGINE_IDENTITY_LOGGER` (`io.camunda.zeebe.engine.identity`): `TRACE` for per-check detail,
  `DEBUG` for command lifecycle, rejections, and cache invalidations.

**Other**
- Added jspecify nullness annotations to touched identity classes.

## Behavioral parity

This increment is a refactor toward CSL with **no intended behavior change**. Follow-up fix commits
restore exact parity with `main`: original rejection message format; skipping checks for
internal/anonymous commands and when authorization is disabled; rejecting (not throwing) authorization
commands that carry no identity claim; groups-claim precedence over mapping-rule group memberships in
OIDC mode; and scope-cache invalidation on writes.

## Test plan

- [x] Authorization Create/Update/Delete + rejection-mapper + security-disabled + anonymous +
      PermissionsBehavior tests — 39/39 green
- [x] Cache-invalidation tests: both grant direction (`shouldReflectNewlyGrantedAuthorizationImmediately`)
      and revoke direction (`shouldReflectRevokedAuthorizationImmediately`) verified
- [x] `./mvnw install -Dquickly -T1C` — full-repo compile green
- [ ] `./mvnw verify -pl zeebe/engine -DskipTests=false -Dquickly` — full engine suite (CI)

Closes camunda/camunda-security-library#451. Part of epic camunda/camunda-security-library#402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)