### PR TITLE
fix: resolve lazy CamundaAuthentication membership off the request thread

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/OidcOverrideBeansConfiguration.java
@@ -9,7 +9,9 @@ package io.camunda.authentication.config;
 
 import static java.util.stream.Collectors.toMap;
 
+import io.camunda.authentication.service.PhysicalTenantMembershipContextPropagator;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
+import io.camunda.security.api.context.MembershipResolutionContextPropagator;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
@@ -106,14 +108,23 @@ public class OidcOverrideBeansConfiguration {
   }
 
   @Bean
+  @ConditionalOnMissingBean
+  public MembershipResolutionContextPropagator membershipResolutionContextPropagator() {
+    return new PhysicalTenantMembershipContextPropagator();
+  }
+
+  @Bean
   public LazyTokenClaimsConverter tokenClaimsConverter(
-      final CamundaSecurityLibraryProperties cslProperties, final MembershipPort membershipPort) {
+      final CamundaSecurityLibraryProperties cslProperties,
+      final MembershipPort membershipPort,
+      final MembershipResolutionContextPropagator membershipResolutionContextPropagator) {
     final var oidcConfig = cslProperties.getAuthentication().getOidc();
     return new LazyTokenClaimsConverter(
         oidcConfig.getUsernameClaim(),
         oidcConfig.getClientIdClaim(),
         oidcConfig.isPreferUsernameClaim(),
-        membershipPort);
+        membershipPort,
+        membershipResolutionContextPropagator);
   }
 
   @Bean

--- a/authentication/src/main/java/io/camunda/authentication/service/PhysicalTenantMembershipContextPropagator.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/PhysicalTenantMembershipContextPropagator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.service;
+
+import io.camunda.security.api.context.MembershipResolutionContextPropagator;
+import io.camunda.spring.utils.PhysicalTenantContext;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * Host implementation of CSL's {@link MembershipResolutionContextPropagator} that carries the
+ * physical tenant resolved while building the authentication onto whatever thread or scope later
+ * materialises a lazy membership list.
+ *
+ * <p>{@link DefaultMembershipService} routes each membership query to a per-tenant service via
+ * {@link PhysicalTenantContext#current()}. Without this propagator that call would throw when the
+ * list resolves outside the request scope — most visibly when persistent web sessions serialise the
+ * {@code CamundaAuthentication} after the request has been dispatched. By capturing the tenant at
+ * construction time (in scope) and rebinding it around the deferred lookup, the routing key is
+ * available wherever resolution happens to run.
+ */
+public final class PhysicalTenantMembershipContextPropagator
+    implements MembershipResolutionContextPropagator {
+
+  @Override
+  public Supplier<List<String>> decorate(final Supplier<List<String>> supplier) {
+    return PhysicalTenantContext.propagateCurrent(supplier);
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -45,7 +45,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha36</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha37</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantContext.java
+++ b/spring-utils/src/main/java/io/camunda/spring/utils/PhysicalTenantContext.java
@@ -9,6 +9,7 @@ package io.camunda.spring.utils;
 
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.context.request.RequestAttributes;
@@ -137,6 +138,39 @@ public final class PhysicalTenantContext {
         Thread.currentThread().getName(),
         physicalTenantId);
     PROPAGATED_PHYSICAL_TENANT_ID.set(physicalTenantId);
+  }
+
+  /**
+   * Wraps {@code supplier} so that the physical tenant currently in effect — captured eagerly, when
+   * this method is called — is bound as the {@linkplain #setPropagatedPhysicalTenant propagated}
+   * tenant for the duration of each {@code supplier.get()} call, restoring any previously
+   * propagated value afterwards. If no tenant is in effect at capture time, {@code supplier} is
+   * returned unchanged.
+   *
+   * <p>Use this to carry the current thread's tenant into a deferred computation that may run after
+   * the request scope is gone — e.g. a lazy membership list materialised during HTTP session
+   * serialisation, or work handed to an async worker — without the caller managing the propagation
+   * {@link ThreadLocal} directly. This is the same capture-by-value strategy {@code
+   * PhysicalTenantPropagatingExecutorService} applies to executor tasks.
+   */
+  public static <T> Supplier<T> propagateCurrent(final Supplier<T> supplier) {
+    final String physicalTenantId = currentOrNull();
+    if (physicalTenantId == null) {
+      return supplier;
+    }
+    return () -> {
+      final String previous = getPropagatedPhysicalTenant();
+      setPropagatedPhysicalTenant(physicalTenantId);
+      try {
+        return supplier.get();
+      } finally {
+        if (previous != null) {
+          setPropagatedPhysicalTenant(previous);
+        } else {
+          clearPropagatedPhysicalTenant();
+        }
+      }
+    };
   }
 
   private static String asString(final Object value) {

--- a/spring-utils/src/test/java/io/camunda/spring/utils/PhysicalTenantContextTest.java
+++ b/spring-utils/src/test/java/io/camunda/spring/utils/PhysicalTenantContextTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.configuration.api.physicaltenants.PhysicalTenantIds;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -23,6 +24,14 @@ class PhysicalTenantContextTest {
   @AfterEach
   void clearRequestContext() {
     RequestContextHolder.resetRequestAttributes();
+    // guarantee the propagation ThreadLocal never bleeds into a later test, even on failure
+    PhysicalTenantContext.clearPropagatedPhysicalTenant();
+  }
+
+  private void bindRequestWithPhysicalTenant(final String physicalTenantId) {
+    final HttpServletRequest request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, physicalTenantId);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
   }
 
   @Test
@@ -113,5 +122,57 @@ class PhysicalTenantContextTest {
     // when / then
     assertThat(PhysicalTenantContext.current())
         .isNotEqualTo(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  void shouldReturnSupplierUnchangedWhenNoTenantInEffect() {
+    // given no request scope and no propagated tenant bound (nothing to capture)
+    final Supplier<String> original = () -> "result";
+
+    // when
+    final Supplier<String> wrapped = PhysicalTenantContext.propagateCurrent(original);
+
+    // then the supplier is returned unchanged and nothing is propagated when it runs
+    assertThat(wrapped).isSameAs(original);
+    assertThat(wrapped.get()).isEqualTo("result");
+    assertThat(PhysicalTenantContext.getPropagatedPhysicalTenant()).isNull();
+  }
+
+  @Test
+  void shouldBindCapturedTenantAndClearWhenNoPriorPropagatedValue() {
+    // given a request scope bound at capture time, but no prior propagated tenant
+    bindRequestWithPhysicalTenant("tenant-a");
+    final Supplier<String> wrapped =
+        PhysicalTenantContext.propagateCurrent(PhysicalTenantContext::getPropagatedPhysicalTenant);
+
+    // simulate a deferred run after the request scope is gone (e.g. session serialisation)
+    RequestContextHolder.resetRequestAttributes();
+
+    // when
+    final String observedDuringRun = wrapped.get();
+
+    // then the captured tenant was propagated during the run and cleared afterwards
+    assertThat(observedDuringRun).isEqualTo("tenant-a");
+    assertThat(PhysicalTenantContext.getPropagatedPhysicalTenant()).isNull();
+  }
+
+  @Test
+  void shouldRestorePriorPropagatedValueAfterRun() {
+    // given an already-propagated tenant on the current thread
+    PhysicalTenantContext.setPropagatedPhysicalTenant("outer");
+    // and a request scope bound at capture time so a different tenant is captured
+    bindRequestWithPhysicalTenant("inner");
+    final Supplier<String> wrapped =
+        PhysicalTenantContext.propagateCurrent(PhysicalTenantContext::getPropagatedPhysicalTenant);
+
+    // simulate a deferred run after the request scope is gone
+    RequestContextHolder.resetRequestAttributes();
+
+    // when
+    final String observedDuringRun = wrapped.get();
+
+    // then the captured tenant was propagated during the run and the prior value restored after
+    assertThat(observedDuringRun).isEqualTo("inner");
+    assertThat(PhysicalTenantContext.getPropagatedPhysicalTenant()).isEqualTo("outer");
   }
 }


### PR DESCRIPTION
## Problem

With persistent web sessions enabled, the session store serialises the `CamundaAuthentication` in `SessionRepositoryFilter`'s commit — which runs **after** `DispatcherServlet` has torn down the request scope. The authentication's membership lists are lazy, and each per-physical-tenant lookup routes via `PhysicalTenantContext.current()`. Off the request thread that call throws, surfacing as a 500 `ConversionFailedException` on any request that refreshes the session (e.g. `POST /v2/authorizations` after the auth-refresh interval).

This is the same off-request-scope resolution class as the async-read case; session serialisation is just another trigger.

## Fix

Use CSL's new `MembershipResolutionContextPropagator` (camunda/camunda-security-library#462) instead of trying to time the resolution:

- `PhysicalTenantMembershipContextPropagator` (host impl) snapshots the physical tenant while the converter runs in scope and rebinds it around the deferred lookup.
- `PhysicalTenantContext.propagateCurrent(Supplier)` is the capture-by-value primitive — the same strategy `PhysicalTenantPropagatingExecutorService` already uses for executor tasks.
- Wired into the `tokenClaimsConverter` bean in `OidcOverrideBeansConfiguration`.

This supersedes the `afterCompletion` `HandlerInterceptor` approach (#56236), which only ran on some session-committing paths and so did not fully fix the 500.

## Verification

Verified locally via the PT smoke test: the previously-failing `POST /v2/authorizations` after an auth refresh no longer 500s.

Closes #55964