### PR TITLE
feat(process-test): make element instance page limit configurable

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -314,7 +314,8 @@ public class CamundaProcessTestExtension
 
     // initialize assertions
     final CamundaDataSource dataSource =
-        new CamundaDataSource(camundaProcessTestContext.createClient());
+        new CamundaDataSource(
+            camundaProcessTestContext.createClient(), runtimeBuilder.getElementInstancePageLimit());
     CamundaAssert.initialize(dataSource);
 
     // initialize result collector
@@ -379,7 +380,9 @@ public class CamundaProcessTestExtension
 
     try {
       final CamundaDataSource dataSource =
-          new CamundaDataSource(camundaProcessTestContext.createClient());
+          new CamundaDataSource(
+              camundaProcessTestContext.createClient(),
+              runtimeBuilder.getElementInstancePageLimit());
       final CoverageTestData coverageData = CoverageTestDataCollector.collectData(dataSource);
       coverageCollector.collectTestRunCoverage(
           context.getRequiredTestClass(),

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -315,7 +315,7 @@ public class CamundaProcessTestExtension
     // initialize assertions
     final CamundaDataSource dataSource =
         new CamundaDataSource(
-            camundaProcessTestContext.createClient(), runtimeBuilder.getElementInstancePageLimit());
+            camundaProcessTestContext.createClient(), runtimeBuilder.getQueryPageLimit());
     CamundaAssert.initialize(dataSource);
 
     // initialize result collector
@@ -381,8 +381,7 @@ public class CamundaProcessTestExtension
     try {
       final CamundaDataSource dataSource =
           new CamundaDataSource(
-              camundaProcessTestContext.createClient(),
-              runtimeBuilder.getElementInstancePageLimit());
+              camundaProcessTestContext.createClient(), runtimeBuilder.getQueryPageLimit());
       final CoverageTestData coverageData = CoverageTestDataCollector.collectData(dataSource);
       coverageCollector.collectTestRunCoverage(
           context.getRequiredTestClass(),

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -26,7 +26,6 @@ import io.camunda.client.api.search.filter.MessageSubscriptionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.filter.UserTaskFilter;
 import io.camunda.client.api.search.filter.VariableFilter;
-import io.camunda.client.api.search.page.AnyPage;
 import io.camunda.client.api.search.response.CorrelatedMessageSubscription;
 import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.client.api.search.response.DecisionInstance;
@@ -51,20 +50,18 @@ public class CamundaDataSource {
    * The default page size used when fetching element instances if no custom limit is configured.
    * Kept for backward compatibility.
    */
-  public static final int DEFAULT_ELEMENT_INSTANCE_PAGE_LIMIT = 100;
-
-  private static final Consumer<AnyPage> DEFAULT_PAGE_REQUEST = page -> page.limit(100);
+  public static final int DEFAULT_QUERY_PAGE_LIMIT = 100;
 
   private final CamundaClient client;
-  private final int elementInstancePageLimit;
+  private final int queryPageLimit;
 
   public CamundaDataSource(final CamundaClient client) {
-    this(client, DEFAULT_ELEMENT_INSTANCE_PAGE_LIMIT);
+    this(client, DEFAULT_QUERY_PAGE_LIMIT);
   }
 
-  public CamundaDataSource(final CamundaClient client, final int elementInstancePageLimit) {
+  public CamundaDataSource(final CamundaClient client, final int queryPageLimit) {
     this.client = client;
-    this.elementInstancePageLimit = elementInstancePageLimit;
+    this.queryPageLimit = queryPageLimit;
   }
 
   public byte[] getDocumentContent(final DocumentReferenceResponse reference) {
@@ -101,7 +98,7 @@ public class CamundaDataSource {
     return client
         .newProcessDefinitionSearchRequest()
         .filter(filter -> filter.processDefinitionId(bpmnProcessId))
-        .page(DEFAULT_PAGE_REQUEST)
+        .page(page -> page.limit(queryPageLimit))
         .sort(sort -> sort.version().desc())
         .send()
         .join()
@@ -128,7 +125,7 @@ public class CamundaDataSource {
         .newElementInstanceSearchRequest()
         .filter(filter)
         .sort(sort -> sort.startDate().asc())
-        .page(page -> page.limit(elementInstancePageLimit))
+        .page(page -> page.limit(queryPageLimit))
         .send()
         .join()
         .items();
@@ -144,7 +141,7 @@ public class CamundaDataSource {
         .newVariableSearchRequest()
         .filter(filter)
         .withFullValues()
-        .page(DEFAULT_PAGE_REQUEST)
+        .page(page -> page.limit(queryPageLimit))
         .send()
         .join()
         .items();
@@ -173,7 +170,7 @@ public class CamundaDataSource {
         .newProcessInstanceSearchRequest()
         .filter(filter)
         .sort(sort -> sort.startDate().asc())
-        .page(DEFAULT_PAGE_REQUEST)
+        .page(page -> page.limit(queryPageLimit))
         .send()
         .join()
         .items();
@@ -184,7 +181,7 @@ public class CamundaDataSource {
         .newIncidentSearchRequest()
         .filter(filter)
         .sort(sort -> sort.creationTime().asc())
-        .page(DEFAULT_PAGE_REQUEST)
+        .page(page -> page.limit(queryPageLimit))
         .send()
         .join()
         .items();
@@ -195,7 +192,7 @@ public class CamundaDataSource {
         .newUserTaskSearchRequest()
         .filter(filter)
         .sort(sort -> sort.creationDate().asc())
-        .page(DEFAULT_PAGE_REQUEST)
+        .page(page -> page.limit(queryPageLimit))
         .send()
         .join()
         .items();
@@ -203,7 +200,13 @@ public class CamundaDataSource {
 
   public List<DecisionInstance> findDecisionInstances(
       final Consumer<DecisionInstanceFilter> filter) {
-    return client.newDecisionInstanceSearchRequest().filter(filter).send().join().items();
+    return client
+        .newDecisionInstanceSearchRequest()
+        .filter(filter)
+        .page(page -> page.limit(queryPageLimit))
+        .send()
+        .join()
+        .items();
   }
 
   public DecisionInstance getDecisionInstance(final String decisionInstanceId) {
@@ -215,7 +218,7 @@ public class CamundaDataSource {
     return client
         .newDecisionDefinitionSearchRequest()
         .filter(f -> f.decisionDefinitionId(decisionDefinitionId))
-        .page(DEFAULT_PAGE_REQUEST)
+        .page(page -> page.limit(queryPageLimit))
         .sort(sort -> sort.version().desc())
         .send()
         .join()
@@ -242,7 +245,7 @@ public class CamundaDataSource {
         .newMessageSubscriptionSearchRequest()
         .filter(filter)
         .sort(sort -> sort.lastUpdatedDate().asc())
-        .page(DEFAULT_PAGE_REQUEST)
+        .page(page -> page.limit(queryPageLimit))
         .send()
         .join()
         .items();
@@ -254,7 +257,7 @@ public class CamundaDataSource {
         .newCorrelatedMessageSubscriptionSearchRequest()
         .filter(filter)
         .sort(sort -> sort.correlationTime().asc())
-        .page(DEFAULT_PAGE_REQUEST)
+        .page(page -> page.limit(queryPageLimit))
         .send()
         .join()
         .items();

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -47,12 +47,24 @@ import java.util.function.Consumer;
 
 public class CamundaDataSource {
 
+  /**
+   * The default page size used when fetching element instances if no custom limit is configured.
+   * Kept for backward compatibility.
+   */
+  public static final int DEFAULT_ELEMENT_INSTANCE_PAGE_LIMIT = 100;
+
   private static final Consumer<AnyPage> DEFAULT_PAGE_REQUEST = page -> page.limit(100);
 
   private final CamundaClient client;
+  private final int elementInstancePageLimit;
 
   public CamundaDataSource(final CamundaClient client) {
+    this(client, DEFAULT_ELEMENT_INSTANCE_PAGE_LIMIT);
+  }
+
+  public CamundaDataSource(final CamundaClient client, final int elementInstancePageLimit) {
     this.client = client;
+    this.elementInstancePageLimit = elementInstancePageLimit;
   }
 
   public byte[] getDocumentContent(final DocumentReferenceResponse reference) {
@@ -116,7 +128,7 @@ public class CamundaDataSource {
         .newElementInstanceSearchRequest()
         .filter(filter)
         .sort(sort -> sort.startDate().asc())
-        .page(DEFAULT_PAGE_REQUEST)
+        .page(page -> page.limit(elementInstancePageLimit))
         .send()
         .join()
         .items();

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -20,6 +20,7 @@ import io.camunda.client.CredentialsProvider;
 import io.camunda.process.test.api.CamundaClientBuilderFactory;
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
 import io.camunda.process.test.api.runtime.CamundaProcessTestContainerProvider;
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.containers.CamundaContainer.MultiTenancyConfiguration;
 import io.camunda.process.test.impl.containers.ContainerFactory;
 import java.net.URI;
@@ -110,6 +111,10 @@ public class CamundaProcessTestRuntimeBuilder {
       CamundaProcessTestRuntimeDefaults.ASSERTION_PROPERTIES.getAssertionTimeout();
   private Optional<Duration> assertionInterval =
       CamundaProcessTestRuntimeDefaults.ASSERTION_PROPERTIES.getAssertionInterval();
+  private int elementInstancePageLimit =
+      CamundaProcessTestRuntimeDefaults.ASSERTION_PROPERTIES
+          .getElementInstancePageLimit()
+          .orElse(CamundaDataSource.DEFAULT_ELEMENT_INSTANCE_PAGE_LIMIT);
 
   // ============ For testing =================
 
@@ -313,6 +318,24 @@ public class CamundaProcessTestRuntimeBuilder {
     return this;
   }
 
+  /**
+   * Sets the page size used when fetching element instances for assertions and coverage reporting.
+   * Increase this if a process instance under test can produce more than the default 100 element
+   * instances, otherwise the latest-started (often terminal) elements may be excluded from
+   * assertions and coverage results.
+   *
+   * @param elementInstancePageLimit the maximum number of element instances to fetch per process
+   *     instance, must be greater than 0
+   */
+  public CamundaProcessTestRuntimeBuilder withElementInstancePageLimit(
+      final int elementInstancePageLimit) {
+    if (elementInstancePageLimit <= 0) {
+      throw new IllegalArgumentException("elementInstancePageLimit must be greater than 0");
+    }
+    this.elementInstancePageLimit = elementInstancePageLimit;
+    return this;
+  }
+
   // ============ Build =================
 
   private void loadContainerProvidersFromServiceLoader() {
@@ -480,5 +503,9 @@ public class CamundaProcessTestRuntimeBuilder {
 
   public Optional<Duration> getAssertionInterval() {
     return assertionInterval;
+  }
+
+  public int getElementInstancePageLimit() {
+    return elementInstancePageLimit;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilder.java
@@ -111,10 +111,10 @@ public class CamundaProcessTestRuntimeBuilder {
       CamundaProcessTestRuntimeDefaults.ASSERTION_PROPERTIES.getAssertionTimeout();
   private Optional<Duration> assertionInterval =
       CamundaProcessTestRuntimeDefaults.ASSERTION_PROPERTIES.getAssertionInterval();
-  private int elementInstancePageLimit =
+  private int queryPageLimit =
       CamundaProcessTestRuntimeDefaults.ASSERTION_PROPERTIES
-          .getElementInstancePageLimit()
-          .orElse(CamundaDataSource.DEFAULT_ELEMENT_INSTANCE_PAGE_LIMIT);
+          .getQueryPageLimit()
+          .orElse(CamundaDataSource.DEFAULT_QUERY_PAGE_LIMIT);
 
   // ============ For testing =================
 
@@ -319,20 +319,19 @@ public class CamundaProcessTestRuntimeBuilder {
   }
 
   /**
-   * Sets the page size used when fetching element instances for assertions and coverage reporting.
-   * Increase this if a process instance under test can produce more than the default 100 element
-   * instances, otherwise the latest-started (often terminal) elements may be excluded from
-   * assertions and coverage results.
+   * Sets the page size used when fetching entities (element instances, process instances,
+   * variables, user tasks, decision instances, etc.) for assertions and coverage reporting.
+   * Increase this if a process instance under test can produce more than the default 100 entities,
+   * otherwise the latest-started (often terminal) entities may be excluded from assertions and
+   * coverage results.
    *
-   * @param elementInstancePageLimit the maximum number of element instances to fetch per process
-   *     instance, must be greater than 0
+   * @param queryPageLimit the maximum number of entities to fetch per query, must be greater than 0
    */
-  public CamundaProcessTestRuntimeBuilder withElementInstancePageLimit(
-      final int elementInstancePageLimit) {
-    if (elementInstancePageLimit <= 0) {
-      throw new IllegalArgumentException("elementInstancePageLimit must be greater than 0");
+  public CamundaProcessTestRuntimeBuilder withQueryPageLimit(final int queryPageLimit) {
+    if (queryPageLimit <= 0) {
+      throw new IllegalArgumentException("queryPageLimit must be greater than 0");
     }
-    this.elementInstancePageLimit = elementInstancePageLimit;
+    this.queryPageLimit = queryPageLimit;
     return this;
   }
 
@@ -505,7 +504,7 @@ public class CamundaProcessTestRuntimeBuilder {
     return assertionInterval;
   }
 
-  public int getElementInstancePageLimit() {
-    return elementInstancePageLimit;
+  public int getQueryPageLimit() {
+    return queryPageLimit;
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/AssertionProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/AssertionProperties.java
@@ -24,12 +24,11 @@ public class AssertionProperties {
 
   public static final String PROPERTY_NAME_ASSERTION_TIMEOUT = "assertion.timeout";
   public static final String PROPERTY_NAME_ASSERTION_INTERVAL = "assertion.interval";
-  public static final String PROPERTY_NAME_ELEMENT_INSTANCE_PAGE_LIMIT =
-      "assertion.elementInstancePageLimit";
+  public static final String PROPERTY_NAME_QUERY_PAGE_LIMIT = "assertion.queryPageLimit";
 
   private final Duration assertionTimeout;
   private final Duration assertionInterval;
-  private final Integer elementInstancePageLimit;
+  private final Integer queryPageLimit;
 
   public AssertionProperties(final Properties properties) {
     assertionTimeout =
@@ -40,9 +39,9 @@ public class AssertionProperties {
         PropertiesUtil.getPropertyOrNull(
             properties, PROPERTY_NAME_ASSERTION_INTERVAL, Duration::parse);
 
-    elementInstancePageLimit =
+    queryPageLimit =
         PropertiesUtil.getPropertyOrNull(
-            properties, PROPERTY_NAME_ELEMENT_INSTANCE_PAGE_LIMIT, Integer::parseInt);
+            properties, PROPERTY_NAME_QUERY_PAGE_LIMIT, Integer::parseInt);
   }
 
   public Optional<Duration> getAssertionTimeout() {
@@ -54,13 +53,14 @@ public class AssertionProperties {
   }
 
   /**
-   * The page size used when fetching element instances for assertions and coverage reporting.
-   * Defaults to 100 if not configured.
+   * The page size used when fetching entities (element instances, process instances, variables,
+   * user tasks, decision instances, etc.) for assertions and coverage reporting. Defaults to 100 if
+   * not configured.
    *
-   * <p>Can be set via the {@code assertion.elementInstancePageLimit} property or the {@code
-   * CAMUNDA_PROCESSTEST_ASSERTION_ELEMENTINSTANCEPAGELIMIT} environment variable.
+   * <p>Can be set via the {@code assertion.queryPageLimit} property or the {@code
+   * CAMUNDA_PROCESSTEST_ASSERTION_QUERYPAGELIMIT} environment variable.
    */
-  public Optional<Integer> getElementInstancePageLimit() {
-    return Optional.ofNullable(elementInstancePageLimit);
+  public Optional<Integer> getQueryPageLimit() {
+    return Optional.ofNullable(queryPageLimit);
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/AssertionProperties.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/properties/AssertionProperties.java
@@ -24,9 +24,12 @@ public class AssertionProperties {
 
   public static final String PROPERTY_NAME_ASSERTION_TIMEOUT = "assertion.timeout";
   public static final String PROPERTY_NAME_ASSERTION_INTERVAL = "assertion.interval";
+  public static final String PROPERTY_NAME_ELEMENT_INSTANCE_PAGE_LIMIT =
+      "assertion.elementInstancePageLimit";
 
   private final Duration assertionTimeout;
   private final Duration assertionInterval;
+  private final Integer elementInstancePageLimit;
 
   public AssertionProperties(final Properties properties) {
     assertionTimeout =
@@ -36,6 +39,10 @@ public class AssertionProperties {
     assertionInterval =
         PropertiesUtil.getPropertyOrNull(
             properties, PROPERTY_NAME_ASSERTION_INTERVAL, Duration::parse);
+
+    elementInstancePageLimit =
+        PropertiesUtil.getPropertyOrNull(
+            properties, PROPERTY_NAME_ELEMENT_INSTANCE_PAGE_LIMIT, Integer::parseInt);
   }
 
   public Optional<Duration> getAssertionTimeout() {
@@ -44,5 +51,16 @@ public class AssertionProperties {
 
   public Optional<Duration> getAssertionInterval() {
     return Optional.ofNullable(assertionInterval);
+  }
+
+  /**
+   * The page size used when fetching element instances for assertions and coverage reporting.
+   * Defaults to 100 if not configured.
+   *
+   * <p>Can be set via the {@code assertion.elementInstancePageLimit} property or the {@code
+   * CAMUNDA_PROCESSTEST_ASSERTION_ELEMENTINSTANCEPAGELIMIT} environment variable.
+   */
+  public Optional<Integer> getElementInstancePageLimit() {
+    return Optional.ofNullable(elementInstancePageLimit);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilderTest.java
@@ -143,25 +143,24 @@ public class CamundaProcessTestRuntimeBuilderTest {
   }
 
   @Test
-  void shouldUseDefaultElementInstancePageLimit() {
+  void shouldUseDefaultQueryPageLimit() {
     // expect
-    assertThat(runtimeBuilder.getElementInstancePageLimit()).isEqualTo(100);
+    assertThat(runtimeBuilder.getQueryPageLimit()).isEqualTo(100);
   }
 
   @Test
-  void shouldOverrideElementInstancePageLimit() {
+  void shouldOverrideQueryPageLimit() {
     // when
-    runtimeBuilder.withElementInstancePageLimit(500);
+    runtimeBuilder.withQueryPageLimit(500);
 
     // then
-    assertThat(runtimeBuilder.getElementInstancePageLimit()).isEqualTo(500);
+    assertThat(runtimeBuilder.getQueryPageLimit()).isEqualTo(500);
   }
 
   @Test
-  void shouldRejectNonPositiveElementInstancePageLimit() {
+  void shouldRejectNonPositiveQueryPageLimit() {
     // when/then
-    org.assertj.core.api.Assertions.assertThatThrownBy(
-            () -> runtimeBuilder.withElementInstancePageLimit(0))
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> runtimeBuilder.withQueryPageLimit(0))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("must be greater than 0");
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilderTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/CamundaProcessTestRuntimeBuilderTest.java
@@ -141,4 +141,28 @@ public class CamundaProcessTestRuntimeBuilderTest {
         .first()
         .isInstanceOf(DummyContainerProvider.class);
   }
+
+  @Test
+  void shouldUseDefaultElementInstancePageLimit() {
+    // expect
+    assertThat(runtimeBuilder.getElementInstancePageLimit()).isEqualTo(100);
+  }
+
+  @Test
+  void shouldOverrideElementInstancePageLimit() {
+    // when
+    runtimeBuilder.withElementInstancePageLimit(500);
+
+    // then
+    assertThat(runtimeBuilder.getElementInstancePageLimit()).isEqualTo(500);
+  }
+
+  @Test
+  void shouldRejectNonPositiveElementInstancePageLimit() {
+    // when/then
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> runtimeBuilder.withElementInstancePageLimit(0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be greater than 0");
+  }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/AssertionPropertiesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/AssertionPropertiesTest.java
@@ -35,7 +35,7 @@ public class AssertionPropertiesTest {
     // then
     assertThat(assertionProperties.getAssertionTimeout()).isEmpty();
     assertThat(assertionProperties.getAssertionInterval()).isEmpty();
-    assertThat(assertionProperties.getElementInstancePageLimit()).isEmpty();
+    assertThat(assertionProperties.getQueryPageLimit()).isEmpty();
   }
 
   @Test
@@ -54,23 +54,23 @@ public class AssertionPropertiesTest {
   }
 
   @Test
-  void shouldReadElementInstancePageLimit() {
+  void shouldReadQueryPageLimit() {
     // given
     final Properties properties = new Properties();
-    properties.setProperty("assertion.elementInstancePageLimit", "500");
+    properties.setProperty("assertion.queryPageLimit", "500");
 
     // when
     final AssertionProperties assertionProperties = new AssertionProperties(properties);
 
     // then
-    assertThat(assertionProperties.getElementInstancePageLimit()).contains(500);
+    assertThat(assertionProperties.getQueryPageLimit()).contains(500);
   }
 
   @Test
-  void shouldRejectInvalidElementInstancePageLimit() {
+  void shouldRejectInvalidQueryPageLimit() {
     // given
     final Properties properties = new Properties();
-    properties.setProperty("assertion.elementInstancePageLimit", "not-a-number");
+    properties.setProperty("assertion.queryPageLimit", "not-a-number");
 
     // when / then
     assertThatThrownBy(() -> new AssertionProperties(properties))
@@ -83,7 +83,7 @@ public class AssertionPropertiesTest {
     final Properties properties = new Properties();
     properties.setProperty("assertion.timeout", "${ASSERTION_TIMEOUT}");
     properties.setProperty("assertion.interval", "${ASSERTION_INTERVAL}");
-    properties.setProperty("assertion.elementInstancePageLimit", "${ELEMENT_INSTANCE_PAGE_LIMIT}");
+    properties.setProperty("assertion.queryPageLimit", "${QUERY_PAGE_LIMIT}");
 
     // when
     final AssertionProperties assertionProperties = new AssertionProperties(properties);
@@ -91,6 +91,6 @@ public class AssertionPropertiesTest {
     // then
     assertThat(assertionProperties.getAssertionTimeout()).isEmpty();
     assertThat(assertionProperties.getAssertionInterval()).isEmpty();
-    assertThat(assertionProperties.getElementInstancePageLimit()).isEmpty();
+    assertThat(assertionProperties.getQueryPageLimit()).isEmpty();
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/AssertionPropertiesTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/runtime/properties/AssertionPropertiesTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+public class AssertionPropertiesTest {
+
+  @Test
+  void shouldReturnDefaults() {
+    // given
+    final Properties properties = new Properties();
+
+    // when
+    final AssertionProperties assertionProperties = new AssertionProperties(properties);
+
+    // then
+    assertThat(assertionProperties.getAssertionTimeout()).isEmpty();
+    assertThat(assertionProperties.getAssertionInterval()).isEmpty();
+    assertThat(assertionProperties.getElementInstancePageLimit()).isEmpty();
+  }
+
+  @Test
+  void shouldReadAssertionTimeoutAndInterval() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("assertion.timeout", "PT30S");
+    properties.setProperty("assertion.interval", "PT1S");
+
+    // when
+    final AssertionProperties assertionProperties = new AssertionProperties(properties);
+
+    // then
+    assertThat(assertionProperties.getAssertionTimeout()).contains(Duration.ofSeconds(30));
+    assertThat(assertionProperties.getAssertionInterval()).contains(Duration.ofSeconds(1));
+  }
+
+  @Test
+  void shouldReadElementInstancePageLimit() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("assertion.elementInstancePageLimit", "500");
+
+    // when
+    final AssertionProperties assertionProperties = new AssertionProperties(properties);
+
+    // then
+    assertThat(assertionProperties.getElementInstancePageLimit()).contains(500);
+  }
+
+  @Test
+  void shouldRejectInvalidElementInstancePageLimit() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("assertion.elementInstancePageLimit", "not-a-number");
+
+    // when / then
+    assertThatThrownBy(() -> new AssertionProperties(properties))
+        .isInstanceOf(NumberFormatException.class);
+  }
+
+  @Test
+  void shouldTreatPlaceholderAsAbsent() {
+    // given
+    final Properties properties = new Properties();
+    properties.setProperty("assertion.timeout", "${ASSERTION_TIMEOUT}");
+    properties.setProperty("assertion.interval", "${ASSERTION_INTERVAL}");
+    properties.setProperty("assertion.elementInstancePageLimit", "${ELEMENT_INSTANCE_PAGE_LIMIT}");
+
+    // when
+    final AssertionProperties assertionProperties = new AssertionProperties(properties);
+
+    // then
+    assertThat(assertionProperties.getAssertionTimeout()).isEmpty();
+    assertThat(assertionProperties.getAssertionInterval()).isEmpty();
+    assertThat(assertionProperties.getElementInstancePageLimit()).isEmpty();
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestRuntimeConfiguration.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.impl.configuration;
 
 import io.camunda.process.test.api.CamundaProcessTestRuntimeMode;
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.runtime.CamundaProcessTestRuntimeDefaults;
 import java.util.Collections;
 import java.util.List;
@@ -52,6 +53,8 @@ public class CamundaProcessTestRuntimeConfiguration {
       CamundaProcessTestRuntimeDefaults.DEFAULT_CONNECTORS_LOGGER_NAME;
 
   private boolean multiTenancyEnabled = false;
+
+  private int queryPageLimit = CamundaDataSource.DEFAULT_QUERY_PAGE_LIMIT;
 
   private CamundaProcessTestRuntimeMode runtimeMode = CamundaProcessTestRuntimeMode.MANAGED;
 
@@ -232,6 +235,14 @@ public class CamundaProcessTestRuntimeConfiguration {
 
   public void setMultiTenancyEnabled(final boolean multiTenancyEnabled) {
     this.multiTenancyEnabled = multiTenancyEnabled;
+  }
+
+  public int getQueryPageLimit() {
+    return queryPageLimit;
+  }
+
+  public void setQueryPageLimit(final int queryPageLimit) {
+    this.queryPageLimit = queryPageLimit;
   }
 
   public CoverageReportConfiguration getCoverage() {


### PR DESCRIPTION
## Description

`CamundaDataSource.findElementInstances()` used a hardcoded page limit of 100 with no
pagination. For process instances that produce more than 100 element instances, the
latest-started (typically terminal) nodes were silently dropped, causing incorrect
coverage reports and element assertions.

This PR exposes the limit as a configurable option following the existing
`assertionTimeout`/`assertionInterval` pattern:

- `withElementInstancePageLimit(int)` on `CamundaProcessTestRuntimeBuilder`
- `assertion.elementInstancePageLimit` property in `camunda-container-runtime.properties`
- `CAMUNDA_PROCESSTEST_ASSERTION_ELEMENTINSTANCEPAGELIMIT` environment variable

The default remains 100 for backward compatibility.
## Checklist



## Related issues

closes #56274 
