### PR TITLE
test: add tests for migrated assignment flow

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/shared.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/api-mocks/shared.ts
@@ -6,6 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import type {ProblemDetails} from '@camunda/camunda-api-zod-schemas/8.10';
+
 type PageInfo = {
 	totalItems: number;
 	startCursor: string | null;
@@ -21,4 +23,15 @@ function createPaginatedResponse<T>(overrides?: Partial<{items: T[]; page: PageI
 	};
 }
 
-export {createPaginatedResponse};
+function createProblemDetails(overrides?: Partial<ProblemDetails>): ProblemDetails {
+	return {
+		type: 'about:blank',
+		title: 'ERROR',
+		status: 500,
+		detail: 'Something went wrong',
+		instance: '/v2/user-tasks/2251799813685281/assignment',
+		...overrides,
+	};
+}
+
+export {createPaginatedResponse, createProblemDetails};

--- a/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-endpoint.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/shared-test-modules/mock-endpoint.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {http, delay as mswDelay, type RequestHandler} from 'msw';
+import {http, delay as mswDelay, type DelayMode, type RequestHandler} from 'msw';
 import type {z} from 'zod';
 
 type RequestMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
@@ -20,14 +20,14 @@ type CreateEndpointMockParams<Method extends RequestMethod> = {
 
 type SuccessMockParams = {
 	successResponse: Response;
-	delay?: number;
+	delay?: DelayMode | number;
 };
 
 type PayloadMockParams<Schema extends z.ZodType> = {
 	schema: Schema;
 	failureResponse: Response;
 	successResponse: Response;
-	delay?: number;
+	delay?: DelayMode | number;
 };
 
 type PayloadMock = {

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/AssignButton.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/AssignButton.test.tsx
@@ -19,6 +19,7 @@ import {
 	mockGetUserTaskEndpoint,
 	mockUnassignTaskEndpoint,
 } from '#/shared-test-modules/mock-handlers';
+import {createProblemDetails} from '#/shared-test-modules/api-mocks/shared';
 import {createUserTask} from '#/shared-test-modules/api-mocks/user-tasks';
 import {Notifications} from '#/shared/notifications/components/Notifications';
 import {notificationsStore} from '#/shared/notifications/notifications.store';
@@ -32,26 +33,6 @@ const assignmentRequestSchema = assignTaskRequestBodySchema.extend({
 	assignee: z.literal(CURRENT_USER),
 	allowOverride: z.literal(false),
 });
-
-function createProblemDetail({
-	title = 'ERROR',
-	status = 500,
-	detail = 'Something went wrong',
-	instance = `/v2/user-tasks/${USER_TASK_KEY}/assignment`,
-}: {
-	title?: string;
-	status?: number;
-	detail?: string;
-	instance?: string;
-} = {}) {
-	return {
-		type: 'about:blank',
-		title,
-		status,
-		detail,
-		instance,
-	};
-}
 
 function getWrapper() {
 	const queryClient = new QueryClient({
@@ -153,7 +134,7 @@ describe('<AssignButton />', () => {
 		worker.use(
 			mockAssignTaskEndpoint({
 				successResponse: HttpResponse.json(
-					createProblemDetail({
+					createProblemDetails({
 						title: 'FORBIDDEN',
 						status: 403,
 						detail: "Unauthorized to perform operation 'UPDATE' on resource 'USER_TASK'",
@@ -179,7 +160,7 @@ describe('<AssignButton />', () => {
 		worker.use(
 			mockUnassignTaskEndpoint({
 				successResponse: HttpResponse.json(
-					createProblemDetail({
+					createProblemDetails({
 						title: 'FORBIDDEN',
 						status: 403,
 						detail: "Unauthorized to perform operation 'UPDATE' on resource 'USER_TASK'",
@@ -211,7 +192,7 @@ describe('<AssignButton />', () => {
 		worker.use(
 			mockAssignTaskEndpoint({
 				successResponse: HttpResponse.json(
-					createProblemDetail({
+					createProblemDetails({
 						title: 'CONFLICT',
 						status: 409,
 						detail: "Command rejected: Reason to deny: 'User not in candidate list'",
@@ -236,7 +217,7 @@ describe('<AssignButton />', () => {
 		worker.use(
 			mockAssignTaskEndpoint({
 				successResponse: HttpResponse.json(
-					createProblemDetail({title: 'DEADLINE_EXCEEDED', status: 504, detail: 'Request timed out'}),
+					createProblemDetails({title: 'DEADLINE_EXCEEDED', status: 504, detail: 'Request timed out'}),
 					{status: 504},
 				),
 			}),
@@ -281,7 +262,7 @@ describe('<AssignButton />', () => {
 		worker.use(
 			mockUnassignTaskEndpoint({
 				successResponse: HttpResponse.json(
-					createProblemDetail({
+					createProblemDetails({
 						title: 'DEADLINE_EXCEEDED',
 						status: 504,
 						detail: 'Request timed out',

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/AssignButton.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/AssignButton.test.tsx
@@ -261,7 +261,7 @@ describe('<AssignButton />', () => {
 
 		worker.use(
 			mockGetUserTaskEndpoint({
-				successResponse: HttpResponse.json(createUserTask({assignee: CURRENT_USER, state: 'CREATED'})),
+				successResponse: HttpResponse.json(createUserTask({assignee: null, state: 'CREATED'})),
 			}),
 		);
 
@@ -346,6 +346,23 @@ describe('<AssignButton />', () => {
 
 		await expect.element(screen.getByText('Assigning...')).toBeVisible();
 		await expect.element(screen.getByRole('button', {name: 'Assign to me'})).not.toBeInTheDocument();
+
+		worker.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(createUserTask({assignee: CURRENT_USER, state: 'CREATED'})),
+			}),
+		);
+
+		screen.rerender(
+			<AssignButton
+				userTaskKey={USER_TASK_KEY}
+				assignee={CURRENT_USER}
+				taskState="CREATED"
+				currentUser={CURRENT_USER}
+			/>,
+		);
+
+		await expect.element(screen.getByRole('button', {name: 'Unassign'})).toBeVisible();
 	});
 
 	it('should show unassigning state when mounted with an assigning assigned task', async ({worker}) => {
@@ -367,5 +384,17 @@ describe('<AssignButton />', () => {
 
 		await expect.element(screen.getByText('Unassigning...')).toBeVisible();
 		await expect.element(screen.getByRole('button', {name: 'Assign to me'})).not.toBeInTheDocument();
+
+		worker.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(createUserTask({assignee: null, state: 'CREATED'})),
+			}),
+		);
+
+		screen.rerender(
+			<AssignButton userTaskKey={USER_TASK_KEY} assignee={null} taskState="CREATED" currentUser={CURRENT_USER} />,
+		);
+
+		await expect.element(screen.getByRole('button', {name: 'Assign to me'})).toBeVisible();
 	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/AssignButton.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/AssignButton.test.tsx
@@ -1,0 +1,371 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {assignTaskRequestBodySchema} from '@camunda/camunda-api-zod-schemas/8.10';
+import {HttpResponse} from 'msw';
+import {z} from 'zod';
+import {render} from 'vitest-browser-react';
+import {afterEach, describe, expect} from 'vitest';
+import {userEvent} from 'vitest/browser';
+import {it} from '#/vitest-modules/test-extend';
+import {
+	mockAssignTaskEndpoint,
+	mockGetUserTaskEndpoint,
+	mockUnassignTaskEndpoint,
+} from '#/shared-test-modules/mock-handlers';
+import {createUserTask} from '#/shared-test-modules/api-mocks/user-tasks';
+import {Notifications} from '#/shared/notifications/components/Notifications';
+import {notificationsStore} from '#/shared/notifications/notifications.store';
+import {AssignButton} from './AssignButton';
+
+const CURRENT_USER = 'demo';
+const USER_TASK_KEY = '2251799813685281';
+const PERMISSION_ERROR = "You don't have the necessary permissions. Contact your admin to request access.";
+
+const assignmentRequestSchema = assignTaskRequestBodySchema.extend({
+	assignee: z.literal(CURRENT_USER),
+	allowOverride: z.literal(false),
+});
+
+function createProblemDetail({
+	title = 'ERROR',
+	status = 500,
+	detail = 'Something went wrong',
+	instance = `/v2/user-tasks/${USER_TASK_KEY}/assignment`,
+}: {
+	title?: string;
+	status?: number;
+	detail?: string;
+	instance?: string;
+} = {}) {
+	return {
+		type: 'about:blank',
+		title,
+		status,
+		detail,
+		instance,
+	};
+}
+
+function getWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {retry: false},
+		},
+	});
+
+	const Wrapper: React.FC<{children: React.ReactNode}> = ({children}) => (
+		<QueryClientProvider client={queryClient}>
+			{children}
+			<Notifications />
+		</QueryClientProvider>
+	);
+
+	return Wrapper;
+}
+
+describe('<AssignButton />', () => {
+	afterEach(() => {
+		notificationsStore.reset();
+	});
+
+	it('should render assign action for an unassigned task', async () => {
+		const screen = await render(
+			<AssignButton userTaskKey={USER_TASK_KEY} assignee={null} taskState="CREATED" currentUser={CURRENT_USER} />,
+			{wrapper: getWrapper()},
+		);
+
+		await expect.element(screen.getByRole('button', {name: 'Assign to me'})).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Unassign'})).not.toBeInTheDocument();
+	});
+
+	it('should render unassign action for an assigned task', async () => {
+		const screen = await render(
+			<AssignButton
+				userTaskKey={USER_TASK_KEY}
+				assignee={CURRENT_USER}
+				taskState="CREATED"
+				currentUser={CURRENT_USER}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await expect.element(screen.getByRole('button', {name: 'Unassign'})).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Assign to me'})).not.toBeInTheDocument();
+	});
+
+	it('should assign the task to the current user', async ({worker}) => {
+		worker.use(
+			mockAssignTaskEndpoint({
+				schema: assignmentRequestSchema,
+				failureResponse: HttpResponse.json({error: 'bad request'}, {status: 400}),
+				successResponse: new HttpResponse(null, {status: 200}),
+			}),
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(createUserTask({assignee: CURRENT_USER, state: 'CREATED'})),
+			}),
+		);
+
+		const screen = await render(
+			<AssignButton userTaskKey={USER_TASK_KEY} assignee={null} taskState="CREATED" currentUser={CURRENT_USER} />,
+			{wrapper: getWrapper()},
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Assign to me'}));
+
+		await expect.element(screen.getByText('Assigning...')).toBeVisible();
+		await expect.element(screen.getByText('Assignment successful')).toBeVisible();
+	});
+
+	it('should unassign the task', async ({worker}) => {
+		worker.use(
+			mockUnassignTaskEndpoint({
+				successResponse: new HttpResponse(null, {status: 200}),
+			}),
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(createUserTask({assignee: null, state: 'CREATED'})),
+			}),
+		);
+
+		const screen = await render(
+			<AssignButton
+				userTaskKey={USER_TASK_KEY}
+				assignee={CURRENT_USER}
+				taskState="CREATED"
+				currentUser={CURRENT_USER}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Unassign'}));
+
+		await expect.element(screen.getByText('Unassigning...')).toBeVisible();
+		await expect.element(screen.getByText('Unassignment successful')).toBeVisible();
+	});
+
+	it('should show an assignment permission error notification', async ({worker}) => {
+		worker.use(
+			mockAssignTaskEndpoint({
+				successResponse: HttpResponse.json(
+					createProblemDetail({
+						title: 'FORBIDDEN',
+						status: 403,
+						detail: "Unauthorized to perform operation 'UPDATE' on resource 'USER_TASK'",
+					}),
+					{status: 403},
+				),
+			}),
+		);
+
+		const screen = await render(
+			<AssignButton userTaskKey={USER_TASK_KEY} assignee={null} taskState="CREATED" currentUser={CURRENT_USER} />,
+			{wrapper: getWrapper()},
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Assign to me'}));
+
+		await expect.element(screen.getByText('Task could not be assigned')).toBeVisible();
+		await expect.element(screen.getByText(PERMISSION_ERROR)).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Assign to me'})).toBeVisible();
+	});
+
+	it('should show an unassignment permission error notification', async ({worker}) => {
+		worker.use(
+			mockUnassignTaskEndpoint({
+				successResponse: HttpResponse.json(
+					createProblemDetail({
+						title: 'FORBIDDEN',
+						status: 403,
+						detail: "Unauthorized to perform operation 'UPDATE' on resource 'USER_TASK'",
+						instance: `/v2/user-tasks/${USER_TASK_KEY}/assignee`,
+					}),
+					{status: 403},
+				),
+			}),
+		);
+
+		const screen = await render(
+			<AssignButton
+				userTaskKey={USER_TASK_KEY}
+				assignee={CURRENT_USER}
+				taskState="CREATED"
+				currentUser={CURRENT_USER}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Unassign'}));
+
+		await expect.element(screen.getByText('Task could not be unassigned')).toBeVisible();
+		await expect.element(screen.getByText(PERMISSION_ERROR)).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Unassign'})).toBeVisible();
+	});
+
+	it('should show the denial reason for an assignment conflict', async ({worker}) => {
+		worker.use(
+			mockAssignTaskEndpoint({
+				successResponse: HttpResponse.json(
+					createProblemDetail({
+						title: 'CONFLICT',
+						status: 409,
+						detail: "Command rejected: Reason to deny: 'User not in candidate list'",
+					}),
+					{status: 409},
+				),
+			}),
+		);
+
+		const screen = await render(
+			<AssignButton userTaskKey={USER_TASK_KEY} assignee={null} taskState="CREATED" currentUser={CURRENT_USER} />,
+			{wrapper: getWrapper()},
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Assign to me'}));
+
+		await expect.element(screen.getByText('Task could not be assigned')).toBeVisible();
+		await expect.element(screen.getByText('User not in candidate list')).toBeVisible();
+	});
+
+	it('should show delayed notification and finish assignment after timeout', async ({worker}) => {
+		worker.use(
+			mockAssignTaskEndpoint({
+				successResponse: HttpResponse.json(
+					createProblemDetail({title: 'DEADLINE_EXCEEDED', status: 504, detail: 'Request timed out'}),
+					{status: 504},
+				),
+			}),
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(createUserTask({assignee: null, state: 'CREATED'})),
+			}),
+		);
+
+		const screen = await render(
+			<AssignButton userTaskKey={USER_TASK_KEY} assignee={null} taskState="CREATED" currentUser={CURRENT_USER} />,
+			{wrapper: getWrapper()},
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Assign to me'}));
+
+		await expect.element(screen.getByText('Task assignment delayed')).toBeVisible();
+		await expect
+			.element(
+				screen.getByText('The task assignment is taking longer than expected to process. It will complete shortly'),
+			)
+			.toBeVisible();
+
+		worker.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(createUserTask({assignee: CURRENT_USER, state: 'CREATED'})),
+			}),
+		);
+
+		screen.rerender(
+			<AssignButton
+				userTaskKey={USER_TASK_KEY}
+				assignee={CURRENT_USER}
+				taskState="CREATED"
+				currentUser={CURRENT_USER}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Assignment successful')).toBeVisible();
+	});
+
+	it('should show delayed notification and finish unassignment after timeout', async ({worker}) => {
+		worker.use(
+			mockUnassignTaskEndpoint({
+				successResponse: HttpResponse.json(
+					createProblemDetail({
+						title: 'DEADLINE_EXCEEDED',
+						status: 504,
+						detail: 'Request timed out',
+						instance: `/v2/user-tasks/${USER_TASK_KEY}/assignee`,
+					}),
+					{status: 504},
+				),
+			}),
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(createUserTask({assignee: CURRENT_USER, state: 'CREATED'})),
+			}),
+		);
+
+		const screen = await render(
+			<AssignButton
+				userTaskKey={USER_TASK_KEY}
+				assignee={CURRENT_USER}
+				taskState="CREATED"
+				currentUser={CURRENT_USER}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await userEvent.click(screen.getByRole('button', {name: 'Unassign'}));
+
+		await expect.element(screen.getByText('Task unassignment delayed')).toBeVisible();
+		await expect
+			.element(
+				screen.getByText('The task unassignment is taking longer than expected to process. It will complete shortly'),
+			)
+			.toBeVisible();
+
+		worker.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(createUserTask({assignee: CURRENT_USER, state: 'CREATED'})),
+			}),
+		);
+
+		screen.rerender(
+			<AssignButton
+				userTaskKey={USER_TASK_KEY}
+				assignee={CURRENT_USER}
+				taskState="CREATED"
+				currentUser={CURRENT_USER}
+			/>,
+		);
+
+		await expect.element(screen.getByText('Unassignment successful')).toBeVisible();
+	});
+
+	it('should show assigning state when mounted with an assigning unassigned task', async ({worker}) => {
+		worker.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(createUserTask({assignee: CURRENT_USER, state: 'ASSIGNING'})),
+			}),
+		);
+
+		const screen = await render(
+			<AssignButton userTaskKey={USER_TASK_KEY} assignee={null} taskState="ASSIGNING" currentUser={CURRENT_USER} />,
+			{wrapper: getWrapper()},
+		);
+
+		await expect.element(screen.getByText('Assigning...')).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Assign to me'})).not.toBeInTheDocument();
+	});
+
+	it('should show unassigning state when mounted with an assigning assigned task', async ({worker}) => {
+		worker.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(createUserTask({assignee: null, state: 'ASSIGNING'})),
+			}),
+		);
+
+		const screen = await render(
+			<AssignButton
+				userTaskKey={USER_TASK_KEY}
+				assignee={CURRENT_USER}
+				taskState="ASSIGNING"
+				currentUser={CURRENT_USER}
+			/>,
+			{wrapper: getWrapper()},
+		);
+
+		await expect.element(screen.getByText('Unassigning...')).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Assign to me'})).not.toBeInTheDocument();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/AsyncActionButton/AsyncActionButton.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/AsyncActionButton/AsyncActionButton.test.tsx
@@ -102,7 +102,7 @@ describe('<AsyncActionButton />', () => {
 		await expect.element(screen.getByRole('button', {name: 'Disabled button'})).toBeDisabled();
 	});
 
-	it('should not render button', async () => {
+	it('should render error state', async () => {
 		const screen = await render(
 			<AsyncActionButton status="error" inlineLoadingProps={{description: 'Failed'}}>
 				Action
@@ -110,5 +110,6 @@ describe('<AsyncActionButton />', () => {
 		);
 
 		await expect.element(screen.getByRole('button', {name: 'Action'})).not.toBeInTheDocument();
+		await expect.element(screen.getByText('Failed')).toBeVisible();
 	});
 });

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/AsyncActionButton/AsyncActionButton.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/components/AsyncActionButton/AsyncActionButton.test.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render} from 'vitest-browser-react';
+import {it} from '#/vitest-modules/test-extend';
+import {describe, expect, vi} from 'vitest';
+import {AsyncActionButton} from './AsyncActionButton';
+
+describe('<AsyncActionButton />', () => {
+	it('should render a button when status is inactive', async () => {
+		const screen = await render(
+			<AsyncActionButton status="inactive" buttonProps={{type: 'button'}}>
+				Click me
+			</AsyncActionButton>,
+		);
+
+		await expect.element(screen.getByRole('button', {name: 'Click me'})).toBeVisible();
+	});
+
+	it('should render have a loading state', async () => {
+		const screen = await render(
+			<AsyncActionButton status="active" inlineLoadingProps={{description: 'Loading...'}}>
+				Click me
+			</AsyncActionButton>,
+		);
+
+		await expect.element(screen.getByText('Loading...')).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Click me'})).not.toBeInTheDocument();
+	});
+
+	it('should render a success statee', async () => {
+		const screen = await render(
+			<AsyncActionButton status="finished" inlineLoadingProps={{description: 'Done!'}}>
+				Click me
+			</AsyncActionButton>,
+		);
+
+		await expect.element(screen.getByText('Done!')).toBeVisible();
+		await expect.element(screen.getByRole('button', {name: 'Click me'})).not.toBeInTheDocument();
+	});
+
+	it('should hide button', async () => {
+		const screen = await render(
+			<AsyncActionButton status="inactive" isHidden>
+				Hidden button
+			</AsyncActionButton>,
+		);
+
+		await expect.element(screen.getByText('Hidden button')).not.toBeVisible();
+	});
+
+	it('should call onError callback after a delay', async () => {
+		vi.useFakeTimers();
+		const onError = vi.fn();
+
+		await render(
+			<AsyncActionButton status="error" onError={onError}>
+				Action
+			</AsyncActionButton>,
+		);
+
+		expect(onError).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(onError).toHaveBeenCalledOnce();
+
+		vi.useRealTimers();
+	});
+
+	it('should call onSuccess callback after a delay', async () => {
+		vi.useFakeTimers();
+		const onSuccess = vi.fn();
+
+		await render(
+			<AsyncActionButton status="finished" inlineLoadingProps={{onSuccess}}>
+				Action
+			</AsyncActionButton>,
+		);
+
+		expect(onSuccess).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(onSuccess).toHaveBeenCalledOnce();
+
+		vi.useRealTimers();
+	});
+
+	it('should allow button configuration', async () => {
+		const screen = await render(
+			<AsyncActionButton status="inactive" buttonProps={{kind: 'primary', size: 'sm', disabled: true}}>
+				Disabled button
+			</AsyncActionButton>,
+		);
+
+		await expect.element(screen.getByRole('button', {name: 'Disabled button'})).toBeDisabled();
+	});
+
+	it('should not render button', async () => {
+		const screen = await render(
+			<AsyncActionButton status="error" inlineLoadingProps={{description: 'Failed'}}>
+				Action
+			</AsyncActionButton>,
+		);
+
+		await expect.element(screen.getByRole('button', {name: 'Action'})).not.toBeInTheDocument();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/parseDenialReason.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/parseDenialReason.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {it} from '#/vitest-modules/test-extend';
+import {describe, expect} from 'vitest';
+import {parseDenialReason} from './parseDenialReason';
+
+function createProblemDetail(overrides: {status?: number; detail?: string} = {}) {
+	return {
+		type: 'about:blank',
+		title: 'CONFLICT',
+		status: overrides.status ?? 409,
+		detail: overrides.detail ?? 'Command rejected',
+		instance: '/v2/user-tasks/123/assignment',
+	};
+}
+
+describe('parseDenialReason', () => {
+	it('should extract denial reason from a 409 problem-detail response', () => {
+		const payload = createProblemDetail({
+			detail: "Command rejected: Reason to deny: 'User not in candidate list'",
+		});
+
+		expect(parseDenialReason(payload, 'assignment')).toBe('User not in candidate list');
+	});
+
+	it('should strip double quotes from extracted reason', () => {
+		const payload = createProblemDetail({
+			detail: 'Command rejected: Reason to deny: "Not allowed"',
+		});
+
+		expect(parseDenialReason(payload, 'assignment')).toBe('Not allowed');
+	});
+
+	it('should strip single quotes from extracted reason', () => {
+		const payload = createProblemDetail({
+			detail: "Command rejected: Reason to deny: 'Cannot assign'",
+		});
+
+		expect(parseDenialReason(payload, 'unassignment')).toBe('Cannot assign');
+	});
+
+	it('should return reason without quotes when no surrounding quotes', () => {
+		const payload = createProblemDetail({
+			detail: 'Command rejected: Reason to deny: Task is locked',
+		});
+
+		expect(parseDenialReason(payload, 'assignment')).toBe('Task is locked');
+	});
+
+	it('should return undefined', () => {
+		expect(
+			parseDenialReason(createProblemDetail({status: 400, detail: "Reason to deny: 'some reason'"}), 'assignment'),
+		).toBeUndefined();
+		expect(
+			parseDenialReason(createProblemDetail({status: 500, detail: "Reason to deny: 'error'"}), 'assignment'),
+		).toBeUndefined();
+		expect(parseDenialReason({invalid: true}, 'assignment')).toBeUndefined();
+		expect(parseDenialReason(undefined, 'assignment')).toBeUndefined();
+		expect(parseDenialReason(null, 'assignment')).toBeUndefined();
+	});
+
+	it('should return generic fallback when detail has no "Reason to deny:" pattern', () => {
+		const payload = createProblemDetail({detail: 'Task assignment conflict without reason'});
+
+		expect(parseDenialReason(payload, 'assignment')).toBe('The task assignment was rejected by the system.');
+	});
+
+	it('should work with completion type', () => {
+		const payload = createProblemDetail({
+			detail: "Command rejected: Reason to deny: 'Task not completable'",
+		});
+
+		expect(parseDenialReason(payload, 'completion')).toBe('Task not completable');
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/parseDenialReason.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/parseDenialReason.test.ts
@@ -7,47 +7,50 @@
  */
 
 import {it} from '#/vitest-modules/test-extend';
+import {createProblemDetails} from '#/shared-test-modules/api-mocks/shared';
 import {describe, expect} from 'vitest';
 import {parseDenialReason} from './parseDenialReason';
 
-function createProblemDetail(overrides: {status?: number; detail?: string} = {}) {
-	return {
-		type: 'about:blank',
-		title: 'CONFLICT',
-		status: overrides.status ?? 409,
-		detail: overrides.detail ?? 'Command rejected',
-		instance: '/v2/user-tasks/123/assignment',
-	};
-}
-
 describe('parseDenialReason', () => {
 	it('should extract denial reason from a 409 problem-detail response', () => {
-		const payload = createProblemDetail({
+		const payload = createProblemDetails({
+			title: 'CONFLICT',
+			status: 409,
 			detail: "Command rejected: Reason to deny: 'User not in candidate list'",
+			instance: '/v2/user-tasks/123/assignment',
 		});
 
 		expect(parseDenialReason(payload, 'assignment')).toBe('User not in candidate list');
 	});
 
 	it('should strip double quotes from extracted reason', () => {
-		const payload = createProblemDetail({
+		const payload = createProblemDetails({
+			title: 'CONFLICT',
+			status: 409,
 			detail: 'Command rejected: Reason to deny: "Not allowed"',
+			instance: '/v2/user-tasks/123/assignment',
 		});
 
 		expect(parseDenialReason(payload, 'assignment')).toBe('Not allowed');
 	});
 
 	it('should strip single quotes from extracted reason', () => {
-		const payload = createProblemDetail({
+		const payload = createProblemDetails({
+			title: 'CONFLICT',
+			status: 409,
 			detail: "Command rejected: Reason to deny: 'Cannot assign'",
+			instance: '/v2/user-tasks/123/assignment',
 		});
 
 		expect(parseDenialReason(payload, 'unassignment')).toBe('Cannot assign');
 	});
 
 	it('should return reason without quotes when no surrounding quotes', () => {
-		const payload = createProblemDetail({
+		const payload = createProblemDetails({
+			title: 'CONFLICT',
+			status: 409,
 			detail: 'Command rejected: Reason to deny: Task is locked',
+			instance: '/v2/user-tasks/123/assignment',
 		});
 
 		expect(parseDenialReason(payload, 'assignment')).toBe('Task is locked');
@@ -55,10 +58,10 @@ describe('parseDenialReason', () => {
 
 	it('should return undefined', () => {
 		expect(
-			parseDenialReason(createProblemDetail({status: 400, detail: "Reason to deny: 'some reason'"}), 'assignment'),
+			parseDenialReason(createProblemDetails({status: 400, detail: "Reason to deny: 'some reason'"}), 'assignment'),
 		).toBeUndefined();
 		expect(
-			parseDenialReason(createProblemDetail({status: 500, detail: "Reason to deny: 'error'"}), 'assignment'),
+			parseDenialReason(createProblemDetails({status: 500, detail: "Reason to deny: 'error'"}), 'assignment'),
 		).toBeUndefined();
 		expect(parseDenialReason({invalid: true}, 'assignment')).toBeUndefined();
 		expect(parseDenialReason(undefined, 'assignment')).toBeUndefined();
@@ -66,14 +69,21 @@ describe('parseDenialReason', () => {
 	});
 
 	it('should return generic fallback when detail has no "Reason to deny:" pattern', () => {
-		const payload = createProblemDetail({detail: 'Task assignment conflict without reason'});
+		const payload = createProblemDetails({
+			title: 'CONFLICT',
+			status: 409,
+			detail: 'Task assignment conflict without reason',
+		});
 
 		expect(parseDenialReason(payload, 'assignment')).toBe('The task assignment was rejected by the system.');
 	});
 
 	it('should work with completion type', () => {
-		const payload = createProblemDetail({
+		const payload = createProblemDetails({
+			title: 'CONFLICT',
+			status: 409,
 			detail: "Command rejected: Reason to deny: 'Task not completable'",
+			instance: '/v2/user-tasks/123/assignment',
 		});
 
 		expect(parseDenialReason(payload, 'completion')).toBe('Task not completable');

--- a/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/taskErrorHandling.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/tasklist/modules/task-details/taskErrorHandling.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {it} from '#/vitest-modules/test-extend';
+import {describe, expect} from 'vitest';
+import {isTaskTimeoutError} from './taskErrorHandling';
+
+describe('isTaskTimeoutError', () => {
+	it('should return true for error with title DEADLINE_EXCEEDED', () => {
+		expect(isTaskTimeoutError({title: 'DEADLINE_EXCEEDED'})).toBe(true);
+	});
+
+	it('should return true for error with title TASK_PROCESSING_TIMEOUT', () => {
+		expect(isTaskTimeoutError({title: 'TASK_PROCESSING_TIMEOUT'})).toBe(true);
+	});
+
+	it('should return true for error with message containing DEADLINE_EXCEEDED', () => {
+		expect(isTaskTimeoutError({message: 'Request failed: DEADLINE_EXCEEDED'})).toBe(true);
+	});
+
+	it('should return true for error with message containing TASK_PROCESSING_TIMEOUT', () => {
+		expect(isTaskTimeoutError({message: 'Error: TASK_PROCESSING_TIMEOUT occurred'})).toBe(true);
+	});
+
+	it('should return false for unrelated error title', () => {
+		expect(isTaskTimeoutError({title: 'NOT_FOUND'})).toBe(false);
+	});
+
+	it('should return false for unrelated error message', () => {
+		expect(isTaskTimeoutError({message: 'Something went wrong'})).toBe(false);
+	});
+
+	it('should return false for null', () => {
+		expect(isTaskTimeoutError(null)).toBe(false);
+	});
+
+	it('should return false for undefined', () => {
+		expect(isTaskTimeoutError(undefined)).toBe(false);
+	});
+
+	it('should return false for empty object', () => {
+		expect(isTaskTimeoutError({})).toBe(false);
+	});
+
+	it('should return false for non-object value', () => {
+		expect(isTaskTimeoutError('DEADLINE_EXCEEDED')).toBe(false);
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/task-assignment.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/task-assignment.test.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test, expect} from '#/pw-modules/test-extend';
+import {HttpResponse} from 'msw';
+import {z} from 'zod';
+import {assignTaskRequestBodySchema} from '@camunda/camunda-api-zod-schemas/8.10';
+import {
+	mockCurrentUserEndpoint,
+	mockGetUserTaskEndpoint,
+	mockLicenseEndpoint,
+	mockQueryUserTasksEndpoint,
+	mockSystemConfigurationEndpoint,
+	mockAssignTaskEndpoint,
+	mockUnassignTaskEndpoint,
+} from '#/shared-test-modules/mock-handlers';
+import {createSystemConfiguration} from '#/shared-test-modules/api-mocks/system-configuration';
+import {createLicense} from '#/shared-test-modules/api-mocks/license';
+import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
+import {createQueryUserTasksResponse, createUserTask} from '#/shared-test-modules/api-mocks/user-tasks';
+
+const currentUser = createCurrentUser({username: 'demo'});
+const unassignedTask = createUserTask({
+	name: 'Review invoice',
+	processName: 'Invoice process',
+	assignee: null,
+	state: 'CREATED',
+});
+const assignedTask = createUserTask({
+	name: 'Review invoice',
+	processName: 'Invoice process',
+	assignee: 'demo',
+	state: 'CREATED',
+});
+
+test.beforeEach(({network}) => {
+	network.use(
+		mockCurrentUserEndpoint({
+			successResponse: HttpResponse.json(currentUser),
+		}),
+		mockSystemConfigurationEndpoint({
+			successResponse: HttpResponse.json(createSystemConfiguration({components: {active: ['tasklist']}})),
+		}),
+		mockLicenseEndpoint({
+			successResponse: HttpResponse.json(createLicense()),
+		}),
+		mockQueryUserTasksEndpoint({
+			successResponse: HttpResponse.json(createQueryUserTasksResponse()),
+		}),
+	);
+});
+
+test.describe('Task assignment', () => {
+	test('should assign an unassigned task to the current user', async ({network, taskDetailPage}) => {
+		network.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(unassignedTask),
+			}),
+			mockAssignTaskEndpoint({
+				schema: assignTaskRequestBodySchema.extend({
+					assignee: z.literal(currentUser.username),
+					allowOverride: z.literal(false),
+				}),
+				failureResponse: HttpResponse.json({error: 'bad request'}, {status: 400}),
+				successResponse: new HttpResponse(null, {status: 200}),
+			}),
+		);
+
+		await taskDetailPage.goto('2251799813685281');
+		await expect(taskDetailPage.assignButton).toBeVisible();
+
+		network.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(assignedTask),
+			}),
+		);
+
+		await taskDetailPage.assignButton.click();
+
+		await expect(taskDetailPage.assignmentSuccessful).toBeVisible();
+		await expect(taskDetailPage.unassignButton).toBeVisible();
+	});
+
+	test('should unassign a task from the current user', async ({network, taskDetailPage}) => {
+		network.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(assignedTask),
+			}),
+			mockUnassignTaskEndpoint({
+				successResponse: new HttpResponse(null, {status: 200}),
+			}),
+		);
+
+		await taskDetailPage.goto('2251799813685281');
+		await expect(taskDetailPage.unassignButton).toBeVisible();
+
+		network.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(unassignedTask),
+			}),
+		);
+
+		await taskDetailPage.unassignButton.click();
+
+		await expect(taskDetailPage.unassignmentSuccessful).toBeVisible();
+		await expect(taskDetailPage.assignButton).toBeVisible();
+	});
+
+	test('should show error notification when assignment fails with 403', async ({network, taskDetailPage}) => {
+		network.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(unassignedTask),
+			}),
+			mockAssignTaskEndpoint({
+				successResponse: HttpResponse.json(
+					{
+						type: 'about:blank',
+						title: 'FORBIDDEN',
+						status: 403,
+						detail: "Unauthorized to perform operation 'UPDATE' on resource 'USER_TASK'",
+						instance: '/v2/user-tasks/2251799813685281/assignment',
+					},
+					{status: 403},
+				),
+			}),
+		);
+
+		await taskDetailPage.goto('2251799813685281');
+		await taskDetailPage.assignButton.click();
+
+		await expect(
+			taskDetailPage.header.notifications.getByNotificationTitle('Task could not be assigned'),
+		).toBeVisible();
+		await expect(taskDetailPage.assignButton).toBeVisible();
+	});
+
+	test('should handle tasks with task listeners', async ({network, taskDetailPage}) => {
+		network.use(
+			mockQueryUserTasksEndpoint({
+				successResponse: HttpResponse.json(createQueryUserTasksResponse()),
+			}),
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(unassignedTask),
+			}),
+			mockAssignTaskEndpoint({
+				successResponse: HttpResponse.json(
+					{
+						type: 'about:blank',
+						title: 'DEADLINE_EXCEEDED',
+						status: 504,
+						detail: 'Request timed out',
+						instance: '/v2/user-tasks/2251799813685281/assignment',
+					},
+					{status: 504},
+				),
+			}),
+		);
+
+		await taskDetailPage.goto('2251799813685281');
+		await taskDetailPage.assignButton.click();
+
+		network.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(assignedTask),
+			}),
+		);
+
+		await expect(taskDetailPage.header.notifications.getByNotificationTitle('Task assignment delayed')).toBeVisible();
+		await expect(taskDetailPage.assignButton).toBeVisible();
+	});
+
+	test('should not show assign button for completed task', async ({network, taskDetailPage}) => {
+		const completedTask = createUserTask({
+			name: 'Review invoice',
+			processName: 'Invoice process',
+			assignee: 'demo',
+			state: 'COMPLETED',
+			completionDate: '2024-01-02T10:00:00.000Z',
+		});
+
+		network.use(
+			mockGetUserTaskEndpoint({
+				successResponse: HttpResponse.json(completedTask),
+			}),
+		);
+
+		await taskDetailPage.goto('2251799813685281');
+
+		await expect(taskDetailPage.assignButton).not.toBeVisible();
+		await expect(taskDetailPage.unassignButton).not.toBeVisible();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/test/pages/TaskDetail.page.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/pages/TaskDetail.page.ts
@@ -66,6 +66,30 @@ class TaskDetailPage extends BasePage {
 		return this.page.getByRole('button', {name: /Turn on notifications/});
 	}
 
+	get assignButton() {
+		return this.page.getByRole('button', {name: /Assign to me/i});
+	}
+
+	get unassignButton() {
+		return this.page.getByRole('button', {name: /^Unassign$/i});
+	}
+
+	get assigningStatus() {
+		return this.page.getByText('Assigning...');
+	}
+
+	get unassigningStatus() {
+		return this.page.getByText('Unassigning...');
+	}
+
+	get assignmentSuccessful() {
+		return this.page.getByText('Assignment successful');
+	}
+
+	get unassignmentSuccessful() {
+		return this.page.getByText('Unassignment successful');
+	}
+
 	taskName(name: string) {
 		return this.page.getByText(name);
 	}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds tests for the migrated parts from https://github.com/camunda/camunda/pull/56173

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/53943
