### PR TITLE
fix: Bump jackson to 2.18.9 (CVE-2026-54515)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -66,7 +66,7 @@
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.7.21</version.identity>
     <version.surefire>3.5.6</version.surefire>
-    <version.jackson>2.18.8</version.jackson>
+    <version.jackson>2.18.9</version.jackson>
     <version.junit>5.11.4</version.junit>
     <version.junit4>4.13.2</version.junit4>
     <version.log4j>2.25.4</version.log4j>


### PR DESCRIPTION

## Description

Bumps the managed jackson-bom from 2.18.8 to 2.18.9 to resolve GHSA-5jmj-h7xm-6q6v (jackson-databind @JsonIgnoreProperties exclusion bypass with case-insensitive deserialization), which the Dependency Vulnerability Gate flags as blocking. Same minor line, dependency-only change.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
