### PR TITLE
fix: repair Process Instance Execution Time dashboard panel

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -8983,9 +8983,9 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "zeebe_process_instance_execution_time_seconds{quantile=\"0.5\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}  > 0",
+              "expr": "histogram_quantile(0.5, sum by (le, physicalTenant, partition) (rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))) > 0",
               "instant": false,
-"legendFormat": "{{physicalTenant}} Partition: {{partition}} quantile-50th",
+              "legendFormat": "{{physicalTenant}} Partition: {{partition}} quantile-50th",
               "range": true,
               "refId": "C"
             },
@@ -8995,9 +8995,9 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "zeebe_process_instance_execution_time_seconds{quantile=\"0.9\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}  > 0",
+              "expr": "histogram_quantile(0.9, sum by (le, physicalTenant, partition) (rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))) > 0",
               "instant": false,
-"legendFormat": "{{physicalTenant}} Partition: {{partition}} quantile-90th",
+              "legendFormat": "{{physicalTenant}} Partition: {{partition}} quantile-90th",
               "range": true,
               "refId": "D"
             },
@@ -9007,9 +9007,9 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "zeebe_process_instance_execution_time_seconds{quantile=\"0.99\", cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}  > 0",
+              "expr": "histogram_quantile(0.99, sum by (le, physicalTenant, partition) (rate(zeebe_process_instance_execution_time_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", physicalTenant=~\"$physicalTenant\", partition=~\"$partition\"}[$__rate_interval]))) > 0",
               "instant": false,
-"legendFormat": "{{physicalTenant}} Partition: {{partition}} quantile-99th",
+              "legendFormat": "{{physicalTenant}} Partition: {{partition}} quantile-99th",
               "range": true,
               "refId": "E"
             }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -36,9 +36,7 @@ public class ExecutionLatencyMetrics {
   public ExecutionLatencyMetrics(final MeterRegistry meterRegistry) {
 
     processInstanceExecutionTime =
-        MicrometerUtil.buildTimer(PROCESS_INSTANCE_EXECUTION)
-            .publishPercentiles(0.5, 0.9, 0.99)
-            .register(meterRegistry);
+        MicrometerUtil.buildTimer(PROCESS_INSTANCE_EXECUTION).register(meterRegistry);
     jobLifeTime = MicrometerUtil.buildTimer(JOB_LIFETIME).register(meterRegistry);
     jobActivationTime = MicrometerUtil.buildTimer(JOB_ACTIVATION_TIME).register(meterRegistry);
     currentCacheInstanceProcessInstances =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
@@ -51,9 +51,11 @@ public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
   },
 
   /**
-   * The execution time of processing a complete process instance. Publishes both SLO histogram
-   * buckets (for cluster-level aggregation via {@code histogram_quantile()}) and pre-computed
-   * percentiles (p50, p90, p99) for convenience; see {@link ExecutionLatencyMetrics}.
+   * The execution time of processing a complete process instance. Publishes SLO histogram buckets;
+   * derive percentiles at query time via {@code histogram_quantile()}. Client-side percentiles are
+   * intentionally not published: the Prometheus registry emits a distribution as either a histogram
+   * or a summary, and once SLO buckets are configured the percentiles would be dropped. See {@link
+   * ExecutionLatencyMetrics}.
    */
   PROCESS_INSTANCE_EXECUTION {
     private static final Duration[] BUCKETS = {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Arrays;
@@ -109,7 +108,7 @@ class MetricsExporterTest {
   }
 
   @Test
-  void shouldObserveProcessInstanceExecutionTimeWithPercentiles() {
+  void shouldObserveProcessInstanceExecutionTimeWithSloHistogram() {
     // given
     final var registry = new SimpleMeterRegistry();
     final var metrics = new ExecutionLatencyMetrics(registry);
@@ -121,13 +120,6 @@ class MetricsExporterTest {
     final var executionTimer = registry.timer("zeebe.process.instance.execution.time");
 
     assertThat(executionTimer.count()).isOne();
-
-    assertThat(
-            Arrays.stream(executionTimer.takeSnapshot().percentileValues())
-                .map(ValueAtPercentile::percentile)
-                .toList())
-        .describedAs("Expected p50, p90, and p99 percentiles to be published")
-        .containsExactlyInAnyOrder(0.5, 0.9, 0.99);
 
     assertThat(
             Arrays.stream(executionTimer.takeSnapshot().histogramCounts())


### PR DESCRIPTION
## Description

The "Process Instance Execution Time (avg)" panel in the internal Zeebe Grafana dashboard showed "No data" because none of its targets matched a series that is actually exported to Prometheus:

- Two targets query `zeebe_process_instance_execution_time_bucket` — the pre-Micrometer metric name. Since the Micrometer migration the metric is exported as `zeebe_process_instance_execution_time_seconds_bucket`.
- Three targets query the client-side percentile series `zeebe_process_instance_execution_time_seconds{quantile=...}`, which is **not** exported for this timer even though it is built with `.publishPercentiles(...)`.

The reason the percentile series is absent: this is the only timer that configures **both** `serviceLevelObjectives` (SLO histogram buckets) and `publishPercentiles`. In `micrometer-registry-prometheus` 1.13+ (Prometheus Java client 1.x), `PrometheusMeterRegistry` emits a distribution as **either** a Summary (with `{quantile}` lines) **or** a Histogram (with `_bucket{le}` lines), never both — and when SLO buckets are present, the client-side percentiles are silently dropped. Timers without SLOs (e.g. the sequencer lock timers) still expose their `{quantile}` series.

## Changes

1. **Dashboard fix** (`monitor/grafana/zeebe.json`): switch the percentile targets to compute p50/p90/p99 with `histogram_quantile()` over `zeebe_process_instance_execution_time_seconds_bucket`, grouped by `physicalTenant` and `partition` to preserve the per-tenant breakdown. This matches the sibling "Data availability latency percentiles" panel and the medic benchmark dashboard. The legacy `_bucket` targets are kept for viewing pre-migration data. Verified against live Prometheus that the corrected queries return data per partition and physical tenant.

2. **Code cleanup**: remove the no-op `.publishPercentiles(...)` on the `PROCESS_INSTANCE_EXECUTION` timer (dropped by the Prometheus registry once SLO buckets are configured), correct the misleading `ExecutionLatencyMetricsDoc` comment, and refocus `MetricsExporterTest` on the SLO histogram buckets that are actually exported.

Closes #55051