### PR TITLE
test: cover resume-to-completion and cancel-suspended batch operation lifecycle API E2E

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts
@@ -18,6 +18,7 @@ import {
   jsonHeaders,
 } from '../../../../utils/http';
 import {
+  cancelBatchOperation,
   createCancellationBatch,
   createCompletedBatchOperation,
   expectBatchState,
@@ -147,6 +148,58 @@ test.describe('Suspend & Resume Batch Operation Tests', () => {
 
     await test.step('Poll until batch operation is suspended', async () => {
       await expectBatchState(request, key, 'SUSPENDED');
+    });
+  });
+
+  test('Resume suspended batch operation runs to completion', async ({
+    request,
+  }) => {
+    const key = await test.step('Create cancel batch operation', async () => {
+      return createCancellationBatch(request, 30, 'batch_suspension_process');
+    });
+
+    await test.step('Suspend batch operation', async () => {
+      const res = await suspendBatchOperation(request, key);
+      await assertStatusCode(res, 204);
+    });
+
+    await test.step('Poll until batch operation is suspended', async () => {
+      await expectBatchState(request, key, 'SUSPENDED');
+    });
+
+    await test.step('Resume batch operation', async () => {
+      const res = await resumeBatchOperation(request, key);
+      await assertStatusCode(res, 204);
+    });
+
+    await test.step('Poll until batch operation is completed', async () => {
+      await expectBatchState(request, key, 'COMPLETED');
+    });
+  });
+
+  test('Cancel suspended batch operation transitions to CANCELED', async ({
+    request,
+  }) => {
+    const key = await test.step('Create cancel batch operation', async () => {
+      return createCancellationBatch(request, 30, 'batch_suspension_process');
+    });
+
+    await test.step('Suspend batch operation', async () => {
+      const res = await suspendBatchOperation(request, key);
+      await assertStatusCode(res, 204);
+    });
+
+    await test.step('Poll until batch operation is suspended', async () => {
+      await expectBatchState(request, key, 'SUSPENDED');
+    });
+
+    await test.step('Cancel suspended batch operation', async () => {
+      const res = await cancelBatchOperation(request, key);
+      await assertStatusCode(res, 204);
+    });
+
+    await test.step('Poll until batch operation is canceled', async () => {
+      await expectBatchState(request, key, 'CANCELED');
     });
   });
 });


### PR DESCRIPTION
## Description

Adds two API E2E tests to the batch operation suspend/resume suite
(`qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/batch-operation/batch-operations-suspend-api-tests.spec.ts`),
closing two gaps in batch-operation lifecycle coverage:

1. **Resume runs to completion** — creates a batch operation, suspends it, polls
   until `SUSPENDED`, resumes it, then polls until it reaches `COMPLETED`. The
   existing resume tests only asserted the `204` response and stopped there, so
   nothing verified that resume actually continues execution end-to-end.

2. **Cancel a suspended batch operation** — creates a batch operation, suspends
   it, polls until `SUSPENDED`, cancels it, then polls until it reaches
   `CANCELED`. This covers the `SUSPENDED -> CANCELED` lifecycle transition,
   which was previously untested. The transition is valid per the engine
   (`PersistedBatchOperation.canCancel()` permits `SUSPENDED`).

Both tests reuse existing request helpers (`suspendBatchOperation`,
`resumeBatchOperation`, `cancelBatchOperation`, `expectBatchState`,
`createCancellationBatch`) and follow the existing suite conventions.

### Note on scope

A "403 Forbidden on lifecycle actions" test was considered but intentionally
**not** added: the cancel/suspend/resume endpoints have no authorization gate
(the `BatchOperationController` documents this explicitly, and
`BatchOperationServices` applies no security context to these methods), so an
under-privileged authenticated user receives `204`, not `403`.




Test Rail test cases 
https://camunda.testrail.com/index.php?/suites/view/17051&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=879386

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview
