### PR TITLE
test: acceptance tests for wait-state statistics endpoint

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/WaitStateStatisticsAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/WaitStateStatisticsAuthorizationIT.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.search.enums.PermissionType;
+import io.camunda.client.api.search.enums.ResourceType;
+import io.camunda.qa.util.auth.Authenticated;
+import io.camunda.qa.util.auth.Permissions;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+class WaitStateStatisticsAuthorizationIT {
+
+  @MultiDbTestApplication
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  private static final String PROCESS_ID = "waitStateStatsAuth";
+  private static final String AUTHORIZED = "authorizedUser";
+  private static final String UNAUTHORIZED = "unauthorizedUser";
+
+  @UserDefinition
+  private static final TestUser AUTHORIZED_USER =
+      new TestUser(
+          AUTHORIZED,
+          "password",
+          List.of(
+              new Permissions(
+                  ResourceType.PROCESS_DEFINITION,
+                  PermissionType.READ_PROCESS_INSTANCE,
+                  List.of("*"))));
+
+  @UserDefinition
+  private static final TestUser UNAUTHORIZED_USER =
+      new TestUser(UNAUTHORIZED, "password", List.of());
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldReturnStatisticsWithReadProcessInstancePermission(
+      @Authenticated(AUTHORIZED) final CamundaClient userClient) {
+    // given
+    final long processInstanceKey = deployAndStartWaitingInstance();
+
+    // when
+    final var actual =
+        userClient.newProcessInstanceWaitStateStatisticsRequest(processInstanceKey).send().join();
+
+    // then
+    assertThat(actual)
+        .singleElement()
+        .satisfies(s -> assertThat(s.getElementId()).isEqualTo("service-task"));
+  }
+
+  @Test
+  void shouldRejectWithForbiddenWhenUnauthorized(
+      @Authenticated(UNAUTHORIZED) final CamundaClient userClient) {
+    // given
+    final long processInstanceKey = deployAndStartWaitingInstance();
+
+    // when
+    final ThrowingCallable request =
+        () ->
+            userClient
+                .newProcessInstanceWaitStateStatisticsRequest(processInstanceKey)
+                .send()
+                .join();
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(request).actual();
+    assertThat(problemException.code()).isEqualTo(403);
+  }
+
+  private static long deployAndStartWaitingInstance() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("service-task", t -> t.zeebeJobType("never-activated"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, PROCESS_ID + ".bpmn");
+    final long processInstanceKey =
+        startProcessInstance(camundaClient, PROCESS_ID).getProcessInstanceKey();
+
+    Awaitility.await("wait state visible for instance %d".formatted(processInstanceKey))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .until(
+            () ->
+                camundaClient
+                    .newElementInstanceWaitStateSearchRequest()
+                    .filter(f -> f.processInstanceKey(processInstanceKey))
+                    .send()
+                    .join()
+                    .items()
+                    .size(),
+            size -> size == 1);
+
+    return processInstanceKey;
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
@@ -241,17 +241,17 @@ public class ProcessInstanceWaitStateStatisticsIT {
     Awaitility.await("wait state reflects migrated element id")
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
-        .until(
+        .untilAsserted(
             () ->
-                camundaClient
-                    .newElementInstanceWaitStateSearchRequest()
-                    .filter(f -> f.processInstanceKey(pik))
-                    .send()
-                    .join()
-                    .items()
-                    .getFirst()
-                    .getElementId(),
-            elementId -> elementId.equals("task-b"));
+                assertThat(
+                        camundaClient
+                            .newElementInstanceWaitStateSearchRequest()
+                            .filter(f -> f.processInstanceKey(pik))
+                            .send()
+                            .join()
+                            .items())
+                    .hasSize(1)
+                    .allSatisfy(item -> assertThat(item.getElementId()).isEqualTo("task-b")));
 
     // then
     final var actual = statistics(pik);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
@@ -209,6 +209,41 @@ public class ProcessInstanceWaitStateStatisticsIT {
   }
 
   @Test
+  void shouldAggregateWaitingCountAcrossMultipleWaitStatesOnSameElement() {
+    // given — assignee set at creation together with an "assigning" task listener makes the user
+    // task enter ASSIGNING immediately, so the USER_TASK wait state and the JOB wait state for the
+    // assigning listener coexist on the same element
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateStatsUserTaskAssigning")
+            .startEvent()
+            .userTask(
+                "user-task",
+                t ->
+                    t.zeebeUserTask()
+                        .zeebeAssignee("initial-assignee")
+                        .zeebeTaskListener(l -> l.assigning().type("assigning-listener")))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateStatsUserTaskAssigning.bpmn");
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateStatsUserTaskAssigning")
+            .getProcessInstanceKey();
+    waitForWaitStates(pik, 2);
+
+    // when
+    final var actual = statistics(pik);
+
+    // then
+    assertThat(actual)
+        .singleElement()
+        .satisfies(
+            s -> {
+              assertThat(s.getElementId()).isEqualTo("user-task");
+              assertThat(s.getWaitingCount()).isEqualTo(2L);
+            });
+  }
+
+  @Test
   void shouldUpdateWaitingCountAfterMigration() {
     // given
     final BpmnModelInstance source =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
@@ -13,14 +13,17 @@ import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.MigrationPlan;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.statistics.response.ProcessInstanceWaitStateStatistics;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.util.List;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
@@ -259,6 +262,20 @@ public class ProcessInstanceWaitStateStatisticsIT {
               assertThat(s.getElementId()).isEqualTo("task-b");
               assertThat(s.getWaitingCount()).isEqualTo(1L);
             });
+  }
+
+  @Test
+  void shouldReturnNotFoundForUnknownProcessInstance() {
+    // given
+    final long unknownProcessInstanceKey = Long.MAX_VALUE;
+
+    // when
+    final ThrowingCallable request = () -> statistics(unknownProcessInstanceKey);
+
+    // then
+    final var problemException =
+        assertThatExceptionOfType(ProblemException.class).isThrownBy(request).actual();
+    assertThat(problemException.code()).isEqualTo(404);
   }
 
   // Barrier: wait until the expected number of wait states for this instance are visible in

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.it.waitstate;
 
+import static io.camunda.it.util.TestHelper.cancelInstance;
+import static io.camunda.it.util.TestHelper.completeJob;
 import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.statistics.response.ProcessInstanceWaitStateStatistics;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -111,6 +114,149 @@ public class ProcessInstanceWaitStateStatisticsIT {
         .satisfies(
             s -> {
               assertThat(s.getElementId()).isEqualTo("message-catch");
+              assertThat(s.getWaitingCount()).isEqualTo(1L);
+            });
+  }
+
+  @Test
+  void shouldRemoveElementWhenWaitStateCompleted() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateStatsComplete")
+            .startEvent()
+            .serviceTask("service-task", t -> t.zeebeJobType("complete-me"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateStatsComplete.bpmn");
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateStatsComplete").getProcessInstanceKey();
+    waitForWaitStates(pik, 1);
+    assertThat(statistics(pik)).hasSize(1);
+
+    // when
+    final long jobKey =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType("complete-me")
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst()
+            .getKey();
+    completeJob(camundaClient, jobKey);
+    waitForWaitStates(pik, 0);
+
+    // then
+    assertThat(statistics(pik)).isEmpty();
+  }
+
+  @Test
+  void shouldRemoveElementWhenInstanceCancelled() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateStatsCancel")
+            .startEvent()
+            .serviceTask("service-task", t -> t.zeebeJobType("never-activated"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateStatsCancel.bpmn");
+    final var instance = startProcessInstance(camundaClient, "waitStateStatsCancel");
+    final long pik = instance.getProcessInstanceKey();
+    waitForWaitStates(pik, 1);
+    assertThat(statistics(pik)).hasSize(1);
+
+    // when
+    cancelInstance(camundaClient, instance);
+    waitForWaitStates(pik, 0);
+
+    // then
+    assertThat(statistics(pik)).isEmpty();
+  }
+
+  @Test
+  void shouldAggregateWaitingCountAcrossMultiInstance() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateStatsMulti")
+            .startEvent()
+            .serviceTask("mi-task", t -> t.zeebeJobType("never-activated"))
+            .multiInstance()
+            .parallel()
+            .zeebeInputCollectionExpression("[1,2,3]")
+            .multiInstanceDone()
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateStatsMulti.bpmn");
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateStatsMulti").getProcessInstanceKey();
+    waitForWaitStates(pik, 3);
+
+    // when
+    final var actual = statistics(pik);
+
+    // then
+    assertThat(actual)
+        .singleElement()
+        .satisfies(
+            s -> {
+              assertThat(s.getElementId()).isEqualTo("mi-task");
+              assertThat(s.getWaitingCount()).isEqualTo(3L);
+            });
+  }
+
+  @Test
+  void shouldUpdateWaitingCountAfterMigration() {
+    // given
+    final BpmnModelInstance source =
+        Bpmn.createExecutableProcess("waitStateStatsMigSource")
+            .startEvent()
+            .serviceTask("task-a", t -> t.zeebeJobType("never-activated"))
+            .endEvent()
+            .done();
+    final BpmnModelInstance target =
+        Bpmn.createExecutableProcess("waitStateStatsMigTarget")
+            .startEvent()
+            .serviceTask("task-b", t -> t.zeebeJobType("never-activated"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, source, "waitStateStatsMigSource.bpmn");
+    final long targetDefKey =
+        deployProcessAndWaitForIt(camundaClient, target, "waitStateStatsMigTarget.bpmn")
+            .getProcessDefinitionKey();
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateStatsMigSource").getProcessInstanceKey();
+    waitForWaitStates(pik, 1);
+
+    // when
+    final var migrationPlan =
+        MigrationPlan.newBuilder()
+            .withTargetProcessDefinitionKey(targetDefKey)
+            .addMappingInstruction("task-a", "task-b")
+            .build();
+    camundaClient.newMigrateProcessInstanceCommand(pik).migrationPlan(migrationPlan).send().join();
+    Awaitility.await("wait state reflects migrated element id")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .until(
+            () ->
+                camundaClient
+                    .newElementInstanceWaitStateSearchRequest()
+                    .filter(f -> f.processInstanceKey(pik))
+                    .send()
+                    .join()
+                    .items()
+                    .getFirst()
+                    .getElementId(),
+            elementId -> elementId.equals("task-b"));
+
+    // then
+    final var actual = statistics(pik);
+    assertThat(actual)
+        .singleElement()
+        .satisfies(
+            s -> {
+              assertThat(s.getElementId()).isEqualTo("task-b");
               assertThat(s.getWaitingCount()).isEqualTo(1L);
             });
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.waitstate;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.statistics.response.ProcessInstanceWaitStateStatistics;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies {@code GET /v2/process-instances/{processInstanceKey}/statistics/wait-states} reports
+ * the waiting count for job, timer, and message wait states.
+ */
+@MultiDbTest
+public class ProcessInstanceWaitStateStatisticsIT {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldReturnWaitingCountForJobWaitState() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateStatsJob")
+            .startEvent()
+            .serviceTask("service-task", t -> t.zeebeJobType("never-activated"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateStatsJob.bpmn");
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateStatsJob").getProcessInstanceKey();
+    waitForWaitStates(pik, 1);
+
+    // when
+    final var actual = statistics(pik);
+
+    // then
+    assertThat(actual)
+        .singleElement()
+        .satisfies(
+            s -> {
+              assertThat(s.getElementId()).isEqualTo("service-task");
+              assertThat(s.getWaitingCount()).isEqualTo(1L);
+            });
+  }
+
+  @Test
+  void shouldReturnWaitingCountForTimerWaitState() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateStatsTimer")
+            .startEvent()
+            .intermediateCatchEvent("timer-catch", e -> e.timerWithDuration("PT1H"))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateStatsTimer.bpmn");
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateStatsTimer").getProcessInstanceKey();
+    waitForWaitStates(pik, 1);
+
+    // when
+    final var actual = statistics(pik);
+
+    // then
+    assertThat(actual)
+        .singleElement()
+        .satisfies(
+            s -> {
+              assertThat(s.getElementId()).isEqualTo("timer-catch");
+              assertThat(s.getWaitingCount()).isEqualTo(1L);
+            });
+  }
+
+  @Test
+  void shouldReturnWaitingCountForMessageWaitState() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("waitStateStatsMessage")
+            .startEvent()
+            .intermediateCatchEvent(
+                "message-catch",
+                e ->
+                    e.message(
+                        m -> m.name("waitStateMsg").zeebeCorrelationKeyExpression("\"key-1\"")))
+            .endEvent()
+            .done();
+    deployProcessAndWaitForIt(camundaClient, process, "waitStateStatsMessage.bpmn");
+    final long pik =
+        startProcessInstance(camundaClient, "waitStateStatsMessage").getProcessInstanceKey();
+    waitForWaitStates(pik, 1);
+
+    // when
+    final var actual = statistics(pik);
+
+    // then
+    assertThat(actual)
+        .singleElement()
+        .satisfies(
+            s -> {
+              assertThat(s.getElementId()).isEqualTo("message-catch");
+              assertThat(s.getWaitingCount()).isEqualTo(1L);
+            });
+  }
+
+  // Barrier: wait until the expected number of wait states for this instance are visible in
+  // secondary storage before asserting on the statistics endpoint.
+  private static void waitForWaitStates(final long processInstanceKey, final int expected) {
+    Awaitility.await(
+            "%d wait states visible for instance %d".formatted(expected, processInstanceKey))
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .until(
+            () ->
+                camundaClient
+                    .newElementInstanceWaitStateSearchRequest()
+                    .filter(f -> f.processInstanceKey(processInstanceKey))
+                    .send()
+                    .join()
+                    .items()
+                    .size(),
+            size -> size == expected);
+  }
+
+  private static List<ProcessInstanceWaitStateStatistics> statistics(
+      final long processInstanceKey) {
+    return camundaClient
+        .newProcessInstanceWaitStateStatisticsRequest(processInstanceKey)
+        .send()
+        .join();
+  }
+}


### PR DESCRIPTION
## Summary

Acceptance tests for `GET /v2/process-instances/{processInstanceKey}/statistics/wait-states` via the Java SDK client, covering all scenarios in the issue's acceptance criteria.

- `ProcessInstanceWaitStateStatisticsIT` — job, timer, and message wait states; element removal on completion and on instance cancellation; multi-instance waiting-count aggregation; waiting count update after process instance migration.
- `WaitStateStatisticsAuthorizationIT` — `READ_PROCESS_INSTANCE` permission returns statistics; unauthorized access rejects with `ProblemException` code 403 (the endpoint checks instance existence/authorization via `getByKey` before aggregating, unlike definition-scoped statistics endpoints which return an empty list instead).
- `WaitStateStatisticsDisabledIT` — with `camunda.data.wait-states.enabled=false`, the exporter writes no rows, so the endpoint returns an empty list rather than an error.

Every behavioral assertion is preceded by an Awaitility barrier on secondary-storage visibility (wait-state search or element-instance search) before calling the statistics endpoint, to avoid the dominant flake pattern in this test suite (asserting before the exporter has caught up).

## Test Plan

- [x] All three files compile cleanly against the module: `./mvnw -pl qa/acceptance-tests test-compile -Dquickly -DskipTests=false`
- [x] Reviewed for flakiness, isolation, and coverage — no Critical/Major findings
- [ ] CI runs the `@MultiDbTest`-parameterized ITs against ES, OS, and RDBMS

> ⚠️ **Stacked on #56431** (branch `56254-wait-state-statistics-query-stacked`), itself stacked on #56320/#56278. Do not merge until the upstream chain has merged; this PR will retarget to `main` and can be rebased then.

Closes #56256

🤖 Generated with [Claude Code](https://claude.com/claude-code)