### PR TITLE
fix: derive raft request timeout from election timeout

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -99,19 +99,18 @@ public final class RaftPartitionFactory {
         brokerCfg.getCluster().getRaft().isEnablePriorityElection());
     partitionConfig.setElectionTimeout(brokerCfg.getCluster().getElectionTimeout());
     partitionConfig.setHeartbeatInterval(brokerCfg.getCluster().getHeartbeatInterval());
-    partitionConfig.setRequestTimeout(brokerCfg.getExperimental().getRaft().getRequestTimeout());
-    partitionConfig.setSnapshotRequestTimeout(
-        brokerCfg.getExperimental().getRaft().getSnapshotRequestTimeout());
-    partitionConfig.setSnapshotChunkSize(
-        (int) brokerCfg.getExperimental().getRaft().getSnapshotChunkSize().toBytes());
-    partitionConfig.setConfigurationChangeTimeout(
-        brokerCfg.getExperimental().getRaft().getConfigurationChangeTimeout());
-    partitionConfig.setMaxQuorumResponseTimeout(
-        brokerCfg.getExperimental().getRaft().getMaxQuorumResponseTimeout());
-    partitionConfig.setMinStepDownFailureCount(
-        brokerCfg.getExperimental().getRaft().getMinStepDownFailureCount());
+    final var raftCfg = brokerCfg.getExperimental().getRaft();
+    partitionConfig.setRequestTimeout(
+        raftCfg.isRequestTimeoutConfigured()
+            ? raftCfg.getRequestTimeout()
+            : brokerCfg.getCluster().getElectionTimeout());
+    partitionConfig.setSnapshotRequestTimeout(raftCfg.getSnapshotRequestTimeout());
+    partitionConfig.setSnapshotChunkSize((int) raftCfg.getSnapshotChunkSize().toBytes());
+    partitionConfig.setConfigurationChangeTimeout(raftCfg.getConfigurationChangeTimeout());
+    partitionConfig.setMaxQuorumResponseTimeout(raftCfg.getMaxQuorumResponseTimeout());
+    partitionConfig.setMinStepDownFailureCount(raftCfg.getMinStepDownFailureCount());
     partitionConfig.setPreferSnapshotReplicationThreshold(
-        brokerCfg.getExperimental().getRaft().getPreferSnapshotReplicationThreshold());
+        raftCfg.getPreferSnapshotReplicationThreshold());
 
     partitionConfig.setReceiveOnLegacySubject(
         brokerCfg.getExperimental().isReceiveOnLegacySubject());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -35,6 +35,7 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
   private int minStepDownFailureCount = DEFAULT_MIN_STEP_DOWN_FAILURE_COUNT;
   private int preferSnapshotReplicationThreshold = DEFAULT_PREFER_SNAPSHOT_REPLICATION_THRESHOLD;
   private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
+  private boolean requestTimeoutConfigured;
 
   private PreAllocationStrategy segmentPreallocationStrategy = DEFAULT_PREALLOCATE_SEGMENT_STRATEGY;
 
@@ -44,6 +45,17 @@ public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public void setRequestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
+    requestTimeoutConfigured = true;
+  }
+
+  /**
+   * Returns whether the request timeout was explicitly configured.
+   *
+   * <p>The default request timeout should follow the cluster election timeout when the operator has
+   * not set an explicit override.
+   */
+  public boolean isRequestTimeoutConfigured() {
+    return requestTimeoutConfigured;
   }
 
   public Duration getSnapshotRequestTimeout() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
@@ -44,6 +44,20 @@ public final class RaftPartitionFactoryTest {
   }
 
   @Test
+  void shouldDefaultRaftRequestTimeoutToElectionTimeout() {
+    // given
+    final Duration expected = Duration.ofSeconds(15);
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setElectionTimeout(expected);
+
+    // when
+    final var partition = buildRaftPartition(brokerCfg);
+
+    // then
+    assertThat(partition.getPartitionConfig().getRequestTimeout()).isEqualTo(expected);
+  }
+
+  @Test
   void shouldSetHeartbeatInterval() {
     // given
     final Duration expected = Duration.ofSeconds(10);


### PR DESCRIPTION
## Description

When the experimental Raft request timeout is left unset, the partition factory now derives it from the configured cluster election timeout instead of using a fixed default. That keeps the request timeout aligned with lower election timeouts and avoids reintroducing the spurious-election behavior discussed in #12421.

## Checklist

- [x] Enable backports when necessary

## Related issues

closes #56043

## Validation

- `cmd /c ".\\mvnw.cmd -pl zeebe/broker -am -Dtest=RaftPartitionFactoryTest -Dsurefire.failIfNoSpecifiedTests=false -DskipITs test"`
- `cmd /c ".\\mvnw.cmd -pl zeebe/broker -am spotless:check -DskipTests -DskipITs"`
- `git diff --check`