### PR TITLE
ci(gha): test github arm runner for check-licenses workflow

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -51,7 +51,7 @@ jobs:
             -DskipQaBuild=true
         - name: single-app
           path: ./
-          runner: gcp-core-16-longrunning
+          runner: linux_16_core_arm
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -120,7 +120,7 @@ jobs:
       id: analyze1
       continue-on-error: true
       timeout-minutes: 30
-      uses: camunda/infra-global-github-actions/fossa/analyze@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/analyze@fossa-arm64
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         branch: ${{  steps.info.outputs.head-ref }}
@@ -130,7 +130,7 @@ jobs:
     - name: Analyze project (attempt 2)
       if: steps.analyze1.outcome != 'success'
       timeout-minutes: 30
-      uses: camunda/infra-global-github-actions/fossa/analyze@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/analyze@fossa-arm64
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         branch: ${{  steps.info.outputs.head-ref }}

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -59,7 +59,7 @@ jobs:
           fossa_cli_arch: linux_amd64
         - name: single-app
           path: ./
-          runner_definition: '"aws-core-32-longrunning"'
+          runner_definition: '"github_linux_16_core_arm"'
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -50,11 +50,13 @@ jobs:
         - name: c8run
           path: ./c8run
           runner_definition: '"gcp-core-4-longrunning"'
+          fossa_commit: fc4fa13813cbc1835129967f10a12f24aa7a393c
         - name: optimize
           path: ./optimize
           runner_definition: '"gcp-core-16-longrunning"'
           maven-config: |
             -DskipQaBuild=true
+          fossa_commit: fc4fa13813cbc1835129967f10a12f24aa7a393c
         - name: single-app
           path: ./
           runner_definition: >-
@@ -62,6 +64,7 @@ jobs:
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true
+          fossa_commit: fossa-arm64
     steps:
     - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -99,11 +102,11 @@ jobs:
         echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
 
     - name: Setup fossa-cli
-      uses: camunda/infra-global-github-actions/fossa/setup@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/setup@${{ matrix.fossa_commit }}
 
     - name: Get context info
       id: info
-      uses: camunda/infra-global-github-actions/fossa/info@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/info@${{ matrix.fossa_commit }}
 
     - name: Adjust pom.xml files for FOSSA
       if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
@@ -138,7 +141,7 @@ jobs:
     # It does not fail for pre-existing issues already present in the base branch.
     - name: Check Pull Request for new License Issues
       if: steps.info.outputs.is-pull-request == 'true'
-      uses: camunda/infra-global-github-actions/fossa/pr-check@fc4fa13813cbc1835129967f10a12f24aa7a393c
+      uses: camunda/infra-global-github-actions/fossa/pr-check@${{ matrix.fossa_commit }}
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         base-ref: ${{ steps.info.outputs.base-ref }}

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -5,6 +5,10 @@
 ---
 name: Check Licenses
 
+defaults:
+  run:
+    shell: bash
+
 on:
   push:
     branches:
@@ -23,6 +27,8 @@ env:
   TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
 
+permissions: {}
+
 jobs:
   analyze:
     name: "Analyze ${{ matrix.project.name }} dependencies"
@@ -30,7 +36,7 @@ jobs:
       # Needed for camunda/infra-global-github-actions/fossa/info
       actions: read
       contents: read
-    runs-on: ${{ matrix.project.runner }}
+    runs-on: ${{ fromJson(matrix.project.runner_definition) }}
     # Skip analysis on fork PRs as they cannot access FOSSA due to lack of credentials
     if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
@@ -43,15 +49,16 @@ jobs:
         project:
         - name: c8run
           path: ./c8run
-          runner: gcp-core-4-longrunning
+          runner_definition: '"gcp-core-4-longrunning"'
         - name: optimize
           path: ./optimize
-          runner: gcp-core-16-longrunning
+          runner_definition: '"gcp-core-16-longrunning"'
           maven-config: |
             -DskipQaBuild=true
         - name: single-app
           path: ./
-          runner: linux_16_core_arm
+          runner_definition: >-
+            {"group":"camunda-self-hosted-runners","labels":"github_linux_16_core_arm"}
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -59,8 +59,7 @@ jobs:
           fossa_cli_arch: linux_amd64
         - name: single-app
           path: ./
-          runner_definition: >-
-            {"group":"camunda-self-hosted-runners","labels":"github_linux_16_core_arm"}
+          runner_definition: '"aws-core-16-longrunning"'
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -59,7 +59,7 @@ jobs:
           fossa_cli_arch: linux_amd64
         - name: single-app
           path: ./
-          runner_definition: '"aws-core-16-longrunning"'
+          runner_definition: '"aws-core-32-longrunning"'
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -50,13 +50,13 @@ jobs:
         - name: c8run
           path: ./c8run
           runner_definition: '"gcp-core-4-longrunning"'
-          fossa_commit: fc4fa13813cbc1835129967f10a12f24aa7a393c
+          fossa_cli_arch: linux_amd64
         - name: optimize
           path: ./optimize
           runner_definition: '"gcp-core-16-longrunning"'
           maven-config: |
             -DskipQaBuild=true
-          fossa_commit: fc4fa13813cbc1835129967f10a12f24aa7a393c
+          fossa_cli_arch: linux_amd64
         - name: single-app
           path: ./
           runner_definition: >-
@@ -64,7 +64,7 @@ jobs:
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true
-          fossa_commit: fossa-arm64
+          fossa_cli_arch: linux_arm64
     steps:
     - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -102,11 +102,13 @@ jobs:
         echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
 
     - name: Setup fossa-cli
-      uses: camunda/infra-global-github-actions/fossa/setup@${{ matrix.fossa_commit }}
+      uses: camunda/infra-global-github-actions/fossa/setup@fossa-arm64
+      with:
+        arch: ${{ matrix.fossa_cli_arch }}
 
     - name: Get context info
       id: info
-      uses: camunda/infra-global-github-actions/fossa/info@${{ matrix.fossa_commit }}
+      uses: camunda/infra-global-github-actions/fossa/info@fossa-arm64
 
     - name: Adjust pom.xml files for FOSSA
       if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
@@ -141,7 +143,7 @@ jobs:
     # It does not fail for pre-existing issues already present in the base branch.
     - name: Check Pull Request for new License Issues
       if: steps.info.outputs.is-pull-request == 'true'
-      uses: camunda/infra-global-github-actions/fossa/pr-check@${{ matrix.fossa_commit }}
+      uses: camunda/infra-global-github-actions/fossa/pr-check@fossa-arm64
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         base-ref: ${{ steps.info.outputs.base-ref }}

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -49,17 +49,17 @@ jobs:
         project:
         - name: c8run
           path: ./c8run
-          runner_definition: '"gcp-core-4-longrunning"'
-          fossa_cli_arch: linux_amd64
+          runner_definition: '"github_linux_4_core_arm"'
+          fossa_cli_arch: linux_arm64
         - name: optimize
           path: ./optimize
-          runner_definition: '"gcp-core-16-longrunning"'
+          runner_definition: '"github_linux_16_core_arm"'
           maven-config: |
             -DskipQaBuild=true
-          fossa_cli_arch: linux_amd64
+          fossa_cli_arch: linux_arm64
         - name: single-app
           path: ./
-          runner_definition: '"github_linux_8_core_arm"'
+          runner_definition: '"github_linux_16_core_arm"'
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -104,7 +104,7 @@ jobs:
     - name: Setup fossa-cli
       uses: camunda/infra-global-github-actions/fossa/setup@fossa-arm64
       with:
-        arch: ${{ matrix.fossa_cli_arch }}
+        arch: ${{ matrix.project.fossa_cli_arch }}
 
     - name: Get context info
       id: info

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -59,7 +59,7 @@ jobs:
           fossa_cli_arch: linux_amd64
         - name: single-app
           path: ./
-          runner_definition: '"github_linux_16_core_arm"'
+          runner_definition: '"github_linux_32_core_arm"'
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -59,7 +59,7 @@ jobs:
           fossa_cli_arch: linux_amd64
         - name: single-app
           path: ./
-          runner_definition: '"github_linux_32_core_arm"'
+          runner_definition: '"github_linux_8_core_arm"'
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -5,6 +5,10 @@
 ---
 name: Check Licenses
 
+defaults:
+  run:
+    shell: bash
+
 on:
   push:
     branches:
@@ -69,15 +73,15 @@ jobs:
         project:
         - name: c8run
           path: ./c8run
-          runner: gcp-core-4-longrunning
+          runner: gcp-arm-4-longrunning
         - name: optimize
           path: ./optimize
-          runner: gcp-core-8-longrunning
+          runner: gcp-arm-8-longrunning
           maven-config: |
             -DskipQaBuild=true
         - name: single-app
           path: ./
-          runner: gcp-core-16-longrunning
+          runner: gcp-arm-16-longrunning
           maven-config: |
             -Dquickly=true
             -DskipQaBuild=true
@@ -120,11 +124,11 @@ jobs:
         echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
 
     - name: Setup fossa-cli
-      uses: camunda/infra-global-github-actions/fossa/setup@ee746fa695a43480b4294e944a6bf6e01b4f8459 # fossa-1.0.17
+      uses: camunda/infra-global-github-actions/fossa/setup@93f5c8735a476ebc5127babd29477cf9610c6bf6 # fossa-1.0.18
 
     - name: Get context info
       id: info
-      uses: camunda/infra-global-github-actions/fossa/info@ee746fa695a43480b4294e944a6bf6e01b4f8459 # fossa-1.0.17
+      uses: camunda/infra-global-github-actions/fossa/info@93f5c8735a476ebc5127babd29477cf9610c6bf6 # fossa-1.0.18
 
     - name: Adjust pom.xml files for FOSSA
       if: contains(fromJson('["optimize", "single-app"]'), matrix.project.name)
@@ -137,7 +141,7 @@ jobs:
       id: analyze1
       continue-on-error: true
       timeout-minutes: 30
-      uses: camunda/infra-global-github-actions/fossa/analyze@ee746fa695a43480b4294e944a6bf6e01b4f8459 # fossa-1.0.17
+      uses: camunda/infra-global-github-actions/fossa/analyze@93f5c8735a476ebc5127babd29477cf9610c6bf6 # fossa-1.0.18
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         branch: ${{  steps.info.outputs.head-ref }}
@@ -147,7 +151,7 @@ jobs:
     - name: Analyze project (attempt 2)
       if: steps.analyze1.outcome != 'success'
       timeout-minutes: 30
-      uses: camunda/infra-global-github-actions/fossa/analyze@ee746fa695a43480b4294e944a6bf6e01b4f8459 # fossa-1.0.17
+      uses: camunda/infra-global-github-actions/fossa/analyze@93f5c8735a476ebc5127babd29477cf9610c6bf6 # fossa-1.0.18
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         branch: ${{  steps.info.outputs.head-ref }}
@@ -159,7 +163,7 @@ jobs:
     # It does not fail for pre-existing issues already present in the base branch.
     - name: Check Pull Request for new License Issues
       if: steps.info.outputs.is-pull-request == 'true'
-      uses: camunda/infra-global-github-actions/fossa/pr-check@ee746fa695a43480b4294e944a6bf6e01b4f8459 # fossa-1.0.17
+      uses: camunda/infra-global-github-actions/fossa/pr-check@93f5c8735a476ebc5127babd29477cf9610c6bf6 # fossa-1.0.18
       with:
         api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
         base-ref: ${{ steps.info.outputs.base-ref }}


### PR DESCRIPTION
## Description

Purpose of this PR is to test the GitHub ARM larger runner for the check-licenses.yml workflow

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
