### PR TITLE
ci: pin Camunda Platform Helm Chart dependency inside load tests

### DIFF
--- a/.github/instructions/load-tests.instructions.md
+++ b/.github/instructions/load-tests.instructions.md
@@ -32,6 +32,16 @@ When reviewing changes to load tests, workflows, or load test infrastructure:
    version; `saas-default/` is SaaS/cloud only and is not version-partitioned.
    See `load-tests/setup/README.md` for the version-dispatcher pattern and layout.
 
+   When **adding a new versioned folder** (e.g. for a new stable branch), include the
+   Renovate annotation immediately above `camunda_platform_helm_chart_version` in the new
+   `newLoadTest.sh`:
+   ```sh
+   # renovate: version=camunda-platform-8.X
+   camunda_platform_helm_chart_version="X.Y.Z"
+   ```
+   This lets Renovate automatically track Helm chart patch updates on that stable branch.
+   See `load-tests/setup/README.md#helm-chart-version-management` for full details.
+
 ## What gets backported
 
 **Never backport** (update the versioned folder on `main` instead):

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -734,6 +734,20 @@
       ],
       "groupName": "form-js",
       "groupSlug": "form-js"
+    },
+    {
+      "description": "Simplify the commit message when updating the Camunda Platform Helm Chart for load tests",
+      "matchDepNames": ["camunda/camunda-platform-helm"],
+      "matchDatasources": ["github-tags"],
+      "matchFileNames": ["load-tests/**"],
+      "commitMessageTopic": "camunda-platform Helm Chart"
+    },
+    {
+      "description": "Authorize the 'main' load test to deploy alpha version of the Camunda Platform Helm Chart",
+      "matchDepNames": ["camunda/camunda-platform-helm"],
+      "matchDatasources": ["github-tags"],
+      "matchFileNames": ["load-tests/setup/main/**"],
+      "ignoreUnstable": false
     }
   ],
   "dockerfile": {
@@ -755,6 +769,18 @@
         "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.* '(?<currentValue>.*)'\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "description": "Track camunda-platform-helm chart tags pinned in load test scripts.",
+      "customType": "regex",
+      "managerFilePatterns": ["load-tests/setup/*/newLoadTest.sh"],
+      "matchStrings": [
+        "renovate: version=(?<parentVersion>.*?)\\s+camunda_platform_helm_chart_version=\"(?<currentValue>[^\"]+)\""
+      ],
+      "extractVersionTemplate": "^{{{parentVersion}}}-(?<version>\\S+)$",
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "camunda/camunda-platform-helm",
+      "versioningTemplate": "regex:(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))(-alpha(?<prerelease>.*))?$"
     },
     {
       "customType": "regex",

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -407,6 +407,49 @@ out by GCP every ~24h.
 
 The `clean` job works regardless and cleans up both the platform and load-test deployments.
 
+## Helm Chart Version Management
+
+The Camunda Platform Helm Chart version pinned in each versioned setup folder is tracked and
+automatically updated by [Renovate](https://docs.renovatebot.com/). A custom regex manager in
+`.github/renovate.json` reads a structured annotation comment immediately before the
+`camunda_platform_helm_chart_version` assignment in each `newLoadTest.sh`.
+
+### Annotation format
+
+```sh
+# renovate: version=<tag-prefix>
+camunda_platform_helm_chart_version="<chart-version>"
+```
+
+The `version=` value must match the GitHub tag prefix used in the
+[`camunda/camunda-platform-helm`](https://github.com/camunda/camunda-platform-helm) repository.
+Tags follow the pattern `<tag-prefix>-<chart-version>`, for example
+`camunda-platform-8.9-14.4.1`.
+
+### Update rules
+
+- **`main`**: Renovate opens PRs for all version types (including pre-releases such as `-alpha`).
+- **`stable/*` branches**: Renovate opens PRs for patch updates only.
+
+In any case, Renovate will try to keep the Camunda Platform Helm Chart to the
+latest available version for the related Camunda version.
+
+### Adding a new versioned folder
+
+When adding a versioned setup folder for a new stable branch (e.g. `stable-8X/`):
+
+1. Add the annotation comment immediately above the `camunda_platform_helm_chart_version`
+   assignment in the new `newLoadTest.sh`:
+
+   ```sh
+   # renovate: version=camunda-platform-8.X
+   camunda_platform_helm_chart_version="a.b.c"
+   ```
+2. The `camunda_platform_helm_chart_version` value should match the actual Helm
+   Chart version for that specific Camunda version.
+
+There should not be any need to update `.github/renovate.json` when a new version is added.
+
 ## Load testing Camunda SaaS
 
 _You need a Kubernetes Cluster at your disposal to run the load test itself, which then connects to your Camunda SaaS Cluster._

--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -1,7 +1,6 @@
 namespace ?= __NAMESPACE__
 secondary_storage ?= __STORAGE_TYPE__
 template_output_dir ?= .
-helm_chart ?= camunda-platform-8.10
 enable_optimize ?= __ENABLE_OPTIMIZE__
 # Enable the chaos-killer CronJob (randomly deletes one matching pod per run).
 # Use named targets (make install-chaos) or pass directly: make install chaos=true
@@ -17,7 +16,7 @@ additional_platform_configuration ?=
 # See the load test README for example values and guidance.
 additional_load_test_configuration ?=
 
-helm_chart_platform := charts/camunda-platform-helm/charts/$(helm_chart)
+helm_chart_platform := charts/camunda-platform
 helm_chart_load_tests := camunda-load-tests/camunda-load-tests
 
 # Scenario: controls the workload profile for the load test.

--- a/load-tests/setup/main/newLoadTest.sh
+++ b/load-tests/setup/main/newLoadTest.sh
@@ -51,7 +51,8 @@ fi
 ### First parameter is used as namespace name
 ### For a new namespace a new folder will be created
 
-helm_chart="camunda-platform-8.10"
+# renovate: version=camunda-platform-8.10
+camunda_platform_helm_chart_version="15.0.0-alpha1"
 namespace="$1"
 
 # Add c8- prefix if not present
@@ -198,16 +199,10 @@ helm repo update
 # The directory where local Helm Charts will be stored in.
 CHARTS_DIR="charts"
 
-# Clone Platform Helm so we can run the latest chart
-# TODO: 347642d30179479f8ab8a2f00b2d979be05f5a8c is the latest commit before the removal of the
-# embedded Bitnami Helm Chart.
-# We should remove the checkout of this specific revision once we have a solution to replace these
-# removed dependencies.
-
-git clone --depth 1 --revision 347642d30179479f8ab8a2f00b2d979be05f5a8c --single-branch https://github.com/camunda/camunda-platform-helm.git "$CHARTS_DIR/camunda-platform-helm"
-
-# Make deps
-helm dependency build "$CHARTS_DIR/camunda-platform-helm/charts/$helm_chart"
+echo "Pulling Camunda Platform Helm Chart: $camunda_platform_helm_chart_version"
+helm pull camunda/camunda-platform \
+    --untar --untardir "$CHARTS_DIR" \
+    --version "$camunda_platform_helm_chart_version" \
 
 echo
 echo "Scaffolding complete. Next steps:"

--- a/load-tests/setup/stable-87/Makefile
+++ b/load-tests/setup/stable-87/Makefile
@@ -1,7 +1,6 @@
 namespace ?= __NAMESPACE__
 secondary_storage ?= __STORAGE_TYPE__
 template_output_dir ?= .
-helm_chart ?= camunda-platform-8.7
 enable_optimize ?= __ENABLE_OPTIMIZE__
 enable_webapps ?= __ENABLE_WEBAPPS__
 # Enable the chaos-killer CronJob (randomly deletes one matching pod per run).
@@ -18,7 +17,7 @@ additional_platform_configuration ?=
 # See the load test README for example values and guidance.
 additional_load_test_configuration ?=
 
-helm_chart_platform := charts/camunda-platform-helm/charts/$(helm_chart)
+helm_chart_platform := charts/camunda-platform
 helm_chart_load_tests := camunda-load-tests/camunda-load-tests
 
 # Scenario: controls the workload profile for the load test.

--- a/load-tests/setup/stable-87/newLoadTest.sh
+++ b/load-tests/setup/stable-87/newLoadTest.sh
@@ -52,7 +52,8 @@ fi
 ### First parameter is used as namespace name
 ### For a new namespace a new folder will be created
 
-helm_chart="camunda-platform-8.7"
+# renovate: version=camunda-platform-8.7
+camunda_platform_helm_chart_version="12.10.0"
 namespace="$1"
 
 # Add c8- prefix if not present
@@ -214,16 +215,10 @@ helm repo update
 # The directory where local Helm Charts will be stored in.
 CHARTS_DIR="charts"
 
-# Clone Platform Helm so we can run the latest chart
-# TODO: 347642d30179479f8ab8a2f00b2d979be05f5a8c is the latest commit before the removal of the
-# embedded Bitnami Helm Chart.
-# We should remove the checkout of this specific revision once we have a solution to replace these
-# removed dependencies.
-
-git clone --depth 1 --revision 347642d30179479f8ab8a2f00b2d979be05f5a8c --single-branch https://github.com/camunda/camunda-platform-helm.git "$CHARTS_DIR/camunda-platform-helm"
-
-# Make deps
-helm dependency build "$CHARTS_DIR/camunda-platform-helm/charts/$helm_chart"
+echo "Pulling Camunda Platform Helm Chart: $camunda_platform_helm_chart_version"
+helm pull camunda/camunda-platform \
+    --untar --untardir "$CHARTS_DIR" \
+    --version "$camunda_platform_helm_chart_version" \
 
 echo
 echo "Scaffolding complete. Next steps:"

--- a/load-tests/setup/stable-88/Makefile
+++ b/load-tests/setup/stable-88/Makefile
@@ -1,7 +1,6 @@
 namespace ?= __NAMESPACE__
 secondary_storage ?= __STORAGE_TYPE__
 template_output_dir ?= .
-helm_chart ?= camunda-platform-8.8
 enable_optimize ?= __ENABLE_OPTIMIZE__
 # Enable the chaos-killer CronJob (randomly deletes one matching pod per run).
 # Use named targets (make install-chaos) or pass directly: make install chaos=true
@@ -17,7 +16,7 @@ additional_platform_configuration ?=
 # See the load test README for example values and guidance.
 additional_load_test_configuration ?=
 
-helm_chart_platform := charts/camunda-platform-helm/charts/$(helm_chart)
+helm_chart_platform := charts/camunda-platform
 helm_chart_load_tests := camunda-load-tests/camunda-load-tests
 
 # Scenario: controls the workload profile for the load test.

--- a/load-tests/setup/stable-88/newLoadTest.sh
+++ b/load-tests/setup/stable-88/newLoadTest.sh
@@ -51,7 +51,8 @@ fi
 ### First parameter is used as namespace name
 ### For a new namespace a new folder will be created
 
-helm_chart="camunda-platform-8.8"
+# renovate: version=camunda-platform-8.8
+camunda_platform_helm_chart_version="13.8.0"
 namespace="$1"
 
 # Add c8- prefix if not present
@@ -189,16 +190,10 @@ helm repo update
 # The directory where local Helm Charts will be stored in.
 CHARTS_DIR="charts"
 
-# Clone Platform Helm so we can run the latest chart
-# TODO: 347642d30179479f8ab8a2f00b2d979be05f5a8c is the latest commit before the removal of the
-# embedded Bitnami Helm Chart.
-# We should remove the checkout of this specific revision once we have a solution to replace these
-# removed dependencies.
-
-git clone --depth 1 --revision 347642d30179479f8ab8a2f00b2d979be05f5a8c --single-branch https://github.com/camunda/camunda-platform-helm.git "$CHARTS_DIR/camunda-platform-helm"
-
-# Make deps
-helm dependency build "$CHARTS_DIR/camunda-platform-helm/charts/$helm_chart"
+echo "Pulling Camunda Platform Helm Chart: $camunda_platform_helm_chart_version"
+helm pull camunda/camunda-platform \
+    --untar --untardir "$CHARTS_DIR" \
+    --version "$camunda_platform_helm_chart_version" \
 
 echo
 echo "Scaffolding complete. Next steps:"

--- a/load-tests/setup/stable-89/Makefile
+++ b/load-tests/setup/stable-89/Makefile
@@ -1,7 +1,6 @@
 namespace ?= __NAMESPACE__
 secondary_storage ?= __STORAGE_TYPE__
 template_output_dir ?= .
-helm_chart ?= camunda-platform-8.9
 enable_optimize ?= __ENABLE_OPTIMIZE__
 # Enable the chaos-killer CronJob (randomly deletes one matching pod per run).
 # Use named targets (make install-chaos) or pass directly: make install chaos=true
@@ -17,7 +16,7 @@ additional_platform_configuration ?=
 # See the load test README for example values and guidance.
 additional_load_test_configuration ?=
 
-helm_chart_platform := charts/camunda-platform-helm/charts/$(helm_chart)
+helm_chart_platform := charts/camunda-platform
 helm_chart_load_tests := camunda-load-tests/camunda-load-tests
 
 # Scenario: controls the workload profile for the load test.

--- a/load-tests/setup/stable-89/newLoadTest.sh
+++ b/load-tests/setup/stable-89/newLoadTest.sh
@@ -51,7 +51,8 @@ fi
 ### First parameter is used as namespace name
 ### For a new namespace a new folder will be created
 
-helm_chart="camunda-platform-8.9"
+# renovate: version=camunda-platform-8.9
+camunda_platform_helm_chart_version="14.6.0"
 namespace="$1"
 
 # Add c8- prefix if not present
@@ -198,11 +199,10 @@ helm repo update
 # The directory where local Helm Charts will be stored in.
 CHARTS_DIR="charts"
 
-# Clone Platform Helm so we can run the latest chart
-git clone --depth 1 --branch main --single-branch https://github.com/camunda/camunda-platform-helm.git "$CHARTS_DIR/camunda-platform-helm"
-
-# Make deps
-helm dependency build "$CHARTS_DIR/camunda-platform-helm/charts/$helm_chart"
+echo "Pulling Camunda Platform Helm Chart: $camunda_platform_helm_chart_version"
+helm pull camunda/camunda-platform \
+    --untar --untardir "$CHARTS_DIR" \
+    --version "$camunda_platform_helm_chart_version" \
 
 echo
 echo "Scaffolding complete. Next steps:"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-88-elasticsearch-stable
       namespace: c8-golden-stable-88-elasticsearch-stable
-      version: 13.9.1
+      version: 13.8.0
       tags:
       - dev
       custom-properties: []

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-88-elasticsearch
       namespace: c8-golden-stable-88-elasticsearch
-      version: 13.9.1
+      version: 13.8.0
       tags:
       - dev
       custom-properties: []

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-88-none
       namespace: c8-golden-stable-88-none
-      version: 13.9.1
+      version: 13.8.0
       tags:
       - dev
       custom-properties: []

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-88-opensearch-stable
       namespace: c8-golden-stable-88-opensearch-stable
-      version: 13.9.1
+      version: 13.8.0
       tags:
       - dev
       custom-properties: []

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/common/configmap-release.yaml
@@ -19,7 +19,7 @@ data:
   info: |-
     - name: c8-golden-stable-88-opensearch
       namespace: c8-golden-stable-88-opensearch
-      version: 13.9.1
+      version: 13.8.0
       tags:
       - dev
       custom-properties: []


### PR DESCRIPTION
## Description

Instead of pulling the content from git and not knowing exactly when breaking changes are being deployed:

* we pull the official Helm Chart that has been released on the Artifact Hub
* the Helm Chart is still inline locally, so we still have access to it
* Renovate is configured to keep the Helm Chart dependency automatically updated

All the versions are lower than the latest versions: once merged, Renovate should propose an update for each of the version.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
