### PR TITLE
fix: fix public variable labels API and add request mapping exception handler

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/variable/PublicApiVariableLabelsIT.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.variable;
+
+import static io.camunda.optimize.rest.providers.GenericExceptionMapper.BAD_REQUEST_ERROR_CODE;
+import static io.camunda.optimize.rest.providers.GenericExceptionMapper.NOT_FOUND_ERROR_CODE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.optimize.AbstractCCSMIT;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.query.variable.DefinitionVariableLabelsDto;
+import io.camunda.optimize.dto.optimize.query.variable.LabelDto;
+import io.camunda.optimize.dto.optimize.query.variable.VariableType;
+import io.camunda.optimize.dto.optimize.rest.ErrorResponseDto;
+import io.camunda.optimize.service.db.writer.ProcessDefinitionWriter;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+public class PublicApiVariableLabelsIT extends AbstractCCSMIT {
+
+  private static final String TEST_ACCESS_TOKEN = "test-access-token";
+
+  @BeforeEach
+  public void configurePublicApiToken() {
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getOptimizeApiConfiguration()
+        .setAccessToken(TEST_ACCESS_TOKEN);
+  }
+
+  @Test
+  public void shouldReturn400WithFieldNameWhenDefinitionKeyIsNull() {
+    // given
+    final DefinitionVariableLabelsDto request = new DefinitionVariableLabelsDto(null, List.of());
+
+    // when
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildModifyVariableLabelsRequest(request)
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
+    assertThat(errorResponse.getErrorCode()).isEqualTo(BAD_REQUEST_ERROR_CODE);
+    assertThat(errorResponse.getDetailedMessage()).contains("definitionKey");
+  }
+
+  @Test
+  public void shouldReturn400WithFieldNameWhenDefinitionKeyIsBlank() {
+    // given
+    final DefinitionVariableLabelsDto request = new DefinitionVariableLabelsDto("  ", List.of());
+
+    // when
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildModifyVariableLabelsRequest(request)
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
+    assertThat(errorResponse.getErrorCode()).isEqualTo(BAD_REQUEST_ERROR_CODE);
+    assertThat(errorResponse.getDetailedMessage()).contains("definitionKey");
+  }
+
+  @Test
+  public void shouldReturn200WhenRequestIsValid() {
+    // given
+    final String definitionKey = "my-process";
+    embeddedOptimizeExtension
+        .getBean(ProcessDefinitionWriter.class)
+        .importProcessDefinitions(
+            List.of(
+                ProcessDefinitionOptimizeDto.builder()
+                    .id("my-process:1")
+                    .key(definitionKey)
+                    .version("1")
+                    .name(definitionKey)
+                    .bpmn20Xml("<definitions/>")
+                    .build()));
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    final LabelDto label = new LabelDto("book availability", "bookAvailable", VariableType.BOOLEAN);
+    final DefinitionVariableLabelsDto request =
+        new DefinitionVariableLabelsDto(definitionKey, List.of(label));
+
+    // when
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildModifyVariableLabelsRequest(request)
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+  }
+
+  @Test
+  public void shouldReturn404WhenDefinitionKeyIsValidButDefinitionDoesNotExist() {
+    // given
+    final DefinitionVariableLabelsDto request =
+        new DefinitionVariableLabelsDto("nonexistent-process", List.of());
+
+    // when — validation passes, service throws NotFoundException
+    final Response response =
+        embeddedOptimizeExtension
+            .getRequestExecutor()
+            .buildModifyVariableLabelsRequest(request)
+            .withBearerToken(TEST_ACCESS_TOKEN)
+            .execute();
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    final ErrorResponseDto errorResponse = response.readEntity(ErrorResponseDto.class);
+    assertThat(errorResponse.getErrorCode()).isEqualTo(NOT_FOUND_ERROR_CODE);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/PublicApiRestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/PublicApiRestService.java
@@ -174,7 +174,7 @@ public class PublicApiRestService {
 
   @PostMapping(LABELS_SUB_PATH)
   public void modifyVariableLabels(
-      @Valid final DefinitionVariableLabelsDto definitionVariableLabelsDto) {
+      @RequestBody @Valid final DefinitionVariableLabelsDto definitionVariableLabelsDto) {
     processVariableLabelService.storeVariableLabels(definitionVariableLabelsDto);
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/GenericExceptionMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/GenericExceptionMapper.java
@@ -14,6 +14,7 @@ import io.camunda.optimize.service.LocalizationService;
 import io.camunda.optimize.service.security.AuthCookieService;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.server.ResponseStatusException;
@@ -46,6 +48,20 @@ public class GenericExceptionMapper {
 
   @Autowired private LocalizationService localizationService;
   @Autowired private AuthCookieService cookieService;
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValidException(
+      final MethodArgumentNotValidException exception) {
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        .contentType(MediaType.APPLICATION_JSON)
+        .body(
+            new ErrorResponseDto(
+                BAD_REQUEST_ERROR_CODE,
+                localizationService.getDefaultLocaleMessageForApiErrorCode(BAD_REQUEST_ERROR_CODE),
+                Optional.ofNullable(exception.getFieldError())
+                    .map(f -> f.getField() + ": " + f.getDefaultMessage())
+                    .orElse(exception.getMessage())));
+  }
 
   @ExceptionHandler(Throwable.class)
   public ResponseEntity<ErrorResponseDto> handleThrowable(

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/GenericExceptionMapper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/providers/GenericExceptionMapper.java
@@ -53,7 +53,7 @@ public class GenericExceptionMapper {
   public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValidException(
       final MethodArgumentNotValidException exception) {
     return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-        .contentType(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .body(
             new ErrorResponseDto(
                 BAD_REQUEST_ERROR_CODE,

--- a/optimize/backend/src/test/java/io/camunda/optimize/OptimizeRequestExecutor.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/OptimizeRequestExecutor.java
@@ -19,6 +19,7 @@ import static jakarta.ws.rs.HttpMethod.PUT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import io.camunda.optimize.dto.optimize.query.security.CredentialsRequestDto;
 import io.camunda.optimize.dto.optimize.query.variable.DefinitionVariableLabelsDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
@@ -242,6 +243,7 @@ public class OptimizeRequestExecutor {
     return this;
   }
 
+  @VisibleForTesting
   public OptimizeRequestExecutor withBearerToken(final String token) {
     requestHeaders.put(HttpHeaders.AUTHORIZATION, "Bearer " + token);
     authCookie = null;

--- a/optimize/backend/src/test/java/io/camunda/optimize/OptimizeRequestExecutor.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/OptimizeRequestExecutor.java
@@ -20,7 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.optimize.dto.optimize.query.security.CredentialsRequestDto;
+import io.camunda.optimize.dto.optimize.query.variable.DefinitionVariableLabelsDto;
 import io.camunda.optimize.exception.OptimizeIntegrationTestException;
+import io.camunda.optimize.rest.PublicApiRestService;
 import io.camunda.optimize.service.security.AuthCookieService;
 import io.camunda.optimize.test.it.extension.IntegrationTestConfigurationUtil;
 import io.camunda.optimize.tomcat.OptimizeResourceConstants;
@@ -31,6 +33,7 @@ import jakarta.ws.rs.client.ClientResponseFilter;
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -228,6 +231,20 @@ public class OptimizeRequestExecutor {
     path = METRICS_ENDPOINT + "/" + OVERALL_IMPORT_TIME_METRIC.getName();
     method = GET;
     mediaType = MediaType.APPLICATION_JSON_VALUE;
+    return this;
+  }
+
+  public OptimizeRequestExecutor buildModifyVariableLabelsRequest(
+      final DefinitionVariableLabelsDto definitionVariableLabelsDto) {
+    path = PublicApiRestService.PUBLIC_PATH + PublicApiRestService.LABELS_SUB_PATH;
+    method = POST;
+    body = Entity.json(definitionVariableLabelsDto);
+    return this;
+  }
+
+  public OptimizeRequestExecutor withBearerToken(final String token) {
+    requestHeaders.put(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+    authCookie = null;
     return this;
   }
 


### PR DESCRIPTION


## Description

<!-- Describe the goal and purpose of this PR. -->

Fixes the public variable labels API and the manner in which we handle bad requests. Previously, requests that failed validation would return a `500 Internal Server Error` instead of `400 Bad Request`. We catch the emitted `MethodArgumentNotValidException` and transform it into `400 Bad Request` instead.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55881
