### PR TITLE
test: cover global task listener search filtering and pagination

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-search-sort-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-search-sort-api-tests.spec.ts
@@ -229,6 +229,110 @@ test.describe.serial('Global Task Listener API Tests - Search and Sort', () => {
     }).toPass(defaultAssertionOptions);
   });
 
+  test('Search Global Task Listeners - filter by type', async ({request}) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {type: {$eq: listeners[0].type}},
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        res,
+      );
+      const body = await res.json();
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].id).toBe(listeners[0].id);
+      expect(body.items[0].type).toBe(listeners[0].type);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Global Task Listeners - filter by eventTypes', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {
+              id: {$in: listeners.map((l) => l.id)},
+              eventTypes: {$in: ['creating']},
+            },
+          },
+        },
+      );
+
+      await assertStatusCode(res, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        res,
+      );
+      const body = await res.json();
+      expect(body.items).toHaveLength(1);
+      expect(body.items[0].id).toBe(`${prefix}-c`);
+      expect(body.items[0].eventTypes).toContain('creating');
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Search Global Task Listeners - pagination with limit and from', async ({
+    request,
+  }) => {
+    await expect(async () => {
+      const firstPage = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {id: {$in: listeners.map((l) => l.id)}},
+            sort: [{field: 'id', order: 'ASC'}],
+            page: {from: 0, limit: 2},
+          },
+        },
+      );
+
+      await assertStatusCode(firstPage, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        firstPage,
+      );
+      const firstBody = await firstPage.json();
+      expect(firstBody.items).toHaveLength(2);
+      expect(firstBody.page.totalItems).toBe(3);
+      expect(firstBody.items[0].id).toBe(`${prefix}-a`);
+      expect(firstBody.items[1].id).toBe(`${prefix}-b`);
+
+      const secondPage = await request.post(
+        buildUrl('/global-task-listeners/search'),
+        {
+          headers: jsonHeaders(),
+          data: {
+            filter: {id: {$in: listeners.map((l) => l.id)}},
+            sort: [{field: 'id', order: 'ASC'}],
+            page: {from: 2, limit: 2},
+          },
+        },
+      );
+
+      await assertStatusCode(secondPage, 200);
+      await validateResponse(
+        {path: '/global-task-listeners/search', method: 'POST', status: '200'},
+        secondPage,
+      );
+      const secondBody = await secondPage.json();
+      expect(secondBody.items).toHaveLength(1);
+      expect(secondBody.page.totalItems).toBe(3);
+      expect(secondBody.items[0].id).toBe(`${prefix}-c`);
+    }).toPass(defaultAssertionOptions);
+  });
+
   test('Search Global Task Listeners - invalid sort field returns 400', async ({
     request,
   }) => {


### PR DESCRIPTION
Extends automated test coverage for the Global User Task Listeners via Orchestration Cluster API epic (#43168) with additional E2E search API assertions.

## What

`global-task-listener-search-sort-api-tests.spec.ts` previously covered sorting and the `id` `$in` filter. This adds:

- filter by `type`
- filter by `eventTypes`
- pagination (`page.from`/`page.limit` + `page.totalItems` across pages)

## Why the split

These E2E additions are metadata-only search assertions and safe to run in the shared parallel E2E suite. The behavioral engine lifecycle coverage (which requires an isolated broker) lives in a separate PR.

Relates to #43168


Test Rail test cases
https://camunda.testrail.com/index.php?/suites/view/17051&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=879386

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview