### PR TITLE
ci: run codeowners lint check in merge queue

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -28,7 +28,7 @@ outputs:
   codeowners-check:
     description: Output whether codeowners check should be performed based on GitHub event
     value: >-
-      ${{ github.event_name == 'pull_request' }}
+      ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
   maven-spotless-linter:
     description: Output whether jobs depending on files relevant for Maven spotless should be run, related checks are based on GitHub events and file changes
     value: >-


### PR DESCRIPTION
## Summary

The `codeowners-check` output in `.github/actions/paths-filter/action.yml` was gated on `pull_request` events only. This means it never ran in the merge queue, so a `CODEOWNERS` change merged to `main` between PR checks running and merge queue entry could break ownership coverage with no CI signal.

Extends the condition to also fire on `merge_group` events, matching the pattern used by every other output in this action.

Prevents the class of problem seen in https://github.com/camunda/camunda/pull/55819#issuecomment-4810221148.

## Change

```diff
-      ${{ github.event_name == 'pull_request' }}
+      ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
```