### PR TITLE
test: Lower AWS Parallelism

### DIFF
--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -85,7 +85,7 @@ jobs:
     permissions:
       contents: read
       actions: write
-    timeout-minutes: 60
+    timeout-minutes: 180
     runs-on: ${{ matrix.runs-on }}
     env:
       TEST_OWNER: ${{ matrix.owner }}
@@ -104,7 +104,7 @@ jobs:
             name: "Camunda QA Module Client Tests"
             maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
             maven-build-threads: 2
-            maven-test-fork-count: 7
+            maven-test-fork-count: 2
             maven-test-profiles: multi-db-test-client
             runs-on: aws-core-8-default
             owner: '@camunda/monorepo-devops-team'
@@ -112,7 +112,7 @@ jobs:
             name: "Camunda QA Module Non-Client Tests"
             maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
             maven-build-threads: 2
-            maven-test-fork-count: 7
+            maven-test-fork-count: 2
             maven-test-profiles: multi-db-test-non-client
             runs-on: aws-core-8-default
             owner: '@camunda/monorepo-devops-team'
@@ -120,7 +120,7 @@ jobs:
             name: "Search Client OpenSearch ITs"
             maven-modules: "'io.camunda:camunda-search-client-connect,io.camunda:camunda-search-client-opensearch'"
             maven-build-threads: 2
-            maven-test-fork-count: 7
+            maven-test-fork-count: 2
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
             owner: '@camunda/core-features'
@@ -128,7 +128,7 @@ jobs:
             name: "Camunda Exporter ITs"
             maven-modules: "'io.camunda:camunda-exporter'"
             maven-build-threads: 2
-            maven-test-fork-count: 7
+            maven-test-fork-count: 2
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
             owner: '@camunda/data-layer'
@@ -136,7 +136,7 @@ jobs:
             name: "Zeebe OpenSearch Exporter ITs"
             maven-modules: "'io.camunda:zeebe-opensearch-exporter'"
             maven-build-threads: 2
-            maven-test-fork-count: 7
+            maven-test-fork-count: 2
             maven-test-profiles: multi-db-test
             runs-on: aws-core-8-default
             owner: '@camunda/data-layer'


### PR DESCRIPTION

## Description

We are sharing a single node OS instance and when we are running tests in parallel we seems to be easily exceeding to max shards per node config. This is lowering the parallelism to see if it would help.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
