### PR TITLE
Transform & deploy-time validation of call activity `businessId`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
@@ -14,6 +14,15 @@ public class ExecutableCallActivity extends ExecutableActivity {
 
   private Expression calledElementProcessId;
 
+  /**
+   * The child Business ID configuration, parsed from the {@code businessId} attribute of the called
+   * element. The {@code null} value of this field is significant: it means the attribute was absent
+   * and the child must inherit the parent's Business ID. A non-null expression means the attribute
+   * was present and overrides inheritance — an empty static expression yields no Business ID, a
+   * non-empty static expression a literal one, and a FEEL expression a dynamically evaluated one.
+   */
+  private Expression calledElementBusinessId;
+
   private boolean propagateAllChildVariablesEnabled;
   private boolean propagateAllParentVariablesEnabled;
 
@@ -36,6 +45,14 @@ public class ExecutableCallActivity extends ExecutableActivity {
 
   public void setCalledElementProcessId(final Expression calledElementProcessIdExpression) {
     calledElementProcessId = calledElementProcessIdExpression;
+  }
+
+  public Expression getCalledElementBusinessId() {
+    return calledElementBusinessId;
+  }
+
+  public void setCalledElementBusinessId(final Expression calledElementBusinessId) {
+    this.calledElementBusinessId = calledElementBusinessId;
   }
 
   public boolean isPropagateAllChildVariablesEnabled() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformer.java
@@ -49,6 +49,8 @@ public final class CallActivityTransformer implements ModelElementTransformer<Ca
 
     callActivity.setCalledElementProcessId(expression);
 
+    transformBusinessId(calledElement, callActivity, expressionLanguage);
+
     final var propagateAllChildVariablesEnabled =
         calledElement.isPropagateAllChildVariablesEnabled();
     callActivity.setPropagateAllChildVariablesEnabled(propagateAllChildVariablesEnabled);
@@ -62,6 +64,24 @@ public final class CallActivityTransformer implements ModelElementTransformer<Ca
 
     final var versionTag = calledElement.getVersionTag();
     callActivity.setVersionTag(versionTag);
+  }
+
+  private static void transformBusinessId(
+      final ZeebeCalledElement calledElement,
+      final ExecutableCallActivity callActivity,
+      final ExpressionLanguage expressionLanguage) {
+    if (!calledElement.hasBusinessId()) {
+      // The attribute is absent: leave the configuration null so the child inherits the parent's
+      // Business ID. This is distinct from a present-but-empty attribute (handled below), which the
+      // value accessor also reports as null but which overrides inheritance with no Business ID.
+      return;
+    }
+
+    // A present-but-empty attribute reads back as null, so represent it as an empty static
+    // expression; both literal and FEEL values are parsed the same way as the process ID.
+    final var businessId = calledElement.getBusinessId();
+    final var expression = expressionLanguage.parseExpression(businessId == null ? "" : businessId);
+    callActivity.setCalledElementBusinessId(expression);
   }
 
   private static void transformLexicographicIndex(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -87,6 +87,8 @@ public final class ZeebeRuntimeValidators {
         ZeebeExpressionValidator.verifyThat(ZeebeCalledElement.class)
             .hasValidExpression(
                 ZeebeCalledElement::getProcessId, ExpressionVerification::isMandatory)
+            .hasValidExpression(
+                ZeebeCalledElement::getBusinessId, ExpressionVerification::isOptional)
             .build(expressionLanguage),
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(TimerEventDefinition.class)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
+import java.time.InstantSource;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class CallActivityTransformerTest {
+
+  private static final String CALL_ACTIVITY_ID = "call-activity";
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
+
+  private BpmnModelInstance processWithCallActivity(final Consumer<CallActivityBuilder> modifier) {
+    return Bpmn.createExecutableProcess()
+        .startEvent()
+        .callActivity(CALL_ACTIVITY_ID, modifier)
+        .done();
+  }
+
+  private ExecutableCallActivity transform(final BpmnModelInstance model) {
+    final List<ExecutableProcess> processes = transformer.transformDefinitions(model);
+    return processes.getFirst().getElementById(CALL_ACTIVITY_ID, ExecutableCallActivity.class);
+  }
+
+  @Test
+  void shouldInheritBusinessIdWhenAttributeIsAbsent() {
+    // given - no businessId attribute
+    final var model = processWithCallActivity(c -> c.zeebeProcessId("child"));
+
+    // when
+    final var element = transform(model);
+
+    // then - null configuration signals "inherit the parent's Business ID"
+    assertThat(element.getCalledElementBusinessId()).isNull();
+  }
+
+  @Test
+  void shouldSetEmptyBusinessIdAsEmptyStaticExpression() {
+    // given - an explicitly empty businessId attribute
+    final var model = processWithCallActivity(c -> c.zeebeProcessId("child").zeebeBusinessId(""));
+
+    // when
+    final var element = transform(model);
+
+    // then - present but empty: a static expression with no value, distinct from "inherit"
+    assertThat(element.getCalledElementBusinessId()).isNotNull();
+    assertThat(element.getCalledElementBusinessId().isStatic()).isTrue();
+    assertThat(element.getCalledElementBusinessId().isValid()).isTrue();
+    assertThat(element.getCalledElementBusinessId().getExpression()).isEmpty();
+  }
+
+  @Test
+  void shouldSetLiteralBusinessIdAsStaticExpression() {
+    // given - a literal businessId
+    final var model =
+        processWithCallActivity(c -> c.zeebeProcessId("child").zeebeBusinessId("order-123"));
+
+    // when
+    final var element = transform(model);
+
+    // then
+    assertThat(element.getCalledElementBusinessId()).isNotNull();
+    assertThat(element.getCalledElementBusinessId().isStatic()).isTrue();
+    assertThat(element.getCalledElementBusinessId().isValid()).isTrue();
+    assertThat(element.getCalledElementBusinessId().getExpression()).isEqualTo("order-123");
+  }
+
+  @Test
+  void shouldParseBusinessIdFeelExpression() {
+    // given - a FEEL expression businessId
+    final var model =
+        processWithCallActivity(c -> c.zeebeProcessId("child").zeebeBusinessId("=orderId"));
+
+    // when
+    final var element = transform(model);
+
+    // then - non-static, valid, with the '=' prefix stripped
+    assertThat(element.getCalledElementBusinessId()).isNotNull();
+    assertThat(element.getCalledElementBusinessId().isStatic()).isFalse();
+    assertThat(element.getCalledElementBusinessId().isValid()).isTrue();
+    assertThat(element.getCalledElementBusinessId().getExpression()).isEqualTo("orderId");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/CallActivityBusinessIdValidationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/CallActivityBusinessIdValidationTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static io.camunda.zeebe.engine.processing.deployment.model.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+final class CallActivityBusinessIdValidationTest {
+
+  private static final String INVALID_FEEL_EXPRESSION = "=a & b";
+  private static final String INVALID_FEEL_EXPRESSION_MESSAGE =
+      "failed to parse expression 'a & b'";
+
+  private static BpmnModelInstance processWithCallActivity(
+      final Consumer<CallActivityBuilder> modifier) {
+    return Bpmn.createExecutableProcess("process")
+        .startEvent()
+        .callActivity("call", modifier)
+        .done();
+  }
+
+  @Test
+  void shouldRejectInvalidBusinessIdFeelExpression() {
+    // given
+    final var process =
+        processWithCallActivity(
+            c -> c.zeebeProcessId("child").zeebeBusinessId(INVALID_FEEL_EXPRESSION));
+
+    // when / then
+    ProcessValidationUtil.validateProcess(
+        process, expect(ZeebeCalledElement.class, INVALID_FEEL_EXPRESSION_MESSAGE));
+  }
+
+  @Test
+  void shouldAcceptValidBusinessIdFeelExpression() {
+    // given
+    final var process =
+        processWithCallActivity(c -> c.zeebeProcessId("child").zeebeBusinessId("=orderId"));
+
+    // when / then
+    ProcessValidationUtil.validateProcess(process);
+  }
+
+  @Test
+  void shouldAcceptLiteralBusinessId() {
+    // given
+    final var process =
+        processWithCallActivity(c -> c.zeebeProcessId("child").zeebeBusinessId("order-123"));
+
+    // when / then
+    ProcessValidationUtil.validateProcess(process);
+  }
+
+  @Test
+  void shouldAcceptEmptyBusinessId() {
+    // given
+    final var process = processWithCallActivity(c -> c.zeebeProcessId("child").zeebeBusinessId(""));
+
+    // when / then
+    ProcessValidationUtil.validateProcess(process);
+  }
+
+  @Test
+  void shouldAcceptAbsentBusinessId() {
+    // given
+    final var process = processWithCallActivity(c -> c.zeebeProcessId("child"));
+
+    // when / then
+    ProcessValidationUtil.validateProcess(process);
+  }
+}


### PR DESCRIPTION
## Description

Wires the `businessId` attribute of `<zeebe:calledElement>` into `ExecutableCallActivity` during BPMN deployment transformation, and rejects processes with an invalid `businessId` FEEL expression at deploy time.

This implements step D4 of [ADR 0003-810](https://github.com/camunda/camunda/blob/main/zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md) (Business ID call activity propagation).

### What changed

**`ExecutableCallActivity`** — adds a `calledElementBusinessId` field (with getter/setter) to carry the parsed Business ID configuration. The field is intentionally `null`-significant:

| Field value | Meaning |
|---|---|
| `null` | Attribute absent → child inherits parent's Business ID |
| Empty static expression | Attribute present but empty → child gets no Business ID |
| Non-empty static expression | Literal Business ID value |
| Non-static expression | FEEL expression, evaluated at runtime |

**`CallActivityTransformer`** — adds `transformBusinessId(...)` which reads `calledElement.getBusinessId()`, distinguishes the "absent" case (using `hasBusinessId()`) from the "present" case, and populates the new field by parsing the value via `ExpressionLanguage`.

**`ZeebeRuntimeValidators`** — adds an `isOptional` expression validator for `ZeebeCalledElement::getBusinessId`, so that invalid FEEL expressions on `businessId` are rejected at deploy time rather than silently failing at runtime.

### Tests

- `CallActivityTransformerTest` — covers all four value forms: absent (inherit), present-empty, literal, and FEEL expression.
- `CallActivityBusinessIdValidationTest` — verifies that invalid FEEL expressions are rejected at deploy time with a clear message, and that all valid forms (absent, empty, literal, valid FEEL) deploy successfully.

## Related issues

closes #56166