### PR TITLE
feat: update ExpressionRecord to include new properties for unary expressions

### DIFF
--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/expression/ExpressionRecord.java
@@ -11,12 +11,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ExpressionType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +35,8 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue SCOPE_KEY_KEY = new StringValue("scopeKey");
+  private static final StringValue INPUT_KEY = new StringValue("input");
+  private static final StringValue TYPE_KEY = new StringValue("type");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -47,14 +51,21 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY, -1L);
 
+  private final StringProperty inputProp = new StringProperty(INPUT_KEY, "");
+
+  private final EnumProperty<ExpressionType> typeProp =
+      new EnumProperty<>(TYPE_KEY, ExpressionType.class, ExpressionType.FEEL);
+
   public ExpressionRecord() {
-    super(6);
+    super(8);
     declareProperty(expressionProp)
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
         .declareProperty(tenantIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(scopeKeyProp);
+        .declareProperty(scopeKeyProp)
+        .declareProperty(inputProp)
+        .declareProperty(typeProp);
   }
 
   @Override
@@ -125,6 +136,26 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   public ExpressionRecord setScopeKey(final long scopeKey) {
     scopeKeyProp.setValue(scopeKey);
+    return this;
+  }
+
+  @Override
+  public String getInput() {
+    return BufferUtil.bufferAsString(inputProp.getValue());
+  }
+
+  public ExpressionRecord setInput(final String input) {
+    inputProp.setValue(input);
+    return this;
+  }
+
+  @Override
+  public ExpressionType getType() {
+    return typeProp.getValue();
+  }
+
+  public ExpressionRecord setType(final ExpressionType type) {
+    typeProp.setValue(type);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -117,6 +117,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.ExpressionType;
 import io.camunda.zeebe.protocol.record.value.GlobalListenerSource;
 import io.camunda.zeebe.protocol.record.value.HistoryDeletionType;
 import io.camunda.zeebe.protocol.record.value.JobResultType;
@@ -669,24 +670,28 @@ final class JsonSerializableToJsonTest {
             () -> {
               final ExpressionRecord record = new ExpressionRecord();
               record
-                  .setExpression("=10 + 5")
+                  .setExpression("> 10")
                   .setResultValue(wrapString("15"))
                   .setScopeKey(1)
                   .setTenantId("test-tenant")
                   .setWarnings(List.of("warning1", "warning2"))
-                  .setVariables(VARIABLES_MSGPACK);
+                  .setVariables(VARIABLES_MSGPACK)
+                  .setInput("=x")
+                  .setType(ExpressionType.UNARY);
               return record;
             },
         """
                 {
                   "tenantId":"test-tenant",
-                  "expression":"=10 + 5",
+                  "expression":"> 10",
                   "resultValue":49,
                   "scopeKey":1,
                   "warnings":["warning1","warning2"],
                   "variables":{
                     "foo":"bar"
-                  }
+                  },
+                  "input":"=x",
+                  "type":"UNARY"
                 }
                 """
       },

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ExpressionRecord.golden
@@ -11,12 +11,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ExpressionRecordValue;
+import io.camunda.zeebe.protocol.record.value.ExpressionType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
@@ -33,6 +35,8 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
   private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue SCOPE_KEY_KEY = new StringValue("scopeKey");
+  private static final StringValue INPUT_KEY = new StringValue("input");
+  private static final StringValue TYPE_KEY = new StringValue("type");
 
   private final StringProperty expressionProp = new StringProperty(EXPRESSION_KEY);
 
@@ -47,14 +51,21 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   private final LongProperty scopeKeyProp = new LongProperty(SCOPE_KEY_KEY, -1L);
 
+  private final StringProperty inputProp = new StringProperty(INPUT_KEY, "");
+
+  private final EnumProperty<ExpressionType> typeProp =
+      new EnumProperty<>(TYPE_KEY, ExpressionType.class, ExpressionType.FEEL);
+
   public ExpressionRecord() {
-    super(6);
+    super(8);
     declareProperty(expressionProp)
         .declareProperty(resultValueProp)
         .declareProperty(warningsProp)
         .declareProperty(tenantIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(scopeKeyProp);
+        .declareProperty(scopeKeyProp)
+        .declareProperty(inputProp)
+        .declareProperty(typeProp);
   }
 
   @Override
@@ -125,6 +136,26 @@ public class ExpressionRecord extends UnifiedRecordValue implements ExpressionRe
 
   public ExpressionRecord setScopeKey(final long scopeKey) {
     scopeKeyProp.setValue(scopeKey);
+    return this;
+  }
+
+  @Override
+  public String getInput() {
+    return BufferUtil.bufferAsString(inputProp.getValue());
+  }
+
+  public ExpressionRecord setInput(final String input) {
+    inputProp.setValue(input);
+    return this;
+  }
+
+  @Override
+  public ExpressionType getType() {
+    return typeProp.getValue();
+  }
+
+  public ExpressionRecord setType(final ExpressionType type) {
+    typeProp.setValue(type);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionRecordValue.java
@@ -73,4 +73,20 @@ public interface ExpressionRecordValue extends RecordValue, TenantOwned, RecordV
    * @return the scope key, or {@code -1} if not set
    */
   long getScopeKey();
+
+  /**
+   * Returns the input value against which a {@link ExpressionType#UNARY} expression is evaluated.
+   *
+   * <p>Only relevant when {@link #getType()} is {@link ExpressionType#UNARY}; empty otherwise.
+   *
+   * @return the input value (never {@code null}, but can be empty)
+   */
+  String getInput();
+
+  /**
+   * Returns the type of the expression to evaluate.
+   *
+   * @return the expression type (never {@code null}, defaults to {@link ExpressionType#FEEL})
+   */
+  ExpressionType getType();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExpressionType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+/**
+ * The type of expression to evaluate.
+ *
+ * <ul>
+ *   <li>{@link #FEEL} – a regular FEEL expression, evaluated as-is.
+ *   <li>{@link #UNARY} – a FEEL unary test, evaluated against a provided input value.
+ * </ul>
+ */
+public enum ExpressionType {
+  FEEL,
+  UNARY,
+}


### PR DESCRIPTION
This pull request extends the `ExpressionRecord` to support additional metadata for expressions, specifically the input value and the type of expression (regular FEEL or UNARY test). It updates both the implementation and the interface, and adds a new enum to represent expression types. The test suite is also updated to verify the new fields.

**Enhancements to Expression Metadata:**

* Added `input` and `type` properties to `ExpressionRecord`, including corresponding getter/setter methods and serialization logic. The default type is `FEEL`, and `input` is only relevant for `UNARY` expressions. [[1]](diffhunk://#diff-3d08a38bc0b2a89f16bda1a82bff65dbc471e4b4553c56f8d3c01fa476fcec61R38-R39) [[2]](diffhunk://#diff-3d08a38bc0b2a89f16bda1a82bff65dbc471e4b4553c56f8d3c01fa476fcec61R54-R68) [[3]](diffhunk://#diff-3d08a38bc0b2a89f16bda1a82bff65dbc471e4b4553c56f8d3c01fa476fcec61R141-R160)
* Updated the `ExpressionRecordValue` interface to include `getInput()` and `getType()` methods, with documentation explaining their purpose and usage.
* Introduced a new `ExpressionType` enum to distinguish between regular FEEL expressions and UNARY tests.

**Testing Updates:**

* Modified `JsonSerializableToJsonTest` to set and verify the new `input` and `type` fields in serialized `ExpressionRecord` objects.

**Dependency Updates:**

* Updated imports in relevant files to include `ExpressionType` and related properties. [[1]](diffhunk://#diff-3d08a38bc0b2a89f16bda1a82bff65dbc471e4b4553c56f8d3c01fa476fcec61R14-R21) [[2]](diffhunk://#diff-5d17d6d0e390c53620a41eb516f809bb926fc5a139fa42c8c8e2802539d16b76R120)