### PR TITLE
fix: guard against null treePath in IncidentUpdateTask.queryData

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -291,7 +291,12 @@ public final class IncidentUpdateTask implements BackgroundTask {
     instances.forEach(
         instance -> {
           data.processInstanceIndices().put(instance.id(), instance.index());
-          data.processInstanceTreePaths().put(instance.key(), instance.treePath());
+          // treePath may be null for documents written before the field existed (e.g. after
+          // replay/upsert/archival). ConcurrentHashMap rejects null values, so we skip the entry
+          // here and let checkDataAndCollectParentTreePaths treat it as missing data.
+          if (instance.treePath() != null) {
+            data.processInstanceTreePaths().put(instance.key(), instance.treePath());
+          }
         });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -314,6 +314,43 @@ final class IncidentUpdateTaskTest {
     }
 
     @Test
+    void shouldRetryWhenProcessInstanceHasNullTreePath() {
+      // given - process instance document exists but treePath is null (e.g. after replay/archival);
+      // ConcurrentHashMap.put would throw NPE without the guard in queryData
+      final var task =
+          new IncidentUpdateTask(
+              metadata,
+              repository,
+              false,
+              10,
+              EXECUTOR,
+              incidentNotifier,
+              metrics,
+              LOGGER,
+              Duration.ZERO);
+      final var instanceWithNullTreePath =
+          new ProcessInstanceDocument(
+              childProcessInstance.id(),
+              childProcessInstance.index(),
+              childProcessInstance.key(),
+              null);
+      when(repository.getProcessInstances(any()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  List.of(parentProcessInstance, instanceWithNullTreePath)));
+
+      // when
+      final var result = task.execute();
+
+      // then - treated as missing data and retried, not thrown as NPE
+      assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(1);
+      verify(metrics).recordIncidentUpdatesRetriesNeeded(1);
+      verify(repository, never()).bulkUpdate(any());
+      verify(incidentNotifier, never()).notifyAsync(any());
+      assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(-1L);
+    }
+
+    @Test
     void shouldFailOnMissingFlowNodeInstance() {
       // given
       final var task =


### PR DESCRIPTION
## Description

`IncidentUpdateTask.queryData` calls `ConcurrentHashMap.put(instance.key(), instance.treePath())` for every process instance returned by the repository. A process instance document can have a `null` `treePath` — for example after replay, upsert, or archival scenarios. `ConcurrentHashMap` rejects null values, so this call throws a `NullPointerException`, which stalls the entire incident update batch silently and prevents incidents from appearing in the Operate UI.

The fix skips inserting entries whose `treePath` is null. The downstream `checkDataAndCollectParentTreePaths` already handles the absence of a tree path for a given process instance key (treats it as missing data and triggers the existing retry / sparse-tree-path fallback), so no further changes are needed.

A regression test `shouldRetryWhenProcessInstanceHasNullTreePath` verifies that a null `treePath` on a process instance document causes the task to retry (returning `incidentCount`) instead of throwing an NPE.

## Checklist

- [ ] Enable backports when necessary — this fix should be evaluated for backport to `stable/8.8` and other affected `8.8.x` branches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLjgECSzvhQ7mLvPb4kUMz)_