### PR TITLE
Resolve & propagate child `businessId` at child process instance creation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -688,7 +688,7 @@ public final class BpmnStateTransitionBehavior {
   }
 
   public long createChildProcessInstance(
-      final DeployedProcess process, final BpmnElementContext context) {
+      final DeployedProcess process, final BpmnElementContext context, final String businessId) {
 
     final var processInstanceKey = keyGenerator.nextKey();
 
@@ -704,7 +704,7 @@ public final class BpmnStateTransitionBehavior {
         .setBpmnElementType(process.getProcess().getElementType())
         .setTenantId(context.getTenantId())
         .setRootProcessInstanceKey(context.getRootProcessInstanceKey())
-        .setBusinessId(context.getBusinessId());
+        .setBusinessId(businessId);
 
     commandWriter.appendFollowUpCommand(
         processInstanceKey, ProcessInstanceIntent.ACTIVATE_ELEMENT, childInstanceRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -92,13 +92,19 @@ public final class CallActivityProcessor
                     processId, element.getBindingType(), element.getVersionTag(), context))
         .flatMap(this::checkProcessHasNoneStartEvent)
         .flatMap(p -> eventSubscriptionBehavior.subscribeToEvents(element, context).map(ok -> p))
+        .flatMap(
+            process ->
+                resolveChildBusinessId(context, element)
+                    .map(businessId -> new CalledProcess(process, businessId)))
         .thenDo(
-            process -> {
+            calledProcess -> {
+              final var process = calledProcess.process();
               final var activated =
                   stateTransitionBehavior.transitionToActivated(context, element.getEventType());
 
               final var childProcessInstanceKey =
-                  stateTransitionBehavior.createChildProcessInstance(process, context);
+                  stateTransitionBehavior.createChildProcessInstance(
+                      process, context, calledProcess.businessId());
 
               final var propagateAllParentVariablesEnabled =
                   element.isPropagateAllParentVariablesEnabled();
@@ -255,6 +261,33 @@ public final class CallActivityProcessor
         processIdExpression, scopeKey, tenantId);
   }
 
+  /**
+   * Resolves the Business ID to assign to the child process instance, per ADR 0003-810 (D2/D3):
+   *
+   * <ul>
+   *   <li><b>inherit</b> (no configuration) — keep the parent's Business ID, preserving the 8.9
+   *       behavior;
+   *   <li><b>literal/empty</b> (static expression) — use the configured value verbatim, so a
+   *       numeric or reserved-word literal is not coerced and an empty value yields no Business ID;
+   *   <li><b>FEEL</b> (dynamic expression) — evaluate at the call-activity element-instance scope.
+   * </ul>
+   *
+   * <p>The evaluation is threaded through the {@link Either} chain so that a FEEL failure can
+   * surface as an incident (handled in a follow-up feature).
+   */
+  private Either<Failure, String> resolveChildBusinessId(
+      final BpmnElementContext context, final ExecutableCallActivity element) {
+    final var businessIdExpression = element.getCalledElementBusinessId();
+    if (businessIdExpression == null) {
+      return Either.right(context.getBusinessId());
+    }
+    if (businessIdExpression.isStatic()) {
+      return Either.right(businessIdExpression.getExpression());
+    }
+    return expressionProcessor.evaluateStringExpression(
+        businessIdExpression, context.getElementInstanceKey(), context.getTenantId());
+  }
+
   private Either<Failure, DeployedProcess> getCalledProcess(
       final DirectBuffer processId,
       final ZeebeBindingType bindingType,
@@ -339,4 +372,6 @@ public final class CallActivityProcessor
     }
     return Either.right(process);
   }
+
+  private record CalledProcess(DeployedProcess process, String businessId) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityBusinessIdTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class CallActivityBusinessIdTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PARENT_PROCESS_ID = "parent-process";
+  private static final String CHILD_PROCESS_ID = "child-process";
+  private static final String PARENT_BUSINESS_ID = "parent-business-id";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance parentProcess(final Consumer<CallActivityBuilder> consumer) {
+    final CallActivityBuilder callActivity =
+        Bpmn.createExecutableProcess(PARENT_PROCESS_ID).startEvent().callActivity("call");
+    callActivity.zeebeProcessId(CHILD_PROCESS_ID);
+    consumer.accept(callActivity);
+    return callActivity.endEvent().done();
+  }
+
+  private static BpmnModelInstance childProcess() {
+    return Bpmn.createExecutableProcess(CHILD_PROCESS_ID).startEvent().endEvent().done();
+  }
+
+  private void deploy(final BpmnModelInstance parent) {
+    ENGINE
+        .deployment()
+        .withXmlResource("parent.bpmn", parent)
+        .withXmlResource("child.bpmn", childProcess())
+        .deploy();
+  }
+
+  private static Record<ProcessInstanceRecordValue> childProcessInstance(final long parentKey) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withParentProcessInstanceKey(parentKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst();
+  }
+
+  @Test
+  public void shouldInheritParentBusinessIdWhenAttributeIsAbsent() {
+    // given - a call activity without a businessId attribute
+    deploy(parentProcess(c -> {}));
+
+    // when
+    final long parentKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PARENT_PROCESS_ID)
+            .withBusinessId(PARENT_BUSINESS_ID)
+            .create();
+
+    // then - the child inherits the parent's Business ID (8.9 behaviour)
+    Assertions.assertThat(childProcessInstance(parentKey).getValue())
+        .hasBusinessId(PARENT_BUSINESS_ID);
+  }
+
+  @Test
+  public void shouldOverrideParentBusinessIdWithLiteral() {
+    // given - a literal businessId overriding inheritance
+    deploy(parentProcess(c -> c.zeebeBusinessId("child-123")));
+
+    // when
+    final long parentKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PARENT_PROCESS_ID)
+            .withBusinessId(PARENT_BUSINESS_ID)
+            .create();
+
+    // then - the literal wins over the parent's Business ID
+    Assertions.assertThat(childProcessInstance(parentKey).getValue()).hasBusinessId("child-123");
+  }
+
+  @Test
+  public void shouldResolveEmptyBusinessIdToEmpty() {
+    // given - an explicitly empty businessId
+    deploy(parentProcess(c -> c.zeebeBusinessId("")));
+
+    // when
+    final long parentKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PARENT_PROCESS_ID)
+            .withBusinessId(PARENT_BUSINESS_ID)
+            .create();
+
+    // then - the child starts with no Business ID, not the inherited one
+    Assertions.assertThat(childProcessInstance(parentKey).getValue()).hasBusinessId("");
+  }
+
+  @Test
+  public void shouldEvaluateFeelBusinessIdAtChildCreation() {
+    // given - a FEEL businessId referencing a process variable
+    deploy(parentProcess(c -> c.zeebeBusinessId("=orderId")));
+
+    // when
+    final long parentKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PARENT_PROCESS_ID)
+            .withVariable("orderId", "child-xyz")
+            .create();
+
+    // then - the expression is evaluated at the call-activity scope and assigned to the child
+    Assertions.assertThat(childProcessInstance(parentKey).getValue()).hasBusinessId("child-xyz");
+  }
+
+  @Test
+  public void shouldKeepChildBusinessIdImmutableAcrossLifecycle() {
+    // given
+    deploy(parentProcess(c -> c.zeebeBusinessId("child-123")));
+
+    // when
+    final long parentKey = ENGINE.processInstance().ofBpmnProcessId(PARENT_PROCESS_ID).create();
+    final long childKey = childProcessInstance(parentKey).getKey();
+
+    // then - the Business ID is stable across the whole child process-instance lifecycle
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(childKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBusinessId())
+        .containsOnly("child-123");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityBusinessIdTest.java
@@ -51,10 +51,12 @@ public final class CallActivityBusinessIdTest {
     return Bpmn.createExecutableProcess(CHILD_PROCESS_ID).startEvent().endEvent().done();
   }
 
-  private static BpmnModelInstance childProcessCalling(final String grandchildBusinessId) {
+  private static BpmnModelInstance childProcessCalling(
+      final Consumer<CallActivityBuilder> grandchildCallActivity) {
     final CallActivityBuilder callActivity =
         Bpmn.createExecutableProcess(CHILD_PROCESS_ID).startEvent().callActivity("call-grandchild");
-    callActivity.zeebeProcessId(GRANDCHILD_PROCESS_ID).zeebeBusinessId(grandchildBusinessId);
+    callActivity.zeebeProcessId(GRANDCHILD_PROCESS_ID);
+    grandchildCallActivity.accept(callActivity);
     return callActivity.endEvent().done();
   }
 
@@ -171,7 +173,7 @@ public final class CallActivityBusinessIdTest {
     ENGINE
         .deployment()
         .withXmlResource("parent.bpmn", parentProcess(c -> c.zeebeBusinessId("level-1")))
-        .withXmlResource("child.bpmn", childProcessCalling("level-2"))
+        .withXmlResource("child.bpmn", childProcessCalling(c -> c.zeebeBusinessId("level-2")))
         .withXmlResource("grandchild.bpmn", grandchildProcess())
         .deploy();
 
@@ -188,11 +190,62 @@ public final class CallActivityBusinessIdTest {
     Assertions.assertThat(childInstance.getValue()).hasBusinessId("level-1");
 
     final Record<ProcessInstanceRecordValue> grandchildInstance =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-            .withParentProcessInstanceKey(childInstance.getKey())
-            .withElementType(BpmnElementType.PROCESS)
-            .getFirst();
+        childProcessInstance(childInstance.getKey());
     Assertions.assertThat(grandchildInstance.getValue()).hasBusinessId("level-2");
+  }
+
+  @Test
+  public void shouldInheritGrandchildBusinessIdFromChildNotParent() {
+    // given - the child overrides its Business ID, the grandchild's call activity sets none
+    ENGINE
+        .deployment()
+        .withXmlResource("parent.bpmn", parentProcess(c -> c.zeebeBusinessId("child-level")))
+        .withXmlResource("child.bpmn", childProcessCalling(c -> {}))
+        .withXmlResource("grandchild.bpmn", grandchildProcess())
+        .deploy();
+
+    // when
+    final long parentKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PARENT_PROCESS_ID)
+            .withBusinessId(PARENT_BUSINESS_ID)
+            .create();
+
+    // then - the grandchild inherits the child's Business ID, not the (different) parent's
+    final Record<ProcessInstanceRecordValue> childInstance = childProcessInstance(parentKey);
+    Assertions.assertThat(childInstance.getValue()).hasBusinessId("child-level");
+
+    final Record<ProcessInstanceRecordValue> grandchildInstance =
+        childProcessInstance(childInstance.getKey());
+    Assertions.assertThat(grandchildInstance.getValue()).hasBusinessId("child-level");
+  }
+
+  @Test
+  public void shouldInheritParentBusinessIdThroughNestedCallActivities() {
+    // given - neither the child nor the grandchild call activity sets a Business ID
+    ENGINE
+        .deployment()
+        .withXmlResource("parent.bpmn", parentProcess(c -> {}))
+        .withXmlResource("child.bpmn", childProcessCalling(c -> {}))
+        .withXmlResource("grandchild.bpmn", grandchildProcess())
+        .deploy();
+
+    // when
+    final long parentKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PARENT_PROCESS_ID)
+            .withBusinessId(PARENT_BUSINESS_ID)
+            .create();
+
+    // then - the parent's Business ID propagates all the way down
+    final Record<ProcessInstanceRecordValue> childInstance = childProcessInstance(parentKey);
+    Assertions.assertThat(childInstance.getValue()).hasBusinessId(PARENT_BUSINESS_ID);
+
+    final Record<ProcessInstanceRecordValue> grandchildInstance =
+        childProcessInstance(childInstance.getKey());
+    Assertions.assertThat(grandchildInstance.getValue()).hasBusinessId(PARENT_BUSINESS_ID);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityBusinessIdTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
 import java.util.function.Consumer;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -31,6 +32,7 @@ public final class CallActivityBusinessIdTest {
 
   private static final String PARENT_PROCESS_ID = "parent-process";
   private static final String CHILD_PROCESS_ID = "child-process";
+  private static final String GRANDCHILD_PROCESS_ID = "grandchild-process";
   private static final String PARENT_BUSINESS_ID = "parent-business-id";
 
   @Rule
@@ -47,6 +49,17 @@ public final class CallActivityBusinessIdTest {
 
   private static BpmnModelInstance childProcess() {
     return Bpmn.createExecutableProcess(CHILD_PROCESS_ID).startEvent().endEvent().done();
+  }
+
+  private static BpmnModelInstance childProcessCalling(final String grandchildBusinessId) {
+    final CallActivityBuilder callActivity =
+        Bpmn.createExecutableProcess(CHILD_PROCESS_ID).startEvent().callActivity("call-grandchild");
+    callActivity.zeebeProcessId(GRANDCHILD_PROCESS_ID).zeebeBusinessId(grandchildBusinessId);
+    return callActivity.endEvent().done();
+  }
+
+  private static BpmnModelInstance grandchildProcess() {
+    return Bpmn.createExecutableProcess(GRANDCHILD_PROCESS_ID).startEvent().endEvent().done();
   }
 
   private void deploy(final BpmnModelInstance parent) {
@@ -150,5 +163,64 @@ public final class CallActivityBusinessIdTest {
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getBusinessId())
         .containsOnly("child-123");
+  }
+
+  @Test
+  public void shouldResolveBusinessIdIndependentlyForNestedCallActivities() {
+    // given - parent -> child -> grandchild, each call activity sets its own literal
+    ENGINE
+        .deployment()
+        .withXmlResource("parent.bpmn", parentProcess(c -> c.zeebeBusinessId("level-1")))
+        .withXmlResource("child.bpmn", childProcessCalling("level-2"))
+        .withXmlResource("grandchild.bpmn", grandchildProcess())
+        .deploy();
+
+    // when
+    final long parentKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PARENT_PROCESS_ID)
+            .withBusinessId(PARENT_BUSINESS_ID)
+            .create();
+
+    // then - each level carries the Business ID configured on its own call activity
+    final Record<ProcessInstanceRecordValue> childInstance = childProcessInstance(parentKey);
+    Assertions.assertThat(childInstance.getValue()).hasBusinessId("level-1");
+
+    final Record<ProcessInstanceRecordValue> grandchildInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(childInstance.getKey())
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst();
+    Assertions.assertThat(grandchildInstance.getValue()).hasBusinessId("level-2");
+  }
+
+  @Test
+  public void shouldDeriveBusinessIdPerInstanceForMultiInstanceCallActivity() {
+    // given - a multi-instance call activity deriving the Business ID from each element
+    final CallActivityBuilder callActivity =
+        Bpmn.createExecutableProcess(PARENT_PROCESS_ID).startEvent().callActivity("call");
+    callActivity.zeebeProcessId(CHILD_PROCESS_ID).zeebeBusinessId("=\"businessId-\" + item");
+    callActivity.multiInstance(
+        b -> b.zeebeInputCollectionExpression("items").zeebeInputElement("item"));
+    deploy(callActivity.endEvent().done());
+
+    // when
+    final long parentKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PARENT_PROCESS_ID)
+            .withVariable("items", List.of("1", "2", "3"))
+            .create();
+
+    // then - each child instance derives its own Business ID at its own scope
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withParentProcessInstanceKey(parentKey)
+                .withBpmnProcessId(CHILD_PROCESS_ID)
+                .filterRootScope()
+                .limit(3))
+        .extracting(r -> r.getValue().getBusinessId())
+        .containsExactlyInAnyOrder("businessId-1", "businessId-2", "businessId-3");
   }
 }


### PR DESCRIPTION
## Description

Implements the runtime resolution and propagation of the child `businessId` when a call activity
activates and creates a child process instance, per [ADR 0003-810](https://github.com/camunda/camunda/blob/main/zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md) (D2/D3).

### What changed

**`CallActivityProcessor`** — added `resolveChildBusinessId` to determine the Business ID for the
child process instance before creation, threaded through the existing `Either<Failure, ?>` chain:

| Configuration | Behaviour |
|---|---|
| Attribute absent | Inherits the parent's Business ID (preserves 8.9 behaviour) |
| Literal / empty | Uses the configured value verbatim; empty yields no Business ID |
| FEEL expression | Evaluated at the call-activity element-instance scope via `ExpressionProcessor` |

A `CalledProcess` record is introduced to carry both the resolved `DeployedProcess` and `businessId`
through the chain without adding mutable state.

**`BpmnStateTransitionBehavior#createChildProcessInstance`** — updated to accept the resolved
`businessId` instead of unconditionally reading `context.getBusinessId()`.

### Tests added (`CallActivityBusinessIdTest`)

- Inherit: absent attribute propagates parent Business ID (regression guard).
- Literal: explicit value overrides the parent Business ID.
- Empty: explicit empty value yields no Business ID on the child.
- FEEL: expression is evaluated at call-activity scope and applied to the child.
- Immutability: child Business ID is stable across the entire process-instance lifecycle.
- Nested call activities: each level carries its own independently resolved Business ID.
- Multi-instance call activity: each child instance derives its own Business ID per element.

### Notes

- FEEL evaluation failures are left as `Either.left(Failure)` so they can surface as incidents in Feature 4 without further changes to this layer.
- Existing inherit behaviour is fully preserved when no `businessId` attribute is present.

## Related issues

Closes #56167