### PR TITLE
deps: bump logback to 1.5.37

### DIFF
--- a/optimize-distro/src/config/environment-logback-demo.xml
+++ b/optimize-distro/src/config/environment-logback-demo.xml
@@ -1,6 +1,9 @@
 <configuration>
   <conversionRule conversionWord="sanitize" class="io.camunda.optimize.util.LogUtil" />
-  <if condition='property("JSON_LOGGING").contains("true")'>
+  <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">
+    <expression>propertyContains("JSON_LOGGING", "true")</expression>
+  </condition>
+  <if>
     <then>
       <appender name="UPGRADE_JSON" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">

--- a/optimize-distro/src/config/environment-logback.xml
+++ b/optimize-distro/src/config/environment-logback.xml
@@ -1,6 +1,9 @@
 <configuration>
   <conversionRule conversionWord="sanitize" class="io.camunda.optimize.util.LogUtil" />
-  <if condition='property("JSON_LOGGING").contains("true")'>
+  <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">
+    <expression>propertyContains("JSON_LOGGING", "true")</expression>
+  </condition>
+  <if>
     <then>
       <appender name="UPGRADE_JSON" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">

--- a/optimize/backend/src/main/resources/logback.xml
+++ b/optimize/backend/src/main/resources/logback.xml
@@ -1,6 +1,9 @@
 <configuration>
   <conversionRule conversionWord="sanitize" converterClass="io.camunda.optimize.util.LogUtil" />
-  <if condition='property("JSON_LOGGING").equals("true")'>
+  <condition class="ch.qos.logback.core.boolex.ExpressionPropertyCondition">
+    <expression>propertyEquals("JSON_LOGGING", "true")</expression>
+  </condition>
+  <if>
     <then>
       <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LogstashEncoder" />

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -64,7 +64,7 @@
     <netty.version>4.1.135.Final</netty.version>
     <log4j2.version>2.25.4</log4j2.version>
     <lombok.version>1.18.34</lombok.version>
-    <logback.version>1.5.25</logback.version>
+    <logback.version>1.5.37</logback.version>
     <slf4j.version>2.0.16</slf4j.version>
     <commons.io.version>2.17.0</commons.io.version>
     <commons.lang3.version>3.18.0</commons.lang3.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -105,7 +105,7 @@
     <!--  Adding spring-security.version to ensure Spring Boot's BOM honors the override regardless of import order.  -->
     <spring-security.version>${version.spring-security}</spring-security.version>
     <version.spring-boot>3.5.15</version.spring-boot>
-    <version.logback>1.5.25</version.logback>
+    <version.logback>1.5.37</version.logback>
     <version.tomcat>10.1.55</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>


### PR DESCRIPTION
## Description

- Bumps logback to 1.5.37
- Migrates  if condition attributes as on 1.5.37, the <if condition=...> attributes support has been dropped: [release notes](https://logback.qos.ch/news.html#1.5.37), [docs](https://logback.qos.ch/manual/configuration.html#conditional)

Smoke test ran locally: ran Optimize once with `JSON_LOGGING=true` and once without, confirmed logs are in json format when `JSON_LOGGING=true`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
