### PR TITLE
ci: add post-minor backwards.compat.version main-bump automation

### DIFF
--- a/.github/workflows/update-backwards-compat-version.yml
+++ b/.github/workflows/update-backwards-compat-version.yml
@@ -1,0 +1,254 @@
+# type: CI Helper - Post-release
+# owner: @camunda/monorepo-devops-team
+name: Update Backwards Compat Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'The minor version that was just released (e.g. 8.10.0). main''s backwards.compat.version will be updated to this value.'
+        type: string
+        required: true
+      userSlackId:
+        description: 'The Slack ID of the user to notify on failure, no mention if omitted.'
+        type: string
+        required: false
+      dryRun:
+        description: 'Whether to perform a dry run where no changes are pushed and no PR is opened, defaults to true.'
+        type: boolean
+        default: true
+
+env:
+  GHA_BEST_PRACTICES_LINTER: enabled
+
+# Serialize runs per releaseVersion so a human dispatch and the camunda-release
+# BPMN dispatch (or a double-click) cannot race while a PR is being opened.
+concurrency:
+  group: update-backwards-compat-version-${{ inputs.releaseVersion }}
+  cancel-in-progress: false
+
+jobs:
+  update-backwards-compat-version:
+    name: "Update backwards.compat.version to ${{ inputs.releaseVersion }} on main"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
+      - name: Validate Release Version
+        env:
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
+        run: |
+          if [[ ! "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.0$ ]]; then
+            echo "ERROR: releaseVersion '${RELEASE_VERSION}' is not a minor release (expected format: X.Y.0)"
+            exit 1
+          fi
+      - name: Git User Setup
+        run: |
+          git config --global user.name "github-actions[update-backwards-compat-version]"
+          git config --global user.email "github-actions[update-backwards-compat-version]@users.noreply.github.com"
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: backwards-compat-update
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Update backwards.compat.version
+        id: update
+        env:
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
+          BRANCH: ci/update-backwards-compat-version-${{ inputs.releaseVersion }}
+        run: |
+          # Idempotent: set the property unconditionally; the git diff is the
+          # single source of truth for whether anything changed. No diff means
+          # main already points at this minor (re-run / already-current), so
+          # there is nothing to open a PR for.
+          ./mvnw -B versions:set-property -DgenerateBackupPoms=false -Dproperty=backwards.compat.version -DnewVersion="${RELEASE_VERSION}" -pl parent
+          if git diff --quiet HEAD -- parent/pom.xml; then
+            echo "backwards.compat.version is already ${RELEASE_VERSION}; no PR needed"
+            echo "outcome=already-up-to-date" >> "$GITHUB_OUTPUT"
+          else
+            git checkout -b "${BRANCH}"
+            git commit -am "build(project): update backwards.compat.version to ${RELEASE_VERSION} after minor release"
+            echo "outcome=opened" >> "$GITHUB_OUTPUT"
+            echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Debug backwards.compat.version after update
+        if: ${{ steps.update.outputs.outcome == 'opened' && inputs.dryRun }}
+        run: |
+          echo "=== backwards.compat.version after update ==="
+          ./mvnw -B help:evaluate -Dexpression=backwards.compat.version -q -DforceStdout -pl parent
+          echo "=== git diff ==="
+          git show --stat HEAD
+      - name: Push branch
+        if: ${{ steps.update.outputs.outcome == 'opened' && !inputs.dryRun }}
+        env:
+          BRANCH: ${{ steps.update.outputs.branch }}
+        # The branch is exclusively owned by this workflow and its content is
+        # deterministic (a single backwards.compat.version bump). On a re-run
+        # after a partial failure the branch may already exist on origin from
+        # the previous attempt: reuse it as-is (the "Open PR" step below reuses
+        # or creates the matching PR) rather than force-overwriting it.
+        run: |
+          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
+            echo "Branch ${BRANCH} already exists on origin; reusing it."
+          else
+            git push origin "${BRANCH}"
+          fi
+      - name: Open PR to main
+        id: pr
+        if: ${{ steps.update.outputs.outcome == 'opened' && !inputs.dryRun }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ inputs.releaseVersion }}
+          BRANCH: ${{ steps.update.outputs.branch }}
+        run: |
+          # Reuse an existing open PR for this branch if a previous run already
+          # opened one (partial-failure re-run); otherwise create it.
+          url=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "${BRANCH}" --state open --json url --jq '.[0].url // ""')
+          if [[ -z "${url}" ]]; then
+            url=$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "${BRANCH}" \
+              --title "build(project): update backwards.compat.version to ${RELEASE_VERSION} after minor release" \
+              --body "After the \`${RELEASE_VERSION}\` minor release, \`backwards.compat.version\` on \`main\` should point to \`${RELEASE_VERSION}\` so that CI validates future development against the newly shipped minor.")
+          fi
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+          number=$(gh pr view "$url" --repo "$GITHUB_REPOSITORY" --json number --jq '.number')
+          echo "number=${number}" >> "$GITHUB_OUTPUT"
+      - name: Resolve PR outputs
+        id: resolve-pr
+        if: always()
+        env:
+          UPDATE_OUTCOME: ${{ steps.update.outputs.outcome }}
+          DRY_RUN: ${{ inputs.dryRun }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          if [[ "$UPDATE_OUTCOME" == "already-up-to-date" ]]; then
+            # Nothing was opened. Emit empty values (not a sentinel string) so the
+            # BPMN's null-fallback degrades cleanly; the BPMN also branches on the
+            # explicit outcome variable and skips the "please merge" path.
+            echo "pr_url=" >> "$GITHUB_OUTPUT"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          elif [[ "$DRY_RUN" == "true" ]]; then
+            echo "pr_url=https://example.com" >> "$GITHUB_OUTPUT"
+            echo "pr_number=dry-run-pr-not-created" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
+            echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Import Camunda Secrets
+        id: camunda-secrets
+        # Only needed for the publishMessage step below, which is skipped on dry-run.
+        if: ${{ success() && !inputs.dryRun }}
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG;
+      # CROSS-REPO CONTRACT with camunda-release (post_release.bpmn, process
+      # `zeebe-post-release`). The receive task `Activity_02mq0mb` correlates on:
+      #   message name  : backwards-compat-version-pr-created
+      #   correlationKey: backwards-compat-update-<releaseVersion>
+      #   variables     : outcome (opened|already-up-to-date),
+      #                   backwards_compat_pr_url, backwards_compat_pr_number,
+      #                   compat_version
+      # Renaming any of these or changing the outcome values WILL strand the
+      # release process at the receive task. Keep in sync with camunda-release.
+      - name: Notify Camunda of completion
+        if: ${{ success() && !inputs.dryRun }}
+        uses: camunda-community-hub/camunda-platform-8-github-action@0fe490e4cf6f0cf59a5c86a127c4354b4b1fc3b7 # 8.3.0
+        with:
+          clientConfig: ${{ steps.camunda-secrets.outputs.CLIENT_CONFIG }}
+          operation: publishMessage
+          messageName: 'backwards-compat-version-pr-created'
+          correlationKey: 'backwards-compat-update-${{ inputs.releaseVersion }}'
+          timeToLive: '240000'
+          variables: |
+            {
+              "workflow_run": {
+                "name": "Update Backwards Compat Version",
+                "conclusion": "success",
+                "head_branch": "${{ steps.update.outputs.branch }}"
+              },
+              "outcome": "${{ steps.update.outputs.outcome }}",
+              "backwards_compat_pr_url": "${{ steps.resolve-pr.outputs.pr_url }}",
+              "backwards_compat_pr_number": "${{ steps.resolve-pr.outputs.pr_number }}",
+              "compat_version": "${{ inputs.releaseVersion }}"
+            }
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  notify:
+    name: Send Slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [update-backwards-compat-version]
+    if: ${{ failure() && !inputs.dryRun }}
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+      - name: Send failure Slack notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Updating backwards.compat.version* to `${{ inputs.releaseVersion }}` on `main` failed!\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ inputs.userSlackId != '' && format('<@{0}>', inputs.userSlackId) || '' }} Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>. This workflow is idempotent: re-dispatch it with the same `releaseVersion` to recover \u2014 it reuses any branch/PR already created."
+                  }
+                }
+              ]
+            }
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/update-backwards-compat-version.yml
+++ b/.github/workflows/update-backwards-compat-version.yml
@@ -73,7 +73,8 @@ jobs:
             echo "outcome=already-up-to-date" >> "$GITHUB_OUTPUT"
           else
             git checkout -b "${BRANCH}"
-            git commit -am "build(project): update backwards.compat.version to ${RELEASE_VERSION} after minor release"
+            # Commit only parent/pom.xml so unrelated changes can never sneak in.
+            git commit -m "build(project): update backwards.compat.version to ${RELEASE_VERSION} after minor release" -- parent/pom.xml
             echo "outcome=opened" >> "$GITHUB_OUTPUT"
             echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
           fi
@@ -88,16 +89,19 @@ jobs:
         if: ${{ steps.update.outputs.outcome == 'opened' && !inputs.dryRun }}
         env:
           BRANCH: ${{ steps.update.outputs.branch }}
-        # The branch is exclusively owned by this workflow and its content is
-        # deterministic (a single backwards.compat.version bump). On a re-run
-        # after a partial failure the branch may already exist on origin from
-        # the previous attempt: reuse it as-is (the "Open PR" step below reuses
-        # or creates the matching PR) rather than force-overwriting it.
+        # The branch is workflow-owned. On a re-run it may already exist on
+        # origin: reuse it only if its parent/pom.xml matches this run, else
+        # fail rather than force-push (a reused PR must never point at a stale
+        # or diverged version).
         run: |
-          if git ls-remote --exit-code --heads origin "${BRANCH}" >/dev/null 2>&1; then
-            echo "Branch ${BRANCH} already exists on origin; reusing it."
-          else
+          git fetch origin "${BRANCH}:refs/remotes/origin/${BRANCH}" || true
+          if ! git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}"; then
             git push origin "${BRANCH}"
+          elif git diff --quiet "origin/${BRANCH}" HEAD -- parent/pom.xml; then
+            echo "Branch ${BRANCH} already up to date on origin; reusing it."
+          else
+            echo "ERROR: origin/${BRANCH} has a different parent/pom.xml; refusing to force-push. Delete the branch or close the PR, then re-dispatch."
+            exit 1
           fi
       - name: Open PR to main
         id: pr

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,6 +45,7 @@
 /.github/workflows/renovatelint.yml                      @camunda/monorepo-devops-team
 /.github/workflows/retry-workflow.yml                    @camunda/monorepo-devops-team
 /.github/workflows/statistics-daily.yml                  @camunda/monorepo-devops-team
+/.github/workflows/update-backwards-compat-version.yml   @camunda/monorepo-devops-team
 /.github/workflows/zeebe-release-stable-dry-run.yml      @camunda/monorepo-devops-team
 /.github/workflows/check-outdated-prs.yml                @camunda/monorepo-devops-team
 /.github/workflows/create-urgent-hotfix-img.yml          @camunda/monorepo-devops-team


### PR DESCRIPTION
## Description

After a **minor** release (`X.Y.0`), `main`'s `backwards.compat.version` must advance to the just-released minor so CI validates future development against the newly shipped version. Today this is done manually after every minor, which has repeatedly blocked the release merge-back (see #51405).

This adds a `workflow_dispatch` helper workflow that:
- validates the input is a minor (`X.Y.0`) version,
- bumps `backwards.compat.version` in `parent/pom.xml` via `mvnw versions:set-property`,
- **diff-gates**: if the property is already current, it stops cleanly (`outcome=already-up-to-date`, no PR),
- otherwise commits to a deterministic, workflow-owned branch and opens (or reuses) a PR to `main`,
- notifies the camunda-release `post_release.bpmn` (`zeebe-post-release`) via a `publishMessage` so the release process can track the bump.

The run is **idempotent**: re-dispatching with the same `releaseVersion` reuses any branch/PR already created (no force-push), and a `notify` job sends a failure Slack with a recovery hint.

This is the camunda/camunda half of the pair; the camunda-release BPMN side is camunda-release. **This PR must merge to `main` before camunda-release PR can be tested**, as the BPMN dispatches this workflow.

## Tests

Can only test the new workflow on dry-run after merge, because it is currently unavailable on main.

## Cross-repo contract

The `publishMessage` step documents the contract inline (message name `backwards-compat-version-pr-created`, correlationKey `backwards-compat-update-<releaseVersion>`, variables `outcome` / `backwards_compat_pr_url` / `backwards_compat_pr_number` / `compat_version`). Renaming any of these would strand the release process at the receive task.

## Related

Related to #51405 (item: update `main`'s compat version after a minor ships).
