### PR TITLE
test: clear all process instances before task-panel tests

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/task-panel.spec.ts
@@ -12,9 +12,10 @@ import {deploy, createInstances} from 'utils/zeebeClient';
 import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
+import {clearAllProcessInstances} from '@requestHelpers';
 
-test.beforeAll(async ({resetData}) => {
-  await resetData();
+test.beforeAll(async ({request}) => {
+  await clearAllProcessInstances(request);
   await deploy([
     './resources/usertask_to_be_assigned.bpmn',
     './resources/usertask_for_scrolling_1.bpmn',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/v1/task-panel.spec.ts
@@ -13,9 +13,10 @@ import {sleep} from 'utils/sleep';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {waitForAssertion} from '../../../utils/waitForAssertion';
+import {clearAllProcessInstances} from '@requestHelpers';
 
-test.beforeAll(async ({resetData}) => {
-  await resetData();
+test.beforeAll(async ({request}) => {
+  await clearAllProcessInstances(request);
   await deploy([
     './resources/usertask_to_be_assigned.bpmn',
     './resources/usertask_for_scrolling_1.bpmn',

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -13,6 +13,7 @@ import {defaultAssertionOptions} from '../constants';
 import {cancelProcessInstance} from '../zeebeClient';
 import {sleep} from '../sleep';
 import {validateResponse} from 'json-body-assertions';
+import {expectBatchState} from './batch-operation-requestHelpers';
 
 export async function getProcessDefinitionKey(
   request: APIRequestContext,
@@ -223,4 +224,66 @@ export async function expectProcessInstanceCanBeFound(
     intervals: [5_000, 10_000, 15_000, 25_000, 35_000],
     timeout: 180_000,
   });
+}
+
+async function countProcessInstances(
+  request: APIRequestContext,
+  state: string,
+): Promise<number> {
+  const res = await request.post(buildUrl('/process-instances/search'), {
+    headers: jsonHeaders(),
+    data: {filter: {state}, page: {limit: 1}},
+  });
+  await assertStatusCode(res, 200);
+  const json = await res.json();
+  return json.page.totalItems as number;
+}
+
+async function runBatchAndWaitForCompletion(
+  request: APIRequestContext,
+  endpoint: '/process-instances/cancellation' | '/process-instances/deletion',
+  filter: Record<string, unknown>,
+): Promise<void> {
+  const res = await request.post(buildUrl(endpoint), {
+    headers: jsonHeaders(),
+    data: {filter},
+  });
+
+  await assertStatusCode(res, 200);
+  await validateResponse(
+    {
+      path: endpoint,
+      method: 'POST',
+      status: '200',
+    },
+    res,
+  );
+  const json = await res.json();
+  const batchKey = json.batchOperationKey;
+
+  await expectBatchState(request, batchKey, 'COMPLETED');
+}
+
+export async function clearAllProcessInstances(
+  request: APIRequestContext,
+): Promise<void> {
+  // Cancel all active instances first.
+  if ((await countProcessInstances(request, 'ACTIVE')) > 0) {
+    await runBatchAndWaitForCompletion(
+      request,
+      '/process-instances/cancellation',
+      {state: 'ACTIVE'},
+    );
+  }
+  // Cancellation moves instances to TERMINATED; delete each terminal state
+  // individually to avoid relying on $or in the search pre-check.
+  for (const state of ['COMPLETED', 'TERMINATED']) {
+    if ((await countProcessInstances(request, state)) > 0) {
+      await runBatchAndWaitForCompletion(
+        request,
+        '/process-instances/deletion',
+        {state},
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Description

Backport of #51751 to `stable/8.9`.

The `task-panel` `beforeAll` hooks (both the v2 `tests/tasklist/task-panel.spec.ts` and the v1 `tests/tasklist/v1/task-panel.spec.ts`) reset state via the `resetData` fixture, which `POST`s to the Tasklist-v1-only dev endpoint `/v1/external/devUtil/recreateData`. That endpoint is `@Profile("e2e-test")`-gated, Elasticsearch-only, and deletes/recreates ES indices directly, which is fragile in the all-in-one orchestration cluster. When it returns a non-ok response the entire `describe` block is skipped with an opaque `Failed to reset data:` error — the fixture only interpolates `response.statusText`, which is empty over HTTP/2, so the real status code is lost and the call never appears in the Playwright trace (it uses raw Node `fetch`, not `request`).

This replaces `resetData()` with `clearAllProcessInstances(request)`, which cancels all active instances then deletes completed/terminated ones via the stable v2 batch API. It is DB-agnostic, not profile-gated, and uses Playwright's `request` context so failures are visible in the trace.

This mirrors the fix already on `main` (#51751); on `main` the `devUtil/recreateData` endpoint was subsequently removed entirely in #50702. `stable/8.9` retains both the v1 and v2 task-panel specs, so the change is applied to both (vs. only the v2 spec on `main`).

Failing nightly run that surfaced this: https://github.com/camunda/camunda/actions/runs/28364257599/job/84026394934

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Backport of #51751
