### PR TITLE
ci: auto-retry RDBMS nightlies (main + 8.9) on self-hosted runner shutdown

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-nightly-8.9-api-rdbms.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-8.9-api-rdbms.yml
@@ -30,10 +30,9 @@ jobs:
 
   # Auto-retry when a matrix leg failed because its self-hosted runner was
   # terminated mid-job (spot preemption / autoscaler scale-down / node eviction)
-  # rather than a real test failure. The reusable retry only re-runs the failed
-  # jobs when one of the runner-shutdown messages below is present in the run's
-  # logs — genuine test failures do not carry them, so they are never masked.
-  # Capped at two retries via run_attempt.
+  # rather than a real test failure. The reusable action only re-runs the failed
+  # jobs when one of the runner-shutdown messages is present in the run logs, so
+  # genuine test failures are never masked. Capped at two retries via run_attempt.
   rerun-failed-jobs:
     needs:
       - nightly-api-tests-rdbms
@@ -41,37 +40,14 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     runs-on: ubuntu-latest
     steps:
-      - name: Import secrets
-        id: secrets
-        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+      - name: Rerun failed jobs on runner shutdown
+        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run: v1.1.0
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_ID;
-            secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_KEY;
-
-      - name: Generate GitHub token
-        id: github-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ steps.secrets.outputs.RETRIGGER_APP_ID }}
-          private-key: ${{ steps.secrets.outputs.RETRIGGER_APP_KEY }}
-          owner: camunda
-          repositories: infra-global-github-actions
-
-      - name: Retry run on runner shutdown
-        env:
-          GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
-        run: |
-          gh workflow run retry-worfklow-run.yml \
-            -R camunda/infra-global-github-actions \
-            --ref main \
-            -f owner="${GITHUB_REPOSITORY_OWNER}" \
-            -f repository="${GITHUB_REPOSITORY#*/}" \
-            -f run-id="${GITHUB_RUN_ID}" \
-            -f attempt="${GITHUB_RUN_ATTEMPT}" \
-            -f error-messages='["The runner has received a shutdown signal", "The operation was canceled."]'
+          error-messages: |
+            The runner has received a shutdown signal
+            lost communication with the server
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-nightly-8.9-api-rdbms.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-8.9-api-rdbms.yml
@@ -27,3 +27,51 @@ jobs:
       branch: stable/8.9
       camunda_mode: all-in-one
     secrets: inherit
+
+  # Auto-retry when a matrix leg failed because its self-hosted runner was
+  # terminated mid-job (spot preemption / autoscaler scale-down / node eviction)
+  # rather than a real test failure. The reusable retry only re-runs the failed
+  # jobs when one of the runner-shutdown messages below is present in the run's
+  # logs — genuine test failures do not carry them, so they are never masked.
+  # Capped at two retries via run_attempt.
+  rerun-failed-jobs:
+    needs:
+      - nightly-api-tests-rdbms
+      - nightly-api-tests-rdbms-all-in-one
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_ID;
+            secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_KEY;
+
+      - name: Generate GitHub token
+        id: github-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ steps.secrets.outputs.RETRIGGER_APP_ID }}
+          private-key: ${{ steps.secrets.outputs.RETRIGGER_APP_KEY }}
+          owner: camunda
+          repositories: infra-global-github-actions
+
+      - name: Retry run on runner shutdown
+        env:
+          GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          gh workflow run retry-worfklow-run.yml \
+            -R camunda/infra-global-github-actions \
+            --ref main \
+            -f owner="${GITHUB_REPOSITORY_OWNER}" \
+            -f repository="${GITHUB_REPOSITORY#*/}" \
+            -f run-id="${GITHUB_RUN_ID}" \
+            -f attempt="${GITHUB_RUN_ATTEMPT}" \
+            -f error-messages='["The runner has received a shutdown signal", "The operation was canceled."]'

--- a/.github/workflows/c8-orchestration-cluster-nightly-8.9-api-rdbms.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-8.9-api-rdbms.yml
@@ -51,3 +51,16 @@ jobs:
           vault-addr: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-nightly-main-api-rdbms.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-main-api-rdbms.yml
@@ -30,10 +30,9 @@ jobs:
 
   # Auto-retry when a matrix leg failed because its self-hosted runner was
   # terminated mid-job (spot preemption / autoscaler scale-down / node eviction)
-  # rather than a real test failure. The reusable retry only re-runs the failed
-  # jobs when one of the runner-shutdown messages below is present in the run's
-  # logs — genuine test failures do not carry them, so they are never masked.
-  # Capped at two retries via run_attempt.
+  # rather than a real test failure. The reusable action only re-runs the failed
+  # jobs when one of the runner-shutdown messages is present in the run logs, so
+  # genuine test failures are never masked. Capped at two retries via run_attempt.
   rerun-failed-jobs:
     needs:
       - nightly-api-tests-rdbms
@@ -41,37 +40,14 @@ jobs:
     if: failure() && fromJSON(github.run_attempt) < 3
     runs-on: ubuntu-latest
     steps:
-      - name: Import secrets
-        id: secrets
-        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+      - name: Rerun failed jobs on runner shutdown
+        uses: camunda/infra-global-github-actions/rerun-failed-run@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # rerun-failed-run: v1.1.0
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_ID;
-            secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_KEY;
-
-      - name: Generate GitHub token
-        id: github-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ steps.secrets.outputs.RETRIGGER_APP_ID }}
-          private-key: ${{ steps.secrets.outputs.RETRIGGER_APP_KEY }}
-          owner: camunda
-          repositories: infra-global-github-actions
-
-      - name: Retry run on runner shutdown
-        env:
-          GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
-        run: |
-          gh workflow run retry-worfklow-run.yml \
-            -R camunda/infra-global-github-actions \
-            --ref main \
-            -f owner="${GITHUB_REPOSITORY_OWNER}" \
-            -f repository="${GITHUB_REPOSITORY#*/}" \
-            -f run-id="${GITHUB_RUN_ID}" \
-            -f attempt="${GITHUB_RUN_ATTEMPT}" \
-            -f error-messages='["The runner has received a shutdown signal", "The operation was canceled."]'
+          error-messages: |
+            The runner has received a shutdown signal
+            lost communication with the server
+          run-id: ${{ github.run_id }}
+          repository: ${{ github.repository }}
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8-orchestration-cluster-nightly-main-api-rdbms.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-main-api-rdbms.yml
@@ -27,3 +27,51 @@ jobs:
       branch: main
       camunda_mode: all-in-one
     secrets: inherit
+
+  # Auto-retry when a matrix leg failed because its self-hosted runner was
+  # terminated mid-job (spot preemption / autoscaler scale-down / node eviction)
+  # rather than a real test failure. The reusable retry only re-runs the failed
+  # jobs when one of the runner-shutdown messages below is present in the run's
+  # logs — genuine test failures do not carry them, so they are never masked.
+  # Capped at two retries via run_attempt.
+  rerun-failed-jobs:
+    needs:
+      - nightly-api-tests-rdbms
+      - nightly-api-tests-rdbms-all-in-one
+    if: failure() && fromJSON(github.run_attempt) < 3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@79632e33d6953d190b940ffa440bf97821cabd80
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_ID;
+            secret/data/products/infra/ci/retrigger-gha-workflow RETRIGGER_APP_KEY;
+
+      - name: Generate GitHub token
+        id: github-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ steps.secrets.outputs.RETRIGGER_APP_ID }}
+          private-key: ${{ steps.secrets.outputs.RETRIGGER_APP_KEY }}
+          owner: camunda
+          repositories: infra-global-github-actions
+
+      - name: Retry run on runner shutdown
+        env:
+          GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
+        run: |
+          gh workflow run retry-worfklow-run.yml \
+            -R camunda/infra-global-github-actions \
+            --ref main \
+            -f owner="${GITHUB_REPOSITORY_OWNER}" \
+            -f repository="${GITHUB_REPOSITORY#*/}" \
+            -f run-id="${GITHUB_RUN_ID}" \
+            -f attempt="${GITHUB_RUN_ATTEMPT}" \
+            -f error-messages='["The runner has received a shutdown signal", "The operation was canceled."]'

--- a/.github/workflows/c8-orchestration-cluster-nightly-main-api-rdbms.yml
+++ b/.github/workflows/c8-orchestration-cluster-nightly-main-api-rdbms.yml
@@ -51,3 +51,16 @@ jobs:
           vault-addr: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

One matrix leg of the RDBMS nightly (`API Tests (RDBMS) (main / Postgres 16 - Mode profiles)`) failed because its **self-hosted runner was terminated mid-job**, while all 23 sibling legs passed. The runner (`camunda-gcp-perf-core-16-default-...`, an ARC ephemeral pod on GKE) logged:

```
##[error]The runner has received a shutdown signal. This can happen when the runner service is stopped, or a manually started runner is canceled.
##[error]The operation was canceled.
```

Every test that executed passed — this is infrastructure (spot preemption / autoscaler scale-down / node eviction), not a code or test defect, so there is no in-repo fix for the failure itself. Per infra guidance, the remedy is an automatic retry.

This adds a `rerun-failed-jobs` job to **both RDBMS nightlies** (main + 8.9) using the org-standard [`camunda/infra-global-github-actions/rerun-failed-run`](https://github.com/camunda/infra-global-github-actions/tree/main/rerun-failed-run) composite action (pinned `v1.1.0`) — the same pattern ~30 org workflows use, including this repo's own [`optimize-ci-data-upgrade-nightly.yml`](https://github.com/camunda/camunda/blob/main/.github/workflows/optimize-ci-data-upgrade-nightly.yml). The job:

- runs only `if: failure() && fromJSON(github.run_attempt) < 3` (capped at **two** retries);
- passes `error-messages` scoped to runner-shutdown symptoms, so the action **re-runs the failed jobs only when the run actually died from a runner shutdown** — genuine test failures do not carry those messages and are therefore never masked or auto-retried;
- passes only Vault creds; the action fetches its own retrigger token from Vault, so no manual app-token wiring and no `actions: write` on `GITHUB_TOKEN` is required.

**Files changed**
- `.github/workflows/c8-orchestration-cluster-nightly-main-api-rdbms.yml`
- `.github/workflows/c8-orchestration-cluster-nightly-8.9-api-rdbms.yml`

**Motivating runs**
- Failed nightly leg: https://github.com/camunda/camunda/actions/runs/28489068489
- Fix-agent verdict (correctly `not-determined` — infra, no code fix): https://github.com/camunda/camunda/actions/runs/28495798077

## Related issues

<!-- N/A — infra-reliability change; no product issue. -->

## Definition of Done

- [ ] Change is scoped to the RDBMS nightly workflows only (main + 8.9)
- [ ] Retry is gated on the runner-shutdown message (does not mask real test failures)
- [ ] Uses the org-standard rerun-failed-run composite action, matching existing camunda/camunda usage