### PR TITLE
test: cover global task listener lifecycle events (updating, completing)

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
@@ -29,6 +29,10 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.AutoClose;
@@ -540,7 +544,7 @@ public class GlobalUserTaskListenersTest {
         .await();
 
     // Cancel the process (with the task)
-    camundaClient.newCancelInstanceCommand(processInstanceKey).send();
+    camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
 
     // then: the "creating" job and the task are correctly canceled
     RecordingExporter.userTaskRecords(UserTaskIntent.CANCELED)
@@ -551,6 +555,133 @@ public class GlobalUserTaskListenersTest {
         .withJobListenerEventType(JobListenerEventType.CREATING)
         .withType("global")
         .await();
+  }
+
+  @Test
+  void shouldTriggerGlobalUpdatingListenerCreatedViaApi() {
+    // given: a global updating listener defined via the API and a process with a user task
+    // Start from a clean broker so that no global listeners created by previous tests leak into
+    // this one (a leftover "creating" listener without a worker would otherwise block user-task
+    // creation and make this test hang).
+    restartBrokerWithCleanState();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id("apiUpdating")
+        .type("apiUpdating")
+        .eventTypes(GlobalTaskListenerEventType.UPDATING)
+        .send()
+        .join();
+
+    setupAutocompleteWorker("apiUpdating");
+
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess("processWithUserTask")
+            .startEvent("start")
+            .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+            .endEvent("end")
+            .done();
+    final long processDefinitionKey = resourcesHelper.deployProcess(processDefinition);
+    final long processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
+    final var userTask =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task")
+            .getFirst()
+            .getValue();
+
+    // when: the user task is updated
+    camundaClient
+        .newUpdateUserTaskCommand(userTask.getUserTaskKey())
+        .priority(55)
+        .action("escalate")
+        .send()
+        .join();
+
+    // then: the global updating listener is executed
+    assertThat(
+            RecordingExporter.records()
+                .skipUntil(
+                    r -> // skip until task update is started
+                    r.getIntent() == UserTaskIntent.UPDATING
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                .limit(
+                    r -> // stop after task update has been completed
+                    r.getIntent() == UserTaskIntent.UPDATED
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                // get all completed task listener jobs
+                .jobRecords()
+                .withJobKind(JobKind.TASK_LISTENER)
+                .withIntent(JobIntent.COMPLETED))
+        .extracting(Record::getValue)
+        // check that all jobs are for updating event
+        .allMatch(job -> job.getJobListenerEventType() == JobListenerEventType.UPDATING)
+        .extracting(JobRecordValue::getType)
+        // check that the global listener has been executed
+        .containsExactly("apiUpdating");
+  }
+
+  @Test
+  void shouldTriggerGlobalCompletingListenerCreatedViaApi() {
+    // given: a global completing listener defined via the API and a process with a user task
+    // Start from a clean broker so that no global listeners created by previous tests leak into
+    // this one (a leftover "creating" listener without a worker would otherwise block user-task
+    // creation and make this test hang).
+    restartBrokerWithCleanState();
+
+    camundaClient
+        .newCreateGlobalTaskListenerRequest()
+        .id("apiCompleting")
+        .type("apiCompleting")
+        .eventTypes(GlobalTaskListenerEventType.COMPLETING)
+        .send()
+        .join();
+
+    setupAutocompleteWorker("apiCompleting");
+
+    final BpmnModelInstance processDefinition =
+        Bpmn.createExecutableProcess("processWithUserTask")
+            .startEvent("start")
+            .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+            .endEvent("end")
+            .done();
+    final long processDefinitionKey = resourcesHelper.deployProcess(processDefinition);
+    final long processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
+    final var userTask =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task")
+            .getFirst()
+            .getValue();
+
+    // when: the user task is completed
+    camundaClient.newCompleteUserTaskCommand(userTask.getUserTaskKey()).send().join();
+
+    // then: the global completing listener is executed
+    assertThat(
+            RecordingExporter.records()
+                .skipUntil(
+                    r -> // skip until task completion is started
+                    r.getIntent() == UserTaskIntent.COMPLETING
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                .limit(
+                    r -> // stop after task completion has been completed
+                    r.getIntent() == UserTaskIntent.COMPLETED
+                            && ((UserTaskRecordValue) r.getValue()).getProcessInstanceKey()
+                                == processInstanceKey)
+                // get all completed task listener jobs
+                .jobRecords()
+                .withJobKind(JobKind.TASK_LISTENER)
+                .withIntent(JobIntent.COMPLETED))
+        .extracting(Record::getValue)
+        // check that all jobs are for completing event
+        .allMatch(job -> job.getJobListenerEventType() == JobListenerEventType.COMPLETING)
+        .extracting(JobRecordValue::getType)
+        // check that the global listener has been executed
+        .containsExactly("apiCompleting");
   }
 
   private void setupAutocompleteWorker(final String jobType) {
@@ -574,6 +705,36 @@ public class GlobalUserTaskListenersTest {
     }
     ZEEBE.start();
     ZEEBE.awaitCompleteTopology();
+  }
+
+  /**
+   * Restarts the broker with an empty global-listener configuration and a fresh data directory.
+   *
+   * <p>The broker is shared and static across all tests in this class, and its data directory is
+   * reused across restarts. Both configuration-defined and API-created global listeners therefore
+   * survive a plain {@link #restartBroker()} and leak into subsequent tests. Tests that rely on API
+   * listeners only (and expect exactly one listener to fire) use this method to guarantee a clean
+   * slate.
+   */
+  private void restartBrokerWithCleanState() {
+    if (ZEEBE.isStarted()) {
+      ZEEBE.stop();
+      RecordingExporter.reset();
+    }
+    // drop configuration-defined listeners and start from an empty data directory so that no
+    // configuration-defined or API-created listener from a previous test survives
+    configureGlobalListeners(List.of());
+    ZEEBE.withWorkingDirectory(createTempDataDirectory());
+    ZEEBE.start();
+    ZEEBE.awaitCompleteTopology();
+  }
+
+  private static Path createTempDataDirectory() {
+    try {
+      return Files.createTempDirectory("global-user-task-listeners-it");
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   private GlobalListenerCfg createListenerConfig(


### PR DESCRIPTION
Extends automated test coverage for the Global User Task Listeners via Orchestration Cluster API epic (#43168) with engine-level behavioral lifecycle tests.

## What

`GlobalUserTaskListenersTest` previously only exercised the `CREATING` and `ASSIGNING` events. This adds behavioral tests verifying that an API-created global task listener fires a `TASK_LISTENER` job with the matching `JobListenerEventType` on further user-task lifecycle events:

- `shouldTriggerGlobalUpdatingListenerCreatedViaApi` — `UPDATING`
- `shouldTriggerGlobalCompletingListenerCreatedViaApi` — `COMPLETING`

A `CANCELING` case was intentionally left out: cancelling an idle user task with a global canceling listener does not currently emit a `TASK_LISTENER` job, so the scenario cannot be asserted as a behavioral test here. (The existing `shouldAllowCancellingUserTaskWhileWaitingForListener` still covers cancellation while a listener job is pending.)

## Test isolation

The broker in this test class is shared and static, and its data directory and global-listener configuration survive restarts. Both configuration-defined and API-created global listeners therefore leak across tests. The new API-only tests restart the broker from a clean state (empty global-listener config + fresh data directory) so that a leftover `creating` listener without a worker cannot block user-task creation and make the tests hang.

The cancel-instance command in `shouldAllowCancellingUserTaskWhileWaitingForListener` is now awaited (`join()`) so a failed request surfaces immediately instead of manifesting later as an exporter await timeout.

## Why the split

Global task listeners are cluster-scoped (no tenant) and apply to every user task in the cluster for the configured event type. Behavioral lifecycle coverage is therefore kept in the isolated-broker engine IT rather than the shared parallel E2E suite, where a listener firing on `completing` would interfere with other parallel tests' user tasks.

The E2E search coverage lives in a separate PR.

Relates to #43168

Test Rail test cases
https://camunda.testrail.com/index.php?/suites/view/17051&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=879386

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview
