### PR TITLE
test: enable PT auth ITs

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
@@ -60,6 +60,7 @@ final class MultiPhysicalTenantAuthorizationIT extends MultiPhysicalTenantAuthor
 
   @BeforeAll
   static void startBroker() {
+    TENANTS.refreshSecondaryStorage(BROKER);
     BROKER.start();
     defaultAdmin = defaultAdminClient(BROKER);
     tenantAAdmin = adminClient(BROKER, TENANT_A);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationIT.java
@@ -33,7 +33,6 @@ import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -50,7 +49,6 @@ import org.junit.jupiter.api.Test;
  * have no ES/OS indices to authorize against.
  */
 @ZeebeIntegration
-@Disabled
 final class MultiPhysicalTenantAuthorizationIT extends MultiPhysicalTenantAuthorizationTestBase {
 
   @TestZeebe(autoStart = false)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationTestBase.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationTestBase.java
@@ -64,7 +64,7 @@ abstract class MultiPhysicalTenantAuthorizationTestBase {
    */
   protected static TestStandaloneBroker configureBroker() {
     final TestStandaloneBroker broker =
-        TENANTS.configure(
+        TENANTS.configureAdminRoles(
             new TestStandaloneBroker()
                 .withAuthorizationsEnabled()
                 .withAuthenticationMethod(AuthenticationMethod.BASIC));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationTestBase.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/MultiPhysicalTenantAuthorizationTestBase.java
@@ -58,9 +58,11 @@ abstract class MultiPhysicalTenantAuthorizationTestBase {
           .build();
 
   /**
-   * Configures a broker for the multi-PT authorization scenario: storage + per-PT admin role (via
-   * the helper's {@code configure}), basic auth, authorizations enabled, and a seeded per-PT admin
-   * user for {@code tenanta} and {@code tenantb}.
+   * Configures a broker for the multi-PT authorization scenario: per-PT admin role (via the
+   * helper's {@code configureAdminRoles}), basic auth, authorizations enabled, and a seeded per-PT
+   * admin user for {@code tenanta} and {@code tenantb}. Secondary storage is intentionally not
+   * applied here; it is (re-)stamped per run via {@code TENANTS.refreshSecondaryStorage(BROKER)} in
+   * {@code @BeforeAll} so each start gets a fresh database identity.
    */
   protected static TestStandaloneBroker configureBroker() {
     final TestStandaloneBroker broker =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
@@ -68,7 +68,7 @@ final class PhysicalTenantAuthorizationEnablementIT {
 
   private static TestStandaloneBroker configure() {
     final TestStandaloneBroker broker =
-        TENANTS.configure(
+        TENANTS.configureAdminRoles(
             new TestStandaloneBroker()
                 .withAuthorizationsEnabled()
                 .withAuthenticationMethod(AuthenticationMethod.BASIC));
@@ -81,6 +81,7 @@ final class PhysicalTenantAuthorizationEnablementIT {
 
   @BeforeAll
   static void startBroker() {
+    TENANTS.refreshSecondaryStorage(BROKER);
     BROKER.start();
     tenantOffAdmin =
         TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_OFF, ADMIN_PASSWORD).build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantAuthorizationEnablementIT.java
@@ -27,7 +27,6 @@ import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -47,7 +46,6 @@ import org.junit.jupiter.api.Test;
  * have no ES/OS indices to authorize against.
  */
 @ZeebeIntegration
-@Disabled
 final class PhysicalTenantAuthorizationEnablementIT {
 
   private static final String TENANT_OFF = "tenantoff";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
@@ -63,7 +63,7 @@ final class PhysicalTenantLogicalTenantScopingIT {
 
   private static TestStandaloneBroker configure() {
     final TestStandaloneBroker broker =
-        TENANTS.configure(
+        TENANTS.configureAdminRoles(
             new TestStandaloneBroker()
                 .withAuthorizationsEnabled()
                 .withAuthenticationMethod(AuthenticationMethod.BASIC)
@@ -75,6 +75,7 @@ final class PhysicalTenantLogicalTenantScopingIT {
 
   @BeforeAll
   static void startBroker() {
+    TENANTS.refreshSecondaryStorage(BROKER);
     BROKER.start();
     tenantAAdmin = TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_A, ADMIN_PASSWORD).build();
     tenantBAdmin = TENANTS.newBasicAuthAdminClientBuilder(BROKER, TENANT_B, ADMIN_PASSWORD).build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantLogicalTenantScopingIT.java
@@ -22,7 +22,6 @@ import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -42,7 +41,6 @@ import org.junit.jupiter.api.Test;
  * have no ES/OS indices to read from.
  */
 @ZeebeIntegration
-@Disabled
 final class PhysicalTenantLogicalTenantScopingIT {
 
   private static final String TENANT_A = "tenanta";

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -74,31 +74,62 @@ public final class PhysicalTenantsITHelper {
     return new Builder();
   }
 
+  /**
+   * Fully configures the broker for the physical tenants: assigns the per-PT admin role and applies
+   * the secondary storage. Suitable for instance-scoped brokers configured once per test instance.
+   * Static brokers reused across runs should instead call {@link #configureAdminRoles} once at
+   * setup and {@link #refreshSecondaryStorage} per {@code @BeforeAll}, so storage is applied
+   * exactly once per start with a fresh database identity.
+   */
   public TestStandaloneBroker configure(final TestStandaloneBroker broker) {
-    tenants.forEach(
-        (tenant, storage) -> {
-          storage.applyTo(broker, tenant);
-          if (!DEFAULT_TENANT_ID.equals(tenant)) {
-            broker.withPtConfig(
-                tenant,
-                camunda ->
-                    camunda
-                        .getSecurity()
-                        .getInitialization()
-                        .setDefaultRoles(
-                            Map.of("admin", Map.of("users", List.of(tenant + "-admin")))));
-          }
-        });
+    configureAdminRoles(broker);
+    return refreshSecondaryStorage(broker);
+  }
+
+  /**
+   * Assigns the {@code admin} default role to each non-default physical tenant's {@code
+   * <tenant>-admin} user. Does not touch secondary storage, so it is safe to call once at static
+   * setup while storage is (re-)applied per run via {@link #refreshSecondaryStorage}.
+   */
+  public TestStandaloneBroker configureAdminRoles(final TestStandaloneBroker broker) {
+    tenants
+        .keySet()
+        .forEach(
+            tenant -> {
+              if (!DEFAULT_TENANT_ID.equals(tenant)) {
+                broker.withPtConfig(
+                    tenant,
+                    camunda ->
+                        camunda
+                            .getSecurity()
+                            .getInitialization()
+                            .setDefaultRoles(
+                                Map.of("admin", Map.of("users", List.of(tenant + "-admin")))));
+              }
+            });
+    return broker;
+  }
+
+  /**
+   * Re-stamps every physical tenant's secondary storage with a fresh database identity. Call in
+   * {@code @BeforeAll} before starting the broker so that a failsafe rerun within the same JVM gets
+   * isolated databases rather than recovering the previous run's exporter position against a
+   * freshly-initialised log. Only the storage is re-applied; default roles and seeded users are
+   * left untouched.
+   */
+  public TestStandaloneBroker refreshSecondaryStorage(final TestStandaloneBroker broker) {
+    tenants.forEach((tenant, storage) -> storage.applyTo(broker, tenant));
     return broker;
   }
 
   /**
    * Seeds a basic-auth per-PT admin {@code <tenantId>-admin} user for a non-{@code default}
-   * physical tenant (matching the {@code defaultRoles.admin} assignment {@link #configure} sets)
-   * into that tenant's {@code security.initialization}, so the user can authenticate via the
-   * tenant-prefixed REST path once authorizations and basic auth are enabled. Basic-auth specific
-   * (an OIDC variant would seed a mapping rule instead). Appends the per-PT admin user to the
-   * tenant's existing initialization users list; call in addition to {@link #configure}.
+   * physical tenant (matching the {@code defaultRoles.admin} assignment {@link
+   * #configureAdminRoles} sets) into that tenant's {@code security.initialization}, so the user can
+   * authenticate via the tenant-prefixed REST path once authorizations and basic auth are enabled.
+   * Basic-auth specific (an OIDC variant would seed a mapping rule instead). Appends the per-PT
+   * admin user to the tenant's existing initialization users list; call in addition to {@link
+   * #configureAdminRoles}.
    */
   public TestStandaloneBroker seedBasicAuthAdminUser(
       final TestStandaloneBroker broker, final String tenantId, final String password) {
@@ -255,10 +286,31 @@ public final class PhysicalTenantsITHelper {
     }
 
     static Storage rdbmsH2(final String dbName) {
-      return rdbms(
-          "jdbc:h2:mem:" + dbName + "-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
-          "sa",
-          "");
+      return new RdbmsH2Storage(dbName);
+    }
+  }
+
+  /**
+   * In-memory H2 storage that mints a fresh database identity on every {@link #applyTo} call rather
+   * than baking one URL at construction. An in-memory H2 with {@code DB_CLOSE_DELAY=-1} survives
+   * for the lifetime of the JVM, so a {@code static} broker reusing a single URL across a failsafe
+   * rerun in the same JVM would recover the previous run's exporter position against a
+   * freshly-initialised log and fail to recover the exporter. Re-stamping a fresh database per
+   * broker start (see {@link #refreshSecondaryStorage}) keeps the secondary storage isolated per
+   * run, in lockstep with the per-lifecycle primary storage.
+   */
+  private record RdbmsH2Storage(String dbName) implements Storage {
+    @Override
+    public void applyTo(final TestStandaloneBroker broker, final String tenantId) {
+      new RdbmsStorage(
+              "jdbc:h2:mem:"
+                  + dbName
+                  + "-"
+                  + UUID.randomUUID()
+                  + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL",
+              "sa",
+              "")
+          .applyTo(broker, tenantId);
     }
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -104,7 +104,7 @@ public final class PhysicalTenantsITHelper {
                             .getSecurity()
                             .getInitialization()
                             .setDefaultRoles(
-                                Map.of("admin", Map.of("users", List.of(tenant + "-admin")))));
+                                Map.of("admin", Map.of("users", List.of(adminUsername(tenant))))));
               }
             });
     return broker;


### PR DESCRIPTION
## Description

Could confirm that https://github.com/camunda/camunda/pull/55943 resolved the instability, locally it passed 175 times in a row:
<img width="800" height="134" alt="image" src="https://github.com/user-attachments/assets/19271830-25c5-48c2-9134-c8c0111859d0" />

However there is a setup issue that prevented looping the tests, that also surfaced in past runs:

The three multi-PT authorization ITs boot a single `static` `TestStandaloneBroker` backed by RDBMS-H2. Each tenant's H2 URL baked a `UUID` into a `static final` field and uses `DB_CLOSE_DELAY=-1`, so the in-memory database survives for the **lifetime of the JVM** — not just the broker. The broker's primary storage (log + RocksDB exporter state) is reset per test lifecycle, but the secondary storage is not.

On a failsafe rerun in the same fork (and on IntelliJ "repeat until failure"), the broker restarts against a fresh log while the RDBMS exporter reads back its last position from the leaked H2 (`RdbmsExporter.open` bumps the broker position to the persisted RDBMS position) and resumes from there. That position no longer exists in the freshly-initialised log, so the exporter fails to recover:

```
IllegalStateException: Expected to find event with the snapshot position 146 in log stream, but nothing was found. Failed to recover 'Exporter-1'.
```

This is what prevented looping, and it also surfaced in past CI runs: the first execution flaked on topology readiness, the failsafe retry then hit this leak (the `-2-output.txt` rerun is flooded with the exporter error), so the retry could never recover and a transient flake became a hard failure — the retry safety net was effectively defeated.

### Fix

Mint a fresh H2 database identity **per broker start**, in lockstep with the per-lifecycle primary storage:

- `RdbmsH2Storage` builds the H2 URL (with a new UUID) on every `applyTo` call instead of once at static init.
- The static-broker ITs re-stamp storage via `refreshSecondaryStorage(broker)` in `@BeforeAll`, before `start()`, so each run — including a same-JVM rerun — gets an isolated database.
- `configure()` is decomposed into `configureAdminRoles` (identity/roles, applied once at static setup) and `refreshSecondaryStorage` (storage, applied per run), so storage is applied exactly once per start. The instance-scoped isolation ITs keep the combined `configure()`.

Follow-up #56116 tracks converting these ITs to `@MultiDbTest` (which provides this isolation natively) and extending the multi-DB setup to support multiple physical tenants per broker.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56006
