### PR TITLE
Rename iteration to loopIteration in agent instance history

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentHistoryItemCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateAgentHistoryItemCommandStep1.java
@@ -105,12 +105,12 @@ public interface CreateAgentHistoryItemCommandStep1 {
     CreateAgentHistoryItemFinalCommandStep jobLease(String jobLease);
 
     /**
-     * Sets the sequential iteration number this item belongs to.
+     * Sets the sequential loopIteration number this item belongs to.
      *
-     * @param iteration the iteration number.
+     * @param loopIteration the loopIteration number.
      * @return this builder for method chaining
      */
-    CreateAgentHistoryItemFinalCommandStep iteration(int iteration);
+    CreateAgentHistoryItemFinalCommandStep loopIteration(int loopIteration);
 
     /**
      * Sets the tool calls associated with this history item.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceHistoryFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AgentInstanceHistoryFilter.java
@@ -44,9 +44,9 @@ public interface AgentInstanceHistoryFilter extends SearchRequestFilter {
 
   AgentInstanceHistoryFilter jobKey(Consumer<BasicLongProperty> fn);
 
-  AgentInstanceHistoryFilter iteration(int value);
+  AgentInstanceHistoryFilter loopIteration(int value);
 
-  AgentInstanceHistoryFilter iteration(Consumer<IntegerProperty> fn);
+  AgentInstanceHistoryFilter loopIteration(Consumer<IntegerProperty> fn);
 
   AgentInstanceHistoryFilter commitStatus(AgentInstanceHistoryCommitStatus value);
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstanceHistory.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AgentInstanceHistory.java
@@ -36,7 +36,7 @@ public interface AgentInstanceHistory {
 
   String getJobLease();
 
-  Integer getIteration();
+  Integer getLoopIteration();
 
   AgentInstanceHistoryRole getRole();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceHistorySort.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/sort/AgentInstanceHistorySort.java
@@ -23,5 +23,5 @@ public interface AgentInstanceHistorySort extends SearchRequestSort<AgentInstanc
 
   AgentInstanceHistorySort historyItemKey();
 
-  AgentInstanceHistorySort iteration();
+  AgentInstanceHistorySort loopIteration();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAgentHistoryItemCommandImpl.java
@@ -204,9 +204,9 @@ public class CreateAgentHistoryItemCommandImpl
   }
 
   @Override
-  public CreateAgentHistoryItemFinalCommandStep iteration(final int iteration) {
-    ArgumentUtil.ensureGreaterThan("iteration", iteration, 0);
-    request.iteration(iteration);
+  public CreateAgentHistoryItemFinalCommandStep loopIteration(final int loopIteration) {
+    ArgumentUtil.ensureGreaterThan("loopIteration", loopIteration, 0);
+    request.loopIteration(loopIteration);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentInstanceHistoryFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/AgentInstanceHistoryFilterImpl.java
@@ -103,15 +103,15 @@ public class AgentInstanceHistoryFilterImpl
   }
 
   @Override
-  public AgentInstanceHistoryFilter iteration(final int value) {
-    return iteration(f -> f.eq(value));
+  public AgentInstanceHistoryFilter loopIteration(final int value) {
+    return loopIteration(f -> f.eq(value));
   }
 
   @Override
-  public AgentInstanceHistoryFilter iteration(final Consumer<IntegerProperty> fn) {
+  public AgentInstanceHistoryFilter loopIteration(final Consumer<IntegerProperty> fn) {
     final IntegerProperty property = new IntegerPropertyImpl();
     fn.accept(property);
-    filter.setIteration(provideSearchRequestProperty(property));
+    filter.setLoopIteration(provideSearchRequestProperty(property));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
@@ -48,7 +48,7 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
   private final long elementInstanceKey;
   private final long jobKey;
   private final String jobLease;
-  private final Integer iteration;
+  private final Integer loopIteration;
   private final AgentInstanceHistoryRole role;
   private final List<AgentInstanceHistoryContent> content;
   private final List<AgentInstanceHistoryToolCall> toolCalls;
@@ -62,7 +62,7 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
     elementInstanceKey = Long.parseLong(result.getElementInstanceKey());
     jobKey = Long.parseLong(result.getJobKey());
     jobLease = result.getJobLease();
-    iteration = result.getIteration();
+    loopIteration = result.getLoopIteration();
     role = EnumUtil.convert(result.getRole(), AgentInstanceHistoryRole.class);
     content =
         result.getContent() != null
@@ -108,8 +108,8 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
   }
 
   @Override
-  public Integer getIteration() {
-    return iteration;
+  public Integer getLoopIteration() {
+    return loopIteration;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentInstanceHistorySortImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/sort/AgentInstanceHistorySortImpl.java
@@ -37,7 +37,7 @@ public class AgentInstanceHistorySortImpl extends SearchRequestSortBase<AgentIns
   }
 
   @Override
-  public AgentInstanceHistorySort iteration() {
-    return field("iteration");
+  public AgentInstanceHistorySort loopIteration() {
+    return field("loopIteration");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/CreateAgentHistoryItemCommandTest.java
@@ -97,7 +97,7 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
     assertThat(body.getRole()).isEqualTo(AgentInstanceHistoryRoleEnum.ASSISTANT);
     assertThat(body.getContent()).hasSize(1);
     assertThat(body.getProducedAt()).isEqualTo(PRODUCED_AT.toString());
-    assertThat(body.getIteration()).isNull();
+    assertThat(body.getLoopIteration()).isNull();
     assertThat(body.getToolCalls()).isNull();
     assertThat(body.getMetrics()).isNull();
   }
@@ -117,7 +117,7 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
         .content(Collections.singletonList(AgentInstanceHistoryContent.text("hello")))
         .producedAt(PRODUCED_AT)
         .jobLease("lease-token")
-        .iteration(3)
+        .loopIteration(3)
         .metrics(
             new AgentInstanceHistoryMetrics().inputTokens(100L).outputTokens(50L).durationMs(200L))
         .execute();
@@ -126,7 +126,7 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
     final AgentInstanceHistoryItemRequest body =
         gatewayService.getLastRequest(AgentInstanceHistoryItemRequest.class);
     assertThat(body.getJobLease()).isEqualTo("lease-token");
-    assertThat(body.getIteration()).isEqualTo(3);
+    assertThat(body.getLoopIteration()).isEqualTo(3);
     assertThat(body.getMetrics().getInputTokens()).isEqualTo(100L);
     assertThat(body.getMetrics().getOutputTokens()).isEqualTo(50L);
     assertThat(body.getMetrics().getDurationMs()).isEqualTo(200L);
@@ -295,11 +295,11 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
         .hasMessage("text content value must not be null or blank");
   }
 
-  // ── Argument validation: iteration ───────────────────────────────────────
+  // ── Argument validation: loopIteration ───────────────────────────────────────
 
-  @ParameterizedTest(name = "iteration={0} should be rejected")
+  @ParameterizedTest(name = "loopIteration={0} should be rejected")
   @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
-  void shouldRejectNonPositiveIteration(final int iteration) {
+  void shouldRejectNonPositiveLoopIteration(final int loopIteration) {
     assertThatThrownBy(
             () ->
                 client
@@ -309,9 +309,9 @@ class CreateAgentHistoryItemCommandTest extends ClientRestTest {
                     .role(AgentInstanceHistoryRole.USER)
                     .content(Collections.singletonList(AgentInstanceHistoryContent.text("hello")))
                     .producedAt(PRODUCED_AT)
-                    .iteration(iteration))
+                    .loopIteration(loopIteration))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("iteration must be greater than 0");
+        .hasMessageContaining("loopIteration must be greater than 0");
   }
 
   // ── Argument validation: content factory null guards ─────────────────────

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
@@ -152,18 +152,18 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
   }
 
   @Test
-  void shouldSearchWithIterationFilter() {
+  void shouldSearchWithLoopIterationFilter() {
     // when
     client
         .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
-        .filter(f -> f.iteration(1))
+        .filter(f -> f.loopIteration(1))
         .send()
         .join();
 
     // then
     final AgentInstanceHistorySearchQuery request =
         gatewayService.getLastRequest(AgentInstanceHistorySearchQuery.class);
-    assertThat(request.getFilter().getIteration().get$Eq()).isEqualTo(1);
+    assertThat(request.getFilter().getLoopIteration().get$Eq()).isEqualTo(1);
   }
 
   @Test
@@ -187,11 +187,11 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
   }
 
   @Test
-  void shouldSearchWithIterationSort() {
+  void shouldSearchWithLoopIterationSort() {
     // when
     client
         .newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY)
-        .sort(s -> s.iteration().asc())
+        .sort(s -> s.loopIteration().asc())
         .send()
         .join();
 
@@ -205,7 +205,8 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
             AgentInstanceHistorySearchQuerySortRequest::getOrder)
         .containsExactly(
             tuple(
-                AgentInstanceHistorySearchQuerySortRequest.FieldEnum.ITERATION, SortOrderEnum.ASC));
+                AgentInstanceHistorySearchQuerySortRequest.FieldEnum.LOOP_ITERATION,
+                SortOrderEnum.ASC));
   }
 
   @Test
@@ -262,7 +263,7 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
             .elementInstanceKey("200")
             .jobKey("300")
             .jobLease("lease-abc")
-            .iteration(3)
+            .loopIteration(3)
             .role(AgentInstanceHistoryRoleEnum.USER)
             .commitStatus(AgentInstanceHistoryCommitStatusEnum.COMMITTED)
             .producedAt(now.toString())
@@ -308,7 +309,7 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
           softly.assertThat(item.getElementInstanceKey()).as("elementInstanceKey").isEqualTo(200L);
           softly.assertThat(item.getJobKey()).as("jobKey").isEqualTo(300L);
           softly.assertThat(item.getJobLease()).as("jobLease").isEqualTo("lease-abc");
-          softly.assertThat(item.getIteration()).as("iteration").isEqualTo(3);
+          softly.assertThat(item.getLoopIteration()).as("loopIteration").isEqualTo(3);
           softly.assertThat(item.getRole()).as("role").isEqualTo(AgentInstanceHistoryRole.USER);
           softly
               .assertThat(item.getCommitStatus())

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -470,7 +470,7 @@
       <column name="PARTITION_ID" type="INTEGER"/>
       <column name="JOB_KEY" type="BIGINT"/>
       <column name="JOB_LEASE" type="NVARCHAR(${userCharColumnSize})"/>
-      <column name="ITERATION" type="INTEGER"/>
+      <column name="LOOP_ITERATION" type="INTEGER"/>
       <column name="ROLE" type="VARCHAR(20)"/>
       <column name="COMMIT_STATUS" type="VARCHAR(20)"/>
       <column name="PRODUCED_AT" type="TIMESTAMP WITH TIME ZONE(3)"/>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
@@ -30,7 +30,7 @@ public class AgentHistoryEntityMapper {
         dbModel.tenantId(),
         dbModel.jobKey(),
         nullToEmpty(dbModel.jobLease()),
-        dbModel.iteration(),
+        dbModel.loopIteration(),
         dbModel.role(),
         dbModel.contentItems() != null ? dbModel.contentItems() : List.of(),
         dbModel.toolCallValues() != null ? dbModel.toolCallValues() : List.of(),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentHistorySearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/AgentHistorySearchColumn.java
@@ -11,7 +11,7 @@ import io.camunda.search.entities.AgentInstanceHistoryEntity;
 
 public enum AgentHistorySearchColumn implements SearchColumn<AgentInstanceHistoryEntity> {
   AGENT_HISTORY_KEY("historyItemKey"),
-  ITERATION("iteration"),
+  LOOP_ITERATION("loopIteration"),
   PRODUCED_AT("producedAt");
 
   private final String property;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
@@ -41,7 +41,7 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
   private int partitionId;
   private long jobKey;
   private String jobLease;
-  private Integer iteration;
+  private Integer loopIteration;
   private AgentInstanceHistoryRole role;
   private AgentInstanceHistoryCommitStatus commitStatus;
   private OffsetDateTime producedAt;
@@ -75,7 +75,7 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
         .partitionId(partitionId)
         .jobKey(jobKey)
         .jobLease(jobLease)
-        .iteration(iteration)
+        .loopIteration(loopIteration)
         .role(role)
         .commitStatus(commitStatus)
         .producedAt(producedAt)
@@ -184,12 +184,12 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
     }
   }
 
-  public Integer iteration() {
-    return iteration;
+  public Integer loopIteration() {
+    return loopIteration;
   }
 
-  public void iteration(final Integer iteration) {
-    this.iteration = iteration;
+  public void loopIteration(final Integer loopIteration) {
+    this.loopIteration = loopIteration;
   }
 
   public AgentInstanceHistoryRole role() {
@@ -375,7 +375,7 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
     private int partitionId;
     private long jobKey;
     private String jobLease;
-    private Integer iteration;
+    private Integer loopIteration;
     private AgentInstanceHistoryRole role;
     private AgentInstanceHistoryCommitStatus commitStatus;
     private OffsetDateTime producedAt;
@@ -440,8 +440,8 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
       return this;
     }
 
-    public Builder iteration(final Integer iteration) {
-      this.iteration = iteration;
+    public Builder loopIteration(final Integer loopIteration) {
+      this.loopIteration = loopIteration;
       return this;
     }
 
@@ -499,7 +499,7 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
       result.partitionId(partitionId);
       result.jobKey(jobKey);
       result.jobLease(jobLease);
-      result.iteration(iteration);
+      result.loopIteration(loopIteration);
       result.role(role);
       result.commitStatus(commitStatus);
       result.producedAt(producedAt);

--- a/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
@@ -27,7 +27,7 @@
       PARTITION_ID,
       JOB_KEY,
       JOB_LEASE,
-      ITERATION,
+      LOOP_ITERATION,
       ROLE,
       COMMIT_STATUS,
       PRODUCED_AT,
@@ -49,7 +49,7 @@
       #{partitionId},
       #{jobKey},
       #{jobLease},
-      #{iteration},
+      #{loopIteration},
       #{role},
       #{commitStatus},
       #{producedAt, jdbcType=TIMESTAMP},
@@ -98,7 +98,7 @@
     <result property="partitionId" column="PARTITION_ID" javaType="java.lang.Integer"/>
     <result property="jobKey" column="JOB_KEY" javaType="long"/>
     <result property="jobLease" column="JOB_LEASE" javaType="java.lang.String"/>
-    <result property="iteration" column="ITERATION" javaType="java.lang.Integer"/>
+    <result property="loopIteration" column="LOOP_ITERATION" javaType="java.lang.Integer"/>
     <result property="role" column="ROLE"
       javaType="io.camunda.search.entities.AgentInstanceHistoryEntity$AgentInstanceHistoryRole"/>
     <result property="commitStatus" column="COMMIT_STATUS"
@@ -128,7 +128,7 @@
           ah.PARTITION_ID,
           ah.JOB_KEY,
           ah.JOB_LEASE,
-          ah.ITERATION,
+          ah.LOOP_ITERATION,
           ah.ROLE,
           ah.COMMIT_STATUS,
           ah.PRODUCED_AT,
@@ -205,9 +205,9 @@
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>
-    <if test="filter.iterationOperations != null and !filter.iterationOperations.isEmpty()">
-      <foreach collection="filter.iterationOperations" item="operation">
-        AND ah.ITERATION
+    <if test="filter.loopIterationOperations != null and !filter.loopIterationOperations.isEmpty()">
+      <foreach collection="filter.loopIterationOperations" item="operation">
+        AND ah.LOOP_ITERATION
         <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
       </foreach>
     </if>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapperTest.java
@@ -39,7 +39,7 @@ class AgentHistoryEntityMapperTest {
     dbModel.partitionId(1);
     dbModel.jobKey(700L);
     dbModel.jobLease("lease-abc");
-    dbModel.iteration(3);
+    dbModel.loopIteration(3);
     dbModel.role(AgentInstanceHistoryRole.ASSISTANT);
     dbModel.commitStatus(AgentInstanceHistoryCommitStatus.COMMITTED);
     dbModel.producedAt(producedAt);
@@ -62,7 +62,7 @@ class AgentHistoryEntityMapperTest {
     assertThat(entity.tenantId()).isEqualTo("<default>");
     assertThat(entity.jobKey()).isEqualTo(700L);
     assertThat(entity.jobLease()).isEqualTo("lease-abc");
-    assertThat(entity.iteration()).isEqualTo(3);
+    assertThat(entity.loopIteration()).isEqualTo(3);
     assertThat(entity.role()).isEqualTo(AgentInstanceHistoryRole.ASSISTANT);
     assertThat(entity.commitStatus()).isEqualTo(AgentInstanceHistoryCommitStatus.COMMITTED);
     assertThat(entity.producedAt()).isEqualTo(producedAt);
@@ -107,7 +107,7 @@ class AgentHistoryEntityMapperTest {
     model.partitionId(1);
     model.jobKey(6L);
     model.jobLease("lease");
-    model.iteration(1);
+    model.loopIteration(1);
     model.role(AgentInstanceHistoryRole.USER);
     model.commitStatus(AgentInstanceHistoryCommitStatus.PENDING);
     model.producedAt(OffsetDateTime.parse("2024-01-01T00:00:00Z"));

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentHistoryDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AgentHistoryDbReaderTest.java
@@ -175,7 +175,7 @@ class AgentHistoryDbReaderTest {
         .partitionId(1)
         .jobKey(60L)
         .jobLease("lease-" + key)
-        .iteration(1)
+        .loopIteration(1)
         .role(AgentInstanceHistoryRole.USER)
         .commitStatus(AgentInstanceHistoryCommitStatus.PENDING)
         .producedAt(OffsetDateTime.parse("2024-01-01T00:00:00Z"))

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -141,8 +141,8 @@ public class AgentInstanceMapper {
           record.setProducedAt(
               OffsetDateTime.parse(request.getProducedAt()).toInstant().toEpochMilli());
 
-          if (request.getIteration() != null) {
-            record.setIteration(request.getIteration());
+          if (request.getLoopIteration() != null) {
+            record.setLoopIteration(request.getLoopIteration());
           }
 
           for (final AgentInstanceMessageContent content : request.getContent()) {

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -1620,9 +1620,9 @@ public class SearchQueryFilterMapper {
       ofNullable(filter.getJobKey())
           .map(mapToKeyOperations("jobKey", validationErrors))
           .ifPresent(builder::jobKeyOperations);
-      ofNullable(filter.getIteration())
-          .map(mapToIntegerOperations("iteration", validationErrors))
-          .ifPresent(builder::iterationOperations);
+      ofNullable(filter.getLoopIteration())
+          .map(mapToIntegerOperations("loopIteration", validationErrors))
+          .ifPresent(builder::loopIterationOperations);
       ofNullable(filter.getCommitStatus())
           .map(mapToStringOperations())
           .ifPresent(builder::commitStatusOperations);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2166,7 +2166,7 @@ public final class SearchQueryResponseMapper {
         .elementInstanceKey(keyToString(entity.elementInstanceKey()))
         .jobKey(keyToString(entity.jobKey()))
         .jobLease(entity.jobLease())
-        .iteration(entity.iteration())
+        .loopIteration(entity.loopIteration())
         .role(AgentInstanceHistoryRoleEnum.fromValue(entity.role().name()))
         .content(content)
         .toolCalls(toolCalls)

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQuerySortRequestMapper.java
@@ -1109,7 +1109,7 @@ public class SearchQuerySortRequestMapper {
     } else {
       switch (field) {
         case HISTORY_ITEM_KEY -> builder.historyItemKey();
-        case ITERATION -> builder.iteration();
+        case LOOP_ITERATION -> builder.loopIteration();
         case PRODUCED_AT -> builder.producedAt();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1249,7 +1249,7 @@ class SearchQueryResponseMapperTest {
       assertThat(result.getElementInstanceKey()).isEqualTo("300");
       assertThat(result.getJobKey()).isEqualTo("600");
       assertThat(result.getJobLease()).isEqualTo("lease-1");
-      assertThat(result.getIteration()).isEqualTo(3);
+      assertThat(result.getLoopIteration()).isEqualTo(3);
       assertThat(result.getRole().getValue()).isEqualTo("USER");
       assertThat(result.getCommitStatus().getValue()).isEqualTo("COMMITTED");
       assertThat(result.getMetrics().getInputTokens()).isEqualTo(10);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistoryFilterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistoryFilterIT.java
@@ -124,25 +124,25 @@ public class AgentHistoryFilterIT {
   }
 
   @TestTemplate
-  public void shouldFilterByIteration(final CamundaRdbmsTestApplication testApplication) {
+  public void shouldFilterByLoopIteration(final CamundaRdbmsTestApplication testApplication) {
     final long agentInstanceKey = nextKey();
     createAndSaveRandomAgentHistoryItem(
-        testApplication, b -> b.agentInstanceKey(agentInstanceKey).iteration(1));
+        testApplication, b -> b.agentInstanceKey(agentInstanceKey).loopIteration(1));
     createAndSaveRandomAgentHistoryItem(
-        testApplication, b -> b.agentInstanceKey(agentInstanceKey).iteration(2));
+        testApplication, b -> b.agentInstanceKey(agentInstanceKey).loopIteration(2));
     createAndSaveRandomAgentHistoryItem(
-        testApplication, b -> b.agentInstanceKey(agentInstanceKey).iteration(2));
+        testApplication, b -> b.agentInstanceKey(agentInstanceKey).loopIteration(2));
 
     final var result =
         search(
             testApplication,
             new AgentInstanceHistoryFilter.Builder()
                 .agentInstanceKeys(agentInstanceKey)
-                .iterations(2)
+                .loopIterations(2)
                 .build());
 
     assertThat(result.total()).isEqualTo(2);
-    assertThat(result.items()).allMatch(e -> e.iteration() == 2);
+    assertThat(result.items()).allMatch(e -> e.loopIteration() == 2);
   }
 
   @TestTemplate

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistoryIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistoryIT.java
@@ -166,7 +166,7 @@ public class AgentHistoryIT {
     assertThat(entity.processDefinitionId()).isEqualTo(dbModel.processDefinitionId());
     assertThat(entity.tenantId()).isEqualTo(dbModel.tenantId());
     assertThat(entity.jobKey()).isEqualTo(dbModel.jobKey());
-    assertThat(entity.iteration()).isEqualTo(dbModel.iteration());
+    assertThat(entity.loopIteration()).isEqualTo(dbModel.loopIteration());
     assertThat(entity.role()).isEqualTo(dbModel.role());
     assertThat(entity.commitStatus()).isEqualTo(dbModel.commitStatus());
     assertThat(entity.metrics().inputTokens()).isEqualTo(dbModel.inputTokens());

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistorySortIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/agenthistory/AgentHistorySortIT.java
@@ -50,19 +50,19 @@ public class AgentHistorySortIT {
   }
 
   @TestTemplate
-  public void shouldSortByIterationAsc(final CamundaRdbmsTestApplication testApplication) {
-    testSortingWithDistinctIterations(
+  public void shouldSortByLoopIterationAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingWithDistinctLoopIterations(
         testApplication,
-        b -> b.iteration().asc(),
-        Comparator.comparingInt(AgentInstanceHistoryEntity::iteration));
+        b -> b.loopIteration().asc(),
+        Comparator.comparingInt(AgentInstanceHistoryEntity::loopIteration));
   }
 
   @TestTemplate
-  public void shouldSortByIterationDesc(final CamundaRdbmsTestApplication testApplication) {
-    testSortingWithDistinctIterations(
+  public void shouldSortByLoopIterationDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSortingWithDistinctLoopIterations(
         testApplication,
-        b -> b.iteration().desc(),
-        Comparator.comparingInt(AgentInstanceHistoryEntity::iteration).reversed());
+        b -> b.loopIteration().desc(),
+        Comparator.comparingInt(AgentInstanceHistoryEntity::loopIteration).reversed());
   }
 
   @TestTemplate
@@ -96,7 +96,7 @@ public class AgentHistorySortIT {
     assertThat(items).isSortedAccordingTo(comparator);
   }
 
-  private void testSortingWithDistinctIterations(
+  private void testSortingWithDistinctLoopIterations(
       final CamundaRdbmsTestApplication testApplication,
       final Function<Builder, ObjectBuilder<AgentInstanceHistorySort>> sortBuilder,
       final Comparator<AgentInstanceHistoryEntity> comparator) {
@@ -104,14 +104,14 @@ public class AgentHistorySortIT {
     final String procDefId = "proc-iter-sort-" + nextStringId();
 
     for (int i = 1; i <= 5; i++) {
-      final int iteration = i;
+      final int loopIteration = i;
       createAndSaveRandomAgentHistoryItems(
           testApplication,
           1,
           b ->
               b.agentInstanceKey(agentInstanceKey)
                   .processDefinitionId(procDefId)
-                  .iteration(iteration));
+                  .loopIteration(loopIteration));
     }
 
     final var items = search(testApplication, agentInstanceKey, sortBuilder);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentHistoryFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AgentHistoryFixtures.java
@@ -40,7 +40,7 @@ public final class AgentHistoryFixtures extends CommonFixtures {
             .partitionId(1)
             .jobKey(nextKey())
             .jobLease("lease-" + key)
-            .iteration(1)
+            .loopIteration(1)
             .role(AgentInstanceHistoryRole.USER)
             .commitStatus(AgentInstanceHistoryCommitStatus.PENDING)
             .producedAt(OffsetDateTime.now())

--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -442,7 +442,7 @@
                   "type": "string"
                 },
                 {
-                  "name": "iteration",
+                  "name": "loopIteration",
                   "type": "number",
                   "nullable": true
                 },

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformer.java
@@ -38,7 +38,7 @@ public class AgentHistoryEntityTransformer
         source.getTenantId(),
         source.getJobKey(),
         source.getJobLease(),
-        source.getIteration(),
+        source.getLoopIteration(),
         toRole(source.getRole()),
         toContent(source.getContent()),
         toToolCalls(source.getToolCalls()),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentHistoryFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AgentHistoryFilterTransformer.java
@@ -17,9 +17,9 @@ import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplat
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.COMMIT_STATUS;
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.ELEMENT_INSTANCE_KEY;
-import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.ITERATION;
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.JOB_KEY;
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.LOOP_ITERATION;
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.PRODUCED_AT;
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.ROLE;
 
@@ -44,7 +44,7 @@ public class AgentHistoryFilterTransformer
     queries.addAll(stringOperations(ROLE, filter.roleOperations()));
     queries.addAll(longOperations(ELEMENT_INSTANCE_KEY, filter.elementInstanceKeyOperations()));
     queries.addAll(longOperations(JOB_KEY, filter.jobKeyOperations()));
-    queries.addAll(intOperations(ITERATION, filter.iterationOperations()));
+    queries.addAll(intOperations(LOOP_ITERATION, filter.loopIterationOperations()));
     queries.addAll(stringOperations(COMMIT_STATUS, filter.commitStatusOperations()));
     queries.addAll(dateTimeOperations(PRODUCED_AT, filter.producedAtOperations()));
     return and(queries);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentHistoryFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AgentHistoryFieldSortingTransformer.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.search.clients.transformers.sort;
 
-import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.ITERATION;
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.KEY;
+import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.LOOP_ITERATION;
 import static io.camunda.webapps.schema.descriptors.template.AgentHistoryTemplate.PRODUCED_AT;
 
 public class AgentHistoryFieldSortingTransformer implements FieldSortingTransformer {
@@ -17,7 +17,7 @@ public class AgentHistoryFieldSortingTransformer implements FieldSortingTransfor
   public String apply(final String domainField) {
     return switch (domainField) {
       case "historyItemKey" -> KEY;
-      case "iteration" -> ITERATION;
+      case "loopIteration" -> LOOP_ITERATION;
       case "producedAt" -> PRODUCED_AT;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformerTest.java
@@ -45,7 +45,7 @@ class AgentHistoryEntityTransformerTest {
     source.setPartitionId(1);
     source.setJobKey(500L);
     source.setJobLease("lease-token");
-    source.setIteration(3);
+    source.setLoopIteration(3);
     source.setRole(AgentHistoryRole.ASSISTANT);
     source.setCommitStatus(AgentHistoryCommitStatus.COMMITTED);
     source.setProducedAt(OffsetDateTime.parse("2024-06-01T12:00:00Z"));
@@ -78,7 +78,7 @@ class AgentHistoryEntityTransformerTest {
     assertThat(result.tenantId()).isEqualTo("<default>");
     assertThat(result.jobKey()).isEqualTo(500L);
     assertThat(result.jobLease()).isEqualTo("lease-token");
-    assertThat(result.iteration()).isEqualTo(3);
+    assertThat(result.loopIteration()).isEqualTo(3);
     assertThat(result.role()).isEqualTo(AgentInstanceHistoryRole.ASSISTANT);
     assertThat(result.commitStatus()).isEqualTo(AgentInstanceHistoryCommitStatus.COMMITTED);
     assertThat(result.producedAt()).isEqualTo(OffsetDateTime.parse("2024-06-01T12:00:00Z"));
@@ -122,16 +122,16 @@ class AgentHistoryEntityTransformerTest {
   }
 
   @Test
-  void shouldMapNullIterationAsNull() {
+  void shouldMapNullLoopIterationAsNull() {
     // given
     final var source = buildSource();
-    source.setIteration(null);
+    source.setLoopIteration(null);
 
     // when
     final AgentInstanceHistoryEntity result = transformer.apply(source);
 
     // then
-    assertThat(result.iteration()).isNull();
+    assertThat(result.loopIteration()).isNull();
   }
 
   @Test

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentHistoryFilterTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AgentHistoryFilterTransformerTest.java
@@ -112,9 +112,9 @@ class AgentHistoryFilterTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
-  void shouldQueryByIteration() {
+  void shouldQueryByLoopIteration() {
     // given
-    final var filter = FilterBuilders.agentInstanceHistory(f -> f.iterations(3));
+    final var filter = FilterBuilders.agentInstanceHistory(f -> f.loopIterations(3));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -124,7 +124,7 @@ class AgentHistoryFilterTransformerTest extends AbstractTransformerTest {
         .isInstanceOfSatisfying(
             SearchTermQuery.class,
             t -> {
-              assertThat(t.field()).isEqualTo("iteration");
+              assertThat(t.field()).isEqualTo("loopIteration");
               assertThat(t.value().intValue()).isEqualTo(3);
             });
   }
@@ -180,7 +180,7 @@ class AgentHistoryFilterTransformerTest extends AbstractTransformerTest {
                     .roles(AgentInstanceHistoryRole.USER)
                     .elementInstanceKeys(200L)
                     .jobKeys(300L)
-                    .iterations(2)
+                    .loopIterations(2)
                     .commitStatuses(AgentInstanceHistoryCommitStatus.PENDING)
                     .producedAtOperations(
                         Operation.eq(OffsetDateTime.parse("2024-06-01T00:00:00Z"))));

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentHistoryFieldSortingTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/AgentHistoryFieldSortingTransformerTest.java
@@ -28,7 +28,8 @@ class AgentHistoryFieldSortingTransformerTest extends AbstractSortTransformerTes
   private static Stream<Arguments> provideSortParameters() {
     return Stream.of(
         new TestArguments(AgentHistoryTemplate.KEY, SortOrder.DESC, s -> s.historyItemKey().desc()),
-        new TestArguments(AgentHistoryTemplate.ITERATION, SortOrder.ASC, s -> s.iteration().asc()),
+        new TestArguments(
+            AgentHistoryTemplate.LOOP_ITERATION, SortOrder.ASC, s -> s.loopIteration().asc()),
         new TestArguments(
             AgentHistoryTemplate.PRODUCED_AT, SortOrder.DESC, s -> s.producedAt().desc()));
   }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
@@ -31,7 +31,7 @@ public record AgentInstanceHistoryEntity(
     String tenantId,
     Long jobKey,
     String jobLease,
-    @Nullable Integer iteration,
+    @Nullable Integer loopIteration,
     AgentInstanceHistoryRole role,
     List<ContentItem> content,
     List<ToolCall> toolCalls,

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceHistoryFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AgentInstanceHistoryFilter.java
@@ -26,7 +26,7 @@ public record AgentInstanceHistoryFilter(
     List<Operation<String>> roleOperations,
     List<Operation<Long>> elementInstanceKeyOperations,
     List<Operation<Long>> jobKeyOperations,
-    List<Operation<Integer>> iterationOperations,
+    List<Operation<Integer>> loopIterationOperations,
     List<Operation<String>> commitStatusOperations,
     List<Operation<OffsetDateTime>> producedAtOperations)
     implements FilterBase {
@@ -44,7 +44,7 @@ public record AgentInstanceHistoryFilter(
     private List<Operation<String>> roleOperations;
     private List<Operation<Long>> elementInstanceKeyOperations;
     private List<Operation<Long>> jobKeyOperations;
-    private List<Operation<Integer>> iterationOperations;
+    private List<Operation<Integer>> loopIterationOperations;
     private List<Operation<String>> commitStatusOperations;
     private List<Operation<OffsetDateTime>> producedAtOperations;
 
@@ -128,19 +128,19 @@ public record AgentInstanceHistoryFilter(
       return jobKeyOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
-    public Builder iterationOperations(final List<Operation<Integer>> operations) {
-      iterationOperations = addValuesToList(iterationOperations, operations);
+    public Builder loopIterationOperations(final List<Operation<Integer>> operations) {
+      loopIterationOperations = addValuesToList(loopIterationOperations, operations);
       return this;
     }
 
     @SafeVarargs
-    public final Builder iterationOperations(
+    public final Builder loopIterationOperations(
         final Operation<Integer> operation, final Operation<Integer>... operations) {
-      return iterationOperations(collectValues(operation, operations));
+      return loopIterationOperations(collectValues(operation, operations));
     }
 
-    public Builder iterations(final Integer value, final Integer... values) {
-      return iterationOperations(FilterUtil.mapDefaultToOperation(value, values));
+    public Builder loopIterations(final Integer value, final Integer... values) {
+      return loopIterationOperations(FilterUtil.mapDefaultToOperation(value, values));
     }
 
     public Builder commitStatusOperations(final List<Operation<String>> operations) {
@@ -183,7 +183,7 @@ public record AgentInstanceHistoryFilter(
           Objects.requireNonNullElse(roleOperations, Collections.emptyList()),
           Objects.requireNonNullElse(elementInstanceKeyOperations, Collections.emptyList()),
           Objects.requireNonNullElse(jobKeyOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(iterationOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(loopIterationOperations, Collections.emptyList()),
           Objects.requireNonNullElse(commitStatusOperations, Collections.emptyList()),
           Objects.requireNonNullElse(producedAtOperations, Collections.emptyList()));
     }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/AgentInstanceHistorySort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/AgentInstanceHistorySort.java
@@ -32,8 +32,8 @@ public record AgentInstanceHistorySort(List<FieldSorting> orderings) implements 
       return this;
     }
 
-    public Builder iteration() {
-      currentOrdering = new FieldSorting("iteration", null);
+    public Builder loopIteration() {
+      currentOrdering = new FieldSorting("loopIteration", null);
       return this;
     }
 

--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
-		"@camunda/camunda-api-zod-schemas": "0.0.80",
+		"@camunda/camunda-api-zod-schemas": "0.0.81",
 		"@camunda/camunda-composite-components": "0.25.2",
 		"@carbon/grid": "11.57.0",
 		"@carbon/layout": "11.54.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -28,7 +28,7 @@
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
-				"@camunda/camunda-api-zod-schemas": "0.0.80",
+				"@camunda/camunda-api-zod-schemas": "0.0.81",
 				"@camunda/camunda-composite-components": "0.25.2",
 				"@carbon/grid": "11.57.0",
 				"@carbon/layout": "11.54.0",
@@ -11328,13 +11328,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.80",
+				"@camunda/camunda-api-zod-schemas": "0.0.81",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.80",
+			"version": "0.0.81",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "26.1.0",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.80",
+		"@camunda/camunda-api-zod-schemas": "0.0.81",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.81
+
+### 🚀 Enhancements
+
+- Rename `iteration` to `loopIteration` in agent instance history schemas (`AgentInstanceHistoryItem`, filter, and sort) ([#56504](https://github.com/camunda/camunda/issues/56504))
+
+### ❤️ Contributors
+
+- [@fabiopaini-camunda](https://github.com/fabiopaini-camunda)
+
 ## v0.0.80
 
 ### 🚀 Enhancements
@@ -122,7 +132,7 @@
 
 - Add typed variable filter schemas for `8.10/process-instance`
   - `processInstanceVariableValueFilterSchema` a discriminated union of single-key operator objects (`$eq` / `$neq` / `$like` / `$in` / `$notIn` / `$exists`) plus the shorthand bare-string form; mirrors
-     backend schema
+    backend schema
   - `processInstanceVariableFilterSchema` now uses the tighter value schema and is exported top-level
   - `ProcessInstanceVariableFilter` and `ProcessInstanceVariableValueFilter` types exported
   - Tightens variable filter validation: rejects multi-operator combinations (e.g. `{$eq: "x", $neq: "y"}`), unknown keys, and operator-shape mismatches
@@ -130,7 +140,6 @@
 ### ❤️ Contributors
 
 - Yuliia Saienko ([@juliasaienko](https://github.com/juliasaienko))
-
 
 ## v0.0.69
 
@@ -1074,3 +1083,4 @@ Accidental empty release
 ### ❤️ Contributors
 
 - Vinicius Goulart
+

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
@@ -176,7 +176,7 @@ const agentInstanceHistoryItemSchema = z.object({
 	elementInstanceKey: z.string(),
 	jobKey: z.string(),
 	jobLease: z.string(),
-	iteration: z.number().int().nullable(),
+	loopIteration: z.number().int().nullable(),
 	role: agentInstanceHistoryRoleSchema,
 	content: z.array(agentInstanceMessageContentSchema),
 	toolCalls: z.array(agentInstanceToolCallSchema),
@@ -192,7 +192,7 @@ const agentInstanceHistoryFilterSchema = z
 		role: getEnumFilterSchema(agentInstanceHistoryRoleSchema),
 		elementInstanceKey: basicStringFilterSchema,
 		jobKey: basicStringFilterSchema,
-		iteration: advancedIntegerFilterSchema,
+		loopIteration: advancedIntegerFilterSchema,
 		commitStatus: getEnumFilterSchema(agentInstanceHistoryCommitStatusSchema),
 		producedAt: advancedDateTimeFilterSchema,
 	})
@@ -203,7 +203,7 @@ const createAgentInstanceHistoryItemRequestBodySchema = z.object({
 	elementInstanceKey: z.string(),
 	jobKey: z.string(),
 	jobLease: z.string(),
-	iteration: z.number().int().nullable().optional(),
+	loopIteration: z.number().int().nullable().optional(),
 	role: agentInstanceHistoryRoleSchema,
 	content: z.array(agentInstanceMessageContentSchema),
 	toolCalls: z.array(agentInstanceToolCallSchema).nullable().optional(),
@@ -218,7 +218,7 @@ const createAgentInstanceHistoryItemResponseBodySchema = z.object({
 type CreateAgentInstanceHistoryItemResponseBody = z.infer<typeof createAgentInstanceHistoryItemResponseBodySchema>;
 
 const queryAgentInstanceHistoryRequestBodySchema = getQueryRequestBodySchema({
-	sortFields: ['producedAt', 'historyItemKey', 'iteration'] as const,
+	sortFields: ['producedAt', 'historyItemKey', 'loopIteration'] as const,
 	filter: agentInstanceHistoryFilterSchema,
 });
 type QueryAgentInstanceHistoryRequestBody = z.infer<typeof queryAgentInstanceHistoryRequestBodySchema>;

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.80",
+	"version": "0.0.81",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentHistoryTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/template/AgentHistoryTemplate.java
@@ -33,7 +33,7 @@ public class AgentHistoryTemplate extends AbstractTemplateDescriptor
   public static final String TENANT_ID = "tenantId";
   public static final String JOB_KEY = "jobKey";
   public static final String JOB_LEASE = "jobLease";
-  public static final String ITERATION = "iteration";
+  public static final String LOOP_ITERATION = "loopIteration";
   public static final String ROLE = "role";
   public static final String COMMIT_STATUS = "commitStatus";
   public static final String PRODUCED_AT = "producedAt";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
@@ -66,7 +66,7 @@ public final class AgentHistoryEntity
 
   /** Nullable — protocol value {@code <= 0} is stored as {@code null}. */
   @SinceVersion(value = "8.10.0", requireDefault = false)
-  private Integer iteration;
+  private Integer loopIteration;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private AgentHistoryRole role;
@@ -206,12 +206,12 @@ public final class AgentHistoryEntity
     return this;
   }
 
-  public Integer getIteration() {
-    return iteration;
+  public Integer getLoopIteration() {
+    return loopIteration;
   }
 
-  public AgentHistoryEntity setIteration(final Integer iteration) {
-    this.iteration = iteration;
+  public AgentHistoryEntity setLoopIteration(final Integer loopIteration) {
+    this.loopIteration = loopIteration;
     return this;
   }
 
@@ -302,7 +302,7 @@ public final class AgentHistoryEntity
         partitionId,
         jobKey,
         jobLease,
-        iteration,
+        loopIteration,
         role,
         commitStatus,
         producedAt,
@@ -334,7 +334,7 @@ public final class AgentHistoryEntity
         && partitionId == that.partitionId
         && jobKey == that.jobKey
         && Objects.equals(jobLease, that.jobLease)
-        && Objects.equals(iteration, that.iteration)
+        && Objects.equals(loopIteration, that.loopIteration)
         && Objects.equals(role, that.role)
         && Objects.equals(commitStatus, that.commitStatus)
         && Objects.equals(producedAt, that.producedAt)
@@ -376,8 +376,8 @@ public final class AgentHistoryEntity
         + ", jobLease='"
         + jobLease
         + '\''
-        + ", iteration="
-        + iteration
+        + ", loopIteration="
+        + loopIteration
         + ", role="
         + role
         + ", commitStatus="

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-history.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/camunda-agent-history.json
@@ -38,7 +38,7 @@
       "jobLease": {
         "type": "keyword"
       },
-      "iteration": {
+      "loopIteration": {
         "type": "integer"
       },
       "role": {

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-history.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/camunda-agent-history.json
@@ -38,7 +38,7 @@
       "jobLease": {
         "type": "keyword"
       },
-      "iteration": {
+      "loopIteration": {
         "type": "integer"
       },
       "role": {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -124,7 +124,7 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
             .setTenantId(job.getTenantId())
             .setJobKey(commandValue.getJobKey())
             .setJobLease(commandValue.getJobLease())
-            .setIteration(commandValue.getIteration())
+            .setLoopIteration(commandValue.getLoopIteration())
             .setRole(commandValue.getRole())
             .setProducedAt(commandValue.getProducedAt())
             .setContent(commandValue.getContent())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
@@ -73,8 +73,8 @@ public final class AgentHistoryClient {
     return this;
   }
 
-  public AgentHistoryClient withIteration(final int iteration) {
-    record.setIteration(iteration);
+  public AgentHistoryClient withLoopIteration(final int loopIteration) {
+    record.setLoopIteration(loopIteration);
     return this;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -96,7 +96,7 @@ public class AgentHistoryHandler
         .setTenantId(value.getTenantId())
         .setJobKey(value.getJobKey())
         .setJobLease(value.getJobLease())
-        .setIteration(ExporterUtil.positiveOrNull(value.getIteration()))
+        .setLoopIteration(ExporterUtil.positiveOrNull(value.getLoopIteration()))
         .setRole(mapRole(value.getRole()))
         .setCommitStatus(mapCommitStatusFromIntent(intent))
         .setProducedAt(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -102,7 +102,7 @@ final class AgentHistoryHandlerTest {
     final String tenantId = "<default>";
     final long jobKey = 500L;
     final String jobLease = "lease-token-abc";
-    final int iteration = 3;
+    final int loopIteration = 3;
     final long producedAtMs = System.currentTimeMillis();
     final long inputTokens = 50L;
     final long outputTokens = 30L;
@@ -134,7 +134,7 @@ final class AgentHistoryHandlerTest {
             .withTenantId(tenantId)
             .withJobKey(jobKey)
             .withJobLease(jobLease)
-            .withIteration(iteration)
+            .withLoopIteration(loopIteration)
             .withRole(io.camunda.zeebe.protocol.record.value.AgentHistoryRole.ASSISTANT)
             .withProducedAt(producedAtMs)
             .withMetrics(
@@ -181,7 +181,7 @@ final class AgentHistoryHandlerTest {
     assertThat(entity.getTenantId()).isEqualTo(tenantId);
     assertThat(entity.getJobKey()).isEqualTo(jobKey);
     assertThat(entity.getJobLease()).isEqualTo(jobLease);
-    assertThat(entity.getIteration()).isEqualTo(iteration);
+    assertThat(entity.getLoopIteration()).isEqualTo(loopIteration);
     assertThat(entity.getRole()).isEqualTo(AgentHistoryRole.ASSISTANT);
     assertThat(entity.getCommitStatus()).isEqualTo(expectedStatus);
     assertThat(entity.getProducedAt())
@@ -544,8 +544,8 @@ final class AgentHistoryHandlerTest {
   }
 
   @Test
-  void shouldConvertNonPositiveIterationToNull() {
-    // given — iteration == 0 (non-positive sentinel → null)
+  void shouldConvertNonPositiveLoopIterationToNull() {
+    // given — loopIteration == 0 (non-positive sentinel → null)
     final var recordValue =
         ImmutableAgentHistoryRecordValue.builder().from(buildMinimalRecordValue(1L, 0)).build();
     final Record<AgentHistoryRecordValue> record =
@@ -558,11 +558,11 @@ final class AgentHistoryHandlerTest {
     underTest.updateEntity(record, entity);
 
     // then
-    assertThat(entity.getIteration()).isNull();
+    assertThat(entity.getLoopIteration()).isNull();
   }
 
   @Test
-  void shouldStorePositiveIterationAsIs() {
+  void shouldStorePositiveLoopIterationAsIs() {
     // given
     final var recordValue =
         ImmutableAgentHistoryRecordValue.builder().from(buildMinimalRecordValue(1L, 5)).build();
@@ -576,7 +576,7 @@ final class AgentHistoryHandlerTest {
     underTest.updateEntity(record, entity);
 
     // then
-    assertThat(entity.getIteration()).isEqualTo(5);
+    assertThat(entity.getLoopIteration()).isEqualTo(5);
   }
 
   @Test
@@ -609,7 +609,7 @@ final class AgentHistoryHandlerTest {
   }
 
   private AgentHistoryRecordValue buildMinimalRecordValue(
-      final long agentInstanceKey, final int iteration) {
+      final long agentInstanceKey, final int loopIteration) {
     return ImmutableAgentHistoryRecordValue.builder()
         .withAgentInstanceKey(agentInstanceKey)
         .withElementInstanceKey(1L)
@@ -620,7 +620,7 @@ final class AgentHistoryHandlerTest {
         .withTenantId("<default>")
         .withJobKey(30L)
         .withJobLease("lease")
-        .withIteration(iteration)
+        .withLoopIteration(loopIteration)
         .withRole(io.camunda.zeebe.protocol.record.value.AgentHistoryRole.ASSISTANT)
         .withProducedAt(System.currentTimeMillis())
         .withMetrics(

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-agent-history-template.json
@@ -49,7 +49,7 @@
             "jobLease": {
               "type": "keyword"
             },
-            "iteration": {
+            "loopIteration": {
               "type": "integer"
             },
             "role": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-history-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-agent-history-template.json
@@ -55,7 +55,7 @@
             "jobLease": {
               "type": "keyword"
             },
-            "iteration": {
+            "loopIteration": {
               "type": "integer"
             },
             "role": {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
@@ -77,7 +77,7 @@ public class AgentHistoryExportHandler implements RdbmsExportHandler<AgentHistor
         .partitionId(record.getPartitionId())
         .jobKey(value.getJobKey())
         .jobLease(value.getJobLease())
-        .iteration(ExportUtil.positiveOrNull(value.getIteration()))
+        .loopIteration(ExportUtil.positiveOrNull(value.getLoopIteration()))
         .role(mapRole(value.getRole()))
         .commitStatus(mapCommitStatus(intent))
         .producedAt(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(producedAtMillis)))

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
@@ -130,7 +130,7 @@ class AgentHistoryExportHandlerTest {
     assertThat(model.partitionId()).isEqualTo(record.getPartitionId());
     assertThat(model.jobKey()).isEqualTo(recordValue.getJobKey());
     assertThat(model.jobLease()).isEqualTo(recordValue.getJobLease());
-    assertThat(model.iteration()).isEqualTo(recordValue.getIteration());
+    assertThat(model.loopIteration()).isEqualTo(recordValue.getLoopIteration());
 
     // role
     assertThat(model.role().name()).isEqualTo(recordValue.getRole().name());
@@ -197,37 +197,40 @@ class AgentHistoryExportHandlerTest {
   }
 
   @Test
-  void shouldMapIterationToNullWhenNotPositive() {
+  void shouldMapLoopIterationToNullWhenNotPositive() {
     // given — zero and negative values
-    final var zeroIteration =
+    final var zeroLoopIteration =
         ImmutableAgentHistoryRecordValue.builder()
             .from(buildRecordValue())
-            .withIteration(0)
+            .withLoopIteration(0)
             .build();
-    final var negativeIteration =
+    final var negativeLoopIteration =
         ImmutableAgentHistoryRecordValue.builder()
             .from(buildRecordValue())
-            .withIteration(-1)
+            .withLoopIteration(-1)
             .build();
 
     final Record<AgentHistoryRecordValue> zeroRecord =
         factory.generateRecord(
             ValueType.AGENT_HISTORY,
-            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(50L).withValue(zeroIteration));
+            r ->
+                r.withIntent(AgentHistoryIntent.CREATED).withKey(50L).withValue(zeroLoopIteration));
     final Record<AgentHistoryRecordValue> negativeRecord =
         factory.generateRecord(
             ValueType.AGENT_HISTORY,
             r ->
-                r.withIntent(AgentHistoryIntent.CREATED).withKey(51L).withValue(negativeIteration));
+                r.withIntent(AgentHistoryIntent.CREATED)
+                    .withKey(51L)
+                    .withValue(negativeLoopIteration));
 
     // when — both records exported
     handler.export(zeroRecord);
     handler.export(negativeRecord);
 
-    // then — both should produce iteration=null
+    // then — both should produce loopIteration=null
     verify(writer, times(2)).create(modelCaptor.capture());
     assertThat(modelCaptor.getAllValues())
-        .extracting(AgentHistoryDbModel::iteration)
+        .extracting(AgentHistoryDbModel::loopIteration)
         .containsOnly((Integer) null);
   }
 
@@ -567,7 +570,7 @@ class AgentHistoryExportHandlerTest {
         .withTenantId("myTenant")
         .withJobKey(600L)
         .withJobLease("myLease")
-        .withIteration(1)
+        .withLoopIteration(1)
         .withRole(AgentHistoryRole.ASSISTANT)
         .withProducedAt(1_700_000_000_000L)
         .withContent(List.of(textContent))

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -200,9 +200,9 @@ paths:
         completes successfully, at which point it transitions to COMMITTED. If the job
         fails or is superseded by a retry, the item is marked DISCARDED.
       x-semantic-establishes:
-        kind: AgentInstanceIteration
+        kind: AgentInstanceLoopIteration
         identifiedBy:
-          - { in: body, name: iteration, semanticType: IterationId }
+          - { in: body, name: loopIteration, semanticType: LoopIterationId }
       parameters:
         - name: agentInstanceKey
           in: path
@@ -455,7 +455,7 @@ components:
           allOf:
             - $ref: '#/components/schemas/AgentInstanceDefinition'
         metrics:
-          description: Aggregated metrics across all iterations of this agent instance.
+          description: Aggregated metrics across all loopIterations of this agent instance.
           allOf:
             - $ref: '#/components/schemas/AgentInstanceMetrics'
         limits:
@@ -790,11 +790,11 @@ components:
         jobLease:
           description: Opaque lease token received from the job activation response.
           type: string
-        iteration:
-          description: Sequential iteration number this item belongs to. Omit if not grouping items into iterations.
+        loopIteration:
+          description: Sequential loopIteration number this item belongs to. Omit if not grouping items into loopIterations.
           nullable: true
           allOf:
-            - $ref: 'identifiers.yaml#/components/schemas/IterationId'
+            - $ref: 'identifiers.yaml#/components/schemas/LoopIterationId'
         role:
           description: The role of this history item in the conversation.
           allOf:
@@ -848,7 +848,7 @@ components:
           enum:
             - producedAt
             - historyItemKey
-            - iteration
+            - loopIteration
         order:
           $ref: 'search-models.yaml#/components/schemas/SortOrderEnum'
 
@@ -889,8 +889,8 @@ components:
           description: The key of the job activation that produced the history item.
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKeyFilterProperty'
-        iteration:
-          description: The iteration number.
+        loopIteration:
+          description: The loopIteration number.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
         commitStatus:
@@ -927,7 +927,7 @@ components:
         - elementInstanceKey
         - jobKey
         - jobLease
-        - iteration
+        - loopIteration
         - role
         - content
         - toolCalls
@@ -954,11 +954,11 @@ components:
         jobLease:
           description: The lease token of the activation that produced this item.
           type: string
-        iteration:
-          description: The sequential iteration number this item belongs to. Null if not provided by the connector.
+        loopIteration:
+          description: The sequential loopIteration number this item belongs to. Null if not provided by the connector.
           nullable: true
           allOf:
-            - $ref: 'identifiers.yaml#/components/schemas/IterationId'
+            - $ref: 'identifiers.yaml#/components/schemas/LoopIterationId'
         role:
           description: The role of this history item in the conversation.
           allOf:

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -791,7 +791,10 @@ components:
           description: Opaque lease token received from the job activation response.
           type: string
         loopIteration:
-          description: Sequential loopIteration number this item belongs to. Omit if not grouping items into loopIterations.
+          description: |
+            The loopIteration this item belongs to. A loopIteration is one pass through the agent
+            feedback loop: one LLM call, its tool dispatches, and their results. Omit if not grouping
+            items by loopIteration.
           nullable: true
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/LoopIterationId'
@@ -890,7 +893,7 @@ components:
           allOf:
             - $ref: 'keys.yaml#/components/schemas/JobKeyFilterProperty'
         loopIteration:
-          description: The loopIteration number.
+          description: Filter by loopIteration number. A loopIteration is one pass through the agent feedback loop (one LLM call, its tool dispatches, and their results).
           allOf:
             - $ref: 'filters.yaml#/components/schemas/IntegerFilterProperty'
         commitStatus:
@@ -955,7 +958,10 @@ components:
           description: The lease token of the activation that produced this item.
           type: string
         loopIteration:
-          description: The sequential loopIteration number this item belongs to. Null if not provided by the connector.
+          description: |
+            The loopIteration this item belongs to. A loopIteration is one pass through the agent
+            feedback loop: one LLM call, its tool dispatches, and their results. Null if not provided
+            by the connector.
           nullable: true
           allOf:
             - $ref: 'identifiers.yaml#/components/schemas/LoopIterationId'

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -203,16 +203,16 @@ components:
       example: order-12345
 
 
-    IterationId:
+    LoopIterationId:
       description: |
-        A client-provided sequential integer identifying a logical iteration: one LLM
+        A client-provided sequential integer identifying a logical loopIteration: one LLM
         call, its tool dispatches, and their results. Must be a positive integer,
-        increasing with each iteration. Established by the
-        connector when appending the first history item of an iteration.
+        increasing with each loopIteration. Established by the
+        connector when appending the first history item of a loopIteration.
       type: integer
       format: int32
       minimum: 1
-      x-semantic-type: IterationId
+      x-semantic-type: LoopIterationId
       x-semantic-client-minted: true
       example: 1
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/identifiers.yaml
@@ -205,9 +205,9 @@ components:
 
     LoopIterationId:
       description: |
-        A client-provided sequential integer identifying a logical loopIteration: one LLM
-        call, its tool dispatches, and their results. Must be a positive integer,
-        increasing with each loopIteration. Established by the
+        A client-provided sequential integer identifying one pass through the agent
+        feedback loop: one LLM call, its tool dispatches, and their results. Must be
+        a positive integer, increasing with each loopIteration. Established by the
         connector when appending the first history item of a loopIteration.
       type: integer
       format: int32

--- a/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
+++ b/zeebe/gateway-protocol/src/main/proto/v2/semantic-kinds.json
@@ -202,10 +202,10 @@
       "description": "An OAuth client. Minted outside the Camunda REST API: by Console in SaaS, by the configured external IdP (EntraID, Keycloak, Okta, …) in Self-Managed with OIDC. Not modelled at all under Self-Managed Basic auth, where m2m apps are users instead. Referenced by the client-membership edges only — never established or fetched via this API."
     },
     {
-      "name": "AgentInstanceIteration",
+      "name": "AgentInstanceLoopIteration",
       "shape": "entity",
-      "identifiers": ["IterationId"],
-      "description": "A logical grouping of one LLM call, its tool dispatches, and their results within an agent instance's conversation history. Identified by a client-minted IterationId supplied by the AI Agent Connector when appending history items."
+      "identifiers": ["LoopIterationId"],
+      "description": "A logical grouping of one LLM call, its tool dispatches, and their results within an agent instance's conversation history. Identified by a client-minted LoopIterationId supplied by the AI Agent Connector when appending history items."
     }
   ]
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -810,7 +810,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
           "jobKey": "%d",
           "jobLease": "lease-abc",
           "role": "USER",
-          "iteration": 2,
+          "loopIteration": 2,
           "content": [
             { "contentType": "TEXT", "text": "What is in the invoice?" },
             { "contentType": "OBJECT", "object": { "key": "value" } }
@@ -843,7 +843,7 @@ class AgentInstanceControllerTest extends RestControllerTest {
         .createAgentHistoryItem(
             assertArg(
                 record -> {
-                  assertThat(record.getIteration()).isEqualTo(2);
+                  assertThat(record.getLoopIteration()).isEqualTo(2);
                   assertThat(record.getContent()).hasSize(2);
                   assertThat(record.getToolCalls()).hasSize(1);
                   assertThat(record.getToolCalls().get(0).getToolCallId()).isEqualTo("tc-001");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
@@ -79,7 +79,7 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
             "elementInstanceKey": "%d",
             "jobKey": "%d",
             "jobLease": "job-lease-1",
-            "iteration": 1,
+            "loopIteration": 1,
             "role": "USER",
             "content": [{ "contentType": "TEXT", "text": "Hello agent" }],
             "toolCalls": [],

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -37,7 +37,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
   private final StringProperty jobLeaseProp = new StringProperty("jobLease", "");
-  private final IntegerProperty iterationProp = new IntegerProperty("iteration", 0);
+  private final IntegerProperty loopIterationProp = new IntegerProperty("loopIteration", 0);
   private final EnumProperty<AgentHistoryRole> roleProp =
       new EnumProperty<>("role", AgentHistoryRole.class, AgentHistoryRole.UNSPECIFIED);
   private final LongProperty producedAtProp = new LongProperty("producedAt", -1L);
@@ -60,7 +60,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProp)
         .declareProperty(jobKeyProp)
         .declareProperty(jobLeaseProp)
-        .declareProperty(iterationProp)
+        .declareProperty(loopIterationProp)
         .declareProperty(roleProp)
         .declareProperty(producedAtProp)
         .declareProperty(contentProp)
@@ -169,12 +169,12 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   }
 
   @Override
-  public int getIteration() {
-    return iterationProp.getValue();
+  public int getLoopIteration() {
+    return loopIterationProp.getValue();
   }
 
-  public AgentHistoryRecord setIteration(final int iteration) {
-    iterationProp.setValue(iteration);
+  public AgentHistoryRecord setLoopIteration(final int loopIteration) {
+    loopIterationProp.setValue(loopIteration);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5010,7 +5010,7 @@ final class JsonSerializableToJsonTest {
                       .setElementInstanceKey(2251799813685249L)
                       .setJobKey(2251799813685252L)
                       .setJobLease("job-lease-abc123")
-                      .setIteration(3)
+                      .setLoopIteration(3)
                       .setRole(AgentHistoryRole.ASSISTANT)
                       .setProducedAt(1748860800000L)
                       .setBpmnProcessId("process");
@@ -5066,7 +5066,7 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKey": 2251799813685249,
           "jobKey": 2251799813685252,
           "jobLease": "job-lease-abc123",
-          "iteration": 3,
+          "loopIteration": 3,
           "role": "ASSISTANT",
           "producedAt": 1748860800000,
           "content": [
@@ -5150,7 +5150,7 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKey": -1,
           "jobKey": -1,
           "jobLease": "",
-          "iteration": 0,
+          "loopIteration": 0,
           "role": "UNSPECIFIED",
           "producedAt": -1,
           "content": [
@@ -5205,7 +5205,7 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKey": -1,
           "jobKey": -1,
           "jobLease": "",
-          "iteration": 0,
+          "loopIteration": 0,
           "role": "UNSPECIFIED",
           "producedAt": -1,
           "content": [],

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -36,7 +36,7 @@ final class AgentHistoryRecordTest {
     assertThat(record.getElementInstanceKey()).isEqualTo(-1L);
     assertThat(record.getJobKey()).isEqualTo(-1L);
     assertThat(record.getJobLease()).isEmpty();
-    assertThat(record.getIteration()).isEqualTo(0);
+    assertThat(record.getLoopIteration()).isEqualTo(0);
     assertThat(record.getRole()).isEqualTo(AgentHistoryRole.UNSPECIFIED);
     assertThat(record.getProducedAt()).isEqualTo(-1L);
     assertThat(record.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
@@ -56,7 +56,7 @@ final class AgentHistoryRecordTest {
             .setElementInstanceKey(2251799813685249L)
             .setJobKey(2251799813685252L)
             .setJobLease("job-lease-abc123")
-            .setIteration(3)
+            .setLoopIteration(3)
             .setRole(AgentHistoryRole.USER)
             .setProducedAt(1717200000000L);
 
@@ -70,7 +70,7 @@ final class AgentHistoryRecordTest {
     assertThat(copy.getElementInstanceKey()).isEqualTo(original.getElementInstanceKey());
     assertThat(copy.getJobKey()).isEqualTo(original.getJobKey());
     assertThat(copy.getJobLease()).isEqualTo(original.getJobLease());
-    assertThat(copy.getIteration()).isEqualTo(original.getIteration());
+    assertThat(copy.getLoopIteration()).isEqualTo(original.getLoopIteration());
     assertThat(copy.getRole()).isEqualTo(original.getRole());
     assertThat(copy.getProducedAt()).isEqualTo(original.getProducedAt());
   }

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryRecord.golden
@@ -36,7 +36,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final LongProperty jobKeyProp = new LongProperty("jobKey", -1L);
   private final StringProperty jobLeaseProp = new StringProperty("jobLease", "");
-  private final IntegerProperty iterationProp = new IntegerProperty("iteration", 0);
+  private final IntegerProperty loopIterationProp = new IntegerProperty("loopIteration", 0);
   private final EnumProperty<AgentHistoryRole> roleProp =
       new EnumProperty<>("role", AgentHistoryRole.class, AgentHistoryRole.UNSPECIFIED);
   private final LongProperty producedAtProp = new LongProperty("producedAt", -1L);
@@ -59,7 +59,7 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
         .declareProperty(tenantIdProp)
         .declareProperty(jobKeyProp)
         .declareProperty(jobLeaseProp)
-        .declareProperty(iterationProp)
+        .declareProperty(loopIterationProp)
         .declareProperty(roleProp)
         .declareProperty(producedAtProp)
         .declareProperty(contentProp)
@@ -168,12 +168,12 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   }
 
   @Override
-  public int getIteration() {
-    return iterationProp.getValue();
+  public int getLoopIteration() {
+    return loopIterationProp.getValue();
   }
 
-  public AgentHistoryRecord setIteration(final int iteration) {
-    iterationProp.setValue(iteration);
+  public AgentHistoryRecord setLoopIteration(final int loopIteration) {
+    loopIterationProp.setValue(loopIteration);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -70,8 +70,8 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
    */
   String getJobLease();
 
-  /** Returns the iteration counter (conversation round with the LLM). */
-  int getIteration();
+  /** Returns the loopIteration counter (conversation round with the LLM). */
+  int getLoopIteration();
 
   /** Returns the role of the message author (e.g. USER, ASSISTANT, TOOL_RESULT). */
   AgentHistoryRole getRole();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -70,7 +70,10 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
    */
   String getJobLease();
 
-  /** Returns the loopIteration counter (conversation round with the LLM). */
+  /**
+   * Returns the loopIteration counter: one pass through the agent feedback loop (one LLM call, its
+   * tool dispatches, and their results).
+   */
   int getLoopIteration();
 
   /** Returns the role of the message author (e.g. USER, ASSISTANT, TOOL_RESULT). */

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -563,7 +563,7 @@ public class CompactRecordLogger {
     result
         .append(shortenKey(value.getAgentInstanceKey()))
         .append("#")
-        .append(value.getIteration())
+        .append(value.getLoopIteration())
         .append(" ")
         .append(value.getRole())
         .append(" @")

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
@@ -162,7 +162,7 @@ class CompactRecordLoggerTest {
                       .withJobKey(3L)
                       .withRole(AgentHistoryRole.ASSISTANT)
                       .withJobLease("1")
-                      .withIteration(2)
+                      .withLoopIteration(2)
                       .withMetrics(
                           ImmutableAgentHistoryMetricsValue.builder()
                               .withInputTokens(100)
@@ -215,7 +215,7 @@ class CompactRecordLoggerTest {
                       .withJobKey(3L)
                       .withRole(AgentHistoryRole.TOOL_RESULT)
                       .withJobLease("1")
-                      .withIteration(3)
+                      .withLoopIteration(3)
                       .addContent(
                           ImmutableAgentHistoryMessageContentValue.builder()
                               .withContentType(AgentHistoryContentType.OBJECT)
@@ -273,7 +273,7 @@ class CompactRecordLoggerTest {
                       .withJobKey(3L)
                       .withRole(AgentHistoryRole.ASSISTANT)
                       .withJobLease("1")
-                      .withIteration(1)
+                      .withLoopIteration(1)
                       .addContent(
                           ImmutableAgentHistoryMessageContentValue.builder()
                               .withContentType(AgentHistoryContentType.DOCUMENT)


### PR DESCRIPTION
## Summary

Renames the `loopIteration` field across all layers of the agent instance history feature. The name `iteration` was ambiguous; `loopIteration` more precisely captures the concept: one pass through the agent feedback loop (one LLM call, its tool dispatches, and their results).

- Renames `iteration`/`Iteration`/`ITERATION`/`IterationId` → `loopIteration`/`LoopIteration`/`LOOP_ITERATION`/`LoopIterationId` across all layers
- Updates the Liquibase creation changeset in place (no migration needed — feature unreleased)
- Clarifies the loopIteration concept in OpenAPI spec (`identifiers.yaml`, `agent-instances.yaml`) and `AgentHistoryRecordValue` Javadoc: a loopIteration is one pass through the agent feedback loop (one LLM call, its tool dispatches, and their results)
- Covers: protocol, engine, exporters (RDBMS/ES/OS/camunda), search domain & transformers, webapps schema, REST API (OpenAPI spec), Java client, TypeScript Zod schemas
- Bumps `camunda-api-zod-schemas` to v0.0.81

**Follow-up PR:** #56667 bumps the pinned version in Operate, Tasklist, and Identity once v0.0.81 is published to npm.

## Test plan

- [ ] All existing unit tests pass on affected modules
- [ ] RDBMS acceptance tests pass (`AgentHistoryIT`, `AgentHistoryFilterIT`, `AgentHistorySortIT`)
- [ ] Gateway REST controller tests pass (`AgentInstanceHistorySearchControllerTest`)
- [ ] Java client tests pass (`CreateAgentHistoryItemCommandTest`, `SearchAgentInstanceHistoryTest`)

Relates to #56504

🤖 Generated with [Claude Code](https://claude.com/claude-code)