### PR TITLE
fix: update LazyTokenClaimsConverter for CSL alpha36

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -14,11 +14,11 @@ import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.core.port.in.OidcProviderConfigurationPort;
 import io.camunda.security.core.port.out.MembershipPort;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
-import io.camunda.security.spring.converter.LazyTokenClaimsConverter;
 import io.camunda.security.spring.converter.OidcTokenAuthenticationConverter;
 import io.camunda.security.spring.converter.OidcUserAuthenticationConverter;
 import io.camunda.security.spring.handler.OAuth2AuthenticationExceptionHandler;
@@ -108,8 +108,12 @@ public class OidcOverrideBeansConfiguration {
   @Bean
   public LazyTokenClaimsConverter tokenClaimsConverter(
       final CamundaSecurityLibraryProperties cslProperties, final MembershipPort membershipPort) {
+    final var oidcConfig = cslProperties.getAuthentication().getOidc();
     return new LazyTokenClaimsConverter(
-        cslProperties.getAuthentication().getOidc(), membershipPort);
+        oidcConfig.getUsernameClaim(),
+        oidcConfig.getClientIdClaim(),
+        oidcConfig.isPreferUsernameClaim(),
+        membershipPort);
   }
 
   @Bean

--- a/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterIntegrationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/converter/OidcUserAuthenticationConverterIntegrationTest.java
@@ -16,7 +16,7 @@ import io.camunda.authentication.config.WebSecurityConfig;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import io.camunda.security.api.model.CamundaAuthentication;
-import io.camunda.security.spring.converter.LazyTokenClaimsConverter;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.spring.converter.OidcUserAuthenticationConverter;
 import java.util.List;
 import java.util.Map;

--- a/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/oidc/OidcBearerUserInfoClaimGapIT.java
@@ -22,7 +22,7 @@ import io.camunda.authentication.config.WebSecurityConfig;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import io.camunda.security.api.model.CamundaAuthentication;
-import io.camunda.security.spring.converter.LazyTokenClaimsConverter;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.spring.converter.OidcTokenAuthenticationConverter;
 import java.time.Instant;
 import java.util.List;

--- a/dist/src/test/java/io/camunda/application/commons/security/NoSecondaryStorageAuthenticationIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/NoSecondaryStorageAuthenticationIT.java
@@ -8,7 +8,7 @@
 package io.camunda.application.commons.security;
 
 import static io.camunda.spring.utils.DatabaseTypeUtils.CAMUNDA_DATABASE_TYPE_NONE;
-import static io.camunda.spring.utils.DatabaseTypeUtils.PROPERTY_CAMUNDA_DATABASE_TYPE;
+import static io.camunda.spring.utils.DatabaseTypeUtils.UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -18,8 +18,8 @@ import io.camunda.authentication.service.NoDBMembershipService;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
-import io.camunda.security.spring.converter.LazyTokenClaimsConverter;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -43,7 +43,7 @@ public class NoSecondaryStorageAuthenticationIT {
     context
         .getEnvironment()
         .getSystemProperties()
-        .put(PROPERTY_CAMUNDA_DATABASE_TYPE, CAMUNDA_DATABASE_TYPE_NONE);
+        .put(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, CAMUNDA_DATABASE_TYPE_NONE);
     context
         .getEnvironment()
         .getSystemProperties()
@@ -63,7 +63,10 @@ public class NoSecondaryStorageAuthenticationIT {
   void shouldAllowOidcAuthenticationInNoDbModeWithLimitedFunctionality() {
     // given - application context with no secondary storage and OIDC auth
     final var context = new AnnotationConfigApplicationContext();
-    context.getEnvironment().getSystemProperties().put(PROPERTY_CAMUNDA_DATABASE_TYPE, "none");
+    context
+        .getEnvironment()
+        .getSystemProperties()
+        .put(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, "none");
     context
         .getEnvironment()
         .getSystemProperties()
@@ -119,8 +122,12 @@ public class NoSecondaryStorageAuthenticationIT {
     public LazyTokenClaimsConverter camundaOAuthPrincipalServiceNoDb(
         final CamundaSecurityLibraryProperties cslProperties,
         final NoDBMembershipService noDBMembershipService) {
+      final var oidcConfig = cslProperties.getAuthentication().getOidc();
       return new LazyTokenClaimsConverter(
-          cslProperties.getAuthentication().getOidc(), noDBMembershipService);
+          oidcConfig.getUsernameClaim(),
+          oidcConfig.getClientIdClaim(),
+          oidcConfig.isPreferUsernameClaim(),
+          noDBMembershipService);
     }
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha35</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha36</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Summary

- Moves `LazyTokenClaimsConverter` import from `io.camunda.security.spring.converter` to `io.camunda.security.core.authz` (class relocated in CSL alpha36)
- Expands the 2-arg constructor call to the new 4-arg form using `OidcConfiguration` getter methods
- Applies the same fix in the `dist` integration test (`NoSecondaryStorageAuthenticationIT`); also corrects the condition property key from the legacy `camunda.database.type` to `camunda.data.secondary-storage.type`

These are purely adapter changes driven by the CSL alpha36 API update — no behavioral changes.

## Test plan

- [ ] `./mvnw verify -pl authentication -DskipTests=false -Dquickly`
- [ ] `./mvnw verify -pl dist -Dit.test=NoSecondaryStorageAuthenticationIT -DskipTests=false -DskipUTs -Dquickly`

🤖 Generated with [Claude Code](https://claude.com/claude-code)