### PR TITLE
Document store integration tests

### DIFF
--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStore.java
@@ -14,7 +14,6 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
-import com.google.cloud.storage.StorageOptions;
 import io.camunda.document.api.DocumentContent;
 import io.camunda.document.api.DocumentCreationRequest;
 import io.camunda.document.api.DocumentError;
@@ -55,20 +54,11 @@ public class GcpDocumentStore implements DocumentStore {
   private final ExecutorService executor;
 
   public GcpDocumentStore(
-      final String bucketName, final String prefix, final ExecutorService executor) {
-    this(bucketName, prefix, new ObjectMapper(), executor);
-  }
-
-  public GcpDocumentStore(
       final String bucketName,
       final String prefix,
-      final ObjectMapper objectMapper,
+      final Storage storage,
       final ExecutorService executor) {
-    this.bucketName = bucketName;
-    this.prefix = prefix;
-    storage = StorageOptions.getDefaultInstance().getService();
-    this.objectMapper = objectMapper;
-    this.executor = executor;
+    this(bucketName, prefix, storage, new ObjectMapper(), executor);
   }
 
   public GcpDocumentStore(

--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
@@ -7,13 +7,23 @@
  */
 package io.camunda.document.store.gcp;
 
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageOptions;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
 
 public class GcpDocumentStoreProvider implements DocumentStoreProvider {
+
+  /**
+   * Null in production. Tests may set this before the broker starts to redirect the GCS client to a
+   * local emulator without touching document store configuration.
+   */
+  @VisibleForTesting public static volatile Supplier<Storage> storageOverride = null;
 
   private static final String BUCKET_NAME_PROPERTY = "BUCKET";
   private static final String PREFIX_PROPERTY = "PREFIX";
@@ -24,7 +34,12 @@ public class GcpDocumentStoreProvider implements DocumentStoreProvider {
   public DocumentStore createDocumentStore(
       final DocumentStoreConfigurationRecord configuration, final ExecutorService executorService) {
     return new GcpDocumentStore(
-        getBucketNameProperty(configuration), getPrefixProperty(configuration), executorService);
+        getBucketNameProperty(configuration),
+        getPrefixProperty(configuration),
+        storageOverride != null
+            ? storageOverride.get()
+            : StorageOptions.getDefaultInstance().getService(),
+        executorService);
   }
 
   private String getBucketNameProperty(final DocumentStoreConfigurationRecord configuration) {

--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
@@ -19,11 +19,7 @@ import java.util.function.Supplier;
 
 public class GcpDocumentStoreProvider implements DocumentStoreProvider {
 
-  /**
-   * Null in production. Tests may set this before the broker starts to redirect the GCS client to a
-   * local emulator without touching document store configuration.
-   */
-  @VisibleForTesting public static volatile Supplier<Storage> storageOverride = null;
+  @VisibleForTesting private static volatile Supplier<Storage> storageOverride = null;
 
   private static final String BUCKET_NAME_PROPERTY = "BUCKET";
   private static final String PREFIX_PROPERTY = "PREFIX";
@@ -33,13 +29,26 @@ public class GcpDocumentStoreProvider implements DocumentStoreProvider {
   @Override
   public DocumentStore createDocumentStore(
       final DocumentStoreConfigurationRecord configuration, final ExecutorService executorService) {
+    final Supplier<Storage> override = storageOverride;
     return new GcpDocumentStore(
         getBucketNameProperty(configuration),
         getPrefixProperty(configuration),
-        storageOverride != null
-            ? storageOverride.get()
-            : StorageOptions.getDefaultInstance().getService(),
+        override != null ? override.get() : StorageOptions.getDefaultInstance().getService(),
         executorService);
+  }
+
+  /**
+   * Redirects the GCS client to an emulator. Call before the broker starts; always call {@link
+   * #clearStorageOverrideForTests()} in an {@code @AfterAll} block.
+   */
+  @VisibleForTesting
+  public static void setStorageOverrideForTests(final Supplier<Storage> override) {
+    storageOverride = override;
+  }
+
+  @VisibleForTesting
+  public static void clearStorageOverrideForTests() {
+    storageOverride = null;
   }
 
   private String getBucketNameProperty(final DocumentStoreConfigurationRecord configuration) {

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -543,6 +543,16 @@
       <artifactId>google-cloud-storage</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.auth</groupId>
+      <artifactId>google-auth-library-credentials</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>
@@ -553,6 +563,18 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-store-azure</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.azure</groupId>
+      <artifactId>azure-storage-blob</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>document-store</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/AbstractDocumentIsolationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/AbstractDocumentIsolationIT.java
@@ -29,22 +29,31 @@ abstract class AbstractDocumentIsolationIT {
 
   protected static final String TENANT_A = "tenanta";
   protected static final String TENANT_B = "tenantb";
+  protected static final String TENANT_C = "tenantc";
   protected static final String STORE_A = "store-a";
   protected static final String STORE_B = "store-b";
+  protected static final String STORE_C = "store-c";
+  protected static final String STORE_DEFAULT = "store-default";
 
   protected static final PhysicalTenantsITHelper TENANTS =
       PhysicalTenantsITHelper.builder()
           .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
           .withTenant(TENANT_A, Storage.none())
           .withTenant(TENANT_B, Storage.none())
+          .withTenant(TENANT_C, Storage.none())
           .build();
 
   protected static CamundaClient clientA;
   protected static CamundaClient clientB;
+  protected static CamundaClient clientC;
+  protected static CamundaClient clientDefault;
 
   protected static void startClients(final TestStandaloneBroker broker) {
     clientA = TENANTS.newClientBuilder(broker, TENANT_A).build();
     clientB = TENANTS.newClientBuilder(broker, TENANT_B).build();
+    clientC = TENANTS.newClientBuilder(broker, TENANT_C).build();
+    clientDefault =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
   }
 
   protected static void closeClients() {
@@ -54,11 +63,17 @@ abstract class AbstractDocumentIsolationIT {
     if (clientB != null) {
       clientB.close();
     }
+    if (clientC != null) {
+      clientC.close();
+    }
+    if (clientDefault != null) {
+      clientDefault.close();
+    }
   }
 
   @SuppressWarnings("resource")
   @Test
-  void shouldDenyReadOfDocumentOwnedByAnotherTenant() {
+  void shouldReturn400WhenReadingFromUnassignedStore() {
     // given
     final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
 
@@ -83,6 +98,19 @@ abstract class AbstractDocumentIsolationIT {
     // when / then
     assertThatThrownBy(
             () -> clientB.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotFindDocumentOwnedByTenantAFromTenantCStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientC.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
         .isInstanceOf(ProblemException.class)
         .matches(e -> ((ProblemException) e).details().getStatus() == 404);
   }
@@ -201,6 +229,24 @@ abstract class AbstractDocumentIsolationIT {
   }
 
   @Test
+  void shouldAllowDefaultTenantToUseItsStore() throws IOException {
+    // given / when
+    final var ref =
+        clientDefault
+            .newCreateDocumentCommand()
+            .content("hello-from-default")
+            .storeId(STORE_DEFAULT)
+            .send()
+            .join();
+
+    // then
+    assertThat(ref.getStoreId()).isEqualTo(STORE_DEFAULT);
+    try (final var stream = clientDefault.newDocumentContentGetRequest(ref).send().join()) {
+      assertThat(stream.readAllBytes()).isEqualTo("hello-from-default".getBytes());
+    }
+  }
+
+  @Test
   void shouldRejectAccessToUnassignedStore() {
     assertThatThrownBy(
             () ->
@@ -216,7 +262,7 @@ abstract class AbstractDocumentIsolationIT {
 
   @SuppressWarnings("resource")
   @Test
-  void shouldIsolateDocumentsBetweenTenantStores() {
+  void shouldReturn400WhenReadingDocumentFromUnassignedStore() {
     // given
     final var ref =
         clientA.newCreateDocumentCommand().content("secret-a").storeId(STORE_A).send().join();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/AbstractDocumentIsolationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/AbstractDocumentIsolationIT.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contract tests for physical-tenant document store isolation. Subclasses supply the store-specific
+ * broker setup via {@code @BeforeAll} / {@code @AfterAll} and call {@link
+ * #startClients(TestStandaloneBroker)} / {@link #closeClients()} from those hooks.
+ */
+abstract class AbstractDocumentIsolationIT {
+
+  protected static final String TENANT_A = "tenanta";
+  protected static final String TENANT_B = "tenantb";
+  protected static final String STORE_A = "store-a";
+  protected static final String STORE_B = "store-b";
+
+  protected static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  protected static CamundaClient clientA;
+  protected static CamundaClient clientB;
+
+  protected static void startClients(final TestStandaloneBroker broker) {
+    clientA = TENANTS.newClientBuilder(broker, TENANT_A).build();
+    clientB = TENANTS.newClientBuilder(broker, TENANT_B).build();
+  }
+
+  protected static void closeClients() {
+    if (clientA != null) {
+      clientA.close();
+    }
+    if (clientB != null) {
+      clientB.close();
+    }
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldDenyReadOfDocumentOwnedByAnotherTenant() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotFindDocumentOwnedByAnotherTenantInOwnStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientB.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @Test
+  void shouldNotOverwriteDocumentOwnedByAnotherTenant() throws IOException {
+    // given
+    final String docId = "doc-" + UUID.randomUUID();
+    final var refB =
+        clientB
+            .newCreateDocumentCommand()
+            .content("original-content-b")
+            .documentId(docId)
+            .send()
+            .join();
+
+    // when
+    clientA
+        .newCreateDocumentCommand()
+        .content("tampered-content-a")
+        .documentId(docId)
+        .send()
+        .join();
+
+    // then
+    try (final var stream = clientB.newDocumentContentGetRequest(refB).send().join()) {
+      assertThat(stream.readAllBytes()).isEqualTo("original-content-b".getBytes());
+    }
+  }
+
+  @Test
+  void shouldDenyDeleteOfDocumentOwnedByAnotherTenantFromUnassignedStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDeleteDocumentCommand(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldNotDeleteDocumentOwnedByAnotherTenant() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
+
+    // when - B targets B's own store; document absent there, A's copy unaffected.
+    // Cloud stores (S3/GCS/Azure) surface a 404 when the blob is missing; local store silently
+    // succeeds. Either outcome is acceptable — the important assertion is that A's document
+    // survives.
+    try {
+      clientB.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
+    } catch (final Exception ignored) {
+      // do nothing
+    }
+
+    // then
+    assertThatCode(
+            () -> {
+              try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
+                assertThat(stream).isNotNull();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotExposeDocumentIdAcrossTenants() {
+    // given
+    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientA.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotExposeDocumentIdAcrossTenantsViaUnassignedStore() {
+    // given
+    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientA
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldAllowTenantToUseItsAssignedStore() throws IOException {
+    // given / when
+    final var ref =
+        clientA.newCreateDocumentCommand().content("hello-from-a").storeId(STORE_A).send().join();
+
+    // then
+    assertThat(ref.getStoreId()).isEqualTo(STORE_A);
+
+    try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
+      assertThat(stream).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldRejectAccessToUnassignedStore() {
+    assertThatThrownBy(
+            () ->
+                clientA
+                    .newCreateDocumentCommand()
+                    .content("attempt")
+                    .storeId(STORE_B)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldIsolateDocumentsBetweenTenantStores() {
+    // given
+    final var ref =
+        clientA.newCreateDocumentCommand().content("secret-a").storeId(STORE_A).send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(STORE_A)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldPreserveContentIndependenceForSameDocumentIdAcrossStores() throws IOException {
+    // given
+    final String docId = "shared-doc-" + UUID.randomUUID();
+    final var refA =
+        clientA
+            .newCreateDocumentCommand()
+            .content("content-from-a")
+            .documentId(docId)
+            .storeId(STORE_A)
+            .send()
+            .join();
+    final var refB =
+        clientB
+            .newCreateDocumentCommand()
+            .content("content-from-b")
+            .documentId(docId)
+            .storeId(STORE_B)
+            .send()
+            .join();
+
+    // when / then
+    try (final var streamA = clientA.newDocumentContentGetRequest(refA).send().join()) {
+      assertThat(streamA.readAllBytes()).isEqualTo("content-from-a".getBytes());
+    }
+    try (final var streamB = clientB.newDocumentContentGetRequest(refB).send().join()) {
+      assertThat(streamB.readAllBytes()).isEqualTo("content-from-b".getBytes());
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/AbstractDocumentIsolationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/AbstractDocumentIsolationIT.java
@@ -24,6 +24,25 @@ import org.junit.jupiter.api.Test;
  * Contract tests for physical-tenant document store isolation. Subclasses supply the store-specific
  * broker setup via {@code @BeforeAll} / {@code @AfterAll} and call {@link
  * #startClients(TestStandaloneBroker)} / {@link #closeClients()} from those hooks.
+ *
+ * <p>Tenant → store mapping (1:1, each tenant assigned only its own store)
+ *
+ * <p>Physical backing per subclass:
+ *
+ * <ul>
+ *   <li><b>Local</b>: 4 separate directories, one per store — trivially isolated.
+ *   <li><b>GCP</b>: 1 shared bucket for all 4 stores; isolation via prefix ({@code tenanta/},
+ *       {@code tenantb/}, {@code tenantc/}, {@code ""} for default).
+ *   <li><b>AWS</b>: 2 buckets — {@code bucket-a} holds store-a (no prefix) + store-c (prefix {@code
+ *       tenantc/}); {@code bucket-b} holds store-b (no prefix) + store-default (prefix {@code
+ *       default/}).
+ *   <li><b>Azure</b>: 2 containers — {@code container-a} holds store-a (no prefix) + store-c
+ *       (prefix {@code tenantc/}); {@code container-b} holds store-b (no prefix) + store-default
+ *       (prefix {@code default/}).
+ * </ul>
+ *
+ * <p>AWS and Azure are the hardest cases: tenanta and tenantc share the same bucket/container, so
+ * isolation is purely prefix-level.
  */
 abstract class AbstractDocumentIsolationIT {
 
@@ -169,8 +188,8 @@ abstract class AbstractDocumentIsolationIT {
     // survives.
     try {
       clientB.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
-    } catch (final Exception ignored) {
-      // do nothing
+    } catch (final ProblemException e) {
+      assertThat(e.details().getStatus()).isEqualTo(404);
     }
 
     // then

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
@@ -7,38 +7,22 @@
  */
 package io.camunda.zeebe.it.physicaltenant;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.ProblemException;
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
 import io.camunda.zeebe.backup.s3.S3BackupStore;
-import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
-import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.testcontainers.MinioContainer;
-import java.io.IOException;
 import java.time.Duration;
-import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Network;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ZeebeIntegration
-final class DocumentIsolationAwsIT {
-
-  private static final String TENANT_A = "tenanta";
-  private static final String TENANT_B = "tenantb";
-  private static final String STORE_A = "store-a";
-  private static final String STORE_B = "store-b";
+final class DocumentIsolationAwsIT extends AbstractDocumentIsolationIT {
 
   private static final String BUCKET_A = "bucket-a";
   private static final String BUCKET_B = "bucket-b";
@@ -48,23 +32,13 @@ final class DocumentIsolationAwsIT {
   private static final MinioContainer MINIO =
       new MinioContainer().withNetwork(NETWORK).withDomain("minio.local", BUCKET_A, BUCKET_B);
 
-  private static final PhysicalTenantsITHelper TENANTS =
-      PhysicalTenantsITHelper.builder()
-          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
-          .withTenant(TENANT_A, Storage.none())
-          .withTenant(TENANT_B, Storage.none())
-          .build();
-
   @SuppressWarnings("resource") // lifecycle managed by @TestZeebe
   @TestZeebe(autoStart = false, purgeAfterEach = false)
   private static final TestStandaloneBroker BROKER =
       TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
 
-  private static CamundaClient clientA;
-  private static CamundaClient clientB;
-
   @BeforeAll
-  static void setupBucket() {
+  static void setUp() {
     final var config =
         new Builder()
             .withBucketName(BUCKET_A)
@@ -98,225 +72,16 @@ final class DocumentIsolationAwsIT {
         .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)
         .start();
 
-    clientA = TENANTS.newClientBuilder(BROKER, TENANT_A).build();
-    clientB = TENANTS.newClientBuilder(BROKER, TENANT_B).build();
+    startClients(BROKER);
   }
 
   @AfterAll
   static void tearDown() {
-    if (clientA != null) {
-      clientA.close();
-    }
-    if (clientB != null) {
-      clientB.close();
-    }
+    closeClients();
     System.clearProperty("aws.endpointUrl");
     System.clearProperty("aws.accessKeyId");
     System.clearProperty("aws.secretAccessKey");
     System.clearProperty("aws.region");
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldDenyReadOfDocumentOwnedByAnotherTenant() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotFindDocumentOwnedByAnotherTenantInOwnStore() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () -> clientB.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
-  }
-
-  @Test
-  void shouldNotOverwriteDocumentOwnedByAnotherTenant() throws IOException {
-    // given
-    final String docId = "doc-" + UUID.randomUUID();
-    final var refB =
-        clientB
-            .newCreateDocumentCommand()
-            .content("original-content-b")
-            .documentId(docId)
-            .send()
-            .join();
-
-    // when
-    clientA
-        .newCreateDocumentCommand()
-        .content("tampered-content-a")
-        .documentId(docId)
-        .send()
-        .join();
-
-    // then
-    try (final var stream = clientB.newDocumentContentGetRequest(refB).send().join()) {
-      assertThat(stream.readAllBytes()).isEqualTo("original-content-b".getBytes());
-    }
-  }
-
-  @Test
-  void shouldDenyDeleteOfDocumentOwnedByAnotherTenantFromUnassignedStore() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDeleteDocumentCommand(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldNotDeleteDocumentOwnedByAnotherTenant() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
-
-    // when - B's delete targets B's own bucket; blob absent there → 404, document A unaffected
-    try {
-      clientB.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
-    } catch (final Exception ignored) {
-      // do nothing
-    }
-
-    // then
-    assertThatCode(
-            () -> {
-              try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
-                assertThat(stream).isNotNull();
-              }
-            })
-        .doesNotThrowAnyException();
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotExposeDocumentIdAcrossTenants() {
-    // given
-    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () -> clientA.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotExposeDocumentIdAcrossTenantsViaUnassignedStore() {
-    // given
-    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientA
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldAllowTenantToUseItsAssignedStore() throws IOException {
-    // given / when
-    final var ref =
-        clientA.newCreateDocumentCommand().content("hello-from-a").storeId(STORE_A).send().join();
-
-    // then
-    assertThat(ref.getStoreId()).isEqualTo(STORE_A);
-
-    try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
-      assertThat(stream).isNotNull();
-    }
-  }
-
-  @Test
-  void shouldRejectAccessToUnassignedStore() {
-    assertThatThrownBy(
-            () ->
-                clientA
-                    .newCreateDocumentCommand()
-                    .content("attempt")
-                    .storeId(STORE_B)
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldIsolateDocumentsBetweenTenantStores() {
-    // given
-    final var ref =
-        clientA.newCreateDocumentCommand().content("secret-a").storeId(STORE_A).send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(STORE_A)
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldPreserveContentIndependenceForSameDocumentIdAcrossStores() throws IOException {
-    // given
-    final String docId = "shared-doc-" + UUID.randomUUID();
-    final var refA =
-        clientA
-            .newCreateDocumentCommand()
-            .content("content-from-a")
-            .documentId(docId)
-            .storeId(STORE_A)
-            .send()
-            .join();
-    final var refB =
-        clientB
-            .newCreateDocumentCommand()
-            .content("content-from-b")
-            .documentId(docId)
-            .storeId(STORE_B)
-            .send()
-            .join();
-
-    // when / then
-    try (final var streamA = clientA.newDocumentContentGetRequest(refA).send().join()) {
-      assertThat(streamA.readAllBytes()).isEqualTo("content-from-a".getBytes());
-    }
-    try (final var streamB = clientB.newDocumentContentGetRequest(refB).send().join()) {
-      assertThat(streamB.readAllBytes()).isEqualTo("content-from-b".getBytes());
-    }
+    NETWORK.close();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import io.camunda.zeebe.backup.s3.S3BackupStore;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.MinioContainer;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Network;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+final class DocumentIsolationAwsIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String STORE_A = "store-a";
+  private static final String STORE_B = "store-b";
+
+  private static final String BUCKET_A = "bucket-a";
+  private static final String BUCKET_B = "bucket-b";
+  private static final Network NETWORK = Network.newNetwork();
+
+  @Container
+  private static final MinioContainer MINIO =
+      new MinioContainer().withNetwork(NETWORK).withDomain("minio.local", BUCKET_A, BUCKET_B);
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @SuppressWarnings("resource") // lifecycle managed by @TestZeebe
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  private static CamundaClient clientA;
+  private static CamundaClient clientB;
+
+  @BeforeAll
+  static void setupBucket() {
+    final var config =
+        new Builder()
+            .withBucketName(BUCKET_A)
+            .withEndpoint(MINIO.externalEndpoint())
+            .withRegion(MINIO.region())
+            .withCredentials(MINIO.accessKey(), MINIO.secretKey())
+            .withApiCallTimeout(Duration.ofSeconds(25))
+            .forcePathStyleAccess(true)
+            .build();
+    try (final var client = S3BackupStore.buildClient(config)) {
+      client.createBucket(cfg -> cfg.bucket(BUCKET_A)).join();
+      client.createBucket(cfg -> cfg.bucket(BUCKET_B)).join();
+    }
+
+    // AwsDocumentStore uses S3Client.create() which reads from system properties.
+    // Using an IP-based endpoint forces path-style access in the AWS SDK v2.
+    final String minioEndpoint = "http://127.0.0.1:" + MINIO.getMappedPort(9000);
+    System.setProperty("aws.endpointUrl", minioEndpoint);
+    System.setProperty("aws.accessKeyId", MINIO.accessKey());
+    System.setProperty("aws.secretAccessKey", MINIO.secretKey());
+    System.setProperty("aws.region", MINIO.region());
+
+    BROKER
+        .withProperty("camunda.document.aws.store-a.bucket-name", BUCKET_A)
+        .withProperty("camunda.document.aws.store-a.region", MINIO.region())
+        .withProperty("camunda.document.aws.store-b.bucket-name", BUCKET_B)
+        .withProperty("camunda.document.aws.store-b.region", MINIO.region())
+        .withProperty("camunda.document.default-store-id", STORE_A)
+        .withProperty("camunda.physical-tenants.tenanta.document.assigned[0]", STORE_A)
+        .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
+        .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)
+        .start();
+
+    clientA = TENANTS.newClientBuilder(BROKER, TENANT_A).build();
+    clientB = TENANTS.newClientBuilder(BROKER, TENANT_B).build();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (clientA != null) {
+      clientA.close();
+    }
+    if (clientB != null) {
+      clientB.close();
+    }
+    System.clearProperty("aws.endpointUrl");
+    System.clearProperty("aws.accessKeyId");
+    System.clearProperty("aws.secretAccessKey");
+    System.clearProperty("aws.region");
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldDenyReadOfDocumentOwnedByAnotherTenant() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotFindDocumentOwnedByAnotherTenantInOwnStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientB.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @Test
+  void shouldNotOverwriteDocumentOwnedByAnotherTenant() throws IOException {
+    // given
+    final String docId = "doc-" + UUID.randomUUID();
+    final var refB =
+        clientB
+            .newCreateDocumentCommand()
+            .content("original-content-b")
+            .documentId(docId)
+            .send()
+            .join();
+
+    // when
+    clientA
+        .newCreateDocumentCommand()
+        .content("tampered-content-a")
+        .documentId(docId)
+        .send()
+        .join();
+
+    // then
+    try (final var stream = clientB.newDocumentContentGetRequest(refB).send().join()) {
+      assertThat(stream.readAllBytes()).isEqualTo("original-content-b".getBytes());
+    }
+  }
+
+  @Test
+  void shouldDenyDeleteOfDocumentOwnedByAnotherTenantFromUnassignedStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDeleteDocumentCommand(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldNotDeleteDocumentOwnedByAnotherTenant() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
+
+    // when - B's delete targets B's own bucket; blob absent there → 404, document A unaffected
+    try {
+      clientB.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
+    } catch (final Exception ignored) {
+      // do nothing
+    }
+
+    // then
+    assertThatCode(
+            () -> {
+              try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
+                assertThat(stream).isNotNull();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotExposeDocumentIdAcrossTenants() {
+    // given
+    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientA.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotExposeDocumentIdAcrossTenantsViaUnassignedStore() {
+    // given
+    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientA
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldAllowTenantToUseItsAssignedStore() throws IOException {
+    // given / when
+    final var ref =
+        clientA.newCreateDocumentCommand().content("hello-from-a").storeId(STORE_A).send().join();
+
+    // then
+    assertThat(ref.getStoreId()).isEqualTo(STORE_A);
+
+    try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
+      assertThat(stream).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldRejectAccessToUnassignedStore() {
+    assertThatThrownBy(
+            () ->
+                clientA
+                    .newCreateDocumentCommand()
+                    .content("attempt")
+                    .storeId(STORE_B)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldIsolateDocumentsBetweenTenantStores() {
+    // given
+    final var ref =
+        clientA.newCreateDocumentCommand().content("secret-a").storeId(STORE_A).send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(STORE_A)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldPreserveContentIndependenceForSameDocumentIdAcrossStores() throws IOException {
+    // given
+    final String docId = "shared-doc-" + UUID.randomUUID();
+    final var refA =
+        clientA
+            .newCreateDocumentCommand()
+            .content("content-from-a")
+            .documentId(docId)
+            .storeId(STORE_A)
+            .send()
+            .join();
+    final var refB =
+        clientB
+            .newCreateDocumentCommand()
+            .content("content-from-b")
+            .documentId(docId)
+            .storeId(STORE_B)
+            .send()
+            .join();
+
+    // when / then
+    try (final var streamA = clientA.newDocumentContentGetRequest(refA).send().join()) {
+      assertThat(streamA.readAllBytes()).isEqualTo("content-from-a".getBytes());
+    }
+    try (final var streamB = clientB.newDocumentContentGetRequest(refB).send().join()) {
+      assertThat(streamB.readAllBytes()).isEqualTo("content-from-b".getBytes());
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAwsIT.java
@@ -62,14 +62,27 @@ final class DocumentIsolationAwsIT extends AbstractDocumentIsolationIT {
     System.setProperty("aws.region", MINIO.region());
 
     BROKER
-        .withProperty("camunda.document.aws.store-a.bucket-name", BUCKET_A)
-        .withProperty("camunda.document.aws.store-a.region", MINIO.region())
-        .withProperty("camunda.document.aws.store-b.bucket-name", BUCKET_B)
-        .withProperty("camunda.document.aws.store-b.region", MINIO.region())
-        .withProperty("camunda.document.default-store-id", STORE_A)
+        .withProperty("camunda.document.aws.store-default.bucket-name", BUCKET_B)
+        .withProperty("camunda.document.aws.store-default.region", MINIO.region())
+        .withProperty("camunda.document.aws.store-default.bucket-path", "default/")
+        .withProperty("camunda.document.default-store-id", STORE_DEFAULT)
+        .withProperty("camunda.physical-tenants.tenanta.document.aws.store-a.bucket-name", BUCKET_A)
+        .withProperty(
+            "camunda.physical-tenants.tenanta.document.aws.store-a.region", MINIO.region())
+        .withProperty("camunda.physical-tenants.tenanta.document.default-store-id", STORE_A)
         .withProperty("camunda.physical-tenants.tenanta.document.assigned[0]", STORE_A)
-        .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
+        .withProperty("camunda.physical-tenants.tenantb.document.aws.store-b.bucket-name", BUCKET_B)
+        .withProperty(
+            "camunda.physical-tenants.tenantb.document.aws.store-b.region", MINIO.region())
         .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)
+        .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
+        .withProperty("camunda.physical-tenants.tenantc.document.aws.store-c.bucket-name", BUCKET_A)
+        .withProperty(
+            "camunda.physical-tenants.tenantc.document.aws.store-c.bucket-path", "tenantc/")
+        .withProperty(
+            "camunda.physical-tenants.tenantc.document.aws.store-c.region", MINIO.region())
+        .withProperty("camunda.physical-tenants.tenantc.document.default-store-id", STORE_C)
+        .withProperty("camunda.physical-tenants.tenantc.document.assigned[0]", STORE_C)
         .start();
 
     startClients(BROKER);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAzureIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAzureIT.java
@@ -7,54 +7,29 @@
  */
 package io.camunda.zeebe.it.physicaltenant;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.azure.storage.blob.BlobServiceClientBuilder;
-import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.ProblemException;
-import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
-import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.testcontainers.AzuriteContainer;
-import java.io.IOException;
-import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ZeebeIntegration
-final class DocumentIsolationAzureIT {
+final class DocumentIsolationAzureIT extends AbstractDocumentIsolationIT {
 
-  private static final String TENANT_A = "tenanta";
-  private static final String TENANT_B = "tenantb";
-  private static final String STORE_A = "store-a";
-  private static final String STORE_B = "store-b";
   private static final String CONTAINER_A = "container-a";
   private static final String CONTAINER_B = "container-b";
 
   @Container private static final AzuriteContainer AZURITE = new AzuriteContainer();
 
-  private static final PhysicalTenantsITHelper TENANTS =
-      PhysicalTenantsITHelper.builder()
-          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
-          .withTenant(TENANT_A, Storage.none())
-          .withTenant(TENANT_B, Storage.none())
-          .build();
-
   @SuppressWarnings("resource") // lifecycle managed by @TestZeebe
   @TestZeebe(autoStart = false, purgeAfterEach = false)
   private static final TestStandaloneBroker BROKER =
       TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
-
-  private static CamundaClient clientA;
-  private static CamundaClient clientB;
 
   @BeforeAll
   static void setUp() {
@@ -78,221 +53,11 @@ final class DocumentIsolationAzureIT {
         .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)
         .start();
 
-    clientA = TENANTS.newClientBuilder(BROKER, TENANT_A).build();
-    clientB = TENANTS.newClientBuilder(BROKER, TENANT_B).build();
+    startClients(BROKER);
   }
 
   @AfterAll
   static void tearDown() {
-    if (clientA != null) {
-      clientA.close();
-    }
-    if (clientB != null) {
-      clientB.close();
-    }
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldDenyReadOfDocumentOwnedByAnotherTenant() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotFindDocumentOwnedByAnotherTenantInOwnStore() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () -> clientB.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
-  }
-
-  @Test
-  void shouldNotOverwriteDocumentOwnedByAnotherTenant() throws IOException {
-    // given
-    final String docId = "doc-" + UUID.randomUUID();
-    final var refB =
-        clientB
-            .newCreateDocumentCommand()
-            .content("original-content-b")
-            .documentId(docId)
-            .send()
-            .join();
-
-    // when
-    clientA
-        .newCreateDocumentCommand()
-        .content("tampered-content-a")
-        .documentId(docId)
-        .send()
-        .join();
-
-    // then
-    try (final var stream = clientB.newDocumentContentGetRequest(refB).send().join()) {
-      assertThat(stream.readAllBytes()).isEqualTo("original-content-b".getBytes());
-    }
-  }
-
-  @Test
-  void shouldDenyDeleteOfDocumentOwnedByAnotherTenantFromUnassignedStore() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDeleteDocumentCommand(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldNotDeleteDocumentOwnedByAnotherTenant() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
-
-    // when - B's delete targets B's own container; blob absent there → 404, document A unaffected
-    try {
-      clientB.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
-    } catch (final Exception ignored) {
-      // do nothing
-    }
-
-    // then
-    assertThatCode(
-            () -> {
-              try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
-                assertThat(stream).isNotNull();
-              }
-            })
-        .doesNotThrowAnyException();
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotExposeDocumentIdAcrossTenants() {
-    // given
-    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () -> clientA.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotExposeDocumentIdAcrossTenantsViaUnassignedStore() {
-    // given
-    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientA
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldAllowTenantToUseItsAssignedStore() throws IOException {
-    // given / when
-    final var ref =
-        clientA.newCreateDocumentCommand().content("hello-from-a").storeId(STORE_A).send().join();
-
-    // then
-    assertThat(ref.getStoreId()).isEqualTo(STORE_A);
-
-    try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
-      assertThat(stream).isNotNull();
-    }
-  }
-
-  @Test
-  void shouldRejectAccessToUnassignedStore() {
-    assertThatThrownBy(
-            () ->
-                clientA
-                    .newCreateDocumentCommand()
-                    .content("attempt")
-                    .storeId(STORE_B)
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldIsolateDocumentsBetweenTenantStores() {
-    // given
-    final var ref =
-        clientA.newCreateDocumentCommand().content("secret-a").storeId(STORE_A).send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(STORE_A)
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldPreserveContentIndependenceForSameDocumentIdAcrossStores() throws IOException {
-    // given
-    final String docId = "shared-doc-" + UUID.randomUUID();
-    final var refA =
-        clientA
-            .newCreateDocumentCommand()
-            .content("content-from-a")
-            .documentId(docId)
-            .storeId(STORE_A)
-            .send()
-            .join();
-    final var refB =
-        clientB
-            .newCreateDocumentCommand()
-            .content("content-from-b")
-            .documentId(docId)
-            .storeId(STORE_B)
-            .send()
-            .join();
-
-    // when / then
-    try (final var streamA = clientA.newDocumentContentGetRequest(refA).send().join()) {
-      assertThat(streamA.readAllBytes()).isEqualTo("content-from-a".getBytes());
-    }
-    try (final var streamB = clientB.newDocumentContentGetRequest(refB).send().join()) {
-      assertThat(streamB.readAllBytes()).isEqualTo("content-from-b".getBytes());
-    }
+    closeClients();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAzureIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAzureIT.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.azure.storage.blob.BlobServiceClientBuilder;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.AzuriteContainer;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+final class DocumentIsolationAzureIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String STORE_A = "store-a";
+  private static final String STORE_B = "store-b";
+  private static final String CONTAINER_A = "container-a";
+  private static final String CONTAINER_B = "container-b";
+
+  @Container private static final AzuriteContainer AZURITE = new AzuriteContainer();
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @SuppressWarnings("resource") // lifecycle managed by @TestZeebe
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  private static CamundaClient clientA;
+  private static CamundaClient clientB;
+
+  @BeforeAll
+  static void setUp() {
+    final var azureClient =
+        new BlobServiceClientBuilder()
+            .connectionString(AZURITE.externalConnectionString())
+            .buildClient();
+    azureClient.createBlobContainer(CONTAINER_A);
+    azureClient.createBlobContainer(CONTAINER_B);
+
+    BROKER
+        .withProperty("camunda.document.azure.store-a.container-name", CONTAINER_A)
+        .withProperty(
+            "camunda.document.azure.store-a.connection-string", AZURITE.externalConnectionString())
+        .withProperty("camunda.document.azure.store-b.container-name", CONTAINER_B)
+        .withProperty(
+            "camunda.document.azure.store-b.connection-string", AZURITE.externalConnectionString())
+        .withProperty("camunda.document.default-store-id", STORE_A)
+        .withProperty("camunda.physical-tenants.tenanta.document.assigned[0]", STORE_A)
+        .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
+        .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)
+        .start();
+
+    clientA = TENANTS.newClientBuilder(BROKER, TENANT_A).build();
+    clientB = TENANTS.newClientBuilder(BROKER, TENANT_B).build();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (clientA != null) {
+      clientA.close();
+    }
+    if (clientB != null) {
+      clientB.close();
+    }
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldDenyReadOfDocumentOwnedByAnotherTenant() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotFindDocumentOwnedByAnotherTenantInOwnStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientB.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @Test
+  void shouldNotOverwriteDocumentOwnedByAnotherTenant() throws IOException {
+    // given
+    final String docId = "doc-" + UUID.randomUUID();
+    final var refB =
+        clientB
+            .newCreateDocumentCommand()
+            .content("original-content-b")
+            .documentId(docId)
+            .send()
+            .join();
+
+    // when
+    clientA
+        .newCreateDocumentCommand()
+        .content("tampered-content-a")
+        .documentId(docId)
+        .send()
+        .join();
+
+    // then
+    try (final var stream = clientB.newDocumentContentGetRequest(refB).send().join()) {
+      assertThat(stream.readAllBytes()).isEqualTo("original-content-b".getBytes());
+    }
+  }
+
+  @Test
+  void shouldDenyDeleteOfDocumentOwnedByAnotherTenantFromUnassignedStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDeleteDocumentCommand(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldNotDeleteDocumentOwnedByAnotherTenant() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
+
+    // when - B's delete targets B's own container; blob absent there → 404, document A unaffected
+    try {
+      clientB.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
+    } catch (final Exception ignored) {
+      // do nothing
+    }
+
+    // then
+    assertThatCode(
+            () -> {
+              try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
+                assertThat(stream).isNotNull();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotExposeDocumentIdAcrossTenants() {
+    // given
+    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientA.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotExposeDocumentIdAcrossTenantsViaUnassignedStore() {
+    // given
+    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientA
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldAllowTenantToUseItsAssignedStore() throws IOException {
+    // given / when
+    final var ref =
+        clientA.newCreateDocumentCommand().content("hello-from-a").storeId(STORE_A).send().join();
+
+    // then
+    assertThat(ref.getStoreId()).isEqualTo(STORE_A);
+
+    try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
+      assertThat(stream).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldRejectAccessToUnassignedStore() {
+    assertThatThrownBy(
+            () ->
+                clientA
+                    .newCreateDocumentCommand()
+                    .content("attempt")
+                    .storeId(STORE_B)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldIsolateDocumentsBetweenTenantStores() {
+    // given
+    final var ref =
+        clientA.newCreateDocumentCommand().content("secret-a").storeId(STORE_A).send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(STORE_A)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldPreserveContentIndependenceForSameDocumentIdAcrossStores() throws IOException {
+    // given
+    final String docId = "shared-doc-" + UUID.randomUUID();
+    final var refA =
+        clientA
+            .newCreateDocumentCommand()
+            .content("content-from-a")
+            .documentId(docId)
+            .storeId(STORE_A)
+            .send()
+            .join();
+    final var refB =
+        clientB
+            .newCreateDocumentCommand()
+            .content("content-from-b")
+            .documentId(docId)
+            .storeId(STORE_B)
+            .send()
+            .join();
+
+    // when / then
+    try (final var streamA = clientA.newDocumentContentGetRequest(refA).send().join()) {
+      assertThat(streamA.readAllBytes()).isEqualTo("content-from-a".getBytes());
+    }
+    try (final var streamB = clientB.newDocumentContentGetRequest(refB).send().join()) {
+      assertThat(streamB.readAllBytes()).isEqualTo("content-from-b".getBytes());
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAzureIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationAzureIT.java
@@ -41,16 +41,35 @@ final class DocumentIsolationAzureIT extends AbstractDocumentIsolationIT {
     azureClient.createBlobContainer(CONTAINER_B);
 
     BROKER
-        .withProperty("camunda.document.azure.store-a.container-name", CONTAINER_A)
+        .withProperty("camunda.document.azure.store-default.container-name", CONTAINER_B)
+        .withProperty("camunda.document.azure.store-default.container-path", "default/")
         .withProperty(
-            "camunda.document.azure.store-a.connection-string", AZURITE.externalConnectionString())
-        .withProperty("camunda.document.azure.store-b.container-name", CONTAINER_B)
+            "camunda.document.azure.store-default.connection-string",
+            AZURITE.externalConnectionString())
+        .withProperty("camunda.document.default-store-id", STORE_DEFAULT)
         .withProperty(
-            "camunda.document.azure.store-b.connection-string", AZURITE.externalConnectionString())
-        .withProperty("camunda.document.default-store-id", STORE_A)
+            "camunda.physical-tenants.tenanta.document.azure.store-a.container-name", CONTAINER_A)
+        .withProperty(
+            "camunda.physical-tenants.tenanta.document.azure.store-a.connection-string",
+            AZURITE.externalConnectionString())
+        .withProperty("camunda.physical-tenants.tenanta.document.default-store-id", STORE_A)
         .withProperty("camunda.physical-tenants.tenanta.document.assigned[0]", STORE_A)
-        .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
+        .withProperty(
+            "camunda.physical-tenants.tenantb.document.azure.store-b.container-name", CONTAINER_B)
+        .withProperty(
+            "camunda.physical-tenants.tenantb.document.azure.store-b.connection-string",
+            AZURITE.externalConnectionString())
         .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)
+        .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
+        .withProperty(
+            "camunda.physical-tenants.tenantc.document.azure.store-c.container-name", CONTAINER_A)
+        .withProperty(
+            "camunda.physical-tenants.tenantc.document.azure.store-c.container-path", "tenantc/")
+        .withProperty(
+            "camunda.physical-tenants.tenantc.document.azure.store-c.connection-string",
+            AZURITE.externalConnectionString())
+        .withProperty("camunda.physical-tenants.tenantc.document.default-store-id", STORE_C)
+        .withProperty("camunda.physical-tenants.tenantc.document.assigned[0]", STORE_C)
         .start();
 
     startClients(BROKER);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationGcpIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationGcpIT.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.cloud.NoCredentials;
+import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.StorageOptions;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.document.store.gcp.GcpDocumentStoreProvider;
+import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
+import io.camunda.zeebe.backup.gcs.GcsBackupStore;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.GcsContainer;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@ZeebeIntegration
+final class DocumentIsolationGcpIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String STORE_A = "store-a";
+  private static final String STORE_B = "store-b";
+
+  private static final String BUCKET_A = "bucket-a";
+  private static final String BUCKET_B = "bucket-b";
+
+  @Container private static final GcsContainer GCS = new GcsContainer();
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @SuppressWarnings("resource") // lifecycle managed by @TestZeebe
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  private static CamundaClient clientA;
+  private static CamundaClient clientB;
+
+  @BeforeAll
+  static void setupBucket() throws Exception {
+    final var config =
+        new GcsBackupConfig.Builder()
+            .withBucketName(BUCKET_A)
+            .withHost(GCS.externalEndpoint())
+            .withoutAuthentication()
+            .build();
+    try (final var client = GcsBackupStore.buildClient(config)) {
+      client.create(BucketInfo.of(BUCKET_A));
+      client.create(BucketInfo.of(BUCKET_B));
+    }
+
+    // TestGcpDocumentStoreProvider installs a storage override on GcpDocumentStoreProvider so
+    // that the broker connects to the local fake-gcs-server instead of storage.googleapis.com.
+    // No HOST key is needed in document store configuration.
+    configure(GCS);
+
+    BROKER
+        .withProperty("camunda.document.gcp.store-a.bucket-name", BUCKET_A)
+        .withProperty("camunda.document.gcp.store-b.bucket-name", BUCKET_B)
+        .withProperty("camunda.document.default-store-id", STORE_A)
+        .withProperty("camunda.physical-tenants.tenanta.document.assigned[0]", STORE_A)
+        .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
+        .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)
+        .start();
+
+    clientA = TENANTS.newClientBuilder(BROKER, TENANT_A).build();
+    clientB = TENANTS.newClientBuilder(BROKER, TENANT_B).build();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (clientA != null) {
+      clientA.close();
+    }
+    if (clientB != null) {
+      clientB.close();
+    }
+    reset();
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldDenyReadOfDocumentOwnedByAnotherTenant() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotFindDocumentOwnedByAnotherTenantInOwnStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientB.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @Test
+  void shouldNotOverwriteDocumentOwnedByAnotherTenant() throws IOException {
+    // given
+    final String docId = "doc-" + UUID.randomUUID();
+    final var refB =
+        clientB
+            .newCreateDocumentCommand()
+            .content("original-content-b")
+            .documentId(docId)
+            .send()
+            .join();
+
+    // when
+    clientA
+        .newCreateDocumentCommand()
+        .content("tampered-content-a")
+        .documentId(docId)
+        .send()
+        .join();
+
+    // then
+    try (final var stream = clientB.newDocumentContentGetRequest(refB).send().join()) {
+      assertThat(stream.readAllBytes()).isEqualTo("original-content-b".getBytes());
+    }
+  }
+
+  @Test
+  void shouldDenyDeleteOfDocumentOwnedByAnotherTenantFromUnassignedStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDeleteDocumentCommand(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldNotDeleteDocumentOwnedByAnotherTenant() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
+
+    // when - B's delete targets B's own bucket; blob absent there → 404, document A unaffected
+    try {
+      clientB.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
+    } catch (final Exception ignored) {
+      // do nothing
+    }
+
+    // then
+    assertThatCode(
+            () -> {
+              try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
+                assertThat(stream).isNotNull();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotExposeDocumentIdAcrossTenants() {
+    // given
+    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientA.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotExposeDocumentIdAcrossTenantsViaUnassignedStore() {
+    // given
+    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientA
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldAllowTenantToUseItsAssignedStore() throws IOException {
+    // given / when
+    final var ref =
+        clientA.newCreateDocumentCommand().content("hello-from-a").storeId(STORE_A).send().join();
+
+    // then
+    assertThat(ref.getStoreId()).isEqualTo(STORE_A);
+
+    try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
+      assertThat(stream).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldRejectAccessToUnassignedStore() {
+    assertThatThrownBy(
+            () ->
+                clientA
+                    .newCreateDocumentCommand()
+                    .content("attempt")
+                    .storeId(STORE_B)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldIsolateDocumentsBetweenTenantStores() {
+    // given
+    final var ref =
+        clientA.newCreateDocumentCommand().content("secret-a").storeId(STORE_A).send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(STORE_A)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldPreserveContentIndependenceForSameDocumentIdAcrossStores() throws IOException {
+    // given
+    final String docId = "shared-doc-" + UUID.randomUUID();
+    final var refA =
+        clientA
+            .newCreateDocumentCommand()
+            .content("content-from-a")
+            .documentId(docId)
+            .storeId(STORE_A)
+            .send()
+            .join();
+    final var refB =
+        clientB
+            .newCreateDocumentCommand()
+            .content("content-from-b")
+            .documentId(docId)
+            .storeId(STORE_B)
+            .send()
+            .join();
+
+    // when / then
+    try (final var streamA = clientA.newDocumentContentGetRequest(refA).send().join()) {
+      assertThat(streamA.readAllBytes()).isEqualTo("content-from-a".getBytes());
+    }
+    try (final var streamB = clientB.newDocumentContentGetRequest(refB).send().join()) {
+      assertThat(streamB.readAllBytes()).isEqualTo("content-from-b".getBytes());
+    }
+  }
+
+  public static void configure(final GcsContainer gcs) {
+    final String endpoint = gcs.externalEndpoint();
+    GcpDocumentStoreProvider.storageOverride =
+        () ->
+            StorageOptions.newBuilder()
+                .setHost(endpoint)
+                .setCredentials(NoCredentials.getInstance())
+                .build()
+                .getService();
+  }
+
+  public static void reset() {
+    GcpDocumentStoreProvider.storageOverride = null;
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationGcpIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationGcpIT.java
@@ -50,13 +50,13 @@ final class DocumentIsolationGcpIT extends AbstractDocumentIsolationIT {
     }
 
     // Redirect GcpDocumentStoreProvider to the local fake-gcs-server.
-    GcpDocumentStoreProvider.storageOverride =
+    GcpDocumentStoreProvider.setStorageOverrideForTests(
         () ->
             StorageOptions.newBuilder()
                 .setHost(GCS.externalEndpoint())
                 .setCredentials(NoCredentials.getInstance())
                 .build()
-                .getService();
+                .getService());
 
     BROKER
         .withProperty("camunda.document.gcp.store-default.bucket-name", SHARED_BUCKET)
@@ -85,6 +85,6 @@ final class DocumentIsolationGcpIT extends AbstractDocumentIsolationIT {
   @AfterAll
   static void tearDown() {
     closeClients();
-    GcpDocumentStoreProvider.storageOverride = null;
+    GcpDocumentStoreProvider.clearStorageOverrideForTests();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationGcpIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationGcpIT.java
@@ -7,63 +7,37 @@
  */
 package io.camunda.zeebe.it.physicaltenant;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.google.cloud.NoCredentials;
 import com.google.cloud.storage.BucketInfo;
 import com.google.cloud.storage.StorageOptions;
-import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.ProblemException;
 import io.camunda.document.store.gcp.GcpDocumentStoreProvider;
 import io.camunda.zeebe.backup.gcs.GcsBackupConfig;
 import io.camunda.zeebe.backup.gcs.GcsBackupStore;
-import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
-import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.testcontainers.GcsContainer;
-import java.io.IOException;
-import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ZeebeIntegration
-final class DocumentIsolationGcpIT {
-
-  private static final String TENANT_A = "tenanta";
-  private static final String TENANT_B = "tenantb";
-  private static final String STORE_A = "store-a";
-  private static final String STORE_B = "store-b";
+final class DocumentIsolationGcpIT extends AbstractDocumentIsolationIT {
 
   private static final String BUCKET_A = "bucket-a";
   private static final String BUCKET_B = "bucket-b";
 
   @Container private static final GcsContainer GCS = new GcsContainer();
 
-  private static final PhysicalTenantsITHelper TENANTS =
-      PhysicalTenantsITHelper.builder()
-          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
-          .withTenant(TENANT_A, Storage.none())
-          .withTenant(TENANT_B, Storage.none())
-          .build();
-
   @SuppressWarnings("resource") // lifecycle managed by @TestZeebe
   @TestZeebe(autoStart = false, purgeAfterEach = false)
   private static final TestStandaloneBroker BROKER =
       TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
 
-  private static CamundaClient clientA;
-  private static CamundaClient clientB;
-
   @BeforeAll
-  static void setupBucket() throws Exception {
+  static void setUp() throws Exception {
     final var config =
         new GcsBackupConfig.Builder()
             .withBucketName(BUCKET_A)
@@ -75,10 +49,14 @@ final class DocumentIsolationGcpIT {
       client.create(BucketInfo.of(BUCKET_B));
     }
 
-    // TestGcpDocumentStoreProvider installs a storage override on GcpDocumentStoreProvider so
-    // that the broker connects to the local fake-gcs-server instead of storage.googleapis.com.
-    // No HOST key is needed in document store configuration.
-    configure(GCS);
+    // Redirect GcpDocumentStoreProvider to the local fake-gcs-server.
+    GcpDocumentStoreProvider.storageOverride =
+        () ->
+            StorageOptions.newBuilder()
+                .setHost(GCS.externalEndpoint())
+                .setCredentials(NoCredentials.getInstance())
+                .build()
+                .getService();
 
     BROKER
         .withProperty("camunda.document.gcp.store-a.bucket-name", BUCKET_A)
@@ -89,237 +67,12 @@ final class DocumentIsolationGcpIT {
         .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)
         .start();
 
-    clientA = TENANTS.newClientBuilder(BROKER, TENANT_A).build();
-    clientB = TENANTS.newClientBuilder(BROKER, TENANT_B).build();
+    startClients(BROKER);
   }
 
   @AfterAll
   static void tearDown() {
-    if (clientA != null) {
-      clientA.close();
-    }
-    if (clientB != null) {
-      clientB.close();
-    }
-    reset();
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldDenyReadOfDocumentOwnedByAnotherTenant() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotFindDocumentOwnedByAnotherTenantInOwnStore() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () -> clientB.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
-  }
-
-  @Test
-  void shouldNotOverwriteDocumentOwnedByAnotherTenant() throws IOException {
-    // given
-    final String docId = "doc-" + UUID.randomUUID();
-    final var refB =
-        clientB
-            .newCreateDocumentCommand()
-            .content("original-content-b")
-            .documentId(docId)
-            .send()
-            .join();
-
-    // when
-    clientA
-        .newCreateDocumentCommand()
-        .content("tampered-content-a")
-        .documentId(docId)
-        .send()
-        .join();
-
-    // then
-    try (final var stream = clientB.newDocumentContentGetRequest(refB).send().join()) {
-      assertThat(stream.readAllBytes()).isEqualTo("original-content-b".getBytes());
-    }
-  }
-
-  @Test
-  void shouldDenyDeleteOfDocumentOwnedByAnotherTenantFromUnassignedStore() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDeleteDocumentCommand(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldNotDeleteDocumentOwnedByAnotherTenant() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
-
-    // when - B's delete targets B's own bucket; blob absent there → 404, document A unaffected
-    try {
-      clientB.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
-    } catch (final Exception ignored) {
-      // do nothing
-    }
-
-    // then
-    assertThatCode(
-            () -> {
-              try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
-                assertThat(stream).isNotNull();
-              }
-            })
-        .doesNotThrowAnyException();
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotExposeDocumentIdAcrossTenants() {
-    // given
-    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () -> clientA.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotExposeDocumentIdAcrossTenantsViaUnassignedStore() {
-    // given
-    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientA
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldAllowTenantToUseItsAssignedStore() throws IOException {
-    // given / when
-    final var ref =
-        clientA.newCreateDocumentCommand().content("hello-from-a").storeId(STORE_A).send().join();
-
-    // then
-    assertThat(ref.getStoreId()).isEqualTo(STORE_A);
-
-    try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
-      assertThat(stream).isNotNull();
-    }
-  }
-
-  @Test
-  void shouldRejectAccessToUnassignedStore() {
-    assertThatThrownBy(
-            () ->
-                clientA
-                    .newCreateDocumentCommand()
-                    .content("attempt")
-                    .storeId(STORE_B)
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldIsolateDocumentsBetweenTenantStores() {
-    // given
-    final var ref =
-        clientA.newCreateDocumentCommand().content("secret-a").storeId(STORE_A).send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(STORE_A)
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldPreserveContentIndependenceForSameDocumentIdAcrossStores() throws IOException {
-    // given
-    final String docId = "shared-doc-" + UUID.randomUUID();
-    final var refA =
-        clientA
-            .newCreateDocumentCommand()
-            .content("content-from-a")
-            .documentId(docId)
-            .storeId(STORE_A)
-            .send()
-            .join();
-    final var refB =
-        clientB
-            .newCreateDocumentCommand()
-            .content("content-from-b")
-            .documentId(docId)
-            .storeId(STORE_B)
-            .send()
-            .join();
-
-    // when / then
-    try (final var streamA = clientA.newDocumentContentGetRequest(refA).send().join()) {
-      assertThat(streamA.readAllBytes()).isEqualTo("content-from-a".getBytes());
-    }
-    try (final var streamB = clientB.newDocumentContentGetRequest(refB).send().join()) {
-      assertThat(streamB.readAllBytes()).isEqualTo("content-from-b".getBytes());
-    }
-  }
-
-  public static void configure(final GcsContainer gcs) {
-    final String endpoint = gcs.externalEndpoint();
-    GcpDocumentStoreProvider.storageOverride =
-        () ->
-            StorageOptions.newBuilder()
-                .setHost(endpoint)
-                .setCredentials(NoCredentials.getInstance())
-                .build()
-                .getService();
-  }
-
-  public static void reset() {
+    closeClients();
     GcpDocumentStoreProvider.storageOverride = null;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationGcpIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationGcpIT.java
@@ -26,8 +26,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ZeebeIntegration
 final class DocumentIsolationGcpIT extends AbstractDocumentIsolationIT {
 
-  private static final String BUCKET_A = "bucket-a";
-  private static final String BUCKET_B = "bucket-b";
+  // All three stores share one GCS bucket but use distinct prefixes, so the isolation tests
+  // exercise prefix-level separation rather than trivially separate buckets.
+  private static final String SHARED_BUCKET = "shared-bucket";
 
   @Container private static final GcsContainer GCS = new GcsContainer();
 
@@ -40,13 +41,12 @@ final class DocumentIsolationGcpIT extends AbstractDocumentIsolationIT {
   static void setUp() throws Exception {
     final var config =
         new GcsBackupConfig.Builder()
-            .withBucketName(BUCKET_A)
+            .withBucketName(SHARED_BUCKET)
             .withHost(GCS.externalEndpoint())
             .withoutAuthentication()
             .build();
     try (final var client = GcsBackupStore.buildClient(config)) {
-      client.create(BucketInfo.of(BUCKET_A));
-      client.create(BucketInfo.of(BUCKET_B));
+      client.create(BucketInfo.of(SHARED_BUCKET));
     }
 
     // Redirect GcpDocumentStoreProvider to the local fake-gcs-server.
@@ -59,12 +59,24 @@ final class DocumentIsolationGcpIT extends AbstractDocumentIsolationIT {
                 .getService();
 
     BROKER
-        .withProperty("camunda.document.gcp.store-a.bucket-name", BUCKET_A)
-        .withProperty("camunda.document.gcp.store-b.bucket-name", BUCKET_B)
-        .withProperty("camunda.document.default-store-id", STORE_A)
+        .withProperty("camunda.document.gcp.store-default.bucket-name", SHARED_BUCKET)
+        .withProperty("camunda.document.gcp.store-default.prefix", "")
+        .withProperty("camunda.document.default-store-id", STORE_DEFAULT)
+        .withProperty(
+            "camunda.physical-tenants.tenanta.document.gcp.store-a.bucket-name", SHARED_BUCKET)
+        .withProperty("camunda.physical-tenants.tenanta.document.gcp.store-a.prefix", "tenanta/")
+        .withProperty("camunda.physical-tenants.tenanta.document.default-store-id", STORE_A)
         .withProperty("camunda.physical-tenants.tenanta.document.assigned[0]", STORE_A)
-        .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
+        .withProperty(
+            "camunda.physical-tenants.tenantb.document.gcp.store-b.bucket-name", SHARED_BUCKET)
+        .withProperty("camunda.physical-tenants.tenantb.document.gcp.store-b.prefix", "tenantb/")
         .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)
+        .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
+        .withProperty(
+            "camunda.physical-tenants.tenantc.document.gcp.store-c.bucket-name", SHARED_BUCKET)
+        .withProperty("camunda.physical-tenants.tenantc.document.gcp.store-c.prefix", "tenantc/")
+        .withProperty("camunda.physical-tenants.tenantc.document.default-store-id", STORE_C)
+        .withProperty("camunda.physical-tenants.tenantc.document.assigned[0]", STORE_C)
         .start();
 
     startClients(BROKER);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationLocalIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationLocalIT.java
@@ -7,14 +7,6 @@
  */
 package io.camunda.zeebe.it.physicaltenant;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import io.camunda.client.CamundaClient;
-import io.camunda.client.api.command.ProblemException;
-import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
-import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
@@ -22,28 +14,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
-import java.util.UUID;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
-final class DocumentIsolationLocalIT {
-
-  private static final String TENANT_A = "tenanta";
-  private static final String TENANT_B = "tenantb";
-  private static final String STORE_A = "store-a";
-  private static final String STORE_B = "store-b";
+final class DocumentIsolationLocalIT extends AbstractDocumentIsolationIT {
 
   private static final Path STORE_DIR_A = createTempDir("doc-store-a-");
   private static final Path STORE_DIR_B = createTempDir("doc-store-b-");
-
-  private static final PhysicalTenantsITHelper TENANTS =
-      PhysicalTenantsITHelper.builder()
-          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
-          .withTenant(TENANT_A, Storage.none())
-          .withTenant(TENANT_B, Storage.none())
-          .build();
 
   @SuppressWarnings("resource") // lifecycle managed by @TestZeebe
   @TestZeebe(purgeAfterEach = false)
@@ -58,226 +36,18 @@ final class DocumentIsolationLocalIT {
               .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
               .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B));
 
-  private static CamundaClient clientA;
-  private static CamundaClient clientB;
-
   @BeforeAll
   static void setUp() {
     clearDirectoryContents(STORE_DIR_A);
     clearDirectoryContents(STORE_DIR_B);
-    clientA = TENANTS.newClientBuilder(BROKER, TENANT_A).build();
-    clientB = TENANTS.newClientBuilder(BROKER, TENANT_B).build();
+    startClients(BROKER);
   }
 
   @AfterAll
   static void tearDown() {
-    if (clientA != null) {
-      clientA.close();
-    }
-    if (clientB != null) {
-      clientB.close();
-    }
+    closeClients();
     deleteDirectory(STORE_DIR_A);
     deleteDirectory(STORE_DIR_B);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldDenyReadOfDocumentOwnedByAnotherTenant() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotFindDocumentOwnedByAnotherTenantInOwnStore() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () -> clientB.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
-  }
-
-  @Test
-  void shouldNotOverwriteDocumentOwnedByAnotherTenant() throws IOException {
-    // given
-    final String docId = "doc-" + UUID.randomUUID();
-    final var refB =
-        clientB
-            .newCreateDocumentCommand()
-            .content("original-content-b")
-            .documentId(docId)
-            .send()
-            .join();
-
-    // when
-    clientA
-        .newCreateDocumentCommand()
-        .content("tampered-content-a")
-        .documentId(docId)
-        .send()
-        .join();
-
-    // then
-    try (final var stream = clientB.newDocumentContentGetRequest(refB).send().join()) {
-      assertThat(stream.readAllBytes()).isEqualTo("original-content-b".getBytes());
-    }
-  }
-
-  @Test
-  void shouldDenyDeleteOfDocumentOwnedByAnotherTenantFromUnassignedStore() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDeleteDocumentCommand(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldNotDeleteDocumentOwnedByAnotherTenant() {
-    // given
-    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
-
-    // when / then
-    clientB.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
-
-    assertThatCode(
-            () -> {
-              try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
-                assertThat(stream).isNotNull();
-              }
-            })
-        .doesNotThrowAnyException();
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotExposeDocumentIdAcrossTenants() {
-    // given
-    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () -> clientA.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldNotExposeDocumentIdAcrossTenantsViaUnassignedStore() {
-    // given
-    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientA
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(ref.getStoreId())
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldAllowTenantToUseItsAssignedStore() throws IOException {
-    // given / when
-    final var ref =
-        clientA.newCreateDocumentCommand().content("hello-from-a").storeId(STORE_A).send().join();
-
-    // then
-    assertThat(ref.getStoreId()).isEqualTo(STORE_A);
-
-    try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
-      assertThat(stream).isNotNull();
-    }
-  }
-
-  @Test
-  void shouldRejectAccessToUnassignedStore() {
-    assertThatThrownBy(
-            () ->
-                clientA
-                    .newCreateDocumentCommand()
-                    .content("attempt")
-                    .storeId(STORE_B)
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @SuppressWarnings("resource")
-  @Test
-  void shouldIsolateDocumentsBetweenTenantStores() {
-    // given
-    final var ref =
-        clientA.newCreateDocumentCommand().content("secret-a").storeId(STORE_A).send().join();
-
-    // when / then
-    assertThatThrownBy(
-            () ->
-                clientB
-                    .newDocumentContentGetRequest(ref.getDocumentId())
-                    .storeId(STORE_A)
-                    .send()
-                    .join())
-        .isInstanceOf(ProblemException.class)
-        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
-  }
-
-  @Test
-  void shouldPreserveContentIndependenceForSameDocumentIdAcrossStores() throws IOException {
-    // given
-    final String docId = "shared-doc-" + UUID.randomUUID();
-    final var refA =
-        clientA
-            .newCreateDocumentCommand()
-            .content("content-from-a")
-            .documentId(docId)
-            .storeId(STORE_A)
-            .send()
-            .join();
-    final var refB =
-        clientB
-            .newCreateDocumentCommand()
-            .content("content-from-b")
-            .documentId(docId)
-            .storeId(STORE_B)
-            .send()
-            .join();
-
-    // when / then
-    try (final var streamA = clientA.newDocumentContentGetRequest(refA).send().join()) {
-      assertThat(streamA.readAllBytes()).isEqualTo("content-from-a".getBytes());
-    }
-    try (final var streamB = clientB.newDocumentContentGetRequest(refB).send().join()) {
-      assertThat(streamB.readAllBytes()).isEqualTo("content-from-b".getBytes());
-    }
   }
 
   private static Path createTempDir(final String prefix) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationLocalIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationLocalIT.java
@@ -22,6 +22,8 @@ final class DocumentIsolationLocalIT extends AbstractDocumentIsolationIT {
 
   private static final Path STORE_DIR_A = createTempDir("doc-store-a-");
   private static final Path STORE_DIR_B = createTempDir("doc-store-b-");
+  private static final Path STORE_DIR_C = createTempDir("doc-store-c-");
+  private static final Path STORE_DIR_DEFAULT = createTempDir("doc-store-default-");
 
   @SuppressWarnings("resource") // lifecycle managed by @TestZeebe
   @TestZeebe(purgeAfterEach = false)
@@ -29,17 +31,31 @@ final class DocumentIsolationLocalIT extends AbstractDocumentIsolationIT {
       TENANTS.configure(
           new TestStandaloneBroker()
               .withUnauthenticatedAccess()
-              .withProperty("camunda.document.local.store-a.path", STORE_DIR_A.toString())
-              .withProperty("camunda.document.local.store-b.path", STORE_DIR_B.toString())
-              .withProperty("camunda.document.default-store-id", STORE_A)
+              .withProperty(
+                  "camunda.document.local.store-default.path", STORE_DIR_DEFAULT.toString())
+              .withProperty("camunda.document.default-store-id", STORE_DEFAULT)
+              .withProperty(
+                  "camunda.physical-tenants.tenanta.document.local.store-a.path",
+                  STORE_DIR_A.toString())
+              .withProperty("camunda.physical-tenants.tenanta.document.default-store-id", STORE_A)
               .withProperty("camunda.physical-tenants.tenanta.document.assigned[0]", STORE_A)
+              .withProperty(
+                  "camunda.physical-tenants.tenantb.document.local.store-b.path",
+                  STORE_DIR_B.toString())
+              .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B)
               .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
-              .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B));
+              .withProperty(
+                  "camunda.physical-tenants.tenantc.document.local.store-c.path",
+                  STORE_DIR_C.toString())
+              .withProperty("camunda.physical-tenants.tenantc.document.default-store-id", STORE_C)
+              .withProperty("camunda.physical-tenants.tenantc.document.assigned[0]", STORE_C));
 
   @BeforeAll
   static void setUp() {
     clearDirectoryContents(STORE_DIR_A);
     clearDirectoryContents(STORE_DIR_B);
+    clearDirectoryContents(STORE_DIR_C);
+    clearDirectoryContents(STORE_DIR_DEFAULT);
     startClients(BROKER);
   }
 
@@ -48,6 +64,8 @@ final class DocumentIsolationLocalIT extends AbstractDocumentIsolationIT {
     closeClients();
     deleteDirectory(STORE_DIR_A);
     deleteDirectory(STORE_DIR_B);
+    deleteDirectory(STORE_DIR_C);
+    deleteDirectory(STORE_DIR_DEFAULT);
   }
 
   private static Path createTempDir(final String prefix) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationLocalIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/DocumentIsolationLocalIT.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+final class DocumentIsolationLocalIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String STORE_A = "store-a";
+  private static final String STORE_B = "store-b";
+
+  private static final Path STORE_DIR_A = createTempDir("doc-store-a-");
+  private static final Path STORE_DIR_B = createTempDir("doc-store-b-");
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @SuppressWarnings("resource") // lifecycle managed by @TestZeebe
+  @TestZeebe(purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withUnauthenticatedAccess()
+              .withProperty("camunda.document.local.store-a.path", STORE_DIR_A.toString())
+              .withProperty("camunda.document.local.store-b.path", STORE_DIR_B.toString())
+              .withProperty("camunda.document.default-store-id", STORE_A)
+              .withProperty("camunda.physical-tenants.tenanta.document.assigned[0]", STORE_A)
+              .withProperty("camunda.physical-tenants.tenantb.document.assigned[0]", STORE_B)
+              .withProperty("camunda.physical-tenants.tenantb.document.default-store-id", STORE_B));
+
+  private static CamundaClient clientA;
+  private static CamundaClient clientB;
+
+  @BeforeAll
+  static void setUp() {
+    clearDirectoryContents(STORE_DIR_A);
+    clearDirectoryContents(STORE_DIR_B);
+    clientA = TENANTS.newClientBuilder(BROKER, TENANT_A).build();
+    clientB = TENANTS.newClientBuilder(BROKER, TENANT_B).build();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    if (clientA != null) {
+      clientA.close();
+    }
+    if (clientB != null) {
+      clientB.close();
+    }
+    deleteDirectory(STORE_DIR_A);
+    deleteDirectory(STORE_DIR_B);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldDenyReadOfDocumentOwnedByAnotherTenant() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotFindDocumentOwnedByAnotherTenantInOwnStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("hello-from-a").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientB.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @Test
+  void shouldNotOverwriteDocumentOwnedByAnotherTenant() throws IOException {
+    // given
+    final String docId = "doc-" + UUID.randomUUID();
+    final var refB =
+        clientB
+            .newCreateDocumentCommand()
+            .content("original-content-b")
+            .documentId(docId)
+            .send()
+            .join();
+
+    // when
+    clientA
+        .newCreateDocumentCommand()
+        .content("tampered-content-a")
+        .documentId(docId)
+        .send()
+        .join();
+
+    // then
+    try (final var stream = clientB.newDocumentContentGetRequest(refB).send().join()) {
+      assertThat(stream.readAllBytes()).isEqualTo("original-content-b".getBytes());
+    }
+  }
+
+  @Test
+  void shouldDenyDeleteOfDocumentOwnedByAnotherTenantFromUnassignedStore() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDeleteDocumentCommand(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldNotDeleteDocumentOwnedByAnotherTenant() {
+    // given
+    final var ref = clientA.newCreateDocumentCommand().content("protected").send().join();
+
+    // when / then
+    clientB.newDeleteDocumentCommand(ref.getDocumentId()).send().join();
+
+    assertThatCode(
+            () -> {
+              try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
+                assertThat(stream).isNotNull();
+              }
+            })
+        .doesNotThrowAnyException();
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotExposeDocumentIdAcrossTenants() {
+    // given
+    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> clientA.newDocumentContentGetRequest(ref.getDocumentId()).send().join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 404);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldNotExposeDocumentIdAcrossTenantsViaUnassignedStore() {
+    // given
+    final var ref = clientB.newCreateDocumentCommand().content("private-b").send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientA
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(ref.getStoreId())
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldAllowTenantToUseItsAssignedStore() throws IOException {
+    // given / when
+    final var ref =
+        clientA.newCreateDocumentCommand().content("hello-from-a").storeId(STORE_A).send().join();
+
+    // then
+    assertThat(ref.getStoreId()).isEqualTo(STORE_A);
+
+    try (final var stream = clientA.newDocumentContentGetRequest(ref).send().join()) {
+      assertThat(stream).isNotNull();
+    }
+  }
+
+  @Test
+  void shouldRejectAccessToUnassignedStore() {
+    assertThatThrownBy(
+            () ->
+                clientA
+                    .newCreateDocumentCommand()
+                    .content("attempt")
+                    .storeId(STORE_B)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  void shouldIsolateDocumentsBetweenTenantStores() {
+    // given
+    final var ref =
+        clientA.newCreateDocumentCommand().content("secret-a").storeId(STORE_A).send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                clientB
+                    .newDocumentContentGetRequest(ref.getDocumentId())
+                    .storeId(STORE_A)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .matches(e -> ((ProblemException) e).details().getStatus() == 400);
+  }
+
+  @Test
+  void shouldPreserveContentIndependenceForSameDocumentIdAcrossStores() throws IOException {
+    // given
+    final String docId = "shared-doc-" + UUID.randomUUID();
+    final var refA =
+        clientA
+            .newCreateDocumentCommand()
+            .content("content-from-a")
+            .documentId(docId)
+            .storeId(STORE_A)
+            .send()
+            .join();
+    final var refB =
+        clientB
+            .newCreateDocumentCommand()
+            .content("content-from-b")
+            .documentId(docId)
+            .storeId(STORE_B)
+            .send()
+            .join();
+
+    // when / then
+    try (final var streamA = clientA.newDocumentContentGetRequest(refA).send().join()) {
+      assertThat(streamA.readAllBytes()).isEqualTo("content-from-a".getBytes());
+    }
+    try (final var streamB = clientB.newDocumentContentGetRequest(refB).send().join()) {
+      assertThat(streamB.readAllBytes()).isEqualTo("content-from-b".getBytes());
+    }
+  }
+
+  private static Path createTempDir(final String prefix) {
+    try {
+      return Files.createTempDirectory(prefix);
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to create temp dir for document store", e);
+    }
+  }
+
+  private static void clearDirectoryContents(final Path dir) {
+    if (dir == null || !Files.exists(dir)) {
+      return;
+    }
+    try (final var paths = Files.walk(dir)) {
+      paths
+          .filter(p -> !p.equals(dir))
+          .sorted(Comparator.reverseOrder())
+          .forEach(
+              p -> {
+                try {
+                  Files.deleteIfExists(p);
+                } catch (final IOException ignored) {
+                  // do nothing
+                }
+              });
+    } catch (final IOException ignored) {
+      // do nothing
+    }
+  }
+
+  private static void deleteDirectory(final Path dir) {
+    clearDirectoryContents(dir);
+    if (dir != null) {
+      try {
+        Files.deleteIfExists(dir);
+      } catch (final IOException ignored) {
+        // do nothing
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Add integration tests proving strong isolation between physical tenants for all document operations via each tenant's `/v2/.../documents` path using `AbstractDocumentIsolationIT`.

- `DocumentIsolationAwsIT`
   - `S3Client.create()` reads from system properties
   - 🗒️ added system properties
- `DocumentIsolationAzureIT`
- `DocumentIsolationGcpIT`
   - Used to default -- `StorageOptions.getDefaultInstance().getService()`
   - ⚠️ minimum tweak of production code `GcpDocumentStoreProvider` 
   - added `storageOverride` and `@VisibleForTesting` to make sure this won't be used outside of this class or tests
- `DocumentIsolationLocalIT`

## Related issues

closes #55172
