### PR TITLE
[stable/8.9] ci: add Spring Boot 4.1 compatibility test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1064,6 +1064,80 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  spring-boot-compatibility-tests:
+    # Verifies the Spring Boot 4 modules (camunda-spring-boot-starter and
+    # camunda-process-test-spring) still build and pass their tests against a
+    # non-default Spring Boot 4 minor version. The version is set by the profile
+    # defined in library-parent/pom.xml.
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    name: "[Spring-Boot-Compatibility] ${{ matrix.name }}"
+    needs: [ detect-changes ]
+    runs-on: gcp-perf-core-8-default
+    timeout-minutes: 30
+    permissions: { }  # GITHUB_TOKEN unused in this job
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "4.1.x"
+            profile: "spring-boot-4.1"
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: spring-boot-compatibility
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -Dquickly
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      - name: Maven Test Build
+        shell: bash
+        # We run unit and integration tests here as there aren't that many tests in the modules.
+        # 'clean' forces recompilation against the profile's Spring Boot version rather than
+        # reusing the default-version artifacts produced by build-zeebe.
+        run: >
+          ./mvnw -T2 -B --no-snapshot-updates
+          -D skipChecks
+          -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
+          -D failsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
+          -P skipFrontendBuild,extract-flaky-tests,${{ matrix.profile }}
+          -pl clients/camunda-spring-boot-starter,clients/camunda-spring-boot-starter-virtual-threads,testing/camunda-process-test-spring
+          clean verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "[Spring-Boot-Compatibility] ${{ matrix.name }}"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "spring-boot-compatibility/${{ matrix.name }}"
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          detailed_junit_tests: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   docker-checks:
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true'
     name: "Docker / Tool / Checks"
@@ -1783,6 +1857,7 @@ jobs:
       - renovatelint
       - setup-tests
       - shell-script-tests
+      - spring-boot-compatibility-tests
       - tasklist-ci
       - validate-pom-metadata
       - zeebe-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1070,7 +1070,7 @@ jobs:
     # non-default Spring Boot 4 minor version. The version is set by the profile
     # defined in library-parent/pom.xml.
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    name: "[Spring-Boot-Compatibility] ${{ matrix.name }}"
+    name: "Clients / Spring-Boot-Starter / Compatibility ${{ matrix.name }}"
     needs: [ detect-changes ]
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
@@ -1085,7 +1085,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "4.1.x"
+          - name: "4.1"
             profile: "spring-boot-4.1"
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
@@ -1128,13 +1128,13 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
-          name: "[Spring-Boot-Compatibility] ${{ matrix.name }}"
+          name: "Clients / Spring-Boot-Starter / Compatibility ${{ matrix.name }}"
       - name: Observe build status
         if: always()
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "spring-boot-compatibility/${{ matrix.name }}"
+          job_name: "spring-boot-starter-compatibility/${{ matrix.name }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
           detailed_junit_tests: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1075,6 +1075,10 @@ jobs:
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
     permissions: { }  # GITHUB_TOKEN unused in this job
+    env:
+      TEST_OWNER: '@camunda/camundaex'
+      TEST_PRODUCT: Camunda
+      TEST_TYPE: Integration
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1089,7 +1089,7 @@ jobs:
             profile: "spring-boot-4.1"
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Print metadata
         uses: ./.github/actions/print-metadata
       - uses: ./.github/actions/setup-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1079,8 +1079,6 @@ jobs:
       TEST_OWNER: '@camunda/camundaex'
       TEST_PRODUCT: Camunda
       TEST_TYPE: Integration
-    outputs:
-      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     strategy:
       fail-fast: false
       matrix:

--- a/library-parent/pom.xml
+++ b/library-parent/pom.xml
@@ -27,4 +27,16 @@
     <!-- No overrides as zeebe-parent was migrated to Spring Boot 4.0.0 -->
   </properties>
 
+  <profiles>
+    <profile>
+      <id>spring-boot-4.1</id>
+      <properties>
+        <!-- For testing Spring Boot 4.1 compatibility. Spring Boot 4.1.0 manages Spring
+             Framework 7.0.8 (same as the default Spring Boot 4.0.x), so version.spring is left
+             at the inherited default; only the Spring Boot version is overridden here. -->
+        <version.spring-boot>4.1.0</version.spring-boot>
+      </properties>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
## Description

Adds CI coverage that verifies the Spring Boot 4 modules still build and pass their tests against a **non-default Spring Boot 4 minor version** (4.1.0), rather than only the default 4.0.x managed by `parent/pom.xml`.

This ports the Spring-Boot-framework compatibility setup that exists on `stable/8.7` (a `spring-boot-3.5` profile + a `spring-boot-compatibility-tests` job in `ci.yml`, see #40803) to 8.9, where the Spring Boot 4 based modules are the default. Note this is a **different axis** from the existing `camunda-spring-boot-starter-compatibility-test.yml` / `camunda-process-test-compatibility.yml` workflows, which test product **client-vs-server version** combinations, not the Spring Boot framework version.

### Changes

- **`library-parent/pom.xml`** — new `spring-boot-4.1` profile overriding `version.spring-boot` to `4.1.0`. The default Spring Boot 4 modules inherit `library-parent` (`camunda-spring-boot-starter` and `camunda-spring-boot-starter-virtual-threads` directly; `camunda-process-test-spring` via `camunda-testing`), so the override propagates to all three. The Spring Boot 3 starter pins its own versions locally and is unaffected.
- **`.github/workflows/ci.yml`** — new `spring-boot-compatibility-tests` job (matrix `profile: spring-boot-4.1`, displayed as `Clients / Spring-Boot-Starter / Compatibility 4.1`), gated on `java-code-changes` and added to the `check-results` `needs:` list so the merge queue enforces it. It runs `build-zeebe -Dquickly`, then a scoped `clean verify` (with the profile) over `camunda-spring-boot-starter`, `camunda-spring-boot-starter-virtual-threads`, and `testing/camunda-process-test-spring`.

### Notes

- On 8.9, `camunda-spring-boot-4-starter` and `camunda-process-test-spring-boot-4` are empty relocation stubs (aliases → the default modules) with no sources/tests, so the job targets the real default modules to avoid a false green.
- `version.spring` is intentionally **not** overridden: Spring Boot 4.1.0 manages Spring Framework 7.0.8 (the same as the 4.0.x default), and Spring Framework 7.1.0 does not exist. Only the Spring Boot version differs.
- `camunda-spring-boot-starter-virtual-threads` is included: running its failsafe IT here initially surfaced a pre-existing (non-4.1-specific) defect in `VirtualThreadsAutoConfiguration` — its `@SpringBootTest` slice provided no `MeterRegistry` bean while the metered executor eagerly dereferenced a `@Lazy` one, and no CI job previously ran this IT. That was fixed upstream in #54648 (which also added a `qa-clients` IT group on `main` so the IT runs on every PR going forward) and backported to `stable/8.9` via #56516, so the module is included here from the start.

### Verification

Confirmed via the job's Maven output (not just job status) that the `spring-boot-4.1` profile actually takes effect and isn't silently falling back to the default:
- The test-execution step downloads and resolves `spring-boot` / `spring-boot-starter` / `spring-boot-dependencies` **`4.1.0`** exclusively — no `4.0.x` (default) or `3.5.x` artifacts appear anywhere in that step's log.
- All targeted tests actually ran and passed (not skipped): `camunda-spring-boot-starter` and `camunda-spring-boot-starter-virtual-threads` unit + integration tests, and the full `camunda-process-test-spring` suite (including several ITs), ending in `BUILD SUCCESS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
