### PR TITLE
fix: osClient cannot be null in Exporter ITs

### DIFF
--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -11,6 +11,10 @@ name: AWS OpenSearch Manual/Scheduled Run Integration Tests
 on:
   workflow_dispatch:
     inputs:
+      ref:
+        description: Branch or commit to test against
+        type: string
+        default: "main"
       opensearch-version:
         description: Version of AWS OpenSearch
         type: choice
@@ -42,6 +46,8 @@ jobs:
         os_version: ${{ fromJSON(format('[{0}]', github.event.inputs.opensearch-version || '"2.19", "3.5"')) }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
       - name: Setup AWS OpenSearch
         uses: ./.github/actions/setup-aws-opensearch-env
         with:

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITTemplateExtension.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITTemplateExtension.java
@@ -19,7 +19,7 @@ import io.camunda.search.test.utils.SearchDBExtension;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -28,11 +28,8 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 
-public class CamundaExporterITTemplateExtension
-    implements TestTemplateInvocationContextProvider, BeforeAllCallback {
+public class CamundaExporterITTemplateExtension implements TestTemplateInvocationContextProvider {
 
-  protected SearchClientAdapter elsClientAdapter;
-  protected SearchClientAdapter osClientAdapter;
   private final SearchDBExtension extension;
 
   public CamundaExporterITTemplateExtension(final SearchDBExtension extension) {
@@ -53,18 +50,23 @@ public class CamundaExporterITTemplateExtension
   }
 
   @Override
-  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
-      final ExtensionContext extensionContext) {
+  public @NonNull Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+      final @NonNull ExtensionContext extensionContext) {
+    final SearchClientAdapter osClientAdapter =
+        new SearchClientAdapter(extension.osClient(), extension.objectMapper());
+
     final var openSearchAwsInstanceUrl =
         Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL)).orElse("");
     if (openSearchAwsInstanceUrl.isEmpty()) {
+      final SearchClientAdapter elsClientAdapter =
+          new SearchClientAdapter(extension.esClient(), extension.objectMapper());
       return Stream.of(
           invocationContext(getConfigWithConnectionDetails(OPENSEARCH), osClientAdapter),
           invocationContext(getConfigWithConnectionDetails(ELASTICSEARCH), elsClientAdapter));
-    } else {
-      return Stream.of(
-          invocationContext(getConfigWithConnectionDetails(OPENSEARCH), osClientAdapter));
     }
+
+    return Stream.of(
+        invocationContext(getConfigWithConnectionDetails(OPENSEARCH), osClientAdapter));
   }
 
   protected ParameterResolver exporterConfigResolver(final ExporterConfiguration config) {
@@ -134,13 +136,5 @@ public class CamundaExporterITTemplateExtension
     config.getConnect().setType(connectionType.getType());
     config.getConnect().setAwsEnabled(extension.isAws());
     return config;
-  }
-
-  @Override
-  public void beforeAll(final ExtensionContext context) throws Exception {
-    if (Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL)).isEmpty()) {
-      elsClientAdapter = new SearchClientAdapter(extension.esClient(), extension.objectMapper());
-    }
-    osClientAdapter = new SearchClientAdapter(extension.osClient(), extension.objectMapper());
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

CamundaExporterITTemplateExtension.beforeAll was calling extension.osClient() before AWSSearchDBExtension.beforeAll had initialized it, due to non-deterministic BeforeAllCallback ordering in JUnit 5.
Fix: move adapter initialization into provideTestTemplateInvocationContexts, which is guaranteed to run after all BeforeAllCallbacks have completed. This also eliminates the need for the adapter fields and the BeforeAllCallback implementation.

Job: **[IT] Camunda Exporter ITs. OS ver.2.19**

Error run:
https://github.com/camunda/camunda/actions/runs/28350957705/job/83984008867

With:
```
[INFO] Running io.camunda.exporter.UserTaskVariableExportIT
Error:  Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 5.167 s <<< FAILURE! -- in io.camunda.exporter.ExporterBulkConsistencyIT
Error:  io.camunda.exporter.ExporterBulkConsistencyIT -- Time elapsed: 5.167 s <<< ERROR!
java.lang.NullPointerException: osClient cannot be null
	at java.base/java.util.Objects.requireNonNull(Objects.java:259)
	at io.camunda.search.test.utils.SearchClientAdapter.<init>(SearchClientAdapter.java:49)
	at io.camunda.exporter.utils.CamundaExporterITTemplateExtension.beforeAll(CamundaExporterITTemplateExtension.java:144)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1808)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
```

Success run:
https://github.com/camunda/camunda/actions/runs/28395303791

With:
```
[INFO] Running io.camunda.exporter.UserTaskVariableExportIT
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 22.75 s -- in io.camunda.exporter.cache.BatchOperationCacheIT
```

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/52892
