### PR TITLE
feat: set the default ES/OS replica count to 1

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -266,8 +266,8 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     public boolean agentHistory = true;
 
     // index settings
-    private Integer numberOfShards = null;
-    private Integer numberOfReplicas = null;
+    private Integer numberOfShards = 1;
+    private Integer numberOfReplicas = 1;
     private int templatePriority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
     // variable name filters

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -266,8 +266,8 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     public boolean agentHistory = true;
 
     // index settings
-    private Integer numberOfShards = 1;
-    private Integer numberOfReplicas = 1;
+    private Integer numberOfShards = null;
+    private Integer numberOfReplicas = null;
     private int templatePriority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
     // variable name filters

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-ad-hoc-sub-process-instruction-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-ad-hoc-sub-process-instruction-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-history-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-instance-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-async-request-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-async-request-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-checkpoint-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-checkpoint-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-cluster-variable-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-command-distribution-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-command-distribution-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-compensation-subscription-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-conditional-evaluation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-conditional-evaluation-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-conditional-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-conditional-subscription-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-decision-evaluation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-decision-evaluation-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-decision-requirements-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-decision-requirements-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-decision-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-decision-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-deployment-distribution-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-deployment-distribution-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-deployment-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-error-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-error-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-escalation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-escalation-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-form-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-form-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-global-listener-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-global-listener-batch-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-global-listener-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-incident-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-incident-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 3,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-batch-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-correlation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-correlation-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-start-correlation-key-lock-release-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-start-correlation-key-lock-release-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-start-event-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-start-event-subscription-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-start-process-instance-request-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-start-process-instance-request-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-subscription-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-message-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-event-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-event-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-batch-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-creation-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-migration-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-migration-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-modification-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-modification-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 3,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-message-subscription-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-resource-deletion-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-resource-deletion-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-resource-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-resource-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-runtime-instruction-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-runtime-instruction-template.json
@@ -10,7 +10,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-signal-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-signal-subscription-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-signal-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-signal-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-template.json
@@ -3,7 +3,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "mappings": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-timer-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-timer-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-user-task-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-user-task-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 3,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-variable-document-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-variable-document-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-variable-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-variable-template.json
@@ -8,7 +8,7 @@
   "template": {
     "settings": {
       "number_of_shards": 1,
-      "number_of_replicas": 0,
+      "number_of_replicas": 1,
       "index.queries.cache.enabled": false
     },
     "aliases": {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterClientIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterClientIT.java
@@ -246,6 +246,6 @@ final class ElasticsearchExporterClientIT {
   private static void assertIndexSettings(final IndexSettings settings) {
     assertThat(settings).isNotNull();
     assertThat(settings.numberOfShards()).isEqualTo("1");
-    assertThat(settings.numberOfReplicas()).isEqualTo("0");
+    assertThat(settings.numberOfReplicas()).isEqualTo("1");
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TemplateReaderTest.java
@@ -44,7 +44,7 @@ final class TemplateReaderTest {
         .isNullOrEmpty();
     assertThat(template.template().settings())
         .containsEntry("number_of_shards", 1)
-        .containsEntry("number_of_replicas", 0)
+        .containsEntry("number_of_replicas", 1)
         .containsEntry("index.queries.cache.enabled", false);
   }
 
@@ -124,7 +124,7 @@ final class TemplateReaderTest {
     assertThat(template.priority()).isEqualTo(20);
     assertThat(template.template().settings())
         .containsEntry("number_of_shards", 1)
-        .containsEntry("number_of_replicas", 0)
+        .containsEntry("number_of_replicas", 1)
         .containsEntry("index.queries.cache.enabled", false);
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -295,8 +295,8 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     public boolean agentHistory = true;
 
     // index settings
-    private Integer numberOfShards = null;
-    private Integer numberOfReplicas = null;
+    private Integer numberOfShards = 1;
+    private Integer numberOfReplicas = 1;
     private int priority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
     // variable name filters

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -295,8 +295,8 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     public boolean agentHistory = true;
 
     // index settings
-    private Integer numberOfShards = 1;
-    private Integer numberOfReplicas = 1;
+    private Integer numberOfShards = null;
+    private Integer numberOfReplicas = null;
     private int priority = DEFAULT_INDEX_TEMPLATE_PRIORITY;
 
     // variable name filters

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-ad-hoc-sub-process-instruction-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-ad-hoc-sub-process-instruction-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-history-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-instance-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-async-request-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-async-request-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-checkpoint-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-checkpoint-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-cluster-variable-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-cluster-variable-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-command-distribution-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-command-distribution-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-compensation-subscription-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-conditional-evaluation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-conditional-evaluation-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-conditional-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-conditional-subscription-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-decision-evaluation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-decision-evaluation-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-decision-requirements-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-decision-requirements-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-decision-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-decision-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-deployment-distribution-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-deployment-distribution-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-deployment-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-error-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-error-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-escalation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-escalation-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-form-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-form-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-global-listener-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-global-listener-batch-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-global-listener-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-global-listener-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-incident-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-incident-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "3",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-batch-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-correlation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-correlation-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-start-correlation-key-lock-release-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-start-correlation-key-lock-release-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-start-event-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-start-event-subscription-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-start-process-instance-request-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-start-process-instance-request-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-subscription-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-message-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-event-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-event-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-batch-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-creation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-creation-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-migration-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-migration-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-modification-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-modification-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "3",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-message-subscription-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-resource-deletion-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-resource-deletion-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-resource-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-resource-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-runtime-instruction-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-runtime-instruction-template.json
@@ -11,7 +11,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-signal-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-signal-subscription-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-signal-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-signal-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-template.json
@@ -4,7 +4,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-timer-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-timer-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-user-task-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-user-task-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "3",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-variable-document-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-variable-document-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-variable-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-variable-template.json
@@ -9,7 +9,7 @@
     "settings": {
       "index": {
         "number_of_shards": "1",
-        "number_of_replicas": "0",
+        "number_of_replicas": "1",
         "queries": {
           "cache": {
             "enabled": false

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TemplateReaderTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TemplateReaderTest.java
@@ -39,7 +39,7 @@ final class TemplateReaderTest {
 
     // then component template settings set
     assertThat(template.template().settings().index().numberOfShards()).isEqualTo(1);
-    assertThat(template.template().settings().index().numberOfReplicas()).isEqualTo(0);
+    assertThat(template.template().settings().index().numberOfReplicas()).isEqualTo(1);
     assertThat(template.template().settings().index().queries().cache().enabled()).isFalse();
 
     // then template settings not set
@@ -64,7 +64,7 @@ final class TemplateReaderTest {
 
     // then
     assertThat(request.template().settings().index().numberOfShards()).isEqualTo(1);
-    assertThat(request.template().settings().index().numberOfReplicas()).isEqualTo(0);
+    assertThat(request.template().settings().index().numberOfReplicas()).isEqualTo(1);
     assertThat(request.template().settings().index().queries().cache().enabled()).isFalse();
 
     final Map<String, Property> expectedProperties =
@@ -133,7 +133,7 @@ final class TemplateReaderTest {
     assertThat(
             templateReader.readComponentTemplate().template().settings().index().numberOfReplicas())
         .as("should have the default number of shards in template")
-        .isEqualTo(0);
+        .isEqualTo(1);
 
     // when
     final PutComponentTemplateRequest request =
@@ -169,7 +169,7 @@ final class TemplateReaderTest {
         .containsExactlyEntriesOf(Map.of("zeebe-record-variable", Alias.builder().build()));
 
     assertThat(template.template().settings().index().numberOfShards()).isEqualTo(1);
-    assertThat(template.template().settings().index().numberOfReplicas()).isEqualTo(0);
+    assertThat(template.template().settings().index().numberOfReplicas()).isEqualTo(1);
     assertThat(template.template().settings().index().queries().cache().enabled()).isFalse();
   }
 
@@ -199,7 +199,7 @@ final class TemplateReaderTest {
         .containsExactlyEntriesOf(Map.of("custom-alias", Alias.builder().build()));
 
     assertThat(request.template().settings().index().numberOfShards()).isEqualTo(1);
-    assertThat(request.template().settings().index().numberOfReplicas()).isEqualTo(0);
+    assertThat(request.template().settings().index().numberOfReplicas()).isEqualTo(1);
     assertThat(request.template().settings().index().queries().cache().enabled()).isFalse();
 
     final Map<String, Property> expectedProperties =
@@ -284,7 +284,7 @@ final class TemplateReaderTest {
                 .index()
                 .numberOfReplicas())
         .as("should have the default number of shards in template")
-        .isEqualTo(0);
+        .isEqualTo(1);
 
     // when
     final PutIndexTemplateRequest request =


### PR DESCRIPTION
Change the default replica count for ES/OS Exporter indices from 0 to 1, aligning with the Camunda Exporter and our SaaS configuration. 
More context in #55366.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55366 
