### PR TITLE
fix: update legend text positioning

### DIFF
--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/generateLegends.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/generateLegends.js
@@ -39,7 +39,8 @@ function draw(chart) {
   }
 
   if (previouslyTruncated[chart.id]) {
-    addText(chart, 3, t('common.viewMore'));
+    const lastIndex = (chart.legend.legendHitBoxes?.length || 0) - 1;
+    addText(chart, lastIndex, t('common.viewMore'));
   } else if (viewMoreClicked[chart.id]) {
     addText(chart, 0, t('common.viewLess'));
   }
@@ -55,7 +56,11 @@ function update(chart, newTruncatedState) {
 }
 
 function addText(chart, position, text) {
-  const {left, width, top} = chart.legend.legendHitBoxes[position];
+  const hitBox = chart.legend.legendHitBoxes?.[position];
+  if (!hitBox) {
+    return;
+  }
+  const {left, width, top} = hitBox;
   const textXPos = left + width / 2 - 20;
   const textYPos = top + 5;
   chart.ctx.fillStyle = 'blue';

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/generateLegends.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/generateLegends.test.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import generateLegends from './generateLegends';
+
+jest.mock('translation', () => ({
+  t: (key) => key,
+}));
+
+function createChart({legendHeight = 200, outerRadius = 100, legendHitBoxes = [], labels = []}) {
+  return {
+    id: 'test-chart',
+    _metasets: [{controller: {outerRadius}}],
+    legend: {
+      height: legendHeight,
+      legendHitBoxes,
+    },
+    options: {
+      plugins: {
+        legend: {
+          autoCollapse: true,
+          maxHeight: undefined,
+          labels: {
+            generateLabels: () =>
+              labels.map((text) => ({
+                text,
+                fillStyle: 'blue',
+                strokeStyle: 'blue',
+              })),
+          },
+        },
+      },
+    },
+    canvas: document.createElement('canvas'),
+    ctx: {
+      fillStyle: '',
+      fillText: jest.fn(),
+    },
+    update: jest.fn(),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('should not crash when legendHitBoxes has fewer items than expected', () => {
+  const chart = createChart({
+    legendHeight: 200,
+    outerRadius: 100,
+    labels: ['Label A', 'Label B'],
+    legendHitBoxes: [
+      {left: 0, width: 50, top: 10},
+      {left: 0, width: 50, top: 30},
+      {left: 0, width: 50, top: 50},
+    ],
+  });
+
+  generateLegends.beforeInit(chart);
+  // First call triggers truncation
+  generateLegends.beforeDraw(chart);
+  // After truncation, previouslyTruncated is set — second call attempts addText
+  generateLegends.beforeDraw(chart);
+
+  // Should not throw — the text should be placed at the last available hitBox
+  expect(chart.ctx.fillText).toHaveBeenCalled();
+});
+
+it('should not crash when legendHitBoxes is empty', () => {
+  const chart = createChart({
+    legendHeight: 200,
+    outerRadius: 100,
+    labels: ['Label A', 'Label B'],
+    legendHitBoxes: [],
+  });
+
+  generateLegends.beforeInit(chart);
+  generateLegends.beforeDraw(chart);
+  generateLegends.beforeDraw(chart);
+
+  // Should not throw
+  expect(chart.ctx.fillText).not.toHaveBeenCalled();
+});
+
+it('should skip drawing when autoCollapse is disabled', () => {
+  const chart = createChart({legendHeight: 200, outerRadius: 100});
+  chart.options.plugins.legend.autoCollapse = false;
+
+  generateLegends.beforeDraw(chart);
+
+  expect(chart.update).not.toHaveBeenCalled();
+  expect(chart.ctx.fillText).not.toHaveBeenCalled();
+});
+
+it('should not truncate when legend height is smaller than chart radius', () => {
+  const chart = createChart({
+    legendHeight: 50,
+    outerRadius: 100,
+    labels: ['Label A', 'Label B', 'Label C'],
+    legendHitBoxes: [
+      {left: 0, width: 50, top: 10},
+      {left: 0, width: 50, top: 30},
+      {left: 0, width: 50, top: 50},
+    ],
+  });
+
+  generateLegends.beforeInit(chart);
+  generateLegends.beforeDraw(chart);
+
+  expect(chart.update).not.toHaveBeenCalled();
+});

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/generateLegends.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/generateLegends.test.js
@@ -12,9 +12,13 @@ jest.mock('translation', () => ({
   t: (key) => key,
 }));
 
+// generateLegends keeps module-level state (previouslyTruncated/viewMoreClicked) keyed by
+// chart.id. Using a unique id per chart instance keeps each test isolated and order-independent.
+let chartIdCounter = 0;
+
 function createChart({legendHeight = 200, outerRadius = 100, legendHitBoxes = [], labels = []}) {
   return {
-    id: 'test-chart',
+    id: `test-chart-${chartIdCounter++}`,
     _metasets: [{controller: {outerRadius}}],
     legend: {
       height: legendHeight,


### PR DESCRIPTION
<!-- ccr-slack-attribution -->
_Requested by **Omran Abazeed** · [Slack thread](https://camunda.slack.com/archives/D0BD229LW13/p1782922169731049)_

## Description

Fixes a crash when opening an Optimize pie chart whose legend needs to collapse.

**Before:** Opening such a chart could crash with `Cannot destructure property 'left' of legendHitBoxes[e] as it is undefined`. This happened when the chart had fewer legend entries than expected — for example, a filtered flow node with 0 frequency.

**After:** The legend renders correctly and no longer crashes.

**How:**
- In `optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/generateLegends.js`, the "View More" text was previously placed at a hardcoded legend index (`3`). It now uses the actual last index of `legendHitBoxes`.
- `addText()` gained a null guard (optional chaining + early return) so it does nothing if the hit box at that position doesn't exist.
- Added a new test file `generateLegends.test.js` covering these cases.

This is a frontend-only change in Optimize. It carries backport labels for `optimize-8.7`, `8.8`, and `8.9`.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Closes #56462
