### PR TITLE
feat: expose ES/OS indices sharding configuration through the load test metrics exporter

### DIFF
--- a/load-tests/metrics-exporter/README.md
+++ b/load-tests/metrics-exporter/README.md
@@ -34,6 +34,7 @@ curl -s http://localhost:9600/metrics | grep "^camunda_loadtest"
 | `camunda_loadtest_operate_root_process_instances`                   | Number of Operate root process instance documents.                                 | gauge   |
 | `camunda_loadtest_optimize_process_instances_completed`             | Number of completed Optimize process instance documents (endDate field present).   | gauge   |
 | `camunda_loadtest_optimize_process_instances`                       | Number of all Optimize process instance documents.                                 | gauge   |
+| `camunda_loadtest_index_shards`                                     | Shard configuration per index, with `index`, `primary`, and `replica` as labels.   | gauge   |
 
 ## Notes
 

--- a/load-tests/metrics-exporter/internal/elasticsearch/indices.go
+++ b/load-tests/metrics-exporter/internal/elasticsearch/indices.go
@@ -1,0 +1,68 @@
+// Package elasticsearch exposes internal Elasticsearch metrics
+package elasticsearch
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
+	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/common"
+	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/esutil"
+)
+
+const namespace = common.Namespace + "_elasticsearch"
+
+// Collector gathers per-index shard configuration metrics from Elasticsearch.
+type Collector struct {
+	esClient *esutil.Client
+	logger   *zap.Logger
+
+	shards *prometheus.GaugeVec
+}
+
+func New(esClient *esutil.Client, logger *zap.Logger, reg prometheus.Registerer) *Collector {
+	c := &Collector{
+		esClient: esClient,
+		logger:   logger,
+		shards: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "index_shards",
+			Help:      "Number of shards per index. The shard_type label is either \"primary\" or \"replica\".",
+		}, []string{"index", "shard_type"}),
+	}
+	reg.MustRegister(c.shards)
+	return c
+}
+
+func (c *Collector) Name() string { return "index" }
+
+func (c *Collector) Collect(ctx context.Context) error {
+	c.logger.Debug("Collecting index shard configuration")
+
+	indices, err := c.esClient.CatIndices(ctx)
+	if err != nil {
+		return fmt.Errorf("fetch index shard info: %w", err)
+	}
+
+	// Reset before setting to drop stale series for indices deleted since the last scrape.
+	c.shards.Reset()
+	for _, idx := range indices {
+		primary, err := strconv.ParseFloat(idx.Primary, 64)
+		if err != nil {
+			c.logger.Warn("failed to parse primary shard count", zap.String("index", idx.Index), zap.String("value", idx.Primary), zap.Error(err))
+			continue
+		}
+		replica, err := strconv.ParseFloat(idx.Replicas, 64)
+		if err != nil {
+			c.logger.Warn("failed to parse replica shard count", zap.String("index", idx.Index), zap.String("value", idx.Replicas), zap.Error(err))
+			continue
+		}
+		c.shards.WithLabelValues(idx.Index, "primary").Set(primary)
+		c.shards.WithLabelValues(idx.Index, "replica").Set(replica)
+	}
+
+	return nil
+}

--- a/load-tests/metrics-exporter/internal/elasticsearch/indices_test.go
+++ b/load-tests/metrics-exporter/internal/elasticsearch/indices_test.go
@@ -1,0 +1,132 @@
+package elasticsearch
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"go.uber.org/zap"
+
+	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/esutil"
+)
+
+func newCatServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func Test_shouldSetGaugeForEachIndex(t *testing.T) {
+	// given
+	srv := newCatServer(t, `[{"index":"idx-a","pri":"3","rep":"1"},{"index":"idx-b","pri":"1","rep":"0"}]`)
+	reg := prometheus.NewRegistry()
+	c := New(esutil.NewClient(srv.URL), zap.NewNop(), reg)
+
+	// when
+	if err := c.Collect(context.Background()); err != nil {
+		t.Fatalf("Collect returned error: %v", err)
+	}
+
+	// then
+	if err := testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP camunda_loadtest_elasticsearch_index_shards Number of shards per index. The shard_type label is either "primary" or "replica".
+# TYPE camunda_loadtest_elasticsearch_index_shards gauge
+camunda_loadtest_elasticsearch_index_shards{index="idx-a",shard_type="primary"} 3
+camunda_loadtest_elasticsearch_index_shards{index="idx-a",shard_type="replica"} 1
+camunda_loadtest_elasticsearch_index_shards{index="idx-b",shard_type="primary"} 1
+camunda_loadtest_elasticsearch_index_shards{index="idx-b",shard_type="replica"} 0
+`), "camunda_loadtest_elasticsearch_index_shards"); err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_shouldProduceNoMetricsWhenNoIndicesExist(t *testing.T) {
+	// given
+	srv := newCatServer(t, `[]`)
+	reg := prometheus.NewRegistry()
+	c := New(esutil.NewClient(srv.URL), zap.NewNop(), reg)
+
+	// when
+	if err := c.Collect(context.Background()); err != nil {
+		t.Fatalf("Collect returned error: %v", err)
+	}
+
+	// then: no gauge series should be emitted
+	count, err := testutil.GatherAndCount(reg, "camunda_loadtest_elasticsearch_index_shards")
+	if err != nil {
+		t.Fatalf("GatherAndCount returned error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 metrics, got %d", count)
+	}
+}
+
+func Test_shouldRemoveStaleSeriesOnSubsequentCollect(t *testing.T) {
+	// given: first collect returns two indices; second collect returns only one
+	// (simulating idx-b being deleted between scrapes).
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 0 {
+			_, _ = w.Write([]byte(`[{"index":"idx-a","pri":"3","rep":"1"},{"index":"idx-b","pri":"1","rep":"0"}]`))
+		} else {
+			_, _ = w.Write([]byte(`[{"index":"idx-a","pri":"3","rep":"1"}]`))
+		}
+		callCount++
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := prometheus.NewRegistry()
+	c := New(esutil.NewClient(srv.URL), zap.NewNop(), reg)
+
+	// when
+	if err := c.Collect(context.Background()); err != nil {
+		t.Fatalf("first Collect returned error: %v", err)
+	}
+	if err := c.Collect(context.Background()); err != nil {
+		t.Fatalf("second Collect returned error: %v", err)
+	}
+
+	// then: only idx-a remains; idx-b is gone
+	if err := testutil.GatherAndCompare(reg, strings.NewReader(`
+# HELP camunda_loadtest_elasticsearch_index_shards Number of shards per index. The shard_type label is either "primary" or "replica".
+# TYPE camunda_loadtest_elasticsearch_index_shards gauge
+camunda_loadtest_elasticsearch_index_shards{index="idx-a",shard_type="primary"} 3
+camunda_loadtest_elasticsearch_index_shards{index="idx-a",shard_type="replica"} 1
+`), "camunda_loadtest_elasticsearch_index_shards"); err != nil {
+		t.Error(err)
+	}
+}
+
+func Test_shouldReturnErrorWhenElasticsearchFails(t *testing.T) {
+	// given
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := New(esutil.NewClient(srv.URL), zap.NewNop(), prometheus.NewRegistry())
+
+	// when
+	err := c.Collect(context.Background())
+
+	// then
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func Test_shouldReportModuleName(t *testing.T) {
+	c := New(esutil.NewClient("http://localhost:9200"), zap.NewNop(), prometheus.NewRegistry())
+	if got := c.Name(); got != "index" {
+		t.Errorf("Name() = %q, want %q", got, "index")
+	}
+}

--- a/load-tests/metrics-exporter/internal/esutil/cat_indices.go
+++ b/load-tests/metrics-exporter/internal/esutil/cat_indices.go
@@ -1,0 +1,51 @@
+package esutil
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// IndexInfo holds the shard configuration for a single index as returned by /_cat/indices.
+type IndexInfo struct {
+	Index    string `json:"index"`
+	Primary  string `json:"pri"`
+	Replicas string `json:"rep"`
+}
+
+// CatIndices fetches per-index primary shard count and replica count via /_cat/indices.
+func (c *Client) CatIndices(ctx context.Context) ([]IndexInfo, error) {
+	endpoint := c.baseURL + "/_cat/indices?format=json&h=index,pri,rep"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build cat-indices request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	res, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("elasticsearch cat-indices: %w", err)
+	}
+	defer res.Body.Close() //nolint:errcheck
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		snippet, _ := io.ReadAll(io.LimitReader(res.Body, 512))
+		return nil, fmt.Errorf("elasticsearch cat-indices: %s: %s", res.Status, strings.TrimSpace(string(snippet)))
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read cat-indices response: %w", err)
+	}
+
+	var indices []IndexInfo
+	if err := json.Unmarshal(body, &indices); err != nil {
+		return nil, fmt.Errorf("parse cat-indices response: %w", err)
+	}
+
+	return indices, nil
+}

--- a/load-tests/metrics-exporter/internal/esutil/cat_indices_test.go
+++ b/load-tests/metrics-exporter/internal/esutil/cat_indices_test.go
@@ -1,0 +1,102 @@
+package esutil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCatIndices_shouldReturnIndexInfo(t *testing.T) {
+	// given
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"index":"test-index","pri":"3","rep":"1"},{"index":"another-index","pri":"1","rep":"0"}]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL)
+
+	// when
+	indices, err := c.CatIndices(context.Background())
+
+	// then
+	if err != nil {
+		t.Fatalf("CatIndices returned error: %v", err)
+	}
+	if len(indices) != 2 {
+		t.Fatalf("expected 2 indices, got %d", len(indices))
+	}
+	if indices[0].Index != "test-index" || indices[0].Primary != "3" || indices[0].Replicas != "1" {
+		t.Errorf("indices[0] = %+v, want {Index:test-index Primary:3 Replicas:1}", indices[0])
+	}
+	if indices[1].Index != "another-index" || indices[1].Primary != "1" || indices[1].Replicas != "0" {
+		t.Errorf("indices[1] = %+v, want {Index:another-index Primary:1 Replicas:0}", indices[1])
+	}
+}
+
+func TestCatIndices_shouldReturnEmptySliceOnNoIndices(t *testing.T) {
+	// given
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL)
+
+	// when
+	indices, err := c.CatIndices(context.Background())
+
+	// then
+	if err != nil {
+		t.Fatalf("CatIndices returned error: %v", err)
+	}
+	if len(indices) != 0 {
+		t.Errorf("expected 0 indices, got %d", len(indices))
+	}
+}
+
+func TestCatIndices_shouldReturnErrorOnHTTPFailure(t *testing.T) {
+	// given
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal server error"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL)
+
+	// when
+	_, err := c.CatIndices(context.Background())
+
+	// then
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestCatIndices_shouldSendRequestToCorrectEndpoint(t *testing.T) {
+	// given
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := NewClient(srv.URL)
+
+	// when
+	_, _ = c.CatIndices(context.Background())
+
+	// then
+	if gotPath != "/_cat/indices" {
+		t.Errorf("request path = %q, want /_cat/indices", gotPath)
+	}
+	if gotQuery != "format=json&h=index,pri,rep" {
+		t.Errorf("request query = %q, want format=json&h=index,pri,rep", gotQuery)
+	}
+}

--- a/load-tests/metrics-exporter/internal/exporter/exporter.go
+++ b/load-tests/metrics-exporter/internal/exporter/exporter.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/esutil"
+	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/elasticsearch"
 	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/operate"
 	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/optimize"
 )
@@ -47,6 +48,7 @@ func Run(ctx context.Context, cfg Config, logger *zap.Logger) error {
 	modules := []Module{
 		optimize.New(esClient, logger.Named("optimize"), reg),
 		operate.New(esClient, logger.Named("operate"), reg),
+		elasticsearch.New(esClient, logger.Named("index"), reg),
 	}
 
 	collector := NewCollector(modules, cfg.ScrapeInterval, logger, reg)

--- a/load-tests/metrics-exporter/internal/integration/integration_test.go
+++ b/load-tests/metrics-exporter/internal/integration/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/esutil"
+	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/indices"
 	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/operate"
 	"github.com/camunda/camunda/load-tests/metrics-exporter/internal/optimize"
 )
@@ -81,6 +82,84 @@ camunda_loadtest_operate_root_process_instances_completed 3
 				"camunda_loadtest_operate_root_process_instances_completed",
 			); err != nil {
 				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestIndicesCollector_shouldExposeShardConfiguration(t *testing.T) {
+	for _, backend := range backends {
+		backend := backend
+		t.Run(backend.name, func(t *testing.T) {
+			// given: a fresh cluster with two test indices with distinct shard configs.
+			// replica=0 avoids yellow health on single-node clusters.
+			baseURL := startSearchContainer(t, backend)
+			createIndex(t, baseURL, "test-shards-alpha", `{
+				"settings": {
+					"number_of_shards": 3,
+					"number_of_replicas": 0
+				}
+			}`)
+			createIndex(t, baseURL, "test-shards-beta", `{
+				"settings": {
+					"number_of_shards": 5,
+					"number_of_replicas": 2
+				}
+			}`)
+
+			reg := prometheus.NewRegistry()
+			c := indices.New(esutil.NewClient(baseURL), zap.NewNop(), reg)
+
+			// when
+			if err := c.Collect(context.Background()); err != nil {
+				t.Fatalf("Collect returned error: %v", err)
+			}
+
+			// then: scan gathered metrics for our test indices; other system indices may
+			// also be present so we do a partial check rather than exact comparison.
+			gathered, err := reg.Gather()
+			if err != nil {
+				t.Fatalf("Gather returned error: %v", err)
+			}
+
+			type shardInfo struct{ primary, replica string }
+			found := map[string]shardInfo{}
+			for _, mf := range gathered {
+				if mf.GetName() != "camunda_loadtest_index_shards" {
+					continue
+				}
+				for _, m := range mf.GetMetric() {
+					var idx, pri, rep string
+					for _, lp := range m.GetLabel() {
+						switch lp.GetName() {
+						case "index":
+							idx = lp.GetValue()
+						case "primary":
+							pri = lp.GetValue()
+						case "replica":
+							rep = lp.GetValue()
+						}
+					}
+					found[idx] = shardInfo{pri, rep}
+				}
+			}
+
+			want := map[string]shardInfo{
+				"test-shards-alpha": {"3", "0"},
+				"test-shards-beta":  {"5", "2"},
+			}
+			for name, cfg := range want {
+				got, ok := found[name]
+				if !ok {
+					t.Errorf("index %q not found in metrics; got: %v", name, found)
+					continue
+				}
+				if got.primary != cfg.primary {
+					t.Errorf("index %q: primary = %q, want %q", name, got.primary, cfg.primary)
+				}
+				if got.replica != cfg.replica {
+					t.Errorf("index %q: replica = %q, want %q", name, got.replica, cfg.replica)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Description

For each indices, we expose a new metrics with the following labels:

* `index`: the name of the index for which the configuration will be exposed
* `shard_type`: the type of shard (`primary` or `replica`)

The value indicates the number of this type of shard for each indices.

We should be able to get the namespaces which don't have replicas configured with:
```
min(camunda_loadtest_elasticsearch_index_shards{shard_type="replica"}) by (namespace) == 0
```

and the related indices:
```
min(camunda_loadtest_elasticsearch_index_shards{shard_type="replica"}) by (index) == 0
```




## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/55404
