### PR TITLE
test: harden clickCancelProcessInstanceDialogButton against DOM detach

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessesPage.ts
@@ -381,7 +381,12 @@ class OperateProcessesPage {
   }
 
   async clickCancelProcessInstanceDialogButton(): Promise<void> {
-    await this.cancelProcessInstanceDialogButton.click();
+    await expect(async () => {
+      await expect(this.cancelProcessInstanceDialogButton).toBeVisible({
+        timeout: 5000,
+      });
+      await this.cancelProcessInstanceDialogButton.click({timeout: 5000});
+    }).toPass({timeout: 30000});
   }
 
   async tableHasInstanceKey(keyStr: string): Promise<boolean> {


### PR DESCRIPTION
## Description

The `processInstancesFilters.spec.ts` E2E test ("Filter by variable and batch operation key and assert results") failed **deterministically on both the original attempt and the retry** in the [C8 Orchestration Cluster E2E Tests Release run](https://github.com/camunda/camunda/actions/runs/28506246028/job/84495323270), failing the job.

Root cause is **test flakiness, not a product regression**: the cancel-instance confirmation dialog's "Apply" button (`getByRole('dialog').getByRole('button', {name: 'Apply'})`) is re-rendered by Carbon as the modal stabilizes, detaching the element from the DOM at the moment Playwright clicks it. The Playwright call log confirms this — the button resolves and becomes "visible, enabled and stable", then reports "element was detached from the DOM, retrying" before timing out.

The sibling method `clickCancelBatchOperationButton` (which opens the same dialog) was already hardened against this exact detach race with a `toPass` retry wrapper in commit `ada52227b` ("use toPass pattern in clickCancelBatchOperationButton to handle DOM detach on click"). The Apply/confirm click that *closes* the dialog was left as a bare `.click()` and never got the equivalent guard — an incomplete fix. This PR applies the same `toPass` pattern to `clickCancelProcessInstanceDialogButton` so the click retries until the re-rendered button is stable.

The other two failures in that run (`operations.spec.ts:75`, `task-history.spec.ts:59`) passed on retry and did not fail the job.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.


## Validation
https://github.com/camunda/camunda/actions/runs/28511856713/job/84514164783 -> e2e test passed

## Related issues



n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014gGP2eZCQDqnTZG2maRZfX)_