### PR TITLE
fix: avoid NPE on null treePath in IncidentUpdateTask

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -293,7 +293,27 @@ public final class IncidentUpdateTask implements BackgroundTask {
     instances.forEach(
         instance -> {
           data.processInstanceIndices().put(instance.id(), instance.index());
-          data.processInstanceTreePaths().put(instance.key(), instance.treePath());
+          // An imported process instance may have a null/empty treePath (e.g. migrated 8.7 data, or
+          // a partial list-view document re-created via upsert after archival, where
+          // ListViewProcessInstanceFromProcessInstanceHandler only writes treePath when non-null).
+          // The treePath map is a ConcurrentHashMap, which rejects null values, so a raw put would
+          // throw an NPE. This is a permanent condition that would never resolve by retrying, so
+          // instead of skipping the entry (which would stall downstream as MISSING_DATA, or fail in
+          // processIncidentInBatch when the key is absent), we fall back to a sparse tree path so
+          // the incident update can still make progress. A genuinely not-yet-imported instance is
+          // absent from this result entirely, so it still has no entry here and is retried.
+          final var treePath = instance.treePath();
+          if (treePath == null || treePath.isEmpty()) {
+            final var sparseTreePath =
+                new TreePath().startTreePath(String.valueOf(instance.key())).toString();
+            logger.warn(
+                "Process instance {} has no treePath. Falling back to the sparse tree path {} so incident updates can make progress.",
+                instance.key(),
+                sparseTreePath);
+            data.processInstanceTreePaths().put(instance.key(), sparseTreePath);
+          } else {
+            data.processInstanceTreePaths().put(instance.key(), treePath);
+          }
         });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -418,6 +418,116 @@ final class IncidentUpdateTaskTest {
     }
 
     @Test
+    void shouldApplySparseTreePathWhenProcessInstanceImportedWithoutTreePath() {
+      // given - the child process instance document exists (is imported) but carries no treePath,
+      // e.g. migrated 8.7 data or a partial list-view document re-created via upsert. Putting a
+      // null treePath into the ConcurrentHashMap used to throw an NPE; and merely skipping the
+      // entry would stall the batch forever in a MISSING_DATA retry loop. Instead a sparse tree
+      // path is applied so the incident update makes progress.
+      final var task =
+          new IncidentUpdateTask(
+              metadata,
+              repository,
+              false,
+              10,
+              EXECUTOR,
+              incidentNotifier,
+              metrics,
+              LOGGER,
+              Duration.ZERO);
+      final var childWithoutTreePath = new ProcessInstanceDocument("3", "list-view", 3, null);
+      when(repository.getProcessInstances(any()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  List.of(parentProcessInstance, childWithoutTreePath)));
+
+      // when
+      final var result = task.execute();
+
+      // then - no NPE, no retry: the batch is processed with a sparse tree path rooted at the PI
+      assertThat(result).succeedsWithin(TIMEOUT);
+      verify(metrics, never()).recordIncidentUpdatesRetriesNeeded(anyInt());
+      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
+      final var update = bulkUpdateCaptor.getValue();
+      assertThat(update.incidentRequests())
+          .hasSize(1)
+          .containsEntry(
+              "5",
+              new DocumentUpdate(
+                  "5",
+                  "incidents",
+                  Map.of(
+                      IncidentTemplate.STATE,
+                      IncidentState.ACTIVE,
+                      IncidentTemplate.TREE_PATH,
+                      "PI_3/FNI_4"),
+                  null));
+      // only the PI and flow node referenced by the sparse path are touched (no parent ancestry)
+      assertThat(update.listViewRequests())
+          .hasSize(2)
+          .containsEntry(
+              "3",
+              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"))
+          .containsEntry(
+              "4",
+              new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"));
+      assertThat(update.flowNodeInstanceRequests())
+          .hasSize(1)
+          .containsEntry(
+              "4",
+              new DocumentUpdate(
+                  "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null));
+      assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(highestPosition);
+      verify(metrics).recordIncidentUpdatesProcessed(1);
+      verify(metrics).recordIncidentUpdatesDocumentsUpdated(4);
+    }
+
+    @Test
+    void shouldApplySparseTreePathWhenProcessInstanceImportedWithEmptyTreePath() {
+      // given - same as above but the treePath is an empty string rather than null; both are
+      // treated as "imported but without a usable tree path".
+      final var task =
+          new IncidentUpdateTask(
+              metadata,
+              repository,
+              false,
+              10,
+              EXECUTOR,
+              incidentNotifier,
+              metrics,
+              LOGGER,
+              Duration.ZERO);
+      final var childWithEmptyTreePath = new ProcessInstanceDocument("3", "list-view", 3, "");
+      when(repository.getProcessInstances(any()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  List.of(parentProcessInstance, childWithEmptyTreePath)));
+
+      // when
+      final var result = task.execute();
+
+      // then - processed with the sparse fallback, not retried
+      assertThat(result).succeedsWithin(TIMEOUT);
+      verify(metrics, never()).recordIncidentUpdatesRetriesNeeded(anyInt());
+      verify(repository).bulkUpdate(bulkUpdateCaptor.capture());
+      final var update = bulkUpdateCaptor.getValue();
+      assertThat(update.incidentRequests())
+          .hasSize(1)
+          .containsEntry(
+              "5",
+              new DocumentUpdate(
+                  "5",
+                  "incidents",
+                  Map.of(
+                      IncidentTemplate.STATE,
+                      IncidentState.ACTIVE,
+                      IncidentTemplate.TREE_PATH,
+                      "PI_3/FNI_4"),
+                  null));
+      assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(highestPosition);
+    }
+
+    @Test
     void shouldFailOnMissingFlowNodeInstance() {
       // given
       final var task =


### PR DESCRIPTION
## Description

`IncidentUpdateTask` throws a `NullPointerException` when a process instance's `treePath` is `null`, originating from `ConcurrentHashMap.put(key, null)` in `queryData`. The task is wrapped by `ReschedulingTask`, so it retries the failing batch forever and incident updates never make progress.

A `treePath` can be `null`/empty in edge cases:
- **8.7 → 8.8 migration** — older process-instance list-view documents may not carry a `treePath`.
- **Replay / upsert re-creation of a partial list-view document** — `ListViewProcessInstanceFromProcessInstanceHandler` only writes `TREE_PATH` when it is non-null, so an upsert-recreated doc (e.g. after archival) can exist without one.

### Why a null-guard alone isn't enough

Simply guarding the `put` converts the hard NPE into a **permanent stall**, because two downstream stages treat a missing entry as a *transient* not-yet-imported condition:
1. `checkDataAndCollectParentTreePaths` returns `MISSING_DATA` → batch skipped, position not advanced → silent retry loop that never converges.
2. `processIncidentInBatch` (`containsKey` check) → with the default `ignoreMissingData=false`, throws an `ExporterException` → retry loop at `ERROR`.

### Fix

Handle it once at the source — in `queryData`, when an imported instance has a null/empty `treePath`, store a **sparse** tree path (`new TreePath().startTreePath(key)`) instead. Both downstream consumers then see a usable value and the incident update makes progress, anchored at the instance's own process instance. A genuinely not-yet-imported instance is absent from `getProcessInstances` entirely, so it still has no entry and is correctly retried. A `WARN` is logged whenever the fallback is applied, so the (permanent) condition is visible in operations.

## Tests

Added to `IncidentUpdateTaskTest.IncidentTreePathTest`:
- `shouldApplySparseTreePathWhenProcessInstanceImportedWithoutTreePath` — imported PI with `null` treePath → no NPE, no retry, sparse `PI_3/FNI_4` applied, only the referenced PI/flow node updated, position advances.
- `shouldApplySparseTreePathWhenProcessInstanceImportedWithEmptyTreePath` — same for an empty-string treePath.

Existing `shouldRetryOnMissingProcessInstance` still guards the genuinely-absent (transient) path. Full suite green (24/24).

closes #56171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
