### PR TITLE
test: fix flaky RefreshablePropertiesTest

### DIFF
--- a/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/RefreshablePropertiesTest.java
+++ b/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/RefreshablePropertiesTest.java
@@ -53,7 +53,7 @@ final class RefreshablePropertiesTest {
   void shouldNotClearUserSetPropertiesOnRefresh() {
     // given a broker with a user-set property that is not part of unified config
     final var broker = new TestStandaloneBroker();
-    broker.withProperty("camunda.security.authorizations.enabled", true);
+    broker.withProperty("camunda.not-part-of-uc", true);
 
     // when refreshable properties are applied and then re-applied
     broker.withRefreshableProperties(
@@ -62,7 +62,7 @@ final class RefreshablePropertiesTest {
         ExtendedConfigurationBuilder.flatPropertiesFor(broker.unifiedConfig()));
 
     // then the user-set property survives both refreshes
-    assertThat(broker.property("camunda.security.authorizations.enabled", Boolean.class, false))
+    assertThat(broker.property("camunda.not-part-of-uc", Boolean.class, false))
         .as("user-set property should not be tracked as refreshable")
         .isTrue();
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Since `camunda.security.authorization` is now part of unified configuration, this test does not pass anymore

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
