### PR TITLE
fix: increase Zeebe ES/OS exporter ILM retention from 1d to 3d

### DIFF
--- a/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
@@ -323,7 +323,7 @@ orchestration:
   # Retention for the ES Exporter indices - legacy Zeebe indices
   retention:
     enabled: true
-    minimumAge: 1d
+    minimumAge: 3d # Optimize needs time to import data before ILM cleanup (see #56443)
   # Retention for the Camunda Exporter
   history:
     retention:

--- a/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
@@ -369,7 +369,7 @@ zeebe:
     ## @param zeebe.retention.enabled if true, the ILM Policy is created and applied to the index templates.
     enabled: true
     ## @param zeebe.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
-    minimumAge: 1d # Optimize needs time to import data before ILM cleanup
+    minimumAge: 3d # Optimize needs time to import data before ILM cleanup (see #56443)
   # @param core.env can be used to set extra environment variables in each broker container
   env:
     # Enable JSON logging for google cloud stackdriver

--- a/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
@@ -342,7 +342,7 @@ orchestration:
   # Retention for the ES Exporter indices - legacy Zeebe indices
   retention:
     enabled: true
-    minimumAge: 1d
+    minimumAge: 3d # Optimize needs time to import data before ILM cleanup (see #56443)
   # Retention for the Camunda Exporter
   history:
     retention:

--- a/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
@@ -301,7 +301,7 @@ orchestration:
   # Retention for the ES Exporter indices - legacy Zeebe indices
   retention:
     enabled: true
-    minimumAge: 1d
+    minimumAge: 3d # Optimize needs time to import data before ILM cleanup (see #56443)
   # Retention for the Camunda Exporter
   history:
     retention:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
@@ -250,7 +250,7 @@ data:
                 prefix: "zeebe-record"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/configmap.yaml
@@ -250,7 +250,7 @@ data:
                 prefix: "zeebe-record"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -266,7 +266,7 @@ data:
                 prefix: "zeebe-record"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/configmap.yaml
@@ -266,7 +266,7 @@ data:
                 prefix: "zeebe-record"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/configmap.yaml
@@ -258,7 +258,7 @@ data:
                 prefix: "zeebe-record"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
     
   log4j2.xml: |

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/configmap.yaml
@@ -28,7 +28,7 @@ data:
                 prefix: "zeebe-record"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
         gateway:
           enable: true

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/configmap.yaml
@@ -28,7 +28,7 @@ data:
                 prefix: "zeebe-record"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
         gateway:
           enable: true

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/configmap-unified.yaml
@@ -239,7 +239,7 @@ data:
                 numberOfReplicas: "1"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/configmap-unified.yaml
@@ -239,7 +239,7 @@ data:
                 numberOfReplicas: "1"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/configmap-unified.yaml
@@ -254,7 +254,7 @@ data:
                 numberOfReplicas: "1"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/configmap-unified.yaml
@@ -254,7 +254,7 @@ data:
                 numberOfReplicas: "1"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
@@ -259,7 +259,7 @@ data:
                 numberOfReplicas: "1"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/configmap.yaml
@@ -259,7 +259,7 @@ data:
                 numberOfReplicas: "1"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -275,7 +275,7 @@ data:
                 numberOfReplicas: "1"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/configmap.yaml
@@ -275,7 +275,7 @@ data:
                 numberOfReplicas: "1"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
           camundaexporter:
             className: "io.camunda.exporter.CamundaExporter"

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/configmap.yaml
@@ -264,7 +264,7 @@ data:
                 numberOfReplicas: "1"
               retention:
                 enabled: true
-                minimumAge: "1d"
+                minimumAge: "3d"
                 policyName: "zeebe-record-retention-policy"
     
   log4j2.xml: |


### PR DESCRIPTION
## Description

Increases the Zeebe ES/OS exporter ILM retention from 1 day to 3 days across all load-test setup variants (main, stable-87, stable-88, stable-89).

When Optimize's import lag grows larger than the Zeebe record ILM retention window, completion events are purged from Elasticsearch before Optimize processes them. Affected process instances remain stuck as `ACTIVE` indefinitely with no recovery path, and eventually fill Elasticsearch disks.

The most reliable trigger is an ES node restart: Optimize's page-size backoff mechanism reduces import throughput to near-zero for ~45 minutes while the cluster recovers. Any Zeebe records that fall outside the 1-day ILM window during that period are permanently lost.

Raising the retention to 3 days gives Optimize a larger safety margin.

Golden files regenerated via `make update-golden` in `load-tests/setup/test/`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56443