### PR TITLE
fix: scope RDBMS schema-version table lookup to the connection's schema

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -270,14 +270,16 @@ public class RdbmsSchemaVersionStore {
   protected boolean tableExists(final Connection connection, final String tableName)
       throws SQLException {
     final var meta = connection.getMetaData();
+    final var catalog = connection.getCatalog();
+    final var schema = connection.getSchema();
     // Try uppercase first (most databases store identifiers in upper case), then as-is.
     try (final var rs =
-        meta.getTables(null, null, tableName.toUpperCase(), new String[] {"TABLE"})) {
+        meta.getTables(catalog, schema, tableName.toUpperCase(), new String[] {"TABLE"})) {
       if (rs.next()) {
         return true;
       }
     }
-    try (final var rs = meta.getTables(null, null, tableName, new String[] {"TABLE"})) {
+    try (final var rs = meta.getTables(catalog, schema, tableName, new String[] {"TABLE"})) {
       return rs.next();
     }
   }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreSchemaScopingH2Test.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreSchemaScopingH2Test.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for cross-schema leakage in {@link RdbmsSchemaVersionStore#tableExists}.
+ *
+ * <p>On a shared server hosting multiple physical tenants (one schema/database per PT), the
+ * table-existence lookup must be scoped to the connection's own catalog/schema. Otherwise a PT
+ * whose schema is still empty would find another PT's {@code RDBMS_SCHEMA_VERSION} table, wrongly
+ * conclude its schema already exists, and then fail the subsequent {@code SELECT} against its own
+ * (empty) schema. Two schemas in a single H2 database reproduce that shared-server topology.
+ */
+class RdbmsSchemaVersionStoreSchemaScopingH2Test {
+
+  private JdbcDataSource newDataSource() {
+    final var ds = new JdbcDataSource();
+    ds.setURL("jdbc:h2:mem:pt-scoping-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1");
+    ds.setUser("sa");
+    ds.setPassword("");
+    return ds;
+  }
+
+  @Test
+  void shouldNotSeeSchemaVersionTableFromAnotherSchema() throws Exception {
+    // given: two schemas in one DB; RDBMS_SCHEMA_VERSION exists only in PT_A
+    final var ds = newDataSource();
+    try (final var conn = ds.getConnection();
+        final var stmt = conn.createStatement()) {
+      stmt.execute("CREATE SCHEMA PT_A");
+      stmt.execute("CREATE SCHEMA PT_B");
+      stmt.execute("CREATE TABLE PT_A.RDBMS_SCHEMA_VERSION (VERSION VARCHAR(255))");
+      stmt.execute("INSERT INTO PT_A.RDBMS_SCHEMA_VERSION (VERSION) VALUES ('8.10.0')");
+    }
+    final var store = new RdbmsSchemaVersionStore(ds, "", "8.10.0");
+
+    // when: resolving the version while connected to the still-empty PT_B schema
+    final String resolved;
+    try (final var conn = ds.getConnection()) {
+      conn.setSchema("PT_B");
+      resolved = store.resolveCurrentSchemaVersion(conn, "");
+    }
+
+    // then: PT_B is treated as a fresh database, not PT_A's version
+    assertThat(resolved).isNull();
+  }
+
+  @Test
+  void shouldSeeSchemaVersionTableInOwnSchema() throws Exception {
+    // given: RDBMS_SCHEMA_VERSION exists in PT_A
+    final var ds = newDataSource();
+    try (final var conn = ds.getConnection();
+        final var stmt = conn.createStatement()) {
+      stmt.execute("CREATE SCHEMA PT_A");
+      stmt.execute("CREATE TABLE PT_A.RDBMS_SCHEMA_VERSION (VERSION VARCHAR(255))");
+      stmt.execute("INSERT INTO PT_A.RDBMS_SCHEMA_VERSION (VERSION) VALUES ('8.10.0')");
+    }
+    final var store = new RdbmsSchemaVersionStore(ds, "", "8.10.0");
+
+    // when: resolving the version while connected to PT_A
+    final String resolved;
+    try (final var conn = ds.getConnection()) {
+      conn.setSchema("PT_A");
+      resolved = store.resolveCurrentSchemaVersion(conn, "");
+    }
+
+    // then: the version stored in PT_A is read back
+    assertThat(resolved).isEqualTo("8.10.0");
+  }
+}


### PR DESCRIPTION
## What

Scopes `RdbmsSchemaVersionStore.tableExists` to the connection's own catalog and schema.

## Why

The method looked up `RDBMS_SCHEMA_VERSION` via JDBC database metadata with a **null catalog and schema**, so the lookup spanned *every* database/schema reachable on the server. With multiple physical tenants on one DB server (a database/schema per PT, e.g. on MySQL/MariaDB/PostgreSQL), the existence check for one PT matched **another** PT's table, concluded the current — still-empty — PT schema was already initialized, and then failed the follow-up `SELECT` against its own empty schema:

```
java.sql.SQLSyntaxErrorException: Table '<pt-db>.RDBMS_SCHEMA_VERSION' doesn't exist
  at io.camunda.db.rdbms.RdbmsSchemaVersionStore.readSchemaVersion(...)
  ... [RDBMS Schema] Failed to determine current schema version. Startup aborted.
```

This aborts startup of every physical tenant after the first. It affects production per-physical-tenant RDBMS support (#52043), not only tests — it simply requires more than one PT to share a database server to manifest, which is why a single-database deployment never hit it.

## Fix

Pass `connection.getCatalog()` and `connection.getSchema()` to the metadata lookup so each connection only sees tables in its own database/schema. **Single-database deployments are unaffected** — the lookup already resolved within that one database.

Adds an H2 regression test (`RdbmsSchemaVersionStoreSchemaScopingH2Test`) that reproduces the shared-server topology with two schemas in one database: it asserts a PT does not see another schema's `RDBMS_SCHEMA_VERSION`, and still reads its own.

## Validation

- `db/rdbms` schema/version tests green, including the new regression test.
- End-to-end: the three `@MultiDbPhysicalTenants` ITs in #56153 pass against a real MySQL with this fix (they fail without it). See that PR for details.

## Context

closes https://github.com/camunda/camunda/issues/56241

Extracted from #56153 (multi-physical-tenant MultiDb ITs), which surfaced the bug and now stacks on top of this PR.

