### PR TITLE
fix: load test's "OutOfcpu" detection logic

### DIFF
--- a/load-tests/docs/scripts/verify-test.sh
+++ b/load-tests/docs/scripts/verify-test.sh
@@ -78,9 +78,9 @@ wait_for_pods() {
     echo "$pods"
     echo "::endgroup::"
 
-    out_of_cpu_pods="$(echo "$pods" | grep OutOfCpu | awk '{print $1}')"
+    out_of_cpu_pods="$(echo "$pods" | grep -iw outofcpu | awk '{print $1}')"
     if [[ -n "$out_of_cpu_pods" ]]; then
-        echo "Detected pods with OutOfCpu status, will delete them..."
+        echo "Detected pods with 'out of CPU' status, will delete them..."
         # Mitigation: sometimes, many pods are scheduled on the same node and the
         # kubelet fails to start them with a "OutOfCpu" error.
         # Although it looks like a Kubernetes bug, these pods stay and are being


### PR DESCRIPTION
[This run](https://github.com/camunda/camunda/actions/runs/28390325974/job/84116605792?pr=56172) was failing due to [the "out of CPU" issue](https://github.com/camunda/camunda/issues/55384) we are facing sometimes, although I implemented a workaround in https://github.com/camunda/camunda/pull/55385.

However, the script was looking for pods reporting `OutOfCpu` although Kubernetes actually reports `OutOfcpu` so the lookup never matched.

You have to squint to spot the issue :eyeglasses::

|           | Value      |
|-----------|------------|
| Looked up | `OutOfCpu` |
| Actual    | `OutOfcpu` |

This is fixed by ignoring the case and looking up for the specific word only.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/55384
