### PR TITLE
fix: return 403 when user lacks READ_JOB_METRIC permission

### DIFF
--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentResourceAccessControllerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentResourceAccessControllerTest.java
@@ -204,7 +204,7 @@ class DocumentResourceAccessControllerTest {
   }
 
   @Test
-  void shouldEnableResourceAccessCheckOnSearchEvenWhenNoResourceIdsProvided() {
+  void shouldThrowResourceAccessDeniedOnSearchWhenNoResourceIdsProvided() {
     // given
     final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
     final var authorization =
@@ -219,23 +219,52 @@ class DocumentResourceAccessControllerTest {
 
     when(resourceAccessProvider.resolveResourceAccess(eq(authentication), eq(authorization)))
         .thenReturn(ResourceAccess.denied(requiredAuthorization));
-    when(tenantAccessProvider.resolveTenantAccess(any())).thenReturn(TenantAccess.wildcard(null));
 
-    final var reference = new AtomicReference<ResourceAccessChecks>();
+    // when - then: denied resource access must immediately throw, not silently produce matchNone
+    assertThatExceptionOfType(ResourceAccessDeniedException.class)
+        .isThrownBy(
+            () ->
+                controller.doSearch(
+                    securityContext,
+                    a -> {
+                      // applier must not be invoked
+                      return null;
+                    }))
+        .withMessageContaining("READ_PROCESS_DEFINITION")
+        .satisfies(err -> assertThat(err.getReason()).isEqualTo(Reason.FORBIDDEN));
+  }
 
-    // when
-    controller.doSearch(
-        securityContext,
-        a -> {
-          reference.set(a);
-          return null;
-        });
+  @Test
+  void shouldThrowResourceAccessDeniedOnSearchWhenAllAnyOfAuthorizationsDenied() {
+    // given
+    final var authentication = CamundaAuthentication.of(a -> a.user("foo"));
+    final var processDefinitionReadAuth =
+        RequiredAuthorization.of(a -> a.processDefinition().readUserTask());
+    final var userTaskReadAuth = RequiredAuthorization.of(a -> a.userTask().read());
+    final var securityContext =
+        SecurityContext.of(
+            s ->
+                s.withAuthentication(authentication)
+                    .withAuthorizationCondition(
+                        AuthorizationConditions.anyOf(
+                            processDefinitionReadAuth, userTaskReadAuth)));
 
-    // then
-    final var result = reference.get();
-    assertThat(result.authorizationCheck().enabled()).isTrue();
-    assertThat(result.authorizationCheck().authorizationCondition())
-        .isEqualTo(AuthorizationConditions.single(requiredAuthorization));
+    when(resourceAccessProvider.resolveResourceAccess(authentication, processDefinitionReadAuth))
+        .thenReturn(ResourceAccess.denied(processDefinitionReadAuth));
+    when(resourceAccessProvider.resolveResourceAccess(authentication, userTaskReadAuth))
+        .thenReturn(ResourceAccess.denied(userTaskReadAuth));
+
+    // when - then: all anyOf branches denied must throw, not silently produce matchNone
+    assertThatExceptionOfType(ResourceAccessDeniedException.class)
+        .isThrownBy(
+            () ->
+                controller.doSearch(
+                    securityContext,
+                    a -> {
+                      // applier must not be invoked
+                      return null;
+                    }))
+        .satisfies(err -> assertThat(err.getReason()).isEqualTo(Reason.FORBIDDEN));
   }
 
   @Test

--- a/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/auth/AbstractResourceAccessController.java
@@ -105,12 +105,17 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
       return AuthorizationCheck.disabled();
     }
 
+    if (resourceAccess.denied()) {
+      throw new ResourceAccessDeniedException(authorization);
+    }
+
     return AuthorizationCheck.enabled(resourceAccess.authorization());
   }
 
   private AuthorizationCheck createAnyOfAuthorizationCheck(
       final CamundaAuthentication authentication, final AnyOfAuthorizationCondition anyOf) {
     final var resolvedAuthorizations = new ArrayList<RequiredAuthorization<?>>();
+    boolean allDenied = true;
     for (final RequiredAuthorization<?> authorization : anyOf.authorizations()) {
       final var resourceAccess = resolveResourceAccess(authentication, authorization);
 
@@ -118,7 +123,15 @@ public abstract class AbstractResourceAccessController implements ResourceAccess
         return AuthorizationCheck.disabled();
       }
 
+      if (!resourceAccess.denied()) {
+        allDenied = false;
+      }
+
       resolvedAuthorizations.add(resourceAccess.authorization());
+    }
+
+    if (allDenied) {
+      throw new ResourceAccessDeniedException(anyOf.authorizations());
     }
 
     return AuthorizationCheck.enabled(AuthorizationConditions.anyOf(resolvedAuthorizations));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -2497,6 +2497,96 @@ public class JobControllerTest extends RestControllerTest {
             "/v2/jobs/statistics/time-series"));
   }
 
+  static Stream<Arguments> jobMetricsAuthorizedEndpoints() {
+    return Stream.of(
+        Arguments.of(
+            "/statistics/global?from=2024-07-28T15:51:28.071Z&to=2024-07-29T15:51:28.071Z",
+            "GET",
+            null),
+        Arguments.of(
+            "/statistics/by-types",
+            "POST",
+            """
+                {
+                  "filter": {
+                    "from": "2024-07-28T15:51:28.071Z",
+                    "to": "2024-07-29T15:51:28.071Z"
+                  }
+                }"""),
+        Arguments.of(
+            "/statistics/by-workers",
+            "POST",
+            """
+                {
+                  "filter": {
+                    "from": "2024-07-28T15:51:28.071Z",
+                    "to": "2024-07-29T15:51:28.071Z",
+                    "jobType": "fetch-customer-data"
+                  }
+                }"""),
+        Arguments.of(
+            "/statistics/time-series",
+            "POST",
+            """
+                {
+                  "filter": {
+                    "from": "2024-07-28T15:51:28.071Z",
+                    "to": "2024-07-29T15:51:28.071Z",
+                    "jobType": "fetch-customer-data"
+                  }
+                }"""));
+  }
+
+  @ParameterizedTest(name = "shouldReturn403For {0} statistics when user lacks READ_JOB_METRIC")
+  @MethodSource("jobMetricsAuthorizedEndpoints")
+  void shouldReturn403ForStatisticsWhenUserNotAuthorized(
+      final String uriSuffix, final String httpMethod, final String requestBody) {
+    // given - feature flag is enabled, but the service throws FORBIDDEN (no READ_JOB_METRIC)
+    when(jobServices.getGlobalStatistics(any(), any()))
+        .thenThrow(
+            new io.camunda.service.exception.ServiceException(
+                "Unauthorized to perform operation 'READ_JOB_METRIC' on resource 'SYSTEM'",
+                io.camunda.service.exception.ServiceException.Status.FORBIDDEN));
+    when(jobServices.getJobTypeStatistics(any(), any()))
+        .thenThrow(
+            new io.camunda.service.exception.ServiceException(
+                "Unauthorized to perform operation 'READ_JOB_METRIC' on resource 'SYSTEM'",
+                io.camunda.service.exception.ServiceException.Status.FORBIDDEN));
+    when(jobServices.getJobWorkerStatistics(any(), any()))
+        .thenThrow(
+            new io.camunda.service.exception.ServiceException(
+                "Unauthorized to perform operation 'READ_JOB_METRIC' on resource 'SYSTEM'",
+                io.camunda.service.exception.ServiceException.Status.FORBIDDEN));
+    when(jobServices.getJobTimeSeriesStatistics(any(), any()))
+        .thenThrow(
+            new io.camunda.service.exception.ServiceException(
+                "Unauthorized to perform operation 'READ_JOB_METRIC' on resource 'SYSTEM'",
+                io.camunda.service.exception.ServiceException.Status.FORBIDDEN));
+
+    // when/then
+    final var requestSpec =
+        "GET".equals(httpMethod)
+            ? webClient.get().uri(JOBS_BASE_URL + uriSuffix).accept(MediaType.APPLICATION_JSON)
+            : webClient
+                .post()
+                .uri(JOBS_BASE_URL + uriSuffix)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(requestBody);
+
+    requestSpec
+        .exchange()
+        .expectStatus()
+        .isForbidden()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .jsonPath("$.status")
+        .isEqualTo(403)
+        .jsonPath("$.title")
+        .isEqualTo("FORBIDDEN");
+  }
+
   @ParameterizedTest(name = "shouldReturn403For {0} statistics when job metrics disabled")
   @MethodSource("jobMetricsDisabledEndpoints")
   void shouldReturn403WhenJobMetricsDisabled(


### PR DESCRIPTION
## Problem

When a user without the `READ_JOB_METRIC` permission called any of the job metrics statistics endpoints (`/statistics/global`, `/statistics/by-types`, `/statistics/by-workers`, `/statistics/time-series`), the API returned **200 OK with an empty result** instead of **403 Forbidden**.

## Root cause

The `AbstractResourceAccessController.createSingleAuthorizationCheck` method received `ResourceAccess.denied()` from the auth provider but, rather than throwing, returned `AuthorizationCheck.enabled(deniedAuth)` — an enabled check carrying an authorization with **no resource IDs**.

The filter transformer then saw an enabled check with no resource IDs and produced a `matchNone()` Elasticsearch query, which silently returned zero results with a 200 status.

The same silent-empty-result behaviour existed for `anyOf` authorization conditions where all branches were denied.

## Fix

Both `createSingleAuthorizationCheck` and `createAnyOfAuthorizationCheck` in `AbstractResourceAccessController` now throw `ResourceAccessDeniedException` immediately when access is denied, matching the behaviour already in place for `doGet` (post-filtering).

The exception propagates through the standard chain:
`ResourceAccessDeniedException` (Reason.FORBIDDEN) → `executeSearchRequest` → `ErrorMapper.mapSearchError` → `ServiceException(FORBIDDEN)` → controller catch → `mapErrorToResponse` → **HTTP 403**

## Changes

- **`AbstractResourceAccessController`** — throw `ResourceAccessDeniedException` when `ResourceAccess.denied()` for both single and anyOf authorization checks
- **`DocumentResourceAccessControllerTest`** — updated the test that relied on the old silent-pass behaviour; added a new test for the anyOf all-denied case
- **`JobControllerTest`** — added `shouldReturn403ForStatisticsWhenUserNotAuthorized` covering all four metrics endpoints

## Testing

```
./mvnw verify -pl search/search-client -DskipTests=false -DskipITs -Dquickly        # 19/19 ✅
./mvnw verify -pl search/search-client-query-transformer \
  -Dtest=DocumentResourceAccessControllerTest -DskipTests=false -DskipITs -Dquickly  # 15/15 ✅
./mvnw verify -pl zeebe/gateway-rest \
  -Dtest=JobControllerTest -DskipTests=false -DskipITs -Dquickly                      # 73/73 ✅
```