### PR TITLE
test: pin client version and upgrade java version

### DIFF
--- a/.github/workflows/c8run-rdbms-regression-test.yml
+++ b/.github/workflows/c8run-rdbms-regression-test.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Install IntelliJ HTTP Client
         shell: bash
         run: |
-          curl -f -L -o ijhttp.zip "https://jb.gg/ijhttp/latest"
+          curl -f -L -o ijhttp.zip "https://download.jetbrains.com/resources/intellij/http-client/262.7132.23/intellij-http-client.zip"
           unzip ijhttp.zip
           ijhttp/ijhttp qa/http/c8run-tests/c8run-tests.http --private-env-file qa/http/http-client.private.env.json --env ${{ matrix.env }} --report -t 60000
 

--- a/.github/workflows/identity-regression-test.yml
+++ b/.github/workflows/identity-regression-test.yml
@@ -139,11 +139,11 @@ jobs:
           ref: ${{ inputs.branch }}
           fetch-depth: 0
 
-      - name: Set up Java 21
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
         with:
-          distribution: temurin
-          java-version: 21
+          distribution: "temurin"
+          java-version: "25"
 
       - name: Download Camunda Distribution Artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -262,7 +262,7 @@ jobs:
       - name: Install IntelliJ HTTP Client
         shell: bash
         run: |
-          curl -f -L -o ijhttp.zip "https://jb.gg/ijhttp/latest"
+          curl -f -L -o ijhttp.zip "https://download.jetbrains.com/resources/intellij/http-client/262.7132.23/intellij-http-client.zip"
           unzip ijhttp.zip
           ijhttp/ijhttp qa/http/${{ matrix.case }} --private-env-file qa/http/http-client.private.env.json --env ${{ matrix.env }} --report -t 60000
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for regression tests, focusing on upgrading dependencies and ensuring consistent tooling versions. The main changes are updating the Java version used in the identity regression tests and pinning the IntelliJ HTTP Client to a specific version in both workflows.

Dependency and tooling updates:

* Updated the Java version in `identity-regression-test.yml` from Java 21 to Java 25 and switched the `actions/setup-java` action to version 4 for improved compatibility and future-proofing.
* Changed the IntelliJ HTTP Client installation in both `c8run-rdbms-regression-test.yml` and `identity-regression-test.yml` to download a specific version (`262.7132.23`) instead of using the latest, ensuring consistent and reproducible test runs. [[1]](diffhunk://#diff-bf886e41b115f7a5da209c91aff89e6c5e77d4c2eac758c50886fb41481eddd7L116-R116) [[2]](diffhunk://#diff-89ab1d1c8695334b40f9f72c54df343a0fbb3eb01e059370bbaf66baf7721317L265-R265)