### PR TITLE
fix: treat ISM 400/404 as no-op for add and change_policy ops

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -771,12 +771,10 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final String operation,
       final String policyName,
       final String indexNamePattern) {
-
     final int status = response.getStatus();
-
     if ((status == 400 || status == 404) && LENIENT_OPERATIONS.contains(operation)) {
       logger.debug(
-          "No managed indices to update for pattern '{}' (operation '{}' '{}' returned {})",
+          "No managed indices to update for pattern '{}' (operation '{}' with '{}' returned {})",
           indexNamePattern,
           operation,
           policyName,
@@ -798,6 +796,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
                   + ", Reason: "
                   + response.getReason()));
     }
+
     return CompletableFuture.completedFuture(null);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import javax.annotation.WillCloseWhenClosed;
@@ -78,6 +79,10 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private static final Time REINDEX_SCROLL_TIMEOUT = Time.of(t -> t.time("30s"));
   private static final Slices AUTO_SLICES =
       Slices.builder().calculation(SlicesCalculation.Auto).build();
+
+  // Operations "change_policy" and "add" return 400 or 404 when no managed indices match the
+  // resolved pattern — both are harmless since there are simply no managed indices to update.
+  private static final Set<String> LENIENT_OPERATIONS = Set.of("change_policy", "add");
 
   private final int partitionId;
   private final HistoryConfiguration config;
@@ -766,14 +771,14 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final String operation,
       final String policyName,
       final String indexNamePattern) {
-    final var status = response.getStatus();
 
-    // change_policy returns 400 or 404 when no managed indices match the resolved pattern —
-    // both are harmless since there are simply no managed indices to update.
-    if ((status == 400 || status == 404) && "change_policy".equals(operation)) {
+    final int status = response.getStatus();
+
+    if ((status == 400 || status == 404) && LENIENT_OPERATIONS.contains(operation)) {
       logger.debug(
-          "No managed indices to update for pattern '{}' (change_policy '{}' returned {})",
+          "No managed indices to update for pattern '{}' (operation '{}' '{}' returned {})",
           indexNamePattern,
+          operation,
           policyName,
           status);
       return CompletableFuture.completedFuture(null);
@@ -782,9 +787,9 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
     if (status >= 400) {
       return CompletableFuture.failedFuture(
           new ExporterException(
-              "Failed to "
+              "Failed to execute operation "
                   + operation
-                  + " index lifecycle policy '"
+                  + " with index lifecycle policy '"
                   + policyName
                   + "' for index: "
                   + indexNamePattern

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -728,20 +728,67 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             executor);
   }
 
+  private CompletableFuture<Void> checkPreconditions(
+      final String policyName, final String indexNamePattern) {
+    final var indexCheck =
+        sendRequestAsync(
+                () ->
+                    genericClient.executeAsync(
+                        Requests.builder().method("HEAD").endpoint("/" + indexNamePattern).build()))
+            .thenApply(resp -> resp.getStatus() == 200);
+
+    final var policyCheck =
+        sendRequestAsync(
+                () ->
+                    genericClient.executeAsync(
+                        Requests.builder()
+                            .method("GET")
+                            .endpoint("/_plugins/_ism/policies/" + policyName)
+                            .build()))
+            .thenApply(resp -> resp.getStatus() == 200);
+
+    return indexCheck
+        .thenCombine(
+            policyCheck,
+            (indexExists, policyExists) -> {
+              final var missing = new ArrayList<String>();
+              if (!indexExists) {
+                missing.add("index '%s' does not exist".formatted(indexNamePattern));
+              }
+              if (!policyExists) {
+                missing.add("ISM policy '%s' does not exist".formatted(policyName));
+              }
+              return missing;
+            })
+        .thenCompose(
+            missing -> {
+              if (missing.isEmpty()) {
+                return CompletableFuture.completedFuture(null);
+              }
+              return CompletableFuture.failedFuture(
+                  new IllegalStateException(
+                      "Cannot apply ISM policy — " + String.join(", ", missing)));
+            });
+  }
+
   private CompletableFuture<Void> doApplyIsmPolicy(
       final String policyName, final String indexNamePattern) {
     logger.debug("Applying policy '{}' to indices: {}", policyName, indexNamePattern);
     final var jsonpMapper = genericClient._transport().jsonpMapper();
-    return sendRequestAsync(
-            () -> {
-              final var addRequest =
-                  Requests.builder()
-                      .method("POST")
-                      .endpoint("/_plugins/_ism/add/" + indexNamePattern)
-                      .json(new AddPolicyRequestBody(policyName), jsonpMapper)
-                      .build();
-              return genericClient.executeAsync(addRequest);
-            })
+    return checkPreconditions(policyName, indexNamePattern)
+        .thenComposeAsync(
+            ignored ->
+                sendRequestAsync(
+                    () -> {
+                      final var addRequest =
+                          Requests.builder()
+                              .method("POST")
+                              .endpoint("/_plugins/_ism/add/" + indexNamePattern)
+                              .json(new AddPolicyRequestBody(policyName), jsonpMapper)
+                              .build();
+                      return genericClient.executeAsync(addRequest);
+                    }),
+            executor)
         .thenComposeAsync(
             resp -> checkIsmResponse(resp, "add", policyName, indexNamePattern), executor)
         .thenComposeAsync(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixes the error that happened here:
* https://github.com/camunda/camunda/actions/runs/28511841303/job/84514328522
* test: `shouldArchiveProcessInstanceAndProcessInstanceDependentEntities`

New run:
https://github.com/camunda/camunda/actions/runs/28523661143/job/84554477606

Note: there are still other errors, this PR only addresses one problem

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
