### PR TITLE
refactor: clean-up unused PersistentWebSession rdbms beans

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -14,7 +14,6 @@ import io.camunda.db.rdbms.DefaultRdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.PerTenantSchemaConfig;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
-import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
 import io.camunda.db.rdbms.sql.TableMetricsMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.zeebe.util.VersionUtil;
@@ -145,17 +144,11 @@ public class MyBatisConfiguration {
     return factoryBean.getObject();
   }
 
-  // TODO: the next 2 mappers are the last remaining default-tenant-only mappers. They should be
-  // refactored to support multi-tenancy, and then these beans can be removed.
+  // TODO: TableMetricsMapper is the last remaining default-tenant-only mapper. It should be
+  // refactored to support multi-tenancy, and then can be removed.
   @Bean
   TableMetricsMapper tableMetricsMapper(
       final Map<String, RdbmsMapperBundle> allRdbmsMapperBundles) {
     return allRdbmsMapperBundles.get(DEFAULT_PHYSICAL_TENANT_ID).tableMetricsMapper();
-  }
-
-  @Bean
-  PersistentWebSessionMapper persistentWebSessionMapper(
-      final Map<String, RdbmsMapperBundle> allRdbmsMapperBundles) {
-    return allRdbmsMapperBundles.get(DEFAULT_PHYSICAL_TENANT_ID).persistentWebSessionMapper();
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -16,12 +16,9 @@ import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.db.rdbms.RdbmsServiceFactory;
 import io.camunda.db.rdbms.read.RdbmsTenantReaders;
-import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
 import io.camunda.db.rdbms.read.service.RdbmsTableRowCountMetrics;
-import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
 import io.camunda.db.rdbms.sql.TableMetricsMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
-import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
 import io.camunda.search.clients.CamundaSearchClients;
 import io.camunda.search.clients.auth.ResourceAccessDelegatingController;
 import io.camunda.search.clients.reader.AuthorizationReader;
@@ -59,18 +56,6 @@ public class RdbmsConfiguration {
     final var metricsConfig = configuration.getData().getSecondaryStorage().getRdbms().getMetrics();
     return new RdbmsTableRowCountMetrics(
         tableMetricsMapper, metricsConfig.getTableRowCountCacheDuration());
-  }
-
-  @Bean
-  public PersistentWebSessionDbReader persistentWebSessionReader(
-      final PersistentWebSessionMapper persistentWebSessionMapper) {
-    return new PersistentWebSessionDbReader(persistentWebSessionMapper);
-  }
-
-  @Bean
-  public PersistentWebSessionWriter persistentWebSessionWriter(
-      final PersistentWebSessionMapper persistentWebSessionMapper) {
-    return new PersistentWebSessionWriter(persistentWebSessionMapper);
   }
 
   @Bean

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PersistentWebSessionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/websession/PersistentWebSessionIT.java
@@ -7,12 +7,13 @@
  */
 package io.camunda.it.rdbms.db.websession;
 
+import static io.camunda.configuration.api.physicaltenants.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.db.rdbms.read.service.PersistentWebSessionDbReader;
-import io.camunda.db.rdbms.write.service.PersistentWebSessionWriter;
+import io.camunda.application.commons.identity.PhysicalTenantScopedPersistentWebSessionClientFactory;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
 import java.util.HashMap;
 import java.util.Map;
@@ -27,10 +28,7 @@ public class PersistentWebSessionIT {
 
   @TestTemplate
   public void shouldSaveAndFindWebSessionById(final CamundaRdbmsTestApplication testApplication) {
-    final PersistentWebSessionDbReader reader =
-        testApplication.bean(PersistentWebSessionDbReader.class);
-    final PersistentWebSessionWriter writer =
-        testApplication.bean(PersistentWebSessionWriter.class);
+    final var persistentWebSessionClient = getPersistentWebSessionClient(testApplication);
 
     // given
     final String sessionId = UUID.randomUUID().toString();
@@ -47,10 +45,11 @@ public class PersistentWebSessionIT {
             sessionId, creationTime, lastAccessedTime, maxInactiveInterval, attributes);
 
     // when
-    writer.upsert(session);
+    persistentWebSessionClient.upsertPersistentWebSession(session);
 
     // then
-    final PersistentWebSessionEntity foundSession = reader.findById(sessionId);
+    final PersistentWebSessionEntity foundSession =
+        persistentWebSessionClient.getPersistentWebSession(sessionId);
     assertThat(foundSession).isNotNull();
     assertThat(foundSession.id()).isEqualTo(sessionId);
     assertThat(foundSession.creationTime()).isEqualTo(creationTime);
@@ -61,12 +60,16 @@ public class PersistentWebSessionIT {
     assertThat(foundSession.attributes().get("role")).isEqualTo("admin".getBytes());
   }
 
+  private PersistentWebSessionClient getPersistentWebSessionClient(
+      final CamundaRdbmsTestApplication testApplication) {
+    return PhysicalTenantScopedPersistentWebSessionClientFactory.fromRdbmsMapperBundles(
+            (testApplication.bean("rdbmsMapperBundles")))
+        .withPhysicalTenant(DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
   @TestTemplate
   public void shouldUpdateExistingWebSession(final CamundaRdbmsTestApplication testApplication) {
-    final PersistentWebSessionDbReader reader =
-        testApplication.bean(PersistentWebSessionDbReader.class);
-    final PersistentWebSessionWriter writer =
-        testApplication.bean(PersistentWebSessionWriter.class);
+    final var persistentWebSessionClient = getPersistentWebSessionClient(testApplication);
 
     // given - create initial session
     final String sessionId = UUID.randomUUID().toString();
@@ -80,7 +83,7 @@ public class PersistentWebSessionIT {
         new PersistentWebSessionEntity(
             sessionId, creationTime, initialAccessTime, 1800L, initialAttributes);
 
-    writer.upsert(initialSession);
+    persistentWebSessionClient.upsertPersistentWebSession(initialSession);
 
     // when - update the session
     final long updatedAccessTime = creationTime + 5000;
@@ -92,10 +95,11 @@ public class PersistentWebSessionIT {
         new PersistentWebSessionEntity(
             sessionId, creationTime, updatedAccessTime, 1800L, updatedAttributes);
 
-    writer.upsert(updatedSession);
+    persistentWebSessionClient.upsertPersistentWebSession(updatedSession);
 
     // then
-    final PersistentWebSessionEntity foundSession = reader.findById(sessionId);
+    final PersistentWebSessionEntity foundSession =
+        persistentWebSessionClient.getPersistentWebSession(sessionId);
     assertThat(foundSession).isNotNull();
     assertThat(foundSession.id()).isEqualTo(sessionId);
     assertThat(foundSession.creationTime()).isEqualTo(creationTime);
@@ -107,10 +111,7 @@ public class PersistentWebSessionIT {
 
   @TestTemplate
   public void shouldDeleteWebSession(final CamundaRdbmsTestApplication testApplication) {
-    final PersistentWebSessionDbReader reader =
-        testApplication.bean(PersistentWebSessionDbReader.class);
-    final PersistentWebSessionWriter writer =
-        testApplication.bean(PersistentWebSessionWriter.class);
+    final var persistentWebSessionClient = getPersistentWebSessionClient(testApplication);
 
     // given - create a session
     final String sessionId = UUID.randomUUID().toString();
@@ -121,24 +122,21 @@ public class PersistentWebSessionIT {
         new PersistentWebSessionEntity(
             sessionId, System.currentTimeMillis(), System.currentTimeMillis(), 1800L, attributes);
 
-    writer.upsert(session);
+    persistentWebSessionClient.upsertPersistentWebSession(session);
 
     // verify it exists
-    assertThat(reader.findById(sessionId)).isNotNull();
+    assertThat(persistentWebSessionClient.getPersistentWebSession(sessionId)).isNotNull();
 
     // when - delete the session
-    writer.deleteById(sessionId);
+    persistentWebSessionClient.deletePersistentWebSession(sessionId);
 
     // then - verify it's gone
-    assertThat(reader.findById(sessionId)).isNull();
+    assertThat(persistentWebSessionClient.getPersistentWebSession(sessionId)).isNull();
   }
 
   @TestTemplate
   public void shouldFindAllWebSessions(final CamundaRdbmsTestApplication testApplication) {
-    final PersistentWebSessionDbReader reader =
-        testApplication.bean(PersistentWebSessionDbReader.class);
-    final PersistentWebSessionWriter writer =
-        testApplication.bean(PersistentWebSessionWriter.class);
+    final var persistentWebSessionClient = getPersistentWebSessionClient(testApplication);
 
     // given - create multiple sessions
     final String sessionId1 = UUID.randomUUID().toString();
@@ -150,14 +148,15 @@ public class PersistentWebSessionIT {
 
     final long now = System.currentTimeMillis();
 
-    writer.upsert(new PersistentWebSessionEntity(sessionId1, now, now, 1800L, attributes));
-    writer.upsert(
+    persistentWebSessionClient.upsertPersistentWebSession(
+        new PersistentWebSessionEntity(sessionId1, now, now, 1800L, attributes));
+    persistentWebSessionClient.upsertPersistentWebSession(
         new PersistentWebSessionEntity(sessionId2, now + 1000, now + 1000, 1800L, attributes));
-    writer.upsert(
+    persistentWebSessionClient.upsertPersistentWebSession(
         new PersistentWebSessionEntity(sessionId3, now + 2000, now + 2000, 1800L, attributes));
 
     // when
-    final var allSessions = reader.findAll();
+    final var allSessions = persistentWebSessionClient.getAllPersistentWebSessions().items();
 
     // then - should contain at least our 3 sessions (may contain more from other tests)
     assertThat(allSessions).isNotNull();
@@ -167,10 +166,7 @@ public class PersistentWebSessionIT {
 
   @TestTemplate
   public void shouldHandleEmptyAttributes(final CamundaRdbmsTestApplication testApplication) {
-    final PersistentWebSessionDbReader reader =
-        testApplication.bean(PersistentWebSessionDbReader.class);
-    final PersistentWebSessionWriter writer =
-        testApplication.bean(PersistentWebSessionWriter.class);
+    final var persistentWebSessionClient = getPersistentWebSessionClient(testApplication);
 
     // given - session with empty attributes
     final String sessionId = UUID.randomUUID().toString();
@@ -185,10 +181,11 @@ public class PersistentWebSessionIT {
             emptyAttributes);
 
     // when
-    writer.upsert(session);
+    persistentWebSessionClient.upsertPersistentWebSession(session);
 
     // then
-    final PersistentWebSessionEntity foundSession = reader.findById(sessionId);
+    final PersistentWebSessionEntity foundSession =
+        persistentWebSessionClient.getPersistentWebSession(sessionId);
     assertThat(foundSession).isNotNull();
     assertThat(foundSession.attributes()).isNotNull();
     assertThat(foundSession.attributes()).isEmpty();
@@ -196,10 +193,7 @@ public class PersistentWebSessionIT {
 
   @TestTemplate
   public void shouldHandleLargeAttributes(final CamundaRdbmsTestApplication testApplication) {
-    final PersistentWebSessionDbReader reader =
-        testApplication.bean(PersistentWebSessionDbReader.class);
-    final PersistentWebSessionWriter writer =
-        testApplication.bean(PersistentWebSessionWriter.class);
+    final var persistentWebSessionClient = getPersistentWebSessionClient(testApplication);
 
     // given - session with large attribute values
     final String sessionId = UUID.randomUUID().toString();
@@ -218,10 +212,11 @@ public class PersistentWebSessionIT {
             sessionId, System.currentTimeMillis(), System.currentTimeMillis(), 1800L, attributes);
 
     // when
-    writer.upsert(session);
+    persistentWebSessionClient.upsertPersistentWebSession(session);
 
     // then
-    final PersistentWebSessionEntity foundSession = reader.findById(sessionId);
+    final PersistentWebSessionEntity foundSession =
+        persistentWebSessionClient.getPersistentWebSession(sessionId);
     assertThat(foundSession).isNotNull();
     assertThat(foundSession.attributes()).hasSize(2);
     assertThat(foundSession.attributes().get("largeAttribute")).isEqualTo(largeData);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
PT implementation of PersistentWebSession was done here https://github.com/camunda/camunda/pull/55777

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
