### PR TITLE
feat: group parameterize stream transport topics

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.zeebe.broker.jobstream.JobStreamMetrics;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.jobstream.RemoteJobStreamErrorHandlerService;
@@ -20,7 +22,6 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
-import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Collection;
 import java.util.Map;
@@ -50,7 +51,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
                 JobStreamServiceStep::readJobActivationProperties,
                 errorHandlerService,
                 new JobStreamMetrics(brokerStartupContext.getMeterRegistry()),
-                StreamTopics.DEFAULT_GROUP);
+                DEFAULT_PHYSICAL_TENANT_ID);
     final var errorHandlerStarted = scheduler.submitActor(errorHandlerService);
 
     errorHandlerStarted.onComplete(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
+import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Collection;
 import java.util.Map;
@@ -48,7 +49,8 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
                 clusterServices.getCommunicationService(),
                 JobStreamServiceStep::readJobActivationProperties,
                 errorHandlerService,
-                new JobStreamMetrics(brokerStartupContext.getMeterRegistry()));
+                new JobStreamMetrics(brokerStartupContext.getMeterRegistry()),
+                StreamTopics.DEFAULT_GROUP);
     final var errorHandlerStarted = scheduler.submitActor(errorHandlerService);
 
     errorHandlerStarted.onComplete(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
 import io.camunda.zeebe.transport.stream.api.ClientStreamService;
 import io.camunda.zeebe.transport.stream.api.ClientStreamer;
+import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 
@@ -43,7 +44,9 @@ public final class JobStreamClientImpl implements JobStreamClient {
     streamService =
         new TransportFactory(schedulingService)
             .createRemoteStreamClient(
-                clusterCommunicationService, new JobClientStreamMetrics(meterRegistry));
+                clusterCommunicationService,
+                new JobClientStreamMetrics(meterRegistry),
+                StreamTopics.DEFAULT_GROUP);
   }
 
   @Override

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.gateway.impl.stream;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
@@ -16,7 +18,6 @@ import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
 import io.camunda.zeebe.transport.stream.api.ClientStreamService;
 import io.camunda.zeebe.transport.stream.api.ClientStreamer;
-import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 
@@ -46,7 +47,7 @@ public final class JobStreamClientImpl implements JobStreamClient {
             .createRemoteStreamClient(
                 clusterCommunicationService,
                 new JobClientStreamMetrics(meterRegistry),
-                StreamTopics.DEFAULT_GROUP);
+                DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   @Override

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -57,18 +57,22 @@ public final class TransportFactory {
       final ClusterCommunicationService clusterCommunicationService,
       final Function<DirectBuffer, M> metadataFactory,
       final RemoteStreamErrorHandler<P> errorHandler,
-      final RemoteStreamMetrics metrics) {
+      final RemoteStreamMetrics metrics,
+      final String physicalTenantId) {
     final RemoteStreamRegistry<M> registry = new RemoteStreamRegistry<>(metrics);
     return new RemoteStreamServiceImpl<>(
         new RemoteStreamerImpl<>(clusterCommunicationService, registry, errorHandler, metrics),
         new RemoteStreamTransport<>(
-            clusterCommunicationService, new RemoteStreamApiHandler<>(registry, metadataFactory)),
+            clusterCommunicationService,
+            new RemoteStreamApiHandler<>(registry, metadataFactory),
+            physicalTenantId),
         registry);
   }
 
   public <M extends BufferWriter> ClientStreamService<M> createRemoteStreamClient(
       final ClusterCommunicationService clusterCommunicationService,
-      final ClientStreamMetrics metrics) {
-    return new ClientStreamServiceImpl<>(clusterCommunicationService, metrics);
+      final ClientStreamMetrics metrics,
+      final String physicalTenantId) {
+    return new ClientStreamServiceImpl<>(clusterCommunicationService, metrics, physicalTenantId);
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  * Manages an instance of {@link ClientStreamer}. Intended to be the main entry point when setting
  * up the client side for remote streams, primarily via {@link
  * io.camunda.zeebe.transport.TransportFactory#createRemoteStreamClient(ClusterCommunicationService,
- * ClientStreamMetrics)}.
+ * ClientStreamMetrics, String)}.
  *
  * @param <M> the type of the streaming metadata
  */

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -62,11 +62,15 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
   private final ClusterCommunicationService communicationService;
   private final ConcurrencyControl executor;
+  private final String physicalTenantId;
 
   ClientStreamRequestManager(
-      final ClusterCommunicationService communicationService, final ConcurrencyControl executor) {
+      final ClusterCommunicationService communicationService,
+      final ConcurrencyControl executor,
+      final String physicalTenantId) {
     this.communicationService = communicationService;
     this.executor = executor;
+    this.physicalTenantId = physicalTenantId;
   }
 
   /**
@@ -165,7 +169,11 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     servers.forEach(
         serverId -> {
           communicationService.unicast(
-              StreamTopics.REMOVE.topic(), payload, Function.identity(), serverId, true);
+              StreamTopics.REMOVE.topic(physicalTenantId),
+              payload,
+              Function.identity(),
+              serverId,
+              true);
           purgeRegistration(streamId, serverId);
         });
   }
@@ -248,7 +256,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
     final var pendingRequest =
         communicationService.send(
-            StreamTopics.ADD.topic(),
+            StreamTopics.ADD.topic(physicalTenantId),
             request,
             Function.identity(),
             Function.identity(),
@@ -307,7 +315,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
     final var pendingRequest =
         communicationService.send(
-            StreamTopics.REMOVE.topic(),
+            StreamTopics.REMOVE.topic(physicalTenantId),
             request,
             Function.identity(),
             Function.identity(),
@@ -403,6 +411,10 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   private void doRemoveAll(final MemberId brokerId) {
     // Do not wait for response, as this is expected to be called while shutting down.
     communicationService.unicast(
-        StreamTopics.REMOVE_ALL.topic(), REMOVE_ALL_REQUEST, Function.identity(), brokerId, true);
+        StreamTopics.REMOVE_ALL.topic(physicalTenantId),
+        REMOVE_ALL_REQUEST,
+        Function.identity(),
+        brokerId,
+        true);
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.scheduler.Actor;
@@ -62,7 +64,7 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   @Override
   protected void onActorStarted() {
     communicationService.replyToAsync(
-        StreamTopics.PUSH.topic(),
+        StreamTopics.PUSH.topic(DEFAULT_PHYSICAL_TENANT_ID),
         MessageUtil::parsePushRequest,
         apiHandler::handlePushRequest,
         BufferUtil::bufferAsArray,

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -39,17 +39,23 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   private final ClusterCommunicationService communicationService;
   private final ClientStreamRegistry<M> registry;
   private final ClientStreamApiHandler apiHandler;
+  private final String physicalTenantId;
 
   public ClientStreamServiceImpl(
-      final ClusterCommunicationService communicationService, final ClientStreamMetrics metrics) {
+      final ClusterCommunicationService communicationService,
+      final ClientStreamMetrics metrics,
+      final String physicalTenantId) {
     this.communicationService = communicationService;
+    this.physicalTenantId = physicalTenantId;
     registry = new ClientStreamRegistry<>(metrics);
 
     // ClientStreamRequestManager must use same actor as this because it is mutating shared
     // ClientStream objects.
     clientStreamManager =
         new ClientStreamManager<>(
-            registry, new ClientStreamRequestManager<>(communicationService, actor), metrics);
+            registry,
+            new ClientStreamRequestManager<>(communicationService, actor, physicalTenantId),
+            metrics);
     apiHandler = new ClientStreamApiHandler(clientStreamManager, actor);
   }
 
@@ -63,7 +69,7 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
         actor::run);
 
     communicationService.replyTo(
-        StreamTopics.RESTART_STREAMS.topic(),
+        StreamTopics.RESTART_STREAMS.topic(physicalTenantId),
         Function.identity(),
         apiHandler::handleRestartRequest,
         Function.identity(),

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransport.java
@@ -42,38 +42,43 @@ public final class RemoteStreamTransport<M> extends Actor {
   private final ClusterCommunicationService transport;
   private final RemoteStreamApiHandler<M> requestHandler;
   private final LongUnaryOperator retryDelaySupplier;
+  private final String physicalTenantId;
 
   public RemoteStreamTransport(
-      final ClusterCommunicationService transport, final RemoteStreamApiHandler<M> requestHandler) {
-    this(transport, requestHandler, new ExponentialBackoff());
+      final ClusterCommunicationService transport,
+      final RemoteStreamApiHandler<M> requestHandler,
+      final String physicalTenantId) {
+    this(transport, requestHandler, new ExponentialBackoff(), physicalTenantId);
   }
 
   @VisibleForTesting
   RemoteStreamTransport(
       final ClusterCommunicationService transport,
       final RemoteStreamApiHandler<M> requestHandler,
-      final LongUnaryOperator retryDelaySupplier) {
+      final LongUnaryOperator retryDelaySupplier,
+      final String physicalTenantId) {
     this.transport = transport;
     this.requestHandler = requestHandler;
     this.retryDelaySupplier = retryDelaySupplier;
+    this.physicalTenantId = physicalTenantId;
   }
 
   @Override
   protected void onActorStarting() {
     transport.replyTo(
-        StreamTopics.ADD.topic(),
+        StreamTopics.ADD.topic(physicalTenantId),
         MessageUtil::parseAddRequest,
         requestHandler::add,
         BufferUtil::bufferAsArray,
         actor::run);
     transport.replyTo(
-        StreamTopics.REMOVE.topic(),
+        StreamTopics.REMOVE.topic(physicalTenantId),
         MessageUtil::parseRemoveRequest,
         requestHandler::remove,
         BufferUtil::bufferAsArray,
         actor::run);
     transport.replyTo(
-        StreamTopics.REMOVE_ALL.topic(),
+        StreamTopics.REMOVE_ALL.topic(physicalTenantId),
         Function.identity(),
         this::onRemoveAll,
         Function.identity(),
@@ -82,9 +87,9 @@ public final class RemoteStreamTransport<M> extends Actor {
 
   @Override
   protected void onActorClosing() {
-    transport.unsubscribe(StreamTopics.ADD.topic());
-    transport.unsubscribe(StreamTopics.REMOVE.topic());
-    transport.unsubscribe(StreamTopics.REMOVE_ALL.topic());
+    transport.unsubscribe(StreamTopics.ADD.topic(physicalTenantId));
+    transport.unsubscribe(StreamTopics.REMOVE.topic(physicalTenantId));
+    transport.unsubscribe(StreamTopics.REMOVE_ALL.topic(physicalTenantId));
     requestHandler.close();
   }
 
@@ -118,7 +123,7 @@ public final class RemoteStreamTransport<M> extends Actor {
   private CompletableFuture<Void> sendRestartStreamsRequest(final MemberId receiver) {
     return transport
         .send(
-            StreamTopics.RESTART_STREAMS.topic(),
+            StreamTopics.RESTART_STREAMS.topic(physicalTenantId),
             ArrayUtil.EMPTY_BYTE_ARRAY,
             Function.identity(),
             Function.identity(),

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerImpl.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.scheduler.Actor;
@@ -91,7 +93,7 @@ public final class RemoteStreamerImpl<M, P extends BufferWriter> extends Actor
 
   private CompletableFuture<byte[]> send(final PushStreamRequest request, final MemberId receiver) {
     return transport.send(
-        StreamTopics.PUSH.topic(),
+        StreamTopics.PUSH.topic(DEFAULT_PHYSICAL_TENANT_ID),
         request,
         BufferUtil::bufferAsArray,
         Function.identity(),

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.transport.stream.impl.messages;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 public enum StreamTopics {
   ADD("stream-add"),
   PUSH("stream-push"),
@@ -14,20 +16,14 @@ public enum StreamTopics {
   REMOVE_ALL("stream-remove-all"),
   RESTART_STREAMS("stream-recreate");
 
-  public static final String DEFAULT_GROUP = "default";
-
   private final String topic;
 
   StreamTopics(final String topic) {
     this.topic = topic;
   }
 
-  public String topic() {
-    return topic;
-  }
-
   public String topic(final String physicalTenantId) {
-    if (DEFAULT_GROUP.equals(physicalTenantId)) {
+    if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
       return topic;
     }
     return physicalTenantId + "-" + topic;

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.transport.stream.impl.messages;
 
 import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 
+import java.util.Objects;
+
 public enum StreamTopics {
   ADD("stream-add"),
   PUSH("stream-push"),
@@ -23,6 +25,7 @@ public enum StreamTopics {
   }
 
   public String topic(final String physicalTenantId) {
+    Objects.requireNonNull(physicalTenantId, "physicalTenantId must not be null");
     if (DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
       return topic;
     }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/StreamTopics.java
@@ -14,6 +14,8 @@ public enum StreamTopics {
   REMOVE_ALL("stream-remove-all"),
   RESTART_STREAMS("stream-recreate");
 
+  public static final String DEFAULT_GROUP = "default";
+
   private final String topic;
 
   StreamTopics(final String topic) {
@@ -22,5 +24,12 @@ public enum StreamTopics {
 
   public String topic() {
     return topic;
+  }
+
+  public String topic(final String physicalTenantId) {
+    if (DEFAULT_GROUP.equals(physicalTenantId)) {
+      return topic;
+    }
+    return physicalTenantId + "-" + topic;
   }
 }

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -52,17 +53,29 @@ class ClientStreamManagerTest {
       new ClientStreamManager<>(
           registry,
           new ClientStreamRequestManager<>(
-              mockTransport, new TestConcurrencyControl(), StreamTopics.DEFAULT_GROUP),
+              mockTransport, new TestConcurrencyControl(), DEFAULT_PHYSICAL_TENANT_ID),
           metrics);
 
   @BeforeEach
   void setup() {
     when(mockTransport.send(any(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(ArrayUtil.EMPTY_BYTE_ARRAY));
-    when(mockTransport.send(eq(StreamTopics.ADD.topic()), any(), any(), any(), any(), any()))
+    when(mockTransport.send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            any(),
+            any()))
         .thenReturn(
             CompletableFuture.completedFuture(BufferUtil.bufferAsArray(new AddStreamResponse())));
-    when(mockTransport.send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), any(), any()))
+    when(mockTransport.send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            any(),
+            any()))
         .thenReturn(
             CompletableFuture.completedFuture(
                 BufferUtil.bufferAsArray(new RemoveStreamResponse())));

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -51,7 +51,8 @@ class ClientStreamManagerTest {
   private final ClientStreamManager<TestMetadata> clientStreamManager =
       new ClientStreamManager<>(
           registry,
-          new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl()),
+          new ClientStreamRequestManager<>(
+              mockTransport, new TestConcurrencyControl(), StreamTopics.DEFAULT_GROUP),
           metrics);
 
   @BeforeEach

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -51,7 +51,8 @@ final class ClientStreamRequestManagerTest {
   private final ClusterCommunicationService mockTransport = mock(ClusterCommunicationService.class);
   private final TestConcurrencyControl concurrencyControl = spy(new TestConcurrencyControl());
   private final ClientStreamRequestManager<TestMetadata> requestManager =
-      new ClientStreamRequestManager<>(mockTransport, concurrencyControl);
+      new ClientStreamRequestManager<>(
+          mockTransport, concurrencyControl, StreamTopics.DEFAULT_GROUP);
   private final AggregatedClientStream<TestMetadata> clientStream =
       new AggregatedClientStream<>(
           UUID.randomUUID(),

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -52,7 +53,7 @@ final class ClientStreamRequestManagerTest {
   private final TestConcurrencyControl concurrencyControl = spy(new TestConcurrencyControl());
   private final ClientStreamRequestManager<TestMetadata> requestManager =
       new ClientStreamRequestManager<>(
-          mockTransport, concurrencyControl, StreamTopics.DEFAULT_GROUP);
+          mockTransport, concurrencyControl, DEFAULT_PHYSICAL_TENANT_ID);
   private final AggregatedClientStream<TestMetadata> clientStream =
       new AggregatedClientStream<>(
           UUID.randomUUID(),
@@ -64,9 +65,21 @@ final class ClientStreamRequestManagerTest {
   void setup() {
     when(mockTransport.send(any(), any(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
-    when(mockTransport.send(eq(StreamTopics.ADD.topic()), any(), any(), any(), any(), any()))
+    when(mockTransport.send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            any(),
+            any()))
         .thenReturn(CompletableFuture.completedFuture(addStreamSuccess));
-    when(mockTransport.send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), any(), any()))
+    when(mockTransport.send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            any(),
+            any()))
         .thenReturn(CompletableFuture.completedFuture(removeStreamSuccess));
     clientStream.open(requestManager, Collections.emptySet());
   }
@@ -78,7 +91,12 @@ final class ClientStreamRequestManagerTest {
     final var serverId = MemberId.anonymous();
     final var pendingRequest = new CompletableFuture<byte[]>();
     when(mockTransport.<byte[], byte[]>send(
-            eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any()))
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
         .thenReturn(pendingRequest);
     requestManager.add(clientStream, serverId);
     requestManager.remove(clientStream, serverId);
@@ -88,7 +106,13 @@ final class ClientStreamRequestManagerTest {
 
     // then - should only have sent one ADD request (the initial one)
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
   }
 
   @Test
@@ -103,7 +127,13 @@ final class ClientStreamRequestManagerTest {
 
     // then - only one request sent ever
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
   }
 
   @Test
@@ -120,12 +150,24 @@ final class ClientStreamRequestManagerTest {
 
     // then - no request sent until we complete the future
     verify(mockTransport, never())
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
 
     // then - completes once future is completed
     pendingRequest.complete(removeStreamSuccess);
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
   }
 
   @Test
@@ -134,7 +176,12 @@ final class ClientStreamRequestManagerTest {
     final var serverId = MemberId.anonymous();
     final var pendingRequest = new CompletableFuture<byte[]>();
     when(mockTransport.<byte[], byte[]>send(
-            eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any()))
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
         .thenReturn(pendingRequest);
     requestManager.add(clientStream, serverId);
     requestManager.remove(clientStream, serverId);
@@ -144,7 +191,13 @@ final class ClientStreamRequestManagerTest {
 
     // then - only one request should have been sent
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
   }
 
   @Test
@@ -162,12 +215,24 @@ final class ClientStreamRequestManagerTest {
 
     // then - no request sent until we complete the future
     verify(mockTransport, never())
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
 
     // then - completes once future is completed
     pendingRequest.completeExceptionally(new RuntimeException("failed"));
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
   }
 
   @Test
@@ -180,7 +245,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport)
-        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     assertThat(clientStream.isConnected(serverId)).isTrue();
   }
 
@@ -188,7 +259,13 @@ final class ClientStreamRequestManagerTest {
   void shouldRetryWhenAddRequestFails() {
     // given
     final var serverId = MemberId.anonymous();
-    when(mockTransport.send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(serverId), any()))
+    when(mockTransport.send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Expected")))
         .thenReturn(CompletableFuture.completedFuture(addStreamSuccess));
 
@@ -197,7 +274,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport, times(2))
-        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     assertThat(clientStream.isConnected(serverId)).isTrue();
   }
 
@@ -208,7 +291,13 @@ final class ClientStreamRequestManagerTest {
     final var errorResponseBuffer =
         BufferUtil.bufferAsArray(new ErrorResponse().code(code).message("Failed"));
     final var serverId = MemberId.anonymous();
-    when(mockTransport.send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(serverId), any()))
+    when(mockTransport.send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
         .thenReturn(CompletableFuture.completedFuture(errorResponseBuffer))
         .thenReturn(CompletableFuture.completedFuture(addStreamSuccess));
 
@@ -217,7 +306,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport, times(2))
-        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     assertThat(clientStream.isConnected(serverId)).isTrue();
   }
 
@@ -232,7 +327,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport)
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     assertThat(clientStream.isConnected(serverId)).isFalse();
   }
 
@@ -248,7 +349,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport)
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     assertThat(clientStream.isConnected(serverId)).isTrue();
   }
 
@@ -262,7 +369,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport, never())
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     assertThat(clientStream.isConnected(serverId)).isFalse();
   }
 
@@ -272,7 +385,12 @@ final class ClientStreamRequestManagerTest {
     final var serverId = MemberId.anonymous();
     requestManager.add(clientStream, serverId);
     when(mockTransport.send(
-            eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any()))
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Expected")))
         .thenReturn(CompletableFuture.completedFuture(removeStreamSuccess));
 
@@ -281,7 +399,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport, times(2))
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     assertThat(clientStream.isConnected(serverId)).isFalse();
   }
 
@@ -293,7 +417,12 @@ final class ClientStreamRequestManagerTest {
         BufferUtil.bufferAsArray(new ErrorResponse().code(code).message("Failed"));
     final var serverId = MemberId.anonymous();
     when(mockTransport.send(
-            eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any()))
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
         .thenReturn(CompletableFuture.completedFuture(errorResponseBuffer))
         .thenReturn(CompletableFuture.completedFuture(removeStreamSuccess));
     requestManager.add(clientStream, serverId);
@@ -303,7 +432,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     verify(concurrencyControl, never()).schedule(any(), any());
     assertThat(clientStream.isConnected(serverId)).isFalse();
   }
@@ -325,7 +460,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     assertThat(clientStream.isConnected(serverId)).isFalse();
     assertThat(registration.state()).isEqualTo(State.CLOSED);
   }
@@ -346,7 +487,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     assertThat(clientStream.isConnected(serverId)).isFalse();
   }
 
@@ -358,7 +505,12 @@ final class ClientStreamRequestManagerTest {
     final var serverId = MemberId.anonymous();
     requestManager.add(clientStream, serverId);
     when(mockTransport.<byte[], byte[]>send(
-            eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any()))
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
         .thenReturn(pendingRequest);
 
     // whe
@@ -367,7 +519,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     verify(concurrencyControl, never()).schedule(any(), any());
     assertThat(clientStream.isConnected(serverId)).isFalse();
   }
@@ -379,7 +537,12 @@ final class ClientStreamRequestManagerTest {
     final var serverId = MemberId.anonymous();
     requestManager.add(clientStream, serverId);
     when(mockTransport.<byte[], byte[]>send(
-            eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any()))
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
         .thenReturn(pendingRequest);
 
     // whe
@@ -388,7 +551,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.REMOVE.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     verify(concurrencyControl, never()).schedule(any(), any());
     assertThat(clientStream.isConnected(serverId)).isFalse();
   }
@@ -399,7 +568,12 @@ final class ClientStreamRequestManagerTest {
     final var pendingRequest = new CompletableFuture<byte[]>();
     final var serverId = MemberId.anonymous();
     when(mockTransport.<byte[], byte[]>send(
-            eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(serverId), any()))
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
         .thenReturn(pendingRequest);
 
     // when - remove all, which will close all registrations
@@ -409,7 +583,13 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport, times(1))
-        .send(eq(StreamTopics.ADD.topic()), any(), any(), any(), eq(serverId), any());
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
     assertThat(clientStream.isConnected(serverId)).isFalse();
   }
 
@@ -425,9 +605,19 @@ final class ClientStreamRequestManagerTest {
 
     // then
     verify(mockTransport)
-        .unicast(eq(StreamTopics.REMOVE_ALL.topic()), any(), any(), eq(server1), anyBoolean());
+        .unicast(
+            eq(StreamTopics.REMOVE_ALL.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            eq(server1),
+            anyBoolean());
     verify(mockTransport)
-        .unicast(eq(StreamTopics.REMOVE_ALL.topic()), any(), any(), eq(server2), anyBoolean());
+        .unicast(
+            eq(StreamTopics.REMOVE_ALL.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            eq(server2),
+            anyBoolean());
   }
 
   private static Stream<MessagingException> provideMessagingFailures() {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
@@ -61,7 +61,8 @@ final class RemoteStreamTransportTest {
                 data.wrap(buffer, 0, buffer.capacity());
                 return data;
               }),
-          senderBackoffSupplier);
+          senderBackoffSupplier,
+          StreamTopics.DEFAULT_GROUP);
   private final AtomixCluster receiver = createClusterNode(nodes.get(1), nodes);
 
   @AfterEach

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamTransportTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.AtomixCluster;
@@ -62,7 +63,7 @@ final class RemoteStreamTransportTest {
                 return data;
               }),
           senderBackoffSupplier,
-          StreamTopics.DEFAULT_GROUP);
+          DEFAULT_PHYSICAL_TENANT_ID);
   private final AtomixCluster receiver = createClusterNode(nodes.get(1), nodes);
 
   @AfterEach
@@ -123,7 +124,7 @@ final class RemoteStreamTransportTest {
       newReceiver
           .getCommunicationService()
           .replyTo(
-              StreamTopics.RESTART_STREAMS.topic(),
+              StreamTopics.RESTART_STREAMS.topic(DEFAULT_PHYSICAL_TENANT_ID),
               Function.identity(),
               (id, ignored) -> ArrayUtil.EMPTY_BYTE_ARRAY,
               Function.identity(),
@@ -141,7 +142,7 @@ final class RemoteStreamTransportTest {
     receiver
         .getCommunicationService()
         .replyTo(
-            StreamTopics.RESTART_STREAMS.topic(),
+            StreamTopics.RESTART_STREAMS.topic(DEFAULT_PHYSICAL_TENANT_ID),
             Function.identity(),
             (id, ignored) -> {
               throw new RuntimeException("I have become error, destroyer of worlds");

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -115,7 +116,7 @@ final class RemoteStreamerTest {
     // then
     Mockito.verify(communicationService, Mockito.timeout(5_000).times(1))
         .send(
-            Mockito.eq(StreamTopics.PUSH.topic()),
+            Mockito.eq(StreamTopics.PUSH.topic(DEFAULT_PHYSICAL_TENANT_ID)),
             Mockito.eq(new PushStreamRequest().streamId(streamId.streamId()).payload(payload)),
             Mockito.any(),
             Mockito.any(),

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
 import io.camunda.zeebe.transport.stream.api.StreamResponseException;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
+import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -408,7 +409,8 @@ final class StreamIntegrationTest {
                 return data;
               },
               dynamicErrorHandler,
-              RemoteStreamMetrics.noop());
+              RemoteStreamMetrics.noop(),
+              StreamTopics.DEFAULT_GROUP);
     }
 
     private void start() {
@@ -444,7 +446,9 @@ final class StreamIntegrationTest {
       final var factory = new TransportFactory(actorScheduler);
       streamService =
           factory.createRemoteStreamClient(
-              cluster.getCommunicationService(), ClientStreamMetrics.noop());
+              cluster.getCommunicationService(),
+              ClientStreamMetrics.noop(),
+              StreamTopics.DEFAULT_GROUP);
     }
 
     private void start() {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.AtomixCluster;
@@ -35,7 +36,6 @@ import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamer;
 import io.camunda.zeebe.transport.stream.api.StreamResponseException;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
-import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -410,7 +410,7 @@ final class StreamIntegrationTest {
               },
               dynamicErrorHandler,
               RemoteStreamMetrics.noop(),
-              StreamTopics.DEFAULT_GROUP);
+              DEFAULT_PHYSICAL_TENANT_ID);
     }
 
     private void start() {
@@ -448,7 +448,7 @@ final class StreamIntegrationTest {
           factory.createRemoteStreamClient(
               cluster.getCommunicationService(),
               ClientStreamMetrics.noop(),
-              StreamTopics.DEFAULT_GROUP);
+              DEFAULT_PHYSICAL_TENANT_ID);
     }
 
     private void start() {


### PR DESCRIPTION
## Description

Add `StreamTopics.topic(physicalTenantId)` overload that returns `<group>-<topic>` for non-default groups and the legacy topic name for `DEFAULT_GROUP` (`"default"`), keeping the wire format byte-identical on existing clusters
- Thread `physicalTenantId` through `RemoteStreamTransport`, `ClientStreamRequestManager`, `ClientStreamServiceImpl`, and `TransportFactory`; callers (broker `JobStreamServiceStep`, gateway `JobStreamClientImpl`) pass `DEFAULT_GROUP` for now
- `PUSH` intentionally stays on a single global topic (group-agnostic) per the design — only the four control topics (`ADD`/`REMOVE`/`REMOVE_ALL`/`RESTART_STREAMS`) are parameterized

## Context

This is the foundation refactor for physical-tenant-aware job streaming (#56219). Future broker and gateway work will pass actual group IDs instead of `DEFAULT_GROUP` to route streams into per-tenant topic namespaces. Without this plumbing, those sub-issues cannot proceed.

No behavior change:  a `default` only cluster emits the same topic strings as before.

## Related issues

closes #56220
