### PR TITLE
Migrate ping endpoint from Console to Hub with M2M token auth

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.application.Profile;
+import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.application.commons.console.ping.PingConsoleTask.LicensePayload;
+import io.camunda.service.ManagementServices;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.error.FatalErrorHandler;
+import io.camunda.zeebe.util.retry.RetryConfiguration;
+import java.net.URI;
+import java.time.Duration;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * Pings the Camunda Console endpoint on a scheduled basis.
+ *
+ * @deprecated Use {@code camunda.hub.ping} configuration instead. This runner is retained for
+ *     backwards compatibility and will be removed in a future release. It is disabled automatically
+ *     when {@code camunda.hub.ping.enabled=true}.
+ */
+@Deprecated
+@Component
+@EnableConfigurationProperties({ConsolePingConfiguration.class})
+@ConditionalOnExpression(
+    "'${camunda.console.ping.enabled:false}' == 'true' "
+        + "and '${camunda.hub.ping.enabled:false}' != 'true'")
+public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleRunner.class);
+  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
+  private final ConsolePingConfiguration pingConfiguration;
+  private final ManagementServices managementServices;
+  private Either<Exception, String> licensePayload;
+  private final BrokerTopologyManager brokerTopologyManager;
+  private final ApplicationContext applicationContext;
+
+  @Autowired
+  public PingConsoleRunner(
+      final ConsolePingConfiguration pingConfigurationProperties,
+      final ManagementServices managementServices,
+      final ApplicationContext applicationContext,
+      final BrokerTopologyManager brokerTopologyManager) {
+    pingConfiguration = pingConfigurationProperties;
+    this.managementServices = managementServices;
+    this.applicationContext = applicationContext;
+    this.brokerTopologyManager = brokerTopologyManager;
+  }
+
+  @Override
+  public void run(final ApplicationArguments args) {
+    LOGGER.warn(
+        "camunda.console.ping is deprecated. Please migrate to camunda.hub.ping configuration.");
+    waitForClusterId()
+        .thenAccept(this::buildLicensePayload)
+        .thenRun(
+            () -> {
+              final var validationResult = validateConfiguration();
+              if (validationResult.isRight()) {
+                startPingTask();
+              } else {
+                LOGGER.error("Configuration validation failed: {}", validationResult.getLeft());
+              }
+            });
+  }
+
+  private void startPingTask() {
+    LOGGER.info(
+        "Console ping is enabled for cluster ID of {}, with endpoint: {}, and period of {}.",
+        brokerTopologyManager.getClusterConfiguration().clusterId().get(),
+        pingConfiguration.endpoint(),
+        pingConfiguration.pingPeriod());
+    final var executor = createTaskExecutor();
+    executor.scheduleAtFixedRate(
+        new PingConsoleTask(pingConfiguration, licensePayload.get()),
+        1000,
+        pingConfiguration.pingPeriod().toMillis(),
+        TimeUnit.MILLISECONDS);
+  }
+
+  @VisibleForTesting
+  protected Either<String, Void> validateConfiguration() {
+    if (pingConfiguration.endpoint() == null) {
+      return Either.left("Ping endpoint must not be null.");
+    }
+    if (pingConfiguration.endpoint().getScheme() == null
+        || pingConfiguration.endpoint().getHost() == null) {
+      return Either.left(
+          String.format("Ping endpoint %s must be a valid URI.", pingConfiguration.endpoint()));
+    }
+    if (brokerTopologyManager.getClusterConfiguration().clusterId().get().isBlank()) {
+      return Either.left("Cluster ID must not be null or empty.");
+    }
+    if (pingConfiguration.clusterName() == null || pingConfiguration.clusterName().isBlank()) {
+      return Either.left("Cluster name must not be null or empty.");
+    }
+    if (pingConfiguration.pingPeriod().isZero() || pingConfiguration.pingPeriod().isNegative()) {
+      return Either.left("Ping period must be greater than zero.");
+    }
+    if (pingConfiguration.retry() != null) {
+      if (pingConfiguration.retry().getMaxRetries() <= 0) {
+        return Either.left("Number of max retries must be greater than zero.");
+      }
+      if (pingConfiguration.retry().getRetryDelayMultiplier() <= 0) {
+        return Either.left("Retry delay multiplier must be greater than zero.");
+      }
+      if (pingConfiguration.retry().getMaxRetryDelay().isZero()
+          || pingConfiguration.retry().getMaxRetryDelay().isNegative()) {
+        return Either.left("Max retry delay must be greater than zero.");
+      }
+      if (pingConfiguration.retry().getMinRetryDelay().isZero()
+          || pingConfiguration.retry().getMinRetryDelay().isNegative()) {
+        return Either.left("Min retry delay must be greater than zero.");
+      }
+      if (pingConfiguration
+              .retry()
+              .getMaxRetryDelay()
+              .compareTo(pingConfiguration.retry().getMinRetryDelay())
+          < 0) {
+        return Either.left("Max retry delay must be greater than or equal to min retry delay.");
+      }
+    }
+    if (licensePayload.isLeft()) {
+      return Either.left(
+          "Failed to parse license payload for Console ping task: "
+              + licensePayload.getLeft().getMessage());
+    }
+    return Either.right(null);
+  }
+
+  private List<String> getActiveProfiles() {
+    return Arrays.stream(applicationContext.getEnvironment().getActiveProfiles())
+        .filter(
+            profile ->
+                profile.equals(Profile.BROKER.getId())
+                    || profile.equals(Profile.GATEWAY.getId())
+                    || profile.equals(Profile.OPERATE.getId())
+                    || profile.equals(Profile.TASKLIST.getId())
+                    || profile.equals(Profile.STANDALONE.getId()))
+        .toList();
+  }
+
+  public ScheduledThreadPoolExecutor createTaskExecutor() {
+    final var threadFactory =
+        Thread.ofPlatform()
+            .name("console-license-ping-", 0)
+            .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(LOGGER))
+            .factory();
+    final var executor = new ScheduledThreadPoolExecutor(1, threadFactory);
+    executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+    executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+    executor.setRemoveOnCancelPolicy(true);
+    return executor;
+  }
+
+  private void buildLicensePayload(final String clusterId) {
+    final ObjectMapper objectMapper = new ObjectMapper();
+    final LicensePayload.License license =
+        new LicensePayload.License(
+            managementServices.isCamundaLicenseValid(),
+            managementServices.getCamundaLicenseType().toString(),
+            managementServices.isCommercialCamundaLicense(),
+            managementServices.getCamundaLicenseExpiresAt() == null
+                ? null
+                : DATE_TIME_FORMATTER.format(managementServices.getCamundaLicenseExpiresAt()));
+    final List<String> activeProfiles = getActiveProfiles();
+    final LicensePayload payload =
+        new LicensePayload(
+            license,
+            clusterId,
+            pingConfiguration.clusterName(),
+            VersionUtil.getVersion(),
+            activeProfiles.isEmpty() ? null : activeProfiles,
+            pingConfiguration.properties());
+    try {
+      licensePayload = Either.right(objectMapper.writeValueAsString(payload));
+    } catch (final JsonProcessingException exception) {
+      licensePayload = Either.left(exception);
+    }
+  }
+
+  private CompletableFuture<String> waitForClusterId() {
+    final CompletableFuture<String> future = new CompletableFuture<>();
+    if (brokerTopologyManager.getClusterConfiguration().clusterId().isPresent()) {
+      future.complete(brokerTopologyManager.getClusterConfiguration().clusterId().get());
+    } else {
+      brokerTopologyManager.addTopologyListener(
+          new BrokerTopologyListener() {
+            @Override
+            public void completedClusterChange() {
+              if (brokerTopologyManager.getClusterConfiguration().clusterId().isPresent()) {
+                future.complete(brokerTopologyManager.getClusterConfiguration().clusterId().get());
+                brokerTopologyManager.removeTopologyListener(this);
+              }
+            }
+          });
+    }
+    return future;
+  }
+
+  @ConfigurationProperties("camunda.console.ping")
+  public record ConsolePingConfiguration(
+      boolean enabled,
+      URI endpoint,
+      String clusterName,
+      Duration pingPeriod,
+      RetryConfiguration retry,
+      Map<String, String> properties) {}
+}

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -48,6 +48,10 @@ import org.springframework.stereotype.Component;
  * @deprecated Use {@code camunda.hub.ping} configuration instead. This runner is retained for
  *     backwards compatibility and will be removed in a future release. It is disabled automatically
  *     when {@code camunda.hub.ping.enabled=true}.
+ *     <p><b>Important:</b> The ping endpoint now requires authentication regardless of which
+ *     configuration path is used. Before upgrading, you must add M2M credentials under {@code
+ *     camunda.console.ping.credentials} ({@code token-endpoint}, {@code client-id}, {@code
+ *     client-secret}). Missing credentials will cause all pings to fail at startup validation.
  */
 @Deprecated
 @Component

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -12,6 +12,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
 import io.camunda.application.commons.console.ping.PingConsoleTask.LicensePayload;
+import io.camunda.application.commons.hub.ping.M2MCredentials;
+import io.camunda.application.commons.hub.ping.M2MTokenProvider;
 import io.camunda.service.ManagementServices;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -97,9 +99,10 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
         brokerTopologyManager.getClusterConfiguration().clusterId().get(),
         pingConfiguration.endpoint(),
         pingConfiguration.pingPeriod());
+    final var tokenProvider = new M2MTokenProvider(pingConfiguration.credentials());
     final var executor = createTaskExecutor();
     executor.scheduleAtFixedRate(
-        new PingConsoleTask(pingConfiguration, licensePayload.get()),
+        new PingConsoleTask(pingConfiguration, tokenProvider, licensePayload.get()),
         1000,
         pingConfiguration.pingPeriod().toMillis(),
         TimeUnit.MILLISECONDS);
@@ -146,6 +149,27 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
           < 0) {
         return Either.left("Max retry delay must be greater than or equal to min retry delay.");
       }
+    }
+    if (pingConfiguration.credentials() == null) {
+      return Either.left("M2M credentials must not be null.");
+    }
+    if (pingConfiguration.credentials().tokenEndpoint() == null) {
+      return Either.left("M2M token endpoint must not be null.");
+    }
+    if (pingConfiguration.credentials().tokenEndpoint().getScheme() == null
+        || pingConfiguration.credentials().tokenEndpoint().getHost() == null) {
+      return Either.left(
+          String.format(
+              "M2M token endpoint %s must be a valid URI.",
+              pingConfiguration.credentials().tokenEndpoint()));
+    }
+    if (pingConfiguration.credentials().clientId() == null
+        || pingConfiguration.credentials().clientId().isBlank()) {
+      return Either.left("M2M client ID must not be null or empty.");
+    }
+    if (pingConfiguration.credentials().clientSecret() == null
+        || pingConfiguration.credentials().clientSecret().isBlank()) {
+      return Either.left("M2M client secret must not be null or empty.");
     }
     if (licensePayload.isLeft()) {
       return Either.left(
@@ -232,5 +256,6 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
       String clusterName,
       Duration pingPeriod,
       RetryConfiguration retry,
-      Map<String, String> properties) {}
+      Map<String, String> properties,
+      M2MCredentials credentials) {}
 }

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleRunner.java
@@ -191,7 +191,7 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
         .toList();
   }
 
-  public ScheduledThreadPoolExecutor createTaskExecutor() {
+  private ScheduledThreadPoolExecutor createTaskExecutor() {
     final var threadFactory =
         Thread.ofPlatform()
             .name("console-license-ping-", 0)

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -75,9 +75,11 @@ public class PingConsoleTask implements Runnable {
     try {
       resp = client.send(request, BodyHandlers.ofString());
     } catch (final IOException | InterruptedException e) {
+      // If the request fails due to a network issue, we should retry.
       throw new RetriableException("Network error: " + e.getMessage());
     }
 
+    // We should retry on server errors, timeouts or too many request.
     if (resp.statusCode() >= 500) {
       LOGGER.debug("Received server error: {}. A retry will be attempted.", resp.statusCode());
       throw new RetriableException("Server error: " + resp.statusCode(), resp.body());
@@ -86,6 +88,7 @@ public class PingConsoleTask implements Runnable {
       throw new RetriableException(
           "Too many requests or timeout: " + resp.statusCode(), resp.body());
     } else if (resp.statusCode() >= 400) {
+      // Should not retry for the remaining 4xx errors, but we log them.
       LOGGER.debug(
           "Received client error response: {}. No retry will be attempted.", resp.statusCode());
     }

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -104,6 +104,12 @@ public class PingConsoleTask implements Runnable {
     }
   }
 
+  private static String truncate(final String s) {
+    return s.length() <= MAX_RESPONSE_BODY_LENGTH
+        ? s
+        : s.substring(0, MAX_RESPONSE_BODY_LENGTH) + "... [truncated]";
+  }
+
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public record LicensePayload(
       License license,
@@ -115,12 +121,6 @@ public class PingConsoleTask implements Runnable {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record License(
         boolean validLicense, String licenseType, boolean isCommercial, String expiresAt) {}
-  }
-
-  private static String truncate(final String s) {
-    return s.length() <= MAX_RESPONSE_BODY_LENGTH
-        ? s
-        : s.substring(0, MAX_RESPONSE_BODY_LENGTH) + "... [truncated]";
   }
 
   @VisibleForTesting

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -97,8 +97,10 @@ public class PingConsoleTask implements Runnable {
           "Too many requests or timeout: " + resp.statusCode(), resp.body());
     } else if (resp.statusCode() >= 400) {
       // Should not retry for the remaining 4xx errors, but we log them.
-      LOGGER.debug(
-          "Received client error response: {}. No retry will be attempted.", resp.statusCode());
+      LOGGER.warn(
+          "Received client error response: {}. No retry will be attempted. Body: {}",
+          resp.statusCode(),
+          truncate(resp.body()));
     }
   }
 
@@ -113,6 +115,12 @@ public class PingConsoleTask implements Runnable {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record License(
         boolean validLicense, String licenseType, boolean isCommercial, String expiresAt) {}
+  }
+
+  private static String truncate(final String s) {
+    return s.length() <= MAX_RESPONSE_BODY_LENGTH
+        ? s
+        : s.substring(0, MAX_RESPONSE_BODY_LENGTH) + "... [truncated]";
   }
 
   @VisibleForTesting

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.retry.RetryConfiguration;
+import io.camunda.zeebe.util.retry.RetryDecorator;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PingConsoleTask implements Runnable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleTask.class);
+  private static final int MAX_RESPONSE_BODY_LENGTH = 1000;
+  private final HttpClient client;
+  private final ConsolePingConfiguration pingConfiguration;
+  private final RetryDecorator retryDecorator;
+  private final String licensePayload;
+
+  @VisibleForTesting
+  public PingConsoleTask(
+      final ConsolePingConfiguration pingConfiguration,
+      final HttpClient client,
+      final String licensePayload) {
+    this.pingConfiguration = pingConfiguration;
+    this.client = client;
+    retryDecorator =
+        new RetryDecorator(
+            pingConfiguration.retry() != null
+                ? pingConfiguration.retry()
+                : new RetryConfiguration());
+    this.licensePayload = licensePayload;
+  }
+
+  public PingConsoleTask(
+      final ConsolePingConfiguration pingConfiguration, final String licensePayload) {
+    this(pingConfiguration, HttpClient.newHttpClient(), licensePayload);
+  }
+
+  @Override
+  public void run() {
+    try {
+      final HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(pingConfiguration.endpoint())
+              .header("Accept", "application/json")
+              .header("Content-Type", "application/json")
+              .POST(HttpRequest.BodyPublishers.ofString(licensePayload))
+              .build();
+
+      retryDecorator.decorate("Ping console.", () -> tryPingConsole(request));
+
+    } catch (final Exception e) {
+      LOGGER.warn("Failed to execute Console ping task. Exception Message: {}", e.getMessage(), e);
+    }
+  }
+
+  @VisibleForTesting
+  protected void tryPingConsole(final HttpRequest request) throws RetriableException {
+    final HttpResponse<String> resp;
+    try {
+      resp = client.send(request, BodyHandlers.ofString());
+    } catch (final IOException | InterruptedException e) {
+      throw new RetriableException("Network error: " + e.getMessage());
+    }
+
+    if (resp.statusCode() >= 500) {
+      LOGGER.debug("Received server error: {}. A retry will be attempted.", resp.statusCode());
+      throw new RetriableException("Server error: " + resp.statusCode(), resp.body());
+    } else if (resp.statusCode() == 429 || resp.statusCode() == 408) {
+      LOGGER.debug("Received client error: {}. A retry will be attempted.", resp.statusCode());
+      throw new RetriableException(
+          "Too many requests or timeout: " + resp.statusCode(), resp.body());
+    } else if (resp.statusCode() >= 400) {
+      LOGGER.debug(
+          "Received client error response: {}. No retry will be attempted.", resp.statusCode());
+    }
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record LicensePayload(
+      License license,
+      String clusterId,
+      String clusterName,
+      String version,
+      List<String> profiles,
+      Map<String, String> properties) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record License(
+        boolean validLicense, String licenseType, boolean isCommercial, String expiresAt) {}
+  }
+
+  @VisibleForTesting
+  static class RetriableException extends RuntimeException {
+    public RetriableException(final String message) {
+      super(message);
+    }
+
+    public RetriableException(final String message, final String responseBody) {
+      super(
+          message
+              + ". Response body: "
+              + (responseBody.length() <= MAX_RESPONSE_BODY_LENGTH
+                  ? responseBody
+                  : responseBody.substring(0, MAX_RESPONSE_BODY_LENGTH) + "... [truncated]"));
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/console/ping/PingConsoleTask.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.console.ping;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.application.commons.hub.ping.M2MTokenProvider;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import io.camunda.zeebe.util.retry.RetryDecorator;
@@ -28,15 +29,18 @@ public class PingConsoleTask implements Runnable {
   private static final int MAX_RESPONSE_BODY_LENGTH = 1000;
   private final HttpClient client;
   private final ConsolePingConfiguration pingConfiguration;
+  private final M2MTokenProvider tokenProvider;
   private final RetryDecorator retryDecorator;
   private final String licensePayload;
 
   @VisibleForTesting
   public PingConsoleTask(
       final ConsolePingConfiguration pingConfiguration,
+      final M2MTokenProvider tokenProvider,
       final HttpClient client,
       final String licensePayload) {
     this.pingConfiguration = pingConfiguration;
+    this.tokenProvider = tokenProvider;
     this.client = client;
     retryDecorator =
         new RetryDecorator(
@@ -47,18 +51,22 @@ public class PingConsoleTask implements Runnable {
   }
 
   public PingConsoleTask(
-      final ConsolePingConfiguration pingConfiguration, final String licensePayload) {
-    this(pingConfiguration, HttpClient.newHttpClient(), licensePayload);
+      final ConsolePingConfiguration pingConfiguration,
+      final M2MTokenProvider tokenProvider,
+      final String licensePayload) {
+    this(pingConfiguration, tokenProvider, HttpClient.newHttpClient(), licensePayload);
   }
 
   @Override
   public void run() {
     try {
+      final String token = tokenProvider.getToken();
       final HttpRequest request =
           HttpRequest.newBuilder()
               .uri(pingConfiguration.endpoint())
               .header("Accept", "application/json")
               .header("Content-Type", "application/json")
+              .header("Authorization", "Bearer " + token)
               .POST(HttpRequest.BodyPublishers.ofString(licensePayload))
               .build();
 

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MCredentials.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MCredentials.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.hub.ping;
+
+import java.net.URI;
+
+public record M2MCredentials(URI tokenEndpoint, String clientId, String clientSecret) {}

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MCredentials.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MCredentials.java
@@ -9,4 +9,13 @@ package io.camunda.application.commons.hub.ping;
 
 import java.net.URI;
 
-public record M2MCredentials(URI tokenEndpoint, String clientId, String clientSecret) {}
+public record M2MCredentials(URI tokenEndpoint, String clientId, String clientSecret) {
+  @Override
+  public String toString() {
+    return "M2MCredentials[tokenEndpoint="
+        + tokenEndpoint
+        + ", clientId="
+        + clientId
+        + ", clientSecret=***]";
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MTokenProvider.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MTokenProvider.java
@@ -9,7 +9,6 @@ package io.camunda.application.commons.hub.ping;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration.M2MCredentials;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -38,7 +37,7 @@ public class M2MTokenProvider {
   }
 
   @VisibleForTesting
-  M2MTokenProvider(final M2MCredentials credentials, final HttpClient httpClient) {
+  public M2MTokenProvider(final M2MCredentials credentials, final HttpClient httpClient) {
     this.credentials = credentials;
     this.httpClient = httpClient;
   }

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MTokenProvider.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MTokenProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.hub.ping;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration.M2MCredentials;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class M2MTokenProvider {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(M2MTokenProvider.class);
+  private static final int TOKEN_EXPIRY_BUFFER_SECONDS = 30;
+  private static final int MAX_RESPONSE_LOG_LENGTH = 500;
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final HttpClient httpClient;
+  private final M2MCredentials credentials;
+  private volatile String cachedToken;
+  private volatile Instant tokenExpiresAt = Instant.EPOCH;
+
+  public M2MTokenProvider(final M2MCredentials credentials) {
+    this(credentials, HttpClient.newHttpClient());
+  }
+
+  @VisibleForTesting
+  M2MTokenProvider(final M2MCredentials credentials, final HttpClient httpClient) {
+    this.credentials = credentials;
+    this.httpClient = httpClient;
+  }
+
+  public synchronized String getToken() throws IOException, InterruptedException {
+    if (cachedToken == null || Instant.now().isAfter(tokenExpiresAt)) {
+      refreshToken();
+    }
+    return cachedToken;
+  }
+
+  private void refreshToken() throws IOException, InterruptedException {
+    LOGGER.debug("Fetching M2M token from {}", credentials.tokenEndpoint());
+    final String requestBody =
+        "grant_type=client_credentials"
+            + "&client_id="
+            + URLEncoder.encode(credentials.clientId(), StandardCharsets.UTF_8)
+            + "&client_secret="
+            + URLEncoder.encode(credentials.clientSecret(), StandardCharsets.UTF_8);
+
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(credentials.tokenEndpoint())
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+            .build();
+
+    final HttpResponse<String> response =
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() != 200) {
+      throw new IOException(
+          "Failed to fetch M2M token: HTTP "
+              + response.statusCode()
+              + ", body: "
+              + truncate(response.body()));
+    }
+
+    final JsonNode json = OBJECT_MAPPER.readTree(response.body());
+    cachedToken = json.get("access_token").asText();
+    final long expiresIn = json.path("expires_in").asLong(3600);
+    tokenExpiresAt = Instant.now().plusSeconds(expiresIn - TOKEN_EXPIRY_BUFFER_SECONDS);
+    LOGGER.debug("Successfully fetched M2M token, expires in {} seconds", expiresIn);
+  }
+
+  private static String truncate(final String s) {
+    return s.length() <= MAX_RESPONSE_LOG_LENGTH
+        ? s
+        : s.substring(0, MAX_RESPONSE_LOG_LENGTH) + "... [truncated]";
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MTokenProvider.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/M2MTokenProvider.java
@@ -76,7 +76,12 @@ public class M2MTokenProvider {
     }
 
     final JsonNode json = OBJECT_MAPPER.readTree(response.body());
-    cachedToken = json.get("access_token").asText();
+    final JsonNode tokenNode = json.path("access_token");
+    if (tokenNode.isMissingNode() || tokenNode.isNull()) {
+      throw new IOException(
+          "Token response missing 'access_token' field. Body: " + truncate(response.body()));
+    }
+    cachedToken = tokenNode.asText();
     final long expiresIn = json.path("expires_in").asLong(3600);
     tokenExpiresAt = Instant.now().plusSeconds(expiresIn - TOKEN_EXPIRY_BUFFER_SECONDS);
     LOGGER.debug("Successfully fetched M2M token, expires in {} seconds", expiresIn);

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubRunner.java
@@ -5,13 +5,13 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.application.commons.console.ping;
+package io.camunda.application.commons.hub.ping;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.application.Profile;
-import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
-import io.camunda.application.commons.console.ping.PingConsoleTask.LicensePayload;
+import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration;
+import io.camunda.application.commons.hub.ping.PingHubTask.LicensePayload;
 import io.camunda.service.ManagementServices;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -41,20 +41,20 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
 
 @Component
-@EnableConfigurationProperties({ConsolePingConfiguration.class})
-@ConditionalOnProperty(prefix = "camunda.console.ping", name = "enabled", havingValue = "true")
-public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListener {
-  private static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleRunner.class);
+@EnableConfigurationProperties({HubPingConfiguration.class})
+@ConditionalOnProperty(prefix = "camunda.hub.ping", name = "enabled", havingValue = "true")
+public class PingHubRunner implements ApplicationRunner, BrokerTopologyListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PingHubRunner.class);
   private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ISO_DATE_TIME;
-  private final ConsolePingConfiguration pingConfiguration;
+  private final HubPingConfiguration pingConfiguration;
   private final ManagementServices managementServices;
   private Either<Exception, String> licensePayload;
   private final BrokerTopologyManager brokerTopologyManager;
   private final ApplicationContext applicationContext;
 
   @Autowired
-  public PingConsoleRunner(
-      final ConsolePingConfiguration pingConfigurationProperties,
+  public PingHubRunner(
+      final HubPingConfiguration pingConfigurationProperties,
       final ManagementServices managementServices,
       final ApplicationContext applicationContext,
       final BrokerTopologyManager brokerTopologyManager) {
@@ -80,17 +80,17 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
   }
 
   private void startPingTask() {
-
     LOGGER.info(
-        "Console ping is enabled cluster ID of {}, with endpoint: {}, and period of {}.",
+        "Hub ping is enabled for cluster ID of {}, with endpoint: {}, and period of {}.",
         brokerTopologyManager.getClusterConfiguration().clusterId().get(),
         pingConfiguration.endpoint(),
         pingConfiguration.pingPeriod());
+    final var tokenProvider = new M2MTokenProvider(pingConfiguration.credentials());
     final var executor = createTaskExecutor();
     executor.scheduleAtFixedRate(
-        new PingConsoleTask(pingConfiguration, licensePayload.get()),
+        new PingHubTask(pingConfiguration, tokenProvider, licensePayload.get()),
         1000,
-        pingConfiguration.pingPeriod.toMillis(),
+        pingConfiguration.pingPeriod().toMillis(),
         TimeUnit.MILLISECONDS);
   }
 
@@ -99,10 +99,10 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
     if (pingConfiguration.endpoint() == null) {
       return Either.left("Ping endpoint must not be null.");
     }
-    if (pingConfiguration.endpoint.getScheme() == null
-        || pingConfiguration.endpoint.getHost() == null) {
+    if (pingConfiguration.endpoint().getScheme() == null
+        || pingConfiguration.endpoint().getHost() == null) {
       return Either.left(
-          String.format("Ping endpoint %s must be a valid URI.", pingConfiguration.endpoint));
+          String.format("Ping endpoint %s must be a valid URI.", pingConfiguration.endpoint()));
     }
     if (brokerTopologyManager.getClusterConfiguration().clusterId().get().isBlank()) {
       return Either.left("Cluster ID must not be null or empty.");
@@ -121,7 +121,7 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
         return Either.left("Retry delay multiplier must be greater than zero.");
       }
       if (pingConfiguration.retry().getMaxRetryDelay().isZero()
-          || pingConfiguration.retry().getMinRetryDelay().isNegative()) {
+          || pingConfiguration.retry().getMaxRetryDelay().isNegative()) {
         return Either.left("Max retry delay must be greater than zero.");
       }
       if (pingConfiguration.retry().getMinRetryDelay().isZero()
@@ -136,9 +136,30 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
         return Either.left("Max retry delay must be greater than or equal to min retry delay.");
       }
     }
+    if (pingConfiguration.credentials() == null) {
+      return Either.left("M2M credentials must not be null.");
+    }
+    if (pingConfiguration.credentials().tokenEndpoint() == null) {
+      return Either.left("M2M token endpoint must not be null.");
+    }
+    if (pingConfiguration.credentials().tokenEndpoint().getScheme() == null
+        || pingConfiguration.credentials().tokenEndpoint().getHost() == null) {
+      return Either.left(
+          String.format(
+              "M2M token endpoint %s must be a valid URI.",
+              pingConfiguration.credentials().tokenEndpoint()));
+    }
+    if (pingConfiguration.credentials().clientId() == null
+        || pingConfiguration.credentials().clientId().isBlank()) {
+      return Either.left("M2M client ID must not be null or empty.");
+    }
+    if (pingConfiguration.credentials().clientSecret() == null
+        || pingConfiguration.credentials().clientSecret().isBlank()) {
+      return Either.left("M2M client secret must not be null or empty.");
+    }
     if (licensePayload.isLeft()) {
       return Either.left(
-          "Failed to parse license payload for Console ping task: "
+          "Failed to parse license payload for Hub ping task: "
               + licensePayload.getLeft().getMessage());
     }
     return Either.right(null);
@@ -159,11 +180,10 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
   public ScheduledThreadPoolExecutor createTaskExecutor() {
     final var threadFactory =
         Thread.ofPlatform()
-            .name("console-license-ping-", 0)
+            .name("hub-license-ping-", 0)
             .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(LOGGER))
             .factory();
     final var executor = new ScheduledThreadPoolExecutor(1, threadFactory);
-    // if the executor is shut down, there is no need to continue executing existing tasks
     executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
     executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
     executor.setRemoveOnCancelPolicy(true);
@@ -214,12 +234,16 @@ public class PingConsoleRunner implements ApplicationRunner, BrokerTopologyListe
     return future;
   }
 
-  @ConfigurationProperties("camunda.console.ping")
-  public record ConsolePingConfiguration(
+  @ConfigurationProperties("camunda.hub.ping")
+  public record HubPingConfiguration(
       boolean enabled,
       URI endpoint,
       String clusterName,
       Duration pingPeriod,
       RetryConfiguration retry,
-      Map<String, String> properties) {}
+      Map<String, String> properties,
+      M2MCredentials credentials) {
+
+    public record M2MCredentials(URI tokenEndpoint, String clientId, String clientSecret) {}
+  }
 }

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubRunner.java
@@ -200,13 +200,14 @@ public class PingHubRunner implements ApplicationRunner, BrokerTopologyListener 
             managementServices.getCamundaLicenseExpiresAt() == null
                 ? null
                 : DATE_TIME_FORMATTER.format(managementServices.getCamundaLicenseExpiresAt()));
+    final List<String> activeProfiles = getActiveProfiles();
     final LicensePayload payload =
         new LicensePayload(
             license,
             clusterId,
             pingConfiguration.clusterName(),
             VersionUtil.getVersion(),
-            getActiveProfiles(),
+            activeProfiles.isEmpty() ? null : activeProfiles,
             pingConfiguration.properties());
     try {
       licensePayload = Either.right(objectMapper.writeValueAsString(payload));

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubRunner.java
@@ -243,8 +243,5 @@ public class PingHubRunner implements ApplicationRunner, BrokerTopologyListener 
       Duration pingPeriod,
       RetryConfiguration retry,
       Map<String, String> properties,
-      M2MCredentials credentials) {
-
-    public record M2MCredentials(URI tokenEndpoint, String clientId, String clientSecret) {}
-  }
+      M2MCredentials credentials) {}
 }

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubRunner.java
@@ -177,7 +177,7 @@ public class PingHubRunner implements ApplicationRunner, BrokerTopologyListener 
         .toList();
   }
 
-  public ScheduledThreadPoolExecutor createTaskExecutor() {
+  private ScheduledThreadPoolExecutor createTaskExecutor() {
     final var threadFactory =
         Thread.ofPlatform()
             .name("hub-license-ping-", 0)

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubTask.java
@@ -5,10 +5,10 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.application.commons.console.ping;
+package io.camunda.application.commons.hub.ping;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.retry.RetryConfiguration;
 import io.camunda.zeebe.util.retry.RetryDecorator;
@@ -22,21 +22,24 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PingConsoleTask implements Runnable {
+public class PingHubTask implements Runnable {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(PingConsoleTask.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(PingHubTask.class);
   private static final int MAX_RESPONSE_BODY_LENGTH = 1000;
   private final HttpClient client;
-  private final ConsolePingConfiguration pingConfiguration;
+  private final HubPingConfiguration pingConfiguration;
   private final RetryDecorator retryDecorator;
   private final String licensePayload;
+  private final M2MTokenProvider tokenProvider;
 
   @VisibleForTesting
-  public PingConsoleTask(
-      final ConsolePingConfiguration pingConfiguration,
+  public PingHubTask(
+      final HubPingConfiguration pingConfiguration,
+      final M2MTokenProvider tokenProvider,
       final HttpClient client,
       final String licensePayload) {
     this.pingConfiguration = pingConfiguration;
+    this.tokenProvider = tokenProvider;
     this.client = client;
     retryDecorator =
         new RetryDecorator(
@@ -46,40 +49,42 @@ public class PingConsoleTask implements Runnable {
     this.licensePayload = licensePayload;
   }
 
-  public PingConsoleTask(
-      final ConsolePingConfiguration pingConfiguration, final String licensePayload) {
-    this(pingConfiguration, HttpClient.newHttpClient(), licensePayload);
+  public PingHubTask(
+      final HubPingConfiguration pingConfiguration,
+      final M2MTokenProvider tokenProvider,
+      final String licensePayload) {
+    this(pingConfiguration, tokenProvider, HttpClient.newHttpClient(), licensePayload);
   }
 
   @Override
   public void run() {
     try {
+      final String token = tokenProvider.getToken();
       final HttpRequest request =
           HttpRequest.newBuilder()
               .uri(pingConfiguration.endpoint())
               .header("Accept", "application/json")
               .header("Content-Type", "application/json")
+              .header("Authorization", "Bearer " + token)
               .POST(HttpRequest.BodyPublishers.ofString(licensePayload))
               .build();
 
-      retryDecorator.decorate("Ping console.", () -> tryPingConsole(request));
+      retryDecorator.decorate("Ping Hub.", () -> tryPingHub(request));
 
     } catch (final Exception e) {
-      LOGGER.warn("Failed to execute Console ping task. Exception Message: {}", e.getMessage(), e);
+      LOGGER.warn("Failed to execute Hub ping task. Exception Message: {}", e.getMessage(), e);
     }
   }
 
   @VisibleForTesting
-  protected void tryPingConsole(final HttpRequest request) throws RetriableException {
+  protected void tryPingHub(final HttpRequest request) throws RetriableException {
     final HttpResponse<String> resp;
     try {
       resp = client.send(request, BodyHandlers.ofString());
     } catch (final IOException | InterruptedException e) {
-      // If the request fails due to a network issue, we should retry.
       throw new RetriableException("Network error: " + e.getMessage());
     }
 
-    // We should retry on server errors, timeouts or too many request.
     if (resp.statusCode() >= 500) {
       LOGGER.debug("Received server error: {}. A retry will be attempted.", resp.statusCode());
       throw new RetriableException("Server error: " + resp.statusCode(), resp.body());
@@ -88,7 +93,6 @@ public class PingConsoleTask implements Runnable {
       throw new RetriableException(
           "Too many requests or timeout: " + resp.statusCode(), resp.body());
     } else if (resp.statusCode() >= 400) {
-      // Should not retry for the remaining 4xx errors, but we log them.
       LOGGER.debug(
           "Received client error response: {}. No retry will be attempted.", resp.statusCode());
     }

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubTask.java
@@ -100,6 +100,12 @@ public class PingHubTask implements Runnable {
     }
   }
 
+  private static String truncate(final String s) {
+    return s.length() <= MAX_RESPONSE_BODY_LENGTH
+        ? s
+        : s.substring(0, MAX_RESPONSE_BODY_LENGTH) + "... [truncated]";
+  }
+
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public record LicensePayload(
       License license,
@@ -111,12 +117,6 @@ public class PingHubTask implements Runnable {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record License(
         boolean validLicense, String licenseType, boolean isCommercial, String expiresAt) {}
-  }
-
-  private static String truncate(final String s) {
-    return s.length() <= MAX_RESPONSE_BODY_LENGTH
-        ? s
-        : s.substring(0, MAX_RESPONSE_BODY_LENGTH) + "... [truncated]";
   }
 
   @VisibleForTesting

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubTask.java
@@ -93,8 +93,10 @@ public class PingHubTask implements Runnable {
       throw new RetriableException(
           "Too many requests or timeout: " + resp.statusCode(), resp.body());
     } else if (resp.statusCode() >= 400) {
-      LOGGER.debug(
-          "Received client error response: {}. No retry will be attempted.", resp.statusCode());
+      LOGGER.warn(
+          "Received client error response: {}. No retry will be attempted. Body: {}",
+          resp.statusCode(),
+          truncate(resp.body()));
     }
   }
 
@@ -109,6 +111,12 @@ public class PingHubTask implements Runnable {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record License(
         boolean validLicense, String licenseType, boolean isCommercial, String expiresAt) {}
+  }
+
+  private static String truncate(final String s) {
+    return s.length() <= MAX_RESPONSE_BODY_LENGTH
+        ? s
+        : s.substring(0, MAX_RESPONSE_BODY_LENGTH) + "... [truncated]";
   }
 
   @VisibleForTesting

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubTask.java
@@ -104,7 +104,7 @@ public class PingHubTask implements Runnable {
       String clusterId,
       String clusterName,
       String version,
-      @JsonInclude(JsonInclude.Include.NON_EMPTY) List<String> profiles,
+      List<String> profiles,
       Map<String, String> properties) {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record License(

--- a/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubTask.java
+++ b/dist/src/main/java/io/camunda/application/commons/hub/ping/PingHubTask.java
@@ -104,7 +104,7 @@ public class PingHubTask implements Runnable {
       String clusterId,
       String clusterName,
       String version,
-      List<String> profiles,
+      @JsonInclude(JsonInclude.Include.NON_EMPTY) List<String> profiles,
       Map<String, String> properties) {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record License(

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -1,0 +1,466 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.service.ManagementServices;
+import io.camunda.service.license.LicenseType;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.util.retry.RetryConfiguration;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+
+@ExtendWith(MockitoExtension.class)
+class PingConsoleConfigurationTest {
+
+  private static final ManagementServices MANAGEMENT_SERVICES = mock(ManagementServices.class);
+  private static final Environment ENVIRONMENT = mock(Environment.class);
+  private static final ApplicationContext APPLICATION_CONTEXT = mock(ApplicationContext.class);
+  private static final BrokerTopologyManager BROKER_TOPOLOGY_MANAGER =
+      mock(BrokerTopologyManager.class);
+  private static final ClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
+      mock(ClusterConfiguration.class);
+  private final ConsolePingConfiguration pingConfiguration =
+      new ConsolePingConfiguration(
+          true,
+          URI.create("http://fake-endpoint.com"),
+          "clusterName",
+          Duration.ofMillis(1000),
+          new RetryConfiguration(),
+          null);
+  private final String licensePayload =
+      "{\"type\":\"SAAS\",\"valid\":true,\"expiresAt\":null,\"commercial\":true}";
+  @Mock private HttpClient mockClient;
+
+  @BeforeAll
+  static void setUp() {
+    when(MANAGEMENT_SERVICES.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(MANAGEMENT_SERVICES.isCamundaLicenseValid()).thenReturn(true);
+    when(MANAGEMENT_SERVICES.isCommercialCamundaLicense()).thenReturn(true);
+    when(MANAGEMENT_SERVICES.getCamundaLicenseExpiresAt()).thenReturn(null);
+    when(APPLICATION_CONTEXT.getEnvironment()).thenReturn(ENVIRONMENT);
+    when(ENVIRONMENT.getActiveProfiles()).thenReturn(new String[] {"broker"});
+    when(BROKER_TOPOLOGY_MANAGER.getClusterConfiguration())
+        .thenReturn(BROKER_CLUSTER_CONFIGURATION);
+    when(BROKER_CLUSTER_CONFIGURATION.clusterId()).thenReturn(Optional.of("clusterId"));
+  }
+
+  @Test
+  void endpointShouldNotBeNull() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true, null, "clusterName", Duration.ofMillis(5000), new RetryConfiguration(), null);
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Ping endpoint must not be null.");
+  }
+
+  @Test
+  void endpointShouldBeValid() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("123"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null);
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Ping endpoint 123 must be a valid URI.");
+  }
+
+  @Test
+  void clusterNameMustNotBeNullOrEmpty() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null);
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Cluster name must not be null or empty.");
+  }
+
+  @Test
+  void pingPeriodMustBePositive() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(-333),
+            new RetryConfiguration(),
+            null);
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Ping period must be greater than zero.");
+  }
+
+  @Test
+  void numberOfMaxRetriesMustBePositive() {
+    // given
+    final RetryConfiguration retryConfiguration = new RetryConfiguration();
+    retryConfiguration.setMaxRetries(0);
+
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            retryConfiguration,
+            null);
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Number of max retries must be greater than zero.");
+  }
+
+  @Test
+  void retryDelayMultiplierMustBePositive() {
+    // given
+    final RetryConfiguration retryConfiguration = new RetryConfiguration();
+    retryConfiguration.setRetryDelayMultiplier(0.0);
+
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            retryConfiguration,
+            null);
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Retry delay multiplier must be greater than zero.");
+  }
+
+  @Test
+  void retryConfigurationCanBeNull() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            null,
+            null);
+
+    // then
+    assertThatCode(
+            () ->
+                new PingConsoleRunner(
+                    consolePingConfiguration,
+                    MANAGEMENT_SERVICES,
+                    APPLICATION_CONTEXT,
+                    BROKER_TOPOLOGY_MANAGER))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void maxRetryDelayMustBePositive() {
+    // given
+    final RetryConfiguration retryConfiguration = new RetryConfiguration();
+    retryConfiguration.setMaxRetryDelay(Duration.ofMillis(0));
+
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            retryConfiguration,
+            null);
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Max retry delay must be greater than zero.");
+  }
+
+  @Test
+  void minRetryDelayMustBePositive() {
+    // given
+    final RetryConfiguration retryConfiguration = new RetryConfiguration();
+    retryConfiguration.setMinRetryDelay(Duration.ofMillis(0));
+
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            retryConfiguration,
+            null);
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("Min retry delay must be greater than zero.");
+  }
+
+  @Test
+  void maxRetryDelayMustBeGreaterThanMinRetryDelay() {
+    // given
+    final RetryConfiguration retryConfiguration = new RetryConfiguration();
+    retryConfiguration.setMinRetryDelay(Duration.ofMillis(1000));
+    retryConfiguration.setMaxRetryDelay(Duration.ofMillis(500));
+
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            retryConfiguration,
+            null);
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft())
+        .isEqualTo("Max retry delay must be greater than or equal to min retry delay.");
+  }
+
+  @Test
+  void shouldSucceedToStartConsolePingForValidConfig() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null);
+    // then
+    assertThatCode(
+            () ->
+                new PingConsoleRunner(
+                    consolePingConfiguration,
+                    MANAGEMENT_SERVICES,
+                    APPLICATION_CONTEXT,
+                    BROKER_TOPOLOGY_MANAGER))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldNotThrowIfFeatureDisabled() {
+    // given an invalid config
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            false,
+            URI.create("123"),
+            null,
+            Duration.ofMillis(-300),
+            new RetryConfiguration(),
+            null);
+
+    // then we assert that it is not throwing an exception due to the feature being disabled
+    assertThatCode(
+            () ->
+                new PingConsoleRunner(
+                    consolePingConfiguration,
+                    MANAGEMENT_SERVICES,
+                    APPLICATION_CONTEXT,
+                    BROKER_TOPOLOGY_MANAGER))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void doesNotRetryOnSuccess() throws Exception {
+    // given
+    final HttpResponse<String> mockResponse = mock(HttpResponse.class);
+    when(mockResponse.statusCode()).thenReturn(200);
+    when(mockClient.send(
+            ArgumentMatchers.<HttpRequest>any(),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenReturn(mockResponse);
+
+    final PingConsoleTask realTask =
+        new PingConsoleTask(pingConfiguration, mockClient, licensePayload);
+    final PingConsoleTask spyTask = Mockito.spy(realTask);
+
+    spyTask.run();
+
+    // then it only runs once
+    verify(spyTask, times(1)).tryPingConsole(any(HttpRequest.class));
+  }
+
+  @Test
+  void shouldRetryOnSendException() throws Exception {
+    // given
+    final HttpResponse<String> mockResponse = mock(HttpResponse.class);
+    when(mockResponse.statusCode()).thenReturn(200);
+    when(mockClient.send(
+            ArgumentMatchers.<HttpRequest>any(),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenThrow(new IOException("IO error"))
+        .thenThrow(new InterruptedException("Interrupted connection error"))
+        .thenReturn(mockResponse); // 3rd try succeeds
+
+    final PingConsoleTask realTask =
+        new PingConsoleTask(pingConfiguration, mockClient, licensePayload);
+    final PingConsoleTask spyTask = Mockito.spy(realTask);
+
+    spyTask.run();
+
+    // then it retries 2 times and runs 3 times in total
+    verify(spyTask, times(3)).tryPingConsole(any(HttpRequest.class));
+  }
+
+  @Test
+  void shouldRetryOnSpecificStatusCodes() throws Exception {
+    // given
+    final HttpResponse<String> firstMockResponse = mock(HttpResponse.class);
+    final HttpResponse<String> secondMockResponse = mock(HttpResponse.class);
+    final HttpResponse<String> thirdMockResponse = mock(HttpResponse.class);
+    when(firstMockResponse.statusCode()).thenReturn(500);
+    when(secondMockResponse.statusCode()).thenReturn(429);
+    when(thirdMockResponse.statusCode()).thenReturn(200);
+    when(mockClient.send(
+            ArgumentMatchers.<HttpRequest>any(),
+            ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
+        .thenReturn(firstMockResponse)
+        .thenReturn(secondMockResponse)
+        .thenReturn(thirdMockResponse);
+
+    final PingConsoleTask realTask =
+        new PingConsoleTask(pingConfiguration, mockClient, licensePayload);
+    final PingConsoleTask spyTask = Mockito.spy(realTask);
+
+    spyTask.run();
+
+    // then it retries 2 times and runs 3 times in total
+    verify(spyTask, times(3)).tryPingConsole(any(HttpRequest.class));
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleConfigurationTest.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.application.commons.hub.ping.M2MCredentials;
+import io.camunda.application.commons.hub.ping.M2MTokenProvider;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -48,6 +50,10 @@ class PingConsoleConfigurationTest {
       mock(BrokerTopologyManager.class);
   private static final ClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
       mock(ClusterConfiguration.class);
+  private static final M2MCredentials VALID_CREDENTIALS =
+      new M2MCredentials(
+          URI.create("http://auth-server.com/token"), "test-client-id", "test-client-secret");
+
   private final ConsolePingConfiguration pingConfiguration =
       new ConsolePingConfiguration(
           true,
@@ -55,7 +61,8 @@ class PingConsoleConfigurationTest {
           "clusterName",
           Duration.ofMillis(1000),
           new RetryConfiguration(),
-          null);
+          null,
+          VALID_CREDENTIALS);
   private final String licensePayload =
       "{\"type\":\"SAAS\",\"valid\":true,\"expiresAt\":null,\"commercial\":true}";
   @Mock private HttpClient mockClient;
@@ -78,7 +85,13 @@ class PingConsoleConfigurationTest {
     // given
     final ConsolePingConfiguration consolePingConfiguration =
         new ConsolePingConfiguration(
-            true, null, "clusterName", Duration.ofMillis(5000), new RetryConfiguration(), null);
+            true,
+            null,
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            VALID_CREDENTIALS);
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -105,7 +118,8 @@ class PingConsoleConfigurationTest {
             "clusterName",
             Duration.ofMillis(5000),
             new RetryConfiguration(),
-            null);
+            null,
+            VALID_CREDENTIALS);
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -132,7 +146,8 @@ class PingConsoleConfigurationTest {
             "",
             Duration.ofMillis(5000),
             new RetryConfiguration(),
-            null);
+            null,
+            VALID_CREDENTIALS);
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -159,7 +174,8 @@ class PingConsoleConfigurationTest {
             "clusterName",
             Duration.ofMillis(-333),
             new RetryConfiguration(),
-            null);
+            null,
+            VALID_CREDENTIALS);
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -189,7 +205,8 @@ class PingConsoleConfigurationTest {
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -219,7 +236,8 @@ class PingConsoleConfigurationTest {
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -246,7 +264,8 @@ class PingConsoleConfigurationTest {
             "clusterName",
             Duration.ofMillis(5000),
             null,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
     // then
     assertThatCode(
@@ -272,7 +291,8 @@ class PingConsoleConfigurationTest {
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -302,7 +322,8 @@ class PingConsoleConfigurationTest {
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -333,7 +354,8 @@ class PingConsoleConfigurationTest {
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
     final PingConsoleRunner runner =
         new PingConsoleRunner(
@@ -352,6 +374,147 @@ class PingConsoleConfigurationTest {
   }
 
   @Test
+  void credentialsMustNotBeNull() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            null);
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("M2M credentials must not be null.");
+  }
+
+  @Test
+  void tokenEndpointMustNotBeNull() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            new M2MCredentials(null, "clientId", "secret"));
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("M2M token endpoint must not be null.");
+  }
+
+  @Test
+  void tokenEndpointMustBeValid() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            new M2MCredentials(URI.create("not-a-valid-uri"), "clientId", "secret"));
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft())
+        .isEqualTo("M2M token endpoint not-a-valid-uri must be a valid URI.");
+  }
+
+  @Test
+  void clientIdMustNotBeNullOrEmpty() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            new M2MCredentials(URI.create("http://auth-server.com/token"), "", "secret"));
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("M2M client ID must not be null or empty.");
+  }
+
+  @Test
+  void clientSecretMustNotBeNullOrEmpty() {
+    // given
+    final ConsolePingConfiguration consolePingConfiguration =
+        new ConsolePingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            new M2MCredentials(URI.create("http://auth-server.com/token"), "clientId", ""));
+
+    final PingConsoleRunner runner =
+        new PingConsoleRunner(
+            consolePingConfiguration,
+            MANAGEMENT_SERVICES,
+            APPLICATION_CONTEXT,
+            BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("M2M client secret must not be null or empty.");
+  }
+
+  @Test
   void shouldSucceedToStartConsolePingForValidConfig() {
     // given
     final ConsolePingConfiguration consolePingConfiguration =
@@ -361,7 +524,8 @@ class PingConsoleConfigurationTest {
             "clusterName",
             Duration.ofMillis(5000),
             new RetryConfiguration(),
-            null);
+            null,
+            VALID_CREDENTIALS);
     // then
     assertThatCode(
             () ->
@@ -383,6 +547,7 @@ class PingConsoleConfigurationTest {
             null,
             Duration.ofMillis(-300),
             new RetryConfiguration(),
+            null,
             null);
 
     // then we assert that it is not throwing an exception due to the feature being disabled
@@ -406,8 +571,16 @@ class PingConsoleConfigurationTest {
             ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
         .thenReturn(mockResponse);
 
+    final M2MTokenProvider tokenProvider =
+        new M2MTokenProvider(VALID_CREDENTIALS, mockClient) {
+          @Override
+          public synchronized String getToken() {
+            return "test-token";
+          }
+        };
+
     final PingConsoleTask realTask =
-        new PingConsoleTask(pingConfiguration, mockClient, licensePayload);
+        new PingConsoleTask(pingConfiguration, tokenProvider, mockClient, licensePayload);
     final PingConsoleTask spyTask = Mockito.spy(realTask);
 
     spyTask.run();
@@ -428,8 +601,16 @@ class PingConsoleConfigurationTest {
         .thenThrow(new InterruptedException("Interrupted connection error"))
         .thenReturn(mockResponse); // 3rd try succeeds
 
+    final M2MTokenProvider tokenProvider =
+        new M2MTokenProvider(VALID_CREDENTIALS, mockClient) {
+          @Override
+          public synchronized String getToken() {
+            return "test-token";
+          }
+        };
+
     final PingConsoleTask realTask =
-        new PingConsoleTask(pingConfiguration, mockClient, licensePayload);
+        new PingConsoleTask(pingConfiguration, tokenProvider, mockClient, licensePayload);
     final PingConsoleTask spyTask = Mockito.spy(realTask);
 
     spyTask.run();
@@ -454,8 +635,16 @@ class PingConsoleConfigurationTest {
         .thenReturn(secondMockResponse)
         .thenReturn(thirdMockResponse);
 
+    final M2MTokenProvider tokenProvider =
+        new M2MTokenProvider(VALID_CREDENTIALS, mockClient) {
+          @Override
+          public synchronized String getToken() {
+            return "test-token";
+          }
+        };
+
     final PingConsoleTask realTask =
-        new PingConsoleTask(pingConfiguration, mockClient, licensePayload);
+        new PingConsoleTask(pingConfiguration, tokenProvider, mockClient, licensePayload);
     final PingConsoleTask spyTask = Mockito.spy(realTask);
 
     spyTask.run();

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.application.commons.hub.ping.M2MCredentials;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -54,6 +55,14 @@ public class PingConsoleRunnerIT {
     wireMockServer = new WireMockServer(0);
     wireMockServer.start();
     configureFor("localhost", wireMockServer.port());
+    stubFor(
+        post(urlEqualTo("/token"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"access_token\":\"test-m2m-token\",\"token_type\":\"Bearer\",\"expires_in\":3600}")));
     stubFor(post(urlEqualTo("/ping")).willReturn(aResponse().withStatus(200).withBody("PONG")));
     when(BROKER_TOPOLOGY_MANAGER.getClusterConfiguration())
         .thenReturn(BROKER_CLUSTER_CONFIGURATION);
@@ -68,7 +77,7 @@ public class PingConsoleRunnerIT {
   @Test
   void shouldSendCorrectPayload() throws Exception {
     // given
-    final String mockUrl = "http://localhost:" + wireMockServer.port() + "/ping";
+    final String baseUrl = "http://localhost:" + wireMockServer.port();
     final Duration pingPeriod = Duration.ofMillis(200);
     final RetryConfiguration retryConfig = new RetryConfiguration();
     final String expectedBody =
@@ -97,9 +106,17 @@ public class PingConsoleRunnerIT {
     when(environment.getActiveProfiles())
         .thenReturn(new String[] {"gateway", "broker", "identity"});
 
+    final M2MCredentials credentials =
+        new M2MCredentials(URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret");
     final ConsolePingConfiguration config =
         new ConsolePingConfiguration(
-            true, URI.create(mockUrl), "test-cluster-name", pingPeriod, retryConfig, null);
+            true,
+            URI.create(baseUrl + "/ping"),
+            "test-cluster-name",
+            pingPeriod,
+            retryConfig,
+            null,
+            credentials);
 
     final PingConsoleRunner pingConsoleRunner =
         new PingConsoleRunner(
@@ -109,12 +126,10 @@ public class PingConsoleRunnerIT {
     pingConsoleRunner.run(null);
 
     // then
-    await()
-        .atMost(10, TimeUnit.SECONDS)
-        .until(() -> wireMockServer.getAllServeEvents().size() >= 3);
+    await().atMost(10, TimeUnit.SECONDS).until(() -> pingEventsCount() >= 3);
 
-    final List<ServeEvent> serveEvents = wireMockServer.getAllServeEvents();
-    final String actualBody = serveEvents.get(0).getRequest().getBodyAsString();
+    final List<ServeEvent> pingEvents = pingServeEvents();
+    final String actualBody = pingEvents.get(0).getRequest().getBodyAsString();
 
     final ObjectMapper mapper = new ObjectMapper();
     final JsonNode expected = mapper.readTree(expectedBody);
@@ -124,9 +139,9 @@ public class PingConsoleRunnerIT {
   }
 
   @Test
-  void shouldNotIncludeAuthorizationHeader() throws Exception {
+  void shouldSendM2MTokenInAuthorizationHeader() throws Exception {
     // given
-    final String mockUrl = "http://localhost:" + wireMockServer.port() + "/ping";
+    final String baseUrl = "http://localhost:" + wireMockServer.port();
 
     applicationContext = mock(ApplicationContext.class);
     final Environment environment = mock(Environment.class);
@@ -137,14 +152,17 @@ public class PingConsoleRunnerIT {
     when(applicationContext.getEnvironment()).thenReturn(environment);
     when(environment.getActiveProfiles()).thenReturn(new String[] {"broker"});
 
+    final M2MCredentials credentials =
+        new M2MCredentials(URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret");
     final ConsolePingConfiguration config =
         new ConsolePingConfiguration(
             true,
-            URI.create(mockUrl),
+            URI.create(baseUrl + "/ping"),
             "test-cluster-name",
             Duration.ofMillis(200),
             new RetryConfiguration(),
-            null);
+            null,
+            credentials);
 
     final PingConsoleRunner pingConsoleRunner =
         new PingConsoleRunner(
@@ -153,12 +171,24 @@ public class PingConsoleRunnerIT {
     // when
     pingConsoleRunner.run(null);
 
-    // then — legacy console ping sends no Authorization header
-    await()
-        .atMost(10, TimeUnit.SECONDS)
-        .until(() -> wireMockServer.getAllServeEvents().size() >= 1);
+    // then
+    await().atMost(10, TimeUnit.SECONDS).until(() -> pingEventsCount() >= 1);
 
-    final List<ServeEvent> serveEvents = wireMockServer.getAllServeEvents();
-    assertThat(serveEvents.get(0).getRequest().containsHeader("Authorization")).isFalse();
+    final List<ServeEvent> pingEvents = pingServeEvents();
+    assertThat(pingEvents).isNotEmpty();
+    assertThat(pingEvents.get(0).getRequest().getHeader("Authorization"))
+        .isEqualTo("Bearer test-m2m-token");
+  }
+
+  private long pingEventsCount() {
+    return wireMockServer.getAllServeEvents().stream()
+        .filter(e -> e.getRequest().getUrl().equals("/ping"))
+        .count();
+  }
+
+  private List<ServeEvent> pingServeEvents() {
+    return wireMockServer.getAllServeEvents().stream()
+        .filter(e -> e.getRequest().getUrl().equals("/ping"))
+        .toList();
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/console/ping/PingConsoleRunnerIT.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.console.ping;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
+import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.service.ManagementServices;
+import io.camunda.service.license.LicenseType;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.retry.RetryConfiguration;
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+
+public class PingConsoleRunnerIT {
+
+  private static final BrokerTopologyManager BROKER_TOPOLOGY_MANAGER =
+      mock(BrokerTopologyManager.class);
+  private static final ClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
+      mock(ClusterConfiguration.class);
+  private ApplicationContext applicationContext;
+  private WireMockServer wireMockServer;
+  private ManagementServices managementServices;
+
+  @BeforeEach
+  void setup() {
+    wireMockServer = new WireMockServer(0);
+    wireMockServer.start();
+    configureFor("localhost", wireMockServer.port());
+    stubFor(post(urlEqualTo("/ping")).willReturn(aResponse().withStatus(200).withBody("PONG")));
+    when(BROKER_TOPOLOGY_MANAGER.getClusterConfiguration())
+        .thenReturn(BROKER_CLUSTER_CONFIGURATION);
+    when(BROKER_CLUSTER_CONFIGURATION.clusterId()).thenReturn(Optional.of("test-cluster-id"));
+  }
+
+  @AfterEach
+  void tearDown() {
+    wireMockServer.stop();
+  }
+
+  @Test
+  void shouldSendCorrectPayload() throws Exception {
+    // given
+    final String mockUrl = "http://localhost:" + wireMockServer.port() + "/ping";
+    final Duration pingPeriod = Duration.ofMillis(200);
+    final RetryConfiguration retryConfig = new RetryConfiguration();
+    final String expectedBody =
+        """
+      {
+        "license": {
+          "validLicense": true,
+          "licenseType": "saas",
+          "isCommercial": true
+        },
+        "clusterId": "test-cluster-id",
+        "clusterName": "test-cluster-name",
+        "version":"%s",
+        "profiles": ["gateway", "broker"]
+      }
+    """
+            .formatted(VersionUtil.getVersion());
+
+    applicationContext = mock(ApplicationContext.class);
+    final Environment environment = mock(Environment.class);
+    managementServices = mock(ManagementServices.class);
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(applicationContext.getEnvironment()).thenReturn(environment);
+    when(environment.getActiveProfiles())
+        .thenReturn(new String[] {"gateway", "broker", "identity"});
+
+    final ConsolePingConfiguration config =
+        new ConsolePingConfiguration(
+            true, URI.create(mockUrl), "test-cluster-name", pingPeriod, retryConfig, null);
+
+    final PingConsoleRunner pingConsoleRunner =
+        new PingConsoleRunner(
+            config, managementServices, applicationContext, BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    pingConsoleRunner.run(null);
+
+    // then
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .until(() -> wireMockServer.getAllServeEvents().size() >= 3);
+
+    final List<ServeEvent> serveEvents = wireMockServer.getAllServeEvents();
+    final String actualBody = serveEvents.get(0).getRequest().getBodyAsString();
+
+    final ObjectMapper mapper = new ObjectMapper();
+    final JsonNode expected = mapper.readTree(expectedBody);
+    final JsonNode actual = mapper.readTree(actualBody);
+
+    assertThat(actual).as("JSON payload did not match expected structure").isEqualTo(expected);
+  }
+
+  @Test
+  void shouldNotIncludeAuthorizationHeader() throws Exception {
+    // given
+    final String mockUrl = "http://localhost:" + wireMockServer.port() + "/ping";
+
+    applicationContext = mock(ApplicationContext.class);
+    final Environment environment = mock(Environment.class);
+    managementServices = mock(ManagementServices.class);
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(applicationContext.getEnvironment()).thenReturn(environment);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {"broker"});
+
+    final ConsolePingConfiguration config =
+        new ConsolePingConfiguration(
+            true,
+            URI.create(mockUrl),
+            "test-cluster-name",
+            Duration.ofMillis(200),
+            new RetryConfiguration(),
+            null);
+
+    final PingConsoleRunner pingConsoleRunner =
+        new PingConsoleRunner(
+            config, managementServices, applicationContext, BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    pingConsoleRunner.run(null);
+
+    // then — legacy console ping sends no Authorization header
+    await()
+        .atMost(10, TimeUnit.SECONDS)
+        .until(() -> wireMockServer.getAllServeEvents().size() >= 1);
+
+    final List<ServeEvent> serveEvents = wireMockServer.getAllServeEvents();
+    assertThat(serveEvents.get(0).getRequest().containsHeader("Authorization")).isFalse();
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubConfigurationTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration;
-import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration.M2MCredentials;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubConfigurationTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.application.commons.console.ping;
+package io.camunda.application.commons.hub.ping;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
@@ -15,7 +15,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration;
+import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration.M2MCredentials;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -39,7 +40,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 
 @ExtendWith(MockitoExtension.class)
-class PingConsoleConfigurationTest {
+class PingHubConfigurationTest {
 
   private static final ManagementServices MANAGEMENT_SERVICES = mock(ManagementServices.class);
   private static final Environment ENVIRONMENT = mock(Environment.class);
@@ -48,14 +49,19 @@ class PingConsoleConfigurationTest {
       mock(BrokerTopologyManager.class);
   private static final ClusterConfiguration BROKER_CLUSTER_CONFIGURATION =
       mock(ClusterConfiguration.class);
-  private final ConsolePingConfiguration pingConfiguration =
-      new ConsolePingConfiguration(
+  private static final M2MCredentials VALID_CREDENTIALS =
+      new M2MCredentials(
+          URI.create("http://auth-server.com/token"), "test-client-id", "test-client-secret");
+
+  private final HubPingConfiguration pingConfiguration =
+      new HubPingConfiguration(
           true,
           URI.create("http://fake-endpoint.com"),
           "clusterName",
           Duration.ofMillis(1000),
           new RetryConfiguration(),
-          null);
+          null,
+          VALID_CREDENTIALS);
   private final String licensePayload =
       "{\"type\":\"SAAS\",\"valid\":true,\"expiresAt\":null,\"commercial\":true}";
   @Mock private HttpClient mockClient;
@@ -76,16 +82,19 @@ class PingConsoleConfigurationTest {
   @Test
   void endpointShouldNotBeNull() {
     // given
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
-            true, null, "clusterName", Duration.ofMillis(5000), new RetryConfiguration(), null);
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
+            true,
+            null,
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            VALID_CREDENTIALS);
 
-    final PingConsoleRunner runner =
-        new PingConsoleRunner(
-            consolePingConfiguration,
-            MANAGEMENT_SERVICES,
-            APPLICATION_CONTEXT,
-            BROKER_TOPOLOGY_MANAGER);
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
 
     // when
     final var result = runner.validateConfiguration();
@@ -98,21 +107,19 @@ class PingConsoleConfigurationTest {
   @Test
   void endpointShouldBeValid() {
     // given
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             true,
             URI.create("123"),
             "clusterName",
             Duration.ofMillis(5000),
             new RetryConfiguration(),
-            null);
+            null,
+            VALID_CREDENTIALS);
 
-    final PingConsoleRunner runner =
-        new PingConsoleRunner(
-            consolePingConfiguration,
-            MANAGEMENT_SERVICES,
-            APPLICATION_CONTEXT,
-            BROKER_TOPOLOGY_MANAGER);
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
 
     // when
     final var result = runner.validateConfiguration();
@@ -125,21 +132,19 @@ class PingConsoleConfigurationTest {
   @Test
   void clusterNameMustNotBeNullOrEmpty() {
     // given
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             true,
             URI.create("http://localhost:8080"),
             "",
             Duration.ofMillis(5000),
             new RetryConfiguration(),
-            null);
+            null,
+            VALID_CREDENTIALS);
 
-    final PingConsoleRunner runner =
-        new PingConsoleRunner(
-            consolePingConfiguration,
-            MANAGEMENT_SERVICES,
-            APPLICATION_CONTEXT,
-            BROKER_TOPOLOGY_MANAGER);
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
 
     // when
     final var result = runner.validateConfiguration();
@@ -152,21 +157,19 @@ class PingConsoleConfigurationTest {
   @Test
   void pingPeriodMustBePositive() {
     // given
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             true,
             URI.create("http://localhost:8080"),
             "clusterName",
             Duration.ofMillis(-333),
             new RetryConfiguration(),
-            null);
+            null,
+            VALID_CREDENTIALS);
 
-    final PingConsoleRunner runner =
-        new PingConsoleRunner(
-            consolePingConfiguration,
-            MANAGEMENT_SERVICES,
-            APPLICATION_CONTEXT,
-            BROKER_TOPOLOGY_MANAGER);
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
 
     // when
     final var result = runner.validateConfiguration();
@@ -182,21 +185,19 @@ class PingConsoleConfigurationTest {
     final RetryConfiguration retryConfiguration = new RetryConfiguration();
     retryConfiguration.setMaxRetries(0);
 
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             true,
             URI.create("http://localhost:8080"),
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
-    final PingConsoleRunner runner =
-        new PingConsoleRunner(
-            consolePingConfiguration,
-            MANAGEMENT_SERVICES,
-            APPLICATION_CONTEXT,
-            BROKER_TOPOLOGY_MANAGER);
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
 
     // when
     final var result = runner.validateConfiguration();
@@ -212,21 +213,19 @@ class PingConsoleConfigurationTest {
     final RetryConfiguration retryConfiguration = new RetryConfiguration();
     retryConfiguration.setRetryDelayMultiplier(0.0);
 
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             true,
             URI.create("http://localhost:8080"),
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
-    final PingConsoleRunner runner =
-        new PingConsoleRunner(
-            consolePingConfiguration,
-            MANAGEMENT_SERVICES,
-            APPLICATION_CONTEXT,
-            BROKER_TOPOLOGY_MANAGER);
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
 
     // when
     final var result = runner.validateConfiguration();
@@ -239,21 +238,21 @@ class PingConsoleConfigurationTest {
   @Test
   void retryConfigurationCanBeNull() {
     // given
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             true,
             URI.create("http://localhost:8080"),
             "clusterName",
             Duration.ofMillis(5000),
             null,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
     // then
     assertThatCode(
             () ->
-                new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES,
-                    APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER))
+                new PingHubRunner(
+                    config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER))
         .doesNotThrowAnyException();
   }
 
@@ -263,21 +262,19 @@ class PingConsoleConfigurationTest {
     final RetryConfiguration retryConfiguration = new RetryConfiguration();
     retryConfiguration.setMaxRetryDelay(Duration.ofMillis(0));
 
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             true,
             URI.create("http://localhost:8080"),
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
-    final PingConsoleRunner runner =
-        new PingConsoleRunner(
-            consolePingConfiguration,
-            MANAGEMENT_SERVICES,
-            APPLICATION_CONTEXT,
-            BROKER_TOPOLOGY_MANAGER);
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
 
     // when
     final var result = runner.validateConfiguration();
@@ -293,21 +290,19 @@ class PingConsoleConfigurationTest {
     final RetryConfiguration retryConfiguration = new RetryConfiguration();
     retryConfiguration.setMinRetryDelay(Duration.ofMillis(0));
 
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             true,
             URI.create("http://localhost:8080"),
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
-    final PingConsoleRunner runner =
-        new PingConsoleRunner(
-            consolePingConfiguration,
-            MANAGEMENT_SERVICES,
-            APPLICATION_CONTEXT,
-            BROKER_TOPOLOGY_MANAGER);
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
 
     // when
     final var result = runner.validateConfiguration();
@@ -324,21 +319,19 @@ class PingConsoleConfigurationTest {
     retryConfiguration.setMinRetryDelay(Duration.ofMillis(1000));
     retryConfiguration.setMaxRetryDelay(Duration.ofMillis(500));
 
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             true,
             URI.create("http://localhost:8080"),
             "clusterName",
             Duration.ofMillis(5000),
             retryConfiguration,
-            null);
+            null,
+            VALID_CREDENTIALS);
 
-    final PingConsoleRunner runner =
-        new PingConsoleRunner(
-            consolePingConfiguration,
-            MANAGEMENT_SERVICES,
-            APPLICATION_CONTEXT,
-            BROKER_TOPOLOGY_MANAGER);
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
 
     // when
     final var result = runner.validateConfiguration();
@@ -350,43 +343,170 @@ class PingConsoleConfigurationTest {
   }
 
   @Test
-  void shouldSucceedToStartConsolePingForValidConfig() {
+  void credentialsMustNotBeNull() {
     // given
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             true,
             URI.create("http://localhost:8080"),
             "clusterName",
             Duration.ofMillis(5000),
             new RetryConfiguration(),
+            null,
             null);
+
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("M2M credentials must not be null.");
+  }
+
+  @Test
+  void tokenEndpointMustNotBeNull() {
+    // given
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            new M2MCredentials(null, "clientId", "secret"));
+
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("M2M token endpoint must not be null.");
+  }
+
+  @Test
+  void tokenEndpointMustBeValid() {
+    // given
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            new M2MCredentials(URI.create("not-a-valid-uri"), "clientId", "secret"));
+
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft())
+        .isEqualTo("M2M token endpoint not-a-valid-uri must be a valid URI.");
+  }
+
+  @Test
+  void clientIdMustNotBeNullOrEmpty() {
+    // given
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            new M2MCredentials(URI.create("http://auth-server.com/token"), "", "secret"));
+
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("M2M client ID must not be null or empty.");
+  }
+
+  @Test
+  void clientSecretMustNotBeNullOrEmpty() {
+    // given
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            new M2MCredentials(URI.create("http://auth-server.com/token"), "clientId", ""));
+
+    final PingHubRunner runner =
+        new PingHubRunner(
+            config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    final var result = runner.validateConfiguration();
+
+    // then
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).isEqualTo("M2M client secret must not be null or empty.");
+  }
+
+  @Test
+  void shouldSucceedToStartHubPingForValidConfig() {
+    // given
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
+            true,
+            URI.create("http://localhost:8080"),
+            "clusterName",
+            Duration.ofMillis(5000),
+            new RetryConfiguration(),
+            null,
+            VALID_CREDENTIALS);
+
     // then
     assertThatCode(
             () ->
-                new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES,
-                    APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER))
+                new PingHubRunner(
+                    config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER))
         .doesNotThrowAnyException();
   }
 
   @Test
   void shouldNotThrowIfFeatureDisabled() {
     // given an invalid config
-    final ConsolePingConfiguration consolePingConfiguration =
-        new ConsolePingConfiguration(
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
             false,
             URI.create("123"),
             null,
             Duration.ofMillis(-300),
             new RetryConfiguration(),
+            null,
             null);
 
     // then we assert that it is not throwing an exception due to the feature being disabled
     assertThatCode(
             () ->
-                new PingConsoleRunner(
-                    consolePingConfiguration, MANAGEMENT_SERVICES,
-                    APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER))
+                new PingHubRunner(
+                    config, MANAGEMENT_SERVICES, APPLICATION_CONTEXT, BROKER_TOPOLOGY_MANAGER))
         .doesNotThrowAnyException();
   }
 
@@ -394,24 +514,29 @@ class PingConsoleConfigurationTest {
   void doesNotRetryOnSuccess() throws Exception {
     // given
     final HttpResponse<String> mockResponse = mock(HttpResponse.class);
-
-    //  when simulate a successful response
     when(mockResponse.statusCode()).thenReturn(200);
-
     when(mockClient.send(
             ArgumentMatchers.<HttpRequest>any(),
             ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
         .thenReturn(mockResponse);
 
-    final PingConsoleTask realTask =
-        new PingConsoleTask(pingConfiguration, mockClient, licensePayload);
+    final M2MTokenProvider tokenProvider =
+        new M2MTokenProvider(VALID_CREDENTIALS, mockClient) {
+          @Override
+          public synchronized String getToken() {
+            return "test-token";
+          }
+        };
 
-    final PingConsoleTask spyTask = Mockito.spy(realTask);
+    final PingHubTask realTask =
+        new PingHubTask(pingConfiguration, tokenProvider, mockClient, licensePayload);
+    final PingHubTask spyTask = Mockito.spy(realTask);
 
+    // when
     spyTask.run();
 
     // then it only runs once
-    verify(spyTask, times(1)).tryPingConsole(any(HttpRequest.class));
+    verify(spyTask, times(1)).tryPingHub(any(HttpRequest.class));
   }
 
   @Test
@@ -419,8 +544,6 @@ class PingConsoleConfigurationTest {
     // given
     final HttpResponse<String> mockResponse = mock(HttpResponse.class);
     when(mockResponse.statusCode()).thenReturn(200);
-
-    // when we simulate 2 failures and 1 success
     when(mockClient.send(
             ArgumentMatchers.<HttpRequest>any(),
             ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
@@ -428,15 +551,23 @@ class PingConsoleConfigurationTest {
         .thenThrow(new InterruptedException("Interrupted connection error"))
         .thenReturn(mockResponse); // 3rd try succeeds
 
-    final PingConsoleTask realTask =
-        new PingConsoleTask(pingConfiguration, mockClient, licensePayload);
+    final M2MTokenProvider tokenProvider =
+        new M2MTokenProvider(VALID_CREDENTIALS, mockClient) {
+          @Override
+          public synchronized String getToken() {
+            return "test-token";
+          }
+        };
 
-    final PingConsoleTask spyTask = Mockito.spy(realTask);
+    final PingHubTask realTask =
+        new PingHubTask(pingConfiguration, tokenProvider, mockClient, licensePayload);
+    final PingHubTask spyTask = Mockito.spy(realTask);
 
+    // when
     spyTask.run();
 
     // then it retries 2 times and runs 3 times in total
-    verify(spyTask, times(3)).tryPingConsole(any(HttpRequest.class));
+    verify(spyTask, times(3)).tryPingHub(any(HttpRequest.class));
   }
 
   @Test
@@ -445,12 +576,9 @@ class PingConsoleConfigurationTest {
     final HttpResponse<String> firstMockResponse = mock(HttpResponse.class);
     final HttpResponse<String> secondMockResponse = mock(HttpResponse.class);
     final HttpResponse<String> thirdMockResponse = mock(HttpResponse.class);
-
-    // when we simulate 2 failed responses (server error and timeout) followed by 1 success:
     when(firstMockResponse.statusCode()).thenReturn(500);
     when(secondMockResponse.statusCode()).thenReturn(429);
     when(thirdMockResponse.statusCode()).thenReturn(200);
-
     when(mockClient.send(
             ArgumentMatchers.<HttpRequest>any(),
             ArgumentMatchers.<HttpResponse.BodyHandler<String>>any()))
@@ -458,14 +586,22 @@ class PingConsoleConfigurationTest {
         .thenReturn(secondMockResponse)
         .thenReturn(thirdMockResponse);
 
-    final PingConsoleTask realTask =
-        new PingConsoleTask(pingConfiguration, mockClient, licensePayload);
+    final M2MTokenProvider tokenProvider =
+        new M2MTokenProvider(VALID_CREDENTIALS, mockClient) {
+          @Override
+          public synchronized String getToken() {
+            return "test-token";
+          }
+        };
 
-    final PingConsoleTask spyTask = Mockito.spy(realTask);
+    final PingHubTask realTask =
+        new PingHubTask(pingConfiguration, tokenProvider, mockClient, licensePayload);
+    final PingHubTask spyTask = Mockito.spy(realTask);
 
+    // when
     spyTask.run();
 
     // then it retries 2 times and runs 3 times in total
-    verify(spyTask, times(3)).tryPingConsole(any(HttpRequest.class));
+    verify(spyTask, times(3)).tryPingHub(any(HttpRequest.class));
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration;
-import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration.M2MCredentials;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;

--- a/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
+++ b/dist/src/test/java/io/camunda/application/commons/hub/ping/PingHubRunnerIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.application.commons.console.ping;
+package io.camunda.application.commons.hub.ping;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
@@ -21,7 +21,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
-import io.camunda.application.commons.console.ping.PingConsoleRunner.ConsolePingConfiguration;
+import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration;
+import io.camunda.application.commons.hub.ping.PingHubRunner.HubPingConfiguration.M2MCredentials;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.LicenseType;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -39,7 +40,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 
-public class PingConsoleRunnerIT {
+public class PingHubRunnerIT {
 
   private static final BrokerTopologyManager BROKER_TOPOLOGY_MANAGER =
       mock(BrokerTopologyManager.class);
@@ -54,6 +55,14 @@ public class PingConsoleRunnerIT {
     wireMockServer = new WireMockServer(0);
     wireMockServer.start();
     configureFor("localhost", wireMockServer.port());
+    stubFor(
+        post(urlEqualTo("/token"))
+            .willReturn(
+                aResponse()
+                    .withStatus(200)
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(
+                        "{\"access_token\":\"test-m2m-token\",\"token_type\":\"Bearer\",\"expires_in\":3600}")));
     stubFor(post(urlEqualTo("/ping")).willReturn(aResponse().withStatus(200).withBody("PONG")));
     when(BROKER_TOPOLOGY_MANAGER.getClusterConfiguration())
         .thenReturn(BROKER_CLUSTER_CONFIGURATION);
@@ -68,7 +77,7 @@ public class PingConsoleRunnerIT {
   @Test
   void shouldSendCorrectPayload() throws Exception {
     // given
-    final String mockUrl = "http://localhost:" + wireMockServer.port() + "/ping";
+    final String baseUrl = "http://localhost:" + wireMockServer.port();
     final Duration pingPeriod = Duration.ofMillis(200);
     final RetryConfiguration retryConfig = new RetryConfiguration();
     final String expectedBody =
@@ -97,30 +106,89 @@ public class PingConsoleRunnerIT {
     when(environment.getActiveProfiles())
         .thenReturn(new String[] {"gateway", "broker", "identity"});
 
-    final ConsolePingConfiguration config =
-        new ConsolePingConfiguration(
-            true, URI.create(mockUrl), "test-cluster-name", pingPeriod, retryConfig, null);
+    final M2MCredentials credentials =
+        new M2MCredentials(URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret");
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
+            true,
+            URI.create(baseUrl + "/ping"),
+            "test-cluster-name",
+            pingPeriod,
+            retryConfig,
+            null,
+            credentials);
 
-    final PingConsoleRunner pingConsoleRunner =
-        new PingConsoleRunner(
-            config, managementServices, applicationContext, BROKER_TOPOLOGY_MANAGER);
+    final PingHubRunner pingHubRunner =
+        new PingHubRunner(config, managementServices, applicationContext, BROKER_TOPOLOGY_MANAGER);
 
     // when
-    pingConsoleRunner.run(null);
+    pingHubRunner.run(null);
 
     // then
-    await()
-        .atMost(10, TimeUnit.SECONDS)
-        .until(() -> wireMockServer.getAllServeEvents().size() >= 3);
+    await().atMost(10, TimeUnit.SECONDS).until(() -> pingEventsCount() >= 3);
 
-    // we validate the first request received by the mock server
-    final List<ServeEvent> serveEvents = wireMockServer.getAllServeEvents();
-    final String actualBody = serveEvents.get(0).getRequest().getBodyAsString();
+    // validate the first ping request received by the mock server
+    final List<ServeEvent> pingEvents = pingServeEvents();
+    assertThat(pingEvents).isNotEmpty();
 
+    final String actualBody = pingEvents.get(0).getRequest().getBodyAsString();
     final ObjectMapper mapper = new ObjectMapper();
     final JsonNode expected = mapper.readTree(expectedBody);
     final JsonNode actual = mapper.readTree(actualBody);
-
     assertThat(actual).as("JSON payload did not match expected structure").isEqualTo(expected);
+  }
+
+  @Test
+  void shouldSendM2MTokenInAuthorizationHeader() throws Exception {
+    // given
+    final String baseUrl = "http://localhost:" + wireMockServer.port();
+    final Duration pingPeriod = Duration.ofMillis(200);
+
+    applicationContext = mock(ApplicationContext.class);
+    final Environment environment = mock(Environment.class);
+    managementServices = mock(ManagementServices.class);
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(applicationContext.getEnvironment()).thenReturn(environment);
+    when(environment.getActiveProfiles()).thenReturn(new String[] {"broker"});
+
+    final M2MCredentials credentials =
+        new M2MCredentials(URI.create(baseUrl + "/token"), "test-client-id", "test-client-secret");
+    final HubPingConfiguration config =
+        new HubPingConfiguration(
+            true,
+            URI.create(baseUrl + "/ping"),
+            "test-cluster-name",
+            pingPeriod,
+            new RetryConfiguration(),
+            null,
+            credentials);
+
+    final PingHubRunner pingHubRunner =
+        new PingHubRunner(config, managementServices, applicationContext, BROKER_TOPOLOGY_MANAGER);
+
+    // when
+    pingHubRunner.run(null);
+
+    // then
+    await().atMost(10, TimeUnit.SECONDS).until(() -> pingEventsCount() >= 1);
+
+    final List<ServeEvent> pingEvents = pingServeEvents();
+    assertThat(pingEvents).isNotEmpty();
+    assertThat(pingEvents.get(0).getRequest().getHeader("Authorization"))
+        .isEqualTo("Bearer test-m2m-token");
+  }
+
+  private long pingEventsCount() {
+    return wireMockServer.getAllServeEvents().stream()
+        .filter(e -> e.getRequest().getUrl().equals("/ping"))
+        .count();
+  }
+
+  private List<ServeEvent> pingServeEvents() {
+    return wireMockServer.getAllServeEvents().stream()
+        .filter(e -> e.getRequest().getUrl().equals("/ping"))
+        .toList();
   }
 }


### PR DESCRIPTION
Replaces the camunda.console.ping configuration with camunda.hub.ping, renaming all classes and package from console/ping to hub/ping.

Adds M2M token support: PingHubTask now fetches an OAuth2 client credentials token before each ping period and attaches it as a Bearer Authorization header. The token is cached and refreshed automatically before expiry.

New config keys:
  camunda.hub.ping.credentials.token-endpoint
  camunda.hub.ping.credentials.client-id
  camunda.hub.ping.credentials.client-secret

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/50924
