### PR TITLE
fix: avoid compacting hot runtime data

### DIFF
--- a/configuration/src/test/java/io/camunda/configuration/RocksDbPropertiesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/RocksDbPropertiesTest.java
@@ -45,7 +45,7 @@ public class RocksDbPropertiesTest {
         "camunda.data.primary-storage.rocks-db.sst-partitioning-enabled=false",
         "camunda.data.primary-storage.rocks-db.column-family-options.max_write_buffer_number=12",
         "camunda.data.primary-storage.rocks-db.column-family-options.write_buffer_size=67108864",
-        "camunda.data.primary-storage.rocks-db.column-family-options.compaction_pri=kOldestSmallestSeqFirst",
+        "camunda.data.primary-storage.rocks-db.column-family-options.compaction_pri=kOldestLargestSeqFirst",
         "camunda.data.primary-storage.rocks-db.memory-fraction=0.5"
       })
   class WithOnlyUnifiedConfigSet {
@@ -123,7 +123,7 @@ public class RocksDbPropertiesTest {
       assertThat(columnFamilyOptions.getProperty("max_write_buffer_number")).isEqualTo("12");
       assertThat(columnFamilyOptions.getProperty("write_buffer_size")).isEqualTo("67108864");
       assertThat(columnFamilyOptions.getProperty("compaction_pri"))
-          .isEqualTo("kOldestSmallestSeqFirst");
+          .isEqualTo("kOldestLargestSeqFirst");
     }
   }
 
@@ -225,7 +225,7 @@ public class RocksDbPropertiesTest {
         "camunda.data.primary-storage.rocks-db.io-rate-bytes-per-second=20971520",
         "camunda.data.primary-storage.rocks-db.wal-disabled=false",
         "camunda.data.primary-storage.rocks-db.sst-partitioning-enabled=false",
-        "camunda.data.primary-storage.rocks-db.column-family-options.compaction_pri=kOldestSmallestSeqFirst",
+        "camunda.data.primary-storage.rocks-db.column-family-options.compaction_pri=kOldestLargestSeqFirst",
         "camunda.data.primary-storage.rocks-db.memory-fraction=0.6",
         // legacy properties (should be ignored when new ones are present)
         "zeebe.broker.experimental.rocksdb.enableStatistics=false",
@@ -308,7 +308,7 @@ public class RocksDbPropertiesTest {
       // New properties should take precedence over legacy ones
       assertThat(columnFamilyOptions).hasSize(1);
       assertThat(columnFamilyOptions.getProperty("compaction_pri"))
-          .isEqualTo("kOldestSmallestSeqFirst");
+          .isEqualTo("kOldestLargestSeqFirst");
     }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/RocksdbCfgTest.java
@@ -90,7 +90,7 @@ public final class RocksdbCfgTest {
 
     // then
     assertThat(rocksDbConfiguration.getColumnFamilyOptions())
-        .containsEntry("compaction_pri", "kOldestSmallestSeqFirst")
+        .containsEntry("compaction_pri", "kOldestLargestSeqFirst")
         .containsEntry("write_buffer_size", "67108864");
     assertThat(rocksDbConfiguration.isStatisticsEnabled()).isTrue();
     assertThat(rocksDbConfiguration.getMemoryLimit()).isEqualTo(DataSize.ofMegabytes(32).toBytes());
@@ -106,7 +106,7 @@ public final class RocksdbCfgTest {
     // then
     final var columnFamilyOptions = rocksdb.getColumnFamilyOptions();
     assertThat(columnFamilyOptions)
-        .containsEntry("compaction_pri", "kOldestSmallestSeqFirst")
+        .containsEntry("compaction_pri", "kOldestLargestSeqFirst")
         .containsEntry("write_buffer_size", "67108864");
   }
 

--- a/zeebe/broker/src/test/resources/system/rocksdb-cfg.yaml
+++ b/zeebe/broker/src/test/resources/system/rocksdb-cfg.yaml
@@ -3,7 +3,7 @@ zeebe:
     experimental:
       rocksdb:
         columnFamilyOptions:
-          compaction_pri: "kOldestSmallestSeqFirst"
+          compaction_pri: "kOldestLargestSeqFirst"
           write_buffer_size: 67108864
         enableStatistics: true
         memoryLimit: 32MB

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -263,7 +263,7 @@ public final class ZeebeRocksDbFactory<
 
     // compaction
     props.setProperty("level_compaction_dynamic_level_bytes", RocksDbOptionsFormatter.format(true));
-    props.setProperty("compaction_pri", "kOldestSmallestSeqFirst");
+    props.setProperty("compaction_pri", "kOldestLargestSeqFirst");
     props.setProperty("compaction_style", "kCompactionStyleLevel");
 
     // L-0 means immediately flushed memtables

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -115,7 +115,7 @@ final class ZeebeRocksDbFactoryTest {
             ColumnFamilyOptions::writeBufferSize,
             ColumnFamilyOptions::compactionPriority,
             ColumnFamilyOptions::numLevels)
-        .containsExactly(16_901_492L, CompactionPriority.OldestSmallestSeqFirst, 4);
+        .containsExactly(16_901_492L, CompactionPriority.OldestLargestSeqFirst, 4);
 
     // then - user options should override defaults
     assertThat(customOptions)
@@ -140,7 +140,7 @@ final class ZeebeRocksDbFactoryTest {
     assertThat(columnFamilyOptions.maxWriteBufferNumber()).isEqualTo(6);
     assertThat(columnFamilyOptions.writeBufferSize()).isEqualTo(3_380_298L);
     assertThat(columnFamilyOptions.compactionPriority())
-        .isEqualTo(CompactionPriority.OldestSmallestSeqFirst);
+        .isEqualTo(CompactionPriority.OldestLargestSeqFirst);
     assertThat(columnFamilyOptions.compactionStyle()).isEqualTo(CompactionStyle.LEVEL);
     assertThat(columnFamilyOptions.level0FileNumCompactionTrigger()).isEqualTo(6);
     assertThat(columnFamilyOptions.level0SlowdownWritesTrigger()).isEqualTo(9);


### PR DESCRIPTION
Switch from `kOldestSmallestSeqFirst` to `kOldestLargestSeqFirst` which:

> In this mode, we will pick a file whose latest update is the oldest. It means there is no incoming data for the range for the longest. Usually it is the coldest range. By compacting coldest range first, we leave the hot ranges in the level. If your use case is to overwrite existing keys in a small range, try options.compaction_pri=kOldestLargestSeqFirst

See https://rocksdb.org/blog/2016/01/29/compaction_pri.html

Closes #56519