### PR TITLE
ci: fix malformed Renovate annotation for @camunda8/spectral-cli (INC-6230)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1881,7 +1881,7 @@ jobs:
     timeout-minutes: 10
     permissions: {}  # GITHUB_TOKEN unused in this job
     env:
-      # renovate: datasource=npm depName=@camunda8/spectral-cli packageName=@camunda8/spectral-cli
+      # renovate: datasource=npm depName=@camunda8/spectral-cli
       SPECTRAL_VERSION: '6.16.1'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@be5b0496892a83e6b3c5cedb818b771e8ed68121 # main


### PR DESCRIPTION
## Summary

Remove the redundant `packageName=@camunda8/spectral-cli` from the inline Renovate annotation in `ci.yml` introduced in https://github.com/camunda/camunda/pull/54164

## Why

The custom regex manager uses `.` (no DOTALL flag), so it cannot match across newlines. Given the annotation:

```yaml
# renovate: datasource=npm depName=@camunda8/spectral-cli packageName=@camunda8/spectral-cli
SPECTRAL_VERSION: '6.16.1'
```

The regex captures `@camunda8/spectral-cli packageName=@camunda8/spectral-cli` as the full `depName`, because it needs `.` to reach the quoted value on the next line. Renovate then uses this as the npm package path, producing:

```
GET https://registry.npmjs.org/@camunda8%2Fspectral-cli%20packageName=@camunda8/spectral-cli
→ 405 Method Not Allowed
INFO: External host error causing abort - skipping
```

`packageName` is identical to `depName` here — removing it fixes the URL construction.

Related: INC-6230