### PR TITLE
feat: add wait-state statistics service layer and REST endpoint

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsTenantReaders.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/RdbmsTenantReaders.java
@@ -50,6 +50,7 @@ import io.camunda.db.rdbms.read.service.UserDbReader;
 import io.camunda.db.rdbms.read.service.UserTaskDbReader;
 import io.camunda.db.rdbms.read.service.VariableDbReader;
 import io.camunda.db.rdbms.read.service.WaitStateDbReader;
+import io.camunda.db.rdbms.read.service.WaitStateStatisticsDbReader;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.search.clients.reader.SearchClientReaders;
 
@@ -103,7 +104,8 @@ public record RdbmsTenantReaders(
     UserDbReader userReader,
     UserTaskDbReader userTaskReader,
     VariableDbReader variableReader,
-    WaitStateDbReader waitStateReader) {
+    WaitStateDbReader waitStateReader,
+    WaitStateStatisticsDbReader waitStateStatisticsReader) {
 
   public static RdbmsTenantReaders create(
       final RdbmsMapperBundle mappers, final RdbmsReaderConfig readerConfig) {
@@ -156,7 +158,8 @@ public record RdbmsTenantReaders(
         new UserDbReader(mappers.userMapper(), readerConfig),
         new UserTaskDbReader(mappers.userTaskMapper(), readerConfig),
         new VariableDbReader(mappers.variableMapper(), readerConfig),
-        new WaitStateDbReader(mappers.waitStateMapper(), readerConfig));
+        new WaitStateDbReader(mappers.waitStateMapper(), readerConfig),
+        new WaitStateStatisticsDbReader(readerConfig));
   }
 
   public SearchClientReaders toSearchClientReaders() {
@@ -202,6 +205,7 @@ public record RdbmsTenantReaders(
         incidentProcessInstanceStatisticsByErrorReader,
         incidentProcessInstanceStatisticsByDefinitionReader,
         globalListenerReader,
-        waitStateReader);
+        waitStateReader,
+        waitStateStatisticsReader);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/WaitStateStatisticsDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/WaitStateStatisticsDbReader.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.read.RdbmsReaderConfig;
+import io.camunda.search.clients.reader.WaitStateStatisticsReader;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
+import io.camunda.search.query.WaitStateStatisticsQuery;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import java.util.Collections;
+import java.util.List;
+
+// STUB: returns an empty result. The data-layer task implements the GROUP BY query
+// (SELECT element_id, COUNT(*) ... GROUP BY element_id). See issue #56254 / parent #56239.
+public class WaitStateStatisticsDbReader extends AbstractEntityReader<WaitStateStatisticsEntity>
+    implements WaitStateStatisticsReader {
+
+  public WaitStateStatisticsDbReader(final RdbmsReaderConfig readerConfig) {
+    super(null, readerConfig);
+  }
+
+  @Override
+  public List<WaitStateStatisticsEntity> aggregate(
+      final WaitStateStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return Collections.emptyList();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
@@ -52,6 +52,7 @@ import io.camunda.search.clients.reader.UserDocumentReader;
 import io.camunda.search.clients.reader.UserTaskDocumentReader;
 import io.camunda.search.clients.reader.VariableDocumentReader;
 import io.camunda.search.clients.reader.WaitStateDocumentReader;
+import io.camunda.search.clients.reader.WaitStateStatisticsDocumentReader;
 import io.camunda.search.clients.reader.utils.IncidentErrorHashCodeNormalizer;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.index.AuthorizationIndex;
@@ -125,6 +126,8 @@ public final class SearchClientReadersFactory {
             executor, descriptors.get(FlowNodeInstanceTemplate.class));
     final var waitStateReader =
         new WaitStateDocumentReader(executor, descriptors.get(WaitStateTemplate.class));
+    final var waitStateStatisticsReader =
+        new WaitStateStatisticsDocumentReader(executor, descriptors.get(WaitStateTemplate.class));
     final var formReader = new FormDocumentReader(executor, descriptors.get(FormIndex.class));
     final var incidentReader =
         new IncidentDocumentReader(executor, descriptors.get(IncidentTemplate.class));
@@ -258,6 +261,7 @@ public final class SearchClientReadersFactory {
         incidentProcessInstanceStatisticsByErrorReader,
         incidentProcessInstanceStatisticsByDefinitionReader,
         globalListenerReader,
-        waitStateReader);
+        waitStateReader,
+        waitStateStatisticsReader);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -206,6 +206,7 @@ public class CamundaServicesConfiguration {
                       securityContextProvider,
                       search,
                       search,
+                      search,
                       incident,
                       executor,
                       converter,

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -356,7 +356,7 @@ public final class SearchQueryResponseMapper {
       final WaitStateStatisticsEntity entity) {
     return ProcessInstanceWaitStateStatisticsResult.Builder.create()
         .elementId(entity.elementId())
-        .waitingCount(entity.count())
+        .waitingCount(entity.waitingCount())
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -137,6 +137,8 @@ import io.camunda.gateway.protocol.model.ProcessInstanceSearchQueryResult;
 import io.camunda.gateway.protocol.model.ProcessInstanceSequenceFlowResult;
 import io.camunda.gateway.protocol.model.ProcessInstanceSequenceFlowsQueryResult;
 import io.camunda.gateway.protocol.model.ProcessInstanceStateEnum;
+import io.camunda.gateway.protocol.model.ProcessInstanceWaitStateStatisticsQueryResult;
+import io.camunda.gateway.protocol.model.ProcessInstanceWaitStateStatisticsResult;
 import io.camunda.gateway.protocol.model.ResourceResult;
 import io.camunda.gateway.protocol.model.ResourceSearchQueryResult;
 import io.camunda.gateway.protocol.model.ResourceTypeEnum;
@@ -232,6 +234,7 @@ import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
 import io.camunda.search.entities.WaitStateMessageDetails;
 import io.camunda.search.entities.WaitStateSignalDetails;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.entities.WaitStateTimerDetails;
 import io.camunda.search.entities.WaitStateUserTaskDetails;
 import io.camunda.search.query.SearchQueryResult;
@@ -339,6 +342,21 @@ public final class SearchQueryResponseMapper {
         .completed(result.completed())
         .elementId(result.flowNodeId())
         .incidents(result.incidents())
+        .build();
+  }
+
+  public static ProcessInstanceWaitStateStatisticsQueryResult
+      toProcessInstanceWaitStateStatisticsResult(final List<WaitStateStatisticsEntity> result) {
+    return ProcessInstanceWaitStateStatisticsQueryResult.Builder.create()
+        .items(result.stream().map(SearchQueryResponseMapper::toWaitStateStatisticsResult).toList())
+        .build();
+  }
+
+  private static ProcessInstanceWaitStateStatisticsResult toWaitStateStatisticsResult(
+      final WaitStateStatisticsEntity entity) {
+    return ProcessInstanceWaitStateStatisticsResult.Builder.create()
+        .elementId(entity.elementId())
+        .waitingCount(entity.count())
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -8,6 +8,7 @@
 package io.camunda.gateway.mapping.http.search;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse;
 import io.camunda.gateway.protocol.model.BatchOperationItemResponse.StateEnum;
@@ -18,6 +19,7 @@ import io.camunda.gateway.protocol.model.IncidentStateEnum;
 import io.camunda.gateway.protocol.model.JobListenerEventTypeEnum;
 import io.camunda.gateway.protocol.model.JobSearchQueryResult;
 import io.camunda.gateway.protocol.model.JobWaitStateDetails;
+import io.camunda.gateway.protocol.model.ProcessInstanceWaitStateStatisticsResult;
 import io.camunda.search.entities.AgentInstanceEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.AgentInstanceHistoryCommitStatus;
@@ -63,6 +65,7 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.entities.WaitStateConditionDetails;
 import io.camunda.search.entities.WaitStateEntity;
 import io.camunda.search.entities.WaitStateJobDetails;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.api.model.user.CamundaUserDTO;
 import java.time.OffsetDateTime;
@@ -719,6 +722,26 @@ class SearchQueryResponseMapperTest {
 
     // then
     assertThat(sequenceFlows.getItems().getFirst().getRootProcessInstanceKey()).isEqualTo("999");
+  }
+
+  @Test
+  void shouldMapWaitStateStatistics() {
+    // given
+    final var entities =
+        List.of(
+            new WaitStateStatisticsEntity("task-a", 1L),
+            new WaitStateStatisticsEntity("task-b", 500L));
+
+    // when
+    final var result =
+        SearchQueryResponseMapper.toProcessInstanceWaitStateStatisticsResult(entities);
+
+    // then
+    assertThat(result.getItems())
+        .extracting(
+            ProcessInstanceWaitStateStatisticsResult::getElementId,
+            ProcessInstanceWaitStateStatisticsResult::getWaitingCount)
+        .containsExactly(tuple("task-a", 1L), tuple("task-b", 500L));
   }
 
   @Test

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/WaitStateStatisticsDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/WaitStateStatisticsDocumentReader.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
+import io.camunda.search.query.WaitStateStatisticsQuery;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.List;
+
+// STUB: returns an empty result. The data-layer task implements the terms aggregation
+// (group by elementId on the wait_state index). See issue #56254 / parent #56239.
+public class WaitStateStatisticsDocumentReader extends DocumentBasedReader
+    implements WaitStateStatisticsReader {
+
+  public WaitStateStatisticsDocumentReader(
+      final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
+    super(executor, indexDescriptor);
+  }
+
+  @Override
+  public List<WaitStateStatisticsEntity> aggregate(
+      final WaitStateStatisticsQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    return List.of();
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/SearchClientReaders.java
@@ -52,4 +52,5 @@ public record SearchClientReaders(
     IncidentProcessInstanceStatisticsByDefinitionReader
         incidentProcessInstanceStatisticsByDefinitionReader,
     GlobalListenerReader globalListenerReader,
-    WaitStateReader waitStateReader) {}
+    WaitStateReader waitStateReader,
+    WaitStateStatisticsReader waitStateStatisticsReader) {}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/WaitStateStatisticsReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/WaitStateStatisticsReader.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import io.camunda.search.entities.WaitStateStatisticsEntity;
+import io.camunda.search.query.WaitStateStatisticsQuery;
+
+public interface WaitStateStatisticsReader
+    extends SearchStatisticsReader<WaitStateStatisticsEntity, WaitStateStatisticsQuery> {}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -60,6 +60,7 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.search.exception.ErrorMessages;
@@ -116,6 +117,7 @@ import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
+import io.camunda.search.query.WaitStateStatisticsQuery;
 import io.camunda.security.core.auth.SecurityContext;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.security.core.authz.ResourceAccessController;
@@ -818,6 +820,18 @@ public class CamundaSearchClients implements SearchClientsProxy {
   public SearchQueryResult<WaitStateEntity> searchWaitStates(
       final ElementInstanceWaitStateQuery query) {
     return doSearchWithReader(requireScopedReaders().waitStateReader(), query);
+  }
+
+  @Override
+  public List<WaitStateStatisticsEntity> waitStateStatistics(final long processInstanceKey) {
+    return doReadWithResourceAccessController(
+        access ->
+            requireScopedReaders()
+                .waitStateStatisticsReader()
+                .aggregate(
+                    new WaitStateStatisticsQuery(
+                        new ProcessInstanceStatisticsFilter(processInstanceKey)),
+                    access));
   }
 
   private CamundaSearchException entityByIdNotFoundException(

--- a/search/search-client/src/main/java/io/camunda/search/clients/WaitStateSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/WaitStateSearchClient.java
@@ -8,13 +8,17 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.query.ElementInstanceWaitStateQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.core.auth.SecurityContext;
+import java.util.List;
 
 public interface WaitStateSearchClient {
 
   SearchQueryResult<WaitStateEntity> searchWaitStates(ElementInstanceWaitStateQuery query);
+
+  List<WaitStateStatisticsEntity> waitStateStatistics(long processInstanceKey);
 
   WaitStateSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -54,6 +54,7 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.exception.NoSecondaryStorageException;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.AgentInstanceHistoryQuery;
@@ -503,6 +504,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<WaitStateEntity> searchWaitStates(
       final ElementInstanceWaitStateQuery query) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public List<WaitStateStatisticsEntity> waitStateStatistics(final long processInstanceKey) {
     throw new NoSecondaryStorageException();
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -56,6 +56,7 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.entities.WaitStateEntity;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.AgentInstanceHistoryQuery;
 import io.camunda.search.query.AgentInstanceQuery;
@@ -506,5 +507,10 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   public SearchQueryResult<WaitStateEntity> searchWaitStates(
       final ElementInstanceWaitStateQuery query) {
     return SearchQueryResult.empty();
+  }
+
+  @Override
+  public List<WaitStateStatisticsEntity> waitStateStatistics(final long processInstanceKey) {
+    return emptyList();
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/WaitStateStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/WaitStateStatisticsAggregation.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+public record WaitStateStatisticsAggregation() implements AggregationBase {
+
+  public static final int AGGREGATION_TERMS_SIZE = 10000;
+  public static final String AGGREGATION_GROUP_ELEMENTS = "group-elements";
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateStatisticsEntity.java
@@ -11,10 +11,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record WaitStateStatisticsEntity(String elementId, Long count) {
+public record WaitStateStatisticsEntity(String elementId, Long waitingCount) {
 
   public WaitStateStatisticsEntity {
     Objects.requireNonNull(elementId, "elementId");
-    Objects.requireNonNull(count, "count");
+    Objects.requireNonNull(waitingCount, "waitingCount");
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateStatisticsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/WaitStateStatisticsEntity.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record WaitStateStatisticsEntity(String elementId, Long count) {
+
+  public WaitStateStatisticsEntity {
+    Objects.requireNonNull(elementId, "elementId");
+    Objects.requireNonNull(count, "count");
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/WaitStateStatisticsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/WaitStateStatisticsQuery.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.aggregation.WaitStateStatisticsAggregation;
+import io.camunda.search.filter.ProcessInstanceStatisticsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.search.sort.SortOption;
+
+public record WaitStateStatisticsQuery(ProcessInstanceStatisticsFilter filter)
+    implements TypedSearchAggregationQuery<
+        ProcessInstanceStatisticsFilter, SortOption, WaitStateStatisticsAggregation> {
+
+  @Override
+  public SortOption sort() {
+    return NoSort.NO_SORT;
+  }
+
+  @Override
+  public WaitStateStatisticsAggregation aggregation() {
+    return new WaitStateStatisticsAggregation();
+  }
+
+  @Override
+  public SearchQueryPage page() {
+    return SearchQueryPage.NO_ENTITIES_QUERY;
+  }
+}

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -16,11 +16,13 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.clients.SequenceFlowSearchClient;
+import io.camunda.search.clients.WaitStateSearchClient;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.entities.SequenceFlowEntity;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessInstanceFilter;
@@ -82,6 +84,7 @@ public final class ProcessInstanceServices
   private static final int MAX_CACHED_DEFINITIONS = 1024;
   private final ProcessInstanceSearchClient processInstanceSearchClient;
   private final SequenceFlowSearchClient sequenceFlowSearchClient;
+  private final WaitStateSearchClient waitStateSearchClient;
   private final IncidentServices incidentServices;
   private final RequestRetryHandler requestRetryHandler;
   private final ExecutorService executor;
@@ -96,6 +99,7 @@ public final class ProcessInstanceServices
       final SecurityContextProvider securityContextProvider,
       final ProcessInstanceSearchClient processInstanceSearchClient,
       final SequenceFlowSearchClient sequenceFlowSearchClient,
+      final WaitStateSearchClient waitStateSearchClient,
       final IncidentServices incidentServices,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
@@ -105,6 +109,7 @@ public final class ProcessInstanceServices
         securityContextProvider,
         processInstanceSearchClient,
         sequenceFlowSearchClient,
+        waitStateSearchClient,
         incidentServices,
         executorProvider,
         brokerRequestAuthorizationConverter,
@@ -118,6 +123,7 @@ public final class ProcessInstanceServices
       final SecurityContextProvider securityContextProvider,
       final ProcessInstanceSearchClient processInstanceSearchClient,
       final SequenceFlowSearchClient sequenceFlowSearchClient,
+      final WaitStateSearchClient waitStateSearchClient,
       final IncidentServices incidentServices,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
@@ -128,6 +134,7 @@ public final class ProcessInstanceServices
         securityContextProvider,
         processInstanceSearchClient,
         sequenceFlowSearchClient,
+        waitStateSearchClient,
         incidentServices,
         executorProvider,
         brokerRequestAuthorizationConverter,
@@ -141,6 +148,7 @@ public final class ProcessInstanceServices
       final SecurityContextProvider securityContextProvider,
       final ProcessInstanceSearchClient processInstanceSearchClient,
       final SequenceFlowSearchClient sequenceFlowSearchClient,
+      final WaitStateSearchClient waitStateSearchClient,
       final IncidentServices incidentServices,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
@@ -151,6 +159,7 @@ public final class ProcessInstanceServices
         securityContextProvider,
         processInstanceSearchClient,
         sequenceFlowSearchClient,
+        waitStateSearchClient,
         incidentServices,
         executorProvider,
         brokerRequestAuthorizationConverter,
@@ -164,6 +173,7 @@ public final class ProcessInstanceServices
       final SecurityContextProvider securityContextProvider,
       final ProcessInstanceSearchClient processInstanceSearchClient,
       final SequenceFlowSearchClient sequenceFlowSearchClient,
+      final WaitStateSearchClient waitStateSearchClient,
       final IncidentServices incidentServices,
       final ApiServicesExecutorProvider executorProvider,
       final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter,
@@ -177,6 +187,7 @@ public final class ProcessInstanceServices
         brokerRequestAuthorizationConverter);
     this.processInstanceSearchClient = processInstanceSearchClient;
     this.sequenceFlowSearchClient = sequenceFlowSearchClient;
+    this.waitStateSearchClient = waitStateSearchClient;
     this.incidentServices = incidentServices;
     this.requestRetryHandler = requestRetryHandler;
     executor = executorProvider.getExecutor();
@@ -210,6 +221,20 @@ public final class ProcessInstanceServices
                     securityContextProvider.provideSecurityContext(
                         authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
                 .processInstanceFlowNodeStatistics(processInstanceKey));
+  }
+
+  public List<WaitStateStatisticsEntity> waitStateStatistics(
+      final long processInstanceKey, final CamundaAuthentication authentication) {
+    // Existence + authorization check: throws ServiceException(NOT_FOUND) / (FORBIDDEN) before
+    // aggregating, since the aggregation alone cannot distinguish "not found" from "no results".
+    getByKey(processInstanceKey, authentication);
+    return executeSearchRequest(
+        () ->
+            waitStateSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, PROCESS_INSTANCE_READ_AUTHORIZATION))
+                .waitStateStatistics(processInstanceKey));
   }
 
   public List<ProcessInstanceEntity> callHierarchy(

--- a/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceRoundRobinDispatchTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.clients.SequenceFlowSearchClient;
+import io.camunda.search.clients.WaitStateSearchClient;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
@@ -56,6 +57,7 @@ final class ProcessInstanceRoundRobinDispatchTest {
             mock(SecurityContextProvider.class),
             mock(ProcessInstanceSearchClient.class),
             mock(SequenceFlowSearchClient.class),
+            mock(WaitStateSearchClient.class),
             mock(IncidentServices.class),
             executorProvider,
             mock(BrokerRequestAuthorizationConverter.class));

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -12,8 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.instancio.Select.field;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -21,10 +23,12 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.clients.SequenceFlowSearchClient;
+import io.camunda.search.clients.WaitStateSearchClient;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.entities.SequenceFlowEntity;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.search.exception.ResourceAccessDeniedException;
@@ -88,6 +92,7 @@ public final class ProcessInstanceServiceTest {
   private ProcessInstanceServices services;
   private ProcessInstanceSearchClient processInstanceSearchClient;
   private SequenceFlowSearchClient sequenceFlowSearchClient;
+  private WaitStateSearchClient waitStateSearchClient;
   private IncidentServices incidentServices;
   private SecurityContextProvider securityContextProvider;
   private CamundaAuthentication authentication;
@@ -100,6 +105,7 @@ public final class ProcessInstanceServiceTest {
   public void before() {
     processInstanceSearchClient = mock(ProcessInstanceSearchClient.class);
     sequenceFlowSearchClient = mock(SequenceFlowSearchClient.class);
+    waitStateSearchClient = mock(WaitStateSearchClient.class);
     authentication = CamundaAuthentication.none();
     authorizationCheck =
         RequiredAuthorization.withRequiredAuthorization(
@@ -109,6 +115,7 @@ public final class ProcessInstanceServiceTest {
     when(processInstanceSearchClient.withSecurityContext(any()))
         .thenReturn(processInstanceSearchClient);
     when(sequenceFlowSearchClient.withSecurityContext(any())).thenReturn(sequenceFlowSearchClient);
+    when(waitStateSearchClient.withSecurityContext(any())).thenReturn(waitStateSearchClient);
     securityContextProvider = mock(SecurityContextProvider.class);
     brokerClient = mock(BrokerClient.class);
     when(brokerClient.getTopologyManager()).thenReturn(new StubbedTopologyManager(3));
@@ -122,6 +129,7 @@ public final class ProcessInstanceServiceTest {
             securityContextProvider,
             processInstanceSearchClient,
             sequenceFlowSearchClient,
+            waitStateSearchClient,
             incidentServices,
             executorProvider,
             brokerRequestAuthorizationConverter);
@@ -202,6 +210,50 @@ public final class ProcessInstanceServiceTest {
         .isEqualTo(
             "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
     assertThat(exception.getStatus()).isEqualTo(Status.FORBIDDEN);
+  }
+
+  @Test
+  void shouldDelegateWaitStateStatisticsToWaitStateClient() {
+    // given
+    final var processInstanceKey = 42L;
+    final var entity =
+        Instancio.of(ProcessInstanceEntity.class)
+            .set(field(ProcessInstanceEntity::processInstanceKey), processInstanceKey)
+            .create();
+    when(processInstanceSearchClient.getProcessInstance(processInstanceKey)).thenReturn(entity);
+    when(waitStateSearchClient.waitStateStatistics(processInstanceKey))
+        .thenReturn(List.of(new WaitStateStatisticsEntity("task-a", 3L)));
+
+    // when
+    final var result = services.waitStateStatistics(processInstanceKey, authentication);
+
+    // then
+    assertThat(result).containsExactly(new WaitStateStatisticsEntity("task-a", 3L));
+    verify(waitStateSearchClient).waitStateStatistics(processInstanceKey);
+  }
+
+  @Test
+  void shouldThrowNotFoundForUnknownProcessInstanceOnWaitStateStatistics() {
+    // given
+    final var processInstanceKey = 99L;
+    when(processInstanceSearchClient.getProcessInstance(processInstanceKey))
+        .thenThrow(
+            new CamundaSearchException(
+                ERROR_ENTITY_BY_KEY_NOT_FOUND.formatted("Process Instance", processInstanceKey),
+                Reason.NOT_FOUND));
+
+    // when
+    final ThrowingCallable executeWaitStateStatistics =
+        () -> services.waitStateStatistics(processInstanceKey, authentication);
+
+    // then
+    final var exception =
+        (ServiceException)
+            assertThatThrownBy(executeWaitStateStatistics)
+                .isInstanceOf(ServiceException.class)
+                .actual();
+    assertThat(exception.getStatus()).isEqualTo(Status.NOT_FOUND);
+    verify(waitStateSearchClient, never()).waitStateStatistics(anyLong());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -209,6 +209,24 @@ public class ProcessInstanceController {
   }
 
   @RequiresSecondaryStorage
+  @CamundaGetMapping(path = "/{processInstanceKey}/statistics/wait-states")
+  public ResponseEntity<Object> waitStateStatistics(
+      @PhysicalTenantId final String physicalTenantId,
+      @PathVariable("processInstanceKey") final Long processInstanceKey) {
+    try {
+      return ResponseEntity.ok()
+          .body(
+              SearchQueryResponseMapper.toProcessInstanceWaitStateStatisticsResult(
+                  serviceRegistry
+                      .processInstanceServices(physicalTenantId)
+                      .waitStateStatistics(
+                          processInstanceKey, authenticationProvider.getCamundaAuthentication())));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  @RequiresSecondaryStorage
   @CamundaGetMapping(path = "/{processInstanceKey}/sequence-flows")
   public ResponseEntity<Object> sequenceFlows(
       @PhysicalTenantId final String physicalTenantId,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -19,6 +19,7 @@ import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.entities.SequenceFlowEntity;
+import io.camunda.search.entities.WaitStateStatisticsEntity;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -2431,6 +2432,72 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .json(response, JsonCompareMode.STRICT);
 
     verify(processInstanceServices).sequenceFlows(eq(processInstanceKey), any());
+  }
+
+  @Test
+  public void shouldReturnWaitStateStatistics() {
+    // given
+    final long processInstanceKey = 1L;
+    when(processInstanceServices.waitStateStatistics(eq(processInstanceKey), any()))
+        .thenReturn(List.of(new WaitStateStatisticsEntity("task-a", 7L)));
+    final var response =
+        """
+            {"items":[
+              {
+                "elementId": "task-a",
+                "waitingCount": 7
+              }
+            ]}""";
+
+    // when / then
+    webClient
+        .get()
+        .uri(
+            "%s/%d/statistics/wait-states"
+                .formatted(PROCESS_INSTANCES_START_URL, processInstanceKey))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(response, JsonCompareMode.STRICT);
+
+    verify(processInstanceServices).waitStateStatistics(eq(processInstanceKey), any());
+  }
+
+  @Test
+  public void shouldReturn404ForUnknownProcessInstanceWaitStateStatistics() {
+    // given
+    final long processInstanceKey = 1L;
+    when(processInstanceServices.waitStateStatistics(eq(processInstanceKey), any()))
+        .thenThrow(
+            new ServiceException(
+                "Process Instance with key '1' not found", ServiceException.Status.NOT_FOUND));
+
+    final var expectedBody =
+        """
+            {
+                "type": "about:blank",
+                "title": "NOT_FOUND",
+                "status": 404,
+                "detail": "Process Instance with key '1' not found",
+                "instance": "/v2/process-instances/1/statistics/wait-states"
+            }""";
+
+    // when / then
+    webClient
+        .get()
+        .uri(
+            "%s/%d/statistics/wait-states"
+                .formatted(PROCESS_INSTANCES_START_URL, processInstanceKey))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectBody()
+        .json(expectedBody, JsonCompareMode.STRICT);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Adds `GET /v2/process-instances/{processInstanceKey}/statistics/wait-states`, returning counts of waiting element instances grouped by `elementId`, mirroring the existing `statistics/element-instances` endpoint.
- Adds the full search contract (domain entity, aggregation/query types, reader interface) and **stub** ES/OpenSearch + RDBMS reader implementations that return empty results — the real terms-aggregation / `GROUP BY` query is a separate data-layer task (parent #56239).
- Adds `ProcessInstanceServices.waitStateStatistics()`, the response mapper, and the REST controller method.

No explicit `waitStatesEnabled` feature-flag check: when the feature is disabled, the exporter writes no `wait_state` rows, so the aggregation returns empty on its own — matching the existing `POST /v2/element-instances/wait-states/search` endpoint, which is gated the same way. Unknown `processInstanceKey` returns 404 via an existence check (`getByKey`) before the aggregation, since the aggregation alone can't distinguish "not found" from "no results".

Design spec and implementation plan are included in this PR under `docs/superpowers/`.

Two notes from code review, neither a blocker:
- The new `WaitStateStatisticsAggregation` constants (`AGGREGATION_TERMS_SIZE`, `AGGREGATION_GROUP_ELEMENTS`) are currently unused scaffolding — the data-layer task wires them into the real ES terms aggregation.
- This endpoint's path names the *condition* being counted (`wait-states`) rather than the entity (`element-instances`, as the sibling endpoint does). This naming was set by the already-merged OpenAPI contract in #56278, not by this PR.

Closes #56255
Stacked on #56278 (branch `56253-wait-state-statistics-endpoint`)

## Test Plan

- [x] `ProcessInstanceServiceTest#shouldDelegateWaitStateStatisticsToWaitStateClient` / `#shouldThrowNotFoundForUnknownProcessInstanceOnWaitStateStatistics`
- [x] `SearchQueryResponseMapperTest#shouldMapWaitStateStatistics`
- [x] `ProcessInstanceControllerTest#shouldReturnWaitStateStatistics` / `#shouldReturn404ForUnknownProcessInstanceWaitStateStatistics`
- [x] Full-repo compile (`./mvnw install -Dquickly -T1C`)
- [x] Reviewed independently (no Critical/Important code defects)