### PR TITLE
ci: authenticate Docker Hub pulls in database integration tests

### DIFF
--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -94,6 +94,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-build
         with:
+          dockerhub-readonly: true
           maven-cache-key-modifier: "it-database-${{ inputs.database-type }}"
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
## Description

The database integration test jobs (Identity, History, etc.) run via the reusable workflow `ci-database-integration-tests-reusable.yml`, which calls `setup-build` without `dockerhub-readonly: true`. As a result, the `docker compose up` step pulls the OpenSearch/Elasticsearch images from Docker Hub **anonymously** and hits the unauthenticated rate limit:

```
Image opensearchproject/opensearch:2.19.5 Error unknown: failed to resolve reference
"docker.io/opensearchproject/opensearch:2.19.5": unexpected status from HEAD request to
https://registry-1.docker.io/v2/opensearchproject/opensearch/manifests/2.19.5: 429 Too Many Requests
```

This applies the same fix as #56059: adding `dockerhub-readonly: true` to the `setup-build` step so Docker Hub pulls are authenticated with read-only credentials and use the higher rate limit.

Since this is the shared reusable workflow, the fix covers every database matrix variant (Identity, History, etc.), not just OpenSearch 2.

## Related

- Follows the pattern from #56059