### PR TITLE
fix: exclude agentic control reports from private report picker

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/report/AgenticControlReportPickerExclusionIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/report/AgenticControlReportPickerExclusionIT.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.report;
+
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.DURATION_STABILITY_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_AVG_TOKENS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_MEDIAN_TOKENS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_TOOL_CALLS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_CONSUMERS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_OUTLIER_BANDS_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.TOKEN_TREND_REPORT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractBrokerlessZeebeCCSMIT;
+import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.dashboard.AgenticControlDashboardService;
+import io.camunda.optimize.service.db.reader.ReportReader;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for the dashboard "Add a Report" picker, which is backed by {@link
+ * ReportReader#getAllPrivateReportsOmitXml()} ({@code GET api/report}). Agentic control reports are
+ * system-generated implementation details flagged with {@code data.agenticControlReport = true};
+ * they must not be selectable when users build their own dashboards. This test runs against
+ * whichever backend the IT suite is configured with, covering both Elasticsearch and OpenSearch.
+ */
+class AgenticControlReportPickerExclusionIT extends AbstractBrokerlessZeebeCCSMIT {
+
+  private static final List<String> AGENTIC_REPORT_IDS =
+      List.of(
+          KPI_COMPLETED_REPORT_ID,
+          KPI_AVG_DURATION_REPORT_ID,
+          KPI_INCIDENT_RATE_REPORT_ID,
+          KPI_AVG_TOKENS_REPORT_ID,
+          KPI_MEDIAN_TOKENS_REPORT_ID,
+          DURATION_STABILITY_REPORT_ID,
+          TOKEN_TREND_REPORT_ID,
+          TOKEN_CONSUMERS_REPORT_ID,
+          TOKEN_OUTLIER_BANDS_REPORT_ID,
+          KPI_DURATION_P50_REPORT_ID,
+          KPI_DURATION_P95_REPORT_ID,
+          FAILURE_RATE_BY_VERSION_REPORT_ID,
+          KPI_TOOL_CALLS_REPORT_ID);
+
+  private ReportReader reportReader;
+
+  @BeforeEach
+  void setUp() {
+    // seeds the agentic control dashboard and its system-generated reports
+    embeddedOptimizeExtension.getBean(AgenticControlDashboardService.class).reconcile();
+    reportReader = embeddedOptimizeExtension.getBean(ReportReader.class);
+  }
+
+  @Test
+  void shouldNotReturnAgenticControlReportsInPrivateReportPicker() {
+    // given the agentic reports were actually persisted by the reconcile above
+    assertThat(reportReader.getReport(KPI_COMPLETED_REPORT_ID)).isPresent();
+
+    // when fetching the private reports backing the "Add a Report" picker
+    final List<ReportDefinitionDto> reports = reportReader.getAllPrivateReportsOmitXml();
+
+    // then none of the agentic control reports leak into the picker
+    assertThat(reports)
+        .extracting(ReportDefinitionDto::getId)
+        .doesNotContainAnyElementsOf(AGENTIC_REPORT_IDS);
+    assertThat(reports)
+        .noneMatch(
+            report ->
+                report.getData() instanceof final ProcessReportDataDto data
+                    && data.isAgenticControlReport());
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/ReportReaderES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/reader/ReportReaderES.java
@@ -15,6 +15,7 @@ import static io.camunda.optimize.service.db.schema.index.report.CombinedReportI
 import static io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex.DATA;
 import static io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex.REPORTS;
 import static io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex.REPORT_ITEM_ID;
+import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.AGENTIC_CONTROL_REPORT;
 import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.INSTANT_PREVIEW_REPORT;
 import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.MANAGEMENT_REPORT;
 
@@ -186,6 +187,7 @@ public class ReportReaderES implements ReportReader {
         b ->
             b.mustNot(m -> m.term(t -> t.field(DATA + "." + MANAGEMENT_REPORT).value(true)))
                 .mustNot(m -> m.term(t -> t.field(DATA + "." + INSTANT_PREVIEW_REPORT).value(true)))
+                .mustNot(m -> m.term(t -> t.field(DATA + "." + AGENTIC_CONTROL_REPORT).value(true)))
                 .mustNot(m -> m.exists(e -> e.field(COLLECTION_ID))));
     final SearchResponse<ReportDefinitionDto> searchResponse =
         performGetReportRequestOmitXml(
@@ -250,6 +252,15 @@ public class ReportReaderES implements ReportReader {
                                                                   DATA
                                                                       + "."
                                                                       + INSTANT_PREVIEW_REPORT)
+                                                              .value(true)))
+                                          .mustNot(
+                                              m ->
+                                                  m.term(
+                                                      t ->
+                                                          t.field(
+                                                                  DATA
+                                                                      + "."
+                                                                      + AGENTIC_CONTROL_REPORT)
                                                               .value(true))))));
     } else {
       countRequest =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/ReportReaderOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/reader/ReportReaderOS.java
@@ -15,6 +15,7 @@ import static io.camunda.optimize.service.db.schema.index.report.AbstractReportI
 import static io.camunda.optimize.service.db.schema.index.report.AbstractReportIndex.DATA;
 import static io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex.REPORTS;
 import static io.camunda.optimize.service.db.schema.index.report.CombinedReportIndex.REPORT_ITEM_ID;
+import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.AGENTIC_CONTROL_REPORT;
 import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.INSTANT_PREVIEW_REPORT;
 import static io.camunda.optimize.service.db.schema.index.report.SingleProcessReportIndex.MANAGEMENT_REPORT;
 
@@ -191,6 +192,7 @@ public class ReportReaderOS implements ReportReader {
             .mustNot(QueryDSL.exists(COLLECTION_ID))
             .mustNot(QueryDSL.term(DATA + "." + MANAGEMENT_REPORT, true))
             .mustNot(QueryDSL.term(DATA + "." + INSTANT_PREVIEW_REPORT, true))
+            .mustNot(QueryDSL.term(DATA + "." + AGENTIC_CONTROL_REPORT, true))
             .build()
             .toQuery();
 
@@ -249,6 +251,7 @@ public class ReportReaderOS implements ReportReader {
           new BoolQuery.Builder()
               .mustNot(QueryDSL.term(DATA + "." + MANAGEMENT_REPORT, true))
               .mustNot(QueryDSL.term(DATA + "." + INSTANT_PREVIEW_REPORT, true))
+              .mustNot(QueryDSL.term(DATA + "." + AGENTIC_CONTROL_REPORT, true))
               .build()
               .toQuery();
       return osClient.count(new String[] {SINGLE_PROCESS_REPORT_INDEX_NAME}, query, errorMessage);

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/report/SingleProcessReportIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/report/SingleProcessReportIndex.java
@@ -19,6 +19,8 @@ public abstract class SingleProcessReportIndex<TBuilder> extends AbstractReportI
   public static final String MANAGEMENT_REPORT = ProcessReportDataDto.Fields.managementReport;
   public static final String INSTANT_PREVIEW_REPORT =
       ProcessReportDataDto.Fields.instantPreviewReport;
+  public static final String AGENTIC_CONTROL_REPORT =
+      ProcessReportDataDto.Fields.agenticControlReport;
 
   public static final int VERSION = 11;
 
@@ -55,6 +57,7 @@ public abstract class SingleProcessReportIndex<TBuilder> extends AbstractReportI
                             Property.of(q -> q.object(k -> k.enabled(false))))
                         .properties(MANAGEMENT_REPORT, Property.of(q -> q.boolean_(k -> k)))
                         .properties(INSTANT_PREVIEW_REPORT, Property.of(q -> q.boolean_(k -> k)))
+                        .properties(AGENTIC_CONTROL_REPORT, Property.of(q -> q.boolean_(k -> k)))
                         .properties(
                             CONFIGURATION,
                             Property.of(


### PR DESCRIPTION
## Description
Agentic control reports are system-generated process reports flagged with data.agenticControlReport = true and created as private reports (null owner, null collectionId). Because getAllPrivateReportsOmitXml() only excluded management and instant-preview reports, these internal reports leaked into the dashboard "Add a Report" tile picker (GET api/report), where they should not be selectable while the agentic Trust Dashboard is still being built.

Add an AGENTIC_CONTROL_REPORT constant + index mapping to SingleProcessReportIndex and a mustNot exclusion on data.agenticControlReport in getAllPrivateReportsOmitXml() and getReportCount() for both Elasticsearch and OpenSearch, mirroring the existing management/instant-preview exclusions and the already-hidden agentic dashboard.

A regression IT asserts the seeded agentic reports are absent from the private report list, running against both ES and OS via the IT suite configuration.

## Screenshot

<img width="2981" height="1285" alt="Screenshot 2026-06-29 at 9 37 25 AM" src="https://github.com/user-attachments/assets/09482c9f-3e34-4f07-8d85-fce866339e6d" />
Dashboard no shows Agentic Reports in the picker
<img width="3002" height="1200" alt="Screenshot 2026-06-29 at 9 38 01 AM" src="https://github.com/user-attachments/assets/753cb769-d87b-4f18-9b75-0139f091d389" />



Closes #55508