### PR TITLE
feat: add partition group to the logging context

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -10,6 +10,7 @@ package io.camunda.it.rdbms.exporter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.RdbmsService;
@@ -69,8 +70,7 @@ class RdbmsExporterBatchOperationsIT {
             new ExporterConfiguration(
                 "foo",
                 Map.of("queueSize", 0, "exportBatchOperationItemsOnCreation", exportPendingItems)),
-            1,
-            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             "",
             null,
             Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -14,6 +14,8 @@ import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.RdbmsServiceFactory;
@@ -160,8 +162,7 @@ class RdbmsExporterIT {
         new ExporterContext(
             null,
             new ExporterConfiguration("foo", Map.of("queueSize", 0)),
-            1,
-            DEFAULT_PHYSICAL_TENANT_ID,
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             "",
             null,
             Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),
@@ -1479,8 +1480,7 @@ class RdbmsExporterIT {
         new ExporterContext(
             null,
             new ExporterConfiguration("interval-flush-test", Map.of("queueSize", 100)),
-            2,
-            DEFAULT_PHYSICAL_TENANT_ID,
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 2),
             "",
             null,
             Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -34,6 +34,7 @@ import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
 import io.atomix.utils.Builder;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.net.InetAddress;
@@ -466,6 +467,7 @@ public interface RaftServer {
     protected RaftElectionConfig electionConfig = RaftElectionConfig.ofDefaultElection();
     protected RaftPartitionConfig partitionConfig = new RaftPartitionConfig();
     protected int partitionId;
+    protected String partitionGroup = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
     protected MeterRegistry meterRegistry;
 
     protected Builder(final MemberId localMemberId) {
@@ -549,6 +551,11 @@ public interface RaftServer {
 
     public Builder withPartitionId(final int partitionId) {
       this.partitionId = partitionId;
+      return this;
+    }
+
+    public Builder withPartitionGroup(final String partitionGroup) {
+      this.partitionGroup = partitionGroup;
       return this;
     }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -34,6 +34,7 @@ import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
 import io.atomix.utils.Builder;
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -466,8 +467,8 @@ public interface RaftServer {
     protected EntryValidator entryValidator = new NoopEntryValidator();
     protected RaftElectionConfig electionConfig = RaftElectionConfig.ofDefaultElection();
     protected RaftPartitionConfig partitionConfig = new RaftPartitionConfig();
-    protected int partitionId;
-    protected String partitionGroup = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+    protected PartitionId partitionId =
+        new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 0);
     protected MeterRegistry meterRegistry;
 
     protected Builder(final MemberId localMemberId) {
@@ -549,13 +550,8 @@ public interface RaftServer {
       return this;
     }
 
-    public Builder withPartitionId(final int partitionId) {
+    public Builder withPartitionId(final PartitionId partitionId) {
       this.partitionId = partitionId;
-      return this;
-    }
-
-    public Builder withPartitionGroup(final String partitionGroup) {
-      this.partitionGroup = partitionGroup;
       return this;
     }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -245,7 +245,6 @@ public class DefaultRaftServer implements RaftServer {
           new RaftContext(
               name,
               partitionId,
-              partitionGroup,
               localMemberId,
               membershipService,
               protocol,

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -245,6 +245,7 @@ public class DefaultRaftServer implements RaftServer {
           new RaftContext(
               name,
               partitionId,
+              partitionGroup,
               localMemberId,
               membershipService,
               protocol,

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -164,6 +164,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private long lastHeartbeat;
   private final RaftPartitionConfig partitionConfig;
   private final int partitionId;
+  private final String partitionGroup;
   private final MeterRegistry meterRegistry;
 
   // after firstCommitIndex is set it will be null
@@ -172,6 +173,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   public RaftContext(
       final String name,
       final int partitionId,
+      final String partitionGroup,
       final MemberId localMemberId,
       final ClusterMembershipService membershipService,
       final RaftServerProtocol protocol,
@@ -187,6 +189,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     this.storage = checkNotNull(storage, "storage cannot be null");
     random = randomFactory.get();
     this.partitionId = partitionId;
+    this.partitionGroup = partitionGroup;
     this.meterRegistry = checkNotNull(meterRegistry, "meterRegistry cannot be null");
     health = HealthReport.healthy(this);
 
@@ -207,7 +210,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     }
 
     threadContext =
-        createThreadContext("raft-server", partitionId, threadContextFactory, localMemberId.id());
+        createThreadContext(
+            "raft-server", partitionId, partitionGroup, threadContextFactory, localMemberId.id());
 
     // Open the metadata store.
     meta = storage.openMetaStore();
@@ -221,7 +225,11 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
             meta,
             () ->
                 createThreadContext(
-                    "raft-log", partitionId, threadContextFactory, localMemberId.id()));
+                    "raft-log",
+                    partitionId,
+                    partitionGroup,
+                    threadContextFactory,
+                    localMemberId.id()));
 
     // Open the snapshot store.
     persistedSnapshotStore = storage.getPersistedSnapshotStore();
@@ -290,6 +298,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private ThreadContext createThreadContext(
       final String name,
       final int partitionId,
+      final String partitionGroup,
       final RaftThreadContextFactory threadContextFactory,
       final String localMemberId) {
     final var context =
@@ -300,6 +309,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     context.execute(
         () -> {
           MDC.put("partitionId", String.valueOf(partitionId));
+          // matches Actor.ACTOR_PROP_PHYSICAL_TENANT
+          MDC.put("physicalTenant", partitionGroup);
           MDC.put("actor-name", name + "-" + partitionId);
           MDC.put("actor-scheduler", "Broker-" + localMemberId);
           MDC.put(RAFT_ROLE_KEY, Role.INACTIVE.name());

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -71,6 +71,7 @@ import io.atomix.raft.storage.system.MetaStore;
 import io.atomix.raft.utils.StateUtil;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.utils.concurrent.ThreadContext;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.SegmentInfo;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -163,8 +164,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   private long lastHeartbeat;
   private final RaftPartitionConfig partitionConfig;
-  private final int partitionId;
-  private final String partitionGroup;
+  private final PartitionId partitionId;
   private final MeterRegistry meterRegistry;
 
   // after firstCommitIndex is set it will be null
@@ -172,8 +172,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   public RaftContext(
       final String name,
-      final int partitionId,
-      final String partitionGroup,
+      final PartitionId partitionId,
       final MemberId localMemberId,
       final ClusterMembershipService membershipService,
       final RaftServerProtocol protocol,
@@ -189,7 +188,6 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     this.storage = checkNotNull(storage, "storage cannot be null");
     random = randomFactory.get();
     this.partitionId = partitionId;
-    this.partitionGroup = partitionGroup;
     this.meterRegistry = checkNotNull(meterRegistry, "meterRegistry cannot be null");
     health = HealthReport.healthy(this);
 
@@ -210,8 +208,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     }
 
     threadContext =
-        createThreadContext(
-            "raft-server", partitionId, partitionGroup, threadContextFactory, localMemberId.id());
+        createThreadContext("raft-server", partitionId, threadContextFactory, localMemberId.id());
 
     // Open the metadata store.
     meta = storage.openMetaStore();
@@ -225,11 +222,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
             meta,
             () ->
                 createThreadContext(
-                    "raft-log",
-                    partitionId,
-                    partitionGroup,
-                    threadContextFactory,
-                    localMemberId.id()));
+                    "raft-log", partitionId, threadContextFactory, localMemberId.id()));
 
     // Open the snapshot store.
     persistedSnapshotStore = storage.getPersistedSnapshotStore();
@@ -240,7 +233,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         .getLatestSnapshot()
         .ifPresent(persistedSnapshot -> currentSnapshot = persistedSnapshot);
     StateUtil.verifySnapshotLogConsistent(
-        partitionId,
+        partitionId.number(),
         getCurrentSnapshotIndex(),
         raftLog.getFirstIndex(),
         raftLog.isEmpty(),
@@ -297,21 +290,20 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   private ThreadContext createThreadContext(
       final String name,
-      final int partitionId,
-      final String partitionGroup,
+      final PartitionId partitionId,
       final RaftThreadContextFactory threadContextFactory,
       final String localMemberId) {
     final var context =
         threadContextFactory.createContext(
-            namedThreads("%s-%s-%d".formatted(name, localMemberId, partitionId), LOGGER),
+            namedThreads("%s-%s-%d".formatted(name, localMemberId, partitionId.number()), LOGGER),
             this::onUncaughtException);
     // in order to set the partition id once in the raft thread
     context.execute(
         () -> {
-          MDC.put("partitionId", String.valueOf(partitionId));
+          MDC.put("partitionId", String.valueOf(partitionId.number()));
           // matches Actor.ACTOR_PROP_PHYSICAL_TENANT
-          MDC.put("physicalTenant", partitionGroup);
-          MDC.put("actor-name", name + "-" + partitionId);
+          MDC.put("physicalTenant", partitionId.group());
+          MDC.put("actor-name", name + "-" + partitionId.number());
           MDC.put("actor-scheduler", "Broker-" + localMemberId);
           MDC.put(RAFT_ROLE_KEY, Role.INACTIVE.name());
         });
@@ -1318,7 +1310,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   }
 
   public int getPartitionId() {
-    return partitionId;
+    return partitionId.number();
   }
 
   public void updateState(final State newState) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -176,6 +176,7 @@ public class RaftPartitionServer implements HealthMonitorable {
     return RaftServer.builder(localMemberId)
         .withName(partition.name())
         .withPartitionId(partitionId)
+        .withPartitionGroup(partition.id().group())
         .withMembershipService(membershipService)
         .withProtocol(createServerProtocol())
         .withPartitionConfig(config)

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -166,7 +166,6 @@ public class RaftPartitionServer implements HealthMonitorable {
   }
 
   private RaftServer buildServer(final MeterRegistry meterRegistry) {
-    final var partitionId = partition.id().number();
     final var electionConfig =
         config.isPriorityElectionEnabled()
             ? RaftElectionConfig.ofPriorityElection(
@@ -175,8 +174,7 @@ public class RaftPartitionServer implements HealthMonitorable {
 
     return RaftServer.builder(localMemberId)
         .withName(partition.name())
-        .withPartitionId(partitionId)
-        .withPartitionGroup(partition.id().group())
+        .withPartitionId(partition.id())
         .withMembershipService(membershipService)
         .withProtocol(createServerProtocol())
         .withPartitionConfig(config)

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -36,6 +36,7 @@ import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
 import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -224,8 +225,7 @@ public final class ControllableRaftContexts {
     final var raft =
         new RaftContext(
             memberId.id() + "-partition-1",
-            1,
-            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             memberId,
             mock(ClusterMembershipService.class, withSettings().stubOnly()),
             new ControllableRaftServerProtocol(memberId, serverProtocols, messageQueue),

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -36,6 +36,7 @@ import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
 import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.snapshots.testing.TestFileBasedSnapshotStore;
@@ -224,6 +225,7 @@ public final class ControllableRaftContexts {
         new RaftContext(
             memberId.id() + "-partition-1",
             1,
+            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
             memberId,
             mock(ClusterMembershipService.class, withSettings().stubOnly()),
             new ControllableRaftServerProtocol(memberId, serverProtocols, messageQueue),

--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -23,6 +23,10 @@
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-cluster</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-scheduler</artifactId>
     </dependency>
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.management;
 
 import io.atomix.cluster.BrokerMemberId;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
 import io.camunda.zeebe.backup.api.BackupManager;
 import io.camunda.zeebe.backup.api.BackupRange;
@@ -41,7 +42,7 @@ public final class BackupService extends Actor implements BackupManager {
   private final String actorName;
   private final JournalInfoProvider journalInfoProvider;
   private final BrokerMemberId brokerMemberId;
-  private final int partitionId;
+  private final PartitionId partitionId;
   private final BackupServiceImpl internalBackupManager;
   private final PersistedSnapshotStore snapshotStore;
   private final Path segmentsDirectory;
@@ -49,7 +50,7 @@ public final class BackupService extends Actor implements BackupManager {
 
   public BackupService(
       final BrokerMemberId brokerMemberId,
-      final int partitionId,
+      final PartitionId partitionId,
       final BackupStore backupStore,
       final PersistedSnapshotStore snapshotStore,
       final Path segmentsDirectory,
@@ -69,16 +70,16 @@ public final class BackupService extends Actor implements BackupManager {
             logStreamWriter,
             backupRangeState,
             checkpointMetadataState,
-            partitionId,
+            partitionId.number(),
             partitionRegistry);
-    actorName = buildActorName("BackupService", partitionId);
+    actorName = buildActorName("BackupService", partitionId.number());
     journalInfoProvider = raftMetadataProvider;
   }
 
   @Override
   protected Map<String, String> createContext() {
     final var context = super.createContext();
-    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    putPartitionContext(context, partitionId);
     return context;
   }
 
@@ -144,7 +145,7 @@ public final class BackupService extends Actor implements BackupManager {
 
     final var future = new CompletableActorFuture<BackupStatus>();
     internalBackupManager
-        .getBackupStatus(partitionId, checkpointId, actor)
+        .getBackupStatus(partitionId.number(), checkpointId, actor)
         .onComplete(
             (backupStatus, throwable) -> {
               if (throwable != null) {
@@ -172,7 +173,8 @@ public final class BackupService extends Actor implements BackupManager {
   @Override
   public ActorFuture<Collection<BackupStatus>> listBackups(final String pattern) {
     final var operationMetrics = metrics.startListingBackups();
-    final var resultFuture = internalBackupManager.listBackups(partitionId, pattern, actor);
+    final var resultFuture =
+        internalBackupManager.listBackups(partitionId.number(), pattern, actor);
     resultFuture.onComplete(operationMetrics::complete);
     resultFuture.onComplete(
         (ignore, error) -> {
@@ -193,7 +195,7 @@ public final class BackupService extends Actor implements BackupManager {
     final var operationMetrics = metrics.startDeleting();
 
     final var backupDeleted =
-        internalBackupManager.deleteBackupIfExists(partitionId, checkpointId, actor);
+        internalBackupManager.deleteBackupIfExists(partitionId.number(), checkpointId, actor);
     backupDeleted.onComplete(operationMetrics::complete);
     backupDeleted.onComplete(
         (ignore, error) -> {
@@ -206,7 +208,7 @@ public final class BackupService extends Actor implements BackupManager {
 
   @Override
   public void failInProgressBackup(final long lastCheckpointId) {
-    internalBackupManager.failInProgressBackups(partitionId, lastCheckpointId, actor);
+    internalBackupManager.failInProgressBackups(partitionId.number(), lastCheckpointId, actor);
   }
 
   @Override
@@ -241,6 +243,6 @@ public final class BackupService extends Actor implements BackupManager {
 
   private BackupIdentifierImpl getBackupId(final long checkpointId) {
     return new BackupIdentifierImpl(
-        brokerMemberId.nodeIdx(), brokerMemberId.zone(), partitionId, checkpointId);
+        brokerMemberId.nodeIdx(), brokerMemberId.zone(), partitionId.number(), checkpointId);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -30,7 +30,6 @@ import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 import java.util.SequencedCollection;
 import org.slf4j.Logger;
@@ -39,7 +38,6 @@ import org.slf4j.LoggerFactory;
 /** Backup manager that takes and manages backup asynchronously */
 public final class BackupService extends Actor implements BackupManager {
   private static final Logger LOG = LoggerFactory.getLogger(BackupService.class);
-  private final String actorName;
   private final JournalInfoProvider journalInfoProvider;
   private final BrokerMemberId brokerMemberId;
   private final PartitionId partitionId;
@@ -59,6 +57,7 @@ public final class BackupService extends Actor implements BackupManager {
       final LogStreamWriter logStreamWriter,
       final DbBackupRangeState backupRangeState,
       final DbCheckpointMetadataState checkpointMetadataState) {
+    super("BackupService", partitionId);
     this.brokerMemberId = brokerMemberId;
     this.partitionId = partitionId;
     this.snapshotStore = snapshotStore;
@@ -72,20 +71,7 @@ public final class BackupService extends Actor implements BackupManager {
             checkpointMetadataState,
             partitionId.number(),
             partitionRegistry);
-    actorName = buildActorName("BackupService", partitionId.number());
     journalInfoProvider = raftMetadataProvider;
-  }
-
-  @Override
-  protected Map<String, String> createContext() {
-    final var context = super.createContext();
-    putPartitionContext(context, partitionId);
-    return context;
-  }
-
-  @Override
-  public String getName() {
-    return actorName;
   }
 
   @Override

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -57,6 +57,7 @@ public final class BrokerTopologyManagerImpl extends Actor
   public BrokerTopologyManagerImpl(
       final Supplier<Set<Member>> membersSupplier,
       final BrokerClientTopologyMetrics topologyMetrics) {
+    super("GatewayTopologyManager");
     this.membersSupplier = membersSupplier;
     this.topologyMetrics = topologyMetrics;
   }
@@ -180,11 +181,6 @@ public final class BrokerTopologyManagerImpl extends Actor
         .findFirst()
         .map(BrokerClientTopologyImpl::configuredClusterState)
         .orElse(BrokerClientTopologyImpl.uninitialized().configuredClusterState());
-  }
-
-  @Override
-  public String getName() {
-    return "GatewayTopologyManager";
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -229,13 +229,9 @@ public final class Broker implements AutoCloseable {
     private final BrokerStartupProcess brokerStartupProcess;
 
     private BrokerStartupActor(final BrokerStartupContextImpl startupContext) {
+      super("Startup");
       startupContext.setConcurrencyControl(actor);
       brokerStartupProcess = new BrokerStartupProcess(startupContext);
-    }
-
-    @Override
-    public String getName() {
-      return "Startup";
     }
 
     private ActorFuture<BrokerContext> start() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.exporter.context;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -27,8 +28,7 @@ public final class ExporterContext implements Context, AutoCloseable {
 
   private final Logger logger;
   private final Configuration configuration;
-  private final int partitionId;
-  private final String physicalTenantId;
+  private final PartitionId partitionId;
   private final String clusterId;
   private final @Nullable String licenseKey;
   private final CompositeMeterRegistry meterRegistry;
@@ -39,8 +39,7 @@ public final class ExporterContext implements Context, AutoCloseable {
   public ExporterContext(
       final Logger logger,
       final Configuration configuration,
-      final int partitionId,
-      final String physicalTenantId,
+      final PartitionId partitionId,
       final String clusterId,
       final @Nullable String licenseKey,
       final MeterRegistry meterRegistry,
@@ -48,15 +47,13 @@ public final class ExporterContext implements Context, AutoCloseable {
     this.logger = logger;
     this.configuration = configuration;
     this.partitionId = partitionId;
-    this.physicalTenantId = physicalTenantId;
     this.clusterId = clusterId;
     this.licenseKey = licenseKey;
     this.meterRegistry =
         MicrometerUtil.wrap(
             meterRegistry,
             Tags.concat(
-                PartitionKeyNames.tags(physicalTenantId, partitionId),
-                Tags.of("exporterId", configuration.getId())));
+                PartitionKeyNames.tags(partitionId), Tags.of("exporterId", configuration.getId())));
     this.clock = clock;
   }
 
@@ -82,12 +79,12 @@ public final class ExporterContext implements Context, AutoCloseable {
 
   @Override
   public int getPartitionId() {
-    return partitionId;
+    return partitionId.number();
   }
 
   @Override
   public String getPhysicalTenantId() {
-    return physicalTenantId;
+    return partitionId.group();
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.exporter.repo;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.exporter.context.ExporterContext;
@@ -30,7 +31,8 @@ import org.slf4j.Logger;
 
 public final class ExporterRepository {
   private static final Logger LOG = Loggers.EXPORTER_LOGGER;
-  private static final int NULL_PARTITION_ID = Integer.MIN_VALUE;
+  private static final PartitionId NULL_PARTITION_ID =
+      new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Integer.MIN_VALUE);
   private final ExternalJarRepository jarRepository;
   private final Map<String, ExporterDescriptor> exporters;
   private @Nullable String licenseKey;
@@ -114,7 +116,6 @@ public final class ExporterRepository {
               LOG,
               descriptor.getConfiguration(),
               NULL_PARTITION_ID,
-              PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
               "",
               licenseKey,
               new SimpleMeterRegistry(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
@@ -32,7 +32,7 @@ import org.slf4j.Logger;
 public final class ExporterRepository {
   private static final Logger LOG = Loggers.EXPORTER_LOGGER;
   private static final PartitionId NULL_PARTITION_ID =
-      new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, Integer.MIN_VALUE);
+      new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 0);
   private final ExternalJarRepository jarRepository;
   private final Map<String, ExporterDescriptor> exporters;
   private @Nullable String licenseKey;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.exporter.stream;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.exporter.context.ExporterContext;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
@@ -51,8 +52,7 @@ final class ExporterContainer implements Controller {
 
   ExporterContainer(
       final ExporterDescriptor descriptor,
-      final int partitionId,
-      final String physicalTenantId,
+      final PartitionId partitionId,
       final String clusterId,
       final String licenseKey,
       final ExporterInitializationInfo initializationInfo,
@@ -66,7 +66,6 @@ final class ExporterContainer implements Controller {
             Loggers.getExporterLogger(descriptor.getId()),
             descriptor.getConfiguration(),
             partitionId,
-            physicalTenantId,
             clusterId,
             licenseKey,
             meterRegistry,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.exporter.stream;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.ExporterMode;
@@ -94,8 +95,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private final Duration distributionInterval;
   private ExporterStateDistributionService exporterDistributionService;
   private ScheduledTimer exporterDistributionTimer;
-  private final int partitionId;
-  private final String physicalTenantId;
+  private final PartitionId partitionId;
   private final EventFilter positionsToSkipFilter;
   private final MeterRegistry meterRegistry;
   private final @Nullable String licenseKey;
@@ -117,8 +117,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       final Function<RecordExporter, RecordExporter> recorderExporter) {
     name = context.getName();
     logStream = Objects.requireNonNull(context.getLogStream());
-    partitionId = logStream.getPartitionId();
-    physicalTenantId = context.getTenantName();
+    partitionId = context.getPartitionId();
     clusterId = context.getClusterId();
     licenseKey = context.getLicenseKey();
     meterRegistry = context.getMeterRegistry();
@@ -130,7 +129,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                     new ExporterContainer(
                         descriptorEntry.getKey(),
                         partitionId,
-                        physicalTenantId,
                         clusterId,
                         licenseKey,
                         descriptorEntry.getValue(),
@@ -141,16 +139,17 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     metrics = new ExporterMetrics(meterRegistry);
     metrics.initializeExporterState(exporterPhase);
     recordExporter =
-        recorderExporter.apply(new RecordExporter(metrics, containers, partitionId, clock));
+        recorderExporter.apply(
+            new RecordExporter(metrics, containers, partitionId.number(), clock));
     exportingRetryStrategy = new BackOffRetryStrategy(actor, Duration.ofSeconds(10));
     zeebeDb = context.getZeebeDb();
     this.exporterPhase = exporterPhase;
     partitionMessagingService = context.getPartitionMessagingService();
 
     final var exporterPositionsLegacySubject =
-        String.format(LEGACY_EXPORTER_STATE_TOPIC_FORMAT, partitionId);
+        String.format(LEGACY_EXPORTER_STATE_TOPIC_FORMAT, partitionId.number());
     exporterPositionsSendingSubject =
-        String.format(EXPORTER_STATE_TOPIC_FORMAT, physicalTenantId, partitionId);
+        String.format(EXPORTER_STATE_TOPIC_FORMAT, partitionId.group(), partitionId.number());
     exporterPositionsReceivingSubjects =
         context.isReceiveOnLegacySubject()
             ? List.of(exporterPositionsLegacySubject, exporterPositionsSendingSubject)
@@ -353,7 +352,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         new ExporterContainer(
             descriptor,
             partitionId,
-            physicalTenantId,
             clusterId,
             licenseKey,
             initializationInfo,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -391,6 +391,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   protected Map<String, String> createContext() {
     final var context = super.createContext();
     context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    context.put(ACTOR_PROP_PHYSICAL_TENANT, physicalTenantId);
     return context;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -75,7 +75,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private final RecordExporter recordExporter;
   private final ZeebeDb zeebeDb;
   private final ExporterMetrics metrics;
-  private final String name;
   private final RetryStrategy exportingRetryStrategy;
   private final Set<FailureListener> listeners = new HashSet<>();
   private LogStreamReader logStreamReader;
@@ -115,7 +114,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       final ExporterDirectorContext context,
       final ExporterPhase exporterPhase,
       final Function<RecordExporter, RecordExporter> recorderExporter) {
-    name = context.getName();
+    super("Exporter", context.getPartitionId());
     logStream = Objects.requireNonNull(context.getLogStream());
     partitionId = context.getPartitionId();
     clusterId = context.getClusterId();
@@ -386,19 +385,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   @Override
-  protected Map<String, String> createContext() {
-    final var context = super.createContext();
-    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
-    context.put(ACTOR_PROP_PHYSICAL_TENANT, physicalTenantId);
-    return context;
-  }
-
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
   protected void onActorStarting() {
     if (exporterMode == ExporterMode.ACTIVE) {
       logStreamReader = logStream.newLogStreamReader();
@@ -461,7 +447,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   protected void handleFailure(final Throwable failure) {
     LOG.error(
         "Actor '{}' failed in phase {} with: {} .",
-        name,
+        getName(),
         actor.getLifecyclePhase(),
         failure,
         failure);
@@ -809,7 +795,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   @Override
   public String componentName() {
-    return name;
+    return getName();
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.exporter.stream;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
 import io.camunda.zeebe.broker.system.partitions.PartitionMessagingService;
@@ -24,7 +25,7 @@ public final class ExporterDirectorContext {
   public static final Duration DEFAULT_DISTRIBUTION_INTERVAL = Duration.ofSeconds(15);
 
   private int id;
-  private String name;
+  private PartitionId partitionId;
   private LogStream logStream;
   private Map<ExporterDescriptor, ExporterInitializationInfo> descriptors;
   private ZeebeDb zeebeDb;
@@ -173,6 +174,15 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext receiveOnLegacySubject(final boolean receiveOnLegacySubject) {
     this.receiveOnLegacySubject = receiveOnLegacySubject;
+    return this;
+  }
+
+  public PartitionId getPartitionId() {
+    return partitionId;
+  }
+
+  public ExporterDirectorContext partitionId(final PartitionId partitionId) {
+    this.partitionId = partitionId;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -44,10 +44,6 @@ public final class ExporterDirectorContext {
     return id;
   }
 
-  public String getName() {
-    return name;
-  }
-
   public LogStream getLogStream() {
     return logStream;
   }
@@ -102,11 +98,6 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext id(final int id) {
     this.id = id;
-    return this;
-  }
-
-  public ExporterDirectorContext name(final String name) {
-    this.name = name;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerService.java
@@ -25,16 +25,10 @@ import java.util.Objects;
 public final class RemoteJobStreamErrorHandlerService extends Actor
     implements PartitionListener, RemoteStreamErrorHandler<ActivatedJob> {
   private final RemoteJobStreamErrorHandler delegate;
-  private final String name;
 
   public RemoteJobStreamErrorHandlerService(final JobStreamErrorHandler errorHandler) {
+    super("RemoteJobStreamErrorHandler");
     delegate = new RemoteJobStreamErrorHandler(errorHandler);
-    name = "RemoteJobStreamErrorHandler";
-  }
-
-  @Override
-  public String getName() {
-    return name;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning;
 
 import static io.camunda.zeebe.scheduler.Actor.ACTOR_PROP_PARTITION_ID;
+import static io.camunda.zeebe.scheduler.Actor.ACTOR_PROP_PHYSICAL_TENANT;
 
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember.Type;
@@ -70,7 +71,11 @@ final class Partition {
     return new Partition(
         context,
         new StartupProcess<>(
-            Map.of(ACTOR_PROP_PARTITION_ID, context.partitionId().toString()),
+            Map.of(
+                ACTOR_PROP_PARTITION_ID,
+                context.partitionId().toString(),
+                ACTOR_PROP_PHYSICAL_TENANT,
+                context.partitionMetadata().id().group()),
             LOGGER,
             List.of(
                 new MetricsStep(context.partitionId()),
@@ -86,7 +91,11 @@ final class Partition {
     return new Partition(
         context,
         new StartupProcess<>(
-            Map.of(ACTOR_PROP_PARTITION_ID, context.partitionId().toString()),
+            Map.of(
+                ACTOR_PROP_PARTITION_ID,
+                context.partitionId().toString(),
+                ACTOR_PROP_PHYSICAL_TENANT,
+                context.partitionMetadata().id().group()),
             LOGGER,
             List.of(
                 new MetricsStep(context.partitionId()),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/RecoveryPartition.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning;
 
 import static io.camunda.zeebe.scheduler.Actor.ACTOR_PROP_PARTITION_ID;
+import static io.camunda.zeebe.scheduler.Actor.ACTOR_PROP_PHYSICAL_TENANT;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupProcess;
@@ -34,7 +35,13 @@ public final class RecoveryPartition {
     return new RecoveryPartition(
         context,
         new StartupProcess<>(
-            Map.of(ACTOR_PROP_PARTITION_ID, String.valueOf(partitionId)), LOGGER, List.of()));
+            Map.of(
+                ACTOR_PROP_PARTITION_ID,
+                String.valueOf(partitionId.number()),
+                ACTOR_PROP_PHYSICAL_TENANT,
+                partitionId.group()),
+            LOGGER,
+            List.of()));
   }
 
   ActorFuture<RecoveryPartition> start() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -169,10 +169,7 @@ public final class ZeebePartitionFactory {
             rocksDbConfiguration,
             consistencyChecks.getSettings(),
             new AccessMetricsConfiguration(databaseCfg.getAccessMetrics()),
-            () ->
-                MicrometerUtil.wrap(
-                    partitionMeterRegistry,
-                    PartitionKeyNames.tags(partitionId.group(), partitionId.number())),
+            () -> MicrometerUtil.wrap(partitionMeterRegistry, PartitionKeyNames.tags(partitionId)),
             rocksDbResources);
     final StateController stateController =
         createStateController(raftPartition, zeebeFactory, snapshotStore, snapshotStore);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
@@ -32,8 +32,7 @@ public class MetricsStep implements StartupStep<PartitionStartupContext> {
     final var brokerRegistry = context.brokerMeterRegistry();
     final var partitionId = context.partitionMetadata().id();
     final var partitionRegistry =
-        MicrometerUtil.wrap(
-            brokerRegistry, PartitionKeyNames.tags(partitionId.group(), partitionId.number()));
+        MicrometerUtil.wrap(brokerRegistry, PartitionKeyNames.tags(partitionId));
     context.partitionMeterRegistry(partitionRegistry);
 
     return CompletableActorFuture.completed(context);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -55,6 +55,7 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
                   ignored -> {
                     final var snapshotTransfer =
                         new SnapshotTransferImpl(
+                            context.partitionMetadata().id(),
                             actor -> new SnapshotTransferServiceClient(context.brokerClient()),
                             snapshotStore.getSnapshotMetrics(),
                             snapshotStore);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -37,7 +37,7 @@ public class SnapshotStoreStep implements StartupStep<PartitionStartupContext> {
     final var snapshotStore =
         new FileBasedSnapshotStore(
             context.brokerConfig().getCluster().getNodeId(),
-            context.partitionId(),
+            context.partitionMetadata().id(),
             context.partitionDirectory(),
             new ChecksumProviderRocksDBImpl(),
             context.partitionMeterRegistry());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning.topology;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.exporter.context.ExporterContext;
@@ -125,8 +126,7 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
         new ExporterContext(
             Loggers.getExporterLogger(descriptor.getId()),
             descriptor.getConfiguration(),
-            1,
-            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             "",
             exporterRepository.getLicenseKey(),
             meterRegistry,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/TopologyManagerImpl.java
@@ -41,14 +41,12 @@ public final class TopologyManagerImpl extends Actor
   private final BrokerInfo localPartitionGroupInfo;
 
   private final List<TopologyPartitionListener> topologyPartitionListeners = new ArrayList<>();
-  private final String actorName;
 
   public TopologyManagerImpl(
       final ClusterMembershipService membershipService, final BrokerInfo partitionGroupInfo) {
+    super("TopologyManager" + partitionGroupInfo.getPartitionGroup());
     this.membershipService = membershipService;
     localPartitionGroupInfo = partitionGroupInfo;
-
-    actorName = "TopologyManager-" + partitionGroupInfo.getPartitionGroup();
   }
 
   @Override
@@ -68,11 +66,6 @@ public final class TopologyManagerImpl extends Actor
   @Override
   public ActorFuture<Void> onBecomingInactive(final int partitionId, final long term) {
     return setInactive(partitionId);
-  }
-
-  @Override
-  public String getName() {
-    return actorName;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -116,6 +116,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
       final MemberId nodeId,
       final HealthTreeMetrics healthGraphMetrics,
       final Set<String> expectedPhysicalTenants) {
+    super("HealthCheckService");
     this.expectedPhysicalTenants = Set.copyOf(expectedPhysicalTenants);
     healthMonitor =
         new CriticalComponentsHealthMonitor(
@@ -198,11 +199,6 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
       readyLogged = true;
       LOG.info("All partitions are installed. Broker is ready!");
     }
-  }
-
-  @Override
-  public String getName() {
-    return "HealthCheckService";
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -33,7 +33,6 @@ import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.slf4j.Logger;
 
@@ -49,7 +48,6 @@ public final class ZeebePartition extends Actor
   private final StartupProcess<PartitionStartupContext> startupProcess;
 
   private Role raftRole;
-  private final String actorName;
   private final List<FailureListener> failureListeners;
   private final HealthMetrics healthMetrics;
   private final RoleMetrics roleMetrics;
@@ -67,6 +65,7 @@ public final class ZeebePartition extends Actor
       final PartitionStartupAndTransitionContextImpl transitionContext,
       final PartitionTransition transition,
       final List<StartupStep<PartitionStartupContext>> startupSteps) {
+    super("ZeebePartition", transitionContext.partitionId());
     context = transitionContext.getPartitionContext();
     adminAccess =
         new ZeebePartitionAdminAccess(
@@ -83,8 +82,6 @@ public final class ZeebePartition extends Actor
 
     transition.setConcurrencyControl(actor);
 
-    final var partitionId = context.getPartitionId();
-    actorName = buildActorName("ZeebePartition", partitionId);
     transitionContext.setComponentHealthMonitor(
         new CriticalComponentsHealthMonitor(
             componentName(context.partitionId()),
@@ -108,18 +105,6 @@ public final class ZeebePartition extends Actor
 
   public PartitionAdminAccess getAdminAccess() {
     return adminAccess;
-  }
-
-  @Override
-  protected Map<String, String> createContext() {
-    final var actorContext = super.createContext();
-    putPartitionContext(actorContext, context.partitionId());
-    return actorContext;
-  }
-
-  @Override
-  public String getName() {
-    return actorName;
   }
 
   @Override
@@ -203,7 +188,7 @@ public final class ZeebePartition extends Actor
 
   @Override
   protected void handleFailure(final Throwable failure) {
-    LOG.warn("Uncaught exception in {}.", actorName, failure);
+    LOG.warn("Uncaught exception in {}.", getName(), failure);
     // Most probably exception happened in the middle of installing leader or follower services
     // because this actor is not doing anything else
     onInstallFailure(failure);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -113,7 +113,7 @@ public final class ZeebePartition extends Actor
   @Override
   protected Map<String, String> createContext() {
     final var actorContext = super.createContext();
-    actorContext.put(ACTOR_PROP_PARTITION_ID, Integer.toString(context.getPartitionId()));
+    putPartitionContext(actorContext, context.partitionId());
     return actorContext;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -31,7 +31,6 @@ import io.camunda.zeebe.util.health.HealthReport;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.Callable;
@@ -59,12 +58,10 @@ public final class AsyncSnapshotDirector extends Actor
   private final Duration snapshotRate;
   private final String processorName;
   private final StreamProcessor streamProcessor;
-  private final String actorName;
   private final StreamProcessorMode streamProcessorMode;
   private final Callable<CompletableFuture<Void>> flushLog;
   private final StatePositionSupplier positionSupplier;
   private final Set<FailureListener> listeners = new HashSet<>();
-  private final PartitionId partitionId;
   private final TreeMap<Long, ActorFuture<Void>> commitAwaiters = new TreeMap<>();
   private CompletableActorFuture<PersistedSnapshot> ongoingSnapshotFuture;
 
@@ -81,12 +78,11 @@ public final class AsyncSnapshotDirector extends Actor
       final StreamProcessorMode streamProcessorMode,
       final Callable<CompletableFuture<Void>> flushLog,
       final StatePositionSupplier positionSupplier) {
+    super("SnapshotDirector", partitionId);
     this.streamProcessor = streamProcessor;
     this.stateController = stateController;
     processorName = streamProcessor.getName();
     this.snapshotRate = snapshotRate;
-    this.partitionId = partitionId;
-    actorName = actorName(partitionId.number());
     this.streamProcessorMode = streamProcessorMode;
     this.flushLog = flushLog;
     this.positionSupplier = positionSupplier;
@@ -125,18 +121,6 @@ public final class AsyncSnapshotDirector extends Actor
   }
 
   @Override
-  protected Map<String, String> createContext() {
-    final var context = super.createContext();
-    putPartitionContext(context, partitionId);
-    return context;
-  }
-
-  @Override
-  public String getName() {
-    return actorName;
-  }
-
-  @Override
   protected void onActorStarting() {
     final var firstSnapshotTime =
         RandomDuration.getRandomDurationMinuteBased(MINIMUM_SNAPSHOT_PERIOD, snapshotRate);
@@ -155,18 +139,13 @@ public final class AsyncSnapshotDirector extends Actor
   @Override
   protected void handleFailure(final Throwable failure) {
     LOG.error(
-        "No snapshot was taken due to failure in '{}'. Will try to take snapshot after snapshot period {}.",
-        actorName,
+        "No snapshot was taken. Will try to take snapshot after snapshot period {}.",
         snapshotRate,
         failure);
 
     resetStateOnFailure(failure);
     healthReport = HealthReport.unhealthy(this).withIssue(failure, Instant.now());
     notifyAllListeners();
-  }
-
-  public static String actorName(final int partitionId) {
-    return buildActorName("SnapshotDirector", partitionId);
   }
 
   private void notifyAllListeners() {
@@ -194,7 +173,7 @@ public final class AsyncSnapshotDirector extends Actor
 
   @Override
   public String componentName() {
-    return actorName;
+    return getName();
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions.impl;
 
 import io.atomix.raft.RaftApplicationEntryCommittedPositionListener;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.logstreams.state.StatePositionSupplier;
 import io.camunda.zeebe.broker.system.partitions.NoEntryAtSnapshotPosition;
 import io.camunda.zeebe.broker.system.partitions.StateController;
@@ -63,7 +64,7 @@ public final class AsyncSnapshotDirector extends Actor
   private final Callable<CompletableFuture<Void>> flushLog;
   private final StatePositionSupplier positionSupplier;
   private final Set<FailureListener> listeners = new HashSet<>();
-  private final int partitionId;
+  private final PartitionId partitionId;
   private final TreeMap<Long, ActorFuture<Void>> commitAwaiters = new TreeMap<>();
   private CompletableActorFuture<PersistedSnapshot> ongoingSnapshotFuture;
 
@@ -73,7 +74,7 @@ public final class AsyncSnapshotDirector extends Actor
   private long commitPosition;
 
   private AsyncSnapshotDirector(
-      final int partitionId,
+      final PartitionId partitionId,
       final StreamProcessor streamProcessor,
       final StateController stateController,
       final Duration snapshotRate,
@@ -85,7 +86,7 @@ public final class AsyncSnapshotDirector extends Actor
     processorName = streamProcessor.getName();
     this.snapshotRate = snapshotRate;
     this.partitionId = partitionId;
-    actorName = actorName(partitionId);
+    actorName = actorName(partitionId.number());
     this.streamProcessorMode = streamProcessorMode;
     this.flushLog = flushLog;
     this.positionSupplier = positionSupplier;
@@ -106,7 +107,7 @@ public final class AsyncSnapshotDirector extends Actor
    * @return snapshot director
    */
   public static AsyncSnapshotDirector of(
-      final int partitionId,
+      final PartitionId partitionId,
       final StreamProcessor streamProcessor,
       final StateController stateController,
       final StreamProcessorMode streamProcessorMode,
@@ -126,7 +127,7 @@ public final class AsyncSnapshotDirector extends Actor
   @Override
   protected Map<String, String> createContext() {
     final var context = super.createContext();
-    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    putPartitionContext(context, partitionId);
     return context;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/AdminApiRequestHandlerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/AdminApiRequestHandlerStep.java
@@ -41,6 +41,7 @@ public final class AdminApiRequestHandlerStep implements PartitionTransitionStep
     final var transport = context.getGatewayBrokerTransport();
     final var handler =
         new AdminApiRequestHandler(
+            context.partitionId(),
             transport,
             context.getAdminAccess(),
             context.getRaftPartition(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -110,7 +110,7 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
     final BackupService backupManager =
         new BackupService(
             context.getMemberId(),
-            context.getPartitionId(),
+            context.partitionId(),
             context.getBackupStore(),
             context.getPersistedSnapshotStore(),
             context.getRaftPartition().dataDirectory().toPath(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
-import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
@@ -123,7 +122,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
     final ExporterDirectorContext exporterCtx =
         new ExporterDirectorContext()
             .id(EXPORTER_PROCESSOR_ID)
-            .name(Actor.buildActorName("Exporter", context.getPartitionId()))
+            .partitionId(context.partitionId())
             .clock(context.getStreamClock())
             .logStream(context.getLogStream())
             .zeebeDb(context.getZeebeDb())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/InterPartitionCommandServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/InterPartitionCommandServiceStep.java
@@ -108,7 +108,7 @@ public final class InterPartitionCommandServiceStep implements PartitionTransiti
 
     final var receiver =
         new InterPartitionCommandReceiverActor(
-            context.getPartitionId(),
+            partitionId,
             context.getClusterCommunicationService(),
             logStreamWriter,
             receivingSubjects);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/InterPartitionCommandServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/InterPartitionCommandServiceStep.java
@@ -136,7 +136,7 @@ public final class InterPartitionCommandServiceStep implements PartitionTransiti
 
     final var sender =
         new InterPartitionCommandSenderService(
-            context.getClusterCommunicationService(), sendingSubject);
+            context.partitionId(), context.getClusterCommunicationService(), sendingSubject);
     final var actorStarted = context.getActorSchedulingService().submitActor(sender);
     actorStarted.onComplete(
         (ignore, error) -> {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
@@ -32,11 +32,8 @@ public final class MetricsStep implements PartitionTransitionStep {
   public ActorFuture<Void> transitionTo(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     final var startupMeterRegistry = context.getPartitionStartupMeterRegistry();
-    final var partitionId = context.partitionId();
     final var transitionRegistry =
-        MicrometerUtil.wrap(
-            startupMeterRegistry,
-            PartitionKeyNames.tags(partitionId.group(), partitionId.number()));
+        MicrometerUtil.wrap(startupMeterRegistry, PartitionKeyNames.tags(context.partitionId()));
     context.setPartitionTransitionMeterRegistry(transitionRegistry);
 
     return context.getConcurrencyControl().createCompletedFuture();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
@@ -61,7 +61,7 @@ public final class SnapshotDirectorPartitionTransitionStep implements PartitionT
       final var continuousBackup = context.getBrokerCfg().getData().getBackup().isContinuous();
       final var director =
           AsyncSnapshotDirector.of(
-              context.getPartitionId(),
+              context.partitionId(),
               context.getStreamProcessor(),
               context.getStateController(),
               processingMode,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -165,6 +165,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
     return StreamProcessor.builder()
         .meterRegistry(context.getPartitionTransitionMeterRegistry())
         .logStream(context.getLogStream())
+        .partitionId(context.partitionId())
         .actorSchedulingService(context.getActorSchedulingService())
         .zeebeDb(context.getZeebeDb())
         .recordProcessors(recordProcessors)

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/AsyncApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/AsyncApiRequestHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.RequestReader;
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler.ResponseWriter;
@@ -39,7 +40,11 @@ public abstract class AsyncApiRequestHandler<R extends RequestReader, W extends 
       ErrorResponseWriter::new;
 
   protected AsyncApiRequestHandler(
-      final Supplier<R> requestReaderSupplier, final Supplier<W> responseWriterSupplier) {
+      final String name,
+      final PartitionId partitionId,
+      final Supplier<R> requestReaderSupplier,
+      final Supplier<W> responseWriterSupplier) {
+    super(name, partitionId);
     this.requestReaderSupplier = requestReaderSupplier;
     this.responseWriterSupplier = responseWriterSupplier;
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.transport.adminapi;
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.configuration.FlowControlCfg;
@@ -33,12 +34,13 @@ public class AdminApiRequestHandler
   private final BrokerMemberId memberId;
 
   public AdminApiRequestHandler(
+      final PartitionId partitionId,
       final AtomixServerTransport transport,
       final PartitionAdminAccess adminAccess,
       final RaftPartition raftPartition,
       final ClusterConfigurationService clusterConfigurationService,
       final BrokerMemberId memberId) {
-    super(ApiRequestReader::new, ApiResponseWriter::new);
+    super("AdminApi", partitionId, ApiRequestReader::new, ApiResponseWriter::new);
     this.transport = transport;
     this.adminAccess = adminAccess;
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -71,7 +71,7 @@ public final class BackupApiRequestHandler
       final DbBackupRangeState backupRangeState,
       final PartitionId partition,
       final boolean backupFeatureEnabled) {
-    super(BackupApiRequestReader::new, BackupApiResponseWriter::new);
+    super("BackupApi", partition, BackupApiRequestReader::new, BackupApiResponseWriter::new);
     this.logStreamWriter = logStreamWriter;
     this.transport = transport;
     this.backupManager = backupManager;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.commandapi;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler;
 import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
@@ -38,8 +39,8 @@ final class CommandApiRequestHandler
   private boolean isDiskSpaceAvailable = true;
   private boolean processingPaused;
 
-  CommandApiRequestHandler() {
-    super(CommandApiRequestReader::new, CommandApiResponseWriter::new);
+  CommandApiRequestHandler(final PartitionId partitionId) {
+    super("CommandApi", partitionId, CommandApiRequestReader::new, CommandApiResponseWriter::new);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
@@ -35,16 +35,12 @@ public final class CommandApiServiceImpl extends Actor
       final ServerTransport serverTransport,
       final ActorSchedulingService scheduler,
       final QueryApiCfg queryApiCfg) {
+    super("CommandApiService", partitionId);
     this.partitionId = partitionId;
     this.serverTransport = serverTransport;
     this.scheduler = scheduler;
-    commandHandler = new CommandApiRequestHandler();
-    queryHandler = new QueryApiRequestHandler(queryApiCfg);
-  }
-
-  @Override
-  public String getName() {
-    return "CommandApiService";
+    commandHandler = new CommandApiRequestHandler(partitionId);
+    queryHandler = new QueryApiRequestHandler(partitionId, queryApiCfg);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointType;
 import io.camunda.zeebe.scheduler.Actor;
 import java.util.List;
-import java.util.Map;
 import org.slf4j.Logger;
 
 /**
@@ -30,9 +29,7 @@ import org.slf4j.Logger;
 public final class InterPartitionCommandReceiverActor extends Actor
     implements DiskSpaceUsageListener, CheckpointListener {
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
-  private final String actorName;
   private final ClusterCommunicationService communicationService;
-  private final PartitionId partitionId;
   private final InterPartitionCommandReceiverImpl receiver;
   private final List<String> receivingSubjects;
 
@@ -41,23 +38,10 @@ public final class InterPartitionCommandReceiverActor extends Actor
       final ClusterCommunicationService communicationService,
       final LogStreamWriter logStreamWriter,
       final List<String> receivingSubjects) {
-    this.partitionId = partitionId;
+    super("InterPartitionCommandReceiverActor", partitionId);
     this.communicationService = communicationService;
     receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
-    actorName = buildActorName(getClass().getSimpleName(), partitionId.number());
     this.receivingSubjects = receivingSubjects;
-  }
-
-  @Override
-  protected Map<String, String> createContext() {
-    final var context = super.createContext();
-    putPartitionContext(context, partitionId);
-    return context;
-  }
-
-  @Override
-  public String getName() {
-    return actorName;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverActor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.transport.partitionapi;
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.utils.serializer.serializers.DefaultSerializers;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageListener;
@@ -31,26 +32,26 @@ public final class InterPartitionCommandReceiverActor extends Actor
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
   private final String actorName;
   private final ClusterCommunicationService communicationService;
-  private final int partitionId;
+  private final PartitionId partitionId;
   private final InterPartitionCommandReceiverImpl receiver;
   private final List<String> receivingSubjects;
 
   public InterPartitionCommandReceiverActor(
-      final int partitionId,
+      final PartitionId partitionId,
       final ClusterCommunicationService communicationService,
       final LogStreamWriter logStreamWriter,
       final List<String> receivingSubjects) {
     this.partitionId = partitionId;
     this.communicationService = communicationService;
     receiver = new InterPartitionCommandReceiverImpl(logStreamWriter);
-    actorName = buildActorName(getClass().getSimpleName(), partitionId);
+    actorName = buildActorName(getClass().getSimpleName(), partitionId.number());
     this.receivingSubjects = receivingSubjects;
   }
 
   @Override
   protected Map<String, String> createContext() {
     final var context = super.createContext();
-    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    putPartitionContext(context, partitionId);
     return context;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandSenderService.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.transport.partitionapi;
 
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.backup.api.CheckpointListener;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyPartitionListener;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
@@ -25,7 +26,10 @@ public final class InterPartitionCommandSenderService extends Actor
   final InterPartitionCommandSenderImpl commandSender;
 
   public InterPartitionCommandSenderService(
-      final ClusterCommunicationService communicationService, final String sendingSubjectPrefix) {
+      final PartitionId partitionId,
+      final ClusterCommunicationService communicationService,
+      final String sendingSubjectPrefix) {
+    super("InterPartitionCommandSenderService", partitionId);
     commandSender = new InterPartitionCommandSenderImpl(communicationService, sendingSubjectPrefix);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.transport.queryapi;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
 import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler;
@@ -41,17 +42,10 @@ public final class QueryApiRequestHandler
 
   private @Nullable QueryService queryService;
   private final QueryApiCfg config;
-  private final String actorName;
 
-  public QueryApiRequestHandler(final QueryApiCfg config) {
-    super(QueryRequestReader::new, QueryResponseWriter::new);
+  public QueryApiRequestHandler(final PartitionId partitionId, final QueryApiCfg config) {
+    super("QueryApi", partitionId, QueryRequestReader::new, QueryResponseWriter::new);
     this.config = config;
-    actorName = "QueryApi";
-  }
-
-  @Override
-  public String getName() {
-    return actorName;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandler.java
@@ -42,7 +42,7 @@ public class SnapshotApiRequestHandler
 
   public SnapshotApiRequestHandler(
       final ServerTransport serverTransport, final BrokerClient brokerClient) {
-    super(SnapshotApiRequestReader::new, SnapshotApiResponseWriter::new);
+    super("SnapshotApi", null, SnapshotApiRequestReader::new, SnapshotApiResponseWriter::new);
     this.serverTransport = serverTransport;
     this.brokerClient = brokerClient;
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -120,7 +120,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
         manage(
             new BackupService(
                 BrokerMemberId.from(nodeId),
-                partitionId,
+                new PartitionId("raft", partitionId),
                 backupStore,
                 snapshotStore,
                 dataDirectory,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterContextTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.exporter.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -29,21 +30,11 @@ public class ExporterContextTest {
       InstantSource.fixed(Instant.ofEpochMilli(123456789));
 
   public ExporterContext makeExporterContext(
-      final int partitionId, final String exporterId, final MeterRegistry underlying) {
-    return makeExporterContext(
-        partitionId, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, exporterId, underlying);
-  }
-
-  public ExporterContext makeExporterContext(
-      final int partitionId,
-      final String physicalTenantId,
-      final String exporterId,
-      final MeterRegistry underlying) {
+      final PartitionId partitionId, final String exporterId, final MeterRegistry underlying) {
     return new ExporterContext(
         LOG,
         new ExporterTestConfiguration<>(exporterId, Collections.emptyMap()),
         partitionId,
-        physicalTenantId,
         "",
         null,
         underlying,
@@ -53,7 +44,11 @@ public class ExporterContextTest {
   @Test
   void shouldReturnDefaultPhysicalTenantId() {
     // given
-    final var context = makeExporterContext(1, "TestExporter", new SimpleMeterRegistry());
+    final var context =
+        makeExporterContext(
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
+            "TestExporter",
+            new SimpleMeterRegistry());
 
     // when
     final var physicalTenantId = context.getPhysicalTenantId();
@@ -66,7 +61,8 @@ public class ExporterContextTest {
   void shouldReturnExplicitPhysicalTenantId() {
     // given
     final var context =
-        makeExporterContext(1, "tenant-a", "TestExporter", new SimpleMeterRegistry());
+        makeExporterContext(
+            new PartitionId("tenant-a", 1), "TestExporter", new SimpleMeterRegistry());
 
     // when
     final var physicalTenantId = context.getPhysicalTenantId();
@@ -78,7 +74,7 @@ public class ExporterContextTest {
   @Test
   void shouldAddTagsAndCleanupWhenClosed() {
     // given
-    final var partitionId = 1;
+    final var partitionId = new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1);
     final var exporterId = "MetricTestExporter";
     final var underlyingMeterRegistry = new SimpleMeterRegistry();
     final var context = makeExporterContext(partitionId, exporterId, underlyingMeterRegistry);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.broker.exporter.stream;
 
-import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
@@ -72,20 +72,10 @@ public final class ExporterContainerRuntime implements CloseableSilently {
   }
 
   public ExporterContainer newContainer(
-      final ExporterDescriptor descriptor, final int partitionId) {
+      final ExporterDescriptor descriptor, final PartitionId partitionId) {
     return newContainer(
         descriptor,
         partitionId,
-        new ExporterInitializationInfo(0, null),
-        new SimpleMeterRegistry());
-  }
-
-  public ExporterContainer newContainer(
-      final ExporterDescriptor descriptor, final int partitionId, final String physicalTenantId) {
-    return newContainer(
-        descriptor,
-        partitionId,
-        physicalTenantId,
         new ExporterInitializationInfo(0, null),
         new SimpleMeterRegistry(),
         pos -> true);
@@ -93,14 +83,14 @@ public final class ExporterContainerRuntime implements CloseableSilently {
 
   public ExporterContainer newContainer(
       final ExporterDescriptor descriptor,
-      final int partitionId,
+      final PartitionId partitionId,
       final ExporterInitializationInfo initializationInfo) {
     return newContainer(descriptor, partitionId, initializationInfo, new SimpleMeterRegistry());
   }
 
   public ExporterContainer newContainer(
       final ExporterDescriptor descriptor,
-      final int partitionId,
+      final PartitionId partitionId,
       final ExporterInitializationInfo initializationInfo,
       final MeterRegistry meterRegistry) {
     return newContainer(descriptor, partitionId, initializationInfo, meterRegistry, pos -> true);
@@ -108,23 +98,7 @@ public final class ExporterContainerRuntime implements CloseableSilently {
 
   public ExporterContainer newContainer(
       final ExporterDescriptor descriptor,
-      final int partitionId,
-      final ExporterInitializationInfo initializationInfo,
-      final MeterRegistry meterRegistry,
-      final ExporterReplayControl replayControl) {
-    return newContainer(
-        descriptor,
-        partitionId,
-        PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
-        initializationInfo,
-        meterRegistry,
-        replayControl);
-  }
-
-  public ExporterContainer newContainer(
-      final ExporterDescriptor descriptor,
-      final int partitionId,
-      final String physicalTenantId,
+      final PartitionId partitionId,
       final ExporterInitializationInfo initializationInfo,
       final MeterRegistry meterRegistry,
       final ExporterReplayControl replayControl) {
@@ -133,7 +107,6 @@ public final class ExporterContainerRuntime implements CloseableSilently {
         new ExporterContainer(
             descriptor,
             partitionId,
-            physicalTenantId,
             "",
             null,
             initializationInfo,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
@@ -42,7 +43,8 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 final class ExporterContainerTest {
 
   private static final String EXPORTER_ID = "fakeExporter";
-  private static final int PARTITION_ID = 123;
+  private static final PartitionId PARTITION_ID =
+      new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 123);
   private static final String REGISTERED_COUNTER_NAME = "zeebe_exporter_counter";
 
   private ExporterContainerRuntime runtime;
@@ -227,7 +229,7 @@ final class ExporterContainerTest {
       assertThat(exporter.getContext().getLogger()).isNotNull();
       assertThat(exporter.getContext().getConfiguration()).isNotNull();
       assertThat(exporter.getContext().getConfiguration().getId()).isEqualTo(EXPORTER_ID);
-      assertThat(exporter.getContext().getPartitionId()).isEqualTo(PARTITION_ID);
+      assertThat(exporter.getContext().getPartitionId()).isEqualTo(PARTITION_ID.number());
       assertThat(exporter.getContext().getConfiguration().getArguments())
           .isEqualTo(Map.of("key", "value"));
     }
@@ -250,7 +252,7 @@ final class ExporterContainerTest {
               .getRepository()
               .validateAndAddExporterDescriptor(
                   "tenantExporter", FakeExporter.class, Map.of("key", "value"));
-      final var container = runtime.newContainer(descriptor, PARTITION_ID, "tenant-a");
+      final var container = runtime.newContainer(descriptor, new PartitionId("tenant-a", 1));
       final var tenantExporter = (FakeExporter) container.getExporter();
 
       // when

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.exporter.stream;
 
 import static org.mockito.Mockito.spy;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
@@ -138,6 +139,8 @@ public final class ExporterRule implements TestRule {
 
     final ExporterDirectorContext context =
         new ExporterDirectorContext()
+            .partitionId(
+                new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_ID))
             .id(EXPORTER_PROCESSOR_ID)
             .name(PROCESSOR_NAME)
             .logStream(stream)

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -142,7 +142,6 @@ public final class ExporterRule implements TestRule {
             .partitionId(
                 new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, PARTITION_ID))
             .id(EXPORTER_PROCESSOR_ID)
-            .name(PROCESSOR_NAME)
             .logStream(stream)
             .clock(StreamClock.system())
             .zeebeDb(capturedZeebeDb)

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
@@ -167,8 +167,7 @@ final class ExternalExporterContainerTest {
     final var container =
         new ExporterContainer(
             descriptor,
-            0,
-            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+            PARTITION_ID,
             "",
             null,
             new ExporterInitializationInfo(0, null),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
@@ -49,6 +50,8 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
  */
 @Execution(ExecutionMode.CONCURRENT)
 final class ExternalExporterContainerTest {
+  private static final PartitionId PARTITION_ID =
+      new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1);
   private static final String EXPORTER_CLASS_NAME = "com.acme.TestExporter";
   private ExporterContainerRuntime runtime;
 
@@ -68,7 +71,7 @@ final class ExternalExporterContainerTest {
     final var exporterClass = createUnloadedExporter();
     final var jarFile = exporterClass.toJar(new File(jarDirectory, "exporter.jar"));
     final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
-    final var container = runtime.newContainer(descriptor, 0);
+    final var container = runtime.newContainer(descriptor, PARTITION_ID);
 
     // when
     container.configureExporter();
@@ -90,7 +93,7 @@ final class ExternalExporterContainerTest {
     final var jarFile = exporterClass.toJar(new File(jarDirectory, "exporter.jar"));
     final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
     final var expectedClassLoader = descriptor.newInstance().getClass().getClassLoader();
-    final var container = runtime.newContainer(descriptor, 0);
+    final var container = runtime.newContainer(descriptor, PARTITION_ID);
 
     // when
     container.openExporter();
@@ -110,7 +113,7 @@ final class ExternalExporterContainerTest {
     final var jarFile = exporterClass.toJar(new File(jarDirectory, "exporter.jar"));
     final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
     final var expectedClassLoader = descriptor.newInstance().getClass().getClassLoader();
-    final var container = runtime.newContainer(descriptor, 0);
+    final var container = runtime.newContainer(descriptor, PARTITION_ID);
 
     // when
     final var record = mock(TypedRecord.class);
@@ -136,8 +139,7 @@ final class ExternalExporterContainerTest {
     final var container =
         new ExporterContainer(
             descriptor,
-            0,
-            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+            PARTITION_ID,
             "",
             null,
             new ExporterInitializationInfo(0, null),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
+import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.logstreams.state.StatePositionSupplier;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.StateControllerImpl;
@@ -128,7 +130,7 @@ public final class AsyncSnapshottingTest {
   private void createSnapshotDirector(final StreamProcessorMode mode) {
     asyncSnapshotDirector =
         AsyncSnapshotDirector.of(
-            1,
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             mockStreamProcessor,
             snapshotController,
             mode,
@@ -248,7 +250,7 @@ public final class AsyncSnapshottingTest {
 
     asyncSnapshotDirector =
         AsyncSnapshotDirector.of(
-            1,
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             mockStreamProcessor,
             snapshotController,
             StreamProcessorMode.PROCESSING,
@@ -276,7 +278,7 @@ public final class AsyncSnapshottingTest {
 
     asyncSnapshotDirector =
         AsyncSnapshotDirector.of(
-            1,
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             mockStreamProcessor,
             snapshotController,
             StreamProcessorMode.REPLAY,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -101,7 +101,8 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
     transitionMeterRegistry =
         MicrometerUtil.wrap(
             startupMeterRegistry,
-            PartitionKeyNames.tags(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1));
+            PartitionKeyNames.tags(
+                new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1)));
     healthMetrics = new HealthTreeMetrics(transitionMeterRegistry);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/RandomizedPartitionTransitionTest.java
@@ -428,10 +428,8 @@ public class RandomizedPartitionTransitionTest {
   }
 
   private static final class TestActor extends Actor {
-
-    @Override
-    public String getName() {
-      return "RandomizedPartitionTransitionTest.testActor";
+    TestActor() {
+      super("RandomizedPartitionTransitionTest.testActor");
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/ApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/ApiRequestHandlerTest.java
@@ -95,7 +95,7 @@ final class ApiRequestHandlerTest {
     TestApiRequestHandler(
         final Supplier<RequestReader> requestReaderSupplier,
         final Supplier<ResponseWriter> responseWriterSupplier) {
-      super(requestReaderSupplier, responseWriterSupplier);
+      super("TestApi", null, requestReaderSupplier, responseWriterSupplier);
     }
 
     @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandlerTest.java
@@ -106,6 +106,7 @@ final class AdminApiRequestHandlerTest {
         @Mock final ClusterConfigurationService clusterConfigurationService) {
       handler =
           new AdminApiRequestHandler(
+              null,
               transport,
               adminAccess,
               raftPartition,
@@ -154,6 +155,7 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
+              null,
               transport,
               adminAccess,
               raftPartition,
@@ -235,6 +237,7 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
+              null,
               transport,
               adminAccess,
               raftPartition,
@@ -316,6 +319,7 @@ final class AdminApiRequestHandlerTest {
       when(adminAccess.forPartition(partitionId)).thenReturn(Optional.of(adminAccess));
       handler =
           new AdminApiRequestHandler(
+              null,
               transport,
               adminAccess,
               raftPartition,
@@ -397,7 +401,7 @@ final class AdminApiRequestHandlerTest {
       final BrokerMemberId memberId = BrokerMemberId.from(1);
       handler =
           new AdminApiRequestHandler(
-              transport, adminAccess, raftPartition, clusterConfigurationService, memberId);
+              null, transport, adminAccess, raftPartition, clusterConfigurationService, memberId);
     }
 
     @BeforeEach

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerPublishMessageRequest;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
@@ -40,7 +42,9 @@ import org.junit.Test;
 
 public class CommandApiRequestHandlerTest {
   @Rule public final ControlledActorSchedulerRule scheduler = new ControlledActorSchedulerRule();
-  final CommandApiRequestHandler handler = new CommandApiRequestHandler();
+  final CommandApiRequestHandler handler =
+      new CommandApiRequestHandler(
+          new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 0));
   private LogStreamWriter logStreamWriter;
 
   @Before

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/queryapi/QueryApiRequestHandlerTest.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.broker.transport.queryapi;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
 import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.engine.state.QueryService.ClosedServiceException;
@@ -321,7 +323,9 @@ final class QueryApiRequestHandlerTest {
   private QueryApiRequestHandler createQueryApiRequestHandler(final boolean enabled) {
     final var config = new QueryApiCfg();
     config.setEnabled(enabled);
-    final var requestHandler = new QueryApiRequestHandler(config);
+    final var requestHandler =
+        new QueryApiRequestHandler(
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1), config);
     scheduler.submitActor(requestHandler);
 
     return requestHandler;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/snapshotapi/SnapshotApiRequestHandlerTest.java
@@ -180,7 +180,11 @@ public class SnapshotApiRequestHandlerTest {
 
     final var transfer =
         submitActor(
-            new SnapshotTransferImpl(ignore -> client, snapshotMetrics, receiverSnapshotStore));
+            new SnapshotTransferImpl(
+                new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
+                ignore -> client,
+                snapshotMetrics,
+                receiverSnapshotStore));
     // when
     final var persistedSnapshot = transfer.getLatestSnapshot(partitionId);
     scheduler.workUntilDone();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
@@ -70,11 +70,6 @@ public class GatewayClusterConfigurationService extends Actor
   }
 
   @Override
-  public String getName() {
-    return "GatewayClusterConfigurationService";
-  }
-
-  @Override
   protected void onActorStarting() {
     LOG.info("Starting Cluster Configuration Manager");
     clusterConfigurationGossiper.start().onComplete(startedFuture);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
@@ -112,7 +112,7 @@ final class ClusterConfigurationGossiperTest {
         final AtomixCluster atomixCluster,
         final ClusterConfigurationGossiperConfig config,
         final TopologyMetrics topologyMetrics) {
-
+      super("Node-" + atomixCluster.getMembershipService().getLocalMember().id());
       gossiper =
           new ClusterConfigurationGossiper(
               this,
@@ -123,11 +123,6 @@ final class ClusterConfigurationGossiperTest {
               this::mergeTopology,
               topologyMetrics);
       this.atomixCluster = atomixCluster;
-    }
-
-    @Override
-    public String getName() {
-      return "Node-" + id();
     }
 
     @Override

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -245,7 +245,7 @@ public class PartitionRestoreService {
     final RestorableSnapshotStore snapshotStore =
         new FileBasedSnapshotStore(
             brokerId,
-            partition.id().number(),
+            partition.id(),
             partition.dataDirectory().toPath(),
             checksumProvider,
             meterRegistry);

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -340,8 +340,7 @@ public class RestoreManager implements CloseableSilently {
       final PartitionMetadata metadata, final RaftPartitionFactory factory) {
     final var partitionId = metadata.id();
     final var partitionRegistry =
-        MicrometerUtil.wrap(
-            meterRegistry, PartitionKeyNames.tags(partitionId.group(), partitionId.number()));
+        MicrometerUtil.wrap(meterRegistry, PartitionKeyNames.tags(partitionId));
 
     return new InstrumentedRaftPartition(
         factory.createRaftPartition(metadata, partitionRegistry), partitionRegistry);

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -116,7 +116,7 @@ class PartitionRestoreServiceTest {
     backupService =
         new BackupService(
             BrokerMemberId.from(nodeId),
-            partitionId,
+            new PartitionId("raft", partitionId),
             backupStore,
             snapshotStore,
             dataDirectory,

--- a/zeebe/scheduler/pom.xml
+++ b/zeebe/scheduler/pom.xml
@@ -23,6 +23,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-cluster</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
     </dependency>

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
@@ -12,9 +12,9 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Loggers;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -34,42 +34,81 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
 
   private static final int MAX_CLOSE_TIMEOUT = 300;
   protected final ActorControl actor = new ActorControl(this);
-  private Map<String, String> context;
+  private final Map<String, String> context;
+  private final String name;
 
   /**
-   * Should be overwritten by sub classes to add more context where the actor is run.
+   * Creates a new actor with name and context derived from the given parameters.
    *
-   * @return the context of the actor
+   * @param name A name for the actor. If {@code null}, the name of the class will be used.
+   * @param partitionId The partition the actor belongs to. Unless this is {@code null}, the actor
+   *     name will end with the partition number and the context will contain the partition group
+   *     and number.
+   * @param additionalContext Any additional context to be included in the actor's context besides
+   *     the automatically added {@link #ACTOR_PROP_NAME}, {@link #ACTOR_PROP_PARTITION_ID} and
+   *     {@link #ACTOR_PROP_PHYSICAL_TENANT}.
    */
-  protected Map<String, String> createContext() {
-    // return an modifiable map in order to simplify sub class implementation
-    final var baseContext = new HashMap<String, String>();
-    baseContext.put(ACTOR_PROP_NAME, getName());
-    return baseContext;
+  protected Actor(
+      @Nullable final String name,
+      @Nullable final PartitionId partitionId,
+      @Nullable final Map<String, String> additionalContext) {
+    final var actorName = Objects.requireNonNullElse(name, getClass().getSimpleName());
+    this.name = partitionId != null ? buildActorName(actorName, partitionId.number()) : actorName;
+    context = buildContext(this.name, partitionId, additionalContext);
   }
 
-  public String getName() {
-    return getClass().getSimpleName();
+  /** Creates an actor, named by its class, without a partition or additional context. */
+  protected Actor() {
+    this(null, null, null);
   }
 
   /**
-   * Adds the partition id and partition group (physical tenant) of the given partition to the actor
-   * context map so that both show up in the MDC of every log line emitted by this actor.
+   * Creates an actor with the provided name, without a partition or additional context.
+   *
+   * @param name A name for the actor. If {@code null}, the name of the class will be used.
    */
-  protected static void putPartitionContext(
-      final Map<String, String> context, final PartitionId partitionId) {
-    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId.number()));
-    context.put(ACTOR_PROP_PHYSICAL_TENANT, partitionId.group());
+  protected Actor(final String name) {
+    this(name, null, null);
   }
 
   /**
-   * @return a map which defines the context where the actor is run. Per default it just returns a
-   *     map with the actor name. Ideally sub classes add more context, like the partition id etc.
+   * Creates a new actor with name and context derived from the given parameters.
+   *
+   * @param name A name for the actor. If {@code null}, the name of the class will be used.
+   * @param partitionId The partition the actor belongs to. Unless this is {@code null}, the actor
+   *     name will end with the partition number and the context will contain the partition group
+   *     and number.
+   */
+  protected Actor(final String name, final PartitionId partitionId) {
+    this(name, partitionId, null);
+  }
+
+  private static Map<String, String> buildContext(
+      final String name,
+      final PartitionId partitionId,
+      final Map<String, String> additionalContext) {
+    final var context =
+        new HashMap<String, String>(
+            3); // most actors have a name and associated partition but no additional context
+    context.put(ACTOR_PROP_NAME, name);
+    if (partitionId != null) {
+      context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId.number()));
+      context.put(ACTOR_PROP_PHYSICAL_TENANT, partitionId.group());
+    }
+    if (additionalContext != null) {
+      context.putAll(additionalContext);
+    }
+    return context;
+  }
+
+  public final String getName() {
+    return name;
+  }
+
+  /**
+   * @return a map that defines the context where the actor is run, as provided to the constructor.
    */
   public Map<String, String> getContext() {
-    if (context == null) {
-      context = Collections.unmodifiableMap(createContext());
-    }
     return context;
   }
 
@@ -98,11 +137,7 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
   }
 
   public static Actor wrap(final Consumer<ActorControl> r) {
-    return new Actor() {
-      @Override
-      public String getName() {
-        return r.toString();
-      }
+    return new Actor(r.toString()) {
 
       @Override
       protected void onActorStarted() {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.scheduler;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Loggers;
 import java.time.Duration;
@@ -24,6 +25,12 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
 
   public static final String ACTOR_PROP_NAME = "actor-name";
   public static final String ACTOR_PROP_PARTITION_ID = "partitionId";
+
+  /**
+   * MDC key for the partition group (a.k.a. physical tenant) the actor belongs to. Mirrors the
+   * {@code physicalTenant} common metrics label (see {@code PartitionKeyNames}).
+   */
+  public static final String ACTOR_PROP_PHYSICAL_TENANT = "physicalTenant";
 
   private static final int MAX_CLOSE_TIMEOUT = 300;
   protected final ActorControl actor = new ActorControl(this);
@@ -43,6 +50,16 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
 
   public String getName() {
     return getClass().getSimpleName();
+  }
+
+  /**
+   * Adds the partition id and partition group (physical tenant) of the given partition to the actor
+   * context map so that both show up in the MDC of every log line emitted by this actor.
+   */
+  protected static void putPartitionContext(
+      final Map<String, String> context, final PartitionId partitionId) {
+    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId.number()));
+    context.put(ACTOR_PROP_PHYSICAL_TENANT, partitionId.group());
   }
 
   /**

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/ActorPartitionContextTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/ActorPartitionContextTest.java
@@ -32,17 +32,9 @@ final class ActorPartitionContextTest {
   }
 
   private static final class PartitionScopedActor extends Actor {
-    private final PartitionId partitionId;
 
     private PartitionScopedActor(final PartitionId partitionId) {
-      this.partitionId = partitionId;
-    }
-
-    @Override
-    protected Map<String, String> createContext() {
-      final var context = super.createContext();
-      putPartitionContext(context, partitionId);
-      return context;
+      super("PartitionScopedActor", partitionId);
     }
   }
 }

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/ActorPartitionContextTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/ActorPartitionContextTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.scheduler;
+
+import static io.camunda.zeebe.scheduler.Actor.ACTOR_PROP_PARTITION_ID;
+import static io.camunda.zeebe.scheduler.Actor.ACTOR_PROP_PHYSICAL_TENANT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.PartitionId;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class ActorPartitionContextTest {
+
+  @Test
+  void shouldExposePartitionIdAndGroupInActorContext() {
+    // given
+    final var actor = new PartitionScopedActor(new PartitionId("my-group", 3));
+
+    // when
+    final Map<String, String> context = actor.getContext();
+
+    // then
+    assertThat(context)
+        .containsEntry(ACTOR_PROP_PARTITION_ID, "3")
+        .containsEntry(ACTOR_PROP_PHYSICAL_TENANT, "my-group");
+  }
+
+  private static final class PartitionScopedActor extends Actor {
+    private final PartitionId partitionId;
+
+    private PartitionScopedActor(final PartitionId partitionId) {
+      this.partitionId = partitionId;
+    }
+
+    @Override
+    protected Map<String, String> createContext() {
+      final var context = super.createContext();
+      putPartitionContext(context, partitionId);
+      return context;
+    }
+  }
+}

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
@@ -48,11 +48,7 @@ public class CriticalComponentsHealthMonitorTest {
   public void setup() {
     graphListener = mock();
     final Actor testActor =
-        new Actor() {
-          @Override
-          public String getName() {
-            return "test-actor";
-          }
+        new Actor("test-actor") {
 
           @Override
           protected void onActorStarting() {

--- a/zeebe/snapshot/pom.xml
+++ b/zeebe/snapshot/pom.xml
@@ -17,6 +17,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-cluster</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -36,8 +36,6 @@ public final class FileBasedSnapshotStore extends Actor
         RestorableSnapshotStore,
         BootstrapSnapshotStore {
 
-  private final String actorName;
-  private final PartitionId partitionId;
   private final FileBasedSnapshotStoreImpl snapshotStore;
 
   public FileBasedSnapshotStore(
@@ -46,8 +44,7 @@ public final class FileBasedSnapshotStore extends Actor
       final Path root,
       final CRC32CChecksumProvider checksumProvider,
       final MeterRegistry meterRegistry) {
-    actorName = buildActorName("SnapshotStore", partitionId.number());
-    this.partitionId = partitionId;
+    super("SnapshotStore", partitionId);
     snapshotStore =
         new FileBasedSnapshotStoreImpl(
             brokerId, root, checksumProvider, actor, new SnapshotMetrics(meterRegistry));
@@ -69,18 +66,6 @@ public final class FileBasedSnapshotStore extends Actor
         root,
         checksumProvider,
         meterRegistry);
-  }
-
-  @Override
-  protected Map<String, String> createContext() {
-    final var context = super.createContext();
-    putPartitionContext(context, partitionId);
-    return context;
-  }
-
-  @Override
-  public String getName() {
-    return actorName;
   }
 
   @Override
@@ -194,11 +179,9 @@ public final class FileBasedSnapshotStore extends Actor
   @Override
   public String toString() {
     return "FileBasedSnapshotStore{"
-        + "actorName='"
-        + actorName
+        + "actor='"
+        + getName()
         + '\''
-        + ", partitionId="
-        + partitionId
         + ", snapshotStore="
         + snapshotStore
         + '}';

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.snapshots.impl;
 
+import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -35,26 +37,44 @@ public final class FileBasedSnapshotStore extends Actor
         BootstrapSnapshotStore {
 
   private final String actorName;
-  private final int partitionId;
+  private final PartitionId partitionId;
   private final FileBasedSnapshotStoreImpl snapshotStore;
 
   public FileBasedSnapshotStore(
       final int brokerId,
-      final int partitionId,
+      final PartitionId partitionId,
       final Path root,
       final CRC32CChecksumProvider checksumProvider,
       final MeterRegistry meterRegistry) {
-    actorName = buildActorName("SnapshotStore", partitionId);
+    actorName = buildActorName("SnapshotStore", partitionId.number());
     this.partitionId = partitionId;
     snapshotStore =
         new FileBasedSnapshotStoreImpl(
             brokerId, root, checksumProvider, actor, new SnapshotMetrics(meterRegistry));
   }
 
+  /**
+   * Convenience constructor that assumes the default partition group. Kept for tests and callers
+   * that only have a numeric partition id.
+   */
+  public FileBasedSnapshotStore(
+      final int brokerId,
+      final int partitionId,
+      final Path root,
+      final CRC32CChecksumProvider checksumProvider,
+      final MeterRegistry meterRegistry) {
+    this(
+        brokerId,
+        new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, partitionId),
+        root,
+        checksumProvider,
+        meterRegistry);
+  }
+
   @Override
   protected Map<String, String> createContext() {
     final var context = super.createContext();
-    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    putPartitionContext(context, partitionId);
     return context;
   }
 

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.snapshots.transfer;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -34,9 +35,11 @@ public class SnapshotTransferImpl extends Actor implements SnapshotTransfer {
   private final ConcurrentHashMap<UUID, CloseableSilently> timers = new ConcurrentHashMap<>();
 
   public SnapshotTransferImpl(
+      final PartitionId partitionId,
       final Function<ConcurrencyControl, SnapshotTransferService> service,
       final SnapshotMetrics snapshotMetrics,
       final ReceivableSnapshotStore snapshotStore) {
+    super("SnapshotTransfer", partitionId);
     this.snapshotMetrics = snapshotMetrics;
     this.snapshotStore = snapshotStore;
     this.service = service.apply(this);

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/transfer/SnapshotTransferTest.java
@@ -17,6 +17,8 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.snapshots.SnapshotCopyUtil;
@@ -72,6 +74,7 @@ public class SnapshotTransferTest {
     takeSnapshotMock = mock(TakeSnapshot.class);
     snapshotTransfer =
         new SnapshotTransferImpl(
+            new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             control ->
                 spy(
                     new SnapshotTransferServiceImpl(

--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -25,6 +25,10 @@
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-cluster</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -18,21 +19,21 @@ final class AsyncProcessingScheduleServiceActor extends Actor {
   private final ProcessingScheduleServiceImpl scheduleService;
   private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
   private final String asyncScheduleActorName;
-  private final int partitionId;
+  private final PartitionId partitionId;
 
   public AsyncProcessingScheduleServiceActor(
       final String name,
       final ProcessingScheduleServiceFactory scheduleServiceFactory,
-      final int partitionId) {
+      final PartitionId partitionId) {
     scheduleService = scheduleServiceFactory.create();
-    asyncScheduleActorName = buildActorName(name, partitionId);
+    asyncScheduleActorName = buildActorName(name, partitionId.number());
     this.partitionId = partitionId;
   }
 
   @Override
   protected Map<String, String> createContext() {
     final var context = super.createContext();
-    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    putPartitionContext(context, partitionId);
     return context;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -12,34 +12,18 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
-import java.util.Map;
 
 final class AsyncProcessingScheduleServiceActor extends Actor {
 
   private final ProcessingScheduleServiceImpl scheduleService;
   private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
-  private final String asyncScheduleActorName;
-  private final PartitionId partitionId;
 
   public AsyncProcessingScheduleServiceActor(
       final String name,
       final ProcessingScheduleServiceFactory scheduleServiceFactory,
       final PartitionId partitionId) {
+    super(name, partitionId);
     scheduleService = scheduleServiceFactory.create();
-    asyncScheduleActorName = buildActorName(name, partitionId.number());
-    this.partitionId = partitionId;
-  }
-
-  @Override
-  protected Map<String, String> createContext() {
-    final var context = super.createContext();
-    putPartitionContext(context, partitionId);
-    return context;
-  }
-
-  @Override
-  public String getName() {
-    return asyncScheduleActorName;
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -17,14 +18,14 @@ import java.util.EnumMap;
 class AsyncScheduleServiceContext {
   private final ActorSchedulingService actorSchedulingService;
   private final ProcessingScheduleServiceFactory actorServiceFactory;
-  private final int partitionId;
+  private final PartitionId partitionId;
 
   private final EnumMap<AsyncTaskGroup, AsyncProcessingScheduleServiceActor> asyncActors;
 
   public AsyncScheduleServiceContext(
       final ActorSchedulingService actorSchedulingService,
       final ProcessingScheduleServiceFactory actorServiceFactory,
-      final int partitionId) {
+      final PartitionId partitionId) {
     this.actorSchedulingService = actorSchedulingService;
     this.actorServiceFactory = actorServiceFactory;
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -37,7 +37,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
@@ -99,7 +98,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private final ZeebeDb zeebeDb;
   // processing
   private final StreamProcessorContext streamProcessorContext;
-  private final String actorName;
   private LogStreamReader logStreamReader;
   private ProcessingStateMachine processingStateMachine;
   private ReplayStateMachine replayStateMachine;
@@ -115,6 +113,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private ProcessingScheduleServiceImpl processorActorService;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
+    super("StreamProcessor", processorBuilder.getProcessingContext().partitionId());
     actorSchedulingService = processorBuilder.getActorSchedulingService();
     lifecycleAwareListeners = new ArrayList<>(processorBuilder.getLifecycleListeners());
     zeebeDb = processorBuilder.getZeebeDb();
@@ -128,7 +127,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             .abortCondition(this::isClosed);
     logStream = streamProcessorContext.getLogStream();
     partitionId = logStream.getPartitionId();
-    actorName = buildActorName("StreamProcessor", partitionId);
     metrics = new StreamProcessorMetrics(streamProcessorContext.getMeterRegistry());
     metrics.initializeProcessorPhase(streamProcessorContext.getStreamProcessorPhase());
     recordProcessors.addAll(processorBuilder.getRecordProcessors());
@@ -136,18 +134,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   public static StreamProcessorBuilder builder() {
     return new StreamProcessorBuilder();
-  }
-
-  @Override
-  protected Map<String, String> createContext() {
-    final var context = super.createContext();
-    putPartitionContext(context, streamProcessorContext.partitionId());
-    return context;
-  }
-
-  @Override
-  public String getName() {
-    return actorName;
   }
 
   @Override
@@ -388,7 +374,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   private void onFailure(final Throwable throwable) {
-    LOG.error("Actor {} failed in phase {}.", actorName, actor.getLifecyclePhase(), throwable);
+    LOG.error("Actor {} failed in phase {}.", getName(), actor.getLifecyclePhase(), throwable);
 
     asyncScheduleServiceContext
         .closeActors(actor)
@@ -463,7 +449,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   @Override
   public String componentName() {
-    return actorName;
+    return getName();
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -141,7 +141,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   @Override
   protected Map<String, String> createContext() {
     final var context = super.createContext();
-    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    putPartitionContext(context, streamProcessorContext.partitionId());
     return context;
   }
 
@@ -178,7 +178,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               scheduledTaskMetrics);
 
       asyncScheduleServiceContext =
-          new AsyncScheduleServiceContext(actorSchedulingService, actorServiceFactory, partitionId);
+          new AsyncScheduleServiceContext(
+              actorSchedulingService, actorServiceFactory, streamProcessorContext.partitionId());
 
       processorActorService = actorServiceFactory.create();
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -51,6 +52,11 @@ public final class StreamProcessorBuilder {
 
   public StreamProcessorBuilder logStream(final LogStream stream) {
     streamProcessorContext.logStream(stream);
+    return this;
+  }
+
+  public StreamProcessorBuilder partitionId(final PartitionId partitionId) {
+    streamProcessorContext.partitionId(partitionId);
     return this;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.stream.impl;
 
+import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
@@ -34,6 +36,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private static final StreamProcessorListener NOOP_LISTENER = processedCommand -> {};
   private ActorControl actor;
   private LogStream logStream;
+  private PartitionId partitionId;
   private LogStreamReader logStreamReader;
   private RecordValues recordValues;
   private TransactionContext transactionContext;
@@ -78,6 +81,22 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   @Override
   public int getPartitionId() {
     return getLogStream().getPartitionId();
+  }
+
+  /**
+   * Returns the composite partition id (partition group + number). Falls back to the default
+   * partition group when none was configured, so callers that only set up a log stream still get a
+   * usable value.
+   */
+  public PartitionId partitionId() {
+    return partitionId != null
+        ? partitionId
+        : new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, getPartitionId());
+  }
+
+  public StreamProcessorContext partitionId(final PartitionId partitionId) {
+    this.partitionId = partitionId;
+    return this;
   }
 
   @Override

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -46,16 +46,12 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
       final MessagingService messagingService,
       final IdGenerator requestIdGenerator,
       final boolean receiveOnLegacySubject) {
+    super("ServerTransport");
     this.messagingService = messagingService;
     this.requestIdGenerator = requestIdGenerator;
     this.receiveOnLegacySubject = receiveOnLegacySubject;
     pendingRequests = new Long2ObjectHashMap<>();
     subscribedTopics = new HashMap<>();
-  }
-
-  @Override
-  public String getName() {
-    return "ServerTransport";
   }
 
   @Override

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -161,6 +161,10 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-cluster</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <resources>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/PartitionKeyNames.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/PartitionKeyNames.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.util.micrometer;
 
+import io.camunda.cluster.PartitionId;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Tags;
 
@@ -30,12 +31,12 @@ public enum PartitionKeyNames implements KeyName {
     }
   };
 
-  public static Tags tags(final String physicalTenantId, final int partitionId) {
+  public static Tags tags(final PartitionId partitionId) {
     return Tags.of(
         PHYSICAL_TENANT.asString(),
-        physicalTenantId,
+        partitionId.group(),
         PARTITION.asString(),
-        String.valueOf(partitionId));
+        String.valueOf(partitionId.number()));
   }
 
   /**


### PR DESCRIPTION
Part of #50539 (observable partition groups). With multiple partition groups (physical tenants), the numerical partition id is only unique within a group, so logs need the partition group as an additional dimension — mirroring the `physicalTenant` common metric label added in #50542.

This sets a new `physicalTenant` MDC key alongside `partitionId` in every partition-scoped actor and directly on the raft threads in `RaftContext`. To do so, partition-scoped actors now carry the composite `PartitionId` instead of a bare int. The production log pattern already prints the full MDC map (`%X`), so the group shows up without a pattern change.

Closes #50541
