### PR TITLE
fix: stop flaky-gate touch-check matching descendant packages of the test

### DIFF
--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -147,10 +147,12 @@ below. Two filters address this before any new flake enters the sticky state.
 
 ### Filter 1 — Package touch-check
 
-`get_pr_changed_paths()` runs:
+`get_pr_changed_paths()` resolves the diff base via `get_merge_base()` (which
+tries `BASE_SHA` first, then `origin/<base_ref>`, so it also works in PR
+merge-ref checkouts) and runs:
 
 ```bash
-git diff --name-only origin/<base_ref>...<head_sha>
+git diff --name-only <merge_base>...<head_sha>
 ```
 
 and extracts the Java package path from every changed `.java` file

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -158,9 +158,17 @@ and extracts the Java package path from every changed `.java` file
 → `io/camunda/zeebe/backup/gcs`).
 
 `filter_by_touch_check()` then silences any new-flaky alert whose Java
-package was not touched by the PR (exact match, or the PR touched a parent
-or child package). A test in `io.camunda.zeebe.backup.gcs` cannot have been
-broken by a PR that only changes `io.camunda.zeebe.agent`.
+package was not touched by the PR — either an exact match, or the PR touched
+a parent package (production code above the test). A test in
+`io.camunda.zeebe.backup.gcs` cannot have been broken by a PR that only
+changes `io.camunda.zeebe.agent`.
+
+The reverse "PR changed a strict sub-package of the test's package" match is
+intentionally **not** used: for shallow/root test packages such as
+`io.camunda` virtually every file in the monorepo is a descendant, so that
+rule degenerated to always-true and defeated the filter (it flagged the
+root-package `InvoiceDecisionTest` on unrelated PRs — #55489). A 60-day replay
+of every known true positive confirmed none relied on the descendant match.
 
 A PR that changes only YAML/config files (no `.java` at all) produces an
 empty `changed_pkg_paths` set with `available=True` — that is still a valid

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -652,18 +652,28 @@ def get_pr_changed_paths(
 
 
 def _package_touched(pkg_path: str, changed_pkg_paths: set[str]) -> bool:
-    """Return True if pkg_path is the same as, a parent of, or a child of any changed package.
+    """Return True if pkg_path is the same as, or a child of, any changed package.
+
+    A flake is treated as possibly PR-caused only when the PR changed the test's
+    own package (exact match) or a parent package (production code above the test).
+
+    The inverse "PR changed a strict sub-package of the test's package" rule was
+    removed: for shallow/root test packages almost every file in the monorepo is a
+    descendant, so that rule degenerated to always-true and defeated the filter.
+    Concretely, InvoiceDecisionTest sits in the root package "io/camunda", and any
+    changed package "io/camunda/<anything>" satisfied startswith("io/camunda/"), so
+    the gate flagged it on unrelated PRs (#55489). A 60-day replay of every known
+    true positive showed none relied on the descendant rule — each matched the test's
+    exact package and edited the test file — so dropping it loses no true positive.
 
     Examples (pkg_path → changed_pkg_paths → result):
       "io/a/b"       {io/a/b}           → True  (exact match)
-      "io/a/b"       {io/a/b/internal}  → True  (changed child of test package)
       "io/a/b/impl"  {io/a/b}           → True  (test is child of changed package)
+      "io/a/b"       {io/a/b/internal}  → False (changed sub-package no longer matches)
       "io/a/b"       {io/x/y}           → False (unrelated)
     """
     for cp in changed_pkg_paths:
         if cp == pkg_path:
-            return True
-        if cp.startswith(pkg_path + "/"):
             return True
         if pkg_path.startswith(cp + "/"):
             return True
@@ -679,8 +689,8 @@ def filter_by_touch_check(
 ) -> list[dict]:
     """Suppress false-positive alerts using a three-stage touch-check filter.
 
-    Stage 1 — package-unrelated: PR does not touch the test's Java package (or any
-      sub/parent package) → suppress. A test flaking in a completely unrelated
+    Stage 1 — package-unrelated: PR does not touch the test's Java package (or a
+      parent package) → suppress. A test flaking in a completely unrelated
       package cannot be this PR's fault. Note: a YAML-only PR with no .java changes
       is a valid no-touch signal (changed_pkg_paths is empty, touch_check_available
       is True). Tests whose package cannot be parsed (empty pkg_path) are kept.

--- a/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
@@ -510,6 +510,32 @@ class TestFilterByTouchCheck(unittest.TestCase):
         result = self._run(tests, changed_pkgs=["io/camunda/zeebe/backup/gcs"])
         self.assertEqual(result, tests)
 
+    def test_parent_package_kept(self):
+        """PR changes a parent package (prod code above the test) → kept."""
+        tests = [_make_test("io.camunda.zeebe.backup.gcs")]
+        result = self._run(tests, changed_pkgs=["io/camunda/zeebe/backup"])
+        self.assertEqual(result, tests)
+
+    def test_descendant_package_no_longer_matches(self):
+        """PR changes only a strict sub-package of the test's package → suppress.
+
+        The descendant rule was removed (see _package_touched): a change inside a
+        sub-package no longer counts as touching the test's package.
+        """
+        tests = [_make_test("io.camunda.zeebe.backup.gcs")]
+        result = self._run(tests, changed_pkgs=["io/camunda/zeebe/backup/gcs/impl"])
+        self.assertEqual(result, [])
+
+    def test_root_package_not_flagged_by_unrelated_change(self):
+        """Regression for #55489: a test in the root io.camunda package must not be
+        flagged just because the PR changed some io/camunda/<area> sub-package."""
+        tests = [_make_test("io.camunda", "InvoiceDecisionTest")]
+        result = self._run(
+            tests,
+            changed_pkgs=["io/camunda/db/rdbms", "io/camunda/search/clients"],
+        )
+        self.assertEqual(result, [])
+
     def test_blank_class_suppressed_when_file_not_in_diff(self):
         test = _make_test("io.camunda.zeebe.backup.gcs", "GcsBackupIT")
         result = self._run(


### PR DESCRIPTION
Follow-up to #55572 — closes a false-positive hole in the flaky-test gate touch-check (internally tracked as GAP-6).

## Problem

`_package_touched()` treated a test as "touched" by the PR when any changed package was a **descendant** (sub-package) of the test's package:

```python
if cp.startswith(pkg_path + "/"):   # PR changed a sub-package of the test
    return True
```

For shallow/root test packages this degenerates to always-true: the whole monorepo lives under `io/camunda/`, so for a test in the root `io.camunda` package every change anywhere matches. `InvoiceDecisionTest` (package `io.camunda`, module `testing/camunda-process-test-example`) was flagged on PR #55489 — a numeric-variable fix that touched `db/rdbms`, `qa/acceptance-tests` and `search/...`, none of them the test's module. The class is a recurring infra flake (flaked on `main` + 4 other PRs in 60 days, including the same parameter a month before #55489 existed), so the alert was a false positive the touch-check should have suppressed.

## Fix

Drop the descendant match. Keep:

- **exact package** (`cp == pkg_path`) — PR changed the test's own package, and
- **parent package** (`pkg_path.startswith(cp + "/")`) — PR changed production code above the test,

plus the existing **test-file-in-diff** override (a PR that edits the test always alerts).

After the fix #55489's `InvoiceDecisionTest` is suppressed (no changed package equals or is a parent of `io/camunda`, and the test file is not in the diff).

## Why this is safe — 60-day true-positive replay

I replayed every known true positive (3 post-#55572 + 5 historical) and recorded which clause matched:

| PR | test package | test file in diff | exact | descendant | parent | kept by |
|----|--------------|:-:|:-:|:-:|:-:|--------|
| #55112 | io/camunda/it/orchestration | yes | ✓ | – | – | exact |
| #55905 | …/rdbms/db/batchoperation | yes | ✓ | – | ✓ | exact |
| #55905 | …/rdbms/db/usertask | yes | ✓ | – | ✓ | exact |
| #55907 | …/zeebe/broker/bootstrap | yes | ✓ | – | ✓ | exact |
| #51785 | …/exporter/appint/transport | yes | ✓ | – | ✓ | exact |
| #54589 | …/rdbms/db/tenant | yes | ✓ | – | – | exact |
| #54680 | io/camunda/container | yes | ✓ | ✓ | – | exact |
| #54700 | …/configuration/physicaltenants | yes | ✓ | – | – | exact |
| #55015 | io/camunda/process/test/api | yes | ✓ | – | – | exact |

**No true positive was ever caught only by the descendant rule** — every one matched the exact package and edited the test file. The descendant match fired in exactly one case (#54680) where the exact match already kept it. Dropping it loses no true positive.

### Residual risk (accepted)

A theoretical true positive where a PR changes **only a strict sub-package** of the test's package and touches neither the test's own package nor the test file would now be suppressed. That shape has never occurred in the gate's history, and the gate is non-blocking, so it is observable if it ever appears.

## Tests

`test_detect_new_flaky_tests.py`: added `test_parent_package_kept`, `test_descendant_package_no_longer_matches`, and `test_root_package_not_flagged_by_unrelated_change` (regression for #55489). Full suite: 49 passed.