### PR TITLE
fix: wrap jobLease with nullToEmpty in AgentHistoryEntityMapper

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.db.rdbms.read.mapper;
 
+import static io.camunda.db.rdbms.read.NullSafeStrings.nullToEmpty;
+
 import io.camunda.db.rdbms.write.domain.AgentHistoryDbModel;
 import io.camunda.search.entities.AgentInstanceHistoryEntity;
 import io.camunda.search.entities.AgentInstanceHistoryEntity.Metrics;
@@ -27,7 +29,7 @@ public class AgentHistoryEntityMapper {
         dbModel.processDefinitionId(),
         dbModel.tenantId(),
         dbModel.jobKey(),
-        dbModel.jobLease(),
+        nullToEmpty(dbModel.jobLease()),
         dbModel.iteration(),
         dbModel.role(),
         dbModel.contentItems() != null ? dbModel.contentItems() : List.of(),


### PR DESCRIPTION
## Summary

- `AgentInstanceAuthorizationIT` fails on Oracle nightly due to Oracle storing empty strings as `NULL`
- `jobLease` is empty during the current transition (e2e implementation incomplete), so Oracle returns `NULL` on fetch
- Fix: wrap `dbModel.jobLease()` with `nullToEmpty()` in `AgentHistoryEntityMapper`

## Context

Regression introduced by #55271. This is a **transitional fix** — once the e2e implementation is complete, `jobLease` will always be populated and the guard becomes a no-op.

CI failure: https://github.com/camunda/camunda/actions/runs/28569850175/job/84705005468

Closes #56495

## Test plan

- [ ] Nightly Oracle CI passes
- [ ] `AgentInstanceAuthorizationIT` green on Oracle

🤖 Generated with [Claude Code](https://claude.com/claude-code)