### PR TITLE
feat: add `businessId` to decision-instance and user-task Zod schema

### DIFF
--- a/identity/client/package-lock.json
+++ b/identity/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "identity-frontend",
       "version": "8.10.0-SNAPSHOT",
       "dependencies": {
-        "@camunda/camunda-api-zod-schemas": "0.0.76",
+        "@camunda/camunda-api-zod-schemas": "0.0.78",
         "@camunda/camunda-composite-components": "0.25.0",
         "@carbon/elements": "11.90.0",
         "@carbon/react": "1.108.0",
@@ -327,9 +327,9 @@
       }
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.76",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.76.tgz",
-      "integrity": "sha512-5acIrmoKOsA3leceAFj41jmu6WD2JCjDuhFgB5YQCu+kUZgrCzfth4xaPKfOfvpVDomWgkgk/NelK39j21xKxw==",
+      "version": "0.0.78",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.78.tgz",
+      "integrity": "sha512-GjRD4dMI8RAB+cTXRSL/XdJYT0VBKEbJNm36iV3SkLF8Z8rI42swvgByQKM80as2D/H1422ht+3lbKlxbTE6nw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -18,7 +18,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@camunda/camunda-api-zod-schemas": "0.0.76",
+    "@camunda/camunda-api-zod-schemas": "0.0.78",
     "@camunda/camunda-composite-components": "0.25.0",
     "@carbon/elements": "11.90.0",
     "@carbon/react": "1.108.0",

--- a/operate/client/e2e-playwright/mocks/decisionInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/decisionInstance.mocks.ts
@@ -58,6 +58,7 @@ const mockEvaluatedDecisionInstance: GetDecisionInstanceResponseBody = {
   ],
   decisionDefinitionType: 'DECISION_TABLE',
   result: '"budget"',
+  businessId: null,
 };
 
 const mockEvaluatedDecisionInstancesSearch: QueryDecisionInstancesResponseBody =
@@ -112,6 +113,7 @@ const mockEvaluatedDecisionInstanceWithoutPanels: GetDecisionInstanceResponseBod
     matchedRules: [],
     decisionDefinitionType: 'LITERAL_EXPRESSION',
     result: '"$1000"',
+    businessId: null,
   };
 
 const mockEvaluatedDecisionInstancesSearchWithoutPanels: QueryDecisionInstancesResponseBody =
@@ -166,6 +168,7 @@ const mockFailedDecisionInstance: GetDecisionInstanceResponseBody = {
   matchedRules: [],
   decisionDefinitionType: 'DECISION_TABLE',
   result: 'null',
+  businessId: null,
 };
 
 const mockFailedDecisionInstancesSearch: QueryDecisionInstancesResponseBody = {

--- a/operate/client/e2e-playwright/mocks/decisions.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/decisions.mocks.ts
@@ -458,6 +458,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '2347238947239',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254748932-1',
@@ -477,6 +478,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '6755399441062312-1',
@@ -496,6 +498,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '4503599627375963-1',
@@ -515,6 +518,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '2251799813830805-1',
@@ -534,6 +538,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254748918-1',
@@ -553,6 +558,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '6755399441062304-1',
@@ -572,6 +578,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '4503599627375956-1',
@@ -591,6 +598,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '2251799813828076-1',
@@ -610,6 +618,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254748904-1',
@@ -629,6 +638,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '6755399441062296-1',
@@ -648,6 +658,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '4503599627375944-1',
@@ -667,6 +678,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '2251799813826769-1',
@@ -686,6 +698,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254748889-1',
@@ -705,6 +718,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '6755399441062283-1',
@@ -724,6 +738,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '4503599627375933-1',
@@ -743,6 +758,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '2251799813826743-1',
@@ -762,6 +778,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254748878-1',
@@ -781,6 +798,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '2251799813687953-1',
@@ -800,6 +818,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254742973-1',
@@ -819,6 +838,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '6755399441057764-1',
@@ -838,6 +858,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '4503599627372771-1',
@@ -857,6 +878,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '2251799813687944-1',
@@ -876,6 +898,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254742960-1',
@@ -895,6 +918,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '6755399441057755-1',
@@ -914,6 +938,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '4503599627372758-1',
@@ -933,6 +958,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '2251799813687933-1',
@@ -952,6 +978,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254742947-1',
@@ -971,6 +998,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '6755399441057744-1',
@@ -990,6 +1018,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '4503599627372745-1',
@@ -1009,6 +1038,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '2251799813687924-1',
@@ -1028,6 +1058,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254742938-1',
@@ -1047,6 +1078,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '6755399441057731-1',
@@ -1066,6 +1098,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '4503599627372732-1',
@@ -1085,6 +1118,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '2251799813687913-1',
@@ -1104,6 +1138,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254742927-1',
@@ -1123,6 +1158,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '6755399441057718-1',
@@ -1142,6 +1178,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '4503599627372723-1',
@@ -1161,6 +1198,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '2251799813687900-1',
@@ -1180,6 +1218,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
     {
       decisionEvaluationInstanceKey: '9007199254742918-1',
@@ -1199,6 +1238,7 @@ const mockDecisionInstances: QueryDecisionInstancesResponseBody = {
       decisionDefinitionType: 'DECISION_TABLE',
       elementInstanceKey: '',
       result: '',
+      businessId: null,
     },
   ],
   page: {

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.3",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.77",
+        "@camunda/camunda-api-zod-schemas": "0.0.78",
         "@camunda/camunda-composite-components": "0.25.0",
         "@carbon/elements": "11.90.0",
         "@carbon/react": "1.108.0",
@@ -459,9 +459,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.77",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.77.tgz",
-      "integrity": "sha512-IXrx3gIjyV5iDrGtRLk3M4Hc8kk/wILAgC30whEx9WSaxU+HJ0N+1kJH0C5fVLWx5YV2w/NeyHBErIt7SEieBA==",
+      "version": "0.0.78",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.78.tgz",
+      "integrity": "sha512-GjRD4dMI8RAB+cTXRSL/XdJYT0VBKEbJNm36iV3SkLF8Z8rI42swvgByQKM80as2D/H1422ht+3lbKlxbTE6nw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.3",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.77",
+    "@camunda/camunda-api-zod-schemas": "0.0.78",
     "@camunda/camunda-composite-components": "0.25.0",
     "@carbon/elements": "11.90.0",
     "@carbon/react": "1.108.0",

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -188,6 +188,7 @@ const mockCalledDecisionInstance = {
   processDefinitionKey: PROCESS_DEFINITION_KEY,
   tenantId: '<default>',
   rootProcessInstanceKey: null,
+  businessId: null,
 } satisfies DecisionInstance;
 
 const mockUserTask = {
@@ -215,6 +216,7 @@ const mockUserTask = {
   externalFormReference: null,
   tags: [],
   priority: 50,
+  businessId: null,
 } satisfies UserTask;
 
 const mockUserTaskWithDetails = {

--- a/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
+++ b/operate/client/src/modules/hooks/useDrilldownNavigation.test.tsx
@@ -142,6 +142,7 @@ describe('useDrillDownNavigation', () => {
           rootProcessInstanceKey: null,
           elementInstanceKey: 'el-inst-1',
           rootDecisionDefinitionKey: 'def-1',
+          businessId: null,
         },
       ]),
     );
@@ -185,6 +186,7 @@ describe('useDrillDownNavigation', () => {
             rootProcessInstanceKey: null,
             elementInstanceKey: 'el-inst-1',
             rootDecisionDefinitionKey: 'def-1',
+            businessId: null,
           },
         ],
         2,

--- a/operate/client/src/modules/mocks/mockDecisionInstance.ts
+++ b/operate/client/src/modules/mocks/mockDecisionInstance.ts
@@ -112,6 +112,7 @@ const invoiceClassification: GetDecisionInstanceResponseBody = {
     areAgeRequirementsSatisfied: 'satisfied',
     paragraph: 'sbl §17',
   }),
+  businessId: null,
 };
 
 const assignApproverGroup: GetDecisionInstanceResponseBody = {
@@ -154,6 +155,7 @@ const assignApproverGroup: GetDecisionInstanceResponseBody = {
   ],
   decisionDefinitionType: 'DECISION_TABLE',
   result: '',
+  businessId: null,
 };
 
 const assignApproverGroupWithoutVariables: GetDecisionInstanceResponseBody = {
@@ -182,6 +184,7 @@ const literalExpression: GetDecisionInstanceResponseBody = {
   matchedRules: [],
   decisionDefinitionType: 'LITERAL_EXPRESSION',
   result: '',
+  businessId: null,
 };
 
 export {

--- a/tasklist/client/e2e/mocks/v2/task.ts
+++ b/tasklist/client/e2e/mocks/v2/task.ts
@@ -33,6 +33,7 @@ const unassignedTask = (customFields: Partial<UserTask> = {}): UserTask => ({
   externalFormReference: null,
   candidateGroups: [],
   candidateUsers: [],
+  businessId: null,
   tags: [],
   ...customFields,
 });

--- a/tasklist/client/package-lock.json
+++ b/tasklist/client/package-lock.json
@@ -11,7 +11,7 @@
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
         "@bpmn-io/form-js-carbon-styles": "1.21.3",
         "@bpmn-io/form-js-viewer": "1.21.3",
-        "@camunda/camunda-api-zod-schemas": "0.0.76",
+        "@camunda/camunda-api-zod-schemas": "0.0.78",
         "@camunda/camunda-composite-components": "0.25.0",
         "@carbon/react": "1.108.0",
         "@monaco-editor/react": "4.7.0",
@@ -578,9 +578,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.76",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.76.tgz",
-      "integrity": "sha512-5acIrmoKOsA3leceAFj41jmu6WD2JCjDuhFgB5YQCu+kUZgrCzfth4xaPKfOfvpVDomWgkgk/NelK39j21xKxw==",
+      "version": "0.0.78",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.78.tgz",
+      "integrity": "sha512-GjRD4dMI8RAB+cTXRSL/XdJYT0VBKEbJNm36iV3SkLF8Z8rI42swvgByQKM80as2D/H1422ht+3lbKlxbTE6nw==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
     "@bpmn-io/form-js-carbon-styles": "1.21.3",
     "@bpmn-io/form-js-viewer": "1.21.3",
-    "@camunda/camunda-api-zod-schemas": "0.0.76",
+    "@camunda/camunda-api-zod-schemas": "0.0.78",
     "@camunda/camunda-composite-components": "0.25.0",
     "@carbon/react": "1.108.0",
     "@monaco-editor/react": "4.7.0",

--- a/tasklist/client/src/modules/mocks/auditLogs.ts
+++ b/tasklist/client/src/modules/mocks/auditLogs.ts
@@ -44,6 +44,8 @@ const auditLog = (customFields: Partial<AuditLog> = {}): AuditLog => ({
   relatedEntityType: null,
   entityDescription: null,
   agentElementId: null,
+  inboundChannelType: null,
+  inboundChannelToolName: null,
   ...customFields,
 });
 

--- a/tasklist/client/src/modules/mocks/task.ts
+++ b/tasklist/client/src/modules/mocks/task.ts
@@ -35,6 +35,7 @@ const unassignedTask = (customFields: Partial<UserTask> = {}): UserTask => ({
   completionDate: null,
   customHeaders: null,
   externalFormReference: null,
+  businessId: null,
   tags: [],
   ...customFields,
 });
@@ -63,6 +64,7 @@ const assignedTask = (customFields: Partial<UserTask> = {}): UserTask => ({
   completionDate: null,
   customHeaders: null,
   externalFormReference: null,
+  businessId: null,
   tags: [],
   ...customFields,
 });
@@ -91,6 +93,7 @@ const completedTask = (customFields: Partial<UserTask> = {}): UserTask => ({
   followUpDate: null,
   customHeaders: null,
   externalFormReference: null,
+  businessId: null,
   tags: [],
   ...customFields,
 });
@@ -121,6 +124,7 @@ const assignedTaskWithForm = (
   completionDate: null,
   customHeaders: null,
   externalFormReference: null,
+  businessId: null,
   tags: [],
   ...customFields,
 });
@@ -151,6 +155,7 @@ const unassignedTaskWithForm = (
   completionDate: null,
   customHeaders: null,
   externalFormReference: null,
+  businessId: null,
   tags: [],
   ...customFields,
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -20,7 +20,7 @@
 	"dependencies": {
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
 		"@devbookhq/splitter": "1.4.2",
-		"@camunda/camunda-api-zod-schemas": "0.0.77",
+		"@camunda/camunda-api-zod-schemas": "0.0.78",
 		"@camunda/camunda-composite-components": "0.24.0",
 		"@carbon/react": "1.109.0",
 		"@carbon/type": "11.61.0",

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/user-tasks.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/user-tasks.ts
@@ -32,6 +32,7 @@ function createUserTask(overrides?: Partial<UserTask>): UserTask {
 		customHeaders: null,
 		formKey: null,
 		externalFormReference: null,
+		businessId: null,
 		tags: [],
 		priority: 50,
 		...overrides,

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -28,7 +28,7 @@
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
-				"@camunda/camunda-api-zod-schemas": "0.0.77",
+				"@camunda/camunda-api-zod-schemas": "0.0.78",
 				"@camunda/camunda-composite-components": "0.24.0",
 				"@carbon/react": "1.109.0",
 				"@carbon/type": "11.61.0",
@@ -11055,13 +11055,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.77",
+				"@camunda/camunda-api-zod-schemas": "0.0.78",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.77",
+			"version": "0.0.78",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.9.3",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.77",
+		"@camunda/camunda-api-zod-schemas": "0.0.78",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.0.78
+
+### 🚀 Enhancements
+
+- Add `businessId` property to decision-instance schema ([#52098](https://github.com/camunda/camunda/issues/52098))
+- Add `businessId` property to user-task schema ([#51691](https://github.com/camunda/camunda/issues/51691))
+
+### ❤️ Contributors
+
+- Christoph Fricke ([@christoph-fricke](https://github.com/christoph-fricke))
+
 ## v0.0.77
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/decision-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/decision-instance.ts
@@ -12,6 +12,7 @@ import {
 	getQueryRequestBodySchema,
 	getQueryResponseBodySchema,
 	advancedDateTimeFilterSchema,
+	advancedStringFilterSchema,
 	basicStringFilterSchema,
 	type Endpoint,
 	getEnumFilterSchema,
@@ -43,6 +44,7 @@ const decisionInstanceSchema = z.object({
 	decisionDefinitionKey: z.string(),
 	elementInstanceKey: z.string(),
 	rootDecisionDefinitionKey: z.string(),
+	businessId: z.string().nullable(),
 });
 type DecisionInstance = z.infer<typeof decisionInstanceSchema>;
 
@@ -55,6 +57,7 @@ const queryDecisionInstancesFilterSchema = z
 		elementInstanceKey: basicStringFilterSchema,
 		rootDecisionDefinitionKey: basicStringFilterSchema,
 		decisionRequirementsKey: basicStringFilterSchema,
+		businessId: advancedStringFilterSchema,
 		...decisionInstanceSchema.pick({
 			evaluationFailure: true,
 			decisionDefinitionId: true,
@@ -87,6 +90,7 @@ const queryDecisionInstancesRequestBodySchema = getQueryRequestBodySchema({
 		'tenantId',
 		'elementInstanceKey',
 		'rootDecisionDefinitionKey',
+		'businessId',
 	] as const,
 	filter: queryDecisionInstancesFilterSchema,
 });

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/user-task.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/user-task.ts
@@ -63,6 +63,7 @@ const userTaskSchema = z.object({
 	externalFormReference: z.string().nullable(),
 	tags: z.array(z.string()),
 	priority: z.number().int().min(0).max(100),
+	businessId: z.string().nullable(),
 });
 type UserTask = z.infer<typeof userTaskSchema>;
 
@@ -72,7 +73,7 @@ const getUserTask: Endpoint<Pick<UserTask, 'userTaskKey'>> = {
 };
 
 const queryUserTasksRequestBodySchema = getQueryRequestBodySchema({
-	sortFields: ['creationDate', 'completionDate', 'followUpDate', 'dueDate', 'priority'] as const,
+	sortFields: ['creationDate', 'completionDate', 'followUpDate', 'dueDate', 'priority', 'businessId'] as const,
 	filter: userTaskSchema
 		.pick({
 			state: true,
@@ -86,6 +87,7 @@ const queryUserTasksRequestBodySchema = getQueryRequestBodySchema({
 		})
 		.extend({
 			assignee: advancedStringFilterSchema,
+			businessId: advancedStringFilterSchema,
 			priority: advancedIntegerFilterSchema,
 			candidateGroup: advancedStringFilterSchema,
 			candidateUser: advancedStringFilterSchema,

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.77",
+	"version": "0.0.78",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

This PR extends the Zod schemata for decision instances and user tasks with the new `businessId` field.

## Checklist

- [x] **Release the new version.**
- [x] Bump version in Identity, Operate, and Tasklist. This will like cause a bunch of TS errors on mock data...

## Related issues

relates #51691, #52098
