### PR TITLE
56055 agentic dashboard UI polish

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticDurationKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticDurationKpiTilesIT.java
@@ -12,7 +12,9 @@ import static io.camunda.optimize.AgenticInstanceFixtures.agenticInstanceWithDur
 import static io.camunda.optimize.AgenticInstanceFixtures.agenticInstanceWithTokens;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.DURATION_STABILITY_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P50_DESCRIPTION;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P95_DESCRIPTION;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.noExtraFilters;
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.rollingEndDateFilter;
@@ -26,8 +28,10 @@ import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinition
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.result.MeasureDto;
 import io.camunda.optimize.dto.optimize.query.report.single.result.hyper.MapResultEntryDto;
+import io.camunda.optimize.service.db.reader.ReportReader;
 import io.camunda.optimize.service.db.report.result.MapCommandResult;
 import io.camunda.optimize.service.report.ReportEvaluationService;
 import java.time.OffsetDateTime;
@@ -42,6 +46,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class AgenticDurationKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
   private AgenticReportEvaluator reports;
+  private ReportReader reportReader;
 
   @BeforeEach
   void setUp() {
@@ -49,6 +54,22 @@ class AgenticDurationKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
     reports =
         new AgenticReportEvaluator(
             embeddedOptimizeExtension.getBean(ReportEvaluationService.class));
+    reportReader = embeddedOptimizeExtension.getBean(ReportReader.class);
+  }
+
+  @Test
+  void shouldPersistDescriptionAsSubtitleForDurationPercentileTiles() {
+    // given the agentic reports were seeded by the reconcile above
+
+    // then each duration percentile NUMBER tile carries its description as the subtitle override
+    assertThat(subtitleOf(KPI_DURATION_P50_REPORT_ID)).isEqualTo(KPI_DURATION_P50_DESCRIPTION);
+    assertThat(subtitleOf(KPI_DURATION_P95_REPORT_ID)).isEqualTo(KPI_DURATION_P95_DESCRIPTION);
+  }
+
+  private String subtitleOf(final String reportId) {
+    final ProcessReportDataDto data =
+        (ProcessReportDataDto) reportReader.getReport(reportId).orElseThrow().getData();
+    return data.getConfiguration().getSubtitle();
   }
 
   @Test

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticExecutionKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticExecutionKpiTilesIT.java
@@ -9,7 +9,12 @@ package io.camunda.optimize.service.dashboard;
 
 import static io.camunda.optimize.AgenticInstanceFixtures.PROC_KEY;
 import static io.camunda.optimize.AgenticInstanceFixtures.agenticInstanceWithTokens;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_DESCRIPTION;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_DESCRIPTION;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.noExtraFilters;
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.rollingEndDateFilter;
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.withDefinitions;
@@ -22,6 +27,8 @@ import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.query.report.AdditionalProcessReportEvaluationFilterDto;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.reader.ReportReader;
 import io.camunda.optimize.service.report.ReportEvaluationService;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -31,6 +38,7 @@ import org.junit.jupiter.api.Test;
 class AgenticExecutionKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
   private AgenticReportEvaluator reports;
+  private ReportReader reportReader;
 
   @BeforeEach
   void setUp() {
@@ -38,6 +46,26 @@ class AgenticExecutionKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
     reports =
         new AgenticReportEvaluator(
             embeddedOptimizeExtension.getBean(ReportEvaluationService.class));
+    reportReader = embeddedOptimizeExtension.getBean(ReportReader.class);
+  }
+
+  @Test
+  void shouldPersistDescriptionAsSubtitleForExecutionNumberTiles() {
+    // given the agentic reports were seeded by the reconcile above
+
+    // then each NUMBER tile carries its description as the subtitle override so the tile renders a
+    // human-readable description instead of the auto-derived measure label
+    assertThat(subtitleOf(KPI_COMPLETED_REPORT_ID)).isEqualTo(KPI_EXECUTION_COMPLETED_DESCRIPTION);
+    assertThat(subtitleOf(KPI_AVG_DURATION_REPORT_ID))
+        .isEqualTo(KPI_EXECUTION_AVG_DURATION_DESCRIPTION);
+    assertThat(subtitleOf(KPI_INCIDENT_RATE_REPORT_ID))
+        .isEqualTo(KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION);
+  }
+
+  private String subtitleOf(final String reportId) {
+    final ProcessReportDataDto data =
+        (ProcessReportDataDto) reportReader.getReport(reportId).orElseThrow().getData();
+    return data.getConfiguration().getSubtitle();
   }
 
   @Test

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticToolCallsKpiTilesIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/dashboard/AgenticToolCallsKpiTilesIT.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.dashboard;
 
 import static io.camunda.optimize.AgenticInstanceFixtures.PROC_KEY;
 import static io.camunda.optimize.AgenticInstanceFixtures.agenticInstanceWithToolCalls;
+import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_TOOL_CALLS_DESCRIPTION;
 import static io.camunda.optimize.service.dashboard.AgenticControlDashboardService.KPI_TOOL_CALLS_REPORT_ID;
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.noExtraFilters;
 import static io.camunda.optimize.service.dashboard.AgenticReportFilters.rollingEndDateFilter;
@@ -20,6 +21,8 @@ import io.camunda.optimize.dto.optimize.ProcessInstanceConstants;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.date.DateUnit;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.reader.ReportReader;
 import io.camunda.optimize.service.report.ReportEvaluationService;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -29,6 +32,7 @@ import org.junit.jupiter.api.Test;
 class AgenticToolCallsKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
 
   private AgenticReportEvaluator reports;
+  private ReportReader reportReader;
 
   @BeforeEach
   void setUp() {
@@ -36,6 +40,18 @@ class AgenticToolCallsKpiTilesIT extends AbstractBrokerlessZeebeCCSMIT {
     reports =
         new AgenticReportEvaluator(
             embeddedOptimizeExtension.getBean(ReportEvaluationService.class));
+    reportReader = embeddedOptimizeExtension.getBean(ReportReader.class);
+  }
+
+  @Test
+  void shouldPersistDescriptionAsSubtitleForToolCallsTile() {
+    // given the agentic reports were seeded by the reconcile above
+
+    // then the total tool calls NUMBER tile carries its description as the subtitle override
+    final ProcessReportDataDto data =
+        (ProcessReportDataDto)
+            reportReader.getReport(KPI_TOOL_CALLS_REPORT_ID).orElseThrow().getData();
+    assertThat(data.getConfiguration().getSubtitle()).isEqualTo(KPI_TOOL_CALLS_DESCRIPTION);
   }
 
   @Test

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -229,6 +229,11 @@ public class AgenticControlDashboardService {
             .groupBy(new NoneGroupByDto())
             .distributedBy(new NoneDistributedByDto())
             .visualization(ProcessVisualization.NUMBER)
+            // Surface the description as the tile subtitle instead of the auto-derived label.
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .subtitle(KPI_EXECUTION_COMPLETED_DESCRIPTION)
+                    .build())
             .filter(
                 ProcessFilterBuilder.filter()
                     .completedInstancesOnly()
@@ -260,6 +265,11 @@ public class AgenticControlDashboardService {
             .groupBy(new NoneGroupByDto())
             .distributedBy(new NoneDistributedByDto())
             .visualization(ProcessVisualization.NUMBER)
+            // Surface the description as the tile subtitle instead of the auto-derived label.
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .subtitle(KPI_EXECUTION_AVG_DURATION_DESCRIPTION)
+                    .build())
             .filter(
                 ProcessFilterBuilder.filter()
                     .completedInstancesOnly()
@@ -291,6 +301,11 @@ public class AgenticControlDashboardService {
             .groupBy(new NoneGroupByDto())
             .distributedBy(new NoneDistributedByDto())
             .visualization(ProcessVisualization.NUMBER)
+            // Surface the description as the tile subtitle instead of the auto-derived label.
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .subtitle(KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION)
+                    .build())
             .filter(
                 ProcessFilterBuilder.filter()
                     .completedInstancesOnly()
@@ -543,6 +558,8 @@ public class AgenticControlDashboardService {
       final PositionDto position) {
     final SingleReportConfigurationDto config = new SingleReportConfigurationDto();
     config.setAggregationTypes(new AggregationDto(AggregationType.PERCENTILE, percentile));
+    // Surface the description as the tile subtitle instead of the auto-derived label.
+    config.setSubtitle(descriptionKey);
     final ProcessReportDataDto reportData =
         ProcessReportDataDto.builder()
             .definitions(Collections.emptyList())
@@ -663,11 +680,13 @@ public class AgenticControlDashboardService {
             .groupBy(new NoneGroupByDto())
             .distributedBy(new NoneDistributedByDto())
             .visualization(ProcessVisualization.NUMBER)
+            // Surface the description as the tile subtitle instead of the auto-derived label.
             .configuration(
                 SingleReportConfigurationDto.builder()
                     .aggregationTypes(
                         new LinkedHashSet<>(
                             Collections.singletonList(new AggregationDto(AggregationType.SUM))))
+                    .subtitle(KPI_TOOL_CALLS_DESCRIPTION)
                     .build())
             .filter(
                 ProcessFilterBuilder.filter()

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -557,6 +557,40 @@ public class AgenticControlDashboardServiceTest {
   }
 
   @Test
+  void shouldExposeAllNumberTileDescriptionsAsSubtitles() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then every KPI number tile surfaces its description as the subtitle override so the tile
+    // shows
+    // a human-readable description instead of the auto-derived measure label
+    assertThat(capturedSubtitle(AgenticControlDashboardService.KPI_COMPLETED_REPORT_ID))
+        .isEqualTo(AgenticControlDashboardService.KPI_EXECUTION_COMPLETED_DESCRIPTION);
+    assertThat(capturedSubtitle(AgenticControlDashboardService.KPI_AVG_DURATION_REPORT_ID))
+        .isEqualTo(AgenticControlDashboardService.KPI_EXECUTION_AVG_DURATION_DESCRIPTION);
+    assertThat(capturedSubtitle(AgenticControlDashboardService.KPI_INCIDENT_RATE_REPORT_ID))
+        .isEqualTo(AgenticControlDashboardService.KPI_EXECUTION_INCIDENT_RATE_DESCRIPTION);
+    assertThat(capturedSubtitle(AgenticControlDashboardService.KPI_DURATION_P50_REPORT_ID))
+        .isEqualTo(AgenticControlDashboardService.KPI_DURATION_P50_DESCRIPTION);
+    assertThat(capturedSubtitle(AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID))
+        .isEqualTo(AgenticControlDashboardService.KPI_DURATION_P95_DESCRIPTION);
+    assertThat(capturedSubtitle(AgenticControlDashboardService.KPI_TOOL_CALLS_REPORT_ID))
+        .isEqualTo(AgenticControlDashboardService.KPI_TOOL_CALLS_DESCRIPTION);
+  }
+
+  private String capturedSubtitle(final String reportId) {
+    final ArgumentCaptor<ProcessReportDataDto> captor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(reportId), isNull(), captor.capture(), any(), any(), isNull());
+    return captor.getValue().getConfiguration().getSubtitle();
+  }
+
+  @Test
   void shouldUpsertTokenTrendReportOnWarmRestart() {
     // given
     when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID))

--- a/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.scss
+++ b/optimize/client/src/components/AgenticControlPlane/AgenticControlPlane.scss
@@ -59,4 +59,14 @@
     line-height: 1.2;
     color: var(--cds-text-secondary);
   }
+
+  // KPI number tiles fit their value to the box with fitty and render the subtitle and delta
+  // badge around it. The inherited overflow:auto on the value wrappers otherwise paints a
+  // spurious 1–2px vertical scrollbar beside the value once those elements stack into a short
+  // tile. The value is always sized to fit here, so render it without an internal scrollbar.
+  // Scoped to this dashboard so number tiles elsewhere keep their default overflow behaviour.
+  .Number,
+  .Number .container {
+    overflow: visible;
+  }
 }

--- a/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.scss
+++ b/optimize/client/src/modules/components/DashboardRenderer/DashboardTile/OptimizeReportTile/OptimizeReportTile.scss
@@ -69,12 +69,23 @@
   // shift when the delta badge renders alongside it.
   &.hasComparisonPeriod .visualization .Number .container {
     font-size: 48px;
+    // Keep the value + badge within the tile; the badge wraps below the number
+    // instead of overflowing horizontally when the value is wide.
+    max-width: 100%;
 
     .data {
-      display: inline-flex;
+      display: flex;
+      flex-wrap: wrap;
       align-items: center;
+      justify-content: center;
       gap: 8px;
+      max-width: 100%;
       font-size: inherit;
+
+      // The badge keeps its intrinsic size and never shrinks the number.
+      .cds--tag {
+        flex-shrink: 0;
+      }
     }
   }
 }

--- a/optimize/client/src/modules/components/ReportRenderer/service.js
+++ b/optimize/client/src/modules/components/ReportRenderer/service.js
@@ -32,6 +32,8 @@ export function getFormatter(measure) {
   }
 }
 
-export const formatValue = (value, measure, precision) => {
-  return getFormatter(measure)(value, precision);
+export const formatValue = (value, measure, precision, shortNotation) => {
+  // shortNotation is only meaningful for the duration formatter; the other formatters
+  // ignore the extra argument, so passing it through is always safe.
+  return getFormatter(measure)(value, precision, shortNotation);
 };

--- a/optimize/client/src/modules/components/ReportRenderer/service.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/service.test.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {formatters} from 'services';
+
+import {formatValue, getFormatter} from './service';
+
+jest.mock('services', () => ({
+  formatters: {
+    frequency: jest.fn((value) => value),
+    duration: jest.fn((value) => value),
+    percentage: jest.fn((value) => value),
+    compact: jest.fn((value) => value),
+  },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+it('should forward the shortNotation flag to the duration formatter', () => {
+  formatValue(5000, 'duration', 2, true);
+
+  expect(formatters.duration).toHaveBeenCalledWith(5000, 2, true);
+});
+
+it('should default shortNotation to undefined when not provided', () => {
+  formatValue(5000, 'duration', 2);
+
+  expect(formatters.duration).toHaveBeenCalledWith(5000, 2, undefined);
+});
+
+it('should pass the extra argument harmlessly to non-duration formatters', () => {
+  formatValue(42, 'frequency', 0, true);
+
+  // the frequency formatter ignores the trailing argument; passing it must not change behaviour
+  expect(formatters.frequency).toHaveBeenCalledWith(42, 0, true);
+});
+
+it('should resolve the formatter by measure name', () => {
+  expect(getFormatter('duration')).toBe(formatters.duration);
+  expect(getFormatter('percentage')).toBe(formatters.percentage);
+  expect(getFormatter('compact')).toBe(formatters.compact);
+});

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/defaultChart/createDefaultChartOptions.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/defaultChart/createDefaultChartOptions.js
@@ -26,7 +26,7 @@ const {createDurationFormattingOptions, duration} = formatters;
 
 export default function createDefaultChartOptions({report, targetValue, theme, formatter}) {
   const {
-    data: {visualization, view, groupBy, configuration},
+    data: {visualization, view, groupBy, configuration, agenticControlReport},
     result,
   } = report;
   const {precision} = configuration;
@@ -57,6 +57,7 @@ export default function createDefaultChartOptions({report, targetValue, theme, f
         measures: result.measures,
         entity: view.entity,
         autoSkip: canBeInterpolated(groupBy),
+        agenticControlReport,
       });
       break;
     default:
@@ -133,6 +134,7 @@ export function createBarOptions({
   groupedByDurationMaxValue = false,
   isHyper,
   visualization,
+  agenticControlReport = false,
 }) {
   const {stackedBar, xLabel, yLabel, logScale, pointMarkers, horizontalBar} = configuration;
   const isHyperNumber = isHyper && visualization === 'number';
@@ -235,6 +237,19 @@ export function createBarOptions({
       font: ({chart}) => ({
         size: Math.min(12, Math.round(chart.height / 32)),
       }),
+      // Agentic control plane charts: keep long category/date labels legible by enforcing a
+      // minimum tick font size and rotating labels instead of letting Chart.js shrink or truncate
+      // them. Opt-in via the agenticControlReport flag; all other reports are left unchanged.
+      ...(agenticControlReport
+        ? {
+            autoSkip: true,
+            maxRotation: 45,
+            minRotation: 0,
+            font: ({chart}) => ({
+              size: Math.max(11, Math.min(12, Math.round(chart.height / 32))),
+            }),
+          }
+        : {}),
     },
     stacked: stacked || isHyperNumber,
     ...groupBy,

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/defaultChart/createDefaultChartOptions.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/defaultChart/createDefaultChartOptions.test.js
@@ -203,6 +203,35 @@ it('should switch tooltip alignment of an item when surpassing 70% of the availa
   expect(newAlignment).toBe('start');
 });
 
+it('should enforce legible group-by axis ticks for agentic control reports', () => {
+  const chartConfig = createBarOptions({
+    configuration: {},
+    measures: [{property: 'frequency', data: []}],
+    agenticControlReport: true,
+  });
+
+  const ticks = chartConfig.scales['x'].ticks;
+  // long category/date labels are rotated rather than truncated/overlapped
+  expect(ticks.maxRotation).toBe(45);
+  expect(ticks.minRotation).toBe(0);
+  expect(ticks.autoSkip).toBe(true);
+  // and the tick font never shrinks below the legibility floor (height 64 / 32 = 2 -> 11)
+  expect(ticks.font({chart: {height: 64}}).size).toBe(11);
+});
+
+it('should leave group-by axis ticks unchanged for non-agentic reports', () => {
+  const chartConfig = createBarOptions({
+    configuration: {},
+    measures: [{property: 'frequency', data: []}],
+  });
+
+  const ticks = chartConfig.scales['x'].ticks;
+  expect(ticks.maxRotation).toBeUndefined();
+  expect(ticks.minRotation).toBeUndefined();
+  // the default font formula has no floor, so a short chart yields a sub-11 size
+  expect(ticks.font({chart: {height: 64}}).size).toBe(2);
+});
+
 it('should set axis-0 scale step to integers if chart has frequency measure', () => {
   const chartConfig = createDefaultChartOptions({
     report: {

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.js
@@ -135,7 +135,14 @@ export function Number({report, formatter, mightFail, overlay}) {
           return (
             <React.Fragment key={idx}>
               <div className="data">
-                {formatValue(measure.data, valueFormat ?? measure.property, precision)}
+                {formatValue(
+                  measure.data,
+                  valueFormat ?? measure.property,
+                  precision,
+                  // Agentic control plane tiles render durations in compact notation
+                  // (e.g. "3d 4h 6min"); all other reports keep the default verbose form.
+                  data.agenticControlReport
+                )}
                 {idx === 0 && overlay}
               </div>
               {/* The auto-derived subtitle is suppressed when an override is rendered below. */}

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.test.js
@@ -9,7 +9,7 @@
 import React, {runLastEffect} from 'react';
 import {shallow} from 'enzyme';
 import update from 'immutability-helper';
-import {loadVariables} from 'services';
+import {loadVariables, formatters} from 'services';
 
 import {Number} from './Number';
 import ProgressBar from './ProgressBar';
@@ -283,6 +283,48 @@ it('should fall back to measure property formatter when valueFormat is not set',
   );
 
   expect(node.find('.data')).toIncludeText('42');
+});
+
+describe('agentic control plane duration formatting', () => {
+  const durationReport = update(report, {
+    data: {view: {properties: {$set: ['duration']}}},
+    result: {
+      measures: {
+        $set: [{data: 5000, property: 'duration', aggregationType: {type: 'avg', value: null}}],
+      },
+    },
+  });
+
+  it('should request short duration notation for agentic control reports', () => {
+    const durationSpy = jest.fn((value) => `${value}-short`);
+    const original = formatters.duration;
+    formatters.duration = durationSpy;
+
+    try {
+      shallow(
+        <Number report={update(durationReport, {data: {agenticControlReport: {$set: true}}})} />
+      );
+
+      // the third positional argument (shortNotation) is true only for agentic tiles
+      expect(durationSpy).toHaveBeenCalledWith(5000, undefined, true);
+    } finally {
+      formatters.duration = original;
+    }
+  });
+
+  it('should keep verbose duration notation for non-agentic reports', () => {
+    const durationSpy = jest.fn((value) => `${value}-verbose`);
+    const original = formatters.duration;
+    formatters.duration = durationSpy;
+
+    try {
+      shallow(<Number report={durationReport} />);
+
+      expect(durationSpy).toHaveBeenCalledWith(5000, undefined, undefined);
+    } finally {
+      formatters.duration = original;
+    }
+  });
 });
 
 describe('overlay prop', () => {


### PR DESCRIPTION
## Description

Four opt-in UI fixes for the Agentic Control Plane dashboard, all gated on the existing `report.data.agenticControlReport` flag so **no other dashboard is affected**.

### Changes
- **Tile subtitles** — the six KPI number tiles that rendered only the auto-derived measure label (Total Executions, Avg duration, Incident rate, P50, P95, Total tool calls) now show their description as a subtitle.
- **Compact durations** — duration tiles render `3d 4h 6min` instead of the verbose `3 days 4 hours 6 minutes`.
- **Delta-badge overflow** — the value + delta badge row wraps/contains within the tile instead of overflowing.
- **Axis legibility** — agentic charts get a minimum tick font size and rotated category/date labels so axis labels stay readable.
- **Scrollbar fix** — removes the spurious internal scrollbar on number tiles (the fitted value box's inherited `overflow:auto`), scoped to this dashboard.


Closes #56055