### PR TITLE
fix: reorder the conditions to await for second token

### DIFF
--- a/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProviderTest.java
+++ b/zeebe/exporters/app-integrations-exporter/src/test/java/io/camunda/exporter/appint/transport/DefaultOAuthCredentialsProviderTest.java
@@ -88,8 +88,8 @@ class DefaultOAuthCredentialsProviderTest {
     // then — a second token request happens before expiry and the cached bearer changes
     await()
         .atMost(Duration.ofSeconds(10))
-        .untilAsserted(() -> assertThat(tokenRequestCount()).isGreaterThanOrEqualTo(2));
-    assertThat(applyAndCaptureAuthorization()).isEqualTo("Bearer tok-2");
+        .untilAsserted(() -> assertThat(applyAndCaptureAuthorization()).isEqualTo("Bearer tok-2"));
+    assertThat(tokenRequestCount()).isEqualTo(2);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Tackle test flakiness reported on https://camunda.slack.com/archives/C071KP5BTHB/p1782804653684259

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
