### PR TITLE
ci: pin submit-build-status to egress-capture release

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -95,7 +95,7 @@ runs:
         job_name_override: "${{ inputs.job_name }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
    ######################## Report build result #############################
-    - uses: camunda/infra-global-github-actions/submit-build-status@main
+    - uses: camunda/infra-global-github-actions/submit-build-status@2fee788847f2b0eedcdd8b324e48ae1fad52fe4f # main
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         job_name_override: "${{ inputs.job_name }}"


### PR DESCRIPTION
## Description

Pins `camunda/infra-global-github-actions/submit-build-status` from the floating `@main` ref to the merged SHA `2fee788` (camunda/infra-global-github-actions#733), which adds per-job **network egress/ingress byte capture** to the build-status telemetry. This brings the action in line with the repo's SHA-pin convention (the other `infra-global-github-actions` actions are pinned with a `# main` annotation).

Functionally this is already live via `@main`: egress/ingress bytes are being recorded per job into `ci-30-162810:prod_ci_analytics.build_status_v2` (columns `network_egress_bytes` / `network_ingress_bytes`). The pin just makes the version explicit and reviewable/renovate-managed.

Verified in BigQuery that rows from this repo now carry populated network byte counts (e.g. `build-restapi-e2e-self-managed`: egress ≈ 427 MB, ingress ≈ 2.9 GB).

## Checklist

- [ ] Enable backports when necessary.

## Related issues

Related: camunda/team-infrastructure#1044
