### PR TITLE
feat: introduce recovery mode rest endpoint

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -48,7 +48,7 @@ paths:
 
   /mode:
     patch:
-      x-eventually-consistent: false
+      x-eventually-consistent: true
       tags:
         - Recovery
       operationId: changeClusterMode
@@ -58,10 +58,12 @@ paths:
         - basicAuth: []
       summary: Change cluster mode
       description: >-
-        Transitions the cluster between processing and recovery mode. Entering recovery mode
-        deactivates all partitions so that only a restricted set of read-only operations remains
-        available; exiting recovery mode returns the cluster to normal processing. Returns the
-        planned cluster change so its progress can be tracked via the topology.
+        Transitions the cluster between processing and recovery mode. This is a non-blocking
+        operation: the request is acknowledged once the change has been accepted, before the
+        transition itself has completed. Entering recovery mode deactivates all partitions so
+        that only a restricted set of read-only operations remains available; exiting recovery
+        mode returns the cluster to normal processing. Returns the planned cluster change so its
+        progress can be monitored via the topology.
       parameters:
         - name: mode
           in: query

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -46,6 +46,56 @@ paths:
           description: The cluster is DOWN and does not have any partition with a healthy leader.
       x-added-in-version: "8.8"
 
+  /mode:
+    patch:
+      x-eventually-consistent: false
+      tags:
+        - Recovery
+      operationId: changeClusterMode
+      x-required-permissions: []
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Change cluster mode
+      description: >-
+        Transitions the cluster between processing and recovery mode. Entering recovery mode
+        deactivates all partitions so that only a restricted set of read-only operations remains
+        available; exiting recovery mode returns the cluster to normal processing. Returns the
+        planned cluster change so its progress can be tracked via the topology.
+      parameters:
+        - name: mode
+          in: query
+          required: true
+          description: The target cluster mode.
+          schema:
+            type: string
+            enum:
+              - PROCESSING
+              - RECOVERING
+        - name: dryRun
+          in: query
+          required: false
+          description: >-
+            If true, the requested change is only validated and the resulting plan is returned,
+            without applying it to the cluster.
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: The mode change request was accepted; returns the planned cluster changes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterModeChangeResponse'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
 ## Schema definitions
 
 components:
@@ -173,3 +223,37 @@ components:
             - healthy
             - unhealthy
             - dead
+
+    ClusterModeChangeResponse:
+      description: The planned changes resulting from a cluster mode transition request.
+      type: object
+      required:
+        - changeId
+        - plannedChanges
+      properties:
+        changeId:
+          description: The ID of the cluster change that was triggered by the request.
+          type: string
+          example: "7"
+        plannedChanges:
+          description: The ordered list of operations that will be applied to complete the change.
+          type: array
+          items:
+            $ref: '#/components/schemas/ClusterModeChangeOperation'
+
+    ClusterModeChangeOperation:
+      description: A single operation that is part of a cluster mode change.
+      type: object
+      required:
+        - operation
+        - mode
+      properties:
+        operation:
+          description: The type of the operation.
+          type: string
+          example: ModeChangeOperation
+        mode:
+          description: The target mode of the operation, if applicable.
+          type: string
+          nullable: true
+          example: RECOVERING

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -48,7 +48,7 @@ paths:
 
   /mode:
     patch:
-      x-eventually-consistent: true
+      x-eventually-consistent: false
       tags:
         - Recovery
       operationId: changeClusterMode

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -69,6 +69,7 @@ tags:
   - name: Message subscription
   - name: Process definition
   - name: Process instance
+  - name: Recovery
   - name: Resource
   - name: Role
   - name: Setup
@@ -445,6 +446,8 @@ paths:
   # Cluster endpoints
   /topology:
     $ref: 'cluster.yaml#/paths/~1topology'
+  /mode:
+    $ref: 'cluster.yaml#/paths/~1mode'
 
   # User endpoints
   /users:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.gateway.protocol.model.ClusterModeChangeOperation;
+import io.camunda.gateway.protocol.model.ClusterModeChangeResponse;
+import io.camunda.service.exception.ServiceException;
+import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.AwaitModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
+import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@CamundaRestController
+@RequestMapping(path = "/v2")
+public final class RecoveryController {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RecoveryController.class);
+
+  private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
+
+  public RecoveryController(
+      final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender) {
+    this.clusterConfigurationRequestSender = clusterConfigurationRequestSender;
+  }
+
+  @CamundaPatchMapping(
+      path = "/mode",
+      consumes = {})
+  public CompletableFuture<ResponseEntity<Object>> changeClusterMode(
+      @PhysicalTenantId final String physicalTenantId,
+      @RequestParam final Mode mode,
+      @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
+    LOG.debug("Requested cluster mode change to {} for physical tenant {}", mode, physicalTenantId);
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            clusterConfigurationRequestSender
+                .modeChange(new ModeChangeRequest(mode, dryRun))
+                .thenApply(RecoveryController::unwrapOrThrow),
+        RecoveryController::toClusterModeChangeResponse,
+        HttpStatus.OK);
+  }
+
+  private static ClusterConfigurationChangeResponse unwrapOrThrow(
+      final Either<ErrorResponse, ClusterConfigurationChangeResponse> result) {
+    if (result.isRight()) {
+      return result.get();
+    }
+    final var error = result.getLeft();
+    throw new ServiceException(error.message(), mapErrorStatus(error.code()));
+  }
+
+  private static Status mapErrorStatus(final ErrorResponse.ErrorCode code) {
+    return switch (code) {
+      case INVALID_REQUEST -> Status.INVALID_ARGUMENT;
+      case OPERATION_NOT_ALLOWED -> Status.FORBIDDEN;
+      case CONCURRENT_MODIFICATION -> Status.INVALID_STATE;
+      case INTERNAL_ERROR -> Status.INTERNAL;
+    };
+  }
+
+  private static ClusterModeChangeResponse toClusterModeChangeResponse(
+      final ClusterConfigurationChangeResponse response) {
+    final List<ClusterModeChangeOperation> plannedChanges =
+        response.plannedChanges().stream()
+            .map(RecoveryController::toClusterModeChangeOperation)
+            .toList();
+    return ClusterModeChangeResponse.Builder.create()
+        .changeId(Long.toString(response.changeId()))
+        .plannedChanges(plannedChanges)
+        .build();
+  }
+
+  private static ClusterModeChangeOperation toClusterModeChangeOperation(
+      final ClusterConfigurationChangeOperation operation) {
+    final String mode =
+        switch (operation) {
+          case final ModeChangeOperation modeChange -> modeChange.mode().name();
+          case final AwaitModeChangeOperation awaitModeChange -> awaitModeChange.mode().name();
+          default -> null;
+        };
+    return ClusterModeChangeOperation.Builder.create()
+        .operation(operation.getClass().getSimpleName())
+        .mode(mode)
+        .build();
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -16,9 +16,9 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.AwaitModeChangeOperation;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -13,8 +13,8 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.util.Either;
 import java.util.List;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.ModeChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.Mode;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.json.JsonCompareMode;
+
+@WebMvcTest(RecoveryController.class)
+public class RecoveryControllerTest extends RestControllerTest {
+
+  @MockitoBean ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2/mode", "/physical-tenants/default/v2/mode"})
+  void shouldChangeClusterModeAndReturnPlannedChanges(final String baseUrl) {
+    // given
+    final var changeResponse =
+        new ClusterConfigurationChangeResponse(
+            7L,
+            Map.of(),
+            Map.of(),
+            List.of(new ModeChangeOperation(MemberId.from("0"), Mode.RECOVERING)));
+    Mockito.when(
+            clusterConfigurationRequestSender.modeChange(
+                new ModeChangeRequest(Mode.RECOVERING, false)))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(changeResponse)));
+
+    final var expectedResponse =
+        """
+        {
+          "changeId": "7",
+          "plannedChanges": [
+            {
+              "operation": "ModeChangeOperation",
+              "mode": "RECOVERING"
+            }
+          ]
+        }
+        """;
+
+    // when / then
+    webClient
+        .patch()
+        .uri(baseUrl + "?mode=RECOVERING&dryRun=false")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(expectedResponse, JsonCompareMode.STRICT);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2/mode", "/physical-tenants/default/v2/mode"})
+  void shouldMapErrorResponseWhenModeChangeRejected(final String baseUrl) {
+    // given
+    Mockito.when(
+            clusterConfigurationRequestSender.modeChange(
+                new ModeChangeRequest(Mode.RECOVERING, false)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(
+                    new ErrorResponse(ErrorCode.CONCURRENT_MODIFICATION, "a change is ongoing"))));
+
+    // when / then
+    webClient
+        .patch()
+        .uri(baseUrl + "?mode=RECOVERING&dryRun=false")
+        .exchange()
+        .expectStatus()
+        .is4xxClientError();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ModeChangeAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ModeChangeAcceptanceIT.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.cluster.clustering.dynamic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientStatusException;
 import io.camunda.zeebe.protocol.Protocol;
@@ -18,6 +19,11 @@ import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -25,8 +31,9 @@ import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 @ZeebeIntegration
 @Timeout(value = 60, unit = TimeUnit.SECONDS)
@@ -45,6 +52,8 @@ final class ModeChangeAcceptanceIT {
           .build();
 
   private static final String JOB_TYPE = "job";
+  private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   @AutoClose CamundaClient camundaClient;
 
   @BeforeEach
@@ -52,8 +61,9 @@ final class ModeChangeAcceptanceIT {
     camundaClient = cluster.availableGateway().newClientBuilder().preferRestOverGrpc(false).build();
   }
 
-  @Test
-  void shouldCycleBetweenRecoveryAndProcessing() {
+  @ParameterizedTest
+  @ValueSource(strings = {"ACTUATOR", "REST"})
+  void shouldCycleBetweenRecoveryAndProcessing(final String trigger) {
     // given
     final var processId = "mode-change-test-process";
     Utils.deployProcessModel(camundaClient, JOB_TYPE, processId);
@@ -61,7 +71,7 @@ final class ModeChangeAcceptanceIT {
 
     for (int i = 0; i < 3; i++) {
       // when - transition to RECOVERING
-      final var toRecovering = actuator.updateMode("RECOVERING", false);
+      final var toRecovering = triggerModeChange(trigger, actuator, "RECOVERING");
       Awaitility.await("Cluster transitions to RECOVERING (iteration " + i + ")")
           .timeout(Duration.ofMinutes(2))
           .untilAsserted(
@@ -76,7 +86,7 @@ final class ModeChangeAcceptanceIT {
           .untilAsserted(() -> assertAllCreateInstanceAttemptsFail(processId));
 
       // when - transition back to PROCESSING
-      final var toProcessing = actuator.updateMode("PROCESSING", false);
+      final var toProcessing = triggerModeChange(trigger, actuator, "PROCESSING");
       Awaitility.await("Cluster transitions to PROCESSING (iteration " + i + ")")
           .timeout(Duration.ofMinutes(2))
           .untilAsserted(
@@ -95,6 +105,33 @@ final class ModeChangeAcceptanceIT {
               PARTITIONS_COUNT, i)
           .containsExactlyInAnyOrderElementsOf(
               IntStream.rangeClosed(1, PARTITIONS_COUNT).boxed().collect(Collectors.toList()));
+    }
+  }
+
+  private long triggerModeChange(
+      final String trigger, final ClusterActuator actuator, final String mode) {
+    if ("ACTUATOR".equals(trigger)) {
+      return actuator.updateMode(mode, false).getChangeId();
+    } else {
+      return triggerModeChangeViaRestEndpoint(mode);
+    }
+  }
+
+  private long triggerModeChangeViaRestEndpoint(final String mode) {
+    try {
+      final var uri =
+          URI.create(
+              "%sv2/mode?mode=%s&dryRun=%s"
+                  .formatted(camundaClient.getConfiguration().getRestAddress(), mode, false));
+      final var request =
+          HttpRequest.newBuilder(uri).method("PATCH", HttpRequest.BodyPublishers.noBody()).build();
+      final var response = HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+      assertThat(response.statusCode())
+          .describedAs("REST mode change response: %s".formatted(response.body()))
+          .isEqualTo(200);
+      return OBJECT_MAPPER.readTree(response.body()).get("changeId").asLong();
+    } catch (final IOException | InterruptedException e) {
+      throw new RuntimeException("Failed to trigger mode change via REST endpoint", e);
     }
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/topology/ClusterActuatorAssert.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/topology/ClusterActuatorAssert.java
@@ -63,9 +63,13 @@ public final class ClusterActuatorAssert
   }
 
   public ClusterActuatorAssert hasCompletedChanges(final PlannedOperationsResponse response) {
+    return hasCompletedChanges(response.getChangeId());
+  }
+
+  public ClusterActuatorAssert hasCompletedChanges(final long changeId) {
     final var currentChange = actual.getTopology().getLastChange();
     Assertions.assertThat(currentChange).isNotNull();
-    Assertions.assertThat(currentChange.getId()).isEqualTo(response.getChangeId());
+    Assertions.assertThat(currentChange.getId()).isEqualTo(changeId);
     Assertions.assertThat(currentChange.getStatus())
         .isEqualTo(CompletedChange.StatusEnum.COMPLETED);
     return this;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce the `/physical-tenants/:tenantId/v2/mode` endpoint to handle transitions between member modes and allow transitioning to `recovery` mode through the REST API. The request is currently placed under a `Recovery` OpenAPI tag.

The clusteradmin `/v2/cluster/mode` REST API will be included later on.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56391
