### PR TITLE
feat: log info on startup when no ES/OS backup repository is configured

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
@@ -17,6 +17,8 @@ import io.camunda.configuration.conditions.ConditionalOnSecondaryStorageType;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.backup.repository.BackupRepositoryPropsRecord;
 import io.camunda.zeebe.util.VersionUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -25,10 +27,22 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @ConditionalOnSecondaryStorageType({elasticsearch, opensearch})
 public class BackupConfig {
 
+  private static final Logger LOG = LoggerFactory.getLogger(BackupConfig.class);
+
   @Bean
   public BackupRepositoryProps backupRepositoryProps(final Camunda camunda) {
     final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
-    return props(VersionUtil.getVersion(), backupConfig(secondaryStorage));
+    final DocumentBasedSecondaryStorageBackup backupConfig = backupConfig(secondaryStorage);
+    final String repositoryName = backupConfig.getRepositoryName();
+    if (repositoryName == null || repositoryName.isBlank()) {
+      LOG.info(
+          "No backup repository configured for {} secondary storage. Backup endpoints are active"
+              + " but will reject all requests until a repository is configured via"
+              + " 'camunda.data.secondary-storage.{}.backup.repository-name'.",
+          secondaryStorage.getType(),
+          secondaryStorage.getType());
+    }
+    return props(VersionUtil.getVersion(), backupConfig);
   }
 
   @Bean("backupThreadPoolExecutor")

--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
@@ -35,7 +35,7 @@ public class BackupConfig {
     final DocumentBasedSecondaryStorageBackup backupConfig = backupConfig(secondaryStorage);
     final String repositoryName = backupConfig.getRepositoryName();
     if (repositoryName == null || repositoryName.isBlank()) {
-      LOG.info(
+      LOG.warn(
           "No backup repository configured for {} secondary storage. Backup endpoints are active"
               + " but will reject all requests until a repository is configured via"
               + " 'camunda.data.secondary-storage.{}.backup.repository-name'.",


### PR DESCRIPTION
Log an INFO message at startup when ES/OS is configured as secondary storage but no backup repository name is set, so operators know backups are unavailable without having to trigger a backup request first.