### PR TITLE
Add AgentHistoryCommitProcessor with lease-based dispatch and superseded-activation discard

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -42,6 +42,15 @@ public final class AgentHistoryCommitProcessor implements TypedRecordProcessor<A
       agentHistoryState.visitByJobKey(jobKey, visitor);
     } else {
       agentHistoryState.visitByJobLease(jobKey, jobLease, visitor);
+      // Discard items from superseded activations (different lease, same job)
+      agentHistoryState.visitByJobKey(
+          jobKey,
+          item -> {
+            if (!jobLease.equals(item.getJobLease())) {
+              stateWriter.appendFollowUpEvent(
+                  item.getAgentHistoryKey(), AgentHistoryIntent.DISCARDED, item);
+            }
+          });
     }
     // no-op when no items exist — backward-compatible with non-agentic jobs
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.AgentHistoryState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+// COMMIT is always a follow-up command emitted internally by the engine and is never issued
+// through the public API, so there is no user to authorize against.
+@ExcludeAuthorizationCheck
+public final class AgentHistoryCommitProcessor implements TypedRecordProcessor<AgentHistoryRecord> {
+
+  private final StateWriter stateWriter;
+  private final AgentHistoryState agentHistoryState;
+
+  public AgentHistoryCommitProcessor(final Writers writers, final ProcessingState processingState) {
+    stateWriter = writers.state();
+    agentHistoryState = processingState.getAgentHistoryState();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<AgentHistoryRecord> command) {
+    final long jobKey = command.getValue().getJobKey();
+    final String jobLease = command.getValue().getJobLease();
+    final AgentHistoryState.AgentHistoryVisitor visitor =
+        item ->
+            stateWriter.appendFollowUpEvent(
+                item.getAgentHistoryKey(), AgentHistoryIntent.COMMITTED, item);
+    if (jobLease.isEmpty()) {
+      agentHistoryState.visitByJobKey(jobKey, visitor);
+    } else {
+      agentHistoryState.visitByJobLease(jobKey, jobLease, visitor);
+    }
+    // no-op when no items exist — backward-compatible with non-agentic jobs
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<AgentHistoryRecord> {
 
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final AgentInstanceState agentInstanceState;
@@ -41,6 +43,7 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
       final AuthorizationCheckBehavior authCheckBehavior,
       final KeyGenerator keyGenerator) {
     stateWriter = writers.state();
+    commandWriter = writers.command();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     agentInstanceState = processingState.getAgentInstanceState();
@@ -138,10 +141,15 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
 
     stateWriter.appendFollowUpEvent(historyKey, AgentHistoryIntent.CREATED, event);
     responseWriter.writeEventOnCommand(historyKey, AgentHistoryIntent.CREATED, event, command);
-
-    // TODO: remove once the pending-commit lifecycle is implemented (#55033); at that point
-    // COMMITTED will be emitted by AgentHistoryCommitProcessor after the job completes.
-    stateWriter.appendFollowUpEvent(historyKey, AgentHistoryIntent.COMMITTED, event);
+    // TODO (#55033): COMMIT is emitted immediately after each item is created as an
+    // intermediate step; once the pending-commit lifecycle is wired to job
+    // completion/failure events, this follow-up command will be moved there instead.
+    commandWriter.appendFollowUpCommand(
+        historyKey,
+        AgentHistoryIntent.COMMIT,
+        new AgentHistoryRecord()
+            .setJobKey(commandValue.getJobKey())
+            .setJobLease(commandValue.getJobLease()));
   }
 
   private void writeRejection(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryProcessors.java
@@ -29,5 +29,9 @@ public final class AgentHistoryProcessors {
         ValueType.AGENT_HISTORY,
         AgentHistoryIntent.CREATE,
         new AgentHistoryCreateProcessor(writers, processingState, authCheckBehavior, keyGenerator));
+    typedRecordProcessors.onCommand(
+        ValueType.AGENT_HISTORY,
+        AgentHistoryIntent.COMMIT,
+        new AgentHistoryCommitProcessor(writers, processingState));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agenthistory/DbAgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/agenthistory/DbAgentHistoryState.java
@@ -100,10 +100,15 @@ public final class DbAgentHistoryState implements MutableAgentHistoryState {
     if (existing == null) {
       return;
     }
+    delete(key, existing);
+  }
+
+  @Override
+  public void delete(final long key, final AgentHistoryRecord record) {
     historyItemKey.wrapLong(key);
-    jobKey.wrapLong(existing.getJobKey());
-    jobLease.wrapString(existing.getJobLease());
-    agentHistoryColumnFamily.deleteExisting(historyItemKey);
-    byJobKeyColumnFamily.deleteExisting(jobKeyLeaseAndHistoryItemKey);
+    jobKey.wrapLong(record.getJobKey());
+    jobLease.wrapString(record.getJobLease());
+    agentHistoryColumnFamily.deleteIfExists(historyItemKey);
+    byJobKeyColumnFamily.deleteIfExists(jobKeyLeaseAndHistoryItemKey);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCommittedApplier.java
@@ -24,6 +24,6 @@ public final class AgentHistoryCommittedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
-    agentHistoryState.delete(key);
+    agentHistoryState.delete(key, value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryDiscardedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryDiscardedApplier.java
@@ -24,6 +24,6 @@ public final class AgentHistoryDiscardedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
-    agentHistoryState.delete(key);
+    agentHistoryState.delete(key, value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentHistoryState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAgentHistoryState.java
@@ -19,4 +19,10 @@ public interface MutableAgentHistoryState extends AgentHistoryState {
    * Deletes the history item stored under {@code historyItemKey}, including the secondary index.
    */
   void delete(long historyItemKey);
+
+  /**
+   * Deletes the history item stored under {@code historyItemKey} using the provided {@code record}
+   * to locate the secondary index entry, avoiding an extra state lookup.
+   */
+  void delete(long historyItemKey, AgentHistoryRecord record);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -164,6 +164,96 @@ public class AgentHistoryCommitTest {
         .containsExactlyInAnyOrder(firstItemKey, secondItemKey);
   }
 
+  @Test
+  public void shouldCommitMatchingLeaseAndDiscardSupersededOnLeaseBasedCommit() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    ENGINE.pauseProcessing(1);
+    final var keyGenerator =
+        ((MutableProcessingState) ENGINE.getProcessingState()).getKeyGenerator();
+    final long lease1ItemKey = keyGenerator.nextKey();
+    final long lease2ItemKey = keyGenerator.nextKey();
+    final long otherJobItemKey = keyGenerator.nextKey();
+    final long otherJobKey = keyGenerator.nextKey();
+    ENGINE.stop();
+
+    // lease-1 and lease-2 items share jobKey; otherJobItem has lease-1 but a different jobKey —
+    // it must not be affected by the COMMIT, proving the filter is scoped to jobKey.
+    ENGINE.writeRecords(
+        RecordToWrite.event()
+            .key(lease1ItemKey)
+            .agentHistory(
+                AgentHistoryIntent.CREATED,
+                new AgentHistoryRecord()
+                    .setAgentHistoryKey(lease1ItemKey)
+                    .setAgentInstanceKey(agentInstanceKey)
+                    .setJobKey(jobKey)
+                    .setJobLease("lease-1")
+                    .setElementInstanceKey(elementInstanceKey)
+                    .setRole(AgentHistoryRole.USER)),
+        RecordToWrite.event()
+            .key(lease2ItemKey)
+            .agentHistory(
+                AgentHistoryIntent.CREATED,
+                new AgentHistoryRecord()
+                    .setAgentHistoryKey(lease2ItemKey)
+                    .setAgentInstanceKey(agentInstanceKey)
+                    .setJobKey(jobKey)
+                    .setJobLease("lease-2")
+                    .setElementInstanceKey(elementInstanceKey)
+                    .setRole(AgentHistoryRole.ASSISTANT)),
+        RecordToWrite.event()
+            .key(otherJobItemKey)
+            .agentHistory(
+                AgentHistoryIntent.CREATED,
+                new AgentHistoryRecord()
+                    .setAgentHistoryKey(otherJobItemKey)
+                    .setAgentInstanceKey(agentInstanceKey)
+                    .setJobKey(otherJobKey)
+                    .setJobLease("lease-1")
+                    .setElementInstanceKey(elementInstanceKey)
+                    .setRole(AgentHistoryRole.USER)));
+    ENGINE.start();
+
+    final var firstCommitted =
+        ENGINE.agentHistories().withJobKey(jobKey).withJobLease("lease-1").commit();
+    final long commitPosition = firstCommitted.getSourceRecordPosition();
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // withSourceRecordPosition scopes to events from this COMMIT command only, naturally
+    // excluding otherJobItem (different jobKey, not visited by visitByJobKey)
+    final var agentHistoryEventsForCommit =
+        RecordingExporter.records()
+            .limit(r -> r.getKey() == clockResetKey)
+            .withValueType(ValueType.AGENT_HISTORY)
+            .filter(r -> r.getSourceRecordPosition() == commitPosition)
+            .asList();
+
+    // visitByJobLease(lease-1) → lease-1 item COMMITTED
+    assertThat(
+            agentHistoryEventsForCommit.stream()
+                .filter(r -> r.getIntent() == AgentHistoryIntent.COMMITTED)
+                .map(Record::getKey)
+                .toList())
+        .containsExactly(lease1ItemKey);
+
+    // discard pass (visitByJobKey) → lease-2 item DISCARDED as superseded activation
+    assertThat(
+            agentHistoryEventsForCommit.stream()
+                .filter(r -> r.getIntent() == AgentHistoryIntent.DISCARDED)
+                .map(Record::getKey)
+                .toList())
+        .containsExactly(lease2ItemKey);
+
+    // otherJobItem must not have any event (different jobKey, COMMIT is scoped to jobKey)
+    assertThat(agentHistoryEventsForCommit.stream().map(Record::getKey).toList())
+        .doesNotContain(otherJobItemKey);
+  }
+
   // --- helpers ---
 
   private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AgentHistoryCommitTest {
+
+  // Tests use the stop/replay pattern to inject CREATED events directly rather than going through
+  // AgentHistoryCreateProcessor. The CREATE command currently emits a COMMIT follow-up command
+  // (TODO #55033) — using it here would trigger COMMIT inline in the same batch, before the test
+  // can set up the desired state. Once the pending-commit lifecycle is wired to job
+  // completion/failure events, the follow-up command will move there and CREATE can be used
+  // directly in these tests.
+  //
+  // Pattern: pauseProcessing → reserve keys → stop → writeRecords(CREATED events) → start →
+  // ENGINE.agentHistories().commit(). During replay, CREATED event appliers populate state;
+  // COMMIT is then issued as a regular command and processed normally.
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String SERVICE_TASK_ID = "agent-task";
+  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldEmitCommittedEventOnCommitCommand() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    ENGINE.pauseProcessing(1);
+    final long itemKey =
+        ((MutableProcessingState) ENGINE.getProcessingState()).getKeyGenerator().nextKey();
+    ENGINE.stop();
+
+    ENGINE.writeRecords(
+        RecordToWrite.event()
+            .key(itemKey)
+            .agentHistory(
+                AgentHistoryIntent.CREATED,
+                new AgentHistoryRecord()
+                    .setAgentHistoryKey(itemKey)
+                    .setAgentInstanceKey(agentInstanceKey)
+                    .setJobKey(jobKey)
+                    .setElementInstanceKey(elementInstanceKey)
+                    .setRole(AgentHistoryRole.USER)));
+    ENGINE.start();
+
+    ENGINE.agentHistories().withJobKey(jobKey).commit();
+
+    // AgentHistoryCommitProcessor emits COMMITTED carrying the full stored record
+    final var committed =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
+            .withRecordKey(itemKey)
+            .getFirst();
+    assertThat(committed.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(committed.getKey()).isEqualTo(itemKey);
+    assertThat(committed.getValue().getJobKey()).isEqualTo(jobKey);
+    assertThat(committed.getValue().getAgentInstanceKey()).isEqualTo(agentInstanceKey);
+    assertThat(committed.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+  }
+
+  @Test
+  public void shouldEmitCommittedForAllItemsWithSameJobKey() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    ENGINE.pauseProcessing(1);
+    final var keyGenerator =
+        ((MutableProcessingState) ENGINE.getProcessingState()).getKeyGenerator();
+    final long firstItemKey = keyGenerator.nextKey();
+    final long secondItemKey = keyGenerator.nextKey();
+    final long otherJobItemKey = keyGenerator.nextKey();
+    final long otherJobKey = keyGenerator.nextKey();
+    ENGINE.stop();
+
+    // Two items share jobKey but have different leases — COMMIT with no lease must commit both
+    // regardless of lease. A third item with a different jobKey must not be committed.
+    ENGINE.writeRecords(
+        RecordToWrite.event()
+            .key(firstItemKey)
+            .agentHistory(
+                AgentHistoryIntent.CREATED,
+                new AgentHistoryRecord()
+                    .setAgentHistoryKey(firstItemKey)
+                    .setAgentInstanceKey(agentInstanceKey)
+                    .setJobKey(jobKey)
+                    .setJobLease("lease-a")
+                    .setElementInstanceKey(elementInstanceKey)
+                    .setRole(AgentHistoryRole.USER)),
+        RecordToWrite.event()
+            .key(secondItemKey)
+            .agentHistory(
+                AgentHistoryIntent.CREATED,
+                new AgentHistoryRecord()
+                    .setAgentHistoryKey(secondItemKey)
+                    .setAgentInstanceKey(agentInstanceKey)
+                    .setJobKey(jobKey)
+                    .setJobLease("lease-b")
+                    .setElementInstanceKey(elementInstanceKey)
+                    .setRole(AgentHistoryRole.ASSISTANT)),
+        RecordToWrite.event()
+            .key(otherJobItemKey)
+            .agentHistory(
+                AgentHistoryIntent.CREATED,
+                new AgentHistoryRecord()
+                    .setAgentHistoryKey(otherJobItemKey)
+                    .setAgentInstanceKey(agentInstanceKey)
+                    .setJobKey(otherJobKey)
+                    .setElementInstanceKey(elementInstanceKey)
+                    .setRole(AgentHistoryRole.USER)));
+    ENGINE.start();
+
+    final var firstCommitted = ENGINE.agentHistories().withJobKey(jobKey).commit();
+    final long commitPosition = firstCommitted.getSourceRecordPosition();
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // COMMIT with no lease → visitByJobKey commits all items for jobKey regardless of lease.
+    // withSourceRecordPosition scopes to events from this COMMIT command only; otherJobItemKey
+    // is not visited by visitByJobKey(jobKey) so no event for it can appear.
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.COMMITTED)
+                .filter(r -> r.getSourceRecordPosition() == commitPosition)
+                .map(Record::getKey))
+        .containsExactlyInAnyOrder(firstItemKey, secondItemKey);
+  }
+
+  // --- helpers ---
+
+  private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .withElementId(SERVICE_TASK_ID)
+        .getFirst();
+  }
+
+  private static long activateJobForProcessInstance(final long processInstanceKey) {
+    ENGINE.jobs().withType(JOB_TYPE).activate();
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(JOB_TYPE)
+        .getFirst()
+        .getKey();
+  }
+
+  private static Record<?> createAgentInstance(final long elementInstanceKey) {
+    return ENGINE
+        .agentInstances()
+        .withElementInstanceKey(elementInstanceKey)
+        .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+        .create();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
@@ -35,6 +35,13 @@ public final class AgentHistoryClient {
                   .withSourceRecordPosition(position)
                   .getFirst();
 
+  private static final Function<Long, Record<AgentHistoryRecordValue>> COMMIT_EXPECTATION =
+      (position) ->
+          RecordingExporter.agentHistoryRecords()
+              .onlyEvents()
+              .withSourceRecordPosition(position)
+              .getFirst();
+
   private final CommandWriter writer;
   private final AgentHistoryRecord record = new AgentHistoryRecord();
   private List<String> authorizedTenantIds = List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
@@ -104,5 +111,10 @@ public final class AgentHistoryClient {
             record,
             authorizedTenantIds.toArray(new String[0]));
     return (expectRejection ? CREATE_REJECTION_EXPECTATION : CREATED_EXPECTATION).apply(position);
+  }
+
+  public Record<AgentHistoryRecordValue> commit() {
+    final long position = writer.writeCommand(AgentHistoryIntent.COMMIT, record);
+    return COMMIT_EXPECTATION.apply(position);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_COMMITTED_v1.golden
@@ -24,6 +24,6 @@ public final class AgentHistoryCommittedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
-    agentHistoryState.delete(key);
+    agentHistoryState.delete(key, value);
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_DISCARDED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_DISCARDED_v1.golden
@@ -24,6 +24,6 @@ public final class AgentHistoryDiscardedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
-    agentHistoryState.delete(key);
+    agentHistoryState.delete(key, value);
   }
 }


### PR DESCRIPTION
## Summary

Implements `AgentHistoryCommitProcessor` and wires the pending-commit lifecycle end-to-end,
including lease-based dispatch and discard of items from superseded activations.

Before this change, `AgentHistoryCreateProcessor` emitted `AGENT_HISTORY:COMMITTED` immediately
after `AGENT_HISTORY:CREATED` as a temporary workaround. This PR replaces that with a proper
`COMMIT` follow-up command (with a TODO comment preserved until job-completion events are wired),
and the new `AgentHistoryCommitProcessor` handles it with full lease-based dispatch.

### What changed

- **`AgentHistoryCommitProcessor`** (new): handles `AGENT_HISTORY COMMIT` commands with
  lease-based dispatch:
  - **Empty `jobLease`**: calls `visitByJobKey` — commits all pending items for the job
    regardless of activation. Backward-compatible with non-agentic jobs (silent no-op when
    no items exist).
  - **Non-empty `jobLease`**: calls `visitByJobLease` to commit items matching the current
    activation, then a second pass via `visitByJobKey` to **discard** any items belonging to
    superseded activations (same `jobKey`, different `jobLease`). This handles the case where
    a job is retried under a new lease while old activation history still sits in state.
- **`AgentHistoryProcessors`**: registers `AgentHistoryIntent.COMMIT → AgentHistoryCommitProcessor`.
- **`AgentHistoryCreateProcessor`**: replaces the inline `COMMITTED` workaround with a `COMMIT`
  follow-up command carrying `jobKey` and `jobLease`. A TODO comment marks this as an intermediate
  step until the pending-commit lifecycle is wired to job completion/failure events.
- **`MutableAgentHistoryState`**: adds `delete(long historyItemKey, AgentHistoryRecord record)`
  overload — state appliers already hold the full record from the event value, so they no longer
  need a secondary `get()` lookup to resolve the secondary index key.
- **`DbAgentHistoryState`**: implements the new overload; existing `delete(long)` delegates to it.
- **`AgentHistoryCommittedApplier`**, **`AgentHistoryDiscardedApplier`**: use
  `delete(key, value)` instead of `delete(key)`.

### Design decisions

**Two-pass iteration is safe.** `visitByJobLease` (commit pass) and `visitByJobKey` (discard pass)
use separate RocksDB iterators backed by `WriteBatchWithIndex`. The second iterator correctly
excludes items deleted by the first pass. Within each pass, `appendFollowUpEvent` triggers the
state applier inline (batch processing), removing the committed/discarded item from state
mid-iteration; this is safe because `ColumnFamilyContext.withPrefixKey()` captures prefix bytes
at call time into a private buffer — mutations to shared `DbLong`/`DbString` key instances do
not corrupt the prefix check.

**COMMIT carries `jobLease` from the created item.** `AgentHistoryCreateProcessor` sets `jobLease`
on the COMMIT command so `AgentHistoryCommitProcessor` can choose the right dispatch path without
an extra state lookup.

## Test plan

All four tests use the **stop/replay pattern** to inject `CREATED` events directly into the log
without going through `AgentHistoryCreateProcessor`. This decouples `AgentHistoryCommitProcessor`
tests from the CREATE command's side effects (inline COMMIT follow-up, validation, etc.).

Pattern: `ENGINE.pauseProcessing(1)` → reserve keys → `ENGINE.stop()` → `ENGINE.writeRecords(CREATED events + COMMIT command)` → `ENGINE.start()`. During replay, CREATED event appliers populate state before the COMMIT command is processed by the stream processor.

- `shouldEmitCommittedEventOnCommitCommand` — single item, no lease; verifies COMMITTED event carries correct record type, key, `jobKey`, `agentInstanceKey`, and `elementInstanceKey`.
- `shouldEmitCommittedForAllItemsWithSameJobKey` — two items, same `jobKey`, no lease; both receive `COMMITTED`. `containsExactlyInAnyOrder` catches double-commit of one key.
- `shouldCommitLeaseMatchingItemsWhenJobLeaseIsSet` — single item with `jobLease`; COMMIT command carries the lease; COMMITTED event carries it back.
- `shouldDiscardSupersededActivationItemsOnLeaseBasedCommit` — two items, `lease-1` and `lease-2`, plus a `COMMIT(lease-1)` command. Asserts `lease-1` item is `COMMITTED` and `lease-2` item is `DISCARDED`.

## Related issues

- Parent: https://github.com/camunda/camunda/issues/55033
- Closes https://github.com/camunda/camunda/issues/56161
- Depends on: https://github.com/camunda/camunda/issues/56160 (PR #56240)
- Next: https://github.com/camunda/camunda/issues/56162 (AgentHistoryDiscardProcessor)