### PR TITLE
Add `businessId` attribute to `zeebe:calledElement` in the BPMN model

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCallActivityBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCallActivityBuilder.java
@@ -57,6 +57,13 @@ public class AbstractCallActivityBuilder<B extends AbstractCallActivityBuilder<B
     return myself;
   }
 
+  public B zeebeBusinessId(final String businessId) {
+    final ZeebeCalledElement calledElement =
+        getCreateSingleExtensionElement(ZeebeCalledElement.class);
+    calledElement.setBusinessId(businessId);
+    return myself;
+  }
+
   public B zeebePropagateAllChildVariables(final boolean propagateAllChildVariables) {
     final ZeebeCalledElement calledElement =
         getCreateSingleExtensionElement(ZeebeCalledElement.class);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -38,6 +38,7 @@ public class ZeebeConstants {
   public static final String ATTRIBUTE_OUTPUT_ELEMENT = "outputElement";
 
   public static final String ATTRIBUTE_PROCESS_ID = "processId";
+  public static final String ATTRIBUTE_BUSINESS_ID = "businessId";
   public static final String ATTRIBUTE_PROPAGATE_ALL_CHILD_VARIABLES = "propagateAllChildVariables";
   public static final String ATTRIBUTE_PROPAGATE_ALL_PARENT_VARIABLES =
       "propagateAllParentVariables";

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledElementImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledElementImpl.java
@@ -29,6 +29,7 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
     implements ZeebeCalledElement {
 
   private static Attribute<String> processIdAttribute;
+  private static Attribute<String> businessIdAttribute;
   private static Attribute<Boolean> propagateAllChildVariablesAttribute;
   private static Attribute<Boolean> propagateAllParentVariablesAttribute;
   private static Attribute<ZeebeBindingType> bindingTypeAttribute;
@@ -46,6 +47,27 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
   @Override
   public void setProcessId(final String processId) {
     processIdAttribute.setValue(this, processId);
+  }
+
+  @Override
+  public String getBusinessId() {
+    return businessIdAttribute.getValue(this);
+  }
+
+  @Override
+  public void setBusinessId(final String businessId) {
+    businessIdAttribute.setValue(this, businessId);
+  }
+
+  @Override
+  public boolean hasBusinessId() {
+    // The attribute is registered in the Zeebe namespace, but because the calledElement itself is
+    // in that namespace the attribute is serialized unprefixed (i.e. stored under the null/local
+    // namespace).
+    // Check both so presence detection is robust regardless of how it was written.
+    return getDomElement().hasAttribute(ZeebeConstants.ATTRIBUTE_BUSINESS_ID)
+        || getDomElement()
+            .hasAttribute(BpmnModelConstants.ZEEBE_NS, ZeebeConstants.ATTRIBUTE_BUSINESS_ID);
   }
 
   @Override
@@ -100,6 +122,12 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
     processIdAttribute =
         typeBuilder
             .stringAttribute(ZeebeConstants.ATTRIBUTE_PROCESS_ID)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    businessIdAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_BUSINESS_ID)
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .build();
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElement.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElement.java
@@ -23,6 +23,18 @@ public interface ZeebeCalledElement extends BpmnModelElementInstance {
 
   void setProcessId(String processId);
 
+  String getBusinessId();
+
+  void setBusinessId(String businessId);
+
+  /**
+   * Returns whether the {@code businessId} attribute is present on the element, independently of
+   * its value. A present-but-empty attribute ({@code businessId=""}) returns {@code true} here
+   * while {@link #getBusinessId()} returns {@code null}, which lets callers distinguish "override
+   * with no Business ID" (present) from "inherit the parent's Business ID" (absent).
+   */
+  boolean hasBusinessId();
+
   boolean isPropagateAllChildVariablesEnabled();
 
   void setPropagateAllChildVariablesEnabled(boolean propagateAllChildVariablesEnabled);

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/CallActivityBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/CallActivityBuilderTest.java
@@ -73,6 +73,25 @@ public class CallActivityBuilderTest {
         .containsExactly("=processIdExpr");
   }
 
+  @Test
+  void shouldSetBusinessId() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity("callActivity", c -> c.zeebeBusinessId("=orderId"))
+            .done();
+
+    // then
+    final ModelElementInstance callActivity = instance.getModelElementById("callActivity");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) callActivity.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledElement.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledElement::getBusinessId)
+        .containsExactly("=orderId");
+  }
+
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   void shouldSetPropagateAllChildVariables(final boolean propagateAllChildVariables) {

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElementTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElementTest.java
@@ -45,6 +45,7 @@ public class ZeebeCalledElementTest extends BpmnModelElementInstanceTest {
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "processId", false, false),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "businessId", false, false),
         new AttributeAssumption(
             BpmnModelConstants.ZEEBE_NS, "propagateAllChildVariables", false, false, true),
         new AttributeAssumption(
@@ -99,5 +100,72 @@ public class ZeebeCalledElementTest extends BpmnModelElementInstanceTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "No enum constant io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType.foo");
+  }
+
+  @Test
+  public void shouldHaveBusinessIdWhenValueIsSet() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .callActivity(
+                "callActivity", c -> c.zeebeProcessId("child").zeebeBusinessId("=orderId"))
+            .done();
+    final String modelXml = Bpmn.convertToString(modelInstance);
+
+    // when
+    final CallActivity callActivity =
+        Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+            .getModelElementById("callActivity");
+    final ZeebeCalledElement calledElement =
+        callActivity.getSingleExtensionElement(ZeebeCalledElement.class);
+
+    // then
+    assertThat(calledElement.hasBusinessId()).isTrue();
+    assertThat(calledElement.getBusinessId()).isEqualTo("=orderId");
+  }
+
+  @Test
+  public void shouldNotHaveBusinessIdWhenAbsent() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .callActivity("callActivity", c -> c.zeebeProcessId("child"))
+            .done();
+    final String modelXml = Bpmn.convertToString(modelInstance);
+
+    // when
+    final CallActivity callActivity =
+        Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+            .getModelElementById("callActivity");
+    final ZeebeCalledElement calledElement =
+        callActivity.getSingleExtensionElement(ZeebeCalledElement.class);
+
+    // then
+    assertThat(calledElement.hasBusinessId()).isFalse();
+    assertThat(calledElement.getBusinessId()).isNull();
+  }
+
+  @Test
+  public void shouldDistinguishEmptyBusinessIdFromAbsentAfterRoundTrip() {
+    // given - an explicitly empty businessId attribute
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .callActivity("callActivity", c -> c.zeebeProcessId("child").zeebeBusinessId(""))
+            .done();
+    final String modelXml = Bpmn.convertToString(modelInstance);
+
+    // when - the model is serialized and parsed again
+    final CallActivity callActivity =
+        Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+            .getModelElementById("callActivity");
+    final ZeebeCalledElement calledElement =
+        callActivity.getSingleExtensionElement(ZeebeCalledElement.class);
+
+    // then - presence survives serialization even though the value reads back as null
+    assertThat(calledElement.hasBusinessId()).isTrue();
+    assertThat(calledElement.getBusinessId()).isNull();
   }
 }


### PR DESCRIPTION
## Description

Adds the optional `businessId` attribute to `zeebe:calledElement` in the `zeebe-bpmn-model` module, per [ADR 0003-810](https://github.com/camunda/camunda/blob/main/zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md). This is the foundational model change that unblocks the deployment-transform, runtime, and incident propagation work.

### What changed

- **`ZeebeConstants`**: Added `ATTRIBUTE_BUSINESS_ID = "businessId"` constant.
- **`ZeebeCalledElement` (interface)**: Added `getBusinessId()`, `setBusinessId(String)`, and `hasBusinessId()`. The `hasBusinessId()` method allows callers to distinguish an *absent* attribute (inherit parent's Business ID) from a *present-but-empty* attribute (override with no Business ID).
- **`ZeebeCalledElementImpl`**: Registered `businessIdAttribute` as a string attribute in the Zeebe namespace with no default value, and implemented the getter/setter/presence-check — mirroring how `processIdAttribute` is handled.
- **`AbstractCallActivityBuilder`**: Added the `zeebeBusinessId(String)` builder helper for fluent process model construction.

### Tests

- Updated `ZeebeCalledElementTest#getAttributesAssumptions` to include the new `businessId` attribute (optional, no default).
- Added builder-level test (`CallActivityBuilderTest#shouldSetBusinessId`) verifying the attribute is set via the fluent API.
- Added three XML round-trip tests:
  - Attribute present with a value is correctly serialized and parsed back.
  - Absent attribute reads as `null` and `hasBusinessId()` returns `false`.
  - Explicitly empty attribute survives serialization — `hasBusinessId()` returns `true` even though `getBusinessId()` returns `null`.

### Design notes

The attribute is registered **without a default value** so the engine can distinguish:
- **Absent** `businessId` → inherit the parent process's Business ID.
- **Present (even if empty)** `businessId` → override with the specified value (or `null`).

`hasBusinessId()` checks both the null namespace and the Zeebe namespace to ensure robust presence detection regardless of how the XML was written.

## Related issues

Closes #56165