### PR TITLE
fix: refresh post-importer-queue write index before reading incident batch

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -167,6 +167,7 @@ public final class BackgroundTaskManagerFactory {
     return new OpenSearchIncidentUpdateRepository(
         partitionId,
         postImporterTemplate.getAlias(),
+        postImporterTemplate.getFullQualifiedName(),
         incidentTemplate.getAlias(),
         listViewTemplate.getAlias(),
         listViewTemplate.getFullQualifiedName(),
@@ -221,6 +222,7 @@ public final class BackgroundTaskManagerFactory {
     return new ElasticsearchIncidentUpdateRepository(
         partitionId,
         postImporterTemplate.getAlias(),
+        postImporterTemplate.getFullQualifiedName(),
         incidentTemplate.getAlias(),
         listViewTemplate.getAlias(),
         listViewTemplate.getFullQualifiedName(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -37,6 +37,7 @@ import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEnt
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.webapps.schema.entities.post.PostImporterActionType;
+import io.camunda.zeebe.exporter.api.ExporterException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -305,7 +306,22 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
             r ->
                 r.index(pendingUpdateFullQualifiedName)
                     .ignoreUnavailable(true)
-                    .allowNoIndices(true));
+                    .allowNoIndices(true))
+        .thenComposeAsync(this::failOnPartialRefresh, executor);
+  }
+
+  private CompletionStage<RefreshResponse> failOnPartialRefresh(final RefreshResponse response) {
+    final int failed =
+        response.shards() != null && response.shards().failed() != null
+            ? response.shards().failed().intValue()
+            : 0;
+    if (failed > 0) {
+      return CompletableFuture.failedFuture(
+          new ExporterException(
+              "Refresh of %s failed on %d shard(s); aborting batch to avoid skipping pending updates"
+                  .formatted(pendingUpdateFullQualifiedName, failed)));
+    }
+    return CompletableFuture.completedFuture(response);
   }
 
   private Query createProcessInstanceDeletedQuery(final Set<Long> processInstanceKeys) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -22,6 +22,7 @@ import co.elastic.clients.elasticsearch.core.bulk.UpdateOperation;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.SourceFilter;
 import co.elastic.clients.elasticsearch.indices.AnalyzeRequest;
+import co.elastic.clients.elasticsearch.indices.RefreshResponse;
 import co.elastic.clients.elasticsearch.indices.analyze.AnalyzeToken;
 import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.webapps.schema.descriptors.index.ImportPositionIndex;
@@ -60,6 +61,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
 
   private final int partitionId;
   private final String pendingUpdateAlias;
+  private final String pendingUpdateFullQualifiedName;
   private final String incidentAlias;
   private final String listViewAlias;
   private final String listViewFullQualifiedName;
@@ -70,6 +72,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
   public ElasticsearchIncidentUpdateRepository(
       final int partitionId,
       final String pendingUpdateAlias,
+      final String pendingUpdateFullQualifiedName,
       final String incidentAlias,
       final String listViewAlias,
       final String listViewFullQualifiedName,
@@ -82,6 +85,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
     super(client, executor, logger);
     this.partitionId = partitionId;
     this.pendingUpdateAlias = pendingUpdateAlias;
+    this.pendingUpdateFullQualifiedName = pendingUpdateFullQualifiedName;
     this.incidentAlias = incidentAlias;
     this.listViewAlias = listViewAlias;
     this.listViewFullQualifiedName = listViewFullQualifiedName;
@@ -96,8 +100,15 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
     final var query = createPendingIncidentsBatchQuery(fromPosition);
     final var request = createPendingIncidentsBatchRequest(size, query);
 
-    return client
-        .search(request, PendingIncidentUpdate.class)
+    // Force a refresh of the post-importer-queue write index before reading the batch so that all
+    // of its shards expose their acknowledged writes. The queue is written without routing, so a
+    // single partition's entries are scattered across all shards, which refresh on independent
+    // timers. Without this, a higher-position entry on an already-refreshed shard can be returned
+    // while a lower-position entry on a not-yet-refreshed shard is still invisible; the cursor
+    // would then advance past the lower entry and, because the lower bound is strict, never revisit
+    // it. See https://github.com/camunda/camunda/issues/56117.
+    return refreshPostImporterQueueIndex()
+        .thenComposeAsync(ignored -> client.search(request, PendingIncidentUpdate.class), executor)
         .thenApplyAsync(this::createPendingIncidentBatch, executor);
   }
 
@@ -287,6 +298,16 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
             executor);
   }
 
+  private CompletionStage<RefreshResponse> refreshPostImporterQueueIndex() {
+    return client
+        .indices()
+        .refresh(
+            r ->
+                r.index(pendingUpdateFullQualifiedName)
+                    .ignoreUnavailable(true)
+                    .allowNoIndices(true));
+  }
+
   private Query createProcessInstanceDeletedQuery(final Set<Long> processInstanceKeys) {
     final var piKeyQ =
         QueryBuilders.terms(
@@ -355,6 +376,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
         .query(query)
         .ignoreUnavailable(true)
         .allowNoIndices(true)
+        .allowPartialSearchResults(false)
         .source(s -> s.filter(sourceFilter))
         .sort(s -> s.field(f -> f.field(PostImporterQueueTemplate.POSITION).order(SortOrder.Asc)))
         .size(size)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -20,6 +20,7 @@ import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEnt
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.webapps.schema.entities.operation.OperationType;
 import io.camunda.webapps.schema.entities.post.PostImporterActionType;
+import io.camunda.zeebe.exporter.api.ExporterException;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
@@ -350,10 +351,25 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
               r ->
                   r.index(pendingUpdateFullQualifiedName)
                       .ignoreUnavailable(true)
-                      .allowNoIndices(true));
+                      .allowNoIndices(true))
+          .thenComposeAsync(this::failOnPartialRefresh, executor);
     } catch (final Exception e) {
       return CompletableFuture.failedFuture(e);
     }
+  }
+
+  private CompletionStage<RefreshResponse> failOnPartialRefresh(final RefreshResponse response) {
+    final int failed =
+        response.shards() != null && response.shards().failed() != null
+            ? response.shards().failed().intValue()
+            : 0;
+    if (failed > 0) {
+      return CompletableFuture.failedFuture(
+          new ExporterException(
+              "Refresh of %s failed on %d shard(s); aborting batch to avoid skipping pending updates"
+                  .formatted(pendingUpdateFullQualifiedName, failed)));
+    }
+    return CompletableFuture.completedFuture(response);
   }
 
   private Query createProcessInstanceDeletedQuery(final Set<Long> processInstanceKeys) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -47,6 +47,7 @@ import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.SourceFilter;
 import org.opensearch.client.opensearch.indices.AnalyzeRequest;
+import org.opensearch.client.opensearch.indices.RefreshResponse;
 import org.opensearch.client.opensearch.indices.analyze.AnalyzeToken;
 import org.slf4j.Logger;
 
@@ -62,6 +63,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
 
   private final int partitionId;
   private final String pendingUpdateAlias;
+  private final String pendingUpdateFullQualifiedName;
   private final String incidentAlias;
   private final String listViewAlias;
   private final String listViewFullQualifiedName;
@@ -72,6 +74,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   public OpenSearchIncidentUpdateRepository(
       final int partitionId,
       final String pendingUpdateAlias,
+      final String pendingUpdateFullQualifiedName,
       final String incidentAlias,
       final String listViewAlias,
       final String listViewFullQualifiedName,
@@ -84,6 +87,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
     super(client, executor, logger);
     this.partitionId = partitionId;
     this.pendingUpdateAlias = pendingUpdateAlias;
+    this.pendingUpdateFullQualifiedName = pendingUpdateFullQualifiedName;
     this.incidentAlias = incidentAlias;
     this.listViewAlias = listViewAlias;
     this.listViewFullQualifiedName = listViewFullQualifiedName;
@@ -95,23 +99,22 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   @Override
   public CompletionStage<PendingIncidentUpdateBatch> getPendingIncidentsBatch(
       final long fromPosition, final int size) {
-    final var query = createPendingIncidentsBatchQuery(fromPosition);
-    final var request = createPendingIncidentsBatchRequest(size, query);
-
-    try {
-      return client
-          .search(request, PendingIncidentUpdate.class)
-          .thenApplyAsync(this::createPendingIncidentBatch, executor);
-    } catch (final Exception e) {
-      return CompletableFuture.failedFuture(e);
-    }
+    // Force a refresh of the post-importer-queue write index before reading the batch so that all
+    // of its shards expose their acknowledged writes. The queue is written without routing, so a
+    // single partition's entries are scattered across all shards, which refresh on independent
+    // timers. Without this, a higher-position entry on an already-refreshed shard can be returned
+    // while a lower-position entry on a not-yet-refreshed shard is still invisible; the cursor
+    // would then advance past the lower entry and, because the lower bound is strict, never revisit
+    // it. See https://github.com/camunda/camunda/issues/56117.
+    return refreshPostImporterQueueIndex()
+        .thenComposeAsync(ignored -> searchPendingIncidents(fromPosition, size), executor)
+        .thenApplyAsync(this::createPendingIncidentBatch, executor);
   }
 
   @Override
   public CompletionStage<Map<String, IncidentDocument>> getIncidentDocuments(
       final List<String> incidentIds) {
     final var request = createIncidentDocumentsRequest(incidentIds);
-
     try {
       return client
           .search(request, IncidentEntity.class)
@@ -328,6 +331,31 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
     }
   }
 
+  private CompletableFuture<SearchResponse<PendingIncidentUpdate>> searchPendingIncidents(
+      final long fromPosition, final int size) {
+    final var query = createPendingIncidentsBatchQuery(fromPosition);
+    final var request = createPendingIncidentsBatchRequest(size, query);
+    try {
+      return client.search(request, PendingIncidentUpdate.class);
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  private CompletionStage<RefreshResponse> refreshPostImporterQueueIndex() {
+    try {
+      return client
+          .indices()
+          .refresh(
+              r ->
+                  r.index(pendingUpdateFullQualifiedName)
+                      .ignoreUnavailable(true)
+                      .allowNoIndices(true));
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
   private Query createProcessInstanceDeletedQuery(final Set<Long> processInstanceKeys) {
     final var piKeyQ =
         QueryBuilders.terms()
@@ -410,6 +438,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
         .query(query)
         .ignoreUnavailable(true)
         .allowNoIndices(true)
+        .allowPartialSearchResults(false)
         .source(s -> s.filter(sourceFilter))
         .sort(s -> s.field(f -> f.field(PostImporterQueueTemplate.POSITION).order(SortOrder.Asc)))
         .size(size)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
@@ -52,6 +52,7 @@ final class ElasticsearchIncidentUpdateRepositoryIT extends IncidentUpdateReposi
     return new ElasticsearchIncidentUpdateRepository(
         PARTITION_ID,
         postImporterQueueTemplate.getAlias(),
+        postImporterQueueTemplate.getFullQualifiedName(),
         incidentTemplate.getAlias(),
         listViewTemplate.getAlias(),
         listViewTemplate.getFullQualifiedName(),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
@@ -16,6 +16,8 @@ import co.elastic.clients.elasticsearch.core.ClearScrollResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesAsyncClient;
+import co.elastic.clients.elasticsearch.indices.RefreshResponse;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
 import io.camunda.webapps.schema.entities.incident.IncidentEntity;
 import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
@@ -32,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -148,6 +151,71 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
     inOrder.verifyNoMoreInteractions();
   }
 
+  @Test
+  void shouldRefreshPostImporterQueueIndexBeforeReadingBatch() {
+    // given
+    final var repository = createRepository();
+    final var indicesClient = Mockito.mock(ElasticsearchIndicesAsyncClient.class);
+    Mockito.when(client.indices()).thenReturn(indicesClient);
+    Mockito.when(indicesClient.refresh(Mockito.any(Function.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalRefreshResponse()));
+    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.any(Class.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalSearchResponse()));
+
+    // when
+    final var result = repository.getPendingIncidentsBatch(-1L, 100);
+
+    // then - the queue write index is refreshed before the batch search runs, so a lagging shard
+    // exposes its writes and no pending entry is skipped by the forward-only cursor
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    final var inOrder = Mockito.inOrder(client, indicesClient);
+    inOrder.verify(indicesClient).refresh(Mockito.any(Function.class));
+    inOrder.verify(client).search(Mockito.any(SearchRequest.class), Mockito.any(Class.class));
+  }
+
+  @Test
+  void shouldFailBatchWithoutSearchingWhenRefreshFails() {
+    // given
+    final var repository = createRepository();
+    final var indicesClient = Mockito.mock(ElasticsearchIndicesAsyncClient.class);
+    Mockito.when(client.indices()).thenReturn(indicesClient);
+    Mockito.when(indicesClient.refresh(Mockito.any(Function.class)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("refresh failed")));
+
+    // when
+    final var result = repository.getPendingIncidentsBatch(-1L, 100);
+
+    // then - a failed refresh must abort the batch (and let it retry) rather than search a
+    // potentially stale, partially-refreshed index and advance the cursor past unseen entries
+    assertThat(result).failsWithin(Duration.ofSeconds(5));
+    Mockito.verify(client, Mockito.never())
+        .search(Mockito.any(SearchRequest.class), Mockito.any(Class.class));
+  }
+
+  @Test
+  void shouldDisablePartialResultsOnPendingBatchSearch() {
+    // given
+    final var repository = createRepository();
+    final var indicesClient = Mockito.mock(ElasticsearchIndicesAsyncClient.class);
+    Mockito.when(client.indices()).thenReturn(indicesClient);
+    Mockito.when(indicesClient.refresh(Mockito.any(Function.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalRefreshResponse()));
+    final var searchCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.when(client.search(searchCaptor.capture(), Mockito.any(Class.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalSearchResponse()));
+
+    // when
+    repository.getPendingIncidentsBatch(-1L, 100).toCompletableFuture().join();
+
+    // then - an unavailable shard must fail the search (triggering a retry) instead of silently
+    // returning partial hits and letting the cursor skip the entries on the missing shard
+    assertThat(searchCaptor.getValue().allowPartialSearchResults()).isFalse();
+  }
+
+  private RefreshResponse buildMinimalRefreshResponse() {
+    return RefreshResponse.of(r -> r.shards(s -> s.total(1).successful(1).failed(0)));
+  }
+
   private ClearScrollResponse buildMinimalClearScrollResponse() {
     return new ClearScrollResponse.Builder().succeeded(true).numFreed(1).build();
   }
@@ -175,6 +243,7 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
     return new ElasticsearchIncidentUpdateRepository(
         1,
         "pendingUpdateAlias",
+        "pendingUpdateFullQualifiedName",
         "incidentAlias",
         "listViewAlias",
         "listViewFullQualifiedName",

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -475,13 +475,27 @@ abstract class IncidentUpdateRepositoryIT {
 
       // precondition - a plain search does not see the lagging lower entry; this is the per-shard
       // refresh skew that previously made the cursor advance past it and skip it forever
-      assertThat(
-              search(
-                  postImporterQueueTemplate.getFullQualifiedName(),
-                  PostImporterQueueTemplate.KEY,
-                  List.of(String.valueOf(LOWER_KEY)),
-                  PostImporterQueueEntity.class))
-          .isEmpty();
+      Awaitility.await()
+          .pollDelay(Duration.ofSeconds(2))
+          .atMost(Duration.ofSeconds(3))
+          .pollInterval(Duration.ofSeconds(1))
+          .untilAsserted(
+              () -> {
+                assertThat(
+                        search(
+                            postImporterQueueTemplate.getFullQualifiedName(),
+                            PostImporterQueueTemplate.KEY,
+                            List.of(String.valueOf(HIGHER_KEY)),
+                            PostImporterQueueEntity.class))
+                    .hasSize(1);
+                assertThat(
+                        search(
+                            postImporterQueueTemplate.getFullQualifiedName(),
+                            PostImporterQueueTemplate.KEY,
+                            List.of(String.valueOf(LOWER_KEY)),
+                            PostImporterQueueEntity.class))
+                    .isEmpty();
+              });
 
       try (final var executor = Executors.newSingleThreadScheduledExecutor()) {
         final var task =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -381,7 +381,6 @@ abstract class IncidentUpdateRepositoryIT {
       // given
       final var metadata = new ExporterMetadata(new ObjectMapper());
       final var repository = createRepository();
-      final var executor = Executors.newSingleThreadScheduledExecutor();
 
       final var incidentNotifier = mock(IncidentNotifier.class);
       when(incidentNotifier.notifyAsync(anyList()))
@@ -404,25 +403,149 @@ abstract class IncidentUpdateRepositoryIT {
                   engineClient.indexExists(listViewTemplate.getFullQualifiedName())
                       && engineClient.indexExists(flowNodeInstanceTemplate.getFullQualifiedName()));
 
-      // when
-      final var incidentUpdateTask =
-          new IncidentUpdateTask(
-              metadata,
-              repository,
-              true,
-              100,
-              executor,
-              incidentNotifier,
-              mock(CamundaExporterMetrics.class),
-              LOGGER);
+      try (final var executor = Executors.newSingleThreadScheduledExecutor()) {
+        // when
+        final var incidentUpdateTask =
+            new IncidentUpdateTask(
+                metadata,
+                repository,
+                true,
+                100,
+                executor,
+                incidentNotifier,
+                mock(CamundaExporterMetrics.class),
+                LOGGER);
 
-      incidentUpdateTask.execute().toCompletableFuture().join();
+        incidentUpdateTask.execute().toCompletableFuture().join();
 
-      // then
+        // then
+        Awaitility.await()
+            .until(() -> metadata.getLastIncidentUpdatePosition() == incidentUpdatePosition);
+      }
+    }
+  }
+
+  @DisabledIfSystemProperty(
+      named = SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL,
+      matches = "^(?=\\s*\\S).*$",
+      disabledReason = "Excluding from AWS OS IT CI")
+  @Nested
+  final class PendingIncidentWatermarkSkipRegressionIT {
+    // The queue index is created with multiple shards (as in production) and with auto-refresh
+    // disabled so the tests, rather than the search engine, decide exactly when a written entry
+    // becomes searchable. This lets us deterministically reproduce a refresh-skew: at search time a
+    // lower-position entry is not yet visible while a higher-position entry is, which is what a
+    // lagging shard produces for the consumer. This test verifies the fix for
+    // https://github.com/camunda/camunda/issues/56117 end to end: the repository force-refreshes
+    // the queue write index before each batch read, so the lagging lower entry becomes visible and
+    // is no longer skipped by the forward-only cursor, and its incident is not left stuck PENDING.
+    private static final int QUEUE_SHARDS = 3;
+    private static final long LOWER_POSITION = 1L;
+    private static final long HIGHER_POSITION = 2L;
+    private static final long LOWER_KEY = 1L;
+    private static final long HIGHER_KEY = 2L;
+
+    @RegressionTest("https://github.com/camunda/camunda/issues/56117")
+    void shouldNotLeaveIncidentPendingWhenLowerPositionEntryLags() throws Exception {
+      // given - two pending incidents, one per queue entry
+      final var metadata = new ExporterMetadata(new ObjectMapper());
+      final var repository = createRepository();
+      final var incidentNotifier = mock(IncidentNotifier.class);
+      when(incidentNotifier.notifyAsync(anyList()))
+          .thenReturn(CompletableFuture.completedFuture(null));
+
+      indexIncident(newIncident(LOWER_KEY));
+      indexIncident(newIncident(HIGHER_KEY));
+
+      // the task queries the list-view and flow-node indices, so they must exist
+      engineClient.createIndex(listViewTemplate, new IndexConfiguration());
+      engineClient.createIndex(flowNodeInstanceTemplate, new IndexConfiguration());
       Awaitility.await()
-          .until(() -> metadata.getLastIncidentUpdatePosition() == incidentUpdatePosition);
+          .until(
+              () ->
+                  engineClient.indexExists(listViewTemplate.getFullQualifiedName())
+                      && engineClient.indexExists(flowNodeInstanceTemplate.getFullQualifiedName()));
 
-      executor.close();
+      // the higher-position entry is written and refreshed first, so it is searchable...
+      createQueueIndexWithManualRefreshOnly();
+      indexPendingUpdate(HIGHER_KEY, HIGHER_POSITION, true);
+      // ...while the lower-position entry is written without a refresh, so it stays invisible,
+      // exactly as a lagging shard would present it to the consumer at search time
+      indexPendingUpdate(LOWER_KEY, LOWER_POSITION, false);
+
+      // precondition - a plain search does not see the lagging lower entry; this is the per-shard
+      // refresh skew that previously made the cursor advance past it and skip it forever
+      assertThat(
+              search(
+                  postImporterQueueTemplate.getFullQualifiedName(),
+                  PostImporterQueueTemplate.KEY,
+                  List.of(String.valueOf(LOWER_KEY)),
+                  PostImporterQueueEntity.class))
+          .isEmpty();
+
+      try (final var executor = Executors.newSingleThreadScheduledExecutor()) {
+        final var task =
+            new IncidentUpdateTask(
+                metadata,
+                repository,
+                // apply with a sparse tree path so the batch processes without the process
+                // instances being present in the list view
+                true,
+                100,
+                executor,
+                incidentNotifier,
+                mock(CamundaExporterMetrics.class),
+                LOGGER,
+                // shorten the missing-data backoff vs. the default 5s; must be a whole second since
+                // uncheckedThreadSleep passes the sub-second remainder to Thread.sleep's nanos arg
+                Duration.ofSeconds(1));
+
+        // when - a single run reads the batch; the repository force-refreshes the queue write index
+        // first, so the lagging lower entry is visible and processed alongside the higher one
+        task.execute().toCompletableFuture().join();
+        Awaitility.await().until(() -> metadata.getLastIncidentUpdatePosition() == HIGHER_POSITION);
+
+        // then - both incidents transition out of PENDING; the lower one is not skipped
+        final var incidents =
+            search(
+                incidentTemplate.getFullQualifiedName(),
+                IncidentTemplate.KEY,
+                List.of(String.valueOf(LOWER_KEY), String.valueOf(HIGHER_KEY)),
+                IncidentEntity.class);
+        assertThat(incidents)
+            .hasSize(2)
+            .allSatisfy(
+                incident -> assertThat(incident.getState()).isEqualTo(IncidentState.ACTIVE));
+        assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(HIGHER_POSITION);
+      }
+    }
+
+    private void createQueueIndexWithManualRefreshOnly() {
+      final var config = new IndexConfiguration();
+      config.setNumberOfShards(QUEUE_SHARDS);
+      config.setNumberOfReplicas(0);
+      // -1 disables periodic refresh: documents only become searchable on an explicit refresh
+      config.setRefreshInterval("-1");
+      engineClient.createIndex(postImporterQueueTemplate, config);
+    }
+
+    private void indexPendingUpdate(final long key, final long position, final boolean refresh)
+        throws PersistenceException {
+      final var entry =
+          new PostImporterQueueEntity()
+              .setActionType(PostImporterActionType.INCIDENT)
+              .setIntent(IncidentIntent.CREATED.name())
+              .setKey(key)
+              .setPartitionId(PARTITION_ID)
+              .setProcessInstanceKey(key)
+              .setPosition(position);
+      final var batchRequest = clientAdapter.createBatchRequest();
+      batchRequest.add(postImporterQueueTemplate.getFullQualifiedName(), entry);
+      if (refresh) {
+        batchRequest.executeWithRefresh();
+      } else {
+        batchRequest.execute();
+      }
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepositoryTest.java
@@ -13,12 +13,21 @@ import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkU
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesAsyncClient;
+import org.opensearch.client.opensearch.indices.RefreshResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,10 +52,85 @@ public final class OpenSearchIncidentUpdateRepositoryTest {
     Mockito.verify(client, Mockito.never()).bulk(Mockito.any(BulkRequest.class));
   }
 
+  @Test
+  void shouldRefreshPostImporterQueueIndexBeforeReadingBatch() throws Exception {
+    // given
+    final var repository = createRepository();
+    final var indicesClient = Mockito.mock(OpenSearchIndicesAsyncClient.class);
+    Mockito.when(client.indices()).thenReturn(indicesClient);
+    Mockito.when(indicesClient.refresh(Mockito.any(Function.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalRefreshResponse()));
+    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.any(Class.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalSearchResponse()));
+
+    // when
+    final var result = repository.getPendingIncidentsBatch(-1L, 100);
+
+    // then - the queue write index is refreshed before the batch search runs, so a lagging shard
+    // exposes its writes and no pending entry is skipped by the forward-only cursor
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    final var inOrder = Mockito.inOrder(client, indicesClient);
+    inOrder.verify(indicesClient).refresh(Mockito.any(Function.class));
+    inOrder.verify(client).search(Mockito.any(SearchRequest.class), Mockito.any(Class.class));
+  }
+
+  @Test
+  void shouldFailBatchWithoutSearchingWhenRefreshFails() throws Exception {
+    // given
+    final var repository = createRepository();
+    final var indicesClient = Mockito.mock(OpenSearchIndicesAsyncClient.class);
+    Mockito.when(client.indices()).thenReturn(indicesClient);
+    Mockito.when(indicesClient.refresh(Mockito.any(Function.class)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("refresh failed")));
+
+    // when
+    final var result = repository.getPendingIncidentsBatch(-1L, 100);
+
+    // then - a failed refresh must abort the batch (and let it retry) rather than search a
+    // potentially stale, partially-refreshed index and advance the cursor past unseen entries
+    assertThat(result).failsWithin(Duration.ofSeconds(5));
+    Mockito.verify(client, Mockito.never())
+        .search(Mockito.any(SearchRequest.class), Mockito.any(Class.class));
+  }
+
+  @Test
+  void shouldDisablePartialResultsOnPendingBatchSearch() throws Exception {
+    // given
+    final var repository = createRepository();
+    final var indicesClient = Mockito.mock(OpenSearchIndicesAsyncClient.class);
+    Mockito.when(client.indices()).thenReturn(indicesClient);
+    Mockito.when(indicesClient.refresh(Mockito.any(Function.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalRefreshResponse()));
+    final var searchCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+    Mockito.when(client.search(searchCaptor.capture(), Mockito.any(Class.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalSearchResponse()));
+
+    // when
+    repository.getPendingIncidentsBatch(-1L, 100).toCompletableFuture().join();
+
+    // then - an unavailable shard must fail the search (triggering a retry) instead of silently
+    // returning partial hits and letting the cursor skip the entries on the missing shard
+    assertThat(searchCaptor.getValue().allowPartialSearchResults()).isFalse();
+  }
+
+  private RefreshResponse buildMinimalRefreshResponse() {
+    return RefreshResponse.of(r -> r.shards(s -> s.total(1).successful(1).failed(0)));
+  }
+
+  private SearchResponse<Object> buildMinimalSearchResponse() {
+    return new SearchResponse.Builder<Object>()
+        .took(1)
+        .timedOut(false)
+        .shards(s -> s.total(1).successful(1).failed(0))
+        .hits(h -> h.total(t -> t.value(0).relation(TotalHitsRelation.Eq)).hits(List.of()))
+        .build();
+  }
+
   private OpenSearchIncidentUpdateRepository createRepository() {
     return new OpenSearchIncidentUpdateRepository(
         1,
         "pendingUpdateAlias",
+        "pendingUpdateFullQualifiedName",
         "incidentAlias",
         "listViewAlias",
         "listViewFullQualifiedName",

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
@@ -43,6 +43,7 @@ final class OpensearchIncidentUpdateRepositoryIT extends IncidentUpdateRepositor
     return new OpenSearchIncidentUpdateRepository(
         PARTITION_ID,
         postImporterQueueTemplate.getAlias(),
+        postImporterQueueTemplate.getFullQualifiedName(),
         incidentTemplate.getAlias(),
         listViewTemplate.getAlias(),
         listViewTemplate.getFullQualifiedName(),


### PR DESCRIPTION
## Description

`IncidentUpdateTask` (camunda-exporter) consumes the `operate-post-importer-queue` index with a strict, forward-only position watermark. On a **multi-shard** queue index, the entries for a single partition are scattered across all primary shards (the queue is written without routing), and shards refresh on independent timers.

A higher-position entry on an already-refreshed shard can therefore be returned while a lower-position entry on a not-yet-refreshed shard is still invisible. The cursor then advances past the lower entry and, because the lower bound is strict (`position > cursor`), **never revisits it** — the corresponding incident stays `PENDING` forever.

This hardens the read path (brownfield, code-only, no migration), mirrored across the Elasticsearch and OpenSearch repositories:

1. **Force-refresh the queue write index before each batch read** so all shards expose their acknowledged writes, eliminating the per-shard refresh skew. The repositories now receive `PostImporterQueueTemplate.getFullQualifiedName()` (the **write** index, not the read alias — the alias would fan out across all archived dated indices), wired through `BackgroundTaskManagerFactory`. The refresh tolerates a missing index (`ignoreUnavailable`/`allowNoIndices`), consistent with the batch search.
2. **`allowPartialSearchResults(false)`** on the batch search so an unavailable/recovering shard makes the search **fail** (and retry) instead of silently returning a partial HTTP 200 and advancing the cursor past the missing shard's entries.

> Note: the greenfield single-shard option from the issue is intentionally **not** included here — this PR is the brownfield read-path fix only.

## Related issues

closes #56117

## Tests

- **Unit** (ES + OS repositories): refresh runs *before* the search; a failed refresh aborts the batch without searching (no cursor advance); the batch search sets `allowPartialSearchResults = false`.
- **Integration** (ES + OS, `PendingIncidentWatermarkSkipRegressionIT`): an end-to-end test that reproduces a lagging-shard refresh skew (multi-shard index, `refresh_interval = -1`, higher entry visible / lower entry buffered), asserts as a precondition that a plain search cannot see the lagging entry, then runs the full task once and verifies **both** incidents transition out of `PENDING` and the watermark advances correctly. This also implicitly guards that the *correct* (write) index is refreshed.

All `camunda-exporter` incident unit + integration tests pass on Elasticsearch and OpenSearch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)