### PR TITLE
fix: set backwards.compat.version to correct previous minor baseline (stable/8.9)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -251,7 +251,7 @@
     <extension.version.os-maven-plugin>1.7.1</extension.version.os-maven-plugin>
 
     <!-- version against which backwards compatibility is checked -->
-    <backwards.compat.version>8.9.11</backwards.compat.version>
+    <backwards.compat.version>8.8.0</backwards.compat.version>
     <ignored.changes.file>ignored-changes.json</ignored.changes.file>
 
     <!--


### PR DESCRIPTION
## Summary

- On `stable/8.9`, `backwards.compat.version` was set to `8.9.11` — a later patch of the *same* branch — which means RevAPI is comparing the current code against itself rather than the previous minor baseline
- The correct value is `8.8.0`, the baseline of the previous minor release line
- This is the same class of bug fixed on `main` in #56063

## Fix

| Branch | Before | After |
|--------|--------|-------|
| `stable/8.9` | `8.9.11` | `8.8.0` |

Related to #51405
See also #56063

## Test plan

- [ ] Confirm `backwards.compat.version` in `parent/pom.xml` reads `8.8.0`
- [ ] Verify RevAPI check passes on next CI run against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)