### PR TITLE
ci: suppress secrets-inherit warnings in pin-check workflow

### DIFF
--- a/.github/workflows/check-action-pins.yml
+++ b/.github/workflows/check-action-pins.yml
@@ -70,6 +70,9 @@ jobs:
               v = v (n++ ? "," : "") "{\"path\":\"" path "\",\"line\":" line "}"
               next
             }
+            # secrets-inherit is intentional: workflow callers pass secrets to reusable workflows
+            # for metrics/observability collection. Suppress entirely rather than demote.
+            /^::/ && /title=secrets-inherit/ { next }
             /^::error /  { sub(/^::error /,  "::warning "); print; next }
             /^::notice / { sub(/^::notice /, "::warning "); print; next }
                          { print }


### PR DESCRIPTION
## Summary

- Adds an awk filter in `check-action-pins.yml` that drops `secrets-inherit` zizmor findings before they surface as `::warning` annotations on PRs
- `secrets: inherit` is intentional in this repo — reusable workflow callers need to forward secrets to the [metrics/observability infrastructure
](https://camunda.github.io/camunda/ci/#ci-health-metrics)- No change to gating behavior: `unpinned-uses` still fails the job; all other audits are still demoted to warnings or dropped

## Context

PRs like #55911 were getting noisy `secrets unconditionally inherited by called workflow` annotations from zizmor's `secrets-inherit` rule. Since passing secrets is a requirement for our metrics collection, these warnings are false positives that clutter the review.

The fix is a single awk condition added to the existing post-processing step in the workflow — it drops any annotation line with `title=secrets-inherit` before the demote-to-warning pass.

## Reviewer notes

The comment in the awk block explains the intent so future reviewers won't wonder if this was accidentally suppressed.