### PR TITLE
ci: auto-classify orphaned issues to project boards using Claude AI

### DIFF
--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -1,6 +1,6 @@
 component/c8-api:
   '(C8-API-)'
-component/C8Run:
+component/c8run:
   '(C8Run-)'
 component/camunda-process-test:
   '(Camunda Process Test-)'

--- a/.github/scripts/.gitignore
+++ b/.github/scripts/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.github/scripts/classify-issue.mjs
+++ b/.github/scripts/classify-issue.mjs
@@ -1,0 +1,448 @@
+#!/usr/bin/env node
+/**
+ * classify-issue.mjs
+ *
+ * Classifies GitHub issues that lack a component/* label using Claude AI,
+ * then routes them to the correct project board.
+ *
+ * Modes:
+ *   --scan [--limit N]   Paginate all open issues, classify orphans (default limit: unlimited)
+ *   --issue <N>          Classify a single issue by number
+ *   --backtest [--limit N]  Test accuracy against N already-labeled issues (default: 100)
+ *
+ * Required env:
+ *   GH_TOKEN             GitHub API token with issues:write and projects:write
+ *   ANTHROPIC_API_KEY    Claude API key
+ *
+ * Optional env:
+ *   AI_CLASSIFY_APPLY_LABEL  'true' to apply labels/project assignments (default: 'false')
+ *   OWNER                    GitHub org (default: 'camunda')
+ *   REPO                     GitHub repo (default: 'camunda')
+ *   GITHUB_STEP_SUMMARY      Written by GHA; path to append job summary markdown
+ */
+
+import Anthropic from '@anthropic-ai/sdk';
+import { execFileSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+const OWNER = process.env.OWNER ?? 'camunda';
+const REPO = process.env.REPO ?? 'camunda';
+const DRY_RUN = process.env.DRY_RUN === 'true';
+
+// Mirrors add-to-projects.yml: component label → project number
+const COMPONENT_TO_PROJECT = {
+  'component/zeebe': 92,
+  'component/operate': 173,
+  'component/tasklist': 173,
+  'component/optimize': 173,
+  'component/data-layer': 184,
+  'component/connectors': 23,
+  'component/identity': 209,
+  'component/management-identity': 209,
+  'component/c8run': 33,
+  'component/feel-js': 79,
+  'component/feel-scala': 79,
+  'component/build-pipeline': 115,
+  'component/release': 115,
+  'component/load-tests': 202,
+  'component/clients': 182,
+  'component/spring-boot-starter': 182,
+  'component/camunda-process-test': 182,
+  'component/c8-api': 182,
+};
+
+const COMPONENT_DESCRIPTIONS = {
+  'component/zeebe': 'Core BPMN/DMN process engine, broker, job streaming, protocol (zeebe/)',
+  'component/operate': 'Process monitoring web application (operate/)',
+  'component/tasklist': 'User task management web application (tasklist/)',
+  'component/optimize': 'Process analytics and reporting (optimize/)',
+  'component/data-layer': 'Database layer: RDBMS, Elasticsearch, OpenSearch (db/, search/)',
+  'component/connectors': 'Out-of-the-box connectors to external systems',
+  'component/identity': 'Authentication and authorization service (identity/)',
+  'component/management-identity': 'Management-level identity and org auth',
+  'component/c8run': 'Packaged local Camunda 8 distribution (c8run/)',
+  'component/feel-js': 'FEEL expression language JavaScript implementation',
+  'component/feel-scala': 'FEEL expression language Scala implementation',
+  'component/build-pipeline': 'CI/CD, GitHub Actions, Maven build infrastructure (.github/)',
+  'component/release': 'Release process, versioning, release automation',
+  'component/load-tests': 'Cluster load and reliability tests (load-tests/)',
+  'component/clients': 'Java and other client libraries (clients/)',
+  'component/spring-boot-starter': 'Spring Boot starter for Camunda (clients/)',
+  'component/camunda-process-test': 'Process testing library (testing/)',
+  'component/c8-api': 'Camunda 8 REST API gateway and public API contracts (gateways/)',
+};
+
+const VALID_LABELS = Object.keys(COMPONENT_TO_PROJECT);
+const anthropic = new Anthropic();
+
+// --- GitHub GraphQL ---
+
+async function graphql(query, variables = {}) {
+  const resp = await fetch('https://api.github.com/graphql', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.GH_TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  const json = await resp.json();
+  if (json.errors) throw new Error(`GraphQL: ${JSON.stringify(json.errors)}`);
+  return json.data;
+}
+
+const ISSUE_FIELDS = `
+  id
+  number
+  title
+  body
+  createdAt
+  url
+  labels(first: 30) { nodes { name } }
+  projectItems(first: 10) {
+    nodes { project { number closed title } }
+  }
+  parent {
+    number
+    projectItems(first: 5) {
+      nodes { project { number closed title } }
+    }
+  }
+  timelineItems(first: 30, itemTypes: [UNLABELED_EVENT]) {
+    nodes {
+      ... on UnlabeledEvent {
+        createdAt
+        actor { login }
+        label { name }
+      }
+    }
+  }
+`;
+
+async function fetchIssue(issueNumber) {
+  const data = await graphql(
+    `query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) { ${ISSUE_FIELDS} }
+      }
+    }`,
+    { owner: OWNER, repo: REPO, number: issueNumber },
+  );
+  return data.repository.issue;
+}
+
+async function* fetchAllOpenIssues() {
+  let cursor = null;
+  while (true) {
+    const data = await graphql(
+      `query($owner: String!, $repo: String!, $after: String) {
+        repository(owner: $owner, name: $repo) {
+          issues(states: OPEN, first: 100, after: $after) {
+            pageInfo { hasNextPage endCursor }
+            nodes { ${ISSUE_FIELDS} }
+          }
+        }
+      }`,
+      { owner: OWNER, repo: REPO, after: cursor },
+    );
+    const page = data.repository.issues;
+    for (const issue of page.nodes) yield issue;
+    if (!page.pageInfo.hasNextPage) break;
+    cursor = page.pageInfo.endCursor;
+  }
+}
+
+// --- Issue predicates ---
+
+function hasActiveBoard(issue) {
+  return issue.projectItems.nodes.some(n => !n.project.closed);
+}
+
+function getComponentLabel(issue) {
+  return issue.labels.nodes.find(l => VALID_LABELS.includes(l.name))?.name ?? null;
+}
+
+function hasLabel(issue, name) {
+  return issue.labels.nodes.some(l => l.name === name);
+}
+
+function isRecentlyCreated(issue) {
+  const tenMinutesAgo = new Date(Date.now() - 10 * 60 * 1000);
+  return new Date(issue.createdAt) > tenMinutesAgo;
+}
+
+// --- AI classification ---
+
+async function classifyWithAI(issue) {
+  const activeParentBoards = issue.parent?.projectItems?.nodes
+    ?.filter(n => !n.project.closed)
+    ?.map(n => `project #${n.project.number} "${n.project.title}"`)
+    ?.join(', ');
+
+  const removedComponentLabels = issue.timelineItems?.nodes
+    ?.filter(n => n.label?.name?.startsWith('component/'))
+    ?.map(n => `"${n.label.name}" removed by @${n.actor?.login ?? 'unknown'} on ${n.createdAt}`)
+    ?.join('\n  ');
+
+  const labelList = VALID_LABELS
+    .map(l => `  ${l}: ${COMPONENT_DESCRIPTIONS[l]}`)
+    .join('\n');
+
+  const lines = [
+    'Classify this GitHub issue from the Camunda 8 monorepo to exactly one component label.',
+    '',
+    'Available labels:',
+    labelList,
+    '',
+    `Title: ${issue.title}`,
+    `Body: ${(issue.body ?? '').slice(0, 800) || '(empty)'}`,
+    `Labels already on issue: ${issue.labels.nodes.map(l => l.name).join(', ') || 'none'}`,
+  ];
+  if (activeParentBoards) lines.push(`Parent issue belongs to: ${activeParentBoards}`);
+  if (removedComponentLabels) {
+    lines.push(
+      `Previously removed component labels (do NOT re-apply):`,
+      `  ${removedComponentLabels}`,
+    );
+  }
+
+  const response = await anthropic.messages.create({
+    model: 'claude-sonnet-4-6',
+    max_tokens: 256,
+    tools: [{
+      name: 'classify',
+      description: 'Classify the issue to a component label',
+      input_schema: {
+        type: 'object',
+        properties: {
+          label: {
+            type: 'string',
+            enum: [...VALID_LABELS, 'none'],
+            description: 'Best-matching component label, or "none" if uncertain',
+          },
+          reasoning: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Up to 2 brief bullet points explaining the classification',
+            maxItems: 2,
+          },
+        },
+        required: ['label', 'reasoning'],
+      },
+    }],
+    tool_choice: { type: 'tool', name: 'classify' },
+    messages: [{ role: 'user', content: lines.join('\n') }],
+  });
+
+  const toolUse = response.content.find(b => b.type === 'tool_use');
+  return toolUse.input;
+}
+
+// --- GitHub mutations ---
+
+function gh(...args) {
+  return execFileSync('gh', args, {
+    env: { ...process.env },
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function addLabels(issueNumber, labels) {
+  gh('issue', 'edit', String(issueNumber), '--add-label', labels.join(','), '--repo', `${OWNER}/${REPO}`);
+}
+
+function postComment(issueNumber, body) {
+  gh('issue', 'comment', String(issueNumber), '--body', body, '--repo', `${OWNER}/${REPO}`);
+}
+
+function addToProject(projectNumber, issueUrl) {
+  gh('project', 'item-add', String(projectNumber), '--owner', OWNER, '--url', issueUrl);
+}
+
+// --- Comment templates ---
+
+function successComment(label, reasoning, applied) {
+  const status = applied ? `Auto-classified as \`${label}\`.` : `**Proposed classification**: \`${label}\` *(not yet applied — pending review)*`;
+  return [
+    '> [!NOTE]',
+    `> ${status}`,
+    ...reasoning.map(r => `> - ${r}`),
+    '>',
+    '> Remove the `ai-classified` label to trigger reclassification.',
+  ].join('\n');
+}
+
+function failureComment() {
+  return [
+    '> [!WARNING]',
+    '> Could not automatically determine a component label for this issue.',
+    '> It has been tagged with `needs component label` for manual review.',
+    '>',
+    '> Remove the `ai-classified` label if you\'d like the classifier to try again.',
+  ].join('\n');
+}
+
+// --- Case handlers ---
+
+async function handleCaseOne(issue) {
+  console.log(`[#${issue.number}] No component label — running AI classification`);
+  const { label, reasoning } = await classifyWithAI(issue);
+
+  if (label === 'none') {
+    console.log(`[#${issue.number}] AI returned none — escalating`);
+    if (!DRY_RUN) addLabels(issue.number, ['ai-classified', 'needs component label']);
+    postComment(issue.number, failureComment());
+    return { action: 'escalated', label: 'needs component label', project: null };
+  }
+
+  console.log(`[#${issue.number}] AI classified as ${label}`);
+  if (!DRY_RUN) addLabels(issue.number, ['ai-classified', label]);
+  postComment(issue.number, successComment(label, reasoning, !DRY_RUN));
+  return { action: DRY_RUN ? 'proposed' : 'classified', label, project: COMPONENT_TO_PROJECT[label] };
+}
+
+async function handleCaseTwo(issue, componentLabel) {
+  const projectNumber = COMPONENT_TO_PROJECT[componentLabel];
+  if (!projectNumber) {
+    console.log(`[#${issue.number}] No project mapping for ${componentLabel} — skipping`);
+    return { action: 'no-mapping', label: componentLabel, project: null };
+  }
+  console.log(`[#${issue.number}] Has ${componentLabel} but no board — adding to project #${projectNumber}`);
+  if (!DRY_RUN) addToProject(projectNumber, issue.url);
+  return { action: DRY_RUN ? 'proposed-direct' : 'direct-assigned', label: componentLabel, project: projectNumber };
+}
+
+// --- Modes ---
+
+async function runScan(limit) {
+  const results = [];
+  let scanned = 0;
+
+  for await (const issue of fetchAllOpenIssues()) {
+    scanned++;
+    if (hasLabel(issue, 'ai-classified')) continue;
+    if (isRecentlyCreated(issue)) continue;
+    if (hasActiveBoard(issue)) continue;
+    if (limit != null && results.length >= limit) break;
+
+    const componentLabel = getComponentLabel(issue);
+    const result = componentLabel
+      ? await handleCaseTwo(issue, componentLabel)
+      : await handleCaseOne(issue);
+
+    results.push({ issue: issue.number, ...result });
+  }
+
+  console.log(`Scanned ${scanned} issues. Processed ${results.length} orphans.`);
+  writeJobSummary(results);
+  return results;
+}
+
+async function runSingle(issueNumber) {
+  const issue = await fetchIssue(issueNumber);
+  if (hasLabel(issue, 'ai-classified')) {
+    console.log(`[#${issueNumber}] Already has ai-classified — skipping`);
+    return;
+  }
+  if (hasActiveBoard(issue)) {
+    console.log(`[#${issueNumber}] Already on an active board — skipping`);
+    return;
+  }
+  const componentLabel = getComponentLabel(issue);
+  if (componentLabel) {
+    console.log(`[#${issueNumber}] Already has component label ${componentLabel} — skipping`);
+    return;
+  }
+  await handleCaseOne(issue);
+}
+
+async function runBacktest(limit) {
+  let correct = 0;
+  let total = 0;
+  const mismatches = [];
+
+  for await (const issue of fetchAllOpenIssues()) {
+    if (total >= limit) break;
+    const trueLabel = getComponentLabel(issue);
+    if (!trueLabel) continue;
+    total++;
+
+    const fakeIssue = {
+      ...issue,
+      labels: { nodes: issue.labels.nodes.filter(l => !l.name.startsWith('component/')) },
+    };
+    const { label: predicted } = await classifyWithAI(fakeIssue);
+    const correct_ = predicted === trueLabel;
+    if (correct_) correct++;
+    else mismatches.push({ issue: issue.number, true: trueLabel, predicted });
+    console.log(`[#${issue.number}] true=${trueLabel} predicted=${predicted} ${correct_ ? '✓' : '✗'}`);
+  }
+
+  const pct = total > 0 ? ((correct / total) * 100).toFixed(1) : '0.0';
+  console.log(`\nAccuracy: ${correct}/${total} (${pct}%)`);
+  if (mismatches.length) {
+    console.log('\nMismatches:');
+    for (const m of mismatches) console.log(`  #${m.issue}: true=${m.true} predicted=${m.predicted}`);
+  }
+}
+
+// --- Job summary ---
+
+function writeJobSummary(results) {
+  const path = process.env.GITHUB_STEP_SUMMARY;
+  if (!path) return;
+
+  const now = new Date().toISOString().replace('T', ' ').slice(0, 19) + ' UTC';
+  const counts = {
+    classified: results.filter(r => r.action === 'classified').length,
+    'direct-assigned': results.filter(r => r.action === 'direct-assigned').length,
+    proposed: results.filter(r => r.action === 'proposed' || r.action === 'proposed-direct').length,
+    escalated: results.filter(r => r.action === 'escalated').length,
+  };
+
+  const ACTION_LABEL = {
+    classified: 'AI classified',
+    proposed: 'AI proposed (review mode)',
+    'proposed-direct': 'Direct assign (review mode)',
+    'direct-assigned': 'Direct assignment',
+    escalated: 'Needs review',
+    'no-mapping': 'No project mapping',
+  };
+
+  const rows = results.map(r =>
+    `| [#${r.issue}](https://github.com/${OWNER}/${REPO}/issues/${r.issue}) | ${ACTION_LABEL[r.action] ?? r.action} | \`${r.label}\` | ${r.project ? `#${r.project}` : '—'} |`,
+  );
+
+  const summary = [
+    `## Issue Classification Run — ${now}`,
+    `| Issue | Action | Label | Project |`,
+    `|-------|--------|-------|---------|`,
+    ...rows,
+    '',
+    `**${results.length} orphans processed.** ` +
+    `${counts.classified} classified, ${counts['direct-assigned']} directly assigned, ` +
+    `${counts.proposed} proposed (review mode), ${counts.escalated} escalated for manual review.`,
+  ].join('\n');
+
+  appendFileSync(path, summary + '\n\n');
+}
+
+// --- Entry point ---
+
+const argv = process.argv.slice(2);
+const limitIdx = argv.indexOf('--limit');
+const limit = limitIdx >= 0 ? parseInt(argv[limitIdx + 1], 10) : null;
+
+if (argv.includes('--backtest')) {
+  await runBacktest(limit ?? 100);
+} else if (argv.includes('--scan')) {
+  await runScan(limit);
+} else if (argv.includes('--issue')) {
+  const n = parseInt(argv[argv.indexOf('--issue') + 1], 10);
+  if (isNaN(n)) { console.error('Invalid issue number'); process.exit(1); }
+  await runSingle(n);
+} else {
+  console.error('Usage: classify-issue.mjs --scan [--limit N] | --issue <N> | --backtest [--limit N]');
+  process.exit(1);
+}

--- a/.github/scripts/classify-issue.mjs
+++ b/.github/scripts/classify-issue.mjs
@@ -15,7 +15,7 @@
  *   ANTHROPIC_API_KEY    Claude API key
  *
  * Optional env:
- *   AI_CLASSIFY_APPLY_LABEL  'true' to apply labels/project assignments (default: 'false')
+ *   DRY_RUN                  'true' to skip label/project writes (default: 'false')
  *   OWNER                    GitHub org (default: 'camunda')
  *   REPO                     GitHub repo (default: 'camunda')
  *   GITHUB_STEP_SUMMARY      Written by GHA; path to append job summary markdown

--- a/.github/scripts/package-lock.json
+++ b/.github/scripts/package-lock.json
@@ -1,0 +1,86 @@
+{
+  "name": "gh-issue-classifier",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "gh-issue-classifier",
+      "version": "1.0.0",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.109.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.109.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.109.0.tgz",
+      "integrity": "sha512-y7P4eLyW5uNut4fXpOUEHqhJwx7dnxrWAfCQE4Lcgm0hSFQuIeHa7CWEKE5dFolEjQJE/RFKkppjri05r2OK/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    }
+  }
+}

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "gh-issue-classifier",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@anthropic-ai/sdk": "0.109.0"
+  }
+}

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -112,13 +112,16 @@ jobs:
           labeled: component/c8run
 
       - id: add-to-feel
-        if: github.event.action != 'labeled' || github.event.label.name == 'component/feel-js'
+        if: >
+          github.event.action != 'labeled'
+            || github.event.label.name == 'component/feel-js'
+            || github.event.label.name == 'component/feel-scala'
         name: Add to Feel Team project
         uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/camunda/projects/79
           github-token: ${{ steps.github-token.outputs.token }}
-          labeled: component/feel-js
+          labeled: component/feel-js, component/feel-scala
 
       - id: add-to-devops
         if: >

--- a/.github/workflows/classify-orphaned-issues.yml
+++ b/.github/workflows/classify-orphaned-issues.yml
@@ -1,0 +1,113 @@
+# type: Project Management
+# owner: @camunda/monorepo-devops-team
+---
+# Hourly scan for open issues not assigned to any active project board.
+#
+# Two cases handled:
+#   1. No component/* label  → Claude AI classifies → applies label → add-to-projects.yml routes
+#   2. Has component/* label → direct GraphQL add to the mapped project board
+#
+# Re-classification guard: the ai-classified label is applied on every classification.
+# Remove it from an issue to force the classifier to try again.
+#
+# Manual trigger (useful for testing):
+#   gh workflow run classify-orphaned-issues.yml -f issue_number=1234
+#   gh workflow run classify-orphaned-issues.yml -f batch_limit=20
+#   gh workflow run classify-orphaned-issues.yml -f batch_limit=20 -f apply_label=true
+#
+name: Classify orphaned issues
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # every hour
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Classify a specific issue number (leave blank to scan all orphans)'
+        required: false
+        type: number
+      batch_limit:
+        description: 'Max orphans to classify per run (scan mode only)'
+        required: false
+        type: number
+        default: 5
+      apply_label:
+        description: 'Apply labels and project assignments (overrides hardcoded default)'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  classify:
+    name: Scan and classify orphaned issues
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        with:
+          github-app-id-vault-key: PROJECT_BOARD_AUTOMATION_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: PROJECT_BOARD_AUTOMATION_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          # Org-wide token needed to add issues to org-level project boards
+          owner: camunda
+          repositories: '!all'
+
+      - name: Get Anthropic API key
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: .github/scripts/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .github/scripts
+
+      - name: Classify orphaned issues
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          ANTHROPIC_API_KEY: ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
+          # DRY_RUN=true unless apply_label is explicitly set to 'true' via workflow_dispatch
+          DRY_RUN: ${{ github.event.inputs.apply_label != 'true' && 'true' || 'false' }}
+        run: |
+          if [[ -n "${{ github.event.inputs.issue_number }}" ]]; then
+            node .github/scripts/classify-issue.mjs --issue ${{ github.event.inputs.issue_number }}
+          else
+            node .github/scripts/classify-issue.mjs --scan --limit ${{ github.event.inputs.batch_limit || 5 }}
+          fi
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -30,3 +30,51 @@ jobs:
         configuration-path: .github/opened_issue_labeler.yml
         enable-versioned-regex: 0
         repo-token: ${{ steps.github-token.outputs.token }}
+
+  ai-classify:
+    name: AI-classify issue if no component label was applied
+    needs: triage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Generate GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        with:
+          github-app-id-vault-key: PROJECT_BOARD_AUTOMATION_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: PROJECT_BOARD_AUTOMATION_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-url: ${{ secrets.VAULT_ADDR }}
+
+      - name: Get Anthropic API key
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: .github/scripts/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .github/scripts
+
+      - name: Classify issue if no component label
+        env:
+          GH_TOKEN: ${{ steps.github-token.outputs.token }}
+          ANTHROPIC_API_KEY: ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
+        run: node .github/scripts/classify-issue.mjs --issue ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary

Issues without a `component/*` label are never routed to a project board by the existing `add-to-projects.yml` workflow, and issues whose board gets archived remain orphaned indefinitely. Currently external Camunda automation detects these and notifies a manager's channel. This replaces that notification with AI-driven automatic classification and routing.

### What changed

**New: AI classification pipeline**
- `opened_issue_labeler.yml` -- new `ai-classify` job runs after the existing regex triage; if no `component/*` label was applied, Claude classifies the issue, applies the label, and posts a comment explaining the decision
- `classify-orphaned-issues.yml` -- new hourly cron scans all open issues for those not in any active project board; handles two cases: no component label (AI classify) and has a label but lost its board (direct GraphQL assignment)
- `.github/scripts/classify-issue.mjs` -- shared classification script used by both workflows; also supports `--backtest` mode to measure accuracy against already-labeled issues before enabling on live issues

**Fixed: pre-existing routing gaps**
- `component/feel-scala` had no routing in `add-to-projects.yml` (now routes to Feel Team project #79)
- `component/C8Run` label name was capitalized in `opened_issue_labeler.yml` but lowercase in routing (now standardized to `component/c8run`)

### Classification signals (in priority order)
1. Parent issue project board membership
2. Existing labels on the issue
3. Issue title and body (first 800 chars)
4. Component label descriptions (from module path map)
5. Label removal history (avoids re-applying labels a human deliberately removed)

### Guard and rollout
- `ai-classified` label is applied on every classification; cron skips issues that carry it; remove it to force reclassification
- Default behavior is dry-run (`DRY_RUN=true`); pass `apply_label=true` via `workflow_dispatch` to apply for real
- Reads `ANTHROPIC_API_KEY` from `secret/data/products/qa/ci/common` (same path used by `c8-orchestration-cluster-e2e-nightly-fix.yml` today -- no Vault changes needed)

## Test plan

- [ ] Dispatch workflow manually on a known orphaned issue: `gh workflow run classify-orphaned-issues.yml -f issue_number=<N>`
- [ ] Verify comment posted on issue with correct label and reasoning
- [ ] Re-run with `-f apply_label=true` and verify label applied + issue added to correct board
- [ ] Run backtest to measure accuracy: `GH_TOKEN=... ANTHROPIC_API_KEY=... node .github/scripts/classify-issue.mjs --backtest --limit 100`
- [ ] Open a test issue without a component label prefix and verify `ai-classify` job runs and classifies it