### PR TITLE
test: extend global user task listener lifecycle and search coverage

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-search-sort-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-search-sort-api-tests.spec.ts
@@ -229,6 +229,110 @@ test.describe.serial('Global Task Listener API Tests - Search and Sort', () => {
     }).toPass(defaultAssertionOptions);
   });
 
+  test('Search Global Task Listeners - filter by type', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {type: {$eq: listeners[0].type}},
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        res,
+      );
+      const body = await res.json();
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].id).toBe(listeners[0].id);
+      expect(body.items[0].type).toBe(listeners[0].type);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Global Task Listeners - filter by eventTypes', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              id: {$in: listeners.map((l) => l.id)},
+              eventTypes: {$in: ['creating']},
+            },
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        res,
+      );
+      const body = await res.json();
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].id).toBe(`${prefix}-c`);
+      expect(body.items[0].eventTypes).toContain('creating');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Global Task Listeners - pagination with limit and from', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const firstPage = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {id: {$in: listeners.map((l) => l.id)}},
+            sort: [{field: 'id', order: 'ASC'}],
+            page: {from: 0, limit: 2},
+          },
+        },
+      );
+
+      await assertStatusCode(firstPage, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        firstPage,
+      );
+      const firstBody = await firstPage.json();
+      expect(firstBody.items).toHaveLength(2);
+      expect(firstBody.page.totalItems).toBe(3);
+      expect(firstBody.items[0].id).toBe(`${prefix}-a`);
+      expect(firstBody.items[1].id).toBe(`${prefix}-b`);
+
+      const secondPage = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {id: {$in: listeners.map((l) => l.id)}},
+            sort: [{field: 'id', order: 'ASC'}],
+            page: {from: 2, limit: 2},
+          },
+        },
+      );
+
+      await assertStatusCode(secondPage, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        secondPage,
+      );
+      const secondBody = await secondPage.json();
+      expect(secondBody.items).toHaveLength(1);
+      expect(secondBody.page.totalItems).toBe(3);
+      expect(secondBody.items[0].id).toBe(`${prefix}-c`);
+    }).toPass(defaultAssertionOptions);
+  });
+
   test('Search Global Task Listeners - invalid sort field returns 400', async ({
     request,
   }) => {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
@@ -553,6 +553,183 @@ public class GlobalUserTaskListenersTest {
         .await();
   }
 
+  @Test
+  void shouldTriggerGlobalUpdatingListenerCreatedViaApi() {
+    // given: a global updating listener defined via the API and a process with a user task
+    restartBroker();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id("apiUpdating")
+        .type("apiUpdating")
+        .eventTypes(GlobalTaskListenerEventType.UPDATING)
+        .send()
+        .join();
+
+    setupAutocompleteWorker("apiUpdating");
+
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess("processWithUserTask")
+            .startEvent("start")
+            .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+            .endEvent("end")
+            .done();
+    final long processDefinitionKey = resourcesHelper.deployProcess(processDefinition);
+    final long processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
+    final var userTask =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task")
+            .getFirst()
+            .getValue();
+
+    // when: the user task is updated
+    camundaClient
+        .newUpdateUserTaskCommand(userTask.getUserTaskKey())
+        .priority(55)
+        .action("escalate")
+        .send()
+        .join();
+
+    // then: the global updating listener is executed
+    assertThat(
+            RecordingExporter.records()
+                .skipUntil(
+                    r -> // skip until task update is started
+                    r.getIntent() == UserTaskIntent.UPDATING
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                .limit(
+                    r -> // stop after task update has been completed
+                    r.getIntent() == UserTaskIntent.UPDATED
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                // get all completed task listener jobs
+                .jobRecords()
+                .withJobKind(JobKind.TASK_LISTENER)
+                .withIntent(JobIntent.COMPLETED))
+        .extracting(Record::getValue)
+        // check that all jobs are for updating event
+        .allMatch(job -> job.getJobListenerEventType() == JobListenerEventType.UPDATING)
+        .extracting(JobRecordValue::getType)
+        // check that the global listener has been executed
+        .containsExactly("apiUpdating");
+  }
+
+  @Test
+  void shouldTriggerGlobalCompletingListenerCreatedViaApi() {
+    // given: a global completing listener defined via the API and a process with a user task
+    restartBroker();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id("apiCompleting")
+        .type("apiCompleting")
+        .eventTypes(GlobalTaskListenerEventType.COMPLETING)
+        .send()
+        .join();
+
+    setupAutocompleteWorker("apiCompleting");
+
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess("processWithUserTask")
+            .startEvent("start")
+            .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+            .endEvent("end")
+            .done();
+    final long processDefinitionKey = resourcesHelper.deployProcess(processDefinition);
+    final long processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
+    final var userTask =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task")
+            .getFirst()
+            .getValue();
+
+    // when: the user task is completed
+    camundaClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
+
+    // then: the global completing listener is executed
+    assertThat(
+            RecordingExporter.records()
+                .skipUntil(
+                    r -> // skip until task completion is started
+                    r.getIntent() == UserTaskIntent.COMPLETING
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                .limit(
+                    r -> // stop after task completion has been completed
+                    r.getIntent() == UserTaskIntent.COMPLETED
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                // get all completed task listener jobs
+                .jobRecords()
+                .withJobKind(JobKind.TASK_LISTENER)
+                .withIntent(JobIntent.COMPLETED))
+        .extracting(Record::getValue)
+        // check that all jobs are for completing event
+        .allMatch(job -> job.getJobListenerEventType() == JobListenerEventType.COMPLETING)
+        .extracting(JobRecordValue::getType)
+        // check that the global listener has been executed
+        .containsExactly("apiCompleting");
+  }
+
+  @Test
+  void shouldTriggerGlobalCancelingListenerCreatedViaApi() {
+    // given: a global canceling listener defined via the API and a process with a user task
+    restartBroker();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id("apiCanceling")
+        .type("apiCanceling")
+        .eventTypes(GlobalTaskListenerEventType.CANCELING)
+        .send()
+        .join();
+
+    setupAutocompleteWorker("apiCanceling");
+
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess("processWithUserTask")
+            .startEvent("start")
+            .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+            .endEvent("end")
+            .done();
+    final long processDefinitionKey = resourcesHelper.deployProcess(processDefinition);
+    final long processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("task")
+        .await();
+
+    // when: the process instance is canceled while the user task is active
+    camundaClient.newCancelInstanceCommand(processInstanceKey).send();
+
+    // then: the global canceling listener is executed
+    assertThat(
+            RecordingExporter.records()
+                .skipUntil(
+                    r -> // skip until task cancellation is started
+                    r.getIntent() == UserTaskIntent.CANCELING
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                .limit(
+                    r -> // stop after task cancellation has been completed
+                    r.getIntent() == UserTaskIntent.CANCELED
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                // get all completed task listener jobs
+                .jobRecords()
+                .withJobKind(JobKind.TASK_LISTENER)
+                .withIntent(JobIntent.COMPLETED))
+        .extracting(Record::getValue)
+        // check that all jobs are for canceling event
+        .allMatch(job -> job.getJobListenerEventType() == JobListenerEventType.CANCELING)
+        .extracting(JobRecordValue::getType)
+        // check that the global listener has been executed
+        .containsExactly("apiCanceling");
+  }
+
   private void setupAutocompleteWorker(final String jobType) {
     camundaClient
         .newWorker()


### PR DESCRIPTION
## Description

Extends automated test coverage for the **Global User Task Listeners via Orchestration Cluster API** epic (#43168) by closing two gaps identified in a coverage audit.

### Gap 1 — Engine integration test (behavioral lifecycle)

`GlobalUserTaskListenersTest` previously only exercised the `CREATING` and `ASSIGNING` events. Added three behavioral tests verifying that an API-created global task listener fires a `TASK_LISTENER` job with the matching `JobListenerEventType` on the remaining user-task lifecycle events:

- `shouldTriggerGlobalUpdatingListenerCreatedViaApi` — `UPDATING`
- `shouldTriggerGlobalCompletingListenerCreatedViaApi` — `COMPLETING`
- `shouldTriggerGlobalCancelingListenerCreatedViaApi` — `CANCELING`

### Gap 2 — E2E API search coverage

`global-task-listener-search-sort-api-tests.spec.ts` covered sorting and the `id` `$in` filter. Added:

- filter by `type`
- filter by `eventTypes`
- pagination (`page.from`/`page.limit` + `page.totalItems` across pages)

### Why the split

Global task listeners are **cluster-scoped** (no tenant) and apply to every user task in the cluster for the configured event type. Behavioral lifecycle coverage is therefore kept in the isolated-broker engine IT rather than the shared parallel E2E suite, where a listener firing on `completing`/`canceling` would interfere with other parallel tests' user tasks. The E2E additions are metadata-only search assertions and safe to run in parallel.

Relates to #43168