### PR TITLE
feat: create single-shard-by-design indices via descriptor default

### DIFF
--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -281,7 +281,7 @@ public class SchemaManager implements CloseableSilently {
   }
 
   private void updateIndexSettings(final IndexDescriptor indexDescriptor) {
-    final var indexSettingsFromConfig = getIndexSettingsFromConfig(indexDescriptor.getIndexName());
+    final var indexSettingsFromConfig = getIndexSettingsFromConfig(indexDescriptor);
     if (indexDescriptor instanceof final IndexTemplateDescriptor indexTemplateDescriptor) {
       searchEngineClient.updateIndexTemplateSettings(
           indexTemplateDescriptor, indexSettingsFromConfig);
@@ -311,7 +311,7 @@ public class SchemaManager implements CloseableSilently {
                         () -> {
                           LOG.debug("Create missing index '{}'", descriptor.getFullQualifiedName());
                           searchEngineClient.createIndex(
-                              descriptor, getIndexSettingsFromConfig(descriptor.getIndexName()));
+                              descriptor, getIndexSettingsFromConfig(descriptor));
                         },
                         virtualThreadExecutor))
             .toArray(CompletableFuture[]::new);
@@ -379,7 +379,7 @@ public class SchemaManager implements CloseableSilently {
   private void createIndexTemplate(final IndexTemplateDescriptor descriptor) {
     try {
       searchEngineClient.createIndexTemplate(
-          descriptor, getIndexSettingsFromConfig(descriptor.getIndexName()), true);
+          descriptor, getIndexSettingsFromConfig(descriptor), true);
       LOG.debug(
           "Index template '{}', has been created / already exists", descriptor.getTemplateName());
 
@@ -417,9 +417,7 @@ public class SchemaManager implements CloseableSilently {
         LOG.debug(
             "Updating template: '{}'", ((IndexTemplateDescriptor) descriptor).getTemplateName());
         searchEngineClient.createIndexTemplate(
-            (IndexTemplateDescriptor) descriptor,
-            getIndexSettingsFromConfig(descriptor.getIndexName()),
-            false);
+            (IndexTemplateDescriptor) descriptor, getIndexSettingsFromConfig(descriptor), false);
       } else {
         LOG.info(
             "Index alias: '{}'. New fields will be added '{}'",
@@ -454,13 +452,10 @@ public class SchemaManager implements CloseableSilently {
     LOG.debug("Deleted archived indices '{}'", archivedIndices);
   }
 
-  private IndexConfiguration getIndexSettingsFromConfig(final String indexName) {
+  private IndexConfiguration getIndexSettingsFromConfig(final IndexDescriptor descriptor) {
+    final var indexName = descriptor.getIndexName();
     final var templateReplicas = getNumberOfReplicasFromConfig(indexName);
-    final var templateShards =
-        config
-            .index()
-            .getShardsByIndexName()
-            .getOrDefault(indexName, config.index().getNumberOfShards());
+    final var templateShards = getNumberOfShardsFromConfig(indexName, descriptor);
 
     final var settings = new IndexConfiguration();
     settings.setNumberOfShards(templateShards);
@@ -469,6 +464,15 @@ public class SchemaManager implements CloseableSilently {
     final var refreshInterval = getRefreshIntervalFromConfig(indexName);
     settings.setRefreshInterval(refreshInterval);
     return settings;
+  }
+
+  private int getNumberOfShardsFromConfig(
+      final String indexName, final IndexDescriptor descriptor) {
+    final var explicit = config.index().getShardsByIndexName().get(indexName);
+    if (explicit != null) {
+      return explicit;
+    }
+    return descriptor.getDefaultShardCount().orElse(config.index().getNumberOfShards());
   }
 
   private int getNumberOfReplicasFromConfig(final String indexName) {

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerIT.java
@@ -136,11 +136,19 @@ public class SchemaManagerIT {
     // when
     initialiseResources(schemaManager);
 
-    // then
+    // then — replicas always follow global; shards on plain index/ descriptors are pinned to 1
+    // by the descriptor default regardless of the global knob (templates still follow global)
     final var retrievedIndex = searchClientAdapter.getIndexAsNode(index.getFullQualifiedName());
-
     assertThat(retrievedIndex.at("/settings/index/number_of_replicas").asInt()).isEqualTo(10);
-    assertThat(retrievedIndex.at("/settings/index/number_of_shards").asInt()).isEqualTo(10);
+    assertThat(retrievedIndex.at("/settings/index/number_of_shards").asInt()).isEqualTo(1);
+
+    final var retrievedTemplate =
+        searchClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
+    assertThat(
+            retrievedTemplate
+                .at("/index_template/template/settings/index/number_of_shards")
+                .asInt())
+        .isEqualTo(10);
   }
 
   @TestTemplate

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
@@ -10,9 +10,11 @@ package io.camunda.search.schema;
 import static io.camunda.search.schema.SchemaMetadataStore.SCHEMA_VERSION_METADATA_ID;
 import static io.camunda.webapps.schema.descriptors.index.MetadataIndex.ID;
 import static io.camunda.webapps.schema.descriptors.index.MetadataIndex.VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -20,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
 import io.camunda.search.schema.exceptions.IncompatibleVersionException;
 import io.camunda.search.schema.utils.TestIndexDescriptor;
@@ -27,6 +30,7 @@ import io.camunda.search.schema.utils.TestTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
+import io.camunda.webapps.schema.descriptors.template.PostImporterQueueTemplate;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 
 class SchemaManagerTest {
 
@@ -337,6 +342,100 @@ class SchemaManagerTest {
     when(searchEngineClient.getDocument(
             metadataIndex.getFullQualifiedName(), SCHEMA_VERSION_METADATA_ID))
         .thenReturn(versionDoc);
+  }
+
+  @Nested
+  class ShardCountPrecedenceTest {
+
+    private SearchEngineClient client;
+    private SearchEngineConfiguration cfg;
+    private MetadataIndex metaIndex;
+
+    @BeforeEach
+    void setUp() {
+      client = mock(SearchEngineClient.class);
+      cfg = SearchEngineConfiguration.of(c -> c);
+      cfg.schemaManager().setCreateSchema(true);
+      cfg.schemaManager().getRetry().setMaxRetries(1);
+      cfg.connect().setIndexPrefix("test");
+      metaIndex = new MetadataIndex("test", true);
+      when(client.indexExists(metaIndex.getFullQualifiedName())).thenReturn(true);
+    }
+
+    private SchemaManager buildManager(
+        final List<IndexDescriptor> indices, final List<IndexTemplateDescriptor> templates) {
+      final var mgr =
+          new SchemaManager(
+              client, indices, templates, cfg, mock(IndexSchemaValidator.class), "8.9.0", null);
+      when(client.getDocument(metaIndex.getFullQualifiedName(), SCHEMA_VERSION_METADATA_ID))
+          .thenReturn(null);
+      return mgr;
+    }
+
+    @Test
+    void shouldUseOneShardForAbstractIndexDescriptorByDefault() {
+      // given
+      cfg.index().setNumberOfShards(3);
+      final var index = new TestIndexDescriptor("test", "mappings.json");
+      final var mgr = buildManager(List.of(metaIndex, index), List.of());
+
+      // when
+      mgr.startup();
+
+      // then
+      final var captor = ArgumentCaptor.forClass(IndexConfiguration.class);
+      verify(client).createIndex(eq(index), captor.capture());
+      assertThat(captor.getValue().getNumberOfShards()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldUseGlobalShardCountForAbstractTemplateDescriptorByDefault() {
+      // given
+      cfg.index().setNumberOfShards(3);
+      final var template = new TestTemplateDescriptor("test", "mappings.json");
+      final var mgr = buildManager(List.of(metaIndex), List.of(template));
+
+      // when
+      mgr.startup();
+
+      // then
+      final var captor = ArgumentCaptor.forClass(IndexConfiguration.class);
+      verify(client).createIndexTemplate(eq(template), captor.capture(), eq(true));
+      assertThat(captor.getValue().getNumberOfShards()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldPinPostImporterQueueTemplateToOneShard() {
+      // given
+      cfg.index().setNumberOfShards(5);
+      final var template = new PostImporterQueueTemplate("test", true);
+      final var mgr = buildManager(List.of(metaIndex), List.of(template));
+
+      // when
+      mgr.startup();
+
+      // then
+      final var captor = ArgumentCaptor.forClass(IndexConfiguration.class);
+      verify(client).createIndexTemplate(eq(template), captor.capture(), eq(true));
+      assertThat(captor.getValue().getNumberOfShards()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldRespectExplicitShardsByIndexNameOverDescriptorDefault() {
+      // given — descriptor default would be 1, but explicit config says 7
+      cfg.index().setNumberOfShards(3);
+      cfg.index().getShardsByIndexName().put("test", 7);
+      final var index = new TestIndexDescriptor("test", "mappings.json");
+      final var mgr = buildManager(List.of(metaIndex, index), List.of());
+
+      // when
+      mgr.startup();
+
+      // then
+      final var captor = ArgumentCaptor.forClass(IndexConfiguration.class);
+      verify(client).createIndex(eq(index), captor.capture());
+      assertThat(captor.getValue().getNumberOfShards()).isEqualTo(7);
+    }
   }
 
   @Nested

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractIndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractIndexDescriptor.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.webapps.schema.descriptors;
 
+import java.util.OptionalInt;
+
 public abstract class AbstractIndexDescriptor implements IndexDescriptor {
 
   public static final String SCHEMA_FOLDER_OPENSEARCH = "/schema/opensearch/create";
@@ -65,6 +67,31 @@ public abstract class AbstractIndexDescriptor implements IndexDescriptor {
         formattedIndexPrefix(),
         getComponentName(),
         getIndexName());
+  }
+
+  /**
+   * Returns the descriptor-level default shard count used when creating this index.
+   *
+   * <p>Precedence in {@code SchemaManager}:
+   *
+   * <ol>
+   *   <li>Explicit per-index override via {@code index.shardsByIndexName} config — always wins.
+   *   <li>This method — overriding it pins a specific index to a fixed shard count regardless of
+   *       the global knob.
+   *   <li>{@code index.numberOfShards} global config — used when this method returns {@code
+   *       OptionalInt.empty()}.
+   * </ol>
+   *
+   * <p>Plain {@code index/} descriptors (this class) default to <b>1 primary shard</b> because they
+   * hold config/definition/singleton data that never benefits from sharding. {@link
+   * AbstractTemplateDescriptor} overrides this back to {@code empty()} so volume-oriented template
+   * indices follow the operator-configured global knob. Individual descriptors that must be pinned
+   * regardless of their base class (e.g. {@code PostImporterQueueTemplate}, {@code MetadataIndex})
+   * override this method explicitly.
+   */
+  @Override
+  public OptionalInt getDefaultShardCount() {
+    return OptionalInt.of(1);
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractTemplateDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractTemplateDescriptor.java
@@ -8,6 +8,7 @@
 package io.camunda.webapps.schema.descriptors;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 public abstract class AbstractTemplateDescriptor extends AbstractIndexDescriptor
     implements IndexTemplateDescriptor {
@@ -19,6 +20,11 @@ public abstract class AbstractTemplateDescriptor extends AbstractIndexDescriptor
 
   public AbstractTemplateDescriptor(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public OptionalInt getDefaultShardCount() {
+    return OptionalInt.empty();
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptor.java
@@ -8,6 +8,7 @@
 package io.camunda.webapps.schema.descriptors;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 
 public interface IndexDescriptor {
 
@@ -38,6 +39,10 @@ public interface IndexDescriptor {
   String getIndexNameWithoutVersion();
 
   String getVersion();
+
+  default OptionalInt getDefaultShardCount() {
+    return OptionalInt.empty();
+  }
 
   default Optional<String> getTenantIdField() {
     return Optional.empty();

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/MetadataIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/MetadataIndex.java
@@ -11,6 +11,7 @@ import static io.camunda.webapps.schema.descriptors.ComponentNames.OPERATE;
 
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.backup.Prio1Backup;
+import java.util.OptionalInt;
 
 public final class MetadataIndex extends AbstractIndexDescriptor implements Prio1Backup {
 
@@ -22,6 +23,11 @@ public final class MetadataIndex extends AbstractIndexDescriptor implements Prio
 
   public MetadataIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public OptionalInt getDefaultShardCount() {
+    return OptionalInt.of(1);
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/PostImporterQueueTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/PostImporterQueueTemplate.java
@@ -12,6 +12,7 @@ import static io.camunda.webapps.schema.descriptors.ComponentNames.OPERATE;
 import io.camunda.webapps.schema.descriptors.AbstractTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import java.util.OptionalInt;
 
 public class PostImporterQueueTemplate extends AbstractTemplateDescriptor
     implements ProcessInstanceDependant, Prio3Backup {
@@ -39,6 +40,11 @@ public class PostImporterQueueTemplate extends AbstractTemplateDescriptor
   @Override
   public String getVersion() {
     return "8.3.0";
+  }
+
+  @Override
+  public OptionalInt getDefaultShardCount() {
+    return OptionalInt.of(1);
   }
 
   @Override


### PR DESCRIPTION
## Summary

- Adds `getDefaultShardCount(): OptionalInt` to `IndexDescriptor` with a three-level precedence in `SchemaManager`: explicit `shardsByIndexName` config → descriptor default → global `numberOfShards`.
- `AbstractIndexDescriptor` defaults to **1 primary shard** — plain `index/` descriptors hold config/definition/singleton data that never benefits from sharding.
- `AbstractTemplateDescriptor` overrides back to `empty()` so volume-oriented template indices follow the operator-configured global knob.
- `PostImporterQueueTemplate` and `MetadataIndex` pin to 1 explicitly, keeping backport cherry-picks self-contained.

This removes the root cause of the post-importer-queue watermark-skip bug (#56117) for fresh installs: a single-shard index refreshes atomically, so entries for one partition can never scatter across independently refreshing shards.

Closes #56245
Related: #56117 (brownfield fix), #56179 (brownfield PR)

## Test plan

- [ ] `SchemaManagerTest$ShardCountPrecedenceTest` — 4 new unit tests covering: `AbstractIndexDescriptor` defaults to 1, `AbstractTemplateDescriptor` follows global, `PostImporterQueueTemplate` pinned to 1, explicit config overrides descriptor default.
- [ ] All existing `SchemaManagerTest` and `webapps-schema` tests pass (170 total).
- [ ] Fresh-install smoke: spin up against a blank ES/OS cluster and confirm `post-importer-queue` and all `index/` indices are created with 1 primary shard; template indices follow the configured global.

🤖 Generated with [Claude Code](https://claude.com/claude-code)