### PR TITLE
ci(#52693): build camunda docker test image once and share to integration-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,12 +533,93 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  build-camunda-docker-test-image:
+    name: "Build / Camunda Docker Test Image"
+    # Build the single-arch camunda test image once and share it to the integration-tests
+    # matrix, replacing a 5-8 min `build-platform-docker` in each shard. Built from the shared
+    # distball (the same UI-less distball the shards test against); transported via GCS because
+    # the shards run on self-hosted gcp-perf runners where the GHA artifact API is
+    # throughput-capped (see build-distball). docker-checks is untouched — it keeps its own
+    # multi-arch build. See #52693 / #54352.
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes, build-distball ]
+    runs-on: gcp-perf-core-8-default
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@b4ba25e5825dccf0f4d25c103b63569a5d1d30c5 # main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 1
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: build-shared
+          dockerhub-readonly: true  # pull the minimus hardened base image
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          minimus: true
+      - name: Fetch GCS build-cache credentials
+        id: gcs-secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
+      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Download distball from GCS
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/target
+          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-zeebe-*.tar.gz" dist/target/
+      # push: false → the action builds with --load, leaving `camunda/camunda:current-test`
+      # in the local daemon. The `current-test` tag MUST match integration-tests' DOCKER_IMAGE_TAG.
+      - uses: ./.github/actions/build-platform-docker
+        id: build-test-image
+        with:
+          repository: camunda/camunda
+          version: current-test
+          dockerfile: camunda.Dockerfile
+          platforms: linux/amd64
+          push: false
+      - name: Save + upload test image to GCS
+        shell: bash
+        # SA lacks storage.buckets.get, so gcloud's parallel-composite precheck fails; disable it.
+        env:
+          CLOUDSDK_STORAGE_PARALLEL_COMPOSITE_UPLOAD_ENABLED: "False"
+        run: |
+          set -euo pipefail
+          docker save camunda/camunda:current-test | gzip > camunda-docker-test-image.tar.gz
+          ls -lh camunda-docker-test-image.tar.gz
+          gcloud storage cp camunda-docker-test-image.tar.gz \
+            "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-docker-test-image.tar.gz"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   utils-cleanup-distball:
     name: "Cleanup / Distribution Tarball Artifact"
     # Delete the run-scoped GCS objects after consumers finish. The `utils-` prefix
     # exempts it from the check-results gate; artifacts self-expire (retention-days: 1)
     # and the bucket TTL covers runs cancelled before this fires.
-    needs: [ build-distball, docker-checks, integration-tests ]
+    needs: [ build-distball, build-camunda-docker-test-image, docker-checks, integration-tests ]
     if: always() && needs.build-distball.result != 'skipped'
     runs-on: ubuntu-slim  # short auth-and-delete job; no need for a full runner
     timeout-minutes: 10
@@ -1291,7 +1372,7 @@ jobs:
   integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "${{ matrix.module }} / Integration / ${{ matrix.name }} ITs (${{ matrix.stressRun }})"
-    needs: [ detect-changes, setup-tests, build-distball ]
+    needs: [ detect-changes, setup-tests, build-distball, build-camunda-docker-test-image ]
     timeout-minutes: 30
     permissions:
       contents: read
@@ -1378,13 +1459,18 @@ jobs:
           gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-zeebe-*.tar.gz" dist/target/
           gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" "${RUNNER_TEMP}/m2-installed.tar"
           tar -xf "${RUNNER_TEMP}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"
-      - uses: ./.github/actions/build-platform-docker
+      # Consume the shared camunda test image instead of a 5-8 min `build-platform-docker`.
+      # build-camunda-docker-test-image saved `camunda/camunda:current-test` to GCS; load it,
+      # re-tag to this shard's local registry and push (the tests resolve it from localhost:5000).
+      - name: Load shared camunda docker test image
         if: ${{ matrix.docker-file != '' }}
-        with:
-          repository: ${{ matrix.docker-repository }}
-          version: ${{ env.DOCKER_IMAGE_TAG }}
-          dockerfile: ${{ matrix.docker-file }}
-          push: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-docker-test-image.tar.gz" "${RUNNER_TEMP}/"
+          docker load -i "${RUNNER_TEMP}/camunda-docker-test-image.tar.gz"
+          docker tag "camunda/camunda:${DOCKER_IMAGE_TAG}" "${{ matrix.docker-repository }}:${DOCKER_IMAGE_TAG}"
+          docker push "${{ matrix.docker-repository }}:${DOCKER_IMAGE_TAG}"
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       - name: Maven Test Build Integration
@@ -2358,6 +2444,7 @@ jobs:
     needs: # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
       - archunit-tests
+      - build-camunda-docker-test-image
       - build-distball
       - build-platform-frontend
       - c8-e2e-test-suite


### PR DESCRIPTION
## What

Part of #52693. Closes #54352.

Each `integration-tests` matrix shard currently rebuilds the camunda test image via `build-platform-docker` (5–8 min on a gcp-perf runner, ~10 shards). This builds it **once** in a new `build-camunda-docker-test-image` job and shares it to the shards.

- New `build-camunda-docker-test-image` job: builds `camunda/camunda:current-test` single-arch `linux/amd64` from the shared distball (`push: false` → `--load`), `docker save | gzip`, uploads to the run-scoped GCS prefix.
- `integration-tests`: replaces the inline `build-platform-docker` step with `gcloud storage cp` + `docker load` + `docker tag` + `docker push localhost:5000/…`. Guarded by the existing `matrix.docker-file != ''` so the 2 entries that don't need an image are untouched.
- `utils-cleanup-distball` and `check-results` needs updated.

## Design notes (deviations from the issue body, which was partly stale)

- **Transport is GCS, not the GHA artifact API.** The shards run on self-hosted gcp-perf runners where the artifact API is throughput-capped — same rationale as `build-distball` (#54583). The image tar lives under the same run-scoped GCS prefix, so the existing `utils-cleanup-distball` recursive delete already covers it.
- **Only one image.** The issue mentioned separate operate/tasklist images for the root group; that's stale (unified webapp). Only `camunda/camunda:current-test` is built in IT.
- The test image is already UI-less today (built from the shared distball), so the producer builds from that same distball — no behaviour change for the tests.
- `docker-checks` is **untouched** — it keeps its own multi-arch build.

## Trade-off

Adds a ~6–7 min serial producer stage before the shards (~+2 min wall-clock) but removes a 5–8 min build from each of ~10 shards → **~44 gcp-perf runner-min/run** saved. Net-positive on the epic's runner-cost goal.

## Risk 🔴

Higher: if the post-`docker load` tag doesn't match `localhost:5000/camunda/camunda:current-test` (what the tests expect), all shards fail. The producer builds/saves `camunda/camunda:current-test`; each shard re-tags to `${{ matrix.docker-repository }}:${DOCKER_IMAGE_TAG}`. Draft until a live CI run confirms the tag flow end-to-end.

## Validation

- actionlint: clean (only pre-existing custom self-hosted runner-label warnings).
- conftest (`--rego-version v0`, `.github` policies): 35/35 pass, 0 failures (the print-metadata WARN is pre-existing across ~24 jobs including `build-distball`).