### PR TITLE
ci: harden npm ci across workflows via reusable retry action

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -44,9 +44,9 @@ runs:
 
     - name: Install node dependencies (npm)
       if: ${{ inputs.package-manager == 'npm' }}
-      working-directory: ${{ inputs.directory }}
-      shell: bash
-      run: npm ci
+      uses: ./.github/actions/npm-ci-with-retry
+      with:
+        directory: ${{ inputs.directory }}
 
     - name: Build frontend (yarn)
       if: ${{ inputs.package-manager == 'yarn' }}

--- a/.github/actions/frontend-sbom-snyk/action.yml
+++ b/.github/actions/frontend-sbom-snyk/action.yml
@@ -54,14 +54,9 @@ runs:
 
     - name: Install dependencies with npm
       if: inputs.package-manager == 'npm'
-      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      uses: ./.github/actions/npm-ci-with-retry
       with:
-        max_attempts: 3
-        retry_on: error
-        retry_wait_seconds: 15
-        timeout_minutes: 10
-        command: |
-          cd "${{ inputs.directory }}" && npm ci
+        directory: ${{ inputs.directory }}
 
     - name: Install dependencies with yarn
       if: inputs.package-manager == 'yarn'

--- a/.github/actions/npm-ci-with-retry/action.yml
+++ b/.github/actions/npm-ci-with-retry/action.yml
@@ -1,0 +1,43 @@
+---
+name: npm ci with retry
+
+# owner: @camunda/monorepo-devops-team
+
+description: >
+  Runs `npm ci` wrapped in retry logic so a singular transient npm-registry
+  network failure does not fail the whole job.
+
+inputs:
+  directory:
+    description: >
+      Directory to install dependencies in. The retry action runs from the
+      repository root and ignores `working-directory`, so this must be passed
+      explicitly.
+    required: true
+  max_attempts:
+    description: Maximum number of attempts before giving up.
+    required: false
+    default: "3"
+  retry_wait_seconds:
+    description: Seconds to wait between attempts.
+    required: false
+    default: "5"
+  timeout_minutes:
+    description: Timeout per attempt in minutes.
+    required: false
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - name: Install node dependencies
+      uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+      with:
+        max_attempts: ${{ inputs.max_attempts }}
+        retry_wait_seconds: ${{ inputs.retry_wait_seconds }}
+        timeout_minutes: ${{ inputs.timeout_minutes }}
+        # Pin to bash so a forward-slash `directory` works consistently on
+        # Linux, container images, and Windows runners (git-bash).
+        shell: bash
+        command: |
+          cd "${{ inputs.directory }}" && npm ci

--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -119,9 +119,9 @@ runs:
 
     - name: Install node dependencies
       if: ${{ inputs.source-build == 'true' }}
-      working-directory: ./tasklist/client
-      shell: bash
-      run: npm ci
+      uses: ./.github/actions/npm-ci-with-retry
+      with:
+        directory: ./tasklist/client
 
     - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
       if: ${{ inputs.source-build == 'true' }}
@@ -130,15 +130,15 @@ runs:
 
     - name: Install node dependencies
       if: ${{ inputs.source-build == 'true' }}
-      working-directory: ./operate/client
-      shell: bash
-      run: npm ci
+      uses: ./.github/actions/npm-ci-with-retry
+      with:
+        directory: ./operate/client
 
     - name: Install node dependencies
       if: ${{ inputs.source-build == 'true' }}
-      working-directory: ./identity/client
-      shell: bash
-      run: npm ci
+      uses: ./.github/actions/npm-ci-with-retry
+      with:
+        directory: ./identity/client
 
     - uses: ./.github/actions/build-zeebe
       if: ${{ inputs.source-build == 'true' }}

--- a/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
+++ b/.github/workflows/c8-orchestration-cluster-responses-regenerate.yml
@@ -75,11 +75,12 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          cache-dependency-path: qa/c8-orchestration-cluster-e2e-test-suite/package-lock.json
+          cache-dependency-path: ${{ env.SUITE_DIR }}/package-lock.json
 
       - name: Install dependencies
-        working-directory: ${{ env.SUITE_DIR }}
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.SUITE_DIR }}
 
       - name: Import Vault secrets
         id: secrets

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -185,8 +185,9 @@ jobs:
           checkout: "false"
 
       - name: Install dependencies
-        run: npm ci
-        working-directory: ./c8run/e2e_tests
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ./c8run/e2e_tests
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
@@ -335,8 +336,9 @@ jobs:
           node-version: 24
 
       - name: Install dependencies
-        run: npm ci
-        working-directory: .\c8run\e2e_tests
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ./c8run/e2e_tests
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -37,6 +37,7 @@ env:
   TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Operate
+  CLIENT_DIR: operate/client
 
 jobs:
   # run every time this CI file is called
@@ -115,7 +116,7 @@ jobs:
       TEST_TYPE: Unit
     defaults:
       run:
-        working-directory: operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -124,8 +125,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - run: npm run test -- --no-file-parallelism --maxWorkers 1 --reporter=blob --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
         name: Unit & Integration tests
         env:
@@ -161,7 +164,7 @@ jobs:
       TEST_TYPE: Unit
     defaults:
       run:
-        working-directory: operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Print metadata
@@ -169,8 +172,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - name: Download blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -192,7 +197,7 @@ jobs:
       TEST_PRODUCT: Operate
     defaults:
       run:
-        working-directory: operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -201,8 +206,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - run: npm run ts-check
         name: Type checks
       - name: Observe build status
@@ -227,7 +234,7 @@ jobs:
       TEST_PRODUCT: Operate
     defaults:
       run:
-        working-directory: operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -236,8 +243,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - run: npm run lint:eslint
         name: ESLint
       - name: Observe build status
@@ -261,7 +270,7 @@ jobs:
       TEST_PRODUCT: Operate
     defaults:
       run:
-        working-directory: operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -270,8 +279,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - run: npm run lint:prettier
         name: Prettier
       - name: Observe build status
@@ -298,7 +309,7 @@ jobs:
       options: --user 1001:1000
     defaults:
       run:
-        working-directory: operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - name: Check out repository code
@@ -310,7 +321,9 @@ jobs:
         with:
           node-version: 24
       - name: Install node dependencies
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - name: Build frontend
         run: npm run build
       - name: Run A11y tests
@@ -349,7 +362,7 @@ jobs:
       options: --user 1001:1000
     defaults:
       run:
-        working-directory: operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - name: Check out repository code
@@ -361,7 +374,9 @@ jobs:
         with:
           node-version: 24
       - name: Install node dependencies
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - name: Build frontend
         run: npm run build:visual-regression
       - name: Run Visual regression tests
@@ -395,7 +410,7 @@ jobs:
       TEST_TYPE: visual-regression
     defaults:
       run:
-        working-directory: operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - name: Check out repository code
@@ -407,7 +422,9 @@ jobs:
         with:
           node-version: 24
       - name: Install node dependencies
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - name: Download blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -436,7 +453,7 @@ jobs:
       options: --user 1001:1000
     defaults:
       run:
-        working-directory: operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -445,12 +462,14 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - name: Build frontend
         run: npm run build
       - name: Run Playwright
-        working-directory: ./operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
         run: npm run generate-screenshots
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -37,6 +37,7 @@ env:
   TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_PRODUCT: Tasklist
+  CLIENT_DIR: tasklist/client
 
 jobs:
   # run this test every time the workflow is triggered
@@ -73,7 +74,7 @@ jobs:
       TEST_PRODUCT: Tasklist
     defaults:
       run:
-        working-directory: tasklist/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -82,8 +83,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - run: npm run ts-check
         name: Type checks
       - name: Observe build status
@@ -107,7 +110,7 @@ jobs:
       TEST_PRODUCT: Tasklist
     defaults:
       run:
-        working-directory: tasklist/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -116,8 +119,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - run: npm run lint:eslint
         name: ESLint
       - name: Observe build status
@@ -140,7 +145,7 @@ jobs:
       TEST_TYPE: Tool
     defaults:
       run:
-        working-directory: tasklist/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -149,8 +154,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - run: npm run lint:stylelint
         name: Stylelint
       - name: Observe build status
@@ -174,7 +181,7 @@ jobs:
       TEST_PRODUCT: Tasklist
     defaults:
       run:
-        working-directory: tasklist/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -183,8 +190,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - run: npm run lint:prettier
         name: Prettier
       - name: Observe build status
@@ -207,7 +216,7 @@ jobs:
       TEST_TYPE: Unit
     defaults:
       run:
-        working-directory: tasklist/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -216,8 +225,10 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
-      - run: npm ci
-        name: Install dependencies
+      - name: Install dependencies
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - run: npm run test:ci
         name: Unit & Integration tests
       - name: Observe build status
@@ -243,7 +254,7 @@ jobs:
       options: --user 1001:1000
     defaults:
       run:
-        working-directory: tasklist/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - name: Check out repository code
@@ -255,7 +266,9 @@ jobs:
         with:
           node-version: 24
       - name: Install node dependencies
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - name: Build frontend
         run: npm run build:visual-regression
       - name: Run Playwright tests
@@ -289,7 +302,7 @@ jobs:
       options: --user 1001:1000
     defaults:
       run:
-        working-directory: tasklist/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - name: Check out repository code
@@ -301,7 +314,9 @@ jobs:
         with:
           node-version: 24
       - name: Install node dependencies
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - name: Build frontend
         run: npm run build
       - name: Run A11y tests

--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -30,12 +30,9 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/npm-ci-with-retry
         with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: npm ci --prefix ${{ env.CLIENT_DIR }}
+          directory: ${{ env.CLIENT_DIR }}
       - name: Type check
         run: npm run typecheck
       - name: Observe build status
@@ -63,12 +60,9 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/npm-ci-with-retry
         with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: npm ci --prefix ${{ env.CLIENT_DIR }}
+          directory: ${{ env.CLIENT_DIR }}
       - name: ESLint
         run: npm run lint:eslint
       - name: Observe build status
@@ -96,12 +90,9 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/npm-ci-with-retry
         with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: npm ci --prefix ${{ env.CLIENT_DIR }}
+          directory: ${{ env.CLIENT_DIR }}
       - name: Knip
         run: npm run lint:knip
       - name: Observe build status
@@ -129,12 +120,9 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/npm-ci-with-retry
         with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: npm ci --prefix ${{ env.CLIENT_DIR }}
+          directory: ${{ env.CLIENT_DIR }}
       - name: Prettier
         run: npm run lint:prettier
       - name: Observe build status
@@ -162,12 +150,9 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/npm-ci-with-retry
         with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: npm ci --prefix ${{ env.CLIENT_DIR }}
+          directory: ${{ env.CLIENT_DIR }}
       - name: Build packages
         run: npm run build
       - name: Observe build status
@@ -202,12 +187,9 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/npm-ci-with-retry
         with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: npm ci --prefix ${{ env.CLIENT_DIR }}
+          directory: ${{ env.CLIENT_DIR }}
       - name: Unit tests
         run: npm run test:unit -w @camunda/orchestration-cluster-webapp
       - name: Upload blob report
@@ -252,12 +234,9 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/npm-ci-with-retry
         with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: npm ci --prefix ${{ env.CLIENT_DIR }}
+          directory: ${{ env.CLIENT_DIR }}
       - name: Build frontend
         run: npm run build -w @camunda/orchestration-cluster-webapp
       - name: Integration tests
@@ -303,12 +282,9 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/npm-ci-with-retry
         with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: npm ci --prefix ${{ env.CLIENT_DIR }}
+          directory: ${{ env.CLIENT_DIR }}
       - name: Build frontend
         run: npm run build -w @camunda/orchestration-cluster-webapp
       - name: Accessibility tests
@@ -354,12 +330,9 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        uses: ./.github/actions/npm-ci-with-retry
         with:
-          timeout_minutes: 3
-          max_attempts: 3
-          retry_wait_seconds: 5
-          command: npm ci --prefix ${{ env.CLIENT_DIR }}
+          directory: ${{ env.CLIENT_DIR }}
       - name: Build frontend
         run: npm run build:visual-regression -w @camunda/orchestration-cluster-webapp
       - name: Visual regression tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1626,9 +1626,10 @@ jobs:
     permissions: { }  # GITHUB_TOKEN unused in this job
     env:
       TEST_OWNER: '@camunda/identity'
+      CLIENT_DIR: identity/client
     defaults:
       run:
-        working-directory: identity/client
+        working-directory: ${{ env.CLIENT_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1637,9 +1638,11 @@ jobs:
         with:
           node-version: 24
           cache: 'npm'
-          cache-dependency-path: 'identity/client/package-lock.json'
+          cache-dependency-path: '${{ env.CLIENT_DIR }}/package-lock.json'
       - name: Install dependencies
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - name: Check formatting
         run: npm run test:format
       - name: Lint code
@@ -1795,9 +1798,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions: {} # GITHUB_TOKEN unused in this job
+    env:
+      SUITE_DIR: qa/c8-orchestration-cluster-e2e-test-suite
     defaults:
       run:
-        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        working-directory: ${{ env.SUITE_DIR }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1806,7 +1811,9 @@ jobs:
         with:
           node-version: 24
       - name: Install dependencies
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.SUITE_DIR }}
       - name: Lint (tsc + eslint)
         run: npm run lint
       - name: Observe build status
@@ -1948,6 +1955,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: read
+    env:
+      VERIFIER_DIR: .github/scripts/x-added-in-version-check
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
       - name: Checkout PR
@@ -1973,10 +1982,11 @@ jobs:
             "https://github.com/"
           echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
       - name: Install verifier dependencies
-        working-directory: ${{ github.workspace }}/.github/scripts/x-added-in-version-check
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.VERIFIER_DIR }}
       - name: Build verifier artefacts (endpoint-map + version-map)
-        working-directory: ${{ github.workspace }}/.github/scripts/x-added-in-version-check
+        working-directory: ${{ github.workspace }}/${{ env.VERIFIER_DIR }}
         env:
           # LATEST_BRANCH is not consumed by the in-repo scripts directly.
           # build-artefacts.mjs clones `return-of-api-added-in-analysis` and
@@ -1991,7 +2001,7 @@ jobs:
       - name: Run PR verifier
         # Verifier exits non-zero on findings, which fails the job and
         # therefore the `check-results` aggregate gate.
-        working-directory: ${{ github.workspace }}/.github/scripts/x-added-in-version-check
+        working-directory: ${{ github.workspace }}/${{ env.VERIFIER_DIR }}
         env:
           OCA_SPEC_PATH: ${{ github.workspace }}/zeebe/gateway-protocol/src/main/proto/v2
           ENDPOINT_MAP_PATH: ./artefacts/endpoint-map.json

--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -25,6 +25,7 @@ env:
   TEST_OWNER: '@camunda/monorepo-devops-team'
   # renovate: datasource=node-version depName=node
   NODE_VERSION: '24.16.0'
+  DOCS_DIR: monorepo-docs-site
 
 jobs:
   # Detect changes to avoid unnecessary builds
@@ -66,14 +67,15 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: monorepo-docs-site/package-lock.json
+          cache-dependency-path: ${{ env.DOCS_DIR }}/package-lock.json
 
       - name: Install dependencies
-        working-directory: monorepo-docs-site
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.DOCS_DIR }}
 
       - name: Build documentation
-        working-directory: monorepo-docs-site
+        working-directory: ${{ env.DOCS_DIR }}
         run: npm run build
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -24,6 +24,7 @@ env:
   TEST_OWNER: '@camunda/monorepo-devops-team'
   # renovate: datasource=node-version depName=node
   NODE_VERSION: '24.16.0'
+  DOCS_DIR: monorepo-docs-site
 
 jobs:
   # Detect changes to avoid unnecessary builds
@@ -80,16 +81,17 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
-          cache-dependency-path: monorepo-docs-site/package-lock.json
+          cache-dependency-path: ${{ env.DOCS_DIR }}/package-lock.json
 
       - name: Install dependencies
         if: github.event.action != 'closed'
-        working-directory: monorepo-docs-site
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.DOCS_DIR }}
 
       - name: Build documentation with PR preview base URL
         if: github.event.action != 'closed'
-        working-directory: monorepo-docs-site
+        working-directory: ${{ env.DOCS_DIR }}
         run: npm run build
         env:
           BASE_URL: /camunda/pr-preview/pr-${{ github.event.pull_request.number }}/

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -16,6 +16,10 @@ concurrency:
   cancel-in-progress: true
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
+env:
+  SUITE_DIR: qa/c8-orchestration-cluster-e2e-test-suite
+  CLIENT_DIR: ./operate/client
+
 jobs:
   read-versions:
     runs-on: ubuntu-latest
@@ -65,19 +69,21 @@ jobs:
           node-version: 24
 
       - name: Install node dependencies
-        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.SUITE_DIR }}
 
       - name: Install frontend dependencies
-        working-directory: ./operate/client
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
 
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
-        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        working-directory: ${{ env.SUITE_DIR }}
 
       - name: Build frontend
-        working-directory: ./operate/client
+        working-directory: ${{ env.CLIENT_DIR }}
         run: npm run build
         env:
           NODE_OPTIONS: --max_old_space_size=4096
@@ -165,7 +171,7 @@ jobs:
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           ZEEBE_REST_ADDRESS: "http://localhost:8080"
         run: npm run test -- --project=operate-e2e
-        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        working-directory: ${{ env.SUITE_DIR }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -28,6 +28,7 @@ on:
 
 env:
   TEST_OWNER: '@camunda/monorepo-devops-team'
+  E2E_DIR: e2e-tests
 
 jobs:
   deploy-8-8:
@@ -172,18 +173,19 @@ jobs:
         with:
           node-version: 24
           cache: npm
-          cache-dependency-path: e2e-tests/package-lock.json
+          cache-dependency-path: ${{ env.E2E_DIR }}/package-lock.json
 
       - name: Install Dependencies
-        working-directory: e2e-tests
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.E2E_DIR }}
 
       - name: Install Playwright Browsers
-        working-directory: e2e-tests
+        working-directory: ${{ env.E2E_DIR }}
         run: npx playwright install chromium --with-deps
 
       - name: Run Smoke Tests
-        working-directory: e2e-tests
+        working-directory: ${{ env.E2E_DIR }}
         env:
           LOCAL_TEST: true
           MINOR_VERSION: SM-${{ matrix.deployment.version }}

--- a/.github/workflows/publish-zod-schemas.yml
+++ b/.github/workflows/publish-zod-schemas.yml
@@ -23,6 +23,7 @@ on:
 env:
   TEST_OWNER: '@camunda/core-features'
   GHA_BEST_PRACTICES_LINTER: enabled
+  CLIENT_DIR: webapp/client
 
 jobs:
   publish-zod-schemas:
@@ -34,7 +35,7 @@ jobs:
       contents: read
     defaults:
       run:
-        working-directory: webapp/client
+        working-directory: ${{ env.CLIENT_DIR }}
         shell: bash
     env:
       TEST_PRODUCT: Camunda
@@ -54,7 +55,9 @@ jobs:
           scope: '@camunda'
 
       - name: Install dependencies
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
 
       - name: Build package (automatic triggers)
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -16,6 +16,10 @@ permissions:
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
 # Exception for main branch: complete builds for every commit needed for confidenence
+env:
+  SUITE_DIR: qa/c8-orchestration-cluster-e2e-test-suite
+  CLIENT_DIR: ./tasklist/client
+
 concurrency:
   cancel-in-progress: true
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
@@ -92,19 +96,21 @@ jobs:
           node-version: 24
 
       - name: Install node dependencies
-        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.SUITE_DIR }}
 
       - name: Install frontend dependencies
-        working-directory: ./tasklist/client
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
 
       - name: Install Playwright
         run: npx playwright install --with-deps chromium
-        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        working-directory: ${{ env.SUITE_DIR }}
 
       - name: Build frontend
-        working-directory: ./tasklist/client
+        working-directory: ${{ env.CLIENT_DIR }}
         run: npm run build
 
       - name: Setup Java
@@ -169,7 +175,7 @@ jobs:
           CAMUNDA_BASIC_AUTH_PASSWORD: "demo"
           ZEEBE_REST_ADDRESS: "http://localhost:8080"
         run: npm run test -- --project=tasklist-e2e
-        working-directory: qa/c8-orchestration-cluster-e2e-test-suite
+        working-directory: ${{ env.SUITE_DIR }}
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.github/workflows/tasklist-update_visual_snapshots.yml
+++ b/.github/workflows/tasklist-update_visual_snapshots.yml
@@ -14,6 +14,9 @@ concurrency:
   cancel-in-progress: true
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
+env:
+  CLIENT_DIR: ./tasklist/client
+
 jobs:
   update-snapshots:
     if: github.event.pull_request.state != 'closed' && (github.event.label.name == 'update-snapshots' || contains( github.event.pull_request.labels.*.name, 'update-snapshots'))
@@ -30,13 +33,14 @@ jobs:
         with:
           node-version: 24
       - name: Install node dependencies
-        working-directory: ./tasklist/client
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.CLIENT_DIR }}
       - name: Build frontend
-        working-directory: ./tasklist/client
+        working-directory: ${{ env.CLIENT_DIR }}
         run: npm run build:visual-regression
       - name: Update snapshots
-        working-directory: ./tasklist/client
+        working-directory: ${{ env.CLIENT_DIR }}
         run: npm run test:visual --update-snapshots
       - name: Commit screenshots
         uses: stefanzweifel/git-auto-commit-action@04702edda442b2e678b25b537cec683a1493fcb9 # v7.1.0

--- a/.github/workflows/verify-x-added-in-version-annotations.yml
+++ b/.github/workflows/verify-x-added-in-version-annotations.yml
@@ -19,6 +19,7 @@ defaults:
 
 env:
   TEST_OWNER: '@camunda/core-features'
+  VERIFIER_DIR: .github/scripts/x-added-in-version-check
 
 jobs:
   verify:
@@ -70,11 +71,12 @@ jobs:
           echo "GIT_TERMINAL_PROMPT=0" >> "$GITHUB_ENV"
 
       - name: Install verifier dependencies
-        working-directory: ${{ github.workspace }}/.github/scripts/x-added-in-version-check
-        run: npm ci
+        uses: ./.github/actions/npm-ci-with-retry
+        with:
+          directory: ${{ env.VERIFIER_DIR }}
 
       - name: Build verifier artefacts (endpoint-map + version-map)
-        working-directory: ${{ github.workspace }}/.github/scripts/x-added-in-version-check
+        working-directory: ${{ github.workspace }}/${{ env.VERIFIER_DIR }}
         env:
           # LATEST_BRANCH is not consumed by the in-repo scripts directly.
           # build-artefacts.mjs clones `return-of-api-added-in-analysis` and
@@ -88,7 +90,7 @@ jobs:
 
       - name: Run CI verifier
         id: verify
-        working-directory: ${{ github.workspace }}/.github/scripts/x-added-in-version-check
+        working-directory: ${{ github.workspace }}/${{ env.VERIFIER_DIR }}
         env:
           # Spec lives in the host checkout (camunda/camunda at the requested ref).
           OCA_SPEC_PATH: ${{ github.workspace }}/zeebe/gateway-protocol/src/main/proto/v2


### PR DESCRIPTION
## What & why

Follow-up to [#55954](https://github.com/camunda/camunda/pull/55954) (INC-6275): a single transient npm-registry connection drop during `npm ci` is enough to fail a whole CI job. That PR fixed it only for `ci-webapp-client.yml`. This applies the hardening **everywhere** and removes the duplication by extracting a reusable composite action.

Closes #56247

## Changes

**1. New composite action — `.github/actions/npm-ci-with-retry`**

Wraps `npm ci` in `nick-fields/retry@ad9845…v4.0.0` (defaults: 3 attempts, 5s backoff, 10 min/attempt — all overridable). The retry action runs from the repository root and ignores `working-directory`, so the required `directory` input is passed explicitly and the step is pinned to `shell: bash` for consistent path handling on Linux, container images, and Windows (git-bash).

**2. Routed every `npm ci` install through it (46 sites)**
- Converted all raw `run: npm ci` steps across 2 composite actions (`setup-c8run`, `build-frontend`) and 13 workflows (`ci-operate`, `ci-tasklist`, `ci.yml`, e2e/docs/preview/publish/verify).
- Consolidated the pre-existing inline retry blocks onto the action: `ci-webapp-client.yml` (9) and the `frontend-sbom-snyk` npm branch.

**3. Single source of truth for install directories**

Where a directory path was duplicated between a job's `working-directory` (and `cache-dependency-path`) and the action's `directory` input, it is now defined once as a workflow- or job-level env var (`CLIENT_DIR` / `SUITE_DIR` / `DOCS_DIR` / `E2E_DIR` / `VERIFIER_DIR`) and referenced everywhere — mirroring the existing `CLIENT_DIR` pattern. `env` is an allowed context in `defaults.run.working-directory`, so the job default resolves correctly.

## Out of scope
- `c8run-build.yaml` — intentionally excluded from the env SSOT: its Windows steps use `\`-separated paths while Linux uses `/`, which would need per-OS values. (Its `npm ci` steps are still routed through the retry action.)
- `setup-c8run` — composite action with no action-level `env` context to serve as a single source.
- `.github/scripts/x-added-in-version-check/build-artefacts.mjs` runs `npm ci` inside a spawned Node process (not a GHA step), so GHA-step retry can't wrap it.
- yarn installs (unchanged).

## Validation
- `actionlint` — no new issues (only pre-existing `gcp-*` self-hosted runner-label false-positives).
- `conftest --policy .github` — 0 failures.
- Full CI run green: composite action verified in Playwright container jobs and on the Windows `c8run-build` runner; the env-based `working-directory` verified at runtime across workflow-level env, job-level env, `cache-dependency-path`, and step `working-directory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)