### PR TITLE
Implement RDBMS read path for AgentHistory

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms;
 import io.camunda.db.rdbms.read.RdbmsTenantReaders;
 import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProvider;
 import io.camunda.db.rdbms.read.replication.ReplicationLogStatusProviderFactory;
+import io.camunda.db.rdbms.read.service.AgentHistoryDbReader;
 import io.camunda.db.rdbms.read.service.AgentInstanceDbReader;
 import io.camunda.db.rdbms.read.service.AuditLogDbReader;
 import io.camunda.db.rdbms.read.service.AuthorizationDbReader;
@@ -231,6 +232,10 @@ public class RdbmsService {
 
   public AgentInstanceDbReader getAgentInstanceDbReader() {
     return tenantReaders.agentInstanceReader();
+  }
+
+  public AgentHistoryDbReader getAgentHistoryDbReader() {
+    return tenantReaders.agentHistoryReader();
   }
 
   public GlobalListenerDbReader getGlobalListenerDbReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsTenantReaders.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsTenantReaders.java
@@ -109,7 +109,7 @@ public record RdbmsTenantReaders(
       final RdbmsMapperBundle mappers, final RdbmsReaderConfig readerConfig) {
     return new RdbmsTenantReaders(
         new AgentInstanceDbReader(mappers.agentInstanceMapper(), readerConfig),
-        new AgentHistoryDbReader(readerConfig),
+        new AgentHistoryDbReader(mappers.agentHistoryMapper(), readerConfig),
         new AuditLogDbReader(mappers.auditLogMapper(), readerConfig),
         new AuthorizationDbReader(mappers.authorizationMapper(), readerConfig),
         new BatchOperationDbReader(mappers.batchOperationMapper(), readerConfig),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/AgentHistoryDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/AgentHistoryDbQuery.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.filter.AgentInstanceHistoryFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record AgentHistoryDbQuery(
+    AgentInstanceHistoryFilter filter,
+    List<String> authorizedResourceIds,
+    List<String> authorizedTenantIds,
+    DbQuerySorting<AgentInstanceHistoryEntity> sort,
+    DbQueryPage page) {
+
+  public static AgentHistoryDbQuery of(
+      final Function<AgentHistoryDbQuery.Builder, ObjectBuilder<AgentHistoryDbQuery>> fn) {
+    return fn.apply(new AgentHistoryDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<AgentHistoryDbQuery> {
+
+    private static final AgentInstanceHistoryFilter EMPTY_FILTER =
+        FilterBuilders.agentInstanceHistory().build();
+
+    private AgentInstanceHistoryFilter filter;
+    private List<String> authorizedResourceIds;
+    private List<String> authorizedTenantIds;
+    private DbQuerySorting<AgentInstanceHistoryEntity> sort;
+    private DbQueryPage page;
+
+    public Builder filter(final AgentInstanceHistoryFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder authorizedResourceIds(final List<String> value) {
+      authorizedResourceIds = value;
+      return this;
+    }
+
+    public Builder authorizedTenantIds(final List<String> value) {
+      authorizedTenantIds = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<AgentInstanceHistoryEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<
+                AgentInstanceHistoryFilter.Builder, ObjectBuilder<AgentInstanceHistoryFilter>>
+            fn) {
+      return filter(FilterBuilders.agentInstanceHistory(fn));
+    }
+
+    public Builder sort(
+        final Function<
+                DbQuerySorting.Builder<AgentInstanceHistoryEntity>,
+                ObjectBuilder<DbQuerySorting<AgentInstanceHistoryEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
+    }
+
+    @Override
+    public AgentHistoryDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(Collections.emptyList()));
+      authorizedResourceIds = Objects.requireNonNullElse(authorizedResourceIds, List.of());
+      authorizedTenantIds = Objects.requireNonNullElse(authorizedTenantIds, List.of());
+      return new AgentHistoryDbQuery(
+          filter, authorizedResourceIds, authorizedTenantIds, sort, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.Metrics;
+import java.util.List;
+
+public class AgentHistoryEntityMapper {
+
+  public static AgentInstanceHistoryEntity toEntity(final AgentHistoryDbModel dbModel) {
+    if (dbModel == null) {
+      return null;
+    }
+    return new AgentInstanceHistoryEntity(
+        dbModel.agentHistoryKey(),
+        dbModel.agentInstanceKey(),
+        dbModel.elementInstanceKey(),
+        dbModel.processInstanceKey(),
+        dbModel.processDefinitionKey(),
+        dbModel.processDefinitionId(),
+        dbModel.tenantId(),
+        dbModel.jobKey(),
+        dbModel.jobLease(),
+        dbModel.iteration(),
+        dbModel.role(),
+        dbModel.contentItems() != null ? dbModel.contentItems() : List.of(),
+        dbModel.toolCallValues() != null ? dbModel.toolCallValues() : List.of(),
+        new Metrics(dbModel.inputTokens(), dbModel.outputTokens(), dbModel.durationMs()),
+        dbModel.commitStatus(),
+        dbModel.producedAt());
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentHistoryDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AgentHistoryDbReader.java
@@ -8,23 +8,64 @@
 package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
+import io.camunda.db.rdbms.read.domain.AgentHistoryDbQuery;
+import io.camunda.db.rdbms.read.mapper.AgentHistoryEntityMapper;
+import io.camunda.db.rdbms.sql.AgentHistoryMapper;
+import io.camunda.db.rdbms.sql.columns.AgentHistorySearchColumn;
 import io.camunda.search.clients.reader.AgentHistoryReader;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.api.model.authz.AuthorizationResourceType;
 import io.camunda.security.core.authz.ResourceAccessChecks;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AgentHistoryDbReader extends AbstractEntityReader<AgentInstanceHistoryEntity>
     implements AgentHistoryReader {
 
-  public AgentHistoryDbReader(final RdbmsReaderConfig readerConfig) {
-    super(null, readerConfig);
+  private static final Logger LOG = LoggerFactory.getLogger(AgentHistoryDbReader.class);
+
+  private final AgentHistoryMapper agentHistoryMapper;
+
+  public AgentHistoryDbReader(
+      final AgentHistoryMapper agentHistoryMapper, final RdbmsReaderConfig readerConfig) {
+    super(AgentHistorySearchColumn.values(), readerConfig);
+    this.agentHistoryMapper = agentHistoryMapper;
   }
 
   @Override
   public SearchQueryResult<AgentInstanceHistoryEntity> search(
       final AgentInstanceHistoryQuery query, final ResourceAccessChecks resourceAccessChecks) {
-    throw new UnsupportedOperationException(
-        "AgentHistoryDbReader is not yet implemented. Tracked in #55271.");
+    final var dbSort = convertSort(query.sort(), AgentHistorySearchColumn.AGENT_HISTORY_KEY);
+
+    if (shouldReturnEmptyResult(resourceAccessChecks)) {
+      return buildSearchQueryResult(0, List.of(), dbSort);
+    }
+
+    final var authorizedResourceIds =
+        resourceAccessChecks
+            .getAuthorizedResourceIdsByType()
+            .getOrDefault(AuthorizationResourceType.PROCESS_DEFINITION.name(), List.of());
+    final var dbPage = convertPaging(dbSort, query.page());
+    final var dbQuery =
+        AgentHistoryDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .authorizedResourceIds(authorizedResourceIds)
+                    .authorizedTenantIds(resourceAccessChecks.getAuthorizedTenantIds())
+                    .sort(dbSort)
+                    .page(dbPage));
+
+    LOG.trace("[RDBMS DB] Search for agent history items with filter {}", dbQuery);
+    return executePagedQuery(
+        () -> agentHistoryMapper.count(dbQuery),
+        () ->
+            agentHistoryMapper.search(dbQuery).stream()
+                .map(AgentHistoryEntityMapper::toEntity)
+                .toList(),
+        dbPage,
+        dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentHistoryMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/AgentHistoryMapper.java
@@ -7,11 +7,17 @@
  */
 package io.camunda.db.rdbms.sql;
 
+import io.camunda.db.rdbms.read.domain.AgentHistoryDbQuery;
 import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+import java.util.List;
 
 public interface AgentHistoryMapper extends ProcessInstanceDependantMapper {
 
   void insert(AgentHistoryDbModel model);
 
   void updateCommitStatus(AgentHistoryDbModel model);
+
+  Long count(AgentHistoryDbQuery query);
+
+  List<AgentHistoryDbModel> search(AgentHistoryDbQuery query);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentHistorySearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentHistorySearchColumn.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+
+public enum AgentHistorySearchColumn implements SearchColumn<AgentInstanceHistoryEntity> {
+  AGENT_HISTORY_KEY("historyItemKey"),
+  ITERATION("iteration"),
+  PRODUCED_AT("producedAt");
+
+  private final String property;
+
+  AgentHistorySearchColumn(final String property) {
+    this.property = property;
+  }
+
+  @Override
+  public String property() {
+    return property;
+  }
+
+  @Override
+  public Class<AgentInstanceHistoryEntity> getEntityClass() {
+    return AgentInstanceHistoryEntity.class;
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
@@ -79,4 +79,150 @@
     <include refid="io.camunda.db.rdbms.sql.Commons.processInstanceHistoryDeletion"/>
   </delete>
 
+  <!-- ===== READ operations ===== -->
+
+  <!--
+    CONTENT and TOOL_CALLS are JSON CLOBs. They are mapped to the raw String properties on
+    AgentHistoryDbModel; AgentHistoryDbModel.contentItems() and toolCallValues() then deserialize
+    them lazily on first access.
+  -->
+  <resultMap id="searchResultMap" type="io.camunda.db.rdbms.write.domain.AgentHistoryDbModel">
+    <id property="agentHistoryKey" column="AGENT_HISTORY_KEY" javaType="long"/>
+    <result property="agentInstanceKey" column="AGENT_INSTANCE_KEY" javaType="long"/>
+    <result property="elementInstanceKey" column="ELEMENT_INSTANCE_KEY" javaType="long"/>
+    <result property="processInstanceKey" column="PROCESS_INSTANCE_KEY" javaType="long"/>
+    <result property="rootProcessInstanceKey" column="ROOT_PROCESS_INSTANCE_KEY" javaType="long"/>
+    <result property="processDefinitionId" column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
+    <result property="processDefinitionKey" column="PROCESS_DEFINITION_KEY" javaType="long"/>
+    <result property="tenantId" column="TENANT_ID" javaType="java.lang.String"/>
+    <result property="partitionId" column="PARTITION_ID" javaType="java.lang.Integer"/>
+    <result property="jobKey" column="JOB_KEY" javaType="long"/>
+    <result property="jobLease" column="JOB_LEASE" javaType="java.lang.String"/>
+    <result property="iteration" column="ITERATION" javaType="java.lang.Integer"/>
+    <result property="role" column="ROLE"
+      javaType="io.camunda.search.entities.AgentInstanceHistoryEntity$AgentInstanceHistoryRole"/>
+    <result property="commitStatus" column="COMMIT_STATUS"
+      javaType="io.camunda.search.entities.AgentInstanceHistoryEntity$AgentInstanceHistoryCommitStatus"/>
+    <result property="producedAt" column="PRODUCED_AT" javaType="java.time.OffsetDateTime"/>
+    <result property="inputTokens" column="INPUT_TOKENS" javaType="long"/>
+    <result property="outputTokens" column="OUTPUT_TOKENS" javaType="long"/>
+    <result property="durationMs" column="DURATION_MS" javaType="long"/>
+    <result property="content" column="CONTENT" javaType="java.lang.String"/>
+    <result property="toolCalls" column="TOOL_CALLS" javaType="java.lang.String"/>
+  </resultMap>
+
+  <select id="search"
+    parameterType="io.camunda.db.rdbms.read.domain.AgentHistoryDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.AgentHistoryMapper.searchResultMap">
+    SELECT * FROM (
+      SELECT * FROM (
+        SELECT
+          ah.AGENT_HISTORY_KEY,
+          ah.AGENT_INSTANCE_KEY,
+          ah.ELEMENT_INSTANCE_KEY,
+          ah.PROCESS_INSTANCE_KEY,
+          ah.ROOT_PROCESS_INSTANCE_KEY,
+          ah.PROCESS_DEFINITION_ID,
+          ah.PROCESS_DEFINITION_KEY,
+          ah.TENANT_ID,
+          ah.PARTITION_ID,
+          ah.JOB_KEY,
+          ah.JOB_LEASE,
+          ah.ITERATION,
+          ah.ROLE,
+          ah.COMMIT_STATUS,
+          ah.PRODUCED_AT,
+          ah.INPUT_TOKENS,
+          ah.OUTPUT_TOKENS,
+          ah.DURATION_MS,
+          ah.CONTENT,
+          ah.TOOL_CALLS
+        FROM ${prefix}AGENT_HISTORY ah
+        <include refid="io.camunda.db.rdbms.sql.AgentHistoryMapper.searchAndAuthFilter"/>
+      ) filtered
+      <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+      <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+      <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+    ) sorted
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+  </select>
+
+  <select id="count" resultType="java.lang.Long">
+    SELECT COUNT(*) FROM (
+      SELECT 1 as col
+      FROM ${prefix}AGENT_HISTORY ah
+      <include refid="io.camunda.db.rdbms.sql.AgentHistoryMapper.searchAndAuthFilter"/>
+      ${count.limit}
+    ) t
+  </select>
+
+  <sql id="searchAndAuthFilter">
+    <where>
+      <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
+        AND ah.PROCESS_DEFINITION_ID IN
+        <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator="," close=")">
+          #{resourceId}
+        </foreach>
+      </if>
+      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+        AND ah.TENANT_ID IN
+        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+      </if>
+      <include refid="io.camunda.db.rdbms.sql.AgentHistoryMapper.searchFilter"/>
+    </where>
+  </sql>
+
+  <sql id="searchFilter">
+    <if test="filter.agentInstanceKeyOperations != null and !filter.agentInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.agentInstanceKeyOperations" item="operation">
+        AND ah.AGENT_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.historyItemKeyOperations != null and !filter.historyItemKeyOperations.isEmpty()">
+      <foreach collection="filter.historyItemKeyOperations" item="operation">
+        AND ah.AGENT_HISTORY_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.roleOperations != null and !filter.roleOperations.isEmpty()">
+      <foreach collection="filter.roleOperations" item="operation">
+        AND ah.ROLE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.elementInstanceKeyOperations != null and !filter.elementInstanceKeyOperations.isEmpty()">
+      <foreach collection="filter.elementInstanceKeyOperations" item="operation">
+        AND ah.ELEMENT_INSTANCE_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.jobKeyOperations != null and !filter.jobKeyOperations.isEmpty()">
+      <foreach collection="filter.jobKeyOperations" item="operation">
+        AND ah.JOB_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.iterationOperations != null and !filter.iterationOperations.isEmpty()">
+      <foreach collection="filter.iterationOperations" item="operation">
+        AND ah.ITERATION
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.commitStatusOperations != null and !filter.commitStatusOperations.isEmpty()">
+      <foreach collection="filter.commitStatusOperations" item="operation">
+        AND ah.COMMIT_STATUS
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if test="filter.producedAtOperations != null and !filter.producedAtOperations.isEmpty()">
+      <foreach collection="filter.producedAtOperations" item="operation">
+        AND ah.PRODUCED_AT
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+  </sql>
+
 </mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapperTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ContentItem.ContentType;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.ToolCall;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AgentHistoryEntityMapperTest {
+
+  @Test
+  void shouldMapAllFields() {
+    final var producedAt = OffsetDateTime.parse("2024-06-01T12:00:00Z");
+
+    final var dbModel = new AgentHistoryDbModel();
+    dbModel.agentHistoryKey(100L);
+    dbModel.agentInstanceKey(200L);
+    dbModel.elementInstanceKey(300L);
+    dbModel.processInstanceKey(400L);
+    dbModel.rootProcessInstanceKey(500L);
+    dbModel.processDefinitionKey(600L);
+    dbModel.processDefinitionId("myProcess");
+    dbModel.tenantId("<default>");
+    dbModel.partitionId(1);
+    dbModel.jobKey(700L);
+    dbModel.jobLease("lease-abc");
+    dbModel.iteration(3);
+    dbModel.role(AgentInstanceHistoryRole.ASSISTANT);
+    dbModel.commitStatus(AgentInstanceHistoryCommitStatus.COMMITTED);
+    dbModel.producedAt(producedAt);
+    dbModel.inputTokens(150L);
+    dbModel.outputTokens(75L);
+    dbModel.durationMs(300L);
+    dbModel.contentItems(
+        List.of(new ContentItem(ContentType.TEXT, "Hello from assistant", null, null)));
+    dbModel.toolCallValues(
+        List.of(new ToolCall("tc-1", "myTool", "Task_1", Map.of("key", "value"))));
+
+    final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
+
+    assertThat(entity.historyItemKey()).isEqualTo(100L);
+    assertThat(entity.agentInstanceKey()).isEqualTo(200L);
+    assertThat(entity.elementInstanceKey()).isEqualTo(300L);
+    assertThat(entity.processInstanceKey()).isEqualTo(400L);
+    assertThat(entity.processDefinitionKey()).isEqualTo(600L);
+    assertThat(entity.processDefinitionId()).isEqualTo("myProcess");
+    assertThat(entity.tenantId()).isEqualTo("<default>");
+    assertThat(entity.jobKey()).isEqualTo(700L);
+    assertThat(entity.jobLease()).isEqualTo("lease-abc");
+    assertThat(entity.iteration()).isEqualTo(3);
+    assertThat(entity.role()).isEqualTo(AgentInstanceHistoryRole.ASSISTANT);
+    assertThat(entity.commitStatus()).isEqualTo(AgentInstanceHistoryCommitStatus.COMMITTED);
+    assertThat(entity.producedAt()).isEqualTo(producedAt);
+    assertThat(entity.metrics().inputTokens()).isEqualTo(150L);
+    assertThat(entity.metrics().outputTokens()).isEqualTo(75L);
+    assertThat(entity.metrics().durationMs()).isEqualTo(300L);
+    assertThat(entity.content()).hasSize(1);
+    assertThat(entity.content().get(0).contentType()).isEqualTo(ContentType.TEXT);
+    assertThat(entity.content().get(0).text()).isEqualTo("Hello from assistant");
+    assertThat(entity.toolCalls()).hasSize(1);
+    assertThat(entity.toolCalls().get(0).toolCallId()).isEqualTo("tc-1");
+    assertThat(entity.toolCalls().get(0).toolName()).isEqualTo("myTool");
+  }
+
+  @Test
+  void shouldMapNullContentAndToolCallsToEmptyLists() {
+    final var dbModel = minimalDbModel(42L);
+    dbModel.contentItems(null);
+    dbModel.toolCallValues(null);
+
+    final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
+
+    assertThat(entity.content()).isEmpty();
+    assertThat(entity.toolCalls()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnNullForNullDbModel() {
+    assertThat(AgentHistoryEntityMapper.toEntity(null)).isNull();
+  }
+
+  private AgentHistoryDbModel minimalDbModel(final long key) {
+    final var model = new AgentHistoryDbModel();
+    model.agentHistoryKey(key);
+    model.agentInstanceKey(1L);
+    model.elementInstanceKey(2L);
+    model.processInstanceKey(3L);
+    model.rootProcessInstanceKey(4L);
+    model.processDefinitionKey(5L);
+    model.processDefinitionId("process");
+    model.tenantId("<default>");
+    model.partitionId(1);
+    model.jobKey(6L);
+    model.jobLease("lease");
+    model.iteration(1);
+    model.role(AgentInstanceHistoryRole.USER);
+    model.commitStatus(AgentInstanceHistoryCommitStatus.PENDING);
+    model.producedAt(OffsetDateTime.parse("2024-01-01T00:00:00Z"));
+    model.inputTokens(0L);
+    model.outputTokens(0L);
+    model.durationMs(0L);
+    model.contentItems(List.of());
+    model.toolCallValues(List.of());
+    return model;
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentHistoryDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentHistoryDbReaderTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.sql.AgentHistoryMapper;
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.security.core.authz.AuthorizationCheck;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.security.core.authz.TenantCheck;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class AgentHistoryDbReaderTest {
+
+  private final AgentHistoryMapper agentHistoryMapper = mock(AgentHistoryMapper.class);
+  private final AgentHistoryDbReader agentHistoryDbReader =
+      new AgentHistoryDbReader(agentHistoryMapper, AbstractEntityReaderTest.TEST_CONFIG);
+
+  // ===== Authorization early-exit =====
+
+  @Test
+  void shouldReturnEmptyResultWhenAuthorizedResourceIdsIsNull() {
+    final var result =
+        agentHistoryDbReader.search(
+            AgentInstanceHistoryQuery.of(b -> b),
+            ResourceAccessChecks.of(
+                AuthorizationCheck.enabled(
+                    RequiredAuthorization.of(a -> a.processDefinition().readProcessInstance())),
+                TenantCheck.disabled()));
+
+    assertThat(result.items()).isEmpty();
+    verify(agentHistoryMapper, times(0)).search(any());
+    verify(agentHistoryMapper, times(0)).count(any());
+  }
+
+  @Test
+  void shouldReturnEmptyResultWhenAuthorizedTenantIdsIsEmpty() {
+    final var result =
+        agentHistoryDbReader.search(
+            AgentInstanceHistoryQuery.of(b -> b),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(List.of())));
+
+    assertThat(result.items()).isEmpty();
+    verify(agentHistoryMapper, times(0)).search(any());
+    verify(agentHistoryMapper, times(0)).count(any());
+  }
+
+  @Test
+  void shouldInjectAuthorizedProcessDefinitionIdsIntoQuery() {
+    final var authorizedIds = List.of("process-a", "process-b");
+    when(agentHistoryMapper.count(any())).thenReturn(1L);
+    when(agentHistoryMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentHistoryDbReader.search(
+        AgentInstanceHistoryQuery.of(b -> b),
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(
+                RequiredAuthorization.of(
+                    a -> a.processDefinition().readProcessInstance().resourceIds(authorizedIds))),
+            TenantCheck.disabled()));
+
+    verify(agentHistoryMapper)
+        .search(argThat(q -> q.authorizedResourceIds().equals(authorizedIds)));
+  }
+
+  @Test
+  void shouldInjectAuthorizedTenantIdsIntoQuery() {
+    final var tenantIds = List.of("tenant-1", "tenant-2");
+    when(agentHistoryMapper.count(any())).thenReturn(1L);
+    when(agentHistoryMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentHistoryDbReader.search(
+        AgentInstanceHistoryQuery.of(b -> b),
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.enabled(tenantIds)));
+
+    verify(agentHistoryMapper).search(argThat(q -> q.authorizedTenantIds().equals(tenantIds)));
+  }
+
+  // ===== Page-size edge case =====
+
+  @Test
+  void shouldReturnEmptyItemsButCorrectTotalWhenPageSizeIsZero() {
+    when(agentHistoryMapper.count(any())).thenReturn(5L);
+
+    final var result =
+        agentHistoryDbReader.search(
+            AgentInstanceHistoryQuery.of(b -> b.page(p -> p.size(0))),
+            ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled()));
+
+    assertThat(result.total()).isEqualTo(5L);
+    assertThat(result.items()).isEmpty();
+    verify(agentHistoryMapper, times(0)).search(any());
+  }
+
+  // ===== Filter pass-through =====
+
+  @Test
+  void shouldPassAgentInstanceKeyFilterToMapper() {
+    when(agentHistoryMapper.count(any())).thenReturn(1L);
+    when(agentHistoryMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentHistoryDbReader.search(
+        AgentInstanceHistoryQuery.of(b -> b.filter(f -> f.agentInstanceKeys(42L))),
+        ResourceAccessChecks.disabled());
+
+    verify(agentHistoryMapper)
+        .search(
+            argThat(
+                q ->
+                    q.filter().agentInstanceKeyOperations().stream()
+                        .anyMatch(op -> op.value().equals(42L))));
+  }
+
+  @Test
+  void shouldPassHistoryItemKeyFilterToMapper() {
+    when(agentHistoryMapper.count(any())).thenReturn(1L);
+    when(agentHistoryMapper.search(any())).thenReturn(List.of(buildModel(1L)));
+
+    agentHistoryDbReader.search(
+        AgentInstanceHistoryQuery.of(b -> b.filter(f -> f.historyItemKeys(99L))),
+        ResourceAccessChecks.disabled());
+
+    verify(agentHistoryMapper)
+        .search(
+            argThat(
+                q ->
+                    q.filter().historyItemKeyOperations().stream()
+                        .anyMatch(op -> op.value().equals(99L))));
+  }
+
+  @Test
+  void shouldReturnMappedEntitiesFromSearch() {
+    when(agentHistoryMapper.count(any())).thenReturn(2L);
+    when(agentHistoryMapper.search(any())).thenReturn(List.of(buildModel(1L), buildModel(2L)));
+
+    final var result =
+        agentHistoryDbReader.search(
+            AgentInstanceHistoryQuery.of(b -> b), ResourceAccessChecks.disabled());
+
+    assertThat(result.total()).isEqualTo(2L);
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items()).extracting(e -> e.historyItemKey()).containsExactly(1L, 2L);
+  }
+
+  // ===== Helpers =====
+
+  private AgentHistoryDbModel buildModel(final long key) {
+    return new AgentHistoryDbModel.Builder()
+        .agentHistoryKey(key)
+        .agentInstanceKey(10L)
+        .elementInstanceKey(20L)
+        .processInstanceKey(30L)
+        .rootProcessInstanceKey(40L)
+        .processDefinitionKey(50L)
+        .processDefinitionId("myProcess")
+        .tenantId("<default>")
+        .partitionId(1)
+        .jobKey(60L)
+        .jobLease("lease-" + key)
+        .iteration(1)
+        .role(AgentInstanceHistoryRole.USER)
+        .commitStatus(AgentInstanceHistoryCommitStatus.PENDING)
+        .producedAt(OffsetDateTime.parse("2024-01-01T00:00:00Z"))
+        .inputTokens(100L)
+        .outputTokens(50L)
+        .durationMs(200L)
+        .contentItems(List.of())
+        .toolCallValues(List.of())
+        .build();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -136,13 +136,7 @@ class AgentInstanceAuthorizationIT {
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey1);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey2);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKey3);
-    // Agent history search is not supported on RDBMS; searchHistory tests are already
-    // individually disabled via @DisabledIfSystemProperty for rdbms.* backends.
-    if (!System.getProperty("test.integration.camunda.database.type", "")
-        .toLowerCase()
-        .startsWith("rdbms")) {
-      waitForHistoryItemsToBeIndexed(adminClient, agentInstanceKey1, 1);
-    }
+    waitForHistoryItemsToBeIndexed(adminClient, agentInstanceKey1, 1);
   }
 
   // ── search ────────────────────────────────────────────────────────────────
@@ -342,7 +336,6 @@ class AgentInstanceAuthorizationIT {
   // ── searchHistory ─────────────────────────────────────────────────────────
 
   @Test
-  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
   void searchHistoryShouldReturnHistoryForAuthorizedUser(
       @Authenticated(USER1) final CamundaClient camundaClient) {
     // user1 has READ_PROCESS_INSTANCE on PROCESS_ID_1
@@ -355,7 +348,6 @@ class AgentInstanceAuthorizationIT {
   }
 
   @Test
-  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
   void searchHistoryShouldReturnEmptyForUnauthorizedUser(
       @Authenticated(USER1) final CamundaClient camundaClient) {
     // user1 has no READ_PROCESS_INSTANCE on PROCESS_ID_2

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -27,11 +27,9 @@ import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 public class AgentInstanceHistorySearchIT {
 
   private static final String AGENT_ELEMENT_ID = "agentHistorySearchElement";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistoryFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistoryFilterIT.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.agenthistory;
+
+import static io.camunda.it.rdbms.db.fixtures.AgentHistoryFixtures.createAndSaveRandomAgentHistoryItem;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import io.camunda.search.filter.AgentInstanceHistoryFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.AgentInstanceHistorySort;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AgentHistoryFilterIT {
+
+  @TestTemplate
+  public void shouldFilterByAgentInstanceKey(final CamundaRdbmsTestApplication testApplication) {
+    final long agentInstanceKey = nextKey();
+    final var model =
+        createAndSaveRandomAgentHistoryItem(
+            testApplication, b -> b.agentInstanceKey(agentInstanceKey));
+    createAndSaveRandomAgentHistoryItem(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceHistoryFilter.Builder().agentInstanceKeys(agentInstanceKey).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().historyItemKey()).isEqualTo(model.agentHistoryKey());
+  }
+
+  @TestTemplate
+  public void shouldFilterByHistoryItemKey(final CamundaRdbmsTestApplication testApplication) {
+    final var model = createAndSaveRandomAgentHistoryItem(testApplication, b -> b);
+    createAndSaveRandomAgentHistoryItem(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceHistoryFilter.Builder()
+                .historyItemKeys(model.agentHistoryKey())
+                .build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().historyItemKey()).isEqualTo(model.agentHistoryKey());
+  }
+
+  @TestTemplate
+  public void shouldFilterByRole(final CamundaRdbmsTestApplication testApplication) {
+    final long agentInstanceKey = nextKey();
+    createAndSaveRandomAgentHistoryItem(
+        testApplication,
+        b -> b.agentInstanceKey(agentInstanceKey).role(AgentInstanceHistoryRole.USER));
+    createAndSaveRandomAgentHistoryItem(
+        testApplication,
+        b -> b.agentInstanceKey(agentInstanceKey).role(AgentInstanceHistoryRole.ASSISTANT));
+    createAndSaveRandomAgentHistoryItem(
+        testApplication,
+        b -> b.agentInstanceKey(agentInstanceKey).role(AgentInstanceHistoryRole.ASSISTANT));
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceHistoryFilter.Builder()
+                .agentInstanceKeys(agentInstanceKey)
+                .roles(AgentInstanceHistoryRole.ASSISTANT)
+                .build());
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.items()).allMatch(e -> e.role() == AgentInstanceHistoryRole.ASSISTANT);
+  }
+
+  @TestTemplate
+  public void shouldFilterByElementInstanceKey(final CamundaRdbmsTestApplication testApplication) {
+    final long elementInstanceKey = nextKey();
+    final var model =
+        createAndSaveRandomAgentHistoryItem(
+            testApplication, b -> b.elementInstanceKey(elementInstanceKey));
+    createAndSaveRandomAgentHistoryItem(testApplication, b -> b);
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceHistoryFilter.Builder()
+                .elementInstanceKeys(elementInstanceKey)
+                .build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().historyItemKey()).isEqualTo(model.agentHistoryKey());
+  }
+
+  @TestTemplate
+  public void shouldFilterByJobKey(final CamundaRdbmsTestApplication testApplication) {
+    final long jobKey = nextKey();
+    final var model = createAndSaveRandomAgentHistoryItem(testApplication, b -> b.jobKey(jobKey));
+    createAndSaveRandomAgentHistoryItem(testApplication, b -> b);
+
+    final var result =
+        search(testApplication, new AgentInstanceHistoryFilter.Builder().jobKeys(jobKey).build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().historyItemKey()).isEqualTo(model.agentHistoryKey());
+  }
+
+  @TestTemplate
+  public void shouldFilterByIteration(final CamundaRdbmsTestApplication testApplication) {
+    final long agentInstanceKey = nextKey();
+    createAndSaveRandomAgentHistoryItem(
+        testApplication, b -> b.agentInstanceKey(agentInstanceKey).iteration(1));
+    createAndSaveRandomAgentHistoryItem(
+        testApplication, b -> b.agentInstanceKey(agentInstanceKey).iteration(2));
+    createAndSaveRandomAgentHistoryItem(
+        testApplication, b -> b.agentInstanceKey(agentInstanceKey).iteration(2));
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceHistoryFilter.Builder()
+                .agentInstanceKeys(agentInstanceKey)
+                .iterations(2)
+                .build());
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.items()).allMatch(e -> e.iteration() == 2);
+  }
+
+  @TestTemplate
+  public void shouldFilterByCommitStatus(final CamundaRdbmsTestApplication testApplication) {
+    final long agentInstanceKey = nextKey();
+    createAndSaveRandomAgentHistoryItem(
+        testApplication,
+        b ->
+            b.agentInstanceKey(agentInstanceKey)
+                .commitStatus(AgentInstanceHistoryCommitStatus.COMMITTED));
+    createAndSaveRandomAgentHistoryItem(
+        testApplication,
+        b ->
+            b.agentInstanceKey(agentInstanceKey)
+                .commitStatus(AgentInstanceHistoryCommitStatus.PENDING));
+    createAndSaveRandomAgentHistoryItem(
+        testApplication,
+        b ->
+            b.agentInstanceKey(agentInstanceKey)
+                .commitStatus(AgentInstanceHistoryCommitStatus.DISCARDED));
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceHistoryFilter.Builder()
+                .agentInstanceKeys(agentInstanceKey)
+                .commitStatuses(AgentInstanceHistoryCommitStatus.COMMITTED)
+                .build());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().commitStatus())
+        .isEqualTo(AgentInstanceHistoryCommitStatus.COMMITTED);
+  }
+
+  @TestTemplate
+  public void shouldFilterByProducedAt(final CamundaRdbmsTestApplication testApplication) {
+    final long agentInstanceKey = nextKey();
+    final OffsetDateTime base = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS).minusDays(10);
+
+    createAndSaveRandomAgentHistoryItem(
+        testApplication, b -> b.agentInstanceKey(agentInstanceKey).producedAt(base.minusDays(1)));
+    createAndSaveRandomAgentHistoryItem(
+        testApplication, b -> b.agentInstanceKey(agentInstanceKey).producedAt(base));
+    createAndSaveRandomAgentHistoryItem(
+        testApplication, b -> b.agentInstanceKey(agentInstanceKey).producedAt(base.plusDays(1)));
+
+    final var result =
+        search(
+            testApplication,
+            new AgentInstanceHistoryFilter.Builder()
+                .agentInstanceKeys(agentInstanceKey)
+                .producedAtOperations(Operation.gte(base))
+                .build());
+
+    assertThat(result.total()).isEqualTo(2);
+    assertThat(result.items()).allMatch(e -> !e.producedAt().isBefore(base));
+  }
+
+  private SearchQueryResult<AgentInstanceHistoryEntity> search(
+      final CamundaRdbmsTestApplication testApplication, final AgentInstanceHistoryFilter filter) {
+    return testApplication
+        .getRdbmsService()
+        .getAgentHistoryDbReader()
+        .search(
+            new AgentInstanceHistoryQuery(
+                filter, AgentInstanceHistorySort.of(b -> b), SearchQueryPage.of(b -> b)),
+            ResourceAccessChecks.disabled());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistoryIT.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.agenthistory;
+
+import static io.camunda.it.rdbms.db.fixtures.AgentHistoryFixtures.createAndSaveRandomAgentHistoryItem;
+import static io.camunda.it.rdbms.db.fixtures.AgentHistoryFixtures.createAndSaveRandomAgentHistoryItems;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.filter.AgentInstanceHistoryFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
+import io.camunda.search.sort.AgentInstanceHistorySort;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AgentHistoryIT {
+
+  @TestTemplate
+  public void shouldFindItemByAgentInstanceKey(final CamundaRdbmsTestApplication testApplication) {
+    final String procDefId = "proc-find-" + nextStringId();
+    final AgentHistoryDbModel model =
+        createAndSaveRandomAgentHistoryItem(testApplication, b -> b.processDefinitionId(procDefId));
+    createAndSaveRandomAgentHistoryItem(testApplication, b -> b.processDefinitionId(procDefId));
+
+    final var result =
+        testApplication
+            .getRdbmsService()
+            .getAgentHistoryDbReader()
+            .search(
+                new AgentInstanceHistoryQuery(
+                    new AgentInstanceHistoryFilter.Builder()
+                        .agentInstanceKeys(model.agentInstanceKey())
+                        .build(),
+                    AgentInstanceHistorySort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))),
+                ResourceAccessChecks.disabled());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().historyItemKey()).isEqualTo(model.agentHistoryKey());
+    assertFieldsMatch(model, result.items().getFirst());
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyResultForUnknownKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    final var result =
+        testApplication
+            .getRdbmsService()
+            .getAgentHistoryDbReader()
+            .search(
+                new AgentInstanceHistoryQuery(
+                    new AgentInstanceHistoryFilter.Builder()
+                        .agentInstanceKeys(Long.MIN_VALUE)
+                        .build(),
+                    AgentInstanceHistorySort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))),
+                ResourceAccessChecks.disabled());
+
+    assertThat(result.total()).isEqualTo(0);
+    assertThat(result.items()).isEmpty();
+  }
+
+  @TestTemplate
+  public void shouldFindAllItemsPaged(final CamundaRdbmsTestApplication testApplication) {
+    final long agentInstanceKey = io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey();
+    createAndSaveRandomAgentHistoryItems(
+        testApplication, 7, b -> b.agentInstanceKey(agentInstanceKey));
+
+    final var result =
+        testApplication
+            .getRdbmsService()
+            .getAgentHistoryDbReader()
+            .search(
+                new AgentInstanceHistoryQuery(
+                    new AgentInstanceHistoryFilter.Builder()
+                        .agentInstanceKeys(agentInstanceKey)
+                        .build(),
+                    AgentInstanceHistorySort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))),
+                ResourceAccessChecks.disabled());
+
+    assertThat(result.total()).isEqualTo(7);
+    assertThat(result.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyItemsButCorrectTotalForPageSizeZero(
+      final CamundaRdbmsTestApplication testApplication) {
+    final String procDefId = "proc-zero-" + nextStringId();
+    final long agentInstanceKey = io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey();
+    createAndSaveRandomAgentHistoryItems(
+        testApplication,
+        3,
+        b -> b.processDefinitionId(procDefId).agentInstanceKey(agentInstanceKey));
+
+    final var result =
+        testApplication
+            .getRdbmsService()
+            .getAgentHistoryDbReader()
+            .search(
+                new AgentInstanceHistoryQuery(
+                    new AgentInstanceHistoryFilter.Builder()
+                        .agentInstanceKeys(agentInstanceKey)
+                        .build(),
+                    AgentInstanceHistorySort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(0))),
+                ResourceAccessChecks.disabled());
+
+    assertThat(result.total()).isEqualTo(3);
+    assertThat(result.items()).isEmpty();
+  }
+
+  @TestTemplate
+  public void shouldPersistCommitStatusUpdate(final CamundaRdbmsTestApplication testApplication) {
+    final AgentHistoryDbModel model = createAndSaveRandomAgentHistoryItem(testApplication, b -> b);
+
+    final var updated =
+        model.copy(
+            b ->
+                ((AgentHistoryDbModel.Builder) b)
+                    .commitStatus(AgentInstanceHistoryCommitStatus.COMMITTED));
+    final var writer = testApplication.getRdbmsService().createWriter(0);
+    writer.getAgentHistoryWriter().updateCommitStatus(updated);
+    writer.flush();
+
+    final var result =
+        testApplication
+            .getRdbmsService()
+            .getAgentHistoryDbReader()
+            .search(
+                new AgentInstanceHistoryQuery(
+                    new AgentInstanceHistoryFilter.Builder()
+                        .agentInstanceKeys(model.agentInstanceKey())
+                        .build(),
+                    AgentInstanceHistorySort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(1))),
+                ResourceAccessChecks.disabled());
+
+    assertThat(result.total()).isEqualTo(1);
+    assertThat(result.items().getFirst().commitStatus())
+        .isEqualTo(AgentInstanceHistoryCommitStatus.COMMITTED);
+  }
+
+  private void assertFieldsMatch(
+      final AgentHistoryDbModel dbModel, final AgentInstanceHistoryEntity entity) {
+    assertThat(entity.historyItemKey()).isEqualTo(dbModel.agentHistoryKey());
+    assertThat(entity.agentInstanceKey()).isEqualTo(dbModel.agentInstanceKey());
+    assertThat(entity.elementInstanceKey()).isEqualTo(dbModel.elementInstanceKey());
+    assertThat(entity.processInstanceKey()).isEqualTo(dbModel.processInstanceKey());
+    assertThat(entity.processDefinitionKey()).isEqualTo(dbModel.processDefinitionKey());
+    assertThat(entity.processDefinitionId()).isEqualTo(dbModel.processDefinitionId());
+    assertThat(entity.tenantId()).isEqualTo(dbModel.tenantId());
+    assertThat(entity.jobKey()).isEqualTo(dbModel.jobKey());
+    assertThat(entity.iteration()).isEqualTo(dbModel.iteration());
+    assertThat(entity.role()).isEqualTo(dbModel.role());
+    assertThat(entity.commitStatus()).isEqualTo(dbModel.commitStatus());
+    assertThat(entity.metrics().inputTokens()).isEqualTo(dbModel.inputTokens());
+    assertThat(entity.metrics().outputTokens()).isEqualTo(dbModel.outputTokens());
+    assertThat(entity.metrics().durationMs()).isEqualTo(dbModel.durationMs());
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistorySortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistorySortIT.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.agenthistory;
+
+import static io.camunda.it.rdbms.db.fixtures.AgentHistoryFixtures.createAndSaveRandomAgentHistoryItems;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentInstanceHistoryEntity;
+import io.camunda.search.filter.AgentInstanceHistoryFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AgentInstanceHistoryQuery;
+import io.camunda.search.sort.AgentInstanceHistorySort;
+import io.camunda.search.sort.AgentInstanceHistorySort.Builder;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class AgentHistorySortIT {
+
+  @TestTemplate
+  public void shouldSortByHistoryItemKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.historyItemKey().asc(),
+        Comparator.comparingLong(AgentInstanceHistoryEntity::historyItemKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByHistoryItemKeyDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication,
+        b -> b.historyItemKey().desc(),
+        Comparator.comparingLong(AgentInstanceHistoryEntity::historyItemKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByIterationAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingWithDistinctIterations(
+        testApplication,
+        b -> b.iteration().asc(),
+        Comparator.comparingInt(AgentInstanceHistoryEntity::iteration));
+  }
+
+  @TestTemplate
+  public void shouldSortByIterationDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingWithDistinctIterations(
+        testApplication,
+        b -> b.iteration().desc(),
+        Comparator.comparingInt(AgentInstanceHistoryEntity::iteration).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByProducedAtAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingWithDistinctProducedAt(
+        testApplication,
+        b -> b.producedAt().asc(),
+        Comparator.comparing(AgentInstanceHistoryEntity::producedAt));
+  }
+
+  @TestTemplate
+  public void shouldSortByProducedAtDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingWithDistinctProducedAt(
+        testApplication,
+        b -> b.producedAt().desc(),
+        Comparator.comparing(AgentInstanceHistoryEntity::producedAt).reversed());
+  }
+
+  private void testSorting(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, ObjectBuilder<AgentInstanceHistorySort>> sortBuilder,
+      final Comparator<AgentInstanceHistoryEntity> comparator) {
+    final long agentInstanceKey = nextKey();
+
+    createAndSaveRandomAgentHistoryItems(
+        testApplication, 5, b -> b.agentInstanceKey(agentInstanceKey));
+
+    final var items = search(testApplication, agentInstanceKey, sortBuilder);
+
+    assertThat(items).hasSize(5);
+    assertThat(items).isSortedAccordingTo(comparator);
+  }
+
+  private void testSortingWithDistinctIterations(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, ObjectBuilder<AgentInstanceHistorySort>> sortBuilder,
+      final Comparator<AgentInstanceHistoryEntity> comparator) {
+    final long agentInstanceKey = nextKey();
+    final String procDefId = "proc-iter-sort-" + nextStringId();
+
+    for (int i = 1; i <= 5; i++) {
+      final int iteration = i;
+      createAndSaveRandomAgentHistoryItems(
+          testApplication,
+          1,
+          b ->
+              b.agentInstanceKey(agentInstanceKey)
+                  .processDefinitionId(procDefId)
+                  .iteration(iteration));
+    }
+
+    final var items = search(testApplication, agentInstanceKey, sortBuilder);
+
+    assertThat(items).hasSize(5);
+    assertThat(items).isSortedAccordingTo(comparator);
+  }
+
+  private void testSortingWithDistinctProducedAt(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, ObjectBuilder<AgentInstanceHistorySort>> sortBuilder,
+      final Comparator<AgentInstanceHistoryEntity> comparator) {
+    final long agentInstanceKey = nextKey();
+    final OffsetDateTime base = OffsetDateTime.now().minusDays(5);
+
+    for (int i = 0; i < 5; i++) {
+      final OffsetDateTime producedAt = base.plusDays(i);
+      createAndSaveRandomAgentHistoryItems(
+          testApplication, 1, b -> b.agentInstanceKey(agentInstanceKey).producedAt(producedAt));
+    }
+
+    final var items = search(testApplication, agentInstanceKey, sortBuilder);
+
+    assertThat(items).hasSize(5);
+    assertThat(items).isSortedAccordingTo(comparator);
+  }
+
+  private java.util.List<AgentInstanceHistoryEntity> search(
+      final CamundaRdbmsTestApplication testApplication,
+      final long agentInstanceKey,
+      final Function<Builder, ObjectBuilder<AgentInstanceHistorySort>> sortBuilder) {
+    return testApplication
+        .getRdbmsService()
+        .getAgentHistoryDbReader()
+        .search(
+            new AgentInstanceHistoryQuery(
+                new AgentInstanceHistoryFilter.Builder()
+                    .agentInstanceKeys(agentInstanceKey)
+                    .build(),
+                AgentInstanceHistorySort.of(sortBuilder),
+                SearchQueryPage.of(b -> b.from(0).size(20))),
+            ResourceAccessChecks.disabled())
+        .items();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentHistoryFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentHistoryFixtures.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import io.camunda.db.rdbms.write.RdbmsWriters;
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
+import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel.Builder;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
+import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryRole;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public final class AgentHistoryFixtures extends CommonFixtures {
+
+  private AgentHistoryFixtures() {}
+
+  public static AgentHistoryDbModel createRandomAgentHistoryItem(
+      final Function<Builder, Builder> builderFunction) {
+    final var key = nextKey();
+    final var agentInstanceKey = nextKey();
+    final var processInstanceKey = nextKey();
+    final var builder =
+        new Builder()
+            .agentHistoryKey(key)
+            .agentInstanceKey(agentInstanceKey)
+            .elementInstanceKey(nextKey())
+            .processInstanceKey(processInstanceKey)
+            .rootProcessInstanceKey(processInstanceKey)
+            .processDefinitionId("process-" + nextStringKey())
+            .processDefinitionKey(nextKey())
+            .tenantId("<default>")
+            .partitionId(1)
+            .jobKey(nextKey())
+            .jobLease("lease-" + key)
+            .iteration(1)
+            .role(AgentInstanceHistoryRole.USER)
+            .commitStatus(AgentInstanceHistoryCommitStatus.PENDING)
+            .producedAt(OffsetDateTime.now())
+            .inputTokens(100L)
+            .outputTokens(50L)
+            .durationMs(200L)
+            .contentItems(List.of())
+            .toolCallValues(List.of());
+    return builderFunction.apply(builder).build();
+  }
+
+  public static List<AgentHistoryDbModel> createAndSaveRandomAgentHistoryItems(
+      final CamundaRdbmsTestApplication testApplication,
+      final int count,
+      final Function<Builder, Builder> builderFunction) {
+    final RdbmsWriters rdbmsWriters = testApplication.getRdbmsService().createWriter(0);
+    final List<AgentHistoryDbModel> models = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      final AgentHistoryDbModel model = createRandomAgentHistoryItem(builderFunction);
+      models.add(model);
+      rdbmsWriters.getAgentHistoryWriter().create(model);
+    }
+    rdbmsWriters.flush();
+    return models;
+  }
+
+  public static AgentHistoryDbModel createAndSaveRandomAgentHistoryItem(
+      final CamundaRdbmsTestApplication testApplication,
+      final Function<Builder, Builder> builderFunction) {
+    return createAndSaveRandomAgentHistoryItems(testApplication, 1, builderFunction).getFirst();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -124,14 +124,8 @@ public class AgentInstanceTenancyIT {
 
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyA);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyB);
-    // Agent history search is not supported on RDBMS; searchHistory tests are already
-    // individually disabled via @DisabledIfSystemProperty for rdbms.* backends.
-    if (!System.getProperty("test.integration.camunda.database.type", "")
-        .toLowerCase()
-        .startsWith("rdbms")) {
-      waitForHistoryItemsToBeIndexed(adminClient, agentInstanceKeyA, 1);
-      waitForHistoryItemsToBeIndexed(adminClient, agentInstanceKeyB, 1);
-    }
+    waitForHistoryItemsToBeIndexed(adminClient, agentInstanceKeyA, 1);
+    waitForHistoryItemsToBeIndexed(adminClient, agentInstanceKeyB, 1);
   }
 
   // ── search ────────────────────────────────────────────────────────────────
@@ -256,7 +250,6 @@ public class AgentInstanceTenancyIT {
   // ── searchHistory ─────────────────────────────────────────────────────────
 
   @Test
-  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
   void searchHistoryShouldReturnOnlyTenantAHistoryForUser1(
       @Authenticated(USER1) final CamundaClient camundaClient) {
     // user1 belongs to TENANT_A only
@@ -270,7 +263,6 @@ public class AgentInstanceTenancyIT {
   }
 
   @Test
-  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
   void searchHistoryShouldReturnAllHistoryForAdmin(
       @Authenticated(ADMIN) final CamundaClient camundaClient) {
     final var resultA =
@@ -283,7 +275,6 @@ public class AgentInstanceTenancyIT {
   }
 
   @Test
-  @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
   void searchHistoryShouldReturnEmptyForUserWithNoTenant(
       @Authenticated(USER2) final CamundaClient camundaClient) {
     final var resultA =

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelCoverageArchTest.java
@@ -55,10 +55,8 @@ class RdbmsDbModelCoverageArchTest {
           "UsageMetricTUStatisticsDbModel", // TU statistics variant; covered by UsageMetricIT
           "UsageMetricTenantStatisticsDbModel", // tenant statistics variant; covered by
           // UsageMetricIT
-          "UsageMetricTUTenantStatisticsDbModel", // TU tenant statistics variant; covered by
-          // UsageMetricIT
-          // Write-path only; AgentHistoryIT will be added with the read-path (#55271)
-          "AgentHistoryDbModel");
+          "UsageMetricTUTenantStatisticsDbModel"); // TU tenant statistics variant; covered by
+  // UsageMetricIT
 
   // IT class simple names scanned from test-jars once at class-load time.
   static final Set<String> IT_SIMPLE_NAMES =

--- a/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/it/rdbms/RdbmsDbModelSortITCoverageArchTest.java
@@ -68,9 +68,7 @@ class RdbmsDbModelSortITCoverageArchTest {
           "CorrelatedMessageSubscriptionDbModel", // composite-key lookup, not a browseable list
           "HistoryDeletionDbModel", // transient internal records
           "SequenceFlowDbModel", // graph element, no ordering needed
-          "UsageMetricDbModel", // statistical aggregation
-          // Write-path only; AgentHistorySortIT will be added with the read-path (#55271)
-          "AgentHistoryDbModel");
+          "UsageMetricDbModel"); // statistical aggregation
 
   // SortIT class simple names scanned from test-jars once at class-load time.
   static final Set<String> SORT_IT_SIMPLE_NAMES =


### PR DESCRIPTION
Closes #55271.

## Summary

Implements the RDBMS secondary-storage reader for `AgentInstanceHistory`. The write path (`AgentHistoryWriter`, insert/update SQL, `AgentHistoryDbModel`) was merged in #55262. This PR adds the symmetric read side and enables the feature across all secondary-storage integration test suites.

### Changes

**Domain types** (`db/rdbms`)
- `AgentHistoryDbQuery` — MyBatis query record (filter, authorised resource IDs, authorised tenant IDs, sort, page). Mirrors `AgentInstanceDbQuery`.
- `AgentHistorySearchColumn` — `SearchColumn` enum for the three user-facing sort fields (`AGENT_HISTORY_KEY`, `ITERATION`, `PRODUCED_AT`).

**Mapper layer** (`db/rdbms`)
- `AgentHistoryEntityMapper` — converts `AgentHistoryDbModel` → `AgentInstanceHistoryEntity`. `jobLease` is passed through directly; the protocol record's `StringProperty("jobLease", "")` default guarantees the value is never null (consistent with the ES/OS path). Null `content`/`toolCalls` columns map to `List.of()`.
- `AgentHistoryMapper.java` — adds `count(AgentHistoryDbQuery)` and `search(AgentHistoryDbQuery)` declarations.
- `AgentHistoryMapper.xml` — adds `searchResultMap` (20 columns), `searchFilter` (8 optional conditions including a `producedAt` range filter), `searchAndAuthFilter` (composes filter with `PROCESS_DEFINITION_ID` and tenant guards), `count`, and `search` (keyset-paginated nested subquery).

**Reader and wiring** (`db/rdbms`)
- `AgentHistoryDbReader` — replaces the `UnsupportedOperationException` stub. Applies the same auth early-exit as `AgentInstanceDbReader` (empty authorised resource/tenant IDs → zero results without a DB round-trip).
- `RdbmsTenantReaders` — wires `agentHistoryMapper` into `AgentHistoryDbReader`.
- `RdbmsService` — exposes `getAgentHistoryDbReader()` for test and future gateway use.

**Unit tests** (`db/rdbms`)
- `AgentHistoryEntityMapperTest` — 3 tests: full-field mapping, null CLOB → empty list, null model → null.
- `AgentHistoryDbReaderTest` — 8 tests: auth early-exit, authorised ID propagation, page-size-zero, filter pass-through, entity mapping.

**RDBMS integration tests** (`qa/acceptance-tests`, `@Tag("rdbms")`)
- `AgentHistoryFixtures` — `createRandomAgentHistoryItem` / `createAndSaveRandomAgentHistoryItem[s]` helpers.
- `AgentHistoryIT` — 5 `@TestTemplate` tests: find by key (full field assertion), unknown key, paging, page-size-zero total, commit-status update round-trip.
- `AgentHistorySortIT` — 6 tests: all three sort columns × ASC/DESC.
- `AgentHistoryFilterIT` — 8 tests: every `AgentInstanceHistoryFilter` field including `producedAt` range filter (`Operation.gte`).

**MultiDb integration tests** (`qa/acceptance-tests`, `@MultiDbTest`)
- Removed `@DisabledIfSystemProperty(matches = "rdbms.*$")` from all `searchHistory` test methods in `AgentInstanceHistorySearchIT`, `AgentInstanceAuthorizationIT`, and `AgentInstanceTenancyIT`.
- Removed the RDBMS-conditional guards in `setUp()` (`waitForHistoryItemsToBeIndexed` now runs on all backends).

**Arch tests** (`qa/archunit-tests`)
- Removed `AgentHistoryDbModel` from the TODO exemption sets in `RdbmsDbModelCoverageArchTest` and `RdbmsDbModelSortITCoverageArchTest`.

### Design notes

- **Authorization resource type** — `AuthorizationResourceType.PROCESS_DEFINITION.name()` for `authorisedResourceIds`, consistent with `AgentInstanceDbReader` and the ES/OS `AgentHistoryFilterTransformer`.
- **Single-table search** — no JOIN needed (`AgentHistory` has no junction table unlike `AgentInstance`).
- **CLOB deserialization** — `AgentHistoryDbModel` stores `CONTENT`/`TOOL_CALLS` as JSON strings and deserializes lazily. The `resultMap` maps to raw `String` fields; `AgentHistoryEntityMapper` calls the accessor methods so deserialization is transparent.

## Test plan

- [x] `./mvnw license:format spotless:apply` applied before every commit
- [x] Unit tests pass (`db/rdbms` module, 11 tests)
- [x] RDBMS ITs pass (114 tests under `-Prdbms` with H2)
- [x] Compiles clean under `-Pe2e-rdbms-test` profile
- [x] Arch test exemptions cleaned up