### PR TITLE
feat: add version filter to Agentic Control Plane 

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticReliabilityKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticReliabilityKpiTilesIT.java
@@ -368,6 +368,37 @@ class AgenticReliabilityKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
   }
 
   @Test
+  void shouldReturnOnlyTheRequestedVersionWhenDefinitionVersionFilterApplied() {
+    final String procKey = "proc-fr-versioned";
+
+    // given version 1: 2 instances, 1 with incident → 50% (must be excluded when scoping to v2)
+    final ProcessInstanceDto v1WithIncident =
+        resolvedIncident(agenticInstance(procKey, "1", 100L, 50L));
+    final ProcessInstanceDto v1Clean = agenticInstance(procKey, "1", 100L, 50L).build();
+    // version 2: 4 instances, 1 with incident → 25% (the only bucket that must be returned)
+    final ProcessInstanceDto v2WithIncident =
+        resolvedIncident(agenticInstance(procKey, "2", 100L, 50L));
+    final List<ProcessInstanceDto> v2Clean =
+        repeat(3, () -> agenticInstance(procKey, "2", 100L, 50L).build());
+
+    persistProcessInstances(
+        Stream.of(List.of(v1WithIncident, v1Clean, v2WithIncident), v2Clean)
+            .flatMap(List::stream)
+            .toList());
+
+    // when scoping the definition filter to version 2 only
+    final ReportDataDefinitionDto scopedToV2 = new ReportDataDefinitionDto(procKey);
+    scopedToV2.setVersions(List.of("2"));
+    final List<MapResultEntryDto> buckets =
+        reports.evaluateMapData(
+            FAILURE_RATE_BY_VERSION_REPORT_ID, withDefinitions(List.of(scopedToV2)));
+
+    // then only the version 2 bucket appears, with its own scoped rate
+    assertThat(buckets).extracting(MapResultEntryDto::getKey).containsExactly("2");
+    assertThat(rateForVersion(buckets, "2")).isEqualTo(25.0);
+  }
+
+  @Test
   void shouldReturnNoErrorWhenNoCompletedAgenticInstancesMatch() {
     // given only running agentic and completed non-agentic instances — nothing to group
     final ProcessInstanceDto running =

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ReportEvaluationHandler.java
@@ -172,7 +172,10 @@ public abstract class ReportEvaluationHandler {
                 .orElse(List.of());
 
         if (!scopedDefinitions.isEmpty()) {
-          // L1: one or more processes selected — validate tenant access for each and combine
+          // L1: one or more processes selected — validate tenant access for each and combine.
+          // The versions requested by the caller (e.g. a specific version selected in the
+          // Agentic Control Plane version filter) are preserved; an empty version list falls
+          // back to ALL_VERSIONS to keep the previous "all versions" behavior.
           final List<ReportDataDefinitionDto> validatedDefs =
               scopedDefinitions.stream()
                   .flatMap(
@@ -183,7 +186,7 @@ public abstract class ReportEvaluationHandler {
                                   scopedDef.getKey(),
                                   reportEvaluationInfo.getUserId())
                               .stream()
-                              .map(this::toReportDataDefinitionDto))
+                              .map(def -> toReportDataDefinitionDto(def, scopedDef.getVersions())))
                   .toList();
           processReportData.setDefinitions(validatedDefs);
         } else {
@@ -218,10 +221,18 @@ public abstract class ReportEvaluationHandler {
 
   private ReportDataDefinitionDto toReportDataDefinitionDto(
       final io.camunda.optimize.dto.optimize.query.definition.DefinitionResponseDto def) {
+    return toReportDataDefinitionDto(def, List.of(ALL_VERSIONS));
+  }
+
+  private ReportDataDefinitionDto toReportDataDefinitionDto(
+      final io.camunda.optimize.dto.optimize.query.definition.DefinitionResponseDto def,
+      final List<String> versions) {
+    final List<String> resolvedVersions =
+        versions == null || versions.isEmpty() ? List.of(ALL_VERSIONS) : versions;
     return new ReportDataDefinitionDto(
         def.getKey(),
         def.getName(),
-        List.of(ALL_VERSIONS),
+        resolvedVersions,
         def.getTenants().stream().map(TenantDto::getId).toList(),
         def.getName());
   }

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -26,6 +26,12 @@
     "processFilter": {
       "label": "Prozess",
       "placeholder": "Alle Prozesse"
+    },
+    "versionFilter": {
+      "label": "Version",
+      "all": "Alle Versionen",
+      "latest": "Neueste Version",
+      "version": "Version {version}"
     }
   },
   "navigation": {

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -26,6 +26,12 @@
     "processFilter": {
       "label": "Process",
       "placeholder": "All processes"
+    },
+    "versionFilter": {
+      "label": "Version",
+      "all": "All versions",
+      "latest": "Latest version",
+      "version": "Version {version}"
     }
   },
   "navigation": {

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.test.tsx
@@ -37,13 +37,13 @@ beforeEach(() => {
 });
 
 it('should show a loading state while the dashboard is being fetched', () => {
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
 
   expect(node.find('Loading')).toExist();
 });
 
 it('should load the agentic dashboard on mount', async () => {
-  shallow(<AgenticControlPlane/>);
+  shallow(<AgenticControlPlane />);
 
   await runAllEffects();
 
@@ -51,7 +51,7 @@ it('should load the agentic dashboard on mount', async () => {
 });
 
 it('should render the dashboard once tiles are loaded', async () => {
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
 
   await runAllEffects();
 
@@ -60,7 +60,7 @@ it('should render the dashboard once tiles are loaded', async () => {
 });
 
 it('should pass the default Last 30 days filter to DashboardRenderer', async () => {
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
 
   await runAllEffects();
 
@@ -86,7 +86,7 @@ it('should pass the default Last 30 days filter to DashboardRenderer', async () 
 });
 
 it('should update the filter when the date preset changes', async () => {
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
 
   await runAllEffects();
 
@@ -114,7 +114,7 @@ it('should update the filter when the date preset changes', async () => {
 });
 
 it('should render the page header with title and description', async () => {
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
 
   await runAllEffects();
 
@@ -126,7 +126,7 @@ it('should pass the loaded tiles to DashboardRenderer', async () => {
   const tiles = [{id: 'report-1', position: {x: 0, y: 0}, dimensions: {width: 4, height: 3}}];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
 
   await runAllEffects();
 
@@ -141,7 +141,7 @@ it('should hide visibleInL0Only tiles when a process is selected', async () => {
   ];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
   await runAllEffects();
 
   (node.find('FilterBar').prop('onProcessScopeChange') as (v: string) => void)('my-process');
@@ -160,7 +160,7 @@ it('should hide visibleInL1Only tiles when no process is selected (L0)', async (
   ];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
   await runAllEffects();
 
   const visibleTiles = node.find('.kpi-section').find('DashboardRenderer').prop('tiles') as {
@@ -170,7 +170,7 @@ it('should hide visibleInL1Only tiles when no process is selected (L0)', async (
 });
 
 it('should include definitions in evaluate calls when a process is selected', async () => {
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
   await runAllEffects();
 
   (node.find('FilterBar').prop('onProcessScopeChange') as (v: string) => void)('my-process');
@@ -188,7 +188,7 @@ it('should include definitions in evaluate calls when a process is selected', as
 });
 
 it('should pass empty definitions in evaluate calls when no process is selected', async () => {
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
   await runAllEffects();
 
   const loadTile = node.find('.kpi-section').find('DashboardRenderer').prop('loadTile') as (
@@ -199,6 +199,60 @@ it('should pass empty definitions in evaluate calls when no process is selected'
   loadTile('report-id', [], {});
 
   expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, []);
+});
+
+it('should include the selected version in evaluate definitions', async () => {
+  const node = shallow(<AgenticControlPlane />);
+  await runAllEffects();
+
+  (node.find('FilterBar').prop('onProcessScopeChange') as (v: string) => void)('my-process');
+  (node.find('FilterBar').prop('onVersionsChange') as (v: string[]) => void)(['3']);
+
+  const loadTile = node.find('.kpi-section').find('DashboardRenderer').prop('loadTile') as (
+    id: string,
+    filter: unknown[],
+    params: unknown
+  ) => void;
+  loadTile('report-id', [], {});
+
+  expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, [
+    {key: 'my-process', versions: ['3']},
+  ]);
+});
+
+it('should pass the selected versions to FilterBar', async () => {
+  const node = shallow(<AgenticControlPlane />);
+  await runAllEffects();
+
+  (node.find('FilterBar').prop('onProcessScopeChange') as (v: string) => void)('my-process');
+  (node.find('FilterBar').prop('onVersionsChange') as (v: string[]) => void)(['2']);
+
+  expect(node.find('FilterBar').prop('versions')).toEqual(['2']);
+});
+
+it('should reset the version to all when the process scope changes', async () => {
+  const node = shallow(<AgenticControlPlane />);
+  await runAllEffects();
+
+  (node.find('FilterBar').prop('onProcessScopeChange') as (v: string) => void)('my-process');
+  (node.find('FilterBar').prop('onVersionsChange') as (v: string[]) => void)(['3']);
+  expect(node.find('FilterBar').prop('versions')).toEqual(['3']);
+
+  // selecting a different process must reset the version filter
+  (node.find('FilterBar').prop('onProcessScopeChange') as (v: string) => void)('other-process');
+
+  expect(node.find('FilterBar').prop('versions')).toEqual(['all']);
+
+  const loadTile = node.find('.kpi-section').find('DashboardRenderer').prop('loadTile') as (
+    id: string,
+    filter: unknown[],
+    params: unknown
+  ) => void;
+  loadTile('report-id', [], {});
+
+  expect(evaluateReport).toHaveBeenCalledWith('report-id', [], {}, [
+    {key: 'other-process', versions: ['all']},
+  ]);
 });
 
 it('should render a reliabilityAndToolCalls tile in its section in both L0 and L1', async () => {
@@ -213,7 +267,7 @@ it('should render a reliabilityAndToolCalls tile in its section in both L0 and L
   ];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
   await runAllEffects();
 
   // L0 (fleet view — no process selected)
@@ -243,7 +297,7 @@ it('should inject the configured top-N limit when evaluating a tile with a topN 
   ];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
   await runAllEffects();
 
   const loadTile = node.find('.token-section').find('DashboardRenderer').prop('loadTile') as (
@@ -260,7 +314,7 @@ it('should not inject a limit for token tiles without a topN config', async () =
   const tiles = [{id: 'token-trend', configuration: {section: 'token'}, position: {x: 0, y: 0}}];
   (loadAgenticDashboard as jest.Mock).mockReturnValueOnce({tiles, availableFilters: []});
 
-  const node = shallow(<AgenticControlPlane/>);
+  const node = shallow(<AgenticControlPlane />);
   await runAllEffects();
 
   const loadTile = node.find('.token-section').find('DashboardRenderer').prop('loadTile') as (

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.tsx
@@ -18,7 +18,7 @@ import {t} from 'translation';
 
 import type {DashboardTile} from 'types';
 
-import {DATE_PRESETS, FilterBar} from './FilterBar';
+import {ALL_VERSIONS, DATE_PRESETS, FilterBar} from './FilterBar';
 import {loadAgenticDashboard} from './service';
 import {TileFooter} from './TileFooter';
 import {getTileTopNLimit} from './tilePagination';
@@ -69,14 +69,20 @@ export function AgenticControlPlane() {
   const [preset, setPreset] = useState('30d');
   const [dashboard, setDashboard] = useState<{tiles: DashboardTile[]} | null>(null);
   const [processScope, setProcessScope] = useState<string | null>(null);
+  const [versions, setVersions] = useState<string[]>([ALL_VERSIONS]);
   const {mightFail} = useErrorHandling();
 
   useEffect(() => {
     mightFail(loadAgenticDashboard(), setDashboard, showError);
   }, [mightFail]);
 
+  const handleProcessScopeChange = useCallback((key: string | null) => {
+    setProcessScope(key);
+    setVersions([ALL_VERSIONS]);
+  }, []);
+
   const selectedPreset = DATE_PRESETS.find((p) => p.id === preset)!;
-  const definitions = processScope ? [{key: processScope, versions: ['all']}] : [];
+  const definitions = processScope ? [{key: processScope, versions}] : [];
   const filter = [presetToFilter(selectedPreset)];
 
   const scopedEvaluateReport = useCallback(
@@ -86,7 +92,7 @@ export function AgenticControlPlane() {
       query: Parameters<typeof evaluateReport>[2]
     ) => evaluateReport(id, tileFilter, query, definitions),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [processScope]
+    [processScope, versions]
   );
 
   const tileLimitById = useMemo(() => {
@@ -119,7 +125,7 @@ export function AgenticControlPlane() {
       );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [processScope, preset, tileLimitById]
+    [processScope, versions, preset, tileLimitById]
   );
 
   if (!dashboard) {
@@ -162,7 +168,9 @@ export function AgenticControlPlane() {
         preset={preset}
         onPresetChange={setPreset}
         processScope={processScope}
-        onProcessScopeChange={setProcessScope}
+        onProcessScopeChange={handleProcessScopeChange}
+        versions={versions}
+        onVersionsChange={setVersions}
       />
       {sections.map(({key, titleKey, loadTile}) => {
         const tiles = visibleTiles?.filter(
@@ -179,7 +187,7 @@ export function AgenticControlPlane() {
             )}
             <div className={`${key}-section`}>
               <DashboardRenderer
-                key={`${processScope ?? '__all__'}-${key}`}
+                key={`${processScope ?? '__all__'}-${versions.join(',')}-${key}`}
                 loadTile={loadTile}
                 tiles={tiles}
                 filter={filter}

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.scss
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.scss
@@ -8,8 +8,9 @@
 
 .FilterBar {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
+  gap: 1.5rem;
   padding: 0.75rem 0;
   border-top: 1px solid var(--cds-border-subtle);
   border-bottom: 1px solid var(--cds-border-subtle);
@@ -21,10 +22,17 @@
     gap: 0.5rem;
   }
 
+  .versionScope {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
   .dateRange {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    margin-left: auto;
   }
 
   .label {

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.test.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.test.tsx
@@ -7,11 +7,11 @@
  */
 
 import {runAllEffects} from '__mocks__/react';
-import {shallow} from 'enzyme';
+import {shallow, ShallowWrapper} from 'enzyme';
 import {ComboBox, MenuItemSelectable} from '@carbon/react';
 
 import {MenuDropdown} from 'components';
-import {loadDefinitions} from 'services';
+import {loadDefinitions, loadVersions} from 'services';
 
 import {FilterBar, DATE_PRESETS} from './FilterBar';
 
@@ -21,6 +21,11 @@ jest.mock('services', () => ({
     {key: 'process-a', name: 'Process A'},
     {key: 'process-b', name: 'Process B'},
   ]),
+  loadVersions: jest.fn().mockResolvedValue([
+    {version: '3', versionTag: null},
+    {version: '2', versionTag: 'v2-tag'},
+    {version: '1', versionTag: null},
+  ]),
 }));
 
 const props = {
@@ -28,7 +33,25 @@ const props = {
   onPresetChange: jest.fn(),
   processScope: null,
   onProcessScopeChange: jest.fn(),
+  versions: ['all'],
+  onVersionsChange: jest.fn(),
 };
+
+function dateRangeDropdown(node: ShallowWrapper) {
+  return node.find('.dateRange').find(MenuDropdown);
+}
+
+function dateRangeItems(node: ShallowWrapper) {
+  return node.find('.dateRange').find(MenuItemSelectable);
+}
+
+function versionDropdown(node: ShallowWrapper) {
+  return node.find('.versionScope').find(MenuDropdown);
+}
+
+function versionItems(node: ShallowWrapper) {
+  return node.find('.versionScope').find(MenuItemSelectable);
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -37,13 +60,13 @@ beforeEach(() => {
 it('should render one option for each date preset', () => {
   const node = shallow(<FilterBar {...props} />);
 
-  expect(node.find(MenuItemSelectable)).toHaveLength(DATE_PRESETS.length);
+  expect(dateRangeItems(node)).toHaveLength(DATE_PRESETS.length);
 });
 
 it('should mark only the active preset as selected', () => {
   const node = shallow(<FilterBar {...props} preset="7d" />);
 
-  const selectedItems = node.find(MenuItemSelectable).filterWhere((n) => n.prop('selected'));
+  const selectedItems = dateRangeItems(node).filterWhere((n) => n.prop('selected'));
   expect(selectedItems).toHaveLength(1);
   expect(selectedItems.prop('label')).toBe('Last 7 days');
 });
@@ -51,13 +74,13 @@ it('should mark only the active preset as selected', () => {
 it('should show the active preset label in the dropdown trigger', () => {
   const node = shallow(<FilterBar {...props} preset="3m" />);
 
-  expect(node.find(MenuDropdown).prop('label')).toBe('Last 3 months');
+  expect(dateRangeDropdown(node).prop('label')).toBe('Last 3 months');
 });
 
 it('should call onPresetChange with the preset id when an option is selected', () => {
   const node = shallow(<FilterBar {...props} />);
 
-  (node.find(MenuItemSelectable).at(0).prop('onChange') as () => void)();
+  (dateRangeItems(node).at(0).prop('onChange') as () => void)();
 
   expect(props.onPresetChange).toHaveBeenCalledWith('7d');
 });
@@ -65,7 +88,7 @@ it('should call onPresetChange with the preset id when an option is selected', (
 it('should default to Last 30 days being selected when preset is 30d', () => {
   const node = shallow(<FilterBar {...props} preset="30d" />);
 
-  const selectedItem = node.find(MenuItemSelectable).filterWhere((n) => n.prop('selected'));
+  const selectedItem = dateRangeItems(node).filterWhere((n) => n.prop('selected'));
   expect(selectedItem.prop('label')).toBe('Last 30 days');
 });
 
@@ -111,4 +134,86 @@ it('should show null selectedItem in ComboBox when no process is selected', () =
   const node = shallow(<FilterBar {...props} processScope={null} />);
 
   expect(node.find(ComboBox).prop('selectedItem')).toBeNull();
+});
+
+it('should disable the version dropdown when no process is selected', () => {
+  const node = shallow(<FilterBar {...props} processScope={null} />);
+
+  expect(versionDropdown(node).prop('disabled')).toBe(true);
+});
+
+it('should enable the version dropdown when a process is selected', () => {
+  const node = shallow(<FilterBar {...props} processScope="process-a" />);
+
+  expect(versionDropdown(node).prop('disabled')).toBe(false);
+});
+
+it('should not load versions when no process is selected', async () => {
+  shallow(<FilterBar {...props} processScope={null} />);
+
+  await runAllEffects();
+
+  expect(loadVersions).not.toHaveBeenCalled();
+});
+
+it('should load versions for the selected process', async () => {
+  shallow(<FilterBar {...props} processScope="process-a" />);
+
+  await runAllEffects();
+
+  expect(loadVersions).toHaveBeenCalledWith('process', null, 'process-a');
+});
+
+it('should render All, Latest and one option per loaded version', async () => {
+  const node = shallow(<FilterBar {...props} processScope="process-a" />);
+
+  await runAllEffects();
+
+  // All + Latest + 3 concrete versions
+  expect(versionItems(node)).toHaveLength(5);
+});
+
+it('should mark All as selected by default', () => {
+  const node = shallow(<FilterBar {...props} processScope="process-a" versions={['all']} />);
+
+  const selected = versionItems(node).filterWhere((n) => n.prop('selected'));
+  expect(selected).toHaveLength(1);
+  expect(selected.prop('label')).toBe('All versions');
+});
+
+it('should call onVersionsChange with [all] when All is selected', () => {
+  const node = shallow(<FilterBar {...props} processScope="process-a" versions={['latest']} />);
+
+  (versionItems(node).at(0).prop('onChange') as () => void)();
+
+  expect(props.onVersionsChange).toHaveBeenCalledWith(['all']);
+});
+
+it('should call onVersionsChange with [latest] when Latest is selected', () => {
+  const node = shallow(<FilterBar {...props} processScope="process-a" />);
+
+  (versionItems(node).at(1).prop('onChange') as () => void)();
+
+  expect(props.onVersionsChange).toHaveBeenCalledWith(['latest']);
+});
+
+it('should call onVersionsChange with a specific version when selected', async () => {
+  const node = shallow(<FilterBar {...props} processScope="process-a" />);
+
+  await runAllEffects();
+
+  // index 2 is the first concrete version ('3')
+  (versionItems(node).at(2).prop('onChange') as () => void)();
+
+  expect(props.onVersionsChange).toHaveBeenCalledWith(['3']);
+});
+
+it('should mark the specific selected version as selected', async () => {
+  const node = shallow(<FilterBar {...props} processScope="process-a" versions={['2']} />);
+
+  await runAllEffects();
+
+  const selected = versionItems(node).filterWhere((n) => n.prop('selected'));
+  expect(selected).toHaveLength(1);
+  expect(selected.prop('label')).toBe('Version 2 (v2-tag)');
 });

--- a/optimize/client/src/components/AgenticControlPlane/FilterBar.tsx
+++ b/optimize/client/src/components/AgenticControlPlane/FilterBar.tsx
@@ -10,8 +10,8 @@ import {useState, useEffect} from 'react';
 import {ComboBox, MenuItemSelectable} from '@carbon/react';
 
 import {MenuDropdown} from 'components';
-import {loadDefinitions} from 'services';
-import type {Definition} from 'services';
+import {loadDefinitions, loadVersions} from 'services';
+import type {Definition, Version} from 'services';
 import {t} from 'translation';
 
 import './FilterBar.scss';
@@ -29,11 +29,35 @@ export const DATE_PRESETS = [
   },
 ] as const;
 
+export const ALL_VERSIONS = 'all';
+export const LATEST_VERSION = 'latest';
+
 interface FilterBarProps {
   preset: string;
   onPresetChange: (id: string) => void;
   processScope: string | null;
   onProcessScopeChange: (key: string | null) => void;
+  versions: string[];
+  onVersionsChange: (versions: string[]) => void;
+}
+
+function formatSpecificVersion(version: string, versionTag: string | null | undefined): string {
+  return (
+    (t('agenticControlPlane.versionFilter.version', {version}) as string) +
+    (versionTag ? ` (${versionTag})` : '')
+  );
+}
+
+function versionLabel(versions: string[], available: Version[]): string {
+  const selected = versions[0];
+  if (selected === ALL_VERSIONS || selected == null) {
+    return t('agenticControlPlane.versionFilter.all') as string;
+  }
+  if (selected === LATEST_VERSION) {
+    return t('agenticControlPlane.versionFilter.latest') as string;
+  }
+  const match = available.find((v) => v.version === selected);
+  return formatSpecificVersion(selected, match?.versionTag);
 }
 
 export function FilterBar({
@@ -41,15 +65,27 @@ export function FilterBar({
   onPresetChange,
   processScope,
   onProcessScopeChange,
+  versions,
+  onVersionsChange,
 }: FilterBarProps) {
   const selected = DATE_PRESETS.find((p) => p.id === preset)!;
   const [processDefinitions, setProcessDefinitions] = useState<Definition[]>([]);
+  const [availableVersions, setAvailableVersions] = useState<Version[]>([]);
 
   useEffect(() => {
     loadDefinitions('process', null).then(setProcessDefinitions);
   }, []);
 
+  useEffect(() => {
+    if (processScope) {
+      loadVersions('process', null, processScope).then(setAvailableVersions);
+    } else {
+      setAvailableVersions([]);
+    }
+  }, [processScope]);
+
   const selectedProcess = processDefinitions.find((d) => d.key === processScope) ?? null;
+  const selectedVersion = versions[0] ?? ALL_VERSIONS;
 
   return (
     <div className="FilterBar">
@@ -65,6 +101,33 @@ export function FilterBar({
           placeholder={t('agenticControlPlane.processFilter.placeholder') as string}
           titleText=""
         />
+      </div>
+      <div className="versionScope">
+        <span className="label">{t('agenticControlPlane.versionFilter.label')}</span>
+        <MenuDropdown
+          label={versionLabel(versions, availableVersions)}
+          size="sm"
+          disabled={!processScope}
+        >
+          <MenuItemSelectable
+            label={t('agenticControlPlane.versionFilter.all') as string}
+            selected={selectedVersion === ALL_VERSIONS}
+            onChange={() => onVersionsChange([ALL_VERSIONS])}
+          />
+          <MenuItemSelectable
+            label={t('agenticControlPlane.versionFilter.latest') as string}
+            selected={selectedVersion === LATEST_VERSION}
+            onChange={() => onVersionsChange([LATEST_VERSION])}
+          />
+          {availableVersions.map((v) => (
+            <MenuItemSelectable
+              key={v.version}
+              label={formatSpecificVersion(v.version, v.versionTag)}
+              selected={selectedVersion === v.version}
+              onChange={() => onVersionsChange([v.version])}
+            />
+          ))}
+        </MenuDropdown>
       </div>
       <div className="dateRange">
         <span className="label">{t('agenticControlPlane.dateRange')}</span>

--- a/optimize/client/src/modules/components/DefinitionSelection/service.ts
+++ b/optimize/client/src/modules/components/DefinitionSelection/service.ts
@@ -7,12 +7,12 @@
  */
 
 import {Tenant} from 'types';
-import {get, post} from 'request';
+import {post} from 'request';
+import {loadVersions} from 'services';
+import type {Version} from 'services';
 
-export type Version = {
-  version: string;
-  versionTag: string | null;
-};
+export {loadVersions};
+export type {Version};
 
 type DefintionWithTenants = {
   key: string;
@@ -21,21 +21,6 @@ type DefintionWithTenants = {
 };
 
 type DefintionWithVersions = {key: string; versions: string[]};
-
-export async function loadVersions(
-  type: string,
-  collectionId: string | null,
-  key: string
-): Promise<Version[]> {
-  const params: {filterByCollectionScope?: string} = {};
-  if (collectionId) {
-    params.filterByCollectionScope = collectionId;
-  }
-
-  const response = await get(`api/definition/${type}/${key}/versions`, params);
-
-  return response.json();
-}
 
 export async function loadTenants(
   type: string,
@@ -49,10 +34,7 @@ export async function loadTenants(
     payload.filterByCollectionScope = collectionId;
   }
 
-  const response = await post(
-    `api/definition/${type}/_resolveTenantsForVersions`,
-    payload
-  );
+  const response = await post(`api/definition/${type}/_resolveTenantsForVersions`, payload);
 
   return response.json();
 }

--- a/optimize/client/src/modules/services/index.js
+++ b/optimize/client/src/modules/services/index.js
@@ -53,4 +53,4 @@ export function capitalize(string) {
 export {loadAlerts, addAlert, removeAlert, editAlert} from './alertService';
 export {default as ignoreFragments} from './ignoreFragments';
 export {default as isReactElement} from './isReactElement';
-export {loadDefinitions} from './loadDefinitions';
+export {loadDefinitions, loadVersions} from './loadDefinitions';

--- a/optimize/client/src/modules/services/index.ts
+++ b/optimize/client/src/modules/services/index.ts
@@ -34,7 +34,7 @@ export {default as getScreenBounds} from './getScreenBounds';
 export {default as ignoreFragments} from './ignoreFragments';
 export {default as isReactElement} from './isReactElement';
 export {incompatibleFilters} from './incompatibleFilters';
-export {loadDefinitions} from './loadDefinitions';
+export {loadDefinitions, loadVersions} from './loadDefinitions';
 
-export type {Definition} from './loadDefinitions';
+export type {Definition, Version} from './loadDefinitions';
 export type {ReportEvaluationPayload} from './reportService';

--- a/optimize/client/src/modules/services/loadDefinitions.ts
+++ b/optimize/client/src/modules/services/loadDefinitions.ts
@@ -13,6 +13,11 @@ export type Definition = {
   name: string | null;
 };
 
+export type Version = {
+  version: string;
+  versionTag: string | null;
+};
+
 export async function loadDefinitions(
   type: string,
   collectionId: string | null,
@@ -29,6 +34,22 @@ export async function loadDefinitions(
   }
 
   const response = await get(`api/definition/${type}/keys`, params);
+
+  return response.json();
+}
+
+export async function loadVersions(
+  type: string,
+  collectionId: string | null,
+  key: string
+): Promise<Version[]> {
+  const params: {filterByCollectionScope?: string} = {};
+
+  if (collectionId) {
+    params.filterByCollectionScope = collectionId;
+  }
+
+  const response = await get(`api/definition/${type}/${key}/versions`, params);
 
   return response.json();
 }


### PR DESCRIPTION
## Description

### Why
The process-scoped (L1) view could only evaluate KPIs across **all** versions, diluting version-specific regressions.

### What
- **UI** — adds a Version dropdown (All / Latest / per-version) to the filter bar: disabled until a process is scoped, and reset to "All" on scope change.
- **Backend** — `ReportEvaluationHandler` no longer hard-codes `ALL_VERSIONS` for L1; it preserves the requested version, falling back to `ALL_VERSIONS` only when none is supplied (no change for existing callers).
- **Refactor** — `loadVersions` / `Version` deduplicated into the shared `modules/services` layer (re-exported for backward compatibility).

### Testing
- FE unit tests for the dropdown and version-scoped evaluation.
- Backend IT scoping the filter to a single version, asserting only that version's bucket returns.

## Related issues

closes https://github.com/camunda/camunda/issues/56139
