### PR TITLE
ci: detect product bugs in orchestration nightly fix agent and skip with bug link

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -239,8 +239,10 @@ jobs:
         env:
           ANTHROPIC_API_KEY:   ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
           GH_TOKEN:            ${{ steps.github-token.outputs.token }}
-          # Broader PAT for filing product-bug issues in OTHER repos (e.g.
-          # camunda/camunda-platform-helm) the camunda-scoped App token cannot reach.
+          # Fallback ONLY. The agent files/searches issues with the qa-processes
+          # GH_TOKEN above first; it falls back to this pre-existing PAT (already used
+          # for workspace-cli checkout above) only if a gh call fails (e.g. a repo the
+          # camunda-scoped App token cannot reach).
           GH_TOKEN_PAT:        ${{ steps.secrets.outputs.GH_TOKEN_PAT }}
           VERSION:             ${{ github.event.inputs.version }}
           TARGET_REF:          ${{ steps.target.outputs.ref }}
@@ -316,8 +318,9 @@ jobs:
           test with the '// Skipped due to bug #<number>: <url>' annotation and open ONE skip PR. The
           skip PR goes in the prs array of /tmp/fix-meta.json and every bug in product_bugs (with
           issue_url + suspect_commit). Skipping is allowed ONLY for a confirmed product bug — never
-          for flakiness or any other reason. To file an issue in a repo other than camunda/camunda,
-          use GH_TOKEN="\$GH_TOKEN_PAT".
+          for flakiness or any other reason. Use the default GH_TOKEN (qa-processes) to file/search
+          issues FIRST; ONLY if a call fails (e.g. a repo other than camunda/camunda) retry it once
+          with GH_TOKEN="\$GH_TOKEN_PAT". Always qa-processes first; the PAT is a backup.
 
           When done (or if no fix is possible), write /tmp/fix-meta.json and stop.
           EOF

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -569,11 +569,15 @@ jobs:
           fi
 
           # A confirmed product bug lands as a skip PR, so its bullets + the skip PR
-          # are reported together under the bug heading.
-          if [ "$pb_count" -gt 0 ]; then
+          # are reported together under the bug heading — but only when the skip PR
+          # actually exists; an issue filed with NO skip PR means the test still fails.
+          if [ "$pb_count" -gt 0 ] && [ "$pr_count" -gt 0 ]; then
             icon=":bug:"
             summary="Product bug(s) — test(s) skipped pending fix:"$'\n'"$(printf '%s\n' "${lines[@]}")"
             [ "$JOB_STATUS" = "failure" ] && summary="${summary}"$'\n'"_(post-processing failed — see run)_"
+          elif [ "$pb_count" -gt 0 ]; then
+            icon=":warning:"
+            summary="Product bug(s) filed but NO skip PR — test(s) still failing, needs attention:"$'\n'"$(printf '%s\n' "${lines[@]}")"
           elif [ "$pr_count" -gt 0 ]; then
             icon=":white_check_mark:"
             summary="$(printf '%s\n' "${lines[@]}")"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -128,7 +128,7 @@ jobs:
           secrets: |
             secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
             secret/data/products/qa/ci/common SLACK_BOT_USER_OAUTH_TOKEN ;
-            secret/data/products/qa/ci/common GH_TOKEN | GH_TOKEN_PAT ;
+            secret/data/products/qa/ci/common GH_TOKEN | GH_PAT ;
 
       - name: Generate GitHub App Token
         id: github-token
@@ -173,13 +173,13 @@ jobs:
         env:
           GOPRIVATE: github.com/camunda/*
           GOTOOLCHAIN: auto
-          GH_TOKEN_PAT: ${{ steps.secrets.outputs.GH_TOKEN_PAT }}
+          GH_PAT: ${{ steps.secrets.outputs.GH_PAT }}
         run: |
           # workspace-cli is a private repo; the qa-processes app token doesn't have access.
           # Add a more-specific insteadOf for workspace-cli that uses the Vault PAT.
           # Git selects the longest-matching insteadOf, so this wins over the global
           # qa-processes rewrite set in "Configure git with GitHub App token".
-          git config --global url."https://x-access-token:${GH_TOKEN_PAT}@github.com/camunda/workspace-cli".insteadOf "https://github.com/camunda/workspace-cli"
+          git config --global url."https://x-access-token:${GH_PAT}@github.com/camunda/workspace-cli".insteadOf "https://github.com/camunda/workspace-cli"
           go install github.com/camunda/workspace-cli/cmd/workspace@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
@@ -243,7 +243,7 @@ jobs:
           # GH_TOKEN above first; it falls back to this pre-existing PAT (already used
           # for workspace-cli checkout above) only if a gh call fails (e.g. a repo the
           # camunda-scoped App token cannot reach).
-          GH_TOKEN_PAT:        ${{ steps.secrets.outputs.GH_TOKEN_PAT }}
+          GH_PAT:        ${{ steps.secrets.outputs.GH_PAT }}
           VERSION:             ${{ github.event.inputs.version }}
           TARGET_REF:          ${{ steps.target.outputs.ref }}
           SAFE_VERSION:        ${{ steps.target.outputs.safe_version }}
@@ -320,7 +320,7 @@ jobs:
           issue_url + suspect_commit). Skipping is allowed ONLY for a confirmed product bug — never
           for flakiness or any other reason. Use the default GH_TOKEN (qa-processes) to file/search
           issues FIRST; ONLY if a call fails (e.g. a repo other than camunda/camunda) retry it once
-          with GH_TOKEN="\$GH_TOKEN_PAT". Always qa-processes first; the PAT is a backup.
+          with GH_TOKEN="\$GH_PAT". Always qa-processes first; the PAT is a backup.
 
           When done (or if no fix is possible), write /tmp/fix-meta.json and stop.
           EOF

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -283,7 +283,8 @@ jobs:
 
           STEP 0 — read ${ws_dir}/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md,
           the "${agents_section}" section. That file is your full operating manual:
-          diagnosis steps, artifact-download patterns, constraints (NEVER skip/fixme),
+          diagnosis steps, artifact-download patterns, constraints (no test.skip()/test.fixme()
+          EXCEPT the gated product-bug skip described below and in Product-Bug Escalation),
           PR conventions, and the /tmp/fix-meta.json schema.
 
           /tmp/test_specs.json contains the failures to address ($(jq 'length' /tmp/test_specs.json) entries).

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -239,6 +239,9 @@ jobs:
         env:
           ANTHROPIC_API_KEY:   ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
           GH_TOKEN:            ${{ steps.github-token.outputs.token }}
+          # Broader PAT for filing product-bug issues in OTHER repos (e.g.
+          # camunda/camunda-platform-helm) the camunda-scoped App token cannot reach.
+          GH_TOKEN_PAT:        ${{ steps.secrets.outputs.GH_TOKEN_PAT }}
           VERSION:             ${{ github.event.inputs.version }}
           TARGET_REF:          ${{ steps.target.outputs.ref }}
           SAFE_VERSION:        ${{ steps.target.outputs.safe_version }}
@@ -304,6 +307,17 @@ jobs:
           CRITICAL for /tmp/fix-meta.json: the "branch" field must be the exact
           headRefName of the PR you opened — never null, never omitted. Obtain it
           with: gh pr view <number> --repo ${REPO} --json headRefName --jq '.headRefName'
+
+          PRODUCT BUGS: if a failure is a genuine product regression (not a test defect), do NOT
+          mask it with a viewport/timeout/selector tweak or a weakened assertion. Follow the
+          "## Product-Bug Escalation" section: pass all three gates, FILE/REUSE a tracking issue
+          against the owning module (dedupe first — search by fingerprint AND by symptom; the issue
+          body MUST carry the 'Fingerprint: nightly-product-bug fp=<FP>' line), then SKIP the failing
+          test with the '// Skipped due to bug #<number>: <url>' annotation and open ONE skip PR. The
+          skip PR goes in the prs array of /tmp/fix-meta.json and every bug in product_bugs (with
+          issue_url + suspect_commit). Skipping is allowed ONLY for a confirmed product bug — never
+          for flakiness or any other reason. To file an issue in a repo other than camunda/camunda,
+          use GH_TOKEN="\$GH_TOKEN_PAT".
 
           When done (or if no fix is possible), write /tmp/fix-meta.json and stop.
           EOF
@@ -511,15 +525,36 @@ jobs:
         run: |
           set -euo pipefail
           prs_json="[]"
+          pbugs_json="[]"
           category=""
-          [ -f /tmp/fix-meta.json ] && prs_json=$(jq -c '.prs // []' /tmp/fix-meta.json 2>/dev/null || echo '[]')
-          [ -f /tmp/fix-meta.json ] && category=$(jq -r '.category // ""' /tmp/fix-meta.json 2>/dev/null || echo "")
+          if [ -f /tmp/fix-meta.json ]; then
+            prs_json=$(jq -c '.prs // []' /tmp/fix-meta.json 2>/dev/null || echo '[]')
+            category=$(jq -r '.category // ""' /tmp/fix-meta.json 2>/dev/null || echo "")
+            # Accept product_bugs (array) and/or a singular product_bug (object).
+            pbugs_json=$(jq -c '(.product_bugs // []) + (if .product_bug then [.product_bug] else [] end)' /tmp/fix-meta.json 2>/dev/null || echo '[]')
+          fi
           pr_count=$(echo "$prs_json" | jq 'length')
+          pb_count=$(echo "$pbugs_json" | jq 'length')
 
-          # Check fix-meta.json first — if a PR was opened report it even when
-          # downstream steps (on-demand trigger, summary) failed.
+          # One bullet per outcome, each carrying its findings (issue link, repo,
+          # root cause, suspected commit/PR).
+          lines=()
+          while IFS= read -r pb; do
+            [ -z "$pb" ] && continue
+            url=$(echo "$pb" | jq -r '.issue_url // ""')
+            repo=$(echo "$pb" | jq -r '.repo // "?"')
+            rc=$(echo "$pb" | jq -r '.root_cause // ""')
+            sc=$(echo "$pb" | jq -r '.suspect_commit // ""')
+            if [ -n "$url" ]; then
+              line="• product bug → <${url}|issue> in \`${repo}\`"
+            else
+              line="• product bug in \`${repo}\` (issue link missing in fix-meta)"
+            fi
+            [ -n "$rc" ] && line="${line} — ${rc}"
+            [ -n "$sc" ] && line="${line} (suspect: ${sc})"
+            lines+=("$line")
+          done < <(echo "$pbugs_json" | jq -c '.[]')
           if [ "$pr_count" -gt 0 ]; then
-            icon=":white_check_mark:"
             pr_links=$(echo "$prs_json" | jq -r --arg repo "${{ github.repository }}" '
               .[] |
               (if .owner != null and .repo != null then "\(.owner)/\(.repo)"
@@ -527,7 +562,18 @@ jobs:
                else $repo end) as $full_repo |
               "<https://github.com/\($full_repo)/pull/\(.number)|PR #\(.number)>"' \
               | tr '\n' '  ')
-            summary="PR(s) opened: ${pr_links}"
+            lines+=("• PR(s) opened: ${pr_links}")
+          fi
+
+          # A confirmed product bug lands as a skip PR, so its bullets + the skip PR
+          # are reported together under the bug heading.
+          if [ "$pb_count" -gt 0 ]; then
+            icon=":bug:"
+            summary="Product bug(s) — test(s) skipped pending fix:"$'\n'"$(printf '%s\n' "${lines[@]}")"
+            [ "$JOB_STATUS" = "failure" ] && summary="${summary}"$'\n'"_(post-processing failed — see run)_"
+          elif [ "$pr_count" -gt 0 ]; then
+            icon=":white_check_mark:"
+            summary="$(printf '%s\n' "${lines[@]}")"
             [ "$JOB_STATUS" = "failure" ] && summary="${summary} _(post-processing failed — see run)_"
           elif [ "$JOB_STATUS" = "failure" ]; then
             icon=":x:"; summary="Agent failed (no fix applied)"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -728,19 +728,24 @@ jobs:
           # Decode the base64-encoded dispatches payload from the triage job.
           DISPATCHES_JSON=$(echo "${DISPATCHES_B64}" | base64 -d)
 
-          # Prefetch ALL open product-bug fingerprints in ONE search, then filter
-          # in-memory in the per-spec loop below — avoids one gh search per failing
-          # spec and the associated rate-limit/timeout risk. Each line is "<fp> <url>".
-          # Fail-open: on any error the map is empty and nothing is suppressed (the
-          # fix agent still dedupes at filing time).
+          # Prefetch open product-bug fingerprints in ONE search (up to gh's 1000-result
+          # cap), then filter in-memory in the per-spec loop below — avoids one gh search
+          # per failing spec and the associated rate-limit/timeout risk. Each line is
+          # "<fp> <url>". Fail-open: on any error the map is empty and nothing is
+          # suppressed (the fix agent still dedupes at filing time). If the cap is ever
+          # exceeded, the surplus issues just aren't prefetched → those tests re-dispatch
+          # (still benign — fail-open); we warn so it's visible.
+          PB_FP_CAP=1000
           PB_FP_MAP=$(mktemp)
           trap 'rm -f "$PB_FP_MAP"' EXIT
           if [ "${SUPPRESS_PRODUCT_BUGS:-true}" = "true" ]; then
             gh search issues "nightly-product-bug is:issue" --owner camunda --state open \
-              --limit 200 --json body,url \
+              --limit "$PB_FP_CAP" --json body,url \
               --jq '.[] | select(.body != null and (.body | test("nightly-product-bug fp=[0-9a-f]{8}"))) | "\(.body | capture("nightly-product-bug fp=(?<f>[0-9a-f]{8})").f) \(.url)"' \
               2>/dev/null > "$PB_FP_MAP" || true
-            echo "Prefetched $(wc -l < "$PB_FP_MAP" | tr -d ' ') open product-bug fingerprint(s)."
+            pb_fp_count=$(wc -l < "$PB_FP_MAP" | tr -d ' ')
+            echo "Prefetched ${pb_fp_count} open product-bug fingerprint(s)."
+            [ "$pb_fp_count" -ge "$PB_FP_CAP" ] && echo "::warning::Open product-bug issues hit the ${PB_FP_CAP} search cap — some fingerprints may not be prefetched; affected tests will re-dispatch (fail-open)."
           fi
 
           while IFS= read -r d; do

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -745,6 +745,34 @@ jobs:
               fi
             fi
 
+            # Drop tests already tracked by an open product bug (per-test fingerprint,
+            # matching what the fix agent embeds in the issue). Suppression is per-test;
+            # the rest of the version's failures still dispatch. Auto-reopens once the
+            # issue is closed (the search misses) and the test is still failing.
+            # Fail-open: any search error keeps the test eligible (agent dedupes at filing).
+            # Skip this for workflow-level dispatches (specs intentionally empty).
+            orig_spec_count=$(echo "$specs" | jq 'length')
+            if [ "$orig_spec_count" -gt 0 ] && [ "${SUPPRESS_PRODUCT_BUGS:-true}" = "true" ]; then
+              kept='[]'
+              while IFS= read -r t; do
+                [ -z "$t" ] && continue
+                tf=$(echo "$t" | jq -r '.file'); tn=$(echo "$t" | jq -r '.test_name')
+                fp=$(printf '%s::%s::%s' "$version" "$tf" "$tn" | sha256sum | cut -c1-8)
+                pb=$(gh search issues "nightly-product-bug fp=${fp}" --owner camunda --state open \
+                       --limit 1 --json url --jq '.[0].url // ""' 2>/dev/null || echo "")
+                if [ -n "$pb" ]; then
+                  echo "  suppressed (open product bug ${pb}): ${tf} > ${tn}"
+                else
+                  kept=$(echo "$kept" | jq -c --argjson t "$t" '. + [$t]')
+                fi
+              done < <(echo "$specs" | jq -c '.[]')
+              specs="$kept"
+              if [ "$(echo "$specs" | jq 'length')" -eq 0 ]; then
+                echo "Version $version: all failing tests tracked by open product bugs — skipping"
+                continue
+              fi
+            fi
+
             echo "Dispatching fix agent: version=$version  failures=$(echo "$specs" | jq 'length')"
             dispatched_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -728,6 +728,21 @@ jobs:
           # Decode the base64-encoded dispatches payload from the triage job.
           DISPATCHES_JSON=$(echo "${DISPATCHES_B64}" | base64 -d)
 
+          # Prefetch ALL open product-bug fingerprints in ONE search, then filter
+          # in-memory in the per-spec loop below — avoids one gh search per failing
+          # spec and the associated rate-limit/timeout risk. Each line is "<fp> <url>".
+          # Fail-open: on any error the map is empty and nothing is suppressed (the
+          # fix agent still dedupes at filing time).
+          PB_FP_MAP=$(mktemp)
+          trap 'rm -f "$PB_FP_MAP"' EXIT
+          if [ "${SUPPRESS_PRODUCT_BUGS:-true}" = "true" ]; then
+            gh search issues "nightly-product-bug is:issue" --owner camunda --state open \
+              --limit 200 --json body,url \
+              --jq '.[] | select(.body != null and (.body | test("nightly-product-bug fp=[0-9a-f]{8}"))) | "\(.body | capture("nightly-product-bug fp=(?<f>[0-9a-f]{8})").f) \(.url)"' \
+              2>/dev/null > "$PB_FP_MAP" || true
+            echo "Prefetched $(wc -l < "$PB_FP_MAP" | tr -d ' ') open product-bug fingerprint(s)."
+          fi
+
           while IFS= read -r d; do
             version=$(echo "$d" | jq -r '.version')
             specs=$(echo "$d" | jq -c '.test_specs')
@@ -746,11 +761,12 @@ jobs:
             fi
 
             # Drop tests already tracked by an open product bug (per-test fingerprint,
-            # matching what the fix agent embeds in the issue). Suppression is per-test;
-            # the rest of the version's failures still dispatch. Self-resuming: once the
-            # issue is closed the search misses, so the test is dispatched again (if still
-            # failing). This only gates dispatch on issue state — it never reopens the issue.
-            # Fail-open: any search error keeps the test eligible (agent dedupes at filing).
+            # matching what the fix agent embeds in the issue). Looked up in-memory
+            # against PB_FP_MAP (prefetched once above) — no API call per spec.
+            # Suppression is per-test; the rest of the version's failures still dispatch.
+            # Self-resuming: once the issue is closed it drops out of the prefetched
+            # map, so the test is dispatched again (if still failing). This only gates
+            # dispatch on issue state — it never reopens the issue.
             # Skip this for workflow-level dispatches (specs intentionally empty).
             orig_spec_count=$(echo "$specs" | jq 'length')
             if [ "$orig_spec_count" -gt 0 ] && [ "${SUPPRESS_PRODUCT_BUGS:-true}" = "true" ]; then
@@ -759,8 +775,7 @@ jobs:
                 [ -z "$t" ] && continue
                 tf=$(echo "$t" | jq -r '.file'); tn=$(echo "$t" | jq -r '.test_name')
                 fp=$(printf '%s::%s::%s' "$version" "$tf" "$tn" | sha256sum | cut -c1-8)
-                pb=$(gh search issues "nightly-product-bug fp=${fp} is:issue" --owner camunda --state open \
-                       --limit 1 --json url --jq '.[0].url // ""' 2>/dev/null || echo "")
+                pb=$(awk -v fp="$fp" '$1 == fp {print $2; exit}' "$PB_FP_MAP")
                 if [ -n "$pb" ]; then
                   echo "  suppressed (open product bug ${pb}): ${tf} > ${tn}"
                 else

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -747,8 +747,9 @@ jobs:
 
             # Drop tests already tracked by an open product bug (per-test fingerprint,
             # matching what the fix agent embeds in the issue). Suppression is per-test;
-            # the rest of the version's failures still dispatch. Auto-reopens once the
-            # issue is closed (the search misses) and the test is still failing.
+            # the rest of the version's failures still dispatch. Self-resuming: once the
+            # issue is closed the search misses, so the test is dispatched again (if still
+            # failing). This only gates dispatch on issue state — it never reopens the issue.
             # Fail-open: any search error keeps the test eligible (agent dedupes at filing).
             # Skip this for workflow-level dispatches (specs intentionally empty).
             orig_spec_count=$(echo "$specs" | jq 'length')

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -758,7 +758,7 @@ jobs:
                 [ -z "$t" ] && continue
                 tf=$(echo "$t" | jq -r '.file'); tn=$(echo "$t" | jq -r '.test_name')
                 fp=$(printf '%s::%s::%s' "$version" "$tf" "$tn" | sha256sum | cut -c1-8)
-                pb=$(gh search issues "nightly-product-bug fp=${fp}" --owner camunda --state open \
+                pb=$(gh search issues "nightly-product-bug fp=${fp} is:issue" --owner camunda --state open \
                        --limit 1 --json url --jq '.[0].url // ""' 2>/dev/null || echo "")
                 if [ -n "$pb" ]; then
                   echo "  suppressed (open product bug ${pb}): ${tf} > ${tn}"

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml
@@ -728,24 +728,27 @@ jobs:
           # Decode the base64-encoded dispatches payload from the triage job.
           DISPATCHES_JSON=$(echo "${DISPATCHES_B64}" | base64 -d)
 
-          # Prefetch open product-bug fingerprints in ONE search (up to gh's 1000-result
-          # cap), then filter in-memory in the per-spec loop below — avoids one gh search
-          # per failing spec and the associated rate-limit/timeout risk. Each line is
-          # "<fp> <url>". Fail-open: on any error the map is empty and nothing is
-          # suppressed (the fix agent still dedupes at filing time). If the cap is ever
-          # exceeded, the surplus issues just aren't prefetched → those tests re-dispatch
-          # (still benign — fail-open); we warn so it's visible.
-          PB_FP_CAP=1000
+          # Prefetch open product-bug issues in ONE search (up to gh's 1000-issue cap),
+          # then filter in-memory in the per-spec loop below — avoids one gh search per
+          # failing spec and the associated rate-limit/timeout risk. We extract EVERY
+          # fingerprint marker from each issue body (an issue reused for multiple failing
+          # tests carries multiple 'fp=' lines), one "<fp> <url>" per match. Fail-open: on
+          # any error the map is empty and nothing is suppressed (the fix agent still
+          # dedupes at filing time). If the issue cap is hit, surplus issues aren't
+          # prefetched → those tests re-dispatch (benign — fail-open); we warn so it shows.
+          PB_ISSUE_CAP=1000
           PB_FP_MAP=$(mktemp)
           trap 'rm -f "$PB_FP_MAP"' EXIT
           if [ "${SUPPRESS_PRODUCT_BUGS:-true}" = "true" ]; then
-            gh search issues "nightly-product-bug is:issue" --owner camunda --state open \
-              --limit "$PB_FP_CAP" --json body,url \
-              --jq '.[] | select(.body != null and (.body | test("nightly-product-bug fp=[0-9a-f]{8}"))) | "\(.body | capture("nightly-product-bug fp=(?<f>[0-9a-f]{8})").f) \(.url)"' \
-              2>/dev/null > "$PB_FP_MAP" || true
+            pb_issues_json=$(gh search issues "nightly-product-bug is:issue" --owner camunda --state open \
+              --limit "$PB_ISSUE_CAP" --json body,url 2>/dev/null || echo '[]')
+            echo "$pb_issues_json" \
+              | jq -r '.[] | (.url) as $u | ((.body // "") | [scan("nightly-product-bug fp=([0-9a-f]{8})")][] | "\(.[0]) \($u)")' \
+              > "$PB_FP_MAP" 2>/dev/null || true
+            pb_issue_count=$(echo "$pb_issues_json" | jq 'length' 2>/dev/null || echo 0)
             pb_fp_count=$(wc -l < "$PB_FP_MAP" | tr -d ' ')
-            echo "Prefetched ${pb_fp_count} open product-bug fingerprint(s)."
-            [ "$pb_fp_count" -ge "$PB_FP_CAP" ] && echo "::warning::Open product-bug issues hit the ${PB_FP_CAP} search cap — some fingerprints may not be prefetched; affected tests will re-dispatch (fail-open)."
+            echo "Prefetched ${pb_fp_count} fingerprint(s) from ${pb_issue_count} open product-bug issue(s)."
+            [ "$pb_issue_count" -ge "$PB_ISSUE_CAP" ] && echo "::warning::Open product-bug issues hit the ${PB_ISSUE_CAP} search cap — some may not be prefetched; affected tests will re-dispatch (fail-open)."
           fi
 
           while IFS= read -r d; do

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -314,8 +314,10 @@ Bound the window with when the test first went red. Name a plausible commit (or 
 change) when you can — it goes in `suspect_commit` and the Slack thread. **If you cannot pin a
 specific commit but Gate A and Gate C clearly hold** (deterministic failure, test still correct, the
 app is visibly misbehaving), still escalate as a product bug with `suspect_commit: "not pinned"` and
-note what you ruled out — do NOT fall back to masking or skipping (both forbidden regardless). Only
-re-examine for a test-side cause if Gate A or Gate C is genuinely in doubt.
+note what you ruled out — i.e. complete the full product-bug escalation (file/reuse the ticket +
+annotated `test.skip(...)` + skip PR). Do NOT instead mask the failure (viewport/timeout/selector
+tweak or a weakened assertion), and do NOT do a bare `test.skip()` without a filed/linked ticket.
+Only re-examine for a test-side cause if Gate A or Gate C is genuinely in doubt.
 
 **Gate C — Confirm the test is still correct.** The assertion must still match intended behavior,
 the selector must target a real element, and the test must not be stale. If the test itself is wrong

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -341,7 +341,7 @@ Orchestration-suite failures almost always trace to a module inside this same re
 > filing/searching issues in `camunda/camunda` and Gate B lookups; qa-processes generally already
 > has the access. ONLY if a call fails (e.g. filing in a different repo such as
 > `camunda/camunda-platform-helm`) retry the SAME command once with the fallback PAT
-> `GH_TOKEN="$GH_TOKEN_PAT" gh ...`. Always qa-processes first; the PAT is a backup.
+> `GH_TOKEN="$GH_PAT" gh ...`. Always qa-processes first; the PAT is a backup.
 
 1. **Compute the fingerprint** — `sha256` of `<version>::<file>::<test_name>`, first 8 chars (MUST
    match the triage dispatcher exactly so it can suppress re-dispatch):

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -280,6 +280,124 @@ test: add operate batch cancel assertion for RDBMS
 fix: retry flaky identity role assignment check
 ```
 
+## Product-Bug Escalation
+
+Read this whenever you suspect a failure is a **product regression**, not a test defect. A
+**product-bug** verdict means: **file (or reuse) a tracking issue against the owning component, then
+SKIP the failing test with a bug-linked annotation and open ONE PR carrying that skip.** Skipping is
+the only sanctioned way to make a confirmed product regression green — you still must NOT mask it
+with a viewport resize, timeout bump, selector tweak, or weakened assertion. **Skipping is allowed
+ONLY here** (a confirmed product bug that passes all three gates AND has a filed/linked ticket); for
+flakiness, a can't-determine failure, or any other reason, `test.skip()` / `test.fixme()` /
+`test.only` remain **absolutely forbidden**.
+
+You may reach a product-bug verdict ONLY after passing **all three gates below, in order**. If any
+gate fails, fall back to the normal test-side fix. Product-bug is not an escape hatch for a test you
+find hard to fix, and you must never mask a regression with a viewport resize, a timeout bump, or a
+weakened assertion (e.g. an Operate variables-scrolling regression must NOT be "fixed" by resizing
+the window).
+
+**Gate A — Rule out flakiness.** The failure must be deterministic. You cannot re-run, so use
+evidence: every retry attempt in `results.json` failed (a `failed → passed` retry is flakiness — fix
+with a wait/retry); and the failure reproduces across both tasklist modes / DBs that share the flow,
+or has failed on consecutive nights. If it looks intermittent → flakiness fix, not a product bug.
+
+**Gate B — Pin it to a recent product change.** Identify the owning module (table below) and find
+the breaking change in the workspace checkout (it is the full `camunda/camunda` repo on
+`${TARGET_REF}`):
+```bash
+git -C "${ws_dir}" log --since=<YYYY-MM-DD> --oneline -- <module-path>   # e.g. operate/ identity/
+# or, for a precise surface:
+gh search code --repo camunda/camunda "<aria-label / data-testid / endpoint>" --limit 5 --json path
+```
+Bound the window with when the test first went red. Name a plausible commit (or documented behavior
+change) when you can — it goes in `suspect_commit` and the Slack thread. **If you cannot pin a
+specific commit but Gate A and Gate C clearly hold** (deterministic failure, test still correct, the
+app is visibly misbehaving), still escalate as a product bug with `suspect_commit: "not pinned"` and
+note what you ruled out — do NOT fall back to masking or skipping (both forbidden regardless). Only
+re-examine for a test-side cause if Gate A or Gate C is genuinely in doubt.
+
+**Gate C — Confirm the test is still correct.** The assertion must still match intended behavior,
+the selector must target a real element, and the test must not be stale. If the test itself is wrong
+→ that is a test fix (Step 4), not a product bug.
+
+### Owning-component routing
+
+Orchestration-suite failures almost always trace to a module inside this same repo (`camunda/camunda`):
+
+| Failure surface | Issue repo | Module path |
+|---|---|---|
+| Operate | `camunda/camunda` | `operate/` |
+| Tasklist | `camunda/camunda` | `tasklist/` |
+| Identity / authorization / RBA | `camunda/camunda` | `identity/`, `authentication/`, `security/` |
+| Zeebe / engine / gateway / REST API | `camunda/camunda` | `zeebe/`, `gateways/`, `service/` |
+| Optimize | `camunda/camunda` | `optimize/` |
+| c8Run setup / packaging | `camunda/camunda` | `c8run/` |
+| Helm chart / deploy config | `camunda/camunda-platform-helm` | `charts/` |
+
+### Filing the bug ticket (dedupe FIRST)
+
+> **Token:** the default `GH_TOKEN` is the App token for `camunda/camunda` — fine for in-repo
+> issues. To file/search issues in a DIFFERENT repo (`camunda/camunda-platform-helm`), prefix the
+> command with the broader PAT: `GH_TOKEN="$GH_TOKEN_PAT" gh issue create --repo <owner>/<repo> ...`.
+
+1. **Compute the fingerprint** — `sha256` of `<version>::<file>::<test_name>`, first 8 chars (MUST
+   match the triage dispatcher exactly so it can suppress re-dispatch):
+   ```bash
+   FP=$(printf '%s::%s::%s' "<version>" "<file>" "<test_name>" | sha256sum | cut -c1-8)
+   ```
+   **Search for an existing issue** (the marker is globally unique):
+   ```bash
+   gh search issues "nightly-product-bug fp=${FP}" --owner camunda --state all \
+     --json number,url,state,repository --jq '.[0]'
+   ```
+   - Open issue exists → reuse it (comment with this nightly run); do NOT file a new one.
+   - Closed issue for the same FP → reopen (`gh issue reopen`) and comment, then reuse its URL.
+   - **Also check for a human-filed bug that predates this automation** (no fingerprint marker):
+     `gh search issues "<key symptom words>" --owner camunda --state open --json number,title,url,repository`
+     and scan titles for the same regression (e.g. #55864 "Variable list is no longer scrollable").
+     If you find a clear match, **reuse it** instead of filing a duplicate: comment linking this
+     nightly run, and **append** the `Fingerprint: nightly-product-bug fp=${FP}` line to its body
+     (`gh issue edit <n> --repo <owner>/<repo> --body "<existing body>\n\nFingerprint: nightly-product-bug fp=${FP}"`)
+     so future runs dedupe and the dispatcher suppresses it. Put its URL in `fix-meta.json`.
+2. **File the issue** when none exists. You MAY use the repo's `create-issue` skill (bug template +
+   component label), but the body MUST contain the fingerprint line below so dedupe works:
+   ```bash
+   gh issue create --repo camunda/camunda \
+     --title "<module>: <one-line symptom> (nightly <version>)" \
+     --label "kind/bug" --label "nightly-detected" \
+     --body "$(cat <<'BODY'
+   Detected by orchestration-cluster nightly triage. The failing test is **correct** and the failure
+   is **not flaky** — it traces to a recent product change.
+
+   - **Failing test:** `<file>` › `<test_name>` (<test_type>, <version>)
+   - **Symptom:** <what the screenshot / error shows>
+   - **Suspected change:** <commit sha + subject, or PR #, or docs reference>
+   - **Nightly run(s):** <e2e / api run URLs>
+   - **Triage run:** <triage_run_url>
+
+   Fingerprint: nightly-product-bug fp=<FP>
+   BODY
+   )"
+   ```
+   The `Fingerprint:` line is **mandatory**. `kind/bug` / `nightly-detected` are defaults — drop a
+   label the repo rejects rather than failing.
+3. **Skip the failing test with a bug-linked annotation**, static `test.skip(...)` form, with the
+   annotation comment on the line directly above — exact format, no deviation:
+   ```ts
+   // Skipped due to bug #<number>: <issue-url>
+   test.skip('<exact test title>', async ({ ... }) => {
+   ```
+   Skip only the failing test (not the whole `describe`) unless every test in the block shares the
+   bug. Lint the changed file.
+4. **Open ONE PR** with the skip(s): `test:` type (commitlint rejects `fix:` for test-only changes),
+   title like `test: skip <spec> pending bug #<number>`, body linking the issue + nightly/triage
+   runs. All product-bug skips for this dispatch go in the same branch + PR.
+5. Record the verdict in `/tmp/fix-meta.json` (see the product-bug schema in **Result manifest**) —
+   the skip PR goes in `prs`, the issue(s) in `product_bugs` — and stop.
+
+---
+
 ## Nightly Fix Agent
 
 This section is read automatically by the Claude Code agent dispatched from
@@ -389,12 +507,16 @@ a specific assertion or action. Typical patterns:
 
 **Step 4 — Decide: fix or stop.**
 
-If the failure is **clearly a product bug** (e.g., a 500 from the server, a
-panel that never renders despite correct backend response, an authorization
-regression) and no test-side change is reasonable: write `{"prs":[]}` to
-`/tmp/fix-meta.json` and stop. Do not open a PR. Do not skip the test.
+If a minimal test-side fix exists, apply it (Step 5 below).
 
-If a minimal test-side fix exists, apply it.
+If the failure is a **product regression** (e.g., a 500 from the server, a panel that never renders
+despite a correct backend response, an authorization regression, lost scrolling) and no test-side
+change is reasonable, follow **`## Product-Bug Escalation`**: pass Gate A (not flaky), Gate B (pin
+the recent product change), Gate C (test still correct), then **file/reuse a tracking issue** against
+the owning module, **skip** the failing test with the `// Skipped due to bug #<number>: <url>`
+annotation, and open ONE skip PR (the skip PR goes in `prs`, the issue in `product_bugs`). Never mask
+the regression with a viewport / timeout / selector tweak or a weakened assertion **instead of**
+skipping.
 
 ### Apply the fix
 
@@ -444,7 +566,7 @@ If a minimal test-side fix exists, apply it.
 
 - **Allowed tools:** `gh`, `git`, `grep`, `rg`, `cat`, `find`, `jq`, `sed`, `awk`, `unzip`, `npx prettier`, `npx eslint`, `npm run responses:regenerate`.
 - **Forbidden:** `make`, `mvn`, `./mvnw`, `docker`, `kubectl`, `helm`, `npm install`, `npm run build`, `npm run test`, `npx playwright test`. The fix agent does **not** execute tests — it fixes from artifact evidence only. Verification is delegated to the on-demand workflows triggered by the calling workflow.
-- **NO skipping — EVER:** `test.skip()`, `test.fixme()`, `test.only`, and all pending variants are banned. There are no exceptions, not even for confirmed product bugs. If you cannot fix in code, write `{"prs":[]}` and stop.
+- **Skipping is forbidden EXCEPT for a confirmed product bug:** the ONLY sanctioned use of `test.skip()` is a product regression that passes all three gates in `## Product-Bug Escalation` and has a filed/linked ticket — there you skip with the mandatory `// Skipped due to bug #<number>: <url>` annotation and open one skip PR. For flakiness, can't-determine, or any other reason, `test.skip()` / `test.fixme()` / `test.only` remain **absolutely forbidden** — never leave a bare `{"prs":[]}` with no issue filed either.
 - **Never edit `json-body-assertions/_generated/responses.json` by hand.** This file is auto-generated. If an API response changes, regenerate it with `npm run responses:regenerate` and commit the result. Manual edits will be overwritten and produce misleading diffs.
 - **Minimal diff:** no refactoring, no dependency bumps, no unrelated edits, no formatting sweeps on untouched files.
 - **PR title type must be `test:`** — commitlint rejects `fix:` for test-only changes (see Commit / PR Conventions above).
@@ -500,6 +622,33 @@ on-demand verification run is triggered: `c8-orchestration-cluster-e2e-tests-on-
 no verification run is triggered and the fix is never validated automatically.**
 
 Use `{"prs": []}` if no PR was opened (regardless of reason).
+
+A confirmed product bug always lands as a skip PR, so `prs` carries that PR (set `has_e2e`/`has_api`
+from the skipped test types so the skip is verified) and `product_bugs` lists one object per
+filed/reused issue (a dispatch may yield several bugs):
+
+```json
+{
+  "prs": [{"number": 1234, "owner": "camunda", "repo": "camunda", "branch": "fix/nightly-8.10-skip-operate-vars", "has_e2e": true, "has_api": false}],
+  "category": "product-bug",
+  "product_bugs": [
+    {
+      "repo": "camunda/camunda",
+      "component": "operate",
+      "issue_url": "https://github.com/camunda/camunda/issues/55864",
+      "issue_number": 55864,
+      "fingerprint": "<FP>",
+      "root_cause": "One sentence: which product change broke which flow.",
+      "suspect_commit": "<sha + subject, or PR #, or docs reference>",
+      "skipped_tests": ["<file> › <test_name>"]
+    }
+  ]
+}
+```
+`category`, the skip PR in `prs`, and a non-empty `product_bugs` are all required for this verdict.
+`suspect_commit` is surfaced directly in the Slack thread. The triage dispatcher reads each issue's
+fingerprint marker to suppress re-dispatch while the issue is open; once the skip PR merges the test
+no longer runs, and when the issue is later closed the skip should be removed so the test runs again.
 
 ## Workflow-Level Failure Fix Agent
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -337,9 +337,11 @@ Orchestration-suite failures almost always trace to a module inside this same re
 
 ### Filing the bug ticket (dedupe FIRST)
 
-> **Token:** the default `GH_TOKEN` is the App token for `camunda/camunda` — fine for in-repo
-> issues. To file/search issues in a DIFFERENT repo (`camunda/camunda-platform-helm`), prefix the
-> command with the broader PAT: `GH_TOKEN="$GH_TOKEN_PAT" gh issue create --repo <owner>/<repo> ...`.
+> **Token:** use the default `GH_TOKEN` (the qa-processes App token) for ALL `gh` calls FIRST —
+> filing/searching issues in `camunda/camunda` and Gate B lookups; qa-processes generally already
+> has the access. ONLY if a call fails (e.g. filing in a different repo such as
+> `camunda/camunda-platform-helm`) retry the SAME command once with the fallback PAT
+> `GH_TOKEN="$GH_TOKEN_PAT" gh ...`. Always qa-processes first; the PAT is a backup.
 
 1. **Compute the fingerprint** — `sha256` of `<version>::<file>::<test_name>`, first 8 chars (MUST
    match the triage dispatcher exactly so it can suppress re-dispatch):

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -305,11 +305,13 @@ or has failed on consecutive nights. If it looks intermittent → flakiness fix,
 **Gate B — Pin it to a recent product change.** Identify the owning module (table below) and find
 the breaking change. You are already inside the `camunda/camunda` checkout (on `${TARGET_REF}`), so
 run `git` from the current directory — do not reference `$ws_dir` (it is not set in your shell):
+
 ```bash
 git log --since=<YYYY-MM-DD> --oneline -- <module-path>   # e.g. operate/ identity/
 # or, for a precise surface:
 gh search code --repo camunda/camunda "<aria-label / data-testid / endpoint>" --limit 5 --json path
 ```
+
 Bound the window with when the test first went red. Name a plausible commit (or documented behavior
 change) when you can — it goes in `suspect_commit` and the Slack thread. **If you cannot pin a
 specific commit but Gate A and Gate C clearly hold** (deterministic failure, test still correct, the
@@ -327,15 +329,15 @@ the selector must target a real element, and the test must not be stale. If the 
 
 Orchestration-suite failures almost always trace to a module inside this same repo (`camunda/camunda`):
 
-| Failure surface | Issue repo | Module path |
-|---|---|---|
-| Operate | `camunda/camunda` | `operate/` |
-| Tasklist | `camunda/camunda` | `tasklist/` |
-| Identity / authorization / RBA | `camunda/camunda` | `identity/`, `authentication/`, `security/` |
-| Zeebe / engine / gateway / REST API | `camunda/camunda` | `zeebe/`, `gateways/`, `service/` |
-| Optimize | `camunda/camunda` | `optimize/` |
-| c8Run setup / packaging | `camunda/camunda` | `c8run/` |
-| Helm chart / deploy config | `camunda/camunda-platform-helm` | `charts/` |
+|           Failure surface           |           Issue repo            |                 Module path                 |
+|-------------------------------------|---------------------------------|---------------------------------------------|
+| Operate                             | `camunda/camunda`               | `operate/`                                  |
+| Tasklist                            | `camunda/camunda`               | `tasklist/`                                 |
+| Identity / authorization / RBA      | `camunda/camunda`               | `identity/`, `authentication/`, `security/` |
+| Zeebe / engine / gateway / REST API | `camunda/camunda`               | `zeebe/`, `gateways/`, `service/`           |
+| Optimize                            | `camunda/camunda`               | `optimize/`                                 |
+| c8Run setup / packaging             | `camunda/camunda`               | `c8run/`                                    |
+| Helm chart / deploy config          | `camunda/camunda-platform-helm` | `charts/`                                   |
 
 ### Filing the bug ticket (dedupe FIRST)
 
@@ -347,14 +349,18 @@ Orchestration-suite failures almost always trace to a module inside this same re
 
 1. **Compute the fingerprint** — `sha256` of `<version>::<file>::<test_name>`, first 8 chars (MUST
    match the triage dispatcher exactly so it can suppress re-dispatch):
+
    ```bash
    FP=$(printf '%s::%s::%s' "<version>" "<file>" "<test_name>" | sha256sum | cut -c1-8)
    ```
+
    **Search for an existing issue** (the marker is globally unique):
+
    ```bash
    gh search issues "nightly-product-bug fp=${FP} is:issue" --owner camunda --state all \
      --limit 1 --json number,url,state,repository --jq '.[0]'
    ```
+
    - Open issue exists → reuse it (comment with this nightly run); do NOT file a new one.
    - Closed issue for the same FP → reopen (`gh issue reopen`) and comment, then reuse its URL.
    - **Also check for a human-filed bug that predates this automation** (no fingerprint marker):
@@ -364,14 +370,18 @@ Orchestration-suite failures almost always trace to a module inside this same re
      nightly run, then **append** the fingerprint line to its body so future runs dedupe and the
      dispatcher suppresses it. Preserve the existing body and use real newlines (a literal `\n` in
      `--body` is written verbatim, not a newline):
+
      ```bash
      body=$(gh issue view <n> --repo <owner>/<repo> --json body --jq .body)
      printf '%s\n\nFingerprint: nightly-product-bug fp=%s\n' "$body" "${FP}" \
        | gh issue edit <n> --repo <owner>/<repo> --body-file -
      ```
+
      Put its URL in `fix-meta.json`.
+
 2. **File the issue** when none exists. You MAY use the repo's `create-issue` skill (bug template +
    component label), but the body MUST contain the fingerprint line below so dedupe works:
+
    ```bash
    gh issue create --repo camunda/camunda \
      --title "<module>: <one-line symptom> (nightly <version>)" \
@@ -390,19 +400,25 @@ Orchestration-suite failures almost always trace to a module inside this same re
    BODY
    )"
    ```
+
    The `Fingerprint:` line is **mandatory**. `kind/bug` / `nightly-detected` are defaults — drop a
    label the repo rejects rather than failing.
+
 3. **Skip the failing test with a bug-linked annotation**, static `test.skip(...)` form, with the
    annotation comment on the line directly above — exact format, no deviation:
+
    ```ts
    // Skipped due to bug #<number>: <issue-url>
    test.skip('<exact test title>', async ({ ... }) => {
    ```
+
    Skip only the failing test (not the whole `describe`) unless every test in the block shares the
    bug. Lint the changed file.
+
 4. **Open ONE PR** with the skip(s): `test:` type (commitlint rejects `fix:` for test-only changes),
    title like `test: skip <spec> pending bug #<number>`, body linking the issue + nightly/triage
    runs. All product-bug skips for this dispatch go in the same branch + PR.
+
 5. Record the verdict in `/tmp/fix-meta.json` (see the product-bug schema in **Result manifest**) —
    the skip PR goes in `prs`, the issue(s) in `product_bugs` — and stop.
 
@@ -655,6 +671,7 @@ filed/reused issue (a dispatch may yield several bugs):
   ]
 }
 ```
+
 `category`, the skip PR in `prs`, and a non-empty `product_bugs` are all required for this verdict.
 `suspect_commit` is surfaced directly in the Slack thread. The triage dispatcher reads each issue's
 fingerprint marker to suppress re-dispatch while the issue is open; once the skip PR merges the test

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -303,10 +303,10 @@ with a wait/retry); and the failure reproduces across both tasklist modes / DBs 
 or has failed on consecutive nights. If it looks intermittent → flakiness fix, not a product bug.
 
 **Gate B — Pin it to a recent product change.** Identify the owning module (table below) and find
-the breaking change in the workspace checkout (it is the full `camunda/camunda` repo on
-`${TARGET_REF}`):
+the breaking change. You are already inside the `camunda/camunda` checkout (on `${TARGET_REF}`), so
+run `git` from the current directory — do not reference `$ws_dir` (it is not set in your shell):
 ```bash
-git -C "${ws_dir}" log --since=<YYYY-MM-DD> --oneline -- <module-path>   # e.g. operate/ identity/
+git log --since=<YYYY-MM-DD> --oneline -- <module-path>   # e.g. operate/ identity/
 # or, for a precise surface:
 gh search code --repo camunda/camunda "<aria-label / data-testid / endpoint>" --limit 5 --json path
 ```

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -351,7 +351,7 @@ Orchestration-suite failures almost always trace to a module inside this same re
    **Search for an existing issue** (the marker is globally unique):
    ```bash
    gh search issues "nightly-product-bug fp=${FP} is:issue" --owner camunda --state all \
-     --json number,url,state,repository --jq '.[0]'
+     --limit 1 --json number,url,state,repository --jq '.[0]'
    ```
    - Open issue exists → reuse it (comment with this nightly run); do NOT file a new one.
    - Closed issue for the same FP → reopen (`gh issue reopen`) and comment, then reuse its URL.

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -350,13 +350,13 @@ Orchestration-suite failures almost always trace to a module inside this same re
    ```
    **Search for an existing issue** (the marker is globally unique):
    ```bash
-   gh search issues "nightly-product-bug fp=${FP}" --owner camunda --state all \
+   gh search issues "nightly-product-bug fp=${FP} is:issue" --owner camunda --state all \
      --json number,url,state,repository --jq '.[0]'
    ```
    - Open issue exists → reuse it (comment with this nightly run); do NOT file a new one.
    - Closed issue for the same FP → reopen (`gh issue reopen`) and comment, then reuse its URL.
    - **Also check for a human-filed bug that predates this automation** (no fingerprint marker):
-     `gh search issues "<key symptom words>" --owner camunda --state open --json number,title,url,repository`
+     `gh search issues "<key symptom words> is:issue" --owner camunda --state open --json number,title,url,repository`
      and scan titles for the same regression (e.g. #55864 "Variable list is no longer scrollable").
      If you find a clear match, **reuse it** instead of filing a duplicate: comment linking this
      nightly run, and **append** the `Fingerprint: nightly-product-bug fp=${FP}` line to its body

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -359,9 +359,15 @@ Orchestration-suite failures almost always trace to a module inside this same re
      `gh search issues "<key symptom words> is:issue" --owner camunda --state open --json number,title,url,repository`
      and scan titles for the same regression (e.g. #55864 "Variable list is no longer scrollable").
      If you find a clear match, **reuse it** instead of filing a duplicate: comment linking this
-     nightly run, and **append** the `Fingerprint: nightly-product-bug fp=${FP}` line to its body
-     (`gh issue edit <n> --repo <owner>/<repo> --body "<existing body>\n\nFingerprint: nightly-product-bug fp=${FP}"`)
-     so future runs dedupe and the dispatcher suppresses it. Put its URL in `fix-meta.json`.
+     nightly run, then **append** the fingerprint line to its body so future runs dedupe and the
+     dispatcher suppresses it. Preserve the existing body and use real newlines (a literal `\n` in
+     `--body` is written verbatim, not a newline):
+     ```bash
+     body=$(gh issue view <n> --repo <owner>/<repo> --json body --jq .body)
+     printf '%s\n\nFingerprint: nightly-product-bug fp=%s\n' "$body" "${FP}" \
+       | gh issue edit <n> --repo <owner>/<repo> --body-file -
+     ```
+     Put its URL in `fix-meta.json`.
 2. **File the issue** when none exists. You MAY use the repo's `create-issue` skill (bug template +
    component label), but the body MUST contain the fingerprint line below so dedupe works:
    ```bash


### PR DESCRIPTION
## Description

Adds a **product-bug** outcome to the orchestration-cluster nightly fix agent (`c8-orchestration-cluster-e2e-nightly-{triage,fix}.yml` + `qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md`) so that genuine product regressions are detected and tracked instead of masked or silently skipped.

When a dispatched failure is **not** a test defect, the agent now follows a gated `## Product-Bug Escalation` path:

1. **Gate A** — rule out flakiness.
2. **Gate B** — pin the regression to a recent product change (`git log <module>`), or escalate with `suspect_commit: "not pinned"` when A+C clearly hold.
3. **Gate C** — confirm the test is still correct.

If all three hold, the agent **files (or reuses) a tracking issue** against the owning module (operate / tasklist / identity / zeebe / optimize / c8run; helm config → camunda-platform-helm), then **skips the failing test with a mandatory annotation** and opens one `test:` PR:

```ts
// Skipped due to bug #<number>: <issue-url>
test.skip('<title>', async ({ ... }) => {
```

Skipping is now permitted **only** for a confirmed product bug with a filed/linked ticket; for flakiness or any other reason `test.skip()`/`test.fixme()`/`test.only` remain forbidden, and masking (viewport/timeout/selector tweak, weakened assertion) is forbidden.

Supporting changes:

- **Dedupe + suppression** — issues carry a deterministic `Fingerprint: nightly-product-bug fp=<sha8>` marker; the agent searches by fingerprint **and** symptom (reusing a pre-existing human-filed bug rather than duplicating it), and the triage workflow skips re-dispatching a test that has an open product-bug issue (auto-reopens when it closes).
- **Slack** — the fix-agent thread reply reports each product bug with its issue link + suspected commit, alongside the skip PR.
- **Token** — `GH_TOKEN_PAT` is wired through for filing issues in repos other than `camunda/camunda`.

Worked example: the Operate variables-scrolling regression (#55864) would now be reused (not duplicated), the `Infinite scrolling` test skipped with `// Skipped due to bug #55864: <link>`, and reported to Slack — instead of an untraceable skip or a window-size mask.

### Backporting

The `qa/.../AGENTS.md` rules are read by the fix agent on each version branch, so this likely wants backporting to `stable/8.9`, `stable/8.8`, `stable/8.7`. Holding off on backport labels pending reviewer confirmation.
