### PR TITLE
ci: update load test to 8.9.6

### DIFF
--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-89-elasticsearch-stable
       namespace: c8-golden-stable-89-elasticsearch-stable
-      version: 14.5.0
+      version: 14.6.0
       tags:
       - dev
       custom-properties: []
@@ -36,13 +36,13 @@ data:
         metrics: http://identity.c8-golden-stable-89-elasticsearch-stable:82/actuator/prometheus
       - name: Optimize
         id: optimize
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8083
         readiness: http://optimize.c8-golden-stable-89-elasticsearch-stable:80/api/readyz
         metrics: http://optimize.c8-golden-stable-89-elasticsearch-stable:8092/actuator/prometheus
       - name: Connectors
         id: connectors
-        version: 8.9.5
+        version: 8.9.6
         url: http://connectors.c8-golden-stable-89-elasticsearch-stable:8080
         readiness: http://connectors.c8-golden-stable-89-elasticsearch-stable:8080/actuator/health/readiness
         metrics: http://connectors.c8-golden-stable-89-elasticsearch-stable:8080/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.5"
+        app.kubernetes.io/version: "8.9.6"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+    app.kubernetes.io/version: 8.9.6
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.9.9"
+        app.kubernetes.io/version: "8.9.11"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+    app.kubernetes.io/version: 8.9.11
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-89-elasticsearch
       namespace: c8-golden-stable-89-elasticsearch
-      version: 14.5.0
+      version: 14.6.0
       tags:
       - dev
       custom-properties: []
@@ -36,13 +36,13 @@ data:
         metrics: http://identity.c8-golden-stable-89-elasticsearch:82/actuator/prometheus
       - name: Optimize
         id: optimize
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8083
         readiness: http://optimize.c8-golden-stable-89-elasticsearch:80/api/readyz
         metrics: http://optimize.c8-golden-stable-89-elasticsearch:8092/actuator/prometheus
       - name: Connectors
         id: connectors
-        version: 8.9.5
+        version: 8.9.6
         url: http://connectors.c8-golden-stable-89-elasticsearch:8080
         readiness: http://connectors.c8-golden-stable-89-elasticsearch:8080/actuator/health/readiness
         metrics: http://connectors.c8-golden-stable-89-elasticsearch:8080/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.5"
+        app.kubernetes.io/version: "8.9.6"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+    app.kubernetes.io/version: 8.9.6
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.9.9"
+        app.kubernetes.io/version: "8.9.11"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+    app.kubernetes.io/version: 8.9.11
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-89-none
       namespace: c8-golden-stable-89-none
-      version: 14.5.0
+      version: 14.6.0
       tags:
       - dev
       custom-properties: []

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-89-opensearch-stable
       namespace: c8-golden-stable-89-opensearch-stable
-      version: 14.5.0
+      version: 14.6.0
       tags:
       - dev
       custom-properties: []
@@ -36,13 +36,13 @@ data:
         metrics: http://identity.c8-golden-stable-89-opensearch-stable:82/actuator/prometheus
       - name: Optimize
         id: optimize
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8083
         readiness: http://optimize.c8-golden-stable-89-opensearch-stable:80/api/readyz
         metrics: http://optimize.c8-golden-stable-89-opensearch-stable:8092/actuator/prometheus
       - name: Connectors
         id: connectors
-        version: 8.9.5
+        version: 8.9.6
         url: http://connectors.c8-golden-stable-89-opensearch-stable:8080
         readiness: http://connectors.c8-golden-stable-89-opensearch-stable:8080/actuator/health/readiness
         metrics: http://connectors.c8-golden-stable-89-opensearch-stable:8080/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.5"
+        app.kubernetes.io/version: "8.9.6"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+    app.kubernetes.io/version: 8.9.6
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.9.9"
+        app.kubernetes.io/version: "8.9.11"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+    app.kubernetes.io/version: 8.9.11
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-89-opensearch
       namespace: c8-golden-stable-89-opensearch
-      version: 14.5.0
+      version: 14.6.0
       tags:
       - dev
       custom-properties: []
@@ -36,13 +36,13 @@ data:
         metrics: http://identity.c8-golden-stable-89-opensearch:82/actuator/prometheus
       - name: Optimize
         id: optimize
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8083
         readiness: http://optimize.c8-golden-stable-89-opensearch:80/api/readyz
         metrics: http://optimize.c8-golden-stable-89-opensearch:8092/actuator/prometheus
       - name: Connectors
         id: connectors
-        version: 8.9.5
+        version: 8.9.6
         url: http://connectors.c8-golden-stable-89-opensearch:8080
         readiness: http://connectors.c8-golden-stable-89-opensearch:8080/actuator/health/readiness
         metrics: http://connectors.c8-golden-stable-89-opensearch:8080/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.5"
+        app.kubernetes.io/version: "8.9.6"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+    app.kubernetes.io/version: 8.9.6
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.9.9"
+        app.kubernetes.io/version: "8.9.11"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+    app.kubernetes.io/version: 8.9.11
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-89-rdbms-optimize
       namespace: c8-golden-stable-89-rdbms-optimize
-      version: 14.5.0
+      version: 14.6.0
       tags:
       - dev
       custom-properties: []
@@ -36,13 +36,13 @@ data:
         metrics: http://identity.c8-golden-stable-89-rdbms-optimize:82/actuator/prometheus
       - name: Optimize
         id: optimize
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8083
         readiness: http://optimize.c8-golden-stable-89-rdbms-optimize:80/api/readyz
         metrics: http://optimize.c8-golden-stable-89-rdbms-optimize:8092/actuator/prometheus
       - name: Connectors
         id: connectors
-        version: 8.9.5
+        version: 8.9.6
         url: http://connectors.c8-golden-stable-89-rdbms-optimize:8080
         readiness: http://connectors.c8-golden-stable-89-rdbms-optimize:8080/actuator/health/readiness
         metrics: http://connectors.c8-golden-stable-89-rdbms-optimize:8080/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.5"
+        app.kubernetes.io/version: "8.9.6"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+    app.kubernetes.io/version: 8.9.6
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.9.9"
+        app.kubernetes.io/version: "8.9.11"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.9"
+    app.kubernetes.io/version: "8.9.11"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+    app.kubernetes.io/version: 8.9.11
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-89-rdbms-stable
       namespace: c8-golden-stable-89-rdbms-stable
-      version: 14.5.0
+      version: 14.6.0
       tags:
       - dev
       custom-properties: []
@@ -36,7 +36,7 @@ data:
         metrics: http://identity.c8-golden-stable-89-rdbms-stable:82/actuator/prometheus
       - name: Connectors
         id: connectors
-        version: 8.9.5
+        version: 8.9.6
         url: http://connectors.c8-golden-stable-89-rdbms-stable:8080
         readiness: http://connectors.c8-golden-stable-89-rdbms-stable:8080/actuator/health/readiness
         metrics: http://connectors.c8-golden-stable-89-rdbms-stable:8080/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.5"
+        app.kubernetes.io/version: "8.9.6"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+    app.kubernetes.io/version: 8.9.6
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-89-rdbms
       namespace: c8-golden-stable-89-rdbms
-      version: 14.5.0
+      version: 14.6.0
       tags:
       - dev
       custom-properties: []
@@ -36,7 +36,7 @@ data:
         metrics: http://identity.c8-golden-stable-89-rdbms:82/actuator/prometheus
       - name: Connectors
         id: connectors
-        version: 8.9.5
+        version: 8.9.6
         url: http://connectors.c8-golden-stable-89-rdbms:8080
         readiness: http://connectors.c8-golden-stable-89-rdbms:8080/actuator/health/readiness
         metrics: http://connectors.c8-golden-stable-89-rdbms:8080/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.5"
+        app.kubernetes.io/version: "8.9.6"
       annotations:
 
     spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.5"
+    app.kubernetes.io/version: "8.9.6"
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+    app.kubernetes.io/version: 8.9.6
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 


### PR DESCRIPTION
## Description

Updates pulled from latest Camunda Platform Helm Chart `main` (on which `stable-89` depends on).

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues


