### PR TITLE
ci: parallelize frontend builds in build-platform-frontend job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,7 @@ jobs:
   build-platform-frontend:
     if: needs.detect-changes.outputs.frontend-changes == 'true'
     needs: [ detect-changes ]
-    runs-on: gcp-core-4-default
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,32 +383,33 @@ jobs:
   build-platform-frontend:
     if: needs.detect-changes.outputs.frontend-changes == 'true'
     needs: [ detect-changes ]
-    runs-on: ubuntu-latest
+    runs-on: gcp-core-4-default
     timeout-minutes: 20
     permissions: { }  # GITHUB_TOKEN unused in this job
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@be5b0496892a83e6b3c5cedb818b771e8ed68121 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         timeout-minutes: 1
-      - uses: ./.github/actions/build-frontend
-        id: build-operate-fe
-        with:
-          directory: ./operate/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        id: build-tasklist-fe
-        with:
-          directory: ./tasklist/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        id: build-identity-fe
-        with:
-          directory: ./identity/client
-          package-manager: "npm"
-      - uses: ./.github/actions/build-frontend
-        id: build-optimize-fe
-        with:
-          directory: ./optimize/client
+      - parallel:
+          - uses: ./.github/actions/build-frontend
+            id: build-operate-fe
+            with:
+              directory: ./operate/client
+              package-manager: "npm"
+          - uses: ./.github/actions/build-frontend
+            id: build-tasklist-fe
+            with:
+              directory: ./tasklist/client
+              package-manager: "npm"
+          - uses: ./.github/actions/build-frontend
+            id: build-identity-fe
+            with:
+              directory: ./identity/client
+              package-manager: "npm"
+          - uses: ./.github/actions/build-frontend
+            id: build-optimize-fe
+            with:
+              directory: ./optimize/client
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Summary

- Uses the new `parallel:` step keyword (GA June 2026) to run the four independent frontend builds concurrently in the `build-platform-frontend` job
- Each build targets a distinct directory (`operate/client`, `tasklist/client`, `identity/client`, `optimize/client`) so there are no shared-write conflicts

## Test plan

- [ ] `build-platform-frontend` job runs and all four frontend builds complete successfully
- [ ] Step timestamps overlap, confirming parallel execution
- [ ] Wall-clock time for the job is ~105s (slowest single build) instead of ~230s (sum of all four)

🤖 Generated with [Claude Code](https://claude.com/claude-code)