### PR TITLE
ci: configure Renovate to update Camunda Docker images for load tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -753,6 +753,18 @@
       "matchDatasources": ["github-tags"],
       "matchFileNames": ["load-tests/setup/main/**"],
       "ignoreUnstable": false
+    },
+    {
+      "description": "Bump Docker images used by load tests ; keep the same major.minor and update only for patch releases",
+      "matchFileNames": [
+        "load-tests/setup/*/values/*.y*ml"
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "docker.io/camunda/zeebe",
+        "docker.io/camunda/camunda"
+      ],
+      "allowedVersions": "<= {{{major}}}.{{{minor}}}"
     }
   ],
   "dockerfile": {
@@ -762,6 +774,12 @@
     "ignorePaths": [
       "zeebe/load-tests/**",
       "clients/go/vendor/**"
+    ]
+  },
+  "helm-values": {
+    "managerFilePatterns": [
+      "**/values.y*ml",
+      "load-tests/setup/*/values/*.y*ml"
     ]
   },
   "customManagers": [


### PR DESCRIPTION
## Description

* The `managerFilePatterns` instructs Renovate to look for Helm Values file in the load tests directories. By default [it only looks for `values.yaml` files](https://docs.renovatebot.com/modules/manager/helm-values/).
* The `packageRules` instructs Renovate to only update the patch release by keep the same major/minor: if the current image is `8.9.5`, Renovate will only propose updates for `<= 8.9`
  * [`allowedVersions` configuration](https://docs.renovatebot.com/configuration-options/#packagerulesallowedversions)
  * [Renovate template variables](https://docs.renovatebot.com/templates/#other-available-fields)

The `helm-values` Renovate manager [knows how to update natively some of the configuration we have](https://docs.renovatebot.com/modules/manager/helm-values/), specifically things like this:
```yaml
orchestration:
  image:
    registry: docker.io
    repository: camunda/camunda
    tag: "8.8.28"
```

Tested here: https://github.com/multani/test-renovate-cphc2/commit/b235c8f8a46ac7fe277f819990d1e107d9371cf7
Produces this:
* https://github.com/multani/test-renovate-cphc2/pull/21
  <img width="524" height="136" alt="image" src="https://github.com/user-attachments/assets/3c172f07-885c-43cb-875c-ae43616bce68" />
* https://github.com/multani/test-renovate-cphc2/pull/19
  <img width="534" height="164" alt="image" src="https://github.com/user-attachments/assets/297847dc-90c5-49ab-a399-51974192ddb9" />


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/pull/56264
* https://docs.renovatebot.com/modules/manager/helm-values/
* https://github.com/camunda/camunda/issues/55702
