### PR TITLE
test: stabilize shouldPassDistinctFeatureFlagsToEachPhysicalTenant

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -231,10 +231,14 @@ class PartitionManagerStepTest {
       final var secondFuture = CONCURRENCY_CONTROL.<BrokerStartupContext>createFuture();
       final var secondStep = new PartitionManagerStep(secondTenantId);
 
-      // when — start both steps
+      // when — start the steps one after the other. They are started sequentially on purpose:
+      // both steps build their PartitionManagerImpl on actor threads, and that construction reads
+      // from the shared RETURNS_DEEP_STUBS clusterServices mock. Mockito's lazy deep-stub
+      // registration is not thread-safe, so driving the same mock from two actor threads
+      // concurrently intermittently corrupts its internal state (WrongTypeOfReturnValue).
       sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
-      secondStep.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, secondFuture);
       assertThat(startupFuture).succeedsWithin(TIME_OUT);
+      secondStep.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, secondFuture);
       assertThat(secondFuture).succeedsWithin(TIME_OUT);
 
       // then — each tenant's ZeebePartitionFactory holds its own flags, not the other's


### PR DESCRIPTION
## Description

Fixes a flaky unit test in `PartitionManagerStepTest`.

`shouldPassDistinctFeatureFlagsToEachPhysicalTenant` started two `PartitionManagerStep`s before awaiting either, so both built their `PartitionManagerImpl` on **separate actor threads** while reading from the same shared `RETURNS_DEEP_STUBS` `clusterServices` mock. Mockito's lazy deep-stub registration is not thread-safe, so concurrent first-time access intermittently crossed the return stubs and threw:

```
WrongTypeOfReturnValue: ClusterMembershipService ... cannot be returned by getCommunicationService()
```

### Fix

Start the two steps **sequentially** (await the first before starting the second). The assertion — each `ZeebePartitionFactory` holds its own `FeatureFlags` — does not require concurrent startup, so serializing removes the data race without weakening the test.

## Why

Test-only change; removes a non-deterministic failure with no impact on production behaviour.

## Alternatives considered

- Replacing the shared `RETURNS_DEEP_STUBS` mock with explicit stubs or per-thread mocks — more invasive and unnecessary, since concurrency is not part of what this test verifies.

