### PR TITLE
test: IT for PT gRPC

### DIFF
--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -92,6 +92,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-gateway-model</artifactId>
       <scope>test</scope>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcBasicAuthIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcBasicAuthIT.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CredentialsProvider;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.qa.util.multidb.MultiDbPhysicalTenants;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * Verifies BASIC-auth isolation across physical tenants over gRPC.
+ *
+ * <ul>
+ *   <li>Absent {@code Camunda-Physical-Tenant} header resolves to {@code default}; querying the
+ *       default PT's user store confirms correct resolution.
+ *   <li>An unknown PT header is rejected with {@code UNAUTHENTICATED} — the PT is not in {@code
+ *       knownTenantIds}, a deliberate choice not to leak tenant existence.
+ *   <li>Credentials seeded in one tenant's user store are accepted on that tenant and rejected on
+ *       another whose store lacks them.
+ * </ul>
+ */
+@MultiDbTest
+@MultiDbPhysicalTenants({"tenanta", "tenantb"})
+@EnabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason = "Physical-tenant secondary storage is RDBMS-only")
+final class PhysicalTenantGrpcBasicAuthIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withAuthenticationMethod(AuthenticationMethod.BASIC);
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String PT_ADMIN_PASSWORD = "ptadmin";
+
+  @Test
+  void shouldRouteAbsentHeaderToDefaultPhysicalTenant() {
+    // given — a client with no physicalTenantId sends no Camunda-Physical-Tenant header
+    try (final var defaultAdmin =
+        defaultGrpcClient(
+            InitializationConfiguration.DEFAULT_USER_USERNAME,
+            InitializationConfiguration.DEFAULT_USER_PASSWORD)) {
+      // when
+      final var users =
+          defaultAdmin
+              .newUsersSearchRequest()
+              .filter(f -> f.username(InitializationConfiguration.DEFAULT_USER_USERNAME))
+              .send()
+              .join()
+              .items();
+      // then — the gateway resolved to 'default'; the default user is found in that PT's store
+      assertThat(users)
+          .as("default user found in the default PT's user store — confirms correct PT resolution")
+          .hasSize(1)
+          .first()
+          .extracting(u -> u.getUsername())
+          .isEqualTo(InitializationConfiguration.DEFAULT_USER_USERNAME);
+    }
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenantHeader() {
+    // given — valid default-PT credentials sent with a Camunda-Physical-Tenant header for a PT
+    // that is not registered; credentials are valid to rule out a missing-auth false positive
+    try (final var unknownPtClient =
+        grpcClient(
+            "unknownpt",
+            InitializationConfiguration.DEFAULT_USER_USERNAME,
+            InitializationConfiguration.DEFAULT_USER_PASSWORD)) {
+      // when / then — the gateway rejects because "unknownpt" is not in knownTenantIds
+      assertThatThrownBy(() -> unknownPtClient.newTopologyRequest().send().join())
+          .as("unknown PT header is rejected — PT is not in knownTenantIds")
+          .hasRootCauseInstanceOf(StatusRuntimeException.class)
+          .rootCause()
+          .satisfies(
+              e ->
+                  assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                      .isEqualTo(Status.Code.UNAUTHENTICATED));
+    }
+  }
+
+  @Test
+  void shouldAuthenticateTenantACredentialsOnlyInTenantA() {
+    // given — tenanta-admin credentials, seeded only in PT-A's user store
+    // when / then — accepted on PT-A
+    try (final var homeClient = grpcClient(TENANT_A, adminUsername(TENANT_A), PT_ADMIN_PASSWORD)) {
+      assertThatNoException()
+          .as("tenanta-admin is accepted on its home PT")
+          .isThrownBy(() -> homeClient.newTopologyRequest().send().join());
+    }
+
+    // when / then — rejected on PT-B whose store does not contain these credentials
+    try (final var wrongTenant = grpcClient(TENANT_B, adminUsername(TENANT_A), PT_ADMIN_PASSWORD)) {
+      assertThatThrownBy(() -> wrongTenant.newTopologyRequest().send().join())
+          .as("tenanta-admin exists only in PT-A's store")
+          .hasRootCauseInstanceOf(StatusRuntimeException.class)
+          .rootCause()
+          .satisfies(
+              e ->
+                  assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                      .isEqualTo(Status.Code.UNAUTHENTICATED));
+    }
+  }
+
+  @Test
+  void shouldAuthenticateTenantBCredentialsOnlyInTenantB() {
+    // given — tenantb-admin credentials, seeded only in PT-B's user store
+    // when / then — accepted on PT-B
+    try (final var homeClient = grpcClient(TENANT_B, adminUsername(TENANT_B), PT_ADMIN_PASSWORD)) {
+      assertThatNoException()
+          .as("tenantb-admin is accepted on its home PT")
+          .isThrownBy(() -> homeClient.newTopologyRequest().send().join());
+    }
+
+    // when / then — rejected on PT-A whose store does not contain these credentials
+    try (final var wrongTenant = grpcClient(TENANT_A, adminUsername(TENANT_B), PT_ADMIN_PASSWORD)) {
+      assertThatThrownBy(() -> wrongTenant.newTopologyRequest().send().join())
+          .as("tenantb-admin exists only in PT-B's store")
+          .hasRootCauseInstanceOf(StatusRuntimeException.class)
+          .rootCause()
+          .satisfies(
+              e ->
+                  assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                      .isEqualTo(Status.Code.UNAUTHENTICATED));
+    }
+  }
+
+  private static String adminUsername(final String tenantId) {
+    return tenantId + "-admin";
+  }
+
+  /**
+   * Builds a gRPC-first basic-auth client for the default physical tenant — no {@code
+   * physicalTenantId}, so no {@code Camunda-Physical-Tenant} header is sent and the gateway must
+   * resolve the absent header to {@code default}.
+   */
+  private static CamundaClient defaultGrpcClient(final String username, final String password) {
+    return BROKER
+        .newClientBuilder()
+        .preferRestOverGrpc(false)
+        .credentialsProvider(basicAuth(username, password))
+        .build();
+  }
+
+  /**
+   * Builds a gRPC-first basic-auth client targeting {@code targetTenantId} with the given
+   * credentials. The username is passed explicitly so callers can use credentials from a different
+   * PT to prove cross-PT rejection in isolation.
+   */
+  private static CamundaClient grpcClient(
+      final String targetTenantId, final String username, final String password) {
+    final String base = BROKER.restAddress().toString().replaceAll("/+$", "");
+    final URI restAddress = URI.create(base + "/physical-tenants/" + targetTenantId);
+    return BROKER
+        .newClientBuilder()
+        .physicalTenantId(targetTenantId)
+        .preferRestOverGrpc(false)
+        .restAddress(restAddress)
+        .grpcAddress(BROKER.grpcAddress())
+        .credentialsProvider(basicAuth(username, password))
+        .build();
+  }
+
+  private static CredentialsProvider basicAuth(final String username, final String password) {
+    return new BasicAuthCredentialsProviderBuilder()
+        .applyEnvironmentOverrides(false)
+        .username(username)
+        .password(password)
+        .build();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcBasicAuthIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcBasicAuthIT.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.it.auth;
 
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.PT_ADMIN_PASSWORD;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.physicalTenantAdminUsername;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -55,7 +57,6 @@ final class PhysicalTenantGrpcBasicAuthIT {
 
   private static final String TENANT_A = "tenanta";
   private static final String TENANT_B = "tenantb";
-  private static final String PT_ADMIN_PASSWORD = "ptadmin";
 
   @Test
   void shouldRouteAbsentHeaderToDefaultPhysicalTenant() {
@@ -107,14 +108,16 @@ final class PhysicalTenantGrpcBasicAuthIT {
   void shouldAuthenticateTenantACredentialsOnlyInTenantA() {
     // given — tenanta-admin credentials, seeded only in PT-A's user store
     // when / then — accepted on PT-A
-    try (final var homeClient = grpcClient(TENANT_A, adminUsername(TENANT_A), PT_ADMIN_PASSWORD)) {
+    try (final var homeClient =
+        grpcClient(TENANT_A, physicalTenantAdminUsername(TENANT_A), PT_ADMIN_PASSWORD)) {
       assertThatNoException()
           .as("tenanta-admin is accepted on its home PT")
           .isThrownBy(() -> homeClient.newTopologyRequest().send().join());
     }
 
     // when / then — rejected on PT-B whose store does not contain these credentials
-    try (final var wrongTenant = grpcClient(TENANT_B, adminUsername(TENANT_A), PT_ADMIN_PASSWORD)) {
+    try (final var wrongTenant =
+        grpcClient(TENANT_B, physicalTenantAdminUsername(TENANT_A), PT_ADMIN_PASSWORD)) {
       assertThatThrownBy(() -> wrongTenant.newTopologyRequest().send().join())
           .as("tenanta-admin exists only in PT-A's store")
           .hasRootCauseInstanceOf(StatusRuntimeException.class)
@@ -130,14 +133,16 @@ final class PhysicalTenantGrpcBasicAuthIT {
   void shouldAuthenticateTenantBCredentialsOnlyInTenantB() {
     // given — tenantb-admin credentials, seeded only in PT-B's user store
     // when / then — accepted on PT-B
-    try (final var homeClient = grpcClient(TENANT_B, adminUsername(TENANT_B), PT_ADMIN_PASSWORD)) {
+    try (final var homeClient =
+        grpcClient(TENANT_B, physicalTenantAdminUsername(TENANT_B), PT_ADMIN_PASSWORD)) {
       assertThatNoException()
           .as("tenantb-admin is accepted on its home PT")
           .isThrownBy(() -> homeClient.newTopologyRequest().send().join());
     }
 
     // when / then — rejected on PT-A whose store does not contain these credentials
-    try (final var wrongTenant = grpcClient(TENANT_A, adminUsername(TENANT_B), PT_ADMIN_PASSWORD)) {
+    try (final var wrongTenant =
+        grpcClient(TENANT_A, physicalTenantAdminUsername(TENANT_B), PT_ADMIN_PASSWORD)) {
       assertThatThrownBy(() -> wrongTenant.newTopologyRequest().send().join())
           .as("tenantb-admin exists only in PT-B's store")
           .hasRootCauseInstanceOf(StatusRuntimeException.class)
@@ -147,10 +152,6 @@ final class PhysicalTenantGrpcBasicAuthIT {
                   assertThat(((StatusRuntimeException) e).getStatus().getCode())
                       .isEqualTo(Status.Code.UNAUTHENTICATED));
     }
-  }
-
-  private static String adminUsername(final String tenantId) {
-    return tenantId + "-admin";
   }
 
   /**

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcBasicAuthStandaloneGatewayIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcBasicAuthStandaloneGatewayIT.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.security.api.model.config.initialization.InitializationConfiguration;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneGateway;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies BASIC-auth isolation across physical tenants over gRPC via a <em>standalone</em> gateway
+ * (embedded gateway disabled on the broker):
+ *
+ * <ul>
+ *   <li>Absent {@code Camunda-Physical-Tenant} header resolves to {@code default} and authenticates
+ *       against the default PT's user store.
+ *   <li>An unknown PT header is rejected with {@code UNAUTHENTICATED} — the PT is not in {@code
+ *       knownTenantIds}, a deliberate choice not to leak tenant existence.
+ *   <li>Credentials seeded in one tenant's user store are accepted on that tenant and rejected on
+ *       another whose store lacks them.
+ * </ul>
+ *
+ * @see PhysicalTenantGrpcBasicAuthIT for the embedded-gateway counterpart
+ */
+@ZeebeIntegration
+final class PhysicalTenantGrpcBasicAuthStandaloneGatewayIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String TENANT_A_PASSWORD = "password-a";
+  private static final String TENANT_B_PASSWORD = "password-b";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      builder()
+          .withTenant(DEFAULT_TENANT_ID, Storage.rdbmsH2("basic-default"))
+          .withTenant(TENANT_A, Storage.rdbmsH2("basic-tenanta"))
+          .withTenant(TENANT_B, Storage.rdbmsH2("basic-tenantb"))
+          .build();
+
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configureAdminRoles(
+          new TestStandaloneBroker()
+              .withAuthenticatedAccess()
+              .withBasicAuth()
+              // Disable the embedded gateway
+              .withGatewayEnabled(false));
+
+  // Standalone gateway wired to the broker's cluster port; shares the same RDBMS stores.
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneGateway GATEWAY =
+      new TestStandaloneGateway()
+          .withAuthenticatedAccess()
+          .withBasicAuth()
+          .withClusterConfig(
+              c -> c.setInitialContactPoints(List.of(BROKER.address(TestZeebePort.CLUSTER))));
+
+  private static CamundaClient defaultAdmin;
+  private static CamundaClient tenantAAdmin;
+  private static CamundaClient tenantBAdmin;
+
+  @BeforeAll
+  static void start() {
+    // Fresh H2 URLs per run; broker and gateway share the same stores so both must use the same
+    // URL.
+    final String defaultUrl = rdbmsH2Url("basic-default");
+    final String tenantAUrl = rdbmsH2Url("basic-tenanta");
+    final String tenantBUrl = rdbmsH2Url("basic-tenantb");
+
+    Storage.rdbms(defaultUrl, "sa", "").applyTo(BROKER, DEFAULT_TENANT_ID);
+    Storage.rdbms(tenantAUrl, "sa", "").applyTo(BROKER, TENANT_A);
+    Storage.rdbms(tenantBUrl, "sa", "").applyTo(BROKER, TENANT_B);
+
+    configureGateway(DEFAULT_TENANT_ID, defaultUrl);
+    configureGateway(TENANT_A, tenantAUrl);
+    configureGateway(TENANT_B, tenantBUrl);
+
+    TENANTS.seedBasicAuthAdminUser(BROKER, TENANT_A, TENANT_A_PASSWORD);
+    TENANTS.seedBasicAuthAdminUser(BROKER, TENANT_B, TENANT_B_PASSWORD);
+
+    BROKER.start();
+    GATEWAY.start();
+
+    // No physicalTenantId — the gateway must resolve the absent header to the default PT.
+    defaultAdmin =
+        GATEWAY
+            .newClientBuilder()
+            .preferRestOverGrpc(false)
+            .credentialsProvider(
+                new BasicAuthCredentialsProviderBuilder()
+                    .applyEnvironmentOverrides(false)
+                    .username(InitializationConfiguration.DEFAULT_USER_USERNAME)
+                    .password(InitializationConfiguration.DEFAULT_USER_PASSWORD)
+                    .build())
+            .build();
+    tenantAAdmin =
+        TENANTS
+            .newBasicAuthAdminClientBuilder(GATEWAY, TENANT_A, TENANT_A_PASSWORD)
+            .preferRestOverGrpc(false)
+            .build();
+    tenantBAdmin =
+        TENANTS
+            .newBasicAuthAdminClientBuilder(GATEWAY, TENANT_B, TENANT_B_PASSWORD)
+            .preferRestOverGrpc(false)
+            .build();
+
+    awaitAuth(defaultAdmin, "default-admin ready");
+    awaitAuth(tenantAAdmin, "tenanta-admin ready");
+    awaitAuth(tenantBAdmin, "tenantb-admin ready");
+  }
+
+  @AfterAll
+  static void closeClients() {
+    CloseHelper.quietCloseAll(defaultAdmin, tenantAAdmin, tenantBAdmin);
+  }
+
+  @Test
+  void shouldRouteAbsentHeaderToDefaultPhysicalTenant() {
+    // given — a client with no physicalTenantId sends no Camunda-Physical-Tenant header
+    // when / then — topology succeeds; default user is authenticated via the default PT's store
+    // (standalone gateway serves topology without the Camunda REST API)
+    assertThatNoException()
+        .as("default user is authenticated via the default PT's user store")
+        .isThrownBy(() -> defaultAdmin.newTopologyRequest().send().join());
+  }
+
+  @Test
+  void shouldAuthenticateTenantACredentialsOnlyInTenantA() {
+    // given — credentials seeded only in PT-A's user store
+    // when / then — accepted on PT-A
+    assertThatNoException()
+        .as("tenanta-admin is accepted on its home PT")
+        .isThrownBy(() -> tenantAAdmin.newTopologyRequest().send().join());
+
+    // when / then — rejected on PT-B whose store does not contain these credentials
+    try (final var wrongTenant =
+        basicAuthClient(GATEWAY, TENANT_B, TENANTS.adminUsername(TENANT_A), TENANT_A_PASSWORD)) {
+      assertThatThrownBy(() -> wrongTenant.newTopologyRequest().send().join())
+          .as("tenanta-admin exists only in PT-A's store")
+          .hasRootCauseInstanceOf(StatusRuntimeException.class)
+          .rootCause()
+          .satisfies(
+              e ->
+                  assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                      .isEqualTo(Status.Code.UNAUTHENTICATED));
+    }
+  }
+
+  @Test
+  void shouldAuthenticateTenantBCredentialsOnlyInTenantB() {
+    // given — credentials seeded only in PT-B's user store
+    // when / then — accepted on PT-B
+    assertThatNoException()
+        .as("tenantb-admin is accepted on its home PT")
+        .isThrownBy(() -> tenantBAdmin.newTopologyRequest().send().join());
+
+    // when / then — rejected on PT-A whose store does not contain these credentials
+    try (final var wrongTenant =
+        basicAuthClient(GATEWAY, TENANT_A, TENANTS.adminUsername(TENANT_B), TENANT_B_PASSWORD)) {
+      assertThatThrownBy(() -> wrongTenant.newTopologyRequest().send().join())
+          .as("tenantb-admin exists only in PT-B's store")
+          .hasRootCauseInstanceOf(StatusRuntimeException.class)
+          .rootCause()
+          .satisfies(
+              e ->
+                  assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                      .isEqualTo(Status.Code.UNAUTHENTICATED));
+    }
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenantHeader() {
+    // given — valid default-PT credentials sent with a Camunda-Physical-Tenant header for a PT
+    // that is not registered; credentials are valid to rule out a missing-auth false positive
+    try (final var client =
+        GATEWAY
+            .newClientBuilder()
+            .preferRestOverGrpc(false)
+            .physicalTenantId("unknownpt")
+            .credentialsProvider(
+                new BasicAuthCredentialsProviderBuilder()
+                    .applyEnvironmentOverrides(false)
+                    .username(InitializationConfiguration.DEFAULT_USER_USERNAME)
+                    .password(InitializationConfiguration.DEFAULT_USER_PASSWORD)
+                    .build())
+            .build()) {
+      // when / then — the gateway rejects because "unknownpt" is not in knownTenantIds,
+      // not because credentials are missing
+      assertThatThrownBy(() -> client.newTopologyRequest().send().join())
+          .as("unknown PT header is rejected — PT is not in knownTenantIds")
+          .hasRootCauseInstanceOf(StatusRuntimeException.class)
+          .rootCause()
+          .satisfies(
+              e ->
+                  assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                      .isEqualTo(Status.Code.UNAUTHENTICATED));
+    }
+  }
+
+  private static void configureGateway(final String tenantId, final String url) {
+    final boolean isDefault = DEFAULT_TENANT_ID.equals(tenantId);
+    if (isDefault) {
+      GATEWAY.withUnifiedConfig(
+          c -> {
+            c.getData().getSecondaryStorage().setType(SecondaryStorageType.rdbms);
+            c.getData().getSecondaryStorage().getRdbms().setUrl(url);
+            c.getData().getSecondaryStorage().getRdbms().setUsername("sa");
+            c.getData().getSecondaryStorage().getRdbms().setPassword("");
+          });
+    } else {
+      GATEWAY.withPtConfig(
+          tenantId,
+          c -> {
+            c.getData().getSecondaryStorage().setType(SecondaryStorageType.rdbms);
+            c.getData().getSecondaryStorage().getRdbms().setUrl(url);
+            c.getData().getSecondaryStorage().getRdbms().setUsername("sa");
+            c.getData().getSecondaryStorage().getRdbms().setPassword("");
+          });
+      // PhysicalTenantRequiredOverrideValidation requires a security.initialization.* key for
+      // every explicitly-configured non-default PT. The gateway never runs initialization — the
+      // key's presence is all the validator checks.
+      GATEWAY.withPtConfig(
+          tenantId,
+          c ->
+              c.getSecurity()
+                  .getInitialization()
+                  .setDefaultRoles(
+                      Map.of("admin", Map.of("users", List.of(TENANTS.adminUsername(tenantId))))));
+    }
+  }
+
+  /**
+   * Builds a gRPC-first basic-auth client targeting {@code targetTenantId} with the given
+   * credentials. The username is passed explicitly so callers can use credentials from a different
+   * PT to prove cross-PT rejection in isolation.
+   */
+  private static CamundaClient basicAuthClient(
+      final TestGateway<?> gateway,
+      final String targetTenantId,
+      final String username,
+      final String password) {
+    return TENANTS
+        .newClientBuilder(gateway, targetTenantId)
+        .preferRestOverGrpc(false)
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder()
+                .applyEnvironmentOverrides(false)
+                .username(username)
+                .password(password)
+                .build())
+        .build();
+  }
+
+  private static void awaitAuth(final CamundaClient client, final String reason) {
+    Awaitility.await(reason)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(() -> client.newTopologyRequest().send().join());
+  }
+
+  private static String rdbmsH2Url(final String prefix) {
+    return "jdbc:h2:mem:" + prefix + "-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcOidcAuthIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcOidcAuthIT.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.DefaultTestContainers;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies OIDC authentication isolation across physical tenants over gRPC: a token issued by one
+ * tenant's IdP (distinct issuer) is accepted on that tenant and rejected on another whose OIDC
+ * configuration points at a different issuer.
+ *
+ * <p>Tests use {@code newTopologyRequest()} rather than a PT-scoped data operation because topology
+ * is served by the gateway layer without partition involvement, making it reliable in this
+ * lightweight OIDC setup. It hits the same gRPC auth interceptor as any other call, so it proves
+ * whether the token is accepted or rejected based on issuer match. {@code Storage.none()} is
+ * intentional: OIDC credentials live in Keycloak, not in a per-PT user store.
+ */
+@Testcontainers
+@ZeebeIntegration
+final class PhysicalTenantGrpcOidcAuthIT {
+
+  @Container
+  static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String REALM_A = "realm-a";
+  private static final String REALM_B = "realm-b";
+  private static final String CLIENT_ID_A = "client-a";
+  private static final String CLIENT_SECRET_A = "secret-a";
+  private static final String CLIENT_ID_B = "client-b";
+  private static final String CLIENT_SECRET_B = "secret-b";
+  private static final String AUDIENCE = "zeebe";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withAuthenticatedAccess()
+              .withAuthenticationMethod(AuthenticationMethod.OIDC));
+
+  // PT-A token targeting PT-A (accepted) and PT-B (rejected — wrong issuer)
+  private static CamundaClient tenantAClient;
+  private static CamundaClient tenantAOnTenantBClient;
+
+  // PT-B token targeting PT-B (accepted) and PT-A (rejected — wrong issuer)
+  private static CamundaClient tenantBClient;
+  private static CamundaClient tenantBOnTenantAClient;
+
+  @BeforeAll
+  static void startBroker(@TempDir final Path tempDir) {
+    configureRealm(REALM_A, CLIENT_ID_A, CLIENT_SECRET_A);
+    configureRealm(REALM_B, CLIENT_ID_B, CLIENT_SECRET_B);
+
+    final String keycloakBase = KEYCLOAK.getAuthServerUrl();
+    // withSecurityConfig sets the broker-wide OIDC issuer used by the default physical tenant;
+    // non-default PTs override it via configureTenantOidc below.
+    // redirectUri must be set because Spring's OAuth2 client registration requires it as a
+    // mandatory field even in resource-server (gRPC) mode where no browser redirect ever occurs.
+    BROKER.withSecurityConfig(
+        c -> {
+          c.getAuthentication().getOidc().setIssuerUri(keycloakBase + "/realms/" + REALM_A);
+          c.getAuthentication().getOidc().setClientId(CLIENT_ID_A);
+          c.getAuthentication().getOidc().setRedirectUri("{baseUrl}/login/oauth2/code/oidc");
+        });
+    // PT-A: same realm as root; PT-B: distinct realm so its issuer differs from PT-A.
+    configureTenantOidc(TENANT_A, keycloakBase + "/realms/" + REALM_A, CLIENT_ID_A);
+    configureTenantOidc(TENANT_B, keycloakBase + "/realms/" + REALM_B, CLIENT_ID_B);
+
+    BROKER.start();
+
+    tenantAClient = oidcClient(REALM_A, CLIENT_ID_A, CLIENT_SECRET_A, TENANT_A, tempDir);
+    tenantAOnTenantBClient = oidcClient(REALM_A, CLIENT_ID_A, CLIENT_SECRET_A, TENANT_B, tempDir);
+    tenantBClient = oidcClient(REALM_B, CLIENT_ID_B, CLIENT_SECRET_B, TENANT_B, tempDir);
+    tenantBOnTenantAClient = oidcClient(REALM_B, CLIENT_ID_B, CLIENT_SECRET_B, TENANT_A, tempDir);
+
+    Awaitility.await("broker ready")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(() -> tenantAClient.newTopologyRequest().send().join());
+  }
+
+  @AfterAll
+  static void closeClients() {
+    CloseHelper.quietCloseAll(
+        tenantAClient, tenantAOnTenantBClient, tenantBClient, tenantBOnTenantAClient);
+  }
+
+  @Test
+  void shouldAuthenticateTenantAOidcTokenOnlyInTenantA() {
+    // given — a token issued by PT-A's IdP (realm-a)
+    // when / then — accepted on PT-A whose OIDC config points at the same issuer
+    assertThatNoException()
+        .as("PT-A token is accepted on PT-A — issuer matches")
+        .isThrownBy(() -> tenantAClient.newTopologyRequest().send().join());
+
+    // when / then — rejected on PT-B whose OIDC config points at a different issuer
+    assertThatThrownBy(() -> tenantAOnTenantBClient.newTopologyRequest().send().join())
+        .as("PT-A token is rejected on PT-B — issuer mismatch")
+        .hasRootCauseInstanceOf(StatusRuntimeException.class)
+        .rootCause()
+        .satisfies(
+            e ->
+                assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                    .isEqualTo(Status.Code.UNAUTHENTICATED));
+  }
+
+  @Test
+  void shouldAuthenticateTenantBOidcTokenOnlyInTenantB() {
+    // given — a token issued by PT-B's IdP (realm-b)
+    // when / then — accepted on PT-B whose OIDC config points at the same issuer
+    assertThatNoException()
+        .as("PT-B token is accepted on PT-B — issuer matches")
+        .isThrownBy(() -> tenantBClient.newTopologyRequest().send().join());
+
+    // when / then — rejected on PT-A whose OIDC config points at a different issuer
+    assertThatThrownBy(() -> tenantBOnTenantAClient.newTopologyRequest().send().join())
+        .as("PT-B token is rejected on PT-A — issuer mismatch")
+        .hasRootCauseInstanceOf(StatusRuntimeException.class)
+        .rootCause()
+        .satisfies(
+            e ->
+                assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                    .isEqualTo(Status.Code.UNAUTHENTICATED));
+  }
+
+  private static void configureTenantOidc(
+      final String tenantId, final String issuerUri, final String clientId) {
+    BROKER.withPtConfig(
+        tenantId,
+        c -> {
+          final var oidc = c.getSecurity().getAuthentication().getOidc();
+          oidc.setIssuerUri(issuerUri);
+          oidc.setClientId(clientId);
+          oidc.setRedirectUri("{baseUrl}/login/oauth2/code/oidc");
+        });
+    // providers.assigned = ["oidc"] selects the per-PT default slot (authentication.oidc.*) as the
+    // active provider for this PT; required for all non-default PTs under OIDC authentication.
+    BROKER.withProperty(
+        "camunda.physical-tenants." + tenantId + ".security.authentication.providers.assigned[0]",
+        "oidc");
+  }
+
+  private static void configureRealm(
+      final String realmName, final String clientId, final String clientSecret) {
+    final var clientRepresentation = new ClientRepresentation();
+    clientRepresentation.setClientId(clientId);
+    clientRepresentation.setEnabled(true);
+    clientRepresentation.setClientAuthenticatorType("client-secret");
+    clientRepresentation.setSecret(clientSecret);
+    clientRepresentation.setServiceAccountsEnabled(true);
+
+    final var realmRepresentation = new RealmRepresentation();
+    realmRepresentation.setRealm(realmName);
+    realmRepresentation.setEnabled(true);
+    realmRepresentation.setClients(List.of(clientRepresentation));
+
+    try (final var admin = KEYCLOAK.getKeycloakAdminClient()) {
+      admin.realms().create(realmRepresentation);
+    }
+  }
+
+  private static CamundaClient oidcClient(
+      final String realm,
+      final String clientId,
+      final String clientSecret,
+      final String targetTenantId,
+      final Path credentialsCacheDir) {
+    return TENANTS
+        .newClientBuilder(BROKER, targetTenantId)
+        .preferRestOverGrpc(false)
+        .credentialsProvider(
+            new OAuthCredentialsProviderBuilder()
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .audience(AUDIENCE)
+                .authorizationServerUrl(
+                    KEYCLOAK.getAuthServerUrl()
+                        + "/realms/"
+                        + realm
+                        + "/protocol/openid-connect/token")
+                .credentialsCachePath(
+                    credentialsCacheDir.resolve(realm + "-on-" + targetTenantId).toString())
+                .build())
+        .build();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcOidcAuthStandaloneGatewayIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcOidcAuthStandaloneGatewayIT.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneGateway;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.DefaultTestContainers;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies OIDC authentication isolation across physical tenants over gRPC via a
+ * <em>standalone</em> gateway (no broker needed — OIDC token validation is self-contained in the
+ * gateway):
+ *
+ * <ul>
+ *   <li>A token issued by PT-A's IdP is accepted on PT-A and rejected on PT-B (issuer mismatch).
+ *   <li>A token issued by PT-B's IdP is accepted on PT-B and rejected on PT-A.
+ * </ul>
+ *
+ * <p>{@code newTopologyRequest()} is used as the sentinel — the standalone gateway serves topology
+ * with an empty broker list (no exception), exercising the auth interceptor without requiring
+ * partition involvement. {@code Storage.none()} is intentional: OIDC credentials live in Keycloak,
+ * not in a per-PT user store.
+ *
+ * @see PhysicalTenantGrpcOidcAuthIT for the embedded-gateway counterpart
+ */
+@Testcontainers
+@ZeebeIntegration
+final class PhysicalTenantGrpcOidcAuthStandaloneGatewayIT {
+
+  @Container
+  static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String REALM_A = "realm-a";
+  private static final String REALM_B = "realm-b";
+  private static final String CLIENT_ID_A = "client-a";
+  private static final String CLIENT_SECRET_A = "secret-a";
+  private static final String CLIENT_ID_B = "client-b";
+  private static final String CLIENT_SECRET_B = "secret-b";
+  private static final String AUDIENCE = "zeebe";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  // Standalone gateway — no broker needed; OIDC token validation is self-contained in the gateway.
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneGateway GATEWAY =
+      new TestStandaloneGateway()
+          .withAuthenticatedAccess()
+          .withAuthenticationMethod(AuthenticationMethod.OIDC);
+
+  // PT-A token targeting PT-A (accepted) and PT-B (rejected — wrong issuer)
+  private static CamundaClient tenantAClient;
+  private static CamundaClient tenantAOnTenantBClient;
+
+  // PT-B token targeting PT-B (accepted) and PT-A (rejected — wrong issuer)
+  private static CamundaClient tenantBClient;
+  private static CamundaClient tenantBOnTenantAClient;
+
+  @BeforeAll
+  static void startGateway(@TempDir final Path tempDir) {
+    configureRealm(REALM_A, CLIENT_ID_A, CLIENT_SECRET_A);
+    configureRealm(REALM_B, CLIENT_ID_B, CLIENT_SECRET_B);
+
+    // Prevents the secondary-storage-sharing validation from rejecting startup when all PTs
+    // default to the same elasticsearch endpoint.
+    GATEWAY.withUnifiedConfig(
+        c -> c.getData().getSecondaryStorage().setType(SecondaryStorageType.none));
+
+    final String keycloakBase = KEYCLOAK.getAuthServerUrl();
+    // Gateway-wide OIDC issuer for the default PT; non-default PTs override via
+    // configureTenantOidc.
+    // redirectUri is mandatory for Spring OAuth2 client registration even in resource-server mode.
+    GATEWAY.withUnifiedConfig(
+        c -> {
+          c.getSecurity()
+              .getAuthentication()
+              .getOidc()
+              .setIssuerUri(keycloakBase + "/realms/" + REALM_A);
+          c.getSecurity().getAuthentication().getOidc().setClientId(CLIENT_ID_A);
+          c.getSecurity()
+              .getAuthentication()
+              .getOidc()
+              .setRedirectUri("{baseUrl}/login/oauth2/code/oidc");
+        });
+    // PT-A: same realm as root; PT-B: distinct realm so its issuer differs from PT-A.
+    configureTenantOidc(TENANT_A, keycloakBase + "/realms/" + REALM_A, CLIENT_ID_A);
+    configureTenantOidc(TENANT_B, keycloakBase + "/realms/" + REALM_B, CLIENT_ID_B);
+
+    GATEWAY.start();
+
+    tenantAClient = oidcClient(REALM_A, CLIENT_ID_A, CLIENT_SECRET_A, TENANT_A, tempDir);
+    tenantAOnTenantBClient = oidcClient(REALM_A, CLIENT_ID_A, CLIENT_SECRET_A, TENANT_B, tempDir);
+    tenantBClient = oidcClient(REALM_B, CLIENT_ID_B, CLIENT_SECRET_B, TENANT_B, tempDir);
+    tenantBOnTenantAClient = oidcClient(REALM_B, CLIENT_ID_B, CLIENT_SECRET_B, TENANT_A, tempDir);
+
+    awaitAuth(tenantAClient, "gateway ready");
+  }
+
+  @AfterAll
+  static void closeClients() {
+    CloseHelper.quietCloseAll(
+        tenantAClient, tenantAOnTenantBClient, tenantBClient, tenantBOnTenantAClient);
+  }
+
+  @Test
+  void shouldAuthenticateTenantAOidcTokenOnlyInTenantA() {
+    // given — a token issued by PT-A's IdP (realm-a)
+    // when / then — accepted on PT-A whose OIDC config points at the same issuer
+    assertThatNoException()
+        .as("PT-A token is accepted on PT-A — issuer matches")
+        .isThrownBy(() -> tenantAClient.newTopologyRequest().send().join());
+
+    // when / then — rejected on PT-B whose OIDC config points at a different issuer
+    assertThatThrownBy(() -> tenantAOnTenantBClient.newTopologyRequest().send().join())
+        .as("PT-A token is rejected on PT-B — issuer mismatch")
+        .hasRootCauseInstanceOf(StatusRuntimeException.class)
+        .rootCause()
+        .satisfies(
+            e ->
+                assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                    .isEqualTo(Status.Code.UNAUTHENTICATED));
+  }
+
+  @Test
+  void shouldAuthenticateTenantBOidcTokenOnlyInTenantB() {
+    // given — a token issued by PT-B's IdP (realm-b)
+    // when / then — accepted on PT-B whose OIDC config points at the same issuer
+    assertThatNoException()
+        .as("PT-B token is accepted on PT-B — issuer matches")
+        .isThrownBy(() -> tenantBClient.newTopologyRequest().send().join());
+
+    // when / then — rejected on PT-A whose OIDC config points at a different issuer
+    assertThatThrownBy(() -> tenantBOnTenantAClient.newTopologyRequest().send().join())
+        .as("PT-B token is rejected on PT-A — issuer mismatch")
+        .hasRootCauseInstanceOf(StatusRuntimeException.class)
+        .rootCause()
+        .satisfies(
+            e ->
+                assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                    .isEqualTo(Status.Code.UNAUTHENTICATED));
+  }
+
+  private static void configureTenantOidc(
+      final String tenantId, final String issuerUri, final String clientId) {
+    GATEWAY.withPtConfig(
+        tenantId,
+        c -> {
+          c.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
+          final var oidc = c.getSecurity().getAuthentication().getOidc();
+          oidc.setIssuerUri(issuerUri);
+          oidc.setClientId(clientId);
+          oidc.setRedirectUri("{baseUrl}/login/oauth2/code/oidc");
+        });
+    // providers.assigned = ["oidc"] selects the per-PT default slot (authentication.oidc.*) as the
+    // active provider for this PT; required for all non-default PTs under OIDC authentication.
+    GATEWAY.withProperty(
+        "camunda.physical-tenants." + tenantId + ".security.authentication.providers.assigned[0]",
+        "oidc");
+    // PhysicalTenantRequiredOverrideValidation requires a security.initialization.* key for every
+    // explicitly-configured non-default PT. The gateway does not run identity initialization, but
+    // the resolver validates config structure at startup the same way the broker does.
+    GATEWAY.withPtConfig(
+        tenantId,
+        c ->
+            c.getSecurity()
+                .getInitialization()
+                .setDefaultRoles(
+                    Map.of("admin", Map.of("users", List.of(TENANTS.adminUsername(tenantId))))));
+  }
+
+  private static void configureRealm(
+      final String realmName, final String clientId, final String clientSecret) {
+    final var clientRepresentation = new ClientRepresentation();
+    clientRepresentation.setClientId(clientId);
+    clientRepresentation.setEnabled(true);
+    clientRepresentation.setClientAuthenticatorType("client-secret");
+    clientRepresentation.setSecret(clientSecret);
+    clientRepresentation.setServiceAccountsEnabled(true);
+
+    final var realmRepresentation = new RealmRepresentation();
+    realmRepresentation.setRealm(realmName);
+    realmRepresentation.setEnabled(true);
+    realmRepresentation.setClients(List.of(clientRepresentation));
+
+    try (final var admin = KEYCLOAK.getKeycloakAdminClient()) {
+      admin.realms().create(realmRepresentation);
+    }
+  }
+
+  private static CamundaClient oidcClient(
+      final String realm,
+      final String clientId,
+      final String clientSecret,
+      final String targetTenantId,
+      final Path credentialsCacheDir) {
+    return TENANTS
+        .newClientBuilder(GATEWAY, targetTenantId)
+        .preferRestOverGrpc(false)
+        .credentialsProvider(
+            new OAuthCredentialsProviderBuilder()
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .audience(AUDIENCE)
+                .authorizationServerUrl(
+                    KEYCLOAK.getAuthServerUrl()
+                        + "/realms/"
+                        + realm
+                        + "/protocol/openid-connect/token")
+                .credentialsCachePath(
+                    credentialsCacheDir.resolve(realm + "-on-" + targetTenantId).toString())
+                .build())
+        .build();
+  }
+
+  private static void awaitAuth(final CamundaClient client, final String reason) {
+    Awaitility.await(reason)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(() -> client.newTopologyRequest().send().join());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcOidcClaimMappingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcOidcClaimMappingIT.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.DefaultTestContainers;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.ProtocolMapperRepresentation;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * Verifies OIDC claim-mapping isolation across physical tenants over gRPC: both PTs trust the SAME
+ * issuer (one shared Keycloak realm), so the issuer cannot be the discriminator. Instead, each PT
+ * maps the caller identity from its OWN distinct custom claim, used as both {@code usernameClaim}
+ * and {@code clientIdClaim}, and each OIDC client's access token carries a distinct custom claim
+ * (injected via a Keycloak hardcoded-claim protocol mapper). A token is accepted only on the PT
+ * whose configured claim it actually carries — on the other PT, neither claim resolves, so
+ * authentication is rejected (UNAUTHENTICATED) — proving that per-PT claim mapping, not just issuer
+ * matching, is applied.
+ *
+ * <p>Tests use {@code newTopologyRequest()} rather than a PT-scoped data operation because topology
+ * is served by the gateway layer without partition involvement, making it reliable in this
+ * lightweight OIDC setup. It hits the same gRPC auth interceptor as any other call, so it proves
+ * whether the token is accepted or rejected based on the mapped client id. {@code Storage.none()}
+ * is intentional: OIDC credentials live in Keycloak, not in a per-PT user store.
+ */
+@Testcontainers
+@ZeebeIntegration
+final class PhysicalTenantGrpcOidcClaimMappingIT {
+
+  @Container
+  static final KeycloakContainer KEYCLOAK = DefaultTestContainers.createDefaultKeycloak();
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String REALM_SHARED = "realm-shared";
+  private static final String CLIENT_ID_A = "client-a";
+  private static final String CLIENT_SECRET_A = "secret-a";
+  private static final String CLIENT_ID_B = "client-b";
+  private static final String CLIENT_SECRET_B = "secret-b";
+  private static final String CLAIM_A = "client-a-id";
+  private static final String CLAIM_B = "client-b-id";
+  private static final String AUDIENCE = "zeebe";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(
+          new TestStandaloneBroker()
+              .withAuthenticatedAccess()
+              .withAuthenticationMethod(AuthenticationMethod.OIDC));
+
+  // client-a token targeting PT-A (accepted) and PT-B (rejected — claim not mapped there)
+  private static CamundaClient clientAOnA;
+  private static CamundaClient clientAOnB;
+
+  // client-b token targeting PT-B (accepted) and PT-A (rejected — claim not mapped there)
+  private static CamundaClient clientBOnB;
+  private static CamundaClient clientBOnA;
+
+  @BeforeAll
+  static void startBroker(@TempDir final Path tempDir) {
+    configureRealm();
+
+    final String issuerUri = KEYCLOAK.getAuthServerUrl() + "/realms/" + REALM_SHARED;
+    // withSecurityConfig sets the broker-wide OIDC issuer used by the default physical tenant;
+    // non-default PTs override it (to the same issuer) plus their claim mapping below.
+    // redirectUri must be set because Spring's OAuth2 client registration requires it as a
+    // mandatory field even in resource-server (gRPC) mode where no browser redirect ever occurs.
+    BROKER.withSecurityConfig(
+        c -> {
+          c.getAuthentication().getOidc().setIssuerUri(issuerUri);
+          c.getAuthentication().getOidc().setClientId(CLIENT_ID_A);
+          c.getAuthentication().getOidc().setRedirectUri("{baseUrl}/login/oauth2/code/oidc");
+        });
+    // Both PTs share the SAME issuer; only the claim mapping differs, isolating claim mapping
+    // from issuer isolation.
+    configureTenantOidc(TENANT_A, issuerUri, CLAIM_A);
+    configureTenantOidc(TENANT_B, issuerUri, CLAIM_B);
+
+    BROKER.start();
+
+    clientAOnA = oidcClient(CLIENT_ID_A, CLIENT_SECRET_A, TENANT_A, tempDir);
+    clientAOnB = oidcClient(CLIENT_ID_A, CLIENT_SECRET_A, TENANT_B, tempDir);
+    clientBOnB = oidcClient(CLIENT_ID_B, CLIENT_SECRET_B, TENANT_B, tempDir);
+    clientBOnA = oidcClient(CLIENT_ID_B, CLIENT_SECRET_B, TENANT_A, tempDir);
+
+    Awaitility.await("broker ready")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(() -> clientAOnA.newTopologyRequest().send().join());
+  }
+
+  @AfterAll
+  static void closeClients() {
+    CloseHelper.quietCloseAll(clientAOnA, clientAOnB, clientBOnB, clientBOnA);
+  }
+
+  @Test
+  void shouldAuthenticateClientAClaimOnlyInTenantA() {
+    // given — a client-a token carrying the "client-a-id" claim
+    // when / then — accepted on PT-A whose clientIdClaim is "client-a-id"
+    assertThatNoException()
+        .as("client-a token is accepted on PT-A — clientIdClaim matches")
+        .isThrownBy(() -> clientAOnA.newTopologyRequest().send().join());
+
+    // when / then — rejected on PT-B whose clientIdClaim is "client-b-id" (not present on token)
+    assertThatThrownBy(() -> clientAOnB.newTopologyRequest().send().join())
+        .as("client-a token is rejected on PT-B — clientIdClaim not present on token")
+        .hasRootCauseInstanceOf(StatusRuntimeException.class)
+        .rootCause()
+        .satisfies(
+            e ->
+                assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                    .isEqualTo(Status.Code.UNAUTHENTICATED));
+  }
+
+  @Test
+  void shouldAuthenticateClientBClaimOnlyInTenantB() {
+    // given — a client-b token carrying the "client-b-id" claim
+    // when / then — accepted on PT-B whose clientIdClaim is "client-b-id"
+    assertThatNoException()
+        .as("client-b token is accepted on PT-B — clientIdClaim matches")
+        .isThrownBy(() -> clientBOnB.newTopologyRequest().send().join());
+
+    // when / then — rejected on PT-A whose clientIdClaim is "client-a-id" (not present on token)
+    assertThatThrownBy(() -> clientBOnA.newTopologyRequest().send().join())
+        .as("client-b token is rejected on PT-A — clientIdClaim not present on token")
+        .hasRootCauseInstanceOf(StatusRuntimeException.class)
+        .rootCause()
+        .satisfies(
+            e ->
+                assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                    .isEqualTo(Status.Code.UNAUTHENTICATED));
+  }
+
+  private static void configureTenantOidc(
+      final String tenantId, final String issuerUri, final String claimName) {
+    BROKER.withPtConfig(
+        tenantId,
+        c -> {
+          final var oidc = c.getSecurity().getAuthentication().getOidc();
+          oidc.setIssuerUri(issuerUri);
+          // Both usernameClaim and clientIdClaim point at this PT's own custom claim: on a token
+          // that doesn't carry it, neither resolves, so authentication is rejected outright.
+          oidc.setUsernameClaim(claimName);
+          oidc.setClientIdClaim(claimName);
+          oidc.setRedirectUri("{baseUrl}/login/oauth2/code/oidc");
+        });
+    // providers.assigned = ["oidc"] selects the per-PT default slot (authentication.oidc.*) as the
+    // active provider for this PT; required for all non-default PTs under OIDC authentication.
+    BROKER.withProperty(
+        "camunda.physical-tenants." + tenantId + ".security.authentication.providers.assigned[0]",
+        "oidc");
+  }
+
+  private static void configureRealm() {
+    final var clientA = clientWithHardcodedClaim(CLIENT_ID_A, CLIENT_SECRET_A, CLAIM_A);
+    final var clientB = clientWithHardcodedClaim(CLIENT_ID_B, CLIENT_SECRET_B, CLAIM_B);
+
+    final var realmRepresentation = new RealmRepresentation();
+    realmRepresentation.setRealm(REALM_SHARED);
+    realmRepresentation.setEnabled(true);
+    realmRepresentation.setClients(List.of(clientA, clientB));
+
+    try (final var admin = KEYCLOAK.getKeycloakAdminClient()) {
+      admin.realms().create(realmRepresentation);
+    }
+  }
+
+  private static ClientRepresentation clientWithHardcodedClaim(
+      final String clientId, final String clientSecret, final String claimName) {
+    final var mapper = new ProtocolMapperRepresentation();
+    mapper.setName(claimName + "-mapper");
+    mapper.setProtocol("openid-connect");
+    mapper.setProtocolMapper("oidc-hardcoded-claim-mapper");
+    mapper.setConfig(
+        Map.of(
+            "claim.name", claimName,
+            "claim.value", clientId,
+            "jsonType.label", "String",
+            "access.token.claim", "true",
+            "id.token.claim", "true"));
+
+    final var clientRepresentation = new ClientRepresentation();
+    clientRepresentation.setClientId(clientId);
+    clientRepresentation.setEnabled(true);
+    clientRepresentation.setClientAuthenticatorType("client-secret");
+    clientRepresentation.setSecret(clientSecret);
+    clientRepresentation.setServiceAccountsEnabled(true);
+    clientRepresentation.setProtocolMappers(List.of(mapper));
+    return clientRepresentation;
+  }
+
+  private static CamundaClient oidcClient(
+      final String clientId,
+      final String clientSecret,
+      final String targetTenantId,
+      final Path credentialsCacheDir) {
+    return TENANTS
+        .newClientBuilder(BROKER, targetTenantId)
+        .preferRestOverGrpc(false)
+        .credentialsProvider(
+            new OAuthCredentialsProviderBuilder()
+                .clientId(clientId)
+                .clientSecret(clientSecret)
+                .audience(AUDIENCE)
+                .authorizationServerUrl(
+                    KEYCLOAK.getAuthServerUrl()
+                        + "/realms/"
+                        + REALM_SHARED
+                        + "/protocol/openid-connect/token")
+                .credentialsCachePath(
+                    credentialsCacheDir.resolve(clientId + "-on-" + targetTenantId).toString())
+                .build())
+        .build();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcPartitionRoutingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcPartitionRoutingIT.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.time.Duration;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the physical-tenant id stamped from the {@code Camunda-Physical-Tenant} gRPC header
+ * is used by the gateway's {@code EndpointManager} to route partition-scoped commands to the
+ * targeted physical tenant's own partition group: a command accepted on one physical tenant's
+ * partitions is rejected when issued against a different physical tenant, because the state it
+ * depends on does not exist there.
+ */
+@ZeebeIntegration
+final class PhysicalTenantGrpcPartitionRoutingIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String TENANT_B = "tenantb";
+  private static final String PROCESS_ID = "routing-proc";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .withTenant(TENANT_B, Storage.none())
+          .build();
+
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  private static CamundaClient tenantAClient;
+  private static CamundaClient tenantBClient;
+
+  @BeforeAll
+  static void start() {
+    BROKER.start();
+    tenantAClient = TENANTS.newClientBuilder(BROKER, TENANT_A).preferRestOverGrpc(false).build();
+    tenantBClient = TENANTS.newClientBuilder(BROKER, TENANT_B).preferRestOverGrpc(false).build();
+  }
+
+  @AfterAll
+  static void close() {
+    CloseHelper.quietCloseAll(tenantAClient, tenantBClient);
+  }
+
+  @Test
+  void shouldRoutePartitionCommandToStampedPhysicalTenant() {
+    // given
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done();
+    Awaitility.await("process deployed to tenant A's partitions")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var deployment =
+                  tenantAClient
+                      .newDeployResourceCommand()
+                      .addProcessModel(model, PROCESS_ID + ".bpmn")
+                      .send()
+                      .join();
+              assertThat(deployment.getProcesses()).isNotEmpty();
+              assertThat(deployment.getProcesses().get(0).getProcessDefinitionKey()).isPositive();
+            });
+
+    // when/then: create-instance for the same PT lands in the same partition group as the deploy
+    final var instanceEvent =
+        tenantAClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join();
+    assertThat(instanceEvent.getProcessInstanceKey()).isPositive();
+
+    // when/then: the same command against a different physical tenant is rejected, since the
+    // process definition was never routed to tenant B's partitions
+    assertThatThrownBy(
+            () ->
+                tenantBClient
+                    .newCreateInstanceCommand()
+                    .bpmnProcessId(PROCESS_ID)
+                    .latestVersion()
+                    .send()
+                    .join())
+        .as("process deployed only to tenant A must not be visible on tenant B's partitions")
+        .hasRootCauseInstanceOf(StatusRuntimeException.class)
+        .rootCause()
+        .satisfies(
+            e ->
+                assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                    .isEqualTo(Status.Code.NOT_FOUND));
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcUnprotectedIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcUnprotectedIT.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the unprotected-API branch of {@link
+ * io.camunda.zeebe.gateway.interceptors.impl.AuthenticationInterceptor}: when authentication is
+ * disabled, a {@code Camunda-Physical-Tenant} header that names a PT not in {@code knownTenantIds}
+ * is rejected with {@link Status#NOT_FOUND} rather than {@link Status#UNAUTHENTICATED}, so an
+ * unauthenticated caller cannot probe whether a tenant is provisioned.
+ *
+ * @see PhysicalTenantGrpcBasicAuthIT for the protected-API (basic-auth) counterpart where the same
+ *     header yields {@link Status#UNAUTHENTICATED}
+ */
+@ZeebeIntegration
+final class PhysicalTenantGrpcUnprotectedIT {
+
+  private static final String TENANT_A = "tenanta";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  @TestZeebe(autoStart = false, purgeAfterEach = false)
+  private static final TestStandaloneBroker BROKER =
+      TENANTS.configure(new TestStandaloneBroker().withUnauthenticatedAccess());
+
+  @BeforeAll
+  static void startBroker() {
+    BROKER.start();
+  }
+
+  @Test
+  void shouldRejectUnknownPhysicalTenantWithNotFound() {
+    // given — a gRPC client targeting a PT not registered in knownTenantIds; no credentials
+    // needed because auth is disabled on this broker
+    try (final var client =
+        BROKER.newClientBuilder().preferRestOverGrpc(false).physicalTenantId("unknownpt").build()) {
+      // when / then — the interceptor returns NOT_FOUND (not UNAUTHENTICATED), proving the
+      // unprotected-API guard fires without leaking whether the tenant is provisioned
+      assertThatThrownBy(() -> client.newTopologyRequest().send().join())
+          .as("unknown PT on an unprotected gRPC API yields NOT_FOUND, not UNAUTHENTICATED")
+          .hasRootCauseInstanceOf(StatusRuntimeException.class)
+          .rootCause()
+          .satisfies(
+              e ->
+                  assertThat(((StatusRuntimeException) e).getStatus().getCode())
+                      .isEqualTo(Status.Code.NOT_FOUND));
+    }
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -233,12 +233,12 @@ public class CamundaMultiDBExtension
   public static final Duration TIMEOUT_DATABASE_EXPORTER_READINESS = Duration.ofMinutes(3);
   public static final Duration TIMEOUT_DATABASE_READINESS = Duration.ofMinutes(3);
   public static final String KEYCLOAK_REALM = "camunda";
+  public static final String PT_ADMIN_PASSWORD = "ptadmin";
   private static final Logger LOGGER = LoggerFactory.getLogger(CamundaMultiDBExtension.class);
   private static final String EXTENSION_COORDINATION_KEY = "extension-running";
   private static final String EXTENSION_NAME = "CamundaMultiDBExtension";
   private static final String PREFERRED_EXTENSION_PROPERTY = "camunda.test.preferred.extension";
   private static final String PREFERRED_EXTENSION_MULTIDB = "multi-db";
-  private static final String PT_ADMIN_PASSWORD = "ptadmin";
 
   /**
    * PT ids are interpolated into SQL identifiers (schema/database names, table prefixes) by the
@@ -277,6 +277,11 @@ public class CamundaMultiDBExtension
 
   public CamundaMultiDBExtension(final TestStandaloneApplication<?> testApplication) {
     defaultTestApplication = testApplication;
+  }
+
+  /** The conventional admin username for a physical tenant: {@code <tenantId>-admin}. */
+  public static String physicalTenantAdminUsername(final String physicalTenantId) {
+    return physicalTenantId + "-admin";
   }
 
   private static ExtensionContext.Store coordinationStore(final ExtensionContext context) {
@@ -421,7 +426,7 @@ public class CamundaMultiDBExtension
               + applicationUnderTest.application.getClass().getName());
     }
     final var rootInit = springApplication.unifiedConfig().getSecurity().getInitialization();
-    final String adminUsername = tenantId + "-admin";
+    final String adminUsername = physicalTenantAdminUsername(tenantId);
 
     // Derive per-PT storage config based on the active database type.
     final String ptUrl;
@@ -517,7 +522,7 @@ public class CamundaMultiDBExtension
   private MultiPhysicalTenantClients buildMultiPhysicalTenantClients(final List<String> tenantIds) {
     final Map<String, CamundaClient> clients = new LinkedHashMap<>();
     for (final String tenantId : tenantIds) {
-      final String adminUsername = tenantId + "-admin";
+      final String adminUsername = physicalTenantAdminUsername(tenantId);
       final String base =
           applicationUnderTest.application.restAddress().toString().replaceAll("/+$", "");
       final URI restAddress = URI.create(base + "/physical-tenants/" + tenantId);


### PR DESCRIPTION
## Description

End-to-end acceptance tests for per-physical-tenant (PT) gRPC authentication and routing (Slice 2 of the Physical Tenants Identity epic). All clients are gRPC-first (`preferRestOverGrpc(false)`).

Covered:

- BASIC isolation, embedded gateway (`PhysicalTenantGrpcBasicAuthIT`, on the MultiDbTest framework via `@MultiDbPhysicalTenants`, RDBMS-only): credentials seeded in one PT's user store are accepted on that PT and rejected (UNAUTHENTICATED) on another; an absent header resolves to `default`; an unknown PT header is rejected UNAUTHENTICATED. Admin credentials are sourced from the framework, not hard-coded.
- BASIC isolation, standalone gateway (`PhysicalTenantGrpcBasicAuthStandaloneGatewayIT`): broker plus a standalone gateway sharing the per-PT RDBMS stores; same isolation, absent-header, and unknown-PT checks.
- OIDC issuer isolation, embedded and standalone gateway (`PhysicalTenantGrpcOidcAuthIT`, `PhysicalTenantGrpcOidcAuthStandaloneGatewayIT`): a token issued by one PT's IdP (distinct issuer) is accepted on that PT and rejected (UNAUTHENTICATED) on another whose OIDC config points at a different issuer.
- OIDC claim mapping (`PhysicalTenantGrpcOidcClaimMappingIT`): both PTs share one issuer and differ only by the claim the caller identity is mapped from. A client-credentials token that carries a PT's configured claim is accepted on that PT and rejected (UNAUTHENTICATED) on the other, proving the targeted PT's claim mapping is applied.
- Partition-group routing (`PhysicalTenantGrpcPartitionRoutingIT`): topology is answered locally by the gateway and does not exercise partition routing, so this deploys a process on one PT and shows a create-instance for it succeeds on that PT and is rejected NOT_FOUND on another, proving the stamped PT id routes partition-scoped commands to the tenant's own partition group.
- Unprotected API (`PhysicalTenantGrpcUnprotectedIT`): with authentication disabled, an unknown PT header is rejected NOT_FOUND (not UNAUTHENTICATED), so an unauthenticated caller cannot probe whether a tenant is provisioned.

Not in scope here, tracked separately:

- Per-PT userinfo augmentation ITs: #56475.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/55888
