### PR TITLE
feat: add wait-state statistics endpoint to OpenAPI spec and Java SDK client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -200,6 +200,7 @@ import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceStatist
 import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceVersionStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionMessageSubscriptionStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessInstanceElementStatisticsRequest;
+import io.camunda.client.api.statistics.request.ProcessInstanceWaitStateStatisticsRequest;
 import io.camunda.client.api.statistics.request.UsageMetricsStatisticsRequest;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1;
@@ -1049,6 +1050,22 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the process instance statistics request
    */
   ProcessInstanceElementStatisticsRequest newProcessInstanceElementStatisticsRequest(
+      final long processInstanceKey);
+
+  /**
+   * Executes a request to query process instance wait state statistics, grouped by element id.
+   *
+   * <pre>
+   * long processInstanceKey = ...;
+   *
+   * camundaClient
+   *  .newProcessInstanceWaitStateStatisticsRequest(processInstanceKey)
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the process instance wait state statistics request
+   */
+  ProcessInstanceWaitStateStatisticsRequest newProcessInstanceWaitStateStatisticsRequest(
       final long processInstanceKey);
 
   /**

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/request/ProcessInstanceWaitStateStatisticsRequest.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/request/ProcessInstanceWaitStateStatisticsRequest.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.statistics.request;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.statistics.response.ProcessInstanceWaitStateStatistics;
+import java.util.List;
+
+public interface ProcessInstanceWaitStateStatisticsRequest
+    extends FinalCommandStep<List<ProcessInstanceWaitStateStatistics>> {}

--- a/clients/java/src/main/java/io/camunda/client/api/statistics/response/ProcessInstanceWaitStateStatistics.java
+++ b/clients/java/src/main/java/io/camunda/client/api/statistics/response/ProcessInstanceWaitStateStatistics.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.statistics.response;
+
+public interface ProcessInstanceWaitStateStatistics {
+
+  String getElementId();
+
+  Long getWaitingCount();
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -211,6 +211,7 @@ import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceStatist
 import io.camunda.client.api.statistics.request.ProcessDefinitionInstanceVersionStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessDefinitionMessageSubscriptionStatisticsRequest;
 import io.camunda.client.api.statistics.request.ProcessInstanceElementStatisticsRequest;
+import io.camunda.client.api.statistics.request.ProcessInstanceWaitStateStatisticsRequest;
 import io.camunda.client.api.statistics.request.UsageMetricsStatisticsRequest;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1;
@@ -400,6 +401,7 @@ import io.camunda.client.impl.statistics.request.ProcessDefinitionInstanceStatis
 import io.camunda.client.impl.statistics.request.ProcessDefinitionInstanceVersionStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.ProcessDefinitionMessageSubscriptionStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.ProcessInstanceElementStatisticsRequestImpl;
+import io.camunda.client.impl.statistics.request.ProcessInstanceWaitStateStatisticsRequestImpl;
 import io.camunda.client.impl.statistics.request.UsageMetricsStatisticsRequestImpl;
 import io.camunda.client.impl.util.AddressUtil;
 import io.camunda.client.impl.util.JobWorkerExecutors;
@@ -985,6 +987,12 @@ public final class CamundaClientImpl implements CamundaClient {
   public ProcessInstanceElementStatisticsRequest newProcessInstanceElementStatisticsRequest(
       final long processInstanceKey) {
     return new ProcessInstanceElementStatisticsRequestImpl(httpClient, processInstanceKey);
+  }
+
+  @Override
+  public ProcessInstanceWaitStateStatisticsRequest newProcessInstanceWaitStateStatisticsRequest(
+      final long processInstanceKey) {
+    return new ProcessInstanceWaitStateStatisticsRequestImpl(httpClient, processInstanceKey);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/request/ProcessInstanceWaitStateStatisticsRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/request/ProcessInstanceWaitStateStatisticsRequestImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.statistics.request;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.statistics.request.ProcessInstanceWaitStateStatisticsRequest;
+import io.camunda.client.api.statistics.response.ProcessInstanceWaitStateStatistics;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.statistics.response.StatisticsResponseMapper;
+import io.camunda.client.protocol.rest.ProcessInstanceWaitStateStatisticsQueryResult;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ProcessInstanceWaitStateStatisticsRequestImpl
+    implements ProcessInstanceWaitStateStatisticsRequest {
+
+  private final long processInstanceKey;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public ProcessInstanceWaitStateStatisticsRequestImpl(
+      final HttpClient httpClient, final long processInstanceKey) {
+    this.httpClient = httpClient;
+    this.processInstanceKey = processInstanceKey;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public FinalCommandStep<List<ProcessInstanceWaitStateStatistics>> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<List<ProcessInstanceWaitStateStatistics>> send() {
+    final HttpCamundaFuture<List<ProcessInstanceWaitStateStatistics>> result =
+        new HttpCamundaFuture<>();
+    httpClient.get(
+        "/process-instances/" + processInstanceKey + "/statistics/wait-states",
+        httpRequestConfig.build(),
+        ProcessInstanceWaitStateStatisticsQueryResult.class,
+        StatisticsResponseMapper::toProcessInstanceWaitStateStatisticsResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/response/ProcessInstanceWaitStateStatisticsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/response/ProcessInstanceWaitStateStatisticsImpl.java
@@ -63,7 +63,7 @@ public class ProcessInstanceWaitStateStatisticsImpl implements ProcessInstanceWa
   @Override
   public String toString() {
     return String.format(
-        "ProcessInstanceWaitStateStatisticsImpl{elementId='%s', waitingCount=%d}",
+        "ProcessInstanceWaitStateStatisticsImpl{elementId='%s', waitingCount=%s}",
         elementId, waitingCount);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/response/ProcessInstanceWaitStateStatisticsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/response/ProcessInstanceWaitStateStatisticsImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.statistics.response;
+
+import io.camunda.client.api.statistics.response.ProcessInstanceWaitStateStatistics;
+import io.camunda.client.protocol.rest.ProcessInstanceWaitStateStatisticsResult;
+import java.util.Objects;
+
+public class ProcessInstanceWaitStateStatisticsImpl implements ProcessInstanceWaitStateStatistics {
+
+  private final String elementId;
+  private final Long waitingCount;
+
+  public ProcessInstanceWaitStateStatisticsImpl(
+      final ProcessInstanceWaitStateStatisticsResult statistics) {
+    elementId = statistics.getElementId();
+    waitingCount = statistics.getWaitingCount();
+  }
+
+  public ProcessInstanceWaitStateStatisticsImpl(final String elementId, final Long waitingCount) {
+    this.elementId = elementId;
+    this.waitingCount = waitingCount;
+  }
+
+  @Override
+  public String getElementId() {
+    return elementId;
+  }
+
+  @Override
+  public Long getWaitingCount() {
+    return waitingCount;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(elementId, waitingCount);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessInstanceWaitStateStatisticsImpl that = (ProcessInstanceWaitStateStatisticsImpl) o;
+    return Objects.equals(elementId, that.elementId)
+        && Objects.equals(waitingCount, that.waitingCount);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "ProcessInstanceWaitStateStatisticsImpl{elementId='%s', waitingCount=%d}",
+        elementId, waitingCount);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/statistics/response/StatisticsResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/statistics/response/StatisticsResponseMapper.java
@@ -37,6 +37,7 @@ import io.camunda.client.api.statistics.response.ProcessDefinitionInstanceVersio
 import io.camunda.client.api.statistics.response.ProcessDefinitionMessageSubscriptionStatistics;
 import io.camunda.client.api.statistics.response.ProcessDefinitionMessageSubscriptionStatisticsItem;
 import io.camunda.client.api.statistics.response.ProcessElementStatistics;
+import io.camunda.client.api.statistics.response.ProcessInstanceWaitStateStatistics;
 import io.camunda.client.api.statistics.response.UsageMetricsStatistics;
 import io.camunda.client.api.statistics.response.UsageMetricsStatisticsItem;
 import io.camunda.client.impl.search.response.SearchResponseImpl;
@@ -51,6 +52,7 @@ import io.camunda.client.protocol.rest.ProcessDefinitionElementStatisticsQueryRe
 import io.camunda.client.protocol.rest.ProcessDefinitionInstanceStatisticsQueryResult;
 import io.camunda.client.protocol.rest.ProcessDefinitionInstanceVersionStatisticsQueryResult;
 import io.camunda.client.protocol.rest.ProcessDefinitionMessageSubscriptionStatisticsQueryResult;
+import io.camunda.client.protocol.rest.ProcessInstanceWaitStateStatisticsQueryResult;
 import io.camunda.client.protocol.rest.StatusMetric;
 import io.camunda.client.protocol.rest.UsageMetricsResponse;
 import io.camunda.client.protocol.rest.UsageMetricsResponseItem;
@@ -93,6 +95,17 @@ public class StatisticsResponseMapper {
     if (response.getItems() != null) {
       return response.getItems().stream()
           .map(ProcessElementStatisticsImpl::new)
+          .collect(Collectors.toList());
+    }
+    return Collections.emptyList();
+  }
+
+  public static List<ProcessInstanceWaitStateStatistics>
+      toProcessInstanceWaitStateStatisticsResponse(
+          final ProcessInstanceWaitStateStatisticsQueryResult response) {
+    if (response.getItems() != null) {
+      return response.getItems().stream()
+          .map(ProcessInstanceWaitStateStatisticsImpl::new)
           .collect(Collectors.toList());
     }
     return Collections.emptyList();

--- a/clients/java/src/test/java/io/camunda/client/process/ProcessInstanceStatisticsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/ProcessInstanceStatisticsTest.java
@@ -19,8 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.client.api.statistics.response.ProcessInstanceWaitStateStatistics;
+import io.camunda.client.protocol.rest.ProcessInstanceWaitStateStatisticsQueryResult;
+import io.camunda.client.protocol.rest.ProcessInstanceWaitStateStatisticsResult;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceStatisticsTest extends ClientRestTest {
@@ -39,5 +44,47 @@ public class ProcessInstanceStatisticsTest extends ClientRestTest {
             "/v2/process-instances/" + PROCESS_INSTANCE_KEY + "/statistics/element-instances");
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
     assertThat(request.getBodyAsString()).isEmpty();
+  }
+
+  @Test
+  void shouldGetProcessInstanceWaitStateStatistics() {
+    // when
+    client.newProcessInstanceWaitStateStatisticsRequest(PROCESS_INSTANCE_KEY).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getUrl())
+        .isEqualTo("/v2/process-instances/" + PROCESS_INSTANCE_KEY + "/statistics/wait-states");
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
+    assertThat(request.getBodyAsString()).isEmpty();
+  }
+
+  @Test
+  void shouldMapProcessInstanceWaitStateStatisticsResponse() {
+    // given
+    final ProcessInstanceWaitStateStatisticsQueryResult response =
+        new ProcessInstanceWaitStateStatisticsQueryResult();
+    response.setItems(Arrays.asList(waitStateItem("task-a", 1L), waitStateItem("task-b", 500L)));
+    gatewayService.onProcessInstanceWaitStateStatisticsRequest(PROCESS_INSTANCE_KEY, response);
+
+    // when
+    final List<ProcessInstanceWaitStateStatistics> result =
+        client.newProcessInstanceWaitStateStatisticsRequest(PROCESS_INSTANCE_KEY).send().join();
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getElementId()).isEqualTo("task-a");
+    assertThat(result.get(0).getWaitingCount()).isEqualTo(1L);
+    assertThat(result.get(1).getElementId()).isEqualTo("task-b");
+    assertThat(result.get(1).getWaitingCount()).isEqualTo(500L);
+  }
+
+  private static ProcessInstanceWaitStateStatisticsResult waitStateItem(
+      final String elementId, final long waitingCount) {
+    final ProcessInstanceWaitStateStatisticsResult item =
+        new ProcessInstanceWaitStateStatisticsResult();
+    item.setElementId(elementId);
+    item.setWaitingCount(waitingCount);
+    return item;
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -84,6 +84,8 @@ public class RestGatewayPaths {
       REST_API_PATH + "/process-instances/%s/call-hierarchy";
   private static final String URL_PROCESS_INSTANCE_SEQUENCE_FLOWS =
       REST_API_PATH + "/process-instances/%s/sequence-flows";
+  private static final String URL_PROCESS_INSTANCE_WAIT_STATE_STATISTICS =
+      REST_API_PATH + "/process-instances/%s/statistics/wait-states";
   private static final String URL_PROCESS_INSTANCES = REST_API_PATH + "/process-instances";
   private static final String URL_PROCESS_INSTANCES_CANCELLATION =
       REST_API_PATH + "/process-instances/cancellation";
@@ -282,6 +284,10 @@ public class RestGatewayPaths {
 
   public static String getProcessInstanceCallHierarchyUrl(final long processInstanceKey) {
     return String.format(URL_PROCESS_INSTANCE_CALL_HIERARCHY, processInstanceKey);
+  }
+
+  public static String getProcessInstanceWaitStateStatisticsUrl(final long processInstanceKey) {
+    return String.format(URL_PROCESS_INSTANCE_WAIT_STATE_STATISTICS, processInstanceKey);
   }
 
   public static String getProcessInstancesUrl(final long processInstanceKey) {

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -67,6 +67,7 @@ import io.camunda.client.protocol.rest.ProcessDefinitionInstanceVersionStatistic
 import io.camunda.client.protocol.rest.ProcessDefinitionResult;
 import io.camunda.client.protocol.rest.ProcessInstanceResult;
 import io.camunda.client.protocol.rest.ProcessInstanceSequenceFlowsQueryResult;
+import io.camunda.client.protocol.rest.ProcessInstanceWaitStateStatisticsQueryResult;
 import io.camunda.client.protocol.rest.ResourceResult;
 import io.camunda.client.protocol.rest.RoleCreateResult;
 import io.camunda.client.protocol.rest.RoleResult;
@@ -239,6 +240,12 @@ public class RestGatewayService {
   public void onProcessInstanceCallHierarchyRequest(
       final long processInstanceKey, final Object[] response) {
     registerGet(RestGatewayPaths.getProcessInstanceCallHierarchyUrl(processInstanceKey), response);
+  }
+
+  public void onProcessInstanceWaitStateStatisticsRequest(
+      final long processInstanceKey, final ProcessInstanceWaitStateStatisticsQueryResult response) {
+    registerGet(
+        RestGatewayPaths.getProcessInstanceWaitStateStatisticsUrl(processInstanceKey), response);
   }
 
   public void onProcessInstanceRequest(

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -191,6 +191,41 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
 
+  /process-instances/{processInstanceKey}/statistics/wait-states:
+    get:
+      x-eventually-consistent: true
+      tags:
+        - Process instance
+      operationId: getProcessInstanceWaitStateStatistics
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Get wait state statistics
+      description: Get statistics about waiting element instances by the process instance key, grouped by element id.
+      parameters:
+        - name: processInstanceKey
+          in: path
+          required: true
+          description: The assigned key of the process instance, which acts as a unique identifier for this process instance.
+          schema:
+            $ref: 'keys.yaml#/components/schemas/ProcessInstanceKey'
+      responses:
+        "200":
+          description: The process instance wait state statistics result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProcessInstanceWaitStateStatisticsQueryResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
   /process-instances/search:
     post:
       x-eventually-consistent: true
@@ -1636,6 +1671,34 @@ components:
           type: array
           items:
             $ref: 'process-definitions.yaml#/components/schemas/ProcessElementStatisticsResult'
+
+    ProcessInstanceWaitStateStatisticsQueryResult:
+      description: Process instance wait state statistics query response.
+      required:
+        - items
+      type: object
+      properties:
+        items:
+          description: The wait state statistics.
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessInstanceWaitStateStatisticsResult'
+
+    ProcessInstanceWaitStateStatisticsResult:
+      description: Process instance wait state statistics response item.
+      type: object
+      required:
+        - elementId
+        - waitingCount
+      properties:
+        elementId:
+          allOf:
+            - $ref: 'identifiers.yaml#/components/schemas/ElementId'
+          description: The element id for which the wait states are aggregated.
+        waitingCount:
+          description: The total number of waiting instances of the element.
+          type: integer
+          format: int64
 
     ProcessInstanceMigrationInstruction:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-instances.yaml
@@ -197,6 +197,9 @@ paths:
       tags:
         - Process instance
       operationId: getProcessInstanceWaitStateStatistics
+      x-permission-enforcement: filter
+      x-required-permissions:
+        - { resourceType: PROCESS_DEFINITION, permissionType: READ_PROCESS_INSTANCE }
       security:
         - bearerAuth: []
         - basicAuth: []

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -357,6 +357,8 @@ paths:
     $ref: 'process-instances.yaml#/paths/~1process-instances~1{processInstanceKey}~1sequence-flows'
   /process-instances/{processInstanceKey}/statistics/element-instances:
     $ref: 'process-instances.yaml#/paths/~1process-instances~1{processInstanceKey}~1statistics~1element-instances'
+  /process-instances/{processInstanceKey}/statistics/wait-states:
+    $ref: 'process-instances.yaml#/paths/~1process-instances~1{processInstanceKey}~1statistics~1wait-states'
 
   # Resource endpoints
   /resources/search:


### PR DESCRIPTION
## Summary

- Adds `GET /v2/process-instances/{processInstanceKey}/statistics/wait-states` to the OpenAPI spec with `x-eventually-consistent: true` and `x-added-in-version: "8.10"`
- Defines `ProcessInstanceWaitStateStatisticsQueryResult` and `ProcessInstanceWaitStateStatisticsResult` schemas in `process-instances.yaml`
- Adds full fluent Java SDK client: `ProcessInstanceWaitStateStatisticsRequest` interface + impl, response interface + impl, `StatisticsResponseMapper` mapping, and `CamundaClient#newProcessInstanceWaitStateStatisticsRequest`

Closes #56253

## Test Plan

- [ ] `ProcessInstanceStatisticsTest#shouldGetProcessInstanceWaitStateStatistics` — verifies correct URL and HTTP method
- [ ] `ProcessInstanceStatisticsTest#shouldMapProcessInstanceWaitStateStatisticsResponse` — verifies response mapping with multiple items
- [ ] Full-repo compile: `./mvnw install -Dquickly -T1C`