### PR TITLE
fix: scope topology lookups to the correct physical tenant

### DIFF
--- a/service/src/main/java/io/camunda/service/PhysicalTenantScopedApiServices.java
+++ b/service/src/main/java/io/camunda/service/PhysicalTenantScopedApiServices.java
@@ -35,6 +35,10 @@ public abstract class PhysicalTenantScopedApiServices<T extends PhysicalTenantSc
     this.physicalTenantId = physicalTenantId;
   }
 
+  protected String getPhysicalTenantId() {
+    return physicalTenantId;
+  }
+
   @Override
   protected final List<BiConsumer<BrokerRequest, CamundaAuthentication>> brokerRequestMutators() {
     return Stream.concat(

--- a/service/src/main/java/io/camunda/service/TopologyServices.java
+++ b/service/src/main/java/io/camunda/service/TopologyServices.java
@@ -58,7 +58,7 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
   }
 
   private boolean hasAPartitionWithAHealthyLeader() {
-    final var topology = brokerClient.getTopologyManager().getTopology();
+    final var topology = brokerClient.getTopologyManager().getTopology(getPhysicalTenantId());
 
     if (topology == null) {
       return false;
@@ -78,7 +78,7 @@ public final class TopologyServices extends PhysicalTenantScopedApiServices<Topo
 
   public CompletableFuture<Topology> getTopology() {
     try {
-      final var clusterState = brokerClient.getTopologyManager().getTopology();
+      final var clusterState = brokerClient.getTopologyManager().getTopology(getPhysicalTenantId());
       if (clusterState == null) {
         return CompletableFuture.failedFuture(
             new ServiceException(

--- a/service/src/test/java/io/camunda/service/TopologyServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TopologyServiceTest.java
@@ -60,7 +60,7 @@ public class TopologyServiceTest {
     clusterState = mock(BrokerClusterState.class);
     topologyManager = mock(BrokerTopologyManager.class);
     when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
-    when(topologyManager.getTopology()).thenReturn(clusterState);
+    when(topologyManager.getTopology(PHYSICAL_TENANT_ID)).thenReturn(clusterState);
     services =
         new TopologyServices(
             PHYSICAL_TENANT_ID,
@@ -87,7 +87,7 @@ public class TopologyServiceTest {
     Assertions.assertThat(status).isEqualTo(ClusterStatus.HEALTHY);
 
     verify(brokerClient).getTopologyManager();
-    verify(topologyManager).getTopology();
+    verify(topologyManager).getTopology(PHYSICAL_TENANT_ID);
     verify(clusterState).getPartitions();
     verify(clusterState).getLeaderForPartition(partitionId1);
     verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
@@ -113,7 +113,7 @@ public class TopologyServiceTest {
     Assertions.assertThat(status).isEqualTo(ClusterStatus.UNHEALTHY);
 
     verify(brokerClient).getTopologyManager();
-    verify(topologyManager).getTopology();
+    verify(topologyManager).getTopology(PHYSICAL_TENANT_ID);
     verify(clusterState).getPartitions();
     verify(clusterState).getLeaderForPartition(partitionId1);
     verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
@@ -133,14 +133,14 @@ public class TopologyServiceTest {
     Assertions.assertThat(status).isEqualTo(ClusterStatus.UNHEALTHY);
 
     verify(brokerClient).getTopologyManager();
-    verify(topologyManager).getTopology();
+    verify(topologyManager).getTopology(PHYSICAL_TENANT_ID);
     verify(clusterState).getPartitions();
   }
 
   @Test
   void shouldReturnUnhealthyWhenNoTopologyExist() {
     // given
-    when(topologyManager.getTopology()).thenReturn(null);
+    when(topologyManager.getTopology(PHYSICAL_TENANT_ID)).thenReturn(null);
 
     // when
     final var status = services.getStatus().join();
@@ -149,7 +149,7 @@ public class TopologyServiceTest {
     Assertions.assertThat(status).isEqualTo(ClusterStatus.UNHEALTHY);
 
     verify(brokerClient).getTopologyManager();
-    verify(topologyManager).getTopology();
+    verify(topologyManager).getTopology(PHYSICAL_TENANT_ID);
     verifyNoInteractions(clusterState);
   }
 
@@ -176,7 +176,7 @@ public class TopologyServiceTest {
     Assertions.assertThat(status).isEqualTo(ClusterStatus.HEALTHY);
 
     verify(brokerClient).getTopologyManager();
-    verify(topologyManager).getTopology();
+    verify(topologyManager).getTopology(PHYSICAL_TENANT_ID);
     verify(clusterState).getPartitions();
     verify(clusterState).getLeaderForPartition(partitionId1);
     verify(clusterState).getPartitionHealth(leaderId1, partitionId1);
@@ -197,7 +197,7 @@ public class TopologyServiceTest {
     if (zone.isEmpty()) {
       zone = null;
     }
-    when(topologyManager.getTopology())
+    when(topologyManager.getTopology(PHYSICAL_TENANT_ID))
         .thenReturn(new TestBrokerClusterState(zone, version, clusterId));
 
     final var expectedTopology =
@@ -241,7 +241,7 @@ public class TopologyServiceTest {
   @Test
   void shouldFailWithUnavailableWhenClusterStateNotYetReceived() {
     // given
-    Mockito.when(topologyManager.getTopology()).thenReturn(null);
+    Mockito.when(topologyManager.getTopology(PHYSICAL_TENANT_ID)).thenReturn(null);
 
     // when / then
     Assertions.assertThatThrownBy(() -> services.getTopology().join())

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -364,7 +364,16 @@ public final class EndpointManager {
 
   public void topology(final ServerStreamObserver<TopologyResponse> responseObserver) {
     final TopologyResponse.Builder topologyResponseBuilder = TopologyResponse.newBuilder();
-    final BrokerClusterState topology = topologyManager.getTopology();
+    final String physicalTenantId;
+    try {
+      physicalTenantId = getPhysicalTenantId();
+    } catch (final Exception e) {
+      responseObserver.onError(e);
+      return;
+    }
+    final BrokerClusterState topology =
+        topologyManager.getTopology(
+            Objects.requireNonNullElse(physicalTenantId, Protocol.DEFAULT_PARTITION_GROUP_NAME));
 
     final String gatewayVersion = VersionUtil.getVersion();
     if (gatewayVersion != null && !gatewayVersion.isBlank()) {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -209,7 +209,8 @@ public final class LongPollingActivateJobsHandler<T> implements ActivateJobsHand
       final InFlightLongPollingActivateJobsRequestsState<T> state,
       final InflightActivateJobsRequest<T> request) {
 
-    final BrokerClusterState topology = brokerClient.getTopologyManager().getTopology();
+    final BrokerClusterState topology =
+        brokerClient.getTopologyManager().getTopology(request.getRequest().getPartitionGroup());
     if (topology != null && request.isOpen()) {
       state.addActiveRequest(request);
 


### PR DESCRIPTION
## Description

TopologyServices.getStatus() and getTopology() ignored the physicalTenantId they hold and always queried the default tenant, causing /v2/status and /v2/topology to return wrong data for non-default tenants.

EndpointManager.topology() (gRPC) likewise always used the default tenant instead of reading the physical tenant ID from the gRPC context.

LongPollingActivateJobsHandler used the default-tenant partition count for round-robin dispatch instead of the partition group carried by the activate-jobs request.

Right now it is not possible to force different topology for each physical tenant. Hence the bug cannot be observed via an IT test. An IT test can be later added to very per PT topology once the cluster configuration support different partition distribution per PT. 

closes #56015
