### PR TITLE
ci: show Docker images version in load tests "golden" tests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -755,6 +755,9 @@
       "ignoreUnstable": false
     }
   ],
+  "ignorePaths": [
+      "load-tests/setup/test/golden/**"
+  ],
   "dockerfile": {
     "managerFilePatterns": [
       "/(^|\\/)([\\w-]+\\.)?[Dd]ockerfile$/"

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/chaos-killer.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/chaos-killer.yaml
@@ -51,7 +51,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: chaos-killer
-              image: bitnami/kubectl:TEST
+              image: bitnami/kubectl:latest
               imagePullPolicy: IfNotPresent
               env:
                 - name: CHAOS_TARGET_PATTERNS

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
 data:
   my_elasticsearch.yml: |-

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/pdb.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -31,7 +30,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: elasticsearch
-        app.kubernetes.io/version: 8.18.0
 
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -70,7 +68,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:TEST
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -99,7 +97,7 @@ spec:
               ephemeral-storage: 50Mi
               memory: 128Mi
         - name: copy-default-plugins
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -143,7 +141,7 @@ spec:
               subPath: app-plugins-dir
       containers:
         - name: elasticsearch
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/master/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/elasticsearch/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.10.0-alpha1
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -100,7 +100,7 @@ spec:
               subPath: application.yml
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "SNAPSHOT"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/main/elasticsearch/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-elasticsearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/main/elasticsearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/elasticsearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
 data:
   my_elasticsearch.yml: |-

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/pdb.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -31,7 +30,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: elasticsearch
-        app.kubernetes.io/version: 8.18.0
 
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -70,7 +68,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:TEST
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -99,7 +97,7 @@ spec:
               ephemeral-storage: 50Mi
               memory: 128Mi
         - name: copy-default-plugins
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -143,7 +141,7 @@ spec:
               subPath: app-plugins-dir
       containers:
         - name: elasticsearch
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/master/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/elasticsearch/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.10.0-alpha1
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -100,7 +100,7 @@ spec:
               subPath: application.yml
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "SNAPSHOT"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/main/max/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/max/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-max-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-max-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/main/max/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/max/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/max/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/max/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/none/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/none/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/main/none/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/none/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/main/none/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/none/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-none-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-none-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/main/none/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/main/none/load-tester/templates/load-test-config.yaml
@@ -8,7 +8,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-none-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 data:
   load-test-config.yaml: |

--- a/load-tests/setup/test/golden/main/none/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/none/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/none/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/none/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-none
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-none
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/none/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/main/none/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/none/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/none/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/none/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/main/none/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/none/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/none/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/none/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/none/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "SNAPSHOT"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://opensearch:9200
         ports:

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/opensearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-opensearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-opensearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.10.0-alpha1
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -106,7 +106,7 @@ spec:
               subPath: application.yml
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "SNAPSHOT"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://opensearch:9200
         ports:

--- a/load-tests/setup/test/golden/main/opensearch/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-opensearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-opensearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/main/opensearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/opensearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-opensearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-opensearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.10.0-alpha1
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -106,7 +106,7 @@ spec:
               subPath: application.yml
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "SNAPSHOT"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/rdbms-optimize/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
 data:
   my_elasticsearch.yml: |-

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/pdb.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -31,7 +30,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: elasticsearch
-        app.kubernetes.io/version: 8.18.0
 
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -70,7 +68,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:TEST
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -99,7 +97,7 @@ spec:
               ephemeral-storage: 50Mi
               memory: 128Mi
         - name: copy-default-plugins
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -143,7 +141,7 @@ spec:
               subPath: app-plugins-dir
       containers:
         - name: elasticsearch
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/master/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/elasticsearch/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-rdbms-optimize
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.10.0-alpha1
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -100,7 +100,7 @@ spec:
               subPath: application.yml
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "SNAPSHOT"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/rdbms-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-rdbms-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-rdbms-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-stable/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "SNAPSHOT"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/main/rdbms/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-rdbms-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-rdbms-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/main/rdbms/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/rdbms/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-rdbms
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-main-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-main-rdbms
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.10.0-alpha1"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.10.0-alpha1
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.10.0-alpha1"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "SNAPSHOT"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "SNAPSHOT"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:SNAPSHOT
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/main/realistic/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-realistic-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-main-realistic-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/main/realistic/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/main/realistic/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/realistic/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: customer-notification
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -174,7 +174,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: dispute-process-request-get-vendor-info
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -307,7 +307,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: dispute-process-request-proof-from-vendor
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -452,7 +452,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: extract-data-from-document
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -585,7 +585,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: inform-about-successful-claim
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -718,7 +718,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: refunding
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-87/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
 data:
   my_elasticsearch.yml: |-

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/master/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/master/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -31,7 +30,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: elasticsearch
-        app.kubernetes.io/version: 8.18.0
 
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -70,7 +68,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:TEST
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -99,7 +97,7 @@ spec:
               ephemeral-storage: 50Mi
               memory: 128Mi
         - name: copy-default-plugins
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.17.4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -143,7 +141,7 @@ spec:
               subPath: app-plugins-dir
       containers:
         - name: elasticsearch
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.17.4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/master/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/master/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/elasticsearch/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.7.20"
+
 data:
   application.yml: |
     server:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.7.20"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.7.20"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.7.20
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.7.20"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.7.20"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.7.20"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.7.19"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.7.19"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.7.19"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.7.19
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.7.19"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.7.19"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/operate/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/operate/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.7.29"
+
 data:
   application.yaml: |
 

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/operate/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/operate/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.7.29"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: operate
-        app.kubernetes.io/version: "8.7.29"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/operate:TEST
+          image: camunda/operate:8.7.29
           command: ['/bin/sh', '/usr/local/operate/bin/migrate']
           securityContext:
             allowPrivilegeEscalation: false
@@ -81,7 +81,7 @@ spec:
               mountPath: /camunda
       containers:
         - name: operate
-          image: camunda/operate:TEST
+          image: camunda/operate:8.7.29
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/operate/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/operate/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.7.29"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/operate/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/operate/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.7.29"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.7.21"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.7.21"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.7.21"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.7.21
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -97,7 +97,7 @@ spec:
               name: environment-config
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.7.21
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.7.21"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.7.21"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/tasklist/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/tasklist/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: "8.7.29"
+
 data:
   application.yaml: |
 

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/tasklist/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/tasklist/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: "8.7.29"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: tasklist
-        app.kubernetes.io/version: "8.7.29"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: tasklist
-          image: camunda/tasklist:TEST
+          image: camunda/tasklist:8.7.29
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/tasklist/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/tasklist/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: "8.7.29"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/tasklist/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/tasklist/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: "8.7.29"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe-gateway/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe-gateway/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.7.33"
+
 apiVersion: v1
 data:
   gateway-log4j2.xml: |

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe-gateway/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe-gateway/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.7.33"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-gateway
-        app.kubernetes.io/version: "8.7.33"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: zeebe-gateway
-          image: docker.io/camunda/zeebe:TEST
+          image: docker.io/camunda/zeebe:8.7.33
           imagePullPolicy: Always
           ports:
             - containerPort: 9600

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe-gateway/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe-gateway/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.7.33"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe-gateway/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe-gateway/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.7.33"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.7.33"
+
 apiVersion: v1
 data:
   application.yaml: |

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.7.33"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.7.33"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/zeebe/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.7.33"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.7.33"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: zeebe
-          image: docker.io/camunda/zeebe:TEST
+          image: docker.io/camunda/zeebe:8.7.33
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
 data:
   my_elasticsearch.yml: |-

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/master/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/master/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -31,7 +30,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: elasticsearch
-        app.kubernetes.io/version: 8.18.0
 
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -70,7 +68,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:TEST
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -99,7 +97,7 @@ spec:
               ephemeral-storage: 50Mi
               memory: 128Mi
         - name: copy-default-plugins
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.17.4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -143,7 +141,7 @@ spec:
               subPath: app-plugins-dir
       containers:
         - name: elasticsearch
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.17.4
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/master/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/master/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/elasticsearch/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-87-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.7.20"
+
 data:
   application.yml: |
     server:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.7.20"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.7.20"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.7.20
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.7.20"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.7.20"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.7.20"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.7.19"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.7.19"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.7.19"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.7.19
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.7.19"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.7.19"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/operate/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/operate/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.7.29"
+
 data:
   application.yaml: |
 

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/operate/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/operate/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.7.29"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: operate
-        app.kubernetes.io/version: "8.7.29"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/operate:TEST
+          image: camunda/operate:8.7.29
           command: ['/bin/sh', '/usr/local/operate/bin/migrate']
           securityContext:
             allowPrivilegeEscalation: false
@@ -81,7 +81,7 @@ spec:
               mountPath: /camunda
       containers:
         - name: operate
-          image: camunda/operate:TEST
+          image: camunda/operate:8.7.29
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/operate/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/operate/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.7.29"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/operate/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/operate/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: operate
-    app.kubernetes.io/version: "8.7.29"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.7.21"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.7.21"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.7.21"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.7.21
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -97,7 +97,7 @@ spec:
               name: environment-config
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.7.21
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.7.21"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.7.21"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/tasklist/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/tasklist/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: "8.7.29"
+
 data:
   application.yaml: |
 

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/tasklist/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/tasklist/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: "8.7.29"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: tasklist
-        app.kubernetes.io/version: "8.7.29"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: tasklist
-          image: camunda/tasklist:TEST
+          image: camunda/tasklist:8.7.29
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/tasklist/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/tasklist/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: "8.7.29"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/tasklist/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/tasklist/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: tasklist
-    app.kubernetes.io/version: "8.7.29"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe-gateway/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe-gateway/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.7.33"
+
 apiVersion: v1
 data:
   gateway-log4j2.xml: |

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe-gateway/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe-gateway/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.7.33"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-gateway
-        app.kubernetes.io/version: "8.7.33"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: zeebe-gateway
-          image: docker.io/camunda/zeebe:TEST
+          image: docker.io/camunda/zeebe:8.7.33
           imagePullPolicy: Always
           ports:
             - containerPort: 9600

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe-gateway/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe-gateway/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.7.33"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe-gateway/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe-gateway/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.7.33"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.7.33"
+
 apiVersion: v1
 data:
   application.yaml: |

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/service.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.7.33"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.7.33"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/zeebe/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.7.33"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.7.33"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: zeebe
-          image: docker.io/camunda/zeebe:TEST
+          image: docker.io/camunda/zeebe:8.7.33
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-87/max/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-87-max-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-87-max-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-87/max/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-87/max/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-87/max/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-87/realistic/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-87-realistic-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-87-realistic-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-87/realistic/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-87/realistic/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-87/realistic/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: customer-notification
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -174,7 +174,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: dispute-process-request-get-vendor-info
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -307,7 +307,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: dispute-process-request-proof-from-vendor
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -452,7 +452,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: extract-data-from-document
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -585,7 +585,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: inform-about-successful-claim
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -718,7 +718,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: refunding
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/chaos-killer.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/chaos-killer.yaml
@@ -51,7 +51,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: chaos-killer
-              image: bitnami/kubectl:TEST
+              image: bitnami/kubectl:latest
               imagePullPolicy: IfNotPresent
               env:
                 - name: CHAOS_TARGET_PATTERNS

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
 data:
   my_elasticsearch.yml: |-

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -31,7 +30,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: elasticsearch
-        app.kubernetes.io/version: 8.18.0
 
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -70,7 +68,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:TEST
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -99,7 +97,7 @@ spec:
               ephemeral-storage: 50Mi
               memory: 128Mi
         - name: copy-default-plugins
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -143,7 +141,7 @@ spec:
               subPath: app-plugins-dir
       containers:
         - name: elasticsearch
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/master/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/elasticsearch/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.8.11"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.8.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.8.12"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.8.12
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.8.24"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.8.24
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -93,7 +93,7 @@ spec:
               name: environment-config
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.8.24
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/configmap-unified.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.8.28"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.8.28
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
 data:
   my_elasticsearch.yml: |-

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/master/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/master/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -31,7 +30,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: elasticsearch
-        app.kubernetes.io/version: 8.18.0
 
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -70,7 +68,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:TEST
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -99,7 +97,7 @@ spec:
               ephemeral-storage: 50Mi
               memory: 128Mi
         - name: copy-default-plugins
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -143,7 +141,7 @@ spec:
               subPath: app-plugins-dir
       containers:
         - name: elasticsearch
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/master/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/master/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/elasticsearch/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.8.11"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.8.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.8.12"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.8.12
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.8.24"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.8.24
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -93,7 +93,7 @@ spec:
               name: environment-config
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.8.24
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/configmap-unified.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.8.28"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.8.28
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-88/max/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-max-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-max-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-88/max/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/max/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/max/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-88/none/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-none-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-none-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-88/none/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-tester/templates/load-test-config.yaml
@@ -8,7 +8,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-none-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 data:
   load-test-config.yaml: |

--- a/load-tests/setup/test/golden/stable-88/none/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/none/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-none
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-none
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.8.12"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.8.12
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/configmap-unified.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/none/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.8.28"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.8.28
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://opensearch:9200
         ports:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-opensearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.8.11"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.8.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.8.12"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.8.12
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.8.24"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.8.24
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -97,7 +97,7 @@ spec:
               name: environment-config
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.8.24
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/configmap-unified.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.8.28"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.8.28
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://opensearch:9200
         ports:

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/opensearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-opensearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-88-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-88-opensearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.8.11"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.8.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/connectors/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.8.11"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.8.12"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
         []
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.8.12
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/identity/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.8.12"
+
 automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.8.24"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.8.24
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -97,7 +97,7 @@ spec:
               name: environment-config
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.8.24
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.8.24"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/configmap-unified.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/configmap-unified.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/serviceaccount.yaml
@@ -14,5 +14,5 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.8.28"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.8.28"
+
       annotations:
 
     spec:
@@ -52,7 +52,7 @@ spec:
         []
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.8.28
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-88/realistic/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-realistic-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-88-realistic-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-88/realistic/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-88/realistic/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-88/realistic/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: customer-notification
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -174,7 +174,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: dispute-process-request-get-vendor-info
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -307,7 +307,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: dispute-process-request-proof-from-vendor
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -452,7 +452,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: extract-data-from-document
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -585,7 +585,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: inform-about-successful-claim
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -718,7 +718,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: refunding
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/chaos-killer.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/chaos-killer.yaml
@@ -51,7 +51,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: chaos-killer
-              image: bitnami/kubectl:TEST
+              image: bitnami/kubectl:latest
               imagePullPolicy: IfNotPresent
               env:
                 - name: CHAOS_TARGET_PATTERNS

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/chaos-killer/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
 data:
   my_elasticsearch.yml: |-

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -31,7 +30,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: elasticsearch
-        app.kubernetes.io/version: 8.18.0
 
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -70,7 +68,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:TEST
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -99,7 +97,7 @@ spec:
               ephemeral-storage: 50Mi
               memory: 128Mi
         - name: copy-default-plugins
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -143,7 +141,7 @@ spec:
               subPath: app-plugins-dir
       containers:
         - name: elasticsearch
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/master/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/elasticsearch/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.6"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.9.6
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.6
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.9.5"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.9.5
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/identity/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.9.11"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.9.11
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -96,7 +96,7 @@ spec:
               subPath: application.yml
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.11
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.9.9"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.9.9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
 data:
   my_elasticsearch.yml: |-

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -31,7 +30,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: elasticsearch
-        app.kubernetes.io/version: 8.18.0
 
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -70,7 +68,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:TEST
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -99,7 +97,7 @@ spec:
               ephemeral-storage: 50Mi
               memory: 128Mi
         - name: copy-default-plugins
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -143,7 +141,7 @@ spec:
               subPath: app-plugins-dir
       containers:
         - name: elasticsearch
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/master/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/elasticsearch/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-elasticsearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.6"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.9.6
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.6
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.9.5"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.9.5
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/identity/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.9.11"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.9.11
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -96,7 +96,7 @@ spec:
               subPath: application.yml
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.11
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.9.9"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.9.9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/max/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-max-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-max-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-89/max/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/max/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/max/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/none/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-89/none/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-89/none/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-none-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-none-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-89/none/load-tester/templates/load-test-config.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-tester/templates/load-test-config.yaml
@@ -8,7 +8,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-none-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 data:
   load-test-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/none/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/none/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-none
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-none
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-none
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.9.5"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.9.5
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/identity/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/none/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.9.9"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.9.9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://opensearch:9200
         ports:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-opensearch-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.6"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.9.6
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.6
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.9.5"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.9.5
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/identity/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.9.11"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.9.11
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -102,7 +102,7 @@ spec:
               subPath: application.yml
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.11
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.9.9"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.9.9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://opensearch:9200
         ports:

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/opensearch/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-opensearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-opensearch
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-opensearch
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.6"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.9.6
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.6
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.9.5"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.9.5
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/identity/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.9.11"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.9.11
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -102,7 +102,7 @@ spec:
               subPath: application.yml
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.11
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: opensearch
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.9.9"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.9.9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/configmap.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
 data:
   my_elasticsearch.yml: |-

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
     ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -31,7 +30,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: elasticsearch
-        app.kubernetes.io/version: 8.18.0
 
         app.kubernetes.io/component: master
         ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
@@ -70,7 +68,7 @@ spec:
       initContainers:
         ## Image that performs the sysctl operation to modify Kernel settings (needed sometimes to avoid boot errors)
         - name: sysctl
-          image: docker.io/bitnamilegacy/os-shell:TEST
+          image: docker.io/bitnamilegacy/os-shell:12-debian-12-r43
           imagePullPolicy: "IfNotPresent"
           command:
             - /bin/bash
@@ -99,7 +97,7 @@ spec:
               ephemeral-storage: 50Mi
               memory: 128Mi
         - name: copy-default-plugins
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false
@@ -143,7 +141,7 @@ spec:
               subPath: app-plugins-dir
       containers:
         - name: elasticsearch
-          image: docker.io/bitnamilegacy/elasticsearch:TEST
+          image: docker.io/bitnamilegacy/elasticsearch:8.18.0
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/master/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/elasticsearch/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: elasticsearch
-    app.kubernetes.io/version: 8.18.0
 
     app.kubernetes.io/component: master
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-rdbms-optimize
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.6"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.9.6
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.6
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.9.5"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.9.5
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/identity/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
 apiVersion: v1
 data:
   environment-config.yaml: |

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: optimize
-        app.kubernetes.io/version: "8.9.11"
+
       annotations:
 
     spec:
@@ -49,7 +49,7 @@ spec:
         - name: harbor-registry
       initContainers:
         - name: migration
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.9.11
           command: ['./upgrade/upgrade.sh', '--skip-warning']
           securityContext:
             allowPrivilegeEscalation: false
@@ -96,7 +96,7 @@ spec:
               subPath: application.yml
       containers:
         - name: optimize
-          image: camunda/optimize:TEST
+          image: camunda/optimize:8.9.11
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: optimize
-    app.kubernetes.io/version: "8.9.11"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.11
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.9.9"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.9.9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-rdbms-stable
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.6"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.9.6
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.6
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.9.5"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.9.5
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/identity/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-stable/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.9.9"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.9.9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -19,7 +19,7 @@ spec:
         spec:
           containers:
           - name: leader-balancer
-            image: curlimages/curl:TEST
+            image: curlimages/curl:7.87.0
             command: ["/bin/sh", "-c"]
             args:
               - |-

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-test-setup/templates/metrics-exporter.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics-exporter
-        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:TEST
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
         args:
           - --es.addresses=http://elastic:9200
         ports:

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/rdbms/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: worker
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:
@@ -30,7 +29,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-rdbms
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: postgresql
-        app.kubernetes.io/version: 17.4.0
 
         app.kubernetes.io/component: primary
     spec:
@@ -62,7 +60,7 @@ spec:
       hostIPC: false
       containers:
         - name: postgresql
-          image: docker.io/bitnamilegacy/postgresql:TEST
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
           imagePullPolicy: "IfNotPresent"
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
   annotations:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
     app.kubernetes.io/component: primary
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -9,6 +9,5 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: postgresql
-    app.kubernetes.io/version: 17.4.0
 
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 data:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/service.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -9,7 +9,6 @@ metadata:
     app.kubernetes.io/instance: c8-golden-stable-89-rdbms
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: keycloak
-    app.kubernetes.io/version: 26.3.3
 
     app.kubernetes.io/component: keycloak
 spec:
@@ -33,7 +32,6 @@ spec:
         app.kubernetes.io/instance: c8-golden-stable-89-rdbms
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak
-        app.kubernetes.io/version: 26.3.3
 
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/app-version: 26.3.3
@@ -72,7 +70,7 @@ spec:
       enableServiceLinks: true
       initContainers:
         - name: prepare-write-dirs
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -114,7 +112,7 @@ spec:
              mountPath: /emptydir
       containers:
         - name: keycloak
-          image: docker.io/camunda/keycloak:TEST
+          image: docker.io/camunda/keycloak:26.3.3
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
 data:
   application.yaml: |    
     server:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: connectors
-        app.kubernetes.io/version: "8.9.6"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: connectors
-          image: camunda/connectors-bundle:TEST
+          image: camunda/connectors-bundle:8.9.6
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   clusterIP: None

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: connectors
-    app.kubernetes.io/version: "8.9.6"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/connectors/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.6
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/identity/configmap.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 data:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/identity/deployment.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
     {}
 spec:
@@ -41,7 +41,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: identity
-        app.kubernetes.io/version: "8.9.5"
+
       annotations:
 
     spec:
@@ -50,7 +50,7 @@ spec:
       initContainers:
       containers:
         - name: camunda-platform
-          image: camunda/identity:TEST
+          image: camunda/identity:8.9.5
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/identity/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: identity
-    app.kubernetes.io/version: "8.9.5"
+
   annotations:
 spec:
   type: ClusterIP

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/identity/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.5
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/configmap.yaml
@@ -13,7 +13,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
 apiVersion: v1
 data:
   startup.sh: |

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/service-headless.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/service.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-gateway
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
     {}
 spec:

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: camunda-platform
     app.kubernetes.io/part-of: camunda-platform
-    app.kubernetes.io/version: 8.9.9
+
     camunda.io/created-by: golden-test
     camunda.io/purpose: load-test
 

--- a/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms/platform/templates/orchestration/statefulset.yaml
@@ -14,7 +14,7 @@ metadata:
     camunda.io/purpose: load-test
 
     app.kubernetes.io/component: zeebe-broker
-    app.kubernetes.io/version: "8.9.9"
+
   annotations:
 spec:
   replicas: 3
@@ -42,7 +42,7 @@ spec:
         camunda.io/purpose: load-test
 
         app.kubernetes.io/component: zeebe-broker
-        app.kubernetes.io/version: "8.9.9"
+
       annotations:
 
     spec:
@@ -51,7 +51,7 @@ spec:
       initContainers:
       containers:
         - name: orchestration
-          image: docker.io/camunda/camunda:TEST
+          image: docker.io/camunda/camunda:8.9.9
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: true

--- a/load-tests/setup/test/golden/stable-89/realistic/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-tester/templates/clients-service.yaml
@@ -9,7 +9,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-realistic-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -28,7 +28,7 @@ metadata:
 
     app.kubernetes.io/name: camunda-load-tests
     app.kubernetes.io/instance: c8-golden-stable-89-realistic-test
-    app.kubernetes.io/version: "8.8.0"
+
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:

--- a/load-tests/setup/test/golden/stable-89/realistic/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-tester/templates/starter.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: starter
-          image: "registry.camunda.cloud/team-zeebe/starter:TEST"
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden/stable-89/realistic/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/stable-89/realistic/load-tester/templates/workers.yaml
@@ -32,7 +32,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: customer-notification
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -174,7 +174,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: dispute-process-request-get-vendor-info
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -307,7 +307,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: dispute-process-request-proof-from-vendor
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -452,7 +452,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: extract-data-from-document
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -585,7 +585,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: inform-about-successful-claim
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS
@@ -718,7 +718,7 @@ spec:
           value: n2-standard-4
       containers:
         - name: refunding
-          image: "registry.camunda.cloud/team-zeebe/worker:TEST"
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
           imagePullPolicy: Always
           env:
             - name: JDK_JAVA_OPTIONS

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -219,10 +219,10 @@ func TestNormalize(t *testing.T) {
 
 	require.NotContains(t, got, "helm.sh/chart")
 	require.NotContains(t, got, "checksum/config")
+	require.NotContains(t, got, "app.kubernetes.io/version")
 	require.NotContains(t, got, "2025-12-31")            // date value normalized away
 	require.Contains(t, got, "deadline-date: TEST_DATE") // label kept, value normalized
-	require.Contains(t, got, "image: registry.example.com/camunda/zeebe:TEST")
-	require.Contains(t, got, `app.kubernetes.io/version: "8.6.0"`) // kept
+	require.Contains(t, got, "image: registry.example.com/camunda/zeebe:8.6.0")
 
 	// Idempotent.
 	require.Equal(t, got, normalize(got))

--- a/load-tests/setup/test/goldenfiles.go
+++ b/load-tests/setup/test/goldenfiles.go
@@ -26,10 +26,10 @@ var normalizePatterns = []struct {
 }{
 	// helm.sh/chart label embeds chart semver — changes on every chart bump.
 	{regexp.MustCompile(`(?m)^\s*helm\.sh/chart:.*$`), ""},
+	// app.kubernetes.io/version is a bit noisy and doesn't bring lot of information in the tests.
+	{regexp.MustCompile(`(?m)^\s*app\.kubernetes\.io/version:.*$`), ""},
 	// deadline-date is a date-stamped namespace label computed at scaffold time.
 	{regexp.MustCompile(`(?m)^(\s*deadline-date:).*$`), "${1} TEST_DATE"},
-	// Image tags rotate per build; keep the image name, normalize the tag to TEST.
-	{regexp.MustCompile(`(image:\s*[^:\s]+:)[^\s"]+`), "${1}TEST"},
 	// checksum/config is derived from ConfigMap content; its diff is captured
 	// by the ConfigMap's own golden file.
 	{regexp.MustCompile(`(?m)^\s*checksum/config:.*$`), ""},


### PR DESCRIPTION
## Description

* Show the Docker image version: it should help us to see what we are actually deploying/running
  * I think they should be stable, unless we are updating a specific application
* Remove the `app.kubernetes.io/version` label from the output: it's not super useful and a bit noisy
* Configure Renovate to ignore any dependencies in the generated golden files: these files are autogenerated and should never be automatically updated directly ; the source should be instead.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/55702
