### PR TITLE
fix: bump load test versions

### DIFF
--- a/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
@@ -25,7 +25,7 @@ global:
     # Image.repository defines the repository from which to fetch the docker images
     repository: "registry.camunda.cloud/team-zeebe"
     # Image.tag defines the tag / version which should be used in the chart
-    tag: 8.7.0
+    tag: 8.7.34
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -282,7 +282,7 @@ zeebe:
   image:
     registry: docker.io
     repository: camunda/zeebe
-    tag: "8.7.33"
+    tag: 8.7.34
   # ClusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
   # PartitionCount defines how many zeebe partitions are set up in the cluster
@@ -404,7 +404,7 @@ zeebeGateway:
     # Image.registry defines which image registry to use
     registry: docker.io
     # Image.tag defines the tag / version which should be used in the chart
-    tag: "8.7.33"
+    tag: 8.7.34
   # LogLevel defines the log level which is used by the gateway
   logLevel: debug
 

--- a/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
@@ -25,7 +25,7 @@ global:
     # Image.repository defines the repository from which to fetch the docker images
     repository: "registry.camunda.cloud/team-zeebe"
     # Image.tag defines the tag / version which should be used in the chart
-    tag: SNAPSHOT
+    tag: 8.8.29
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -236,7 +236,7 @@ orchestration:
   image:
     registry: docker.io
     repository: camunda/camunda
-    tag: "8.8.28"
+    tag: 8.8.29
   ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
   ## @param core.partitionCount defines how many partitions are set up in the cluster

--- a/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
@@ -25,7 +25,7 @@ global:
     # Image.repository defines the repository from which to fetch the docker images
     repository: "registry.camunda.cloud/team-zeebe"
     # Image.tag defines the tag / version which should be used in the chart
-    tag: SNAPSHOT
+    tag: 8.9.11
     ## @param global.image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
     pullPolicy: Always
     ## @param global.image.pullSecrets can be used to configure image pull secrets https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -203,7 +203,7 @@ orchestration:
   image:
     registry: docker.io
     repository: camunda/camunda
-    tag: "8.9.9"
+    tag: 8.9.11
   ## @param core.clusterSize defines the amount of brokers (=replicas), which are deployed via helm
   clusterSize: "3"
   ## @param core.partitionCount defines how many partitions are set up in the cluster

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/camunda/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/camunda/configmap-release.yaml
@@ -57,7 +57,7 @@ data:
         metrics: http://tasklist.c8-golden-stable-87-elasticsearch-stable:9600/actuator/prometheus
       - name: Zeebe Gateway
         id: zeebeGateway
-        version: 8.7.33
+        version: 8.7.34
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8088
@@ -65,6 +65,6 @@ data:
         metrics: http://zeebe-gateway.c8-golden-stable-87-elasticsearch-stable:9600/actuator/prometheus
       - name: Zeebe
         id: zeebe
-        version: 8.7.33
+        version: 8.7.34
         readiness: http://zeebe.c8-golden-stable-87-elasticsearch-stable:9600/actuator/health/readiness
         metrics: http://zeebe.c8-golden-stable-87-elasticsearch-stable:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe-gateway/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe-gateway/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: zeebe-gateway
-          image: docker.io/camunda/zeebe:8.7.33
+          image: docker.io/camunda/zeebe:8.7.34
           imagePullPolicy: Always
           ports:
             - containerPort: 9600

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: zeebe
-          image: docker.io/camunda/zeebe:8.7.33
+          image: docker.io/camunda/zeebe:8.7.34
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/camunda/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/camunda/configmap-release.yaml
@@ -57,7 +57,7 @@ data:
         metrics: http://tasklist.c8-golden-stable-87-elasticsearch:9600/actuator/prometheus
       - name: Zeebe Gateway
         id: zeebeGateway
-        version: 8.7.33
+        version: 8.7.34
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8088
@@ -65,6 +65,6 @@ data:
         metrics: http://zeebe-gateway.c8-golden-stable-87-elasticsearch:9600/actuator/prometheus
       - name: Zeebe
         id: zeebe
-        version: 8.7.33
+        version: 8.7.34
         readiness: http://zeebe.c8-golden-stable-87-elasticsearch:9600/actuator/health/readiness
         metrics: http://zeebe.c8-golden-stable-87-elasticsearch:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe-gateway/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe-gateway/deployment.yaml
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: zeebe-gateway
-          image: docker.io/camunda/zeebe:8.7.33
+          image: docker.io/camunda/zeebe:8.7.34
           imagePullPolicy: Always
           ports:
             - containerPort: 9600

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: zeebe
-          image: docker.io/camunda/zeebe:8.7.33
+          image: docker.io/camunda/zeebe:8.7.34
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/common/configmap-release.yaml
@@ -48,26 +48,26 @@ data:
         metrics: http://connectors.c8-golden-stable-88-elasticsearch-stable:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/operate
         readiness: http://camunda.c8-golden-stable-88-elasticsearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-elasticsearch-stable:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/tasklist
         readiness: http://camunda.c8-golden-stable-88-elasticsearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-elasticsearch-stable:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/identity
         readiness: http://camunda.c8-golden-stable-88-elasticsearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-elasticsearch-stable:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.8.28
+        version: 8.8.29
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8088

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.8.28
+          image: docker.io/camunda/camunda:8.8.29
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/common/configmap-release.yaml
@@ -48,26 +48,26 @@ data:
         metrics: http://connectors.c8-golden-stable-88-elasticsearch:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/operate
         readiness: http://camunda.c8-golden-stable-88-elasticsearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-elasticsearch:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/tasklist
         readiness: http://camunda.c8-golden-stable-88-elasticsearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-elasticsearch:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/identity
         readiness: http://camunda.c8-golden-stable-88-elasticsearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-elasticsearch:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.8.28
+        version: 8.8.29
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8088

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.8.28
+          image: docker.io/camunda/camunda:8.8.29
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/common/configmap-release.yaml
@@ -36,26 +36,26 @@ data:
         metrics: http://identity.c8-golden-stable-88-none:82/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/operate
         readiness: http://camunda.c8-golden-stable-88-none:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-none:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/tasklist
         readiness: http://camunda.c8-golden-stable-88-none:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-none:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/identity
         readiness: http://camunda.c8-golden-stable-88-none:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-none:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.8.28
+        version: 8.8.29
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8088

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.8.28
+          image: docker.io/camunda/camunda:8.8.29
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/common/configmap-release.yaml
@@ -48,26 +48,26 @@ data:
         metrics: http://connectors.c8-golden-stable-88-opensearch-stable:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/operate
         readiness: http://camunda.c8-golden-stable-88-opensearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-opensearch-stable:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/tasklist
         readiness: http://camunda.c8-golden-stable-88-opensearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-opensearch-stable:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/identity
         readiness: http://camunda.c8-golden-stable-88-opensearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-opensearch-stable:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.8.28
+        version: 8.8.29
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8088

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.8.28
+          image: docker.io/camunda/camunda:8.8.29
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/common/configmap-release.yaml
@@ -48,26 +48,26 @@ data:
         metrics: http://connectors.c8-golden-stable-88-opensearch:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/operate
         readiness: http://camunda.c8-golden-stable-88-opensearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-opensearch:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/tasklist
         readiness: http://camunda.c8-golden-stable-88-opensearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-opensearch:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.8.28
+        version: 8.8.29
         url: http://localhost:8088/identity
         readiness: http://camunda.c8-golden-stable-88-opensearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-88-opensearch:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.8.28
+        version: 8.8.29
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8088

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.8.28
+          image: docker.io/camunda/camunda:8.8.29
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/common/configmap-release.yaml
@@ -48,26 +48,26 @@ data:
         metrics: http://connectors.c8-golden-stable-89-elasticsearch-stable:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-89-elasticsearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-elasticsearch-stable:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-89-elasticsearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-elasticsearch-stable:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/identity
         readiness: http://camunda.c8-golden-stable-89-elasticsearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-elasticsearch-stable:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.9.9
+        version: 8.9.11
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.9.9
+          image: docker.io/camunda/camunda:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/common/configmap-release.yaml
@@ -48,26 +48,26 @@ data:
         metrics: http://connectors.c8-golden-stable-89-elasticsearch:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-89-elasticsearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-elasticsearch:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-89-elasticsearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-elasticsearch:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/identity
         readiness: http://camunda.c8-golden-stable-89-elasticsearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-elasticsearch:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.9.9
+        version: 8.9.11
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.9.9
+          image: docker.io/camunda/camunda:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/common/configmap-release.yaml
@@ -36,26 +36,26 @@ data:
         metrics: http://identity.c8-golden-stable-89-none:82/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-89-none:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-none:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-89-none:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-none:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/identity
         readiness: http://camunda.c8-golden-stable-89-none:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-none:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.9.9
+        version: 8.9.11
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.9.9
+          image: docker.io/camunda/camunda:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/common/configmap-release.yaml
@@ -48,26 +48,26 @@ data:
         metrics: http://connectors.c8-golden-stable-89-opensearch-stable:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-89-opensearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-opensearch-stable:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-89-opensearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-opensearch-stable:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/identity
         readiness: http://camunda.c8-golden-stable-89-opensearch-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-opensearch-stable:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.9.9
+        version: 8.9.11
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.9.9
+          image: docker.io/camunda/camunda:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/common/configmap-release.yaml
@@ -48,26 +48,26 @@ data:
         metrics: http://connectors.c8-golden-stable-89-opensearch:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-89-opensearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-opensearch:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-89-opensearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-opensearch:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/identity
         readiness: http://camunda.c8-golden-stable-89-opensearch:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-opensearch:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.9.9
+        version: 8.9.11
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.9.9
+          image: docker.io/camunda/camunda:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/common/configmap-release.yaml
@@ -48,26 +48,26 @@ data:
         metrics: http://connectors.c8-golden-stable-89-rdbms-optimize:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-89-rdbms-optimize:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-rdbms-optimize:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-89-rdbms-optimize:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-rdbms-optimize:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/identity
         readiness: http://camunda.c8-golden-stable-89-rdbms-optimize:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-rdbms-optimize:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.9.9
+        version: 8.9.11
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.9.9
+          image: docker.io/camunda/camunda:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/common/configmap-release.yaml
@@ -42,26 +42,26 @@ data:
         metrics: http://connectors.c8-golden-stable-89-rdbms-stable:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-89-rdbms-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-rdbms-stable:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-89-rdbms-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-rdbms-stable:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/identity
         readiness: http://camunda.c8-golden-stable-89-rdbms-stable:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-rdbms-stable:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.9.9
+        version: 8.9.11
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.9.9
+          image: docker.io/camunda/camunda:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/common/configmap-release.yaml
@@ -42,26 +42,26 @@ data:
         metrics: http://connectors.c8-golden-stable-89-rdbms:8080/actuator/prometheus
       - name: Operate
         id: operate
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/operate
         readiness: http://camunda.c8-golden-stable-89-rdbms:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-rdbms:9600/actuator/prometheus
       - name: Tasklist
         id: tasklist
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/tasklist
         readiness: http://camunda.c8-golden-stable-89-rdbms:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-rdbms:9600/actuator/prometheus
       - name: Orchestration Identity
         id: orchestrationIdentity
-        version: 8.9.9
+        version: 8.9.11
         url: http://localhost:8080/identity
         readiness: http://camunda.c8-golden-stable-89-rdbms:9600/actuator/health/readiness
         metrics: http://camunda.c8-golden-stable-89-rdbms:9600/actuator/prometheus
     
       - name: Orchestration Cluster
         id: orchestration
-        version: 8.9.9
+        version: 8.9.11
         urls:
           grpc: http://localhost:26500
           http: http://localhost:8080

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/statefulset.yaml
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:8.9.9
+          image: docker.io/camunda/camunda:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true


### PR DESCRIPTION
## Description

Renovate currently has issues (cf. https://app.incident.io/camunda/incidents/6230), bumping the versions manually.

We need to deploy >= 8.9.10 to have the fix for https://github.com/camunda/camunda/issues/55404

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/55702
* https://github.com/camunda/camunda/issues/55404