### PR TITLE
fix: Dissallow Reindex By ID Partial Results

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -459,6 +459,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             .requestCache(false)
             .allowNoIndices(true)
             .ignoreUnavailable(true)
+            .allowPartialSearchResults(false)
             .query(query)
             .size(size)
             .source(s -> s.fetch(false))

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -473,6 +473,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             .requestCache(false)
             .allowNoIndices(true)
             .ignoreUnavailable(true)
+            .allowPartialSearchResults(false)
             .query(query)
             .size(size)
             .source(s -> s.fetch(false))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -304,6 +304,24 @@ final class ElasticsearchArchiverRepositoryTest extends AbstractArchiverReposito
   }
 
   @Test
+  void shouldDisallowPartialSearchResultsWhenGettingArchiveDocIdsBatch() {
+    // given
+    when(client.search(any(SearchRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(searchResponse()));
+
+    // when
+    ((ElasticsearchArchiverRepository) repository)
+        .getArchiveDocIdsBatch(
+            "source-index", Map.of("key", List.of("1")), Map.of(), Map.of(), List.of(), 10)
+        .join();
+
+    // then
+    final var captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(client).search(captor.capture());
+    assertThat(captor.getValue().allowPartialSearchResults()).isFalse();
+  }
+
+  @Test
   void shouldPropagateRoutingForEachBulkDeleteOperation() {
     // given
     final var docs =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -233,6 +233,24 @@ final class OpenSearchArchiverRepositoryTest extends AbstractArchiverRepositoryT
   }
 
   @Test
+  void shouldDisallowPartialSearchResultsWhenGettingArchiveDocIdsBatch() throws IOException {
+    // given
+    when(client.search(any(SearchRequest.class), eq(Object.class)))
+        .thenReturn(CompletableFuture.completedFuture(searchResponse()));
+
+    // when
+    ((OpenSearchArchiverRepository) repository)
+        .getArchiveDocIdsBatch(
+            "source-index", Map.of("key", List.of("1")), Map.of(), Map.of(), List.of(), 10)
+        .join();
+
+    // then
+    final var captor = ArgumentCaptor.forClass(SearchRequest.class);
+    verify(client).search(captor.capture(), eq(Object.class));
+    assertThat(captor.getValue().allowPartialSearchResults()).isFalse();
+  }
+
+  @Test
   void shouldPropagateRoutingForEachBulkDeleteOperation() throws IOException {
     // given
     final var docs =


### PR DESCRIPTION


## Description

If we get partial resutls when getting a batch of IDs to archive, we could end up skipping some docs. Instead setting it to fail at that moment so that we can retry the operation.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
