### PR TITLE
test(engine): cover suspended-execute rejection and multi-batch loop

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ExecuteBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/ExecuteBatchOperationTest.java
@@ -25,6 +25,8 @@ import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -131,5 +133,76 @@ public final class ExecuteBatchOperationTest extends AbstractBatchOperationTest 
         .containsOnly(
             RejectionType.NOT_FOUND,
             "No batch operation found for key '%d'.".formatted(batchOperationKey));
+  }
+
+  @Test
+  public void shouldRejectExecuteWhenBatchOperationIsSuspended() {
+    // given
+    final var processInstanceKeys = Set.of(1L, 2L, 3L);
+    final var batchOperationKey = createNewCancelProcessInstanceBatchOperation(processInstanceKeys);
+
+    engine.batchOperation().newLifecycle().withBatchOperationKey(batchOperationKey).suspend();
+
+    RecordingExporter.batchOperationLifecycleRecords()
+        .withBatchOperationKey(batchOperationKey)
+        .withIntent(BatchOperationIntent.SUSPENDED)
+        .await();
+
+    // when
+    engine
+        .batchOperation()
+        .newExecution()
+        .withBatchOperationKey(batchOperationKey)
+        .expectRejection()
+        .execute();
+
+    // then
+    assertThat(
+            RecordingExporter.batchOperationExecutionRecords(BatchOperationExecutionIntent.EXECUTE)
+                .withBatchOperationKey(batchOperationKey)
+                .onlyCommandRejections()
+                .getFirst())
+        .extracting(Record::getRejectionType, Record::getRejectionReason)
+        .containsOnly(
+            RejectionType.INVALID_STATE,
+            "Batch operation '%d' is suspended.".formatted(batchOperationKey));
+  }
+
+  @Test
+  public void shouldProcessAllItemsAcrossMultipleBatches() {
+    // given
+    final var processInstanceKeys =
+        LongStream.rangeClosed(1, 25).boxed().collect(Collectors.toSet());
+    final var batchOperationKey = createNewCancelProcessInstanceBatchOperation(processInstanceKeys);
+
+    // then
+    assertThat(
+            RecordingExporter.batchOperationLifecycleRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .withIntent(BatchOperationIntent.COMPLETED)
+                .exists())
+        .isTrue();
+
+    processInstanceKeys.forEach(
+        key ->
+            assertThat(
+                    RecordingExporter.processInstanceRecords()
+                        .withRecordType(RecordType.COMMAND)
+                        .withProcessInstanceKey(key)
+                        .withIntent(ProcessInstanceIntent.CANCEL)
+                        .exists())
+                .describedAs("process instance %d should have been cancelled", key)
+                .isTrue());
+
+    final var executingCycles =
+        RecordingExporter.batchOperationExecutionRecords()
+            .withBatchOperationKey(batchOperationKey)
+            .limit(
+                r ->
+                    r.getIntent() == BatchOperationExecutionIntent.EXECUTED
+                        && r.getValue().getItemKeys().isEmpty())
+            .filter(r -> r.getIntent() == BatchOperationExecutionIntent.EXECUTING)
+            .count();
+    assertThat(executingCycles).isEqualTo(3);
   }
 }


### PR DESCRIPTION
## Description

(Unit test) Adds two engine-level tests to `ExecuteBatchOperationTest` to close coverage gaps in the batch-operation EXECUTE processor (`BatchOperationExecutionExecuteProcessor`). These are **pure test additions** — no production code changes.

### New tests

1. **`shouldRejectExecuteWhenBatchOperationIsSuspended`**
   - Creates a cancel batch operation, suspends it via the lifecycle command, and awaits `BatchOperationIntent.SUSPENDED`.
   - Sends an `EXECUTE` command and asserts it is rejected with `RejectionType.INVALID_STATE` and reason `"Batch operation '%d' is suspended."`.
   - Covers the previously-untested `isSuspended()` rejection branch of the processor.

2. **`shouldProcessAllItemsAcrossMultipleBatches`**
   - Creates a cancel batch operation with 25 items (greater than `BATCH_SIZE = 10`), forcing the processor to loop across multiple batches.
   - Asserts the operation reaches `BatchOperationIntent.COMPLETED`, each process instance receives a `ProcessInstanceIntent.CANCEL` command, and the number of `EXECUTING` cycles (bounded by the final `EXECUTED` event with empty item keys) equals 3.



Test Rail test cases 
https://camunda.testrail.com/index.php?/suites/view/17051&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=879386

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview
