### PR TITLE
ci: increase timeout for docker.elastic.co to fix Renovate scan abort (INC-6230)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,6 +47,11 @@
       "password": "{{ secrets.ARTIFACTORY_PASSWORD }}"
     },
     {
+      "hostType": "docker",
+      "matchHost": "https://docker.elastic.co",
+      "timeout": 30000
+    },
+    {
       "timeout": 10000
     }
   ],


### PR DESCRIPTION
## Summary

- Adds a per-host `timeout: 30000` rule for `docker.elastic.co` in Renovate's `hostRules`
- The global 10s timeout stays in place for all other hosts

## Why

Root cause of INC-6230: Renovate's scan aborts entirely when fetching the tag list from `docker.elastic.co`. The registry paginates through a very large number of tags (8.x snapshots → 9.3.x), and the response takes >10 seconds, hitting the global `"timeout": 10000`. Renovate treats this as a fatal "External host error" and terminates the entire repository scan — no new PRs, no rebase of existing ones, no dashboard update.

Evidence from Renovate log (job `8739fc1b-9a7d-455b-b6b8-2b74ed824f9f` on 2026-06-30):
```
WARN: Host error — docker.elastic.co/kibana/kibana — TimeoutError: Timeout awaiting 'request' for 10000ms (total: 10002ms)
INFO: External host error causing abort - skipping
```

## Test plan

- [ ] Merge and wait for the next Renovate scan — new PRs should appear and the dependency dashboard should update
- [ ] If 30s is still not enough, fallback is to disable Kibana tracking via a `packageRule` with `enabled: false`

Related to INC-6230