### PR TITLE
fix: materialise lazy CamundaAuthentication lists before session serialisation

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/identity/SessionCamundaAuthenticationMaterializationInterceptor.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/SessionCamundaAuthenticationMaterializationInterceptor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.identity;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.spring.context.holder.HttpSessionBasedAuthenticationHolder;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Forces materialisation of lazy membership lists in the session-held {@link CamundaAuthentication}
+ * during {@code afterCompletion} — while {@code RequestContextHolder} (and therefore {@code
+ * PhysicalTenantContext}) is still bound to the current request thread — so that Java serialisation
+ * of the session attribute during {@code SessionRepositoryFilter.commitSession} (which runs after
+ * {@code DispatcherServlet} resets the request scope) can succeed without invoking the suppliers.
+ *
+ * <p>Without this, {@code LazyList.writeReplace()} calls the membership supplier during
+ * serialisation; the supplier calls {@code PhysicalTenantContext.current()}, which throws because
+ * the request scope is already torn down, causing a 500 {@code ConversionFailedException}.
+ */
+class SessionCamundaAuthenticationMaterializationInterceptor implements HandlerInterceptor {
+
+  @Override
+  public void afterCompletion(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final Object handler,
+      final Exception ex) {
+    final var session = request.getSession(false);
+    if (session == null) {
+      return;
+    }
+    final var attr =
+        session.getAttribute(
+            HttpSessionBasedAuthenticationHolder.CAMUNDA_AUTHENTICATION_SESSION_HOLDER_KEY);
+    if (!(attr instanceof final CamundaAuthentication auth)) {
+      return;
+    }
+    // Touch each list to trigger LazyList.resolve() while the request scope is still active.
+    // LazyList memoises the result and clears the supplier, so the subsequent writeReplace()
+    // during commitSession returns the cached value without needing PhysicalTenantContext.
+    auth.authenticatedGroupIds().size();
+    auth.authenticatedRoleIds().size();
+    auth.authenticatedTenantIds().size();
+    auth.authenticatedMappingRuleIds().size();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -33,6 +33,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
  * Host-side wiring for persistent web sessions. The session lifecycle beans (repository, mapper,
@@ -68,6 +70,16 @@ public class WebSessionRepositoryConfiguration {
   @Bean
   public WebSessionAttributeConverter webSessionAttributeConverter() {
     return new MigratingWebSessionAttributeConverter();
+  }
+
+  @Bean
+  public WebMvcConfigurer sessionMaterializationInterceptorConfigurer() {
+    return new WebMvcConfigurer() {
+      @Override
+      public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(new SessionCamundaAuthenticationMaterializationInterceptor());
+      }
+    };
   }
 
   @Bean

--- a/dist/src/test/java/io/camunda/application/commons/identity/SessionCamundaAuthenticationMaterializationInterceptorTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/SessionCamundaAuthenticationMaterializationInterceptorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.identity;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import io.camunda.security.spring.context.holder.HttpSessionBasedAuthenticationHolder;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
+
+class SessionCamundaAuthenticationMaterializationInterceptorTest {
+
+  private final SessionCamundaAuthenticationMaterializationInterceptor interceptor =
+      new SessionCamundaAuthenticationMaterializationInterceptor();
+
+  @Test
+  void shouldSkipWhenNoSessionExists() {
+    // given — request with no session
+    final var request = new MockHttpServletRequest();
+
+    // when/then — no exception
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                interceptor.afterCompletion(
+                    request, new MockHttpServletResponse(), new Object(), null));
+  }
+
+  @Test
+  void shouldSkipWhenSessionHasNoCamundaAuthentication() {
+    // given — session without the authentication attribute
+    final var session = new MockHttpSession();
+    session.setAttribute("some.other.key", "some-value");
+    final var request = new MockHttpServletRequest();
+    request.setSession(session);
+
+    // when/then — no exception
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                interceptor.afterCompletion(
+                    request, new MockHttpServletResponse(), new Object(), null));
+  }
+
+  /**
+   * Documents the root cause: if LazyList.writeReplace() calls a supplier that throws (e.g. because
+   * PhysicalTenantContext.current() is unavailable after the request scope is cleared), Java
+   * serialisation of CamundaAuthentication fails.
+   */
+  @Test
+  void shouldDocumentThatSerializationFailsWhenLazySupplierThrows() {
+    // given — lazy supplier that simulates PhysicalTenantContext.current() called post-request
+    final Supplier<List<String>> throwingSupplier =
+        () -> {
+          throw new IllegalStateException(
+              "PhysicalTenantContext.current() called outside a request scope");
+        };
+    final var auth =
+        CamundaAuthentication.of(b -> b.user("alice").tenantsSupplier(throwingSupplier));
+
+    // then — serialisation throws because LazyList.writeReplace() invokes the supplier
+    assertThatThrownBy(() -> serialize(auth)).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  void shouldMaterializeLazyListsBeforeSerializationHappens() throws Exception {
+    // given — CamundaAuthentication with lazy suppliers that become unavailable after the
+    // request scope is cleared (simulating PhysicalTenantContext.current() post-request)
+    final var contextAvailable = new AtomicBoolean(true);
+    final Supplier<List<String>> contextSensitiveSupplier =
+        () -> {
+          if (!contextAvailable.get()) {
+            throw new IllegalStateException(
+                "PhysicalTenantContext.current() called outside a request scope");
+          }
+          return List.of("tenant-1");
+        };
+    final var auth =
+        CamundaAuthentication.of(
+            b ->
+                b.user("alice")
+                    .groupIdsSupplier(contextSensitiveSupplier)
+                    .roleIdsSupplier(contextSensitiveSupplier)
+                    .tenantsSupplier(contextSensitiveSupplier)
+                    .mappingRulesSupplier(contextSensitiveSupplier));
+
+    final var session = new MockHttpSession();
+    session.setAttribute(
+        HttpSessionBasedAuthenticationHolder.CAMUNDA_AUTHENTICATION_SESSION_HOLDER_KEY, auth);
+    final var request = new MockHttpServletRequest();
+    request.setSession(session);
+
+    // when — interceptor runs while context is still available (inside afterCompletion)
+    interceptor.afterCompletion(request, new MockHttpServletResponse(), new Object(), null);
+
+    // then — mark context as unavailable (simulates DispatcherServlet clearing
+    // RequestContextHolder)
+    contextAvailable.set(false);
+
+    // Serialisation must succeed because LazyList is already materialised; the supplier is
+    // not called again during writeReplace()
+    assertThatNoException().isThrownBy(() -> serialize(auth));
+  }
+
+  private static byte[] serialize(final Object obj) throws IOException {
+    final var baos = new ByteArrayOutputStream();
+    try (final var oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(obj);
+    }
+    return baos.toByteArray();
+  }
+}


### PR DESCRIPTION
## What's happening

When persistent web sessions are enabled, `CamundaAuthentication` is stored in the HTTP session with its membership lists (groups, roles, tenants, mapping rules) held as lazy values — they don't execute the underlying database query until the list is first accessed. The query is routed to the correct physical-tenant service via `PhysicalTenantContext.current()`, which reads the current tenant from the active request scope.

The problem is **when** Java serialises the session. Spring Session's `SessionRepositoryFilter` commits (saves) the session in a `finally` block, **after** `DispatcherServlet` has finished handling the request and already cleared the request scope from `RequestContextHolder`. When serialisation triggers `LazyList.writeReplace()` to materialise the lists, the supplier calls `PhysicalTenantContext.current()`, finds no request scope, and throws `IllegalStateException`. This propagates as a `ConversionFailedException` 500.

The bug only surfaces on the **second** request (or any subsequent one within the authentication refresh interval), because that's when `HttpSessionBasedAuthenticationHolder` rebuilds `CamundaAuthentication` with fresh lazy lists and marks the session dirty — which triggers the save, which triggers the serialisation.

## Why this fix works

`HandlerInterceptor.afterCompletion()` runs **inside** `DispatcherServlet`, before the request scope is cleared. By touching each lazy list field there, we force `LazyList.resolve()` to execute — with `PhysicalTenantContext.current()` still available — and memoise the result. `LazyList` clears the supplier reference after the first resolution, so when `writeReplace()` is called during serialisation (after the scope is gone), it returns the already-resolved list without invoking the supplier again.

The interceptor is only registered when `@ConditionalOnPersistentWebSessionEnabled` is active, returns immediately if there's no session or no `CamundaAuthentication` in it, and adds no overhead for requests that don't touch the session.

## Testing

- `shouldDocumentThatSerializationFailsWhenLazySupplierThrows` — regression test that proves the bug: serialisation of a `CamundaAuthentication` with a throwing supplier fails.
- `shouldMaterializeLazyListsBeforeSerializationHappens` — proves the fix: after `afterCompletion()` runs, serialisation succeeds even when the supplier subsequently becomes unavailable (simulating the cleared request scope).

Closes #55964