### PR TITLE
feat: enable snapshot chunking with new default of 8MiB

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartitionConfig.java
@@ -31,8 +31,9 @@ public class RaftPartitionConfig {
   private static final Duration DEFAULT_MAX_QUORUM_RESPONSE_TIMEOUT = Duration.ofSeconds(0);
   private static final int DEFAULT_SNAPSHOT_REPLICATION_THRESHOLD = 100;
   private static final boolean DEFAULT_RECEIVE_ON_LEGACY_SUBJECT = true;
-  // Keep in sync with the default in ExperimentalRaftCfg, which usually overrides this.
+  // Keep in sync with the defaults in ExperimentalRaftCfg, which usually override these.
   private static final Duration DEFAULT_CONFIGURATION_CHANGE_TIMEOUT = Duration.ofSeconds(10);
+  private static final int DEFAULT_SNAPSHOT_CHUNK_SIZE = 8 * 1024 * 1024;
   private static final long DEFAULT_REBALANCE_REPLICATION_LAG_THRESHOLD = 8L * 1024 * 1024;
   private static final Duration DEFAULT_REBALANCE_REPLICATION_TIMEOUT = Duration.ofSeconds(10);
   private static final int DEFAULT_REBALANCE_MAX_TRANSFER_ATTEMPTS = 3;
@@ -53,7 +54,7 @@ public class RaftPartitionConfig {
   private RaftStorageConfig storageConfig;
   private EntryValidator entryValidator;
   private Duration configurationChangeTimeout = DEFAULT_CONFIGURATION_CHANGE_TIMEOUT;
-  private int snapshotChunkSize;
+  private int snapshotChunkSize = DEFAULT_SNAPSHOT_CHUNK_SIZE;
   private boolean receiveOnLegacySubject = DEFAULT_RECEIVE_ON_LEGACY_SUBJECT;
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -416,6 +416,7 @@ final class LeaderAppender {
     if (member.getNextSnapshotIndex() != persistedSnapshot.getIndex()) {
       try {
         final SnapshotChunkReader snapshotChunkReader = persistedSnapshot.newChunkReader();
+        snapshotChunkReader.setMaximumChunkSize(raft.getSnapshotChunkSize());
         member.setSnapshotChunkReader(snapshotChunkReader);
       } catch (final UncheckedIOException e) {
         LOGGER.warn(

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -416,7 +416,9 @@ final class LeaderAppender {
     if (member.getNextSnapshotIndex() != persistedSnapshot.getIndex()) {
       try {
         final SnapshotChunkReader snapshotChunkReader = persistedSnapshot.newChunkReader();
-        snapshotChunkReader.setMaximumChunkSize(raft.getSnapshotChunkSize());
+        if (raft.getSnapshotChunkSize() > 0) {
+          snapshotChunkReader.setMaximumChunkSize(raft.getSnapshotChunkSize());
+        }
         member.setSnapshotChunkReader(snapshotChunkReader);
       } catch (final UncheckedIOException e) {
         LOGGER.warn(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalRaftCfg.java
@@ -16,7 +16,7 @@ import org.springframework.util.unit.DataSize;
 public final class ExperimentalRaftCfg implements ConfigurationEntry {
 
   public static final Duration DEFAULT_SNAPSHOT_REQUEST_TIMEOUT = Duration.ofMillis(2500);
-  public static final DataSize DEFAULT_SNAPSHOT_CHUNK_SIZE = DataSize.ofGigabytes(1);
+  public static final DataSize DEFAULT_SNAPSHOT_CHUNK_SIZE = DataSize.ofMegabytes(8);
   private static final Duration DEFAULT_CONFIGURATION_CHANGE_TIMEOUT = Duration.ofSeconds(10);
   // Requests should time out faster than the election timeout to ensure that a single missed
   // heartbeat does not cause immediate re-election.

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -187,7 +187,8 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
         channel.write(buffer);
       }
 
-      if (snapshotChunk.getTotalFileSize() == channel.position()) {
+      if (snapshotChunk.getTotalFileSize()
+          == snapshotChunk.getFileBlockPosition() + snapshotChunk.getContentLength()) {
         channel.force(true);
       }
     } catch (final IOException e) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -179,17 +179,17 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
 
     try (final var channel =
         FileChannel.open(snapshotFile, StandardOpenOption.WRITE, StandardOpenOption.CREATE)) {
-      final ByteBuffer buffer = ByteBuffer.wrap(snapshotChunk.getContent());
+      channel.position(snapshotChunk.getFileBlockPosition());
 
+      final var buffer = ByteBuffer.wrap(snapshotChunk.getContent());
       while (buffer.hasRemaining()) {
-        final int newLimit = Math.min(buffer.capacity(), buffer.position() + BLOCK_SIZE);
-        channel.position(snapshotChunk.getFileBlockPosition() + buffer.position());
-        channel.write(buffer.limit(newLimit));
-        buffer.limit(buffer.capacity());
+        //noinspection ResultOfMethodCallIgnored
+        channel.write(buffer);
       }
 
-      channel.force(true);
-
+      if (snapshotChunk.getTotalFileSize() == channel.position()) {
+        channel.force(true);
+      }
     } catch (final IOException e) {
       throw new SnapshotWriteException(
           String.format("Failed to write snapshot chunk %s", snapshotChunk), e);


### PR DESCRIPTION
This finally enables snapshot chunking. We previously defaulted to a chunk size of 1GiB which is unrealistic for most deployments because we expect no single SST file to exceed that.
Defaulting to 8MiB effectively enables this for most deployments.

Follow up after #12795