### PR TITLE
ci(#52693): share distball m2 with reusable database + webapp-UT workflows

### DIFF
--- a/.github/actions/gcs-build-cache-auth/README.md
+++ b/.github/actions/gcs-build-cache-auth/README.md
@@ -1,0 +1,75 @@
+# GCS Build-Cache Auth Action
+
+## Intro
+
+Authenticates `gcloud` against the run-scoped GCS build-cache bucket
+(`camunda-monorepo-ci-artifacts`) used to share the Zeebe distball and the
+locally-installed `m2` SNAPSHOT tarball across jobs (see #52693).
+
+It bundles the three steps every build-cache consumer repeated verbatim:
+
+1. Fetch the `monorepo-build-cache-sa` service account from Vault (WIF provider +
+   service account, no long-lived key).
+2. Authenticate via `google-github-actions/auth` using Workload Identity Federation.
+3. Install the gcloud CLI via `google-github-actions/setup-gcloud`.
+
+After this action runs, the caller issues its own `gcloud storage` command
+(`cp` upload/download, or `rm` cleanup) — the storage operation stays at the call
+site so upload/download/delete intent is visible where it happens.
+
+Most build jobs get this indirectly: `setup-build` nests this action behind its
+opt-in `gcs-build-cache-auth: true` input (auto-disabled for fork PRs). Call this
+action directly when either:
+
+- the job has no build stack (no `setup-build`), e.g. the lightweight
+  `check-results` cleanup; or
+- a long step runs between `setup-build` and the `gcloud storage` command (e.g.
+  `build-distball`'s ~15-min build), so auth must happen late to keep the WIF/OIDC
+  token fresh.
+
+## Prerequisites
+
+- The repository must be checked out first (e.g. `actions/checkout`), since this
+  action is referenced by local path.
+- The calling job needs `permissions: id-token: write` so `google-github-actions/auth`
+  can mint the OIDC token for WIF.
+
+## Usage
+
+### Inputs
+
+|      Input      |                     Description                     | Required | Default |
+|-----------------|-----------------------------------------------------|----------|---------|
+| vault-addr      | Vault address (`secrets.VAULT_ADDR`)                | true     |         |
+| vault-role-id   | Vault AppRole role id (`secrets.VAULT_ROLE_ID`)     | true     |         |
+| vault-secret-id | Vault AppRole secret id (`secrets.VAULT_SECRET_ID`) | true     |         |
+
+### Outputs
+
+None. Authentication state is applied to the runner environment; downstream
+`gcloud` / `gcloud storage` steps in the same job pick it up automatically.
+
+## Example
+
+```yaml
+jobs:
+  consume-distball:
+    permissions:
+      contents: read
+      id-token: write  # required for WIF auth
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Download distball from GCS
+        shell: bash
+        run: |
+          set -euo pipefail
+          gcloud storage cp \
+            "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" \
+            "${RUNNER_TEMP}/m2-installed.tar"
+```
+

--- a/.github/actions/gcs-build-cache-auth/action.yml
+++ b/.github/actions/gcs-build-cache-auth/action.yml
@@ -1,0 +1,37 @@
+# owner: @camunda/monorepo-devops-team
+name: GCS build-cache auth
+description: >-
+  Vault-fetch the monorepo-build-cache service account and authenticate gcloud
+  via Workload Identity Federation. After this action, `gcloud storage` commands
+  can read/write the run-scoped build-cache bucket. The caller still runs its own
+  `gcloud storage` step (upload/download/delete) so intent stays at the call site.
+inputs:
+  vault-addr:
+    description: Vault address (secrets.VAULT_ADDR)
+    required: true
+  vault-role-id:
+    description: Vault AppRole role id (secrets.VAULT_ROLE_ID)
+    required: true
+  vault-secret-id:
+    description: Vault AppRole secret id (secrets.VAULT_SECRET_ID)
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Fetch GCS build-cache credentials
+      id: gcs-secrets
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+      with:
+        url: ${{ inputs.vault-addr }}
+        method: approle
+        roleId: ${{ inputs.vault-role-id }}
+        secretId: ${{ inputs.vault-secret-id }}
+        exportEnv: false
+        secrets: |
+          secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
+          secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
+    - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+      with:
+        workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+        service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+    - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3

--- a/.github/actions/restore-shared-m2/README.md
+++ b/.github/actions/restore-shared-m2/README.md
@@ -1,0 +1,48 @@
+# Restore Shared m2 SNAPSHOTs Action
+
+## Intro
+
+Restores the `io.camunda` `-SNAPSHOT` artifacts that the `build-distball` job installed
+locally and archived to the GCS build-cache as `m2-installed.tar`, so downstream
+`mvn verify` runs see them without re-running the reactor (saves ~2–15 min per job; see
+issue camunda/camunda#52693).
+
+It downloads the run-scoped `m2-installed.tar` and extracts it into
+`~/.m2/repository/installed`. The distball tarball itself (`camunda-zeebe-*.tar.gz`) is
+**not** restored here — callers that need it download it separately, since not every
+consumer does.
+
+## Prerequisites
+
+- The repository must be checked out first (e.g. `actions/checkout`), since this action
+  is referenced by local path.
+- gcloud must already be authenticated against the build-cache bucket — e.g. via
+  [`setup-build`](../setup-build) with `gcs-build-cache-auth: true`, or a direct
+  [`gcs-build-cache-auth`](../gcs-build-cache-auth) step.
+- `GCS_BUILD_CACHE_BUCKET` must be set at the workflow level, and the job must run in the
+  same `github.run_id` as the `build-distball` job that produced the tarball.
+
+## Usage
+
+### Inputs
+
+None.
+
+### Outputs
+
+None. Extracts `-SNAPSHOT`s into `~/.m2/repository/installed` on the runner.
+
+## Example
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+  - uses: ./.github/actions/setup-build
+    with:
+      vault-address: ${{ secrets.VAULT_ADDR }}
+      vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+      vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      gcs-build-cache-auth: true  # authenticates gcloud for the restore below
+  - uses: ./.github/actions/restore-shared-m2
+```
+

--- a/.github/actions/restore-shared-m2/action.yml
+++ b/.github/actions/restore-shared-m2/action.yml
@@ -1,0 +1,18 @@
+# owner: @camunda/monorepo-devops-team
+name: Restore shared m2 SNAPSHOTs
+description: >-
+  Download the run-scoped m2-installed.tar (the io.camunda SNAPSHOTs that build-distball
+  installed and archived to the GCS build-cache) and extract it into the local Maven
+  repository, so `mvn verify` sees the SNAPSHOTs without re-running the reactor (#52693).
+  Requires gcloud to be authenticated already (e.g. setup-build's gcs-build-cache-auth: true)
+  and the GCS_BUILD_CACHE_BUCKET env var to be set at the workflow level.
+runs:
+  using: composite
+  steps:
+    - name: Restore io.camunda SNAPSHOTs from GCS
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "${HOME}/.m2/repository/installed"
+        gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" "${RUNNER_TEMP}/m2-installed.tar"
+        tar -xf "${RUNNER_TEMP}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"

--- a/.github/actions/setup-build/README.md
+++ b/.github/actions/setup-build/README.md
@@ -1,0 +1,86 @@
+# Setup Build Action
+
+## Intro
+
+Sets up the standard stack needed to build, install, and run monorepo projects, so
+individual jobs don't repeat the same bootstrap. In one step it:
+
+- detects fork PRs (via [`is-fork`](../is-fork)) and disables all credential-dependent
+  features when secrets aren't available;
+- imports CI secrets from Vault (Nexus, DockerHub, Minimus);
+- installs the JDK (`actions/setup-java`);
+- registers the Maven problem matcher and configures the Maven cache
+  (via [`setup-maven-cache`](../setup-maven-cache));
+- merges Camunda Nexus + Google Central mirrors with any extra mirrors/servers and
+  writes `settings.xml`;
+- optionally sets the build time zone;
+- optionally logs into DockerHub, Harbor, and Minimus;
+- optionally authenticates gcloud against the GCS build-cache
+  (via [`gcs-build-cache-auth`](../gcs-build-cache-auth)).
+
+All credential features are **automatically disabled for fork PRs**, since Vault
+secrets can't be retrieved there.
+
+## Prerequisites
+
+- The repository must be checked out first (e.g. `actions/checkout`), since this
+  action and its nested actions are referenced by local path.
+- To use any Vault-backed feature (Nexus mirror, DockerHub/Harbor/Minimus login,
+  GCS auth), pass `vault-address` / `vault-role-id` / `vault-secret-id`.
+- `gcs-build-cache-auth: true` additionally requires the job to grant
+  `permissions: id-token: write` (Workload Identity Federation).
+
+## Usage
+
+### Inputs
+
+|          Input           |                                             Description                                              | Required |  Default  |
+|--------------------------|------------------------------------------------------------------------------------------------------|----------|-----------|
+| camunda-nexus            | Use Camunda Nexus as a Maven mirror (disabled for fork PRs)                                          | false    | `"true"`  |
+| dockerhub                | Log into DockerHub with a CI account (disabled for fork PRs)                                         | false    | `"false"` |
+| dockerhub-readonly       | Log into DockerHub with a read-only account to avoid rate limits                                     | false    | `"false"` |
+| harbor                   | Log into Harbor with a CI account (disabled for fork PRs)                                            | false    | `"false"` |
+| minimus                  | Log into Minimus with a CI account (disabled for fork PRs)                                           | false    | `"false"` |
+| gcs-build-cache-auth     | Opt-in: set `"true"` to authenticate gcloud to the GCS build-cache via WIF (needs `id-token: write`) | false    | `"false"` |
+| java-distribution        | Java distribution to install                                                                         | false    | `temurin` |
+| java-version             | JDK version to install                                                                               | false    | `"21"`    |
+| maven-cache-key-modifier | Modifier for the Maven cache key                                                                     | false    | `shared`  |
+| maven-mirrors            | JSON list of extra Maven mirrors (merged with Nexus, extras win)                                     | false    | `'[]'`    |
+| maven-servers            | JSON list of extra Maven servers (merged with Nexus, extras win)                                     | false    | `'[]'`    |
+| time-zone                | TZ identifier for the build env, e.g. `Europe/Berlin` (Linux only)                                   | false    |           |
+| vault-address            | Vault URL to retrieve secrets from                                                                   | false    |           |
+| vault-role-id            | Vault AppRole role id                                                                                | false    |           |
+| vault-secret-id          | Vault AppRole secret id                                                                              | false    |           |
+
+### Outputs
+
+None.
+
+## Notes
+
+- `dockerhub` and `dockerhub-readonly` are mutually exclusive — enabling both fails
+  the action.
+- The Vault path for the DockerHub account is inferred from the calling workflow's
+  file name (`operate-*`, `optimize-*`, `tasklist-*`, `zeebe-*`), defaulting to
+  `camunda`.
+
+## Example
+
+```yaml
+jobs:
+  build:
+    permissions:
+      contents: read
+      id-token: write  # only needed when gcs-build-cache-auth is true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          maven-cache-key-modifier: build-shared
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          gcs-build-cache-auth: true  # share the run-scoped distball / m2 tarball
+```
+

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -37,6 +37,14 @@ inputs:
       Minimus login is automatically disabled for fork PRs.
     required: false
     default: "false"
+  gcs-build-cache-auth:
+    description: |
+      If enabled, authenticates gcloud against the GCS build-cache bucket via Workload
+      Identity Federation, so subsequent `gcloud storage` steps can share the run-scoped
+      distball / m2 tarball (see #52693). Requires the job to grant `permissions: id-token: write`.
+      Automatically disabled for fork PRs (no Vault access).
+    required: false
+    default: "false"
   java-distribution:
     description: Java distribution to use
     required: false
@@ -272,3 +280,13 @@ runs:
       registry: reg.mini.dev
       username: minimus
       password: ${{ steps.secrets.outputs.minimus-token }}
+  - name: Authenticate to GCS build-cache
+    # GCS build-cache auth is disabled for fork PRs (no Vault access)
+    if: >-
+      steps.is-fork.outputs.is-fork != 'true' &&
+      inputs.gcs-build-cache-auth == 'true'
+    uses: ./.github/actions/gcs-build-cache-auth
+    with:
+      vault-addr: ${{ inputs.vault-address }}
+      vault-role-id: ${{ inputs.vault-role-id }}
+      vault-secret-id: ${{ inputs.vault-secret-id }}

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -58,6 +58,16 @@ on:
         required: false
         type: string
         default: "gcp-perf-core-16-default"
+      use-shared-distball:
+        required: false
+        type: boolean
+        default: false
+        description: >-
+          When true, restore the io.camunda SNAPSHOTs from the run-scoped GCS
+          artifact produced by ci.yml's build-distball job instead of running a
+          local build-zeebe reactor. Only safe when called from a run that has a
+          build-distball job (i.e. ci.yml). Standalone callers must leave this
+          false so the build-zeebe fallback runs. See #52693.
     outputs:
       flakyTests:
         description: "Flaky tests detected during database integration tests"
@@ -70,11 +80,14 @@ env:
   TEST_OWNER: '@camunda/monorepo-devops-team'
   GHA_BEST_PRACTICES_LINTER: enabled
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
+  GCS_BUILD_CACHE_BUCKET: camunda-monorepo-ci-artifacts
 
 jobs:
   integration-tests:
     name: "${{ inputs.database-type }}"
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
     timeout-minutes: 20
     runs-on: ${{ inputs.runs-on }}
     env:
@@ -107,8 +120,43 @@ jobs:
             docker compose -f db/docker-compose.yml logs
             exit 1
           }
-      # Build the platform before running the integration tests; skipping frontend
+      # When called from ci.yml (use-shared-distball=true) restore the io.camunda SNAPSHOTs
+      # that build-distball installed + archived to GCS, instead of re-running the ~2 min
+      # reactor in each of the ~15 database/history/identity matrix entries. gcp-perf runners
+      # pull from GCS (same-region, non-billable); the GHA artifact API is throughput-capped
+      # on self-hosted runners. github.run_id is stable across nested workflow_call, so it
+      # addresses the same run-scoped prefix build-distball wrote. See #52693.
+      - name: Fetch GCS build-cache credentials
+        if: ${{ inputs.use-shared-distball }}
+        id: gcs-secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
+      - if: ${{ inputs.use-shared-distball }}
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+      - if: ${{ inputs.use-shared-distball }}
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Restore io.camunda SNAPSHOTs from GCS
+        if: ${{ inputs.use-shared-distball }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${HOME}/.m2/repository/installed"
+          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" "${RUNNER_TEMP}/m2-installed.tar"
+          tar -xf "${RUNNER_TEMP}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"
+      # Fallback for standalone callers (zeebe-rdbms / zeebe-search) whose run has no
+      # build-distball: build the platform locally, skipping frontend.
       - uses: ./.github/actions/build-zeebe
+        if: ${{ !inputs.use-shared-distball }}
         id: build-zeebe
         with:
           maven-extra-args: -T1C -PskipFrontendBuild

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -112,6 +112,8 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          # Authenticate gcloud when consuming the shared distball (see restore step below)
+          gcs-build-cache-auth: ${{ inputs.use-shared-distball }}
       # start the required database service
       - name: Start Database service
         if: ${{ inputs.database-type != 'h2' }}
@@ -126,33 +128,9 @@ jobs:
       # pull from GCS (same-region, non-billable); the GHA artifact API is throughput-capped
       # on self-hosted runners. github.run_id is stable across nested workflow_call, so it
       # addresses the same run-scoped prefix build-distball wrote. See #52693.
-      - name: Fetch GCS build-cache credentials
-        if: ${{ inputs.use-shared-distball }}
-        id: gcs-secrets
-        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
-            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
+      # (gcloud is authenticated by setup-build's gcs-build-cache-auth above.)
       - if: ${{ inputs.use-shared-distball }}
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
-          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
-      - if: ${{ inputs.use-shared-distball }}
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
-      - name: Restore io.camunda SNAPSHOTs from GCS
-        if: ${{ inputs.use-shared-distball }}
-        run: |
-          set -euo pipefail
-          mkdir -p "${HOME}/.m2/repository/installed"
-          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" "${RUNNER_TEMP}/m2-installed.tar"
-          tar -xf "${RUNNER_TEMP}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"
+        uses: ./.github/actions/restore-shared-m2
       # Fallback for standalone callers (zeebe-rdbms / zeebe-search) whose run has no
       # build-distball: build the platform locally, skipping frontend.
       - uses: ./.github/actions/build-zeebe

--- a/.github/workflows/ci-operate.yml
+++ b/.github/workflows/ci-operate.yml
@@ -16,6 +16,11 @@ on:
         description: "Set to true if Operate back-end code was changed"
         type: boolean
         required: true
+      use-shared-distball:
+        description: "Restore the shared distball m2 from GCS in ci-webapp-run-ut-reuseable instead of build-zeebe. Set by ci.yml only (which has a build-distball job); leave false for standalone workflow_dispatch."
+        type: boolean
+        required: false
+        default: false
   workflow_call:
     inputs:
       runFeTests:
@@ -26,6 +31,11 @@ on:
         description: "Set to true if Operate back-end code was changed"
         type: boolean
         required: true
+      use-shared-distball:
+        description: "Restore the shared distball m2 from GCS in ci-webapp-run-ut-reuseable instead of build-zeebe. Set by ci.yml only (which has a build-distball job); leave false for standalone workflow_dispatch."
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -44,7 +54,11 @@ jobs:
   operate-backend-unit-tests:
     name: "Unit"
     uses: ./.github/workflows/ci-webapp-run-ut-reuseable.yml
-    permissions: {} # GITHUB_TOKEN unused in this job
+    # When ci.yml sets use-shared-distball, the reusable workflow restores the shared distball
+    # m2 from GCS via WIF instead of running build-zeebe (see #52693); that needs id-token.
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     strategy:
       fail-fast: false
@@ -62,6 +76,7 @@ jobs:
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
       owner: ${{ matrix.owner }}
+      use-shared-distball: ${{ inputs.use-shared-distball }}
 
   # Checks to see if Operate can properly build itself
   build-operate-backend:

--- a/.github/workflows/ci-optimize.yml
+++ b/.github/workflows/ci-optimize.yml
@@ -16,6 +16,11 @@ on:
         description: "Set to true if Optimize back-end code was changed"
         type: boolean
         required: true
+      use-shared-distball:
+        description: "Restore the shared distball m2 from GCS in ci-webapp-run-ut-reuseable instead of build-zeebe. Set by ci.yml only (which has a build-distball job); leave false for standalone workflow_dispatch."
+        type: boolean
+        required: false
+        default: false
   workflow_call:
     inputs:
       runFeTests:
@@ -26,6 +31,11 @@ on:
         description: "Set to true if Optimize back-end code was changed"
         type: boolean
         required: true
+      use-shared-distball:
+        description: "Restore the shared distball m2 from GCS in ci-webapp-run-ut-reuseable instead of build-zeebe. Set by ci.yml only (which has a build-distball job); leave false for standalone workflow_dispatch."
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -43,7 +53,11 @@ jobs:
   optimize-backend-unit-tests:
     name: "Unit"
     uses: ./.github/workflows/ci-webapp-run-ut-reuseable.yml
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    # When ci.yml sets use-shared-distball, the reusable workflow restores the shared distball
+    # m2 from GCS via WIF instead of running build-zeebe (see #52693); that needs id-token.
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     strategy:
       fail-fast: false
@@ -61,6 +75,7 @@ jobs:
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
       owner: ${{ matrix.owner }}
+      use-shared-distball: ${{ inputs.use-shared-distball }}
 
   optimize-it-elasticsearch:
     name: "Integration / Elasticsearch ITs"

--- a/.github/workflows/ci-tasklist.yml
+++ b/.github/workflows/ci-tasklist.yml
@@ -16,6 +16,11 @@ on:
         description: "Set to true to run back end tests for Tasklist"
         type: boolean
         required: true
+      use-shared-distball:
+        description: "Restore the shared distball m2 from GCS in ci-webapp-run-ut-reuseable instead of build-zeebe. Set by ci.yml only (which has a build-distball job); leave false for standalone workflow_dispatch."
+        type: boolean
+        required: false
+        default: false
   workflow_call:
     inputs:
       runFeTests:
@@ -26,6 +31,11 @@ on:
         description: "Set to true if Tasklist back-end code was changed"
         type: boolean
         required: true
+      use-shared-distball:
+        description: "Restore the shared distball m2 from GCS in ci-webapp-run-ut-reuseable instead of build-zeebe. Set by ci.yml only (which has a build-distball job); leave false for standalone workflow_dispatch."
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -44,7 +54,11 @@ jobs:
   tasklist-backend-unit-tests:
     name: "Unit"
     uses: ./.github/workflows/ci-webapp-run-ut-reuseable.yml
-    permissions: { }  # GITHUB_TOKEN unused in this job
+    # When ci.yml sets use-shared-distball, the reusable workflow restores the shared distball
+    # m2 from GCS via WIF instead of running build-zeebe (see #52693); that needs id-token.
+    permissions:
+      contents: read
+      id-token: write
     secrets: inherit
     strategy:
       fail-fast: false
@@ -62,6 +76,7 @@ jobs:
       suite: ${{ matrix.suite }}
       suiteName: ${{ matrix.suiteName }}
       owner: ${{ matrix.owner }}
+      use-shared-distball: ${{ inputs.use-shared-distball }}
 
   fe-type-check:
     if: inputs.runFeTests

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -69,37 +69,15 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          # Authenticate gcloud when consuming the shared distball (see restore step below)
+          gcs-build-cache-auth: ${{ inputs.use-shared-distball }}
       # When called from ci.yml (use-shared-distball=true) restore the io.camunda SNAPSHOTs
       # build-distball archived to GCS instead of re-running the ~2 min reactor in each of the
       # operate/tasklist/optimize back-end UT entries. github.run_id is stable across nested
       # workflow_call, addressing the same run-scoped prefix build-distball wrote. See #52693.
-      - name: Fetch GCS build-cache credentials
-        if: ${{ inputs.use-shared-distball }}
-        id: gcs-secrets
-        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
-            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
+      # (gcloud is authenticated by setup-build's gcs-build-cache-auth above.)
       - if: ${{ inputs.use-shared-distball }}
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
-          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
-      - if: ${{ inputs.use-shared-distball }}
-        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
-      - name: Restore io.camunda SNAPSHOTs from GCS
-        if: ${{ inputs.use-shared-distball }}
-        run: |
-          set -euo pipefail
-          mkdir -p "${HOME}/.m2/repository/installed"
-          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" "${RUNNER_TEMP}/m2-installed.tar"
-          tar -xf "${RUNNER_TEMP}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"
+        uses: ./.github/actions/restore-shared-m2
       # Fallback when the run has no build-distball job: build the platform locally.
       - uses: ./.github/actions/build-zeebe
         if: ${{ !inputs.use-shared-distball }}

--- a/.github/workflows/ci-webapp-run-ut-reuseable.yml
+++ b/.github/workflows/ci-webapp-run-ut-reuseable.yml
@@ -24,12 +24,22 @@ on:
         description: "Canonical GitHub team handle owning the suite under test, e.g. '@camunda/data-layer'"
         required: true
         type: string
+      use-shared-distball:
+        required: false
+        type: boolean
+        default: false
+        description: >-
+          When true, restore the io.camunda SNAPSHOTs from the run-scoped GCS
+          artifact produced by ci.yml's build-distball job instead of running a
+          local build-zeebe reactor. Only safe when the run has a build-distball
+          job (i.e. via ci.yml). See #52693.
 
 env:
   GHA_BEST_PRACTICES_LINTER: enabled
   TEST_OWNER: ${{ inputs.owner }}
   TEST_TYPE: Unit
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
+  GCS_BUILD_CACHE_BUCKET: camunda-monorepo-ci-artifacts
 
 defaults:
   run:
@@ -44,7 +54,9 @@ jobs:
     name: "Unit - Back End - ${{ inputs.suiteName}}"
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 10
-    permissions: { }
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Print metadata
@@ -57,7 +69,40 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      # When called from ci.yml (use-shared-distball=true) restore the io.camunda SNAPSHOTs
+      # build-distball archived to GCS instead of re-running the ~2 min reactor in each of the
+      # operate/tasklist/optimize back-end UT entries. github.run_id is stable across nested
+      # workflow_call, addressing the same run-scoped prefix build-distball wrote. See #52693.
+      - name: Fetch GCS build-cache credentials
+        if: ${{ inputs.use-shared-distball }}
+        id: gcs-secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
+            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
+      - if: ${{ inputs.use-shared-distball }}
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
+          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
+      - if: ${{ inputs.use-shared-distball }}
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+      - name: Restore io.camunda SNAPSHOTs from GCS
+        if: ${{ inputs.use-shared-distball }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${HOME}/.m2/repository/installed"
+          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" "${RUNNER_TEMP}/m2-installed.tar"
+          tar -xf "${RUNNER_TEMP}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"
+      # Fallback when the run has no build-distball job: build the platform locally.
       - uses: ./.github/actions/build-zeebe
+        if: ${{ !inputs.use-shared-distball }}
         id: build-zeebe
         with:
           maven-extra-args: -T1C -Dquickly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,23 +499,13 @@ jobs:
           compression-level: 6
           if-no-files-found: error
       # integration-tests' gcp-perf shards consume these from GCS (ingress is free).
-      - name: Fetch GCS build-cache credentials
-        id: gcs-secrets
-        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+      # Authenticate here (not via setup-build) so the WIF/OIDC token is fresh: the
+      # build-zeebe step above can run ~15 min, close to the OIDC token lifetime.
+      - uses: ./.github/actions/gcs-build-cache-auth
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
-            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
-          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Upload distball + SNAPSHOTs to GCS
         shell: bash
         # SA lacks storage.buckets.get, so gcloud's parallel-composite precheck fails; disable it.
@@ -527,67 +517,6 @@ jobs:
             "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/$(basename "${{ steps.build-zeebe.outputs.distball }}")"
           gcloud storage cp m2-installed.tar \
             "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar"
-      - name: Observe build status
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/observe-build-status
-        with:
-          build_status: ${{ job.status }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
-  utils-cleanup-distball:
-    name: "Cleanup / Distribution Tarball Artifact"
-    # Delete the run-scoped GCS objects after consumers finish. The `utils-` prefix
-    # exempts it from the check-results gate; artifacts self-expire (retention-days: 1)
-    # and the bucket TTL covers runs cancelled/failed before this fires.
-    # Must list every GCS consumer so cleanup never deletes the m2 tarball out from under a
-    # still-running restore: docker-checks + integration-tests, plus the reusable database/
-    # webapp back-end-UT consumers wired via #52693 (they pull m2 from the same run prefix).
-    needs: [ build-distball, docker-checks, integration-tests, database-integration-tests, history-tests, identity-tests, operate-ci, tasklist-ci, optimize-ci ]
-    # Clean up only when build-distball succeeded and no consumer failed or was cancelled
-    # (skipped consumers -- both are conditional -- don't block cleanup). If any failed or was
-    # cancelled, keep the GCS objects so "Re-run failed jobs" can re-fetch the distball --
-    # build-distball won't re-run (it already succeeded) so it won't re-upload. Orphaned objects
-    # on failed runs are reaped by the bucket TTL (Infra-owned).
-    if: >-
-      always()
-      && needs.build-distball.result == 'success'
-      && !contains(needs.*.result, 'failure')
-      && !contains(needs.*.result, 'cancelled')
-    runs-on: ubuntu-slim  # short auth-and-delete job; no need for a full runner
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: camunda/infra-global-github-actions/start-build-monitor@7a9c6f3e477321400802c88290068f88a7ed5684 # main
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        timeout-minutes: 1
-      - name: Fetch GCS build-cache credentials
-        id: gcs-secrets
-        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
-            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
-          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
-      - name: Delete run-scoped GCS objects
-        shell: bash
-        run: |
-          set -euo pipefail
-          gcloud storage rm --recursive "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/" \
-            || echo "No objects to delete for run ${GITHUB_RUN_ID}"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -1382,6 +1311,10 @@ jobs:
         with:
           test_product: "${{ matrix.name }}"
           test_owner: "${{ matrix.owner }}"
+      # Consume the shared distball instead of a ~15 min reactor build. These shards run
+      # on self-hosted gcp-perf runners where the artifact API is throughput-capped, so
+      # they pull from GCS (same-region, non-billable). See build-distball.
+      # gcs-build-cache-auth authenticates gcloud for the GCS download below.
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -1390,36 +1323,17 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           minimus: true
-      # Consume the shared distball instead of a ~15 min reactor build. These shards run
-      # on self-hosted gcp-perf runners where the artifact API is throughput-capped, so
-      # they pull from GCS (same-region, non-billable). See build-distball.
-      - name: Fetch GCS build-cache credentials
-        id: gcs-secrets
-        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          exportEnv: false
-          secrets: |
-            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa SERVICE_ACCOUNT | GCS_SA;
-            secret/data/products/camunda/ci/build-cache/monorepo-build-cache-sa WORKLOAD_IDENTITY_PROVIDER | GCS_WIF;
-      - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: ${{ steps.gcs-secrets.outputs.GCS_WIF }}
-          service_account: ${{ steps.gcs-secrets.outputs.GCS_SA }}
-      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
-      # Restore the io.camunda SNAPSHOTs archived by build-distball for `mvn verify` below
-      # (the GHA Maven cache doesn't carry locally-installed SNAPSHOTs between jobs).
-      - name: Download distball + SNAPSHOTs from GCS
+          gcs-build-cache-auth: true
+      # Download the shared distball tarball; restore-shared-m2 below handles the SNAPSHOTs.
+      - name: Download distball from GCS
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p dist/target "${HOME}/.m2/repository/installed"
+          mkdir -p dist/target
           gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/camunda-zeebe-*.tar.gz" dist/target/
-          gcloud storage cp "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/m2-installed.tar" "${RUNNER_TEMP}/m2-installed.tar"
-          tar -xf "${RUNNER_TEMP}/m2-installed.tar" -C "${HOME}/.m2/repository/installed"
+      # Restore the io.camunda SNAPSHOTs archived by build-distball for `mvn verify` below
+      # (the GHA Maven cache doesn't carry locally-installed SNAPSHOTs between jobs).
+      - uses: ./.github/actions/restore-shared-m2
       - uses: ./.github/actions/build-platform-docker
         if: ${{ matrix.docker-file != '' }}
         with:
@@ -2397,14 +2311,15 @@ jobs:
 
   check-results:
     # Used by the merge queue to check all tests, including the unit test matrix.
-    # New test jobs must be added to the `needs` lists!
+    # New test jobs must be added to the `needs` list!
     # This name is hard-coded in the branch rules; remember to update that if this name changes
     if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 3
+    timeout-minutes: 10
     permissions:
       actions: read
       checks: read
+      id-token: write
       pull-requests: write
     needs: # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
@@ -2463,6 +2378,37 @@ jobs:
         with:
           github_token: ${{ github.token }}
           has_failures: ${{ contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure') }}
+      # Clean up the run-scoped GCS objects (distball + m2 tarball) only when build-distball
+      # succeeded and no other job failed or was cancelled. If any did, keep them so
+      # "Re-run failed jobs" can re-fetch the distball (build-distball won't re-run, so it won't
+      # re-upload). needs.* here spans every check-results dependency (broader than the old
+      # consumer-only gate) — strictly safer: a failure anywhere keeps the objects for a rerun.
+      # Orphaned objects on abandoned runs are reaped by the bucket TTL (Infra-owned).
+      # continue-on-error keeps a Vault/GCS infra flake from failing the merge-queue gate.
+      - name: Authenticate to GCS build-cache
+        if: >-
+          needs.build-distball.result == 'success'
+          && !contains(needs.*.result, 'failure')
+          && !contains(needs.*.result, 'cancelled')
+        continue-on-error: true
+        uses: ./.github/actions/gcs-build-cache-auth
+        with:
+          vault-addr: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Delete run-scoped GCS objects
+        if: >-
+          needs.build-distball.result == 'success'
+          && !contains(needs.*.result, 'failure')
+          && !contains(needs.*.result, 'cancelled')
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          # rm fails if the prefix is already empty OR if auth was skipped/flaky (gcloud unset);
+          # either way this is non-fatal — the bucket TTL reaps anything left behind.
+          gcloud storage rm --recursive "gs://${GCS_BUILD_CACHE_BUCKET}/${GITHUB_RUN_ID}/" \
+            || echo "Cleanup skipped for run ${GITHUB_RUN_ID} (nothing to delete, or gcloud auth unavailable)"
       - run: |
           echo "The \`check-results\` job has the function to fail if any previous job was unsuccessful!"
           echo "If you're reading this and wondering what the is the problem, please check other GHA jobs of this workflow run to for errors/cancellation and see their logs."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,8 +467,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Only io.camunda reactor SNAPSHOTs are needed; drop the distro assemblies
-          # (shipped as the distball), sources/javadoc and bookkeeping to ~halve the payload.
+          # `installed/` is the split-local-repository partition holding only artifacts this
+          # reactor installed (see maven resolver split local repository), so archive the whole
+          # tree rather than filtering to io/camunda -- robust if the group id ever changes.
+          # Drop the distro assemblies (shipped as the distball), sources/javadoc and
+          # bookkeeping to ~halve the payload.
           tar \
             --exclude='*.tar.gz' \
             --exclude='*-sources.jar' \
@@ -476,7 +479,7 @@ jobs:
             --exclude='*.lastUpdated' \
             --exclude='_remote.repositories' \
             --exclude='*.repositories' \
-            -cf m2-installed.tar -C "${HOME}/.m2/repository/installed" io/camunda
+            -cf m2-installed.tar -C "${HOME}/.m2/repository/installed" .
           ls -lh m2-installed.tar
       # docker-checks (GitHub-hosted) consumes these via the artifact API.
       - name: Upload distball (artifact)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,8 +434,9 @@ jobs:
     # self-hosted gcp-perf consumers (integration-tests, and the reusable database/webapp-UT
     # workflows) use GCS, since the artifact API is throughput-capped on self-hosted runners.
     # Gated on the union of all consumers' conditions so the artifact exists whenever one runs;
-    # frontend-changes is included because the webapp back-end UTs run on it. See #52693.
-    if: needs.detect-changes.outputs.camunda-docker-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
+    # frontend-changes is included because the webapp back-end UTs run on it; rdbms-integration-tests
+    # is included because its filter is a superset of java-code-changes (adds rdbms-change). See #52693.
+    if: needs.detect-changes.outputs.camunda-docker-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' || needs.detect-changes.outputs.rdbms-integration-tests == 'true'
     needs: [ detect-changes ]
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
@@ -1193,7 +1194,7 @@ jobs:
 
   rdbms-integration-tests:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
-    needs: [ detect-changes ]
+    needs: [ detect-changes, build-distball ]
     name: "General / Integration / RDBMS ITs"
     timeout-minutes: 30
     runs-on: gcp-perf-core-8-default
@@ -1205,11 +1206,18 @@ jobs:
         include: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:stress-test') && fromJson('[{"stressRun":1},{"stressRun":2},{"stressRun":3},{"stressRun":4},{"stressRun":5},{"stressRun":6},{"stressRun":7},{"stressRun":8},{"stressRun":9},{"stressRun":10}]') || fromJson('[{"stressRun":1}]') }}
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
-    permissions: { }  # no GITHUB_TOKEN is needed
+    permissions:
+      contents: read
+      id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token for the GCS distball download
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@7a9c6f3e477321400802c88290068f88a7ed5684 # main
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         timeout-minutes: 1
+      # Consume the shared distball's io.camunda SNAPSHOTs instead of a ~15 min reactor build.
+      # This job runs on a self-hosted gcp-perf runner where the artifact API is throughput-capped,
+      # so restore-shared-m2 pulls from GCS (same-region, non-billable). RDBMS ITs run in-process
+      # (no Docker image build), so only the m2 SNAPSHOTs are needed, not the distball tarball.
+      # gcs-build-cache-auth authenticates gcloud for that download. See build-distball.
       - uses: ./.github/actions/setup-build
         with:
           dockerhub-readonly: true
@@ -1217,9 +1225,8 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - uses: ./.github/actions/build-zeebe
-        with:
-          maven-extra-args: -T1C -PskipFrontendBuild
+          gcs-build-cache-auth: true
+      - uses: ./.github/actions/restore-shared-m2
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
       # Run integration tests with RDBMS database

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2315,7 +2315,7 @@ jobs:
     # This name is hard-coded in the branch rules; remember to update that if this name changes
     if: always()
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 3
     permissions:
       actions: read
       checks: read
@@ -2362,6 +2362,8 @@ jobs:
       - webapp-client
       - zeebe-ci
       - zeebe-unit-tests
+    env:
+      SHOULD_CLEANUP_GCS: ${{ needs.build-distball.result == 'success' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         timeout-minutes: 1
@@ -2386,10 +2388,7 @@ jobs:
       # Orphaned objects on abandoned runs are reaped by the bucket TTL (Infra-owned).
       # continue-on-error keeps a Vault/GCS infra flake from failing the merge-queue gate.
       - name: Authenticate to GCS build-cache
-        if: >-
-          needs.build-distball.result == 'success'
-          && !contains(needs.*.result, 'failure')
-          && !contains(needs.*.result, 'cancelled')
+        if: env.SHOULD_CLEANUP_GCS == 'true'
         continue-on-error: true
         uses: ./.github/actions/gcs-build-cache-auth
         with:
@@ -2397,10 +2396,7 @@ jobs:
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
       - name: Delete run-scoped GCS objects
-        if: >-
-          needs.build-distball.result == 'success'
-          && !contains(needs.*.result, 'failure')
-          && !contains(needs.*.result, 'cancelled')
+        if: env.SHOULD_CLEANUP_GCS == 'true'
         continue-on-error: true
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1177,6 +1177,7 @@ jobs:
     permissions:
       contents: read
       id-token: write  # granted through to the reusable workflow's WIF GCS auth
+      actions: write   # reusable workflow's send-slack-notification job declares it; validated at startup even though ci.yml never triggers it
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-db-versions.outputs.ci-database-matrix) }}
@@ -1197,6 +1198,7 @@ jobs:
     permissions:
       contents: read
       id-token: write  # granted through to the reusable workflow's WIF GCS auth
+      actions: write   # reusable workflow's send-slack-notification job declares it; validated at startup even though ci.yml never triggers it
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-db-versions.outputs.ci-database-matrix) }}
@@ -1221,6 +1223,7 @@ jobs:
     permissions:
       contents: read
       id-token: write  # granted through to the reusable workflow's WIF GCS auth
+      actions: write   # reusable workflow's send-slack-notification job declares it; validated at startup even though ci.yml never triggers it
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-db-versions.outputs.ci-database-matrix) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -542,7 +542,10 @@ jobs:
     # Delete the run-scoped GCS objects after consumers finish. The `utils-` prefix
     # exempts it from the check-results gate; artifacts self-expire (retention-days: 1)
     # and the bucket TTL covers runs cancelled/failed before this fires.
-    needs: [ build-distball, docker-checks, integration-tests ]
+    # Must list every GCS consumer so cleanup never deletes the m2 tarball out from under a
+    # still-running restore: docker-checks + integration-tests, plus the reusable database/
+    # webapp back-end-UT consumers wired via #52693 (they pull m2 from the same run prefix).
+    needs: [ build-distball, docker-checks, integration-tests, database-integration-tests, history-tests, identity-tests, operate-ci, tasklist-ci, optimize-ci ]
     # Clean up only when build-distball succeeded and no consumer failed or was cancelled
     # (skipped consumers -- both are conditional -- don't block cleanup). If any failed or was
     # cancelled, keep the GCS objects so "Re-run failed jobs" can re-fetch the distball --

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -429,12 +429,13 @@ jobs:
 
   build-distball:
     name: "Build / Distribution Tarball"
-    # Build the distball once and share it, replacing a ~15 min reactor build in each
-    # consumer. Transport differs by runner: docker-checks (GitHub-hosted) uses the GHA
-    # artifact API; the integration-tests shards (self-hosted gcp-perf) use GCS, since
-    # the artifact API is throughput-capped on self-hosted runners. Gated on the union
-    # of both consumers' conditions so the artifact exists whenever one runs. See #52693.
-    if: needs.detect-changes.outputs.camunda-docker-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true'
+    # Build the distball once and share it, replacing a reactor build in each consumer.
+    # Transport differs by runner: docker-checks (GitHub-hosted) uses the GHA artifact API;
+    # self-hosted gcp-perf consumers (integration-tests, and the reusable database/webapp-UT
+    # workflows) use GCS, since the artifact API is throughput-capped on self-hosted runners.
+    # Gated on the union of all consumers' conditions so the artifact exists whenever one runs;
+    # frontend-changes is included because the webapp back-end UTs run on it. See #52693.
+    if: needs.detect-changes.outputs.camunda-docker-tests == 'true' || needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
     needs: [ detect-changes ]
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
@@ -1169,7 +1170,10 @@ jobs:
   database-integration-tests:
     name: "Database Integration Tests / ${{ matrix.name }}"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes, generate-db-versions ]
+    needs: [ detect-changes, generate-db-versions, build-distball ]
+    permissions:
+      contents: read
+      id-token: write  # granted through to the reusable workflow's WIF GCS auth
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-db-versions.outputs.ci-database-matrix) }}
@@ -1181,11 +1185,15 @@ jobs:
       database-image-version: "${{ matrix.database-image-version }}"
       database-name: "${{ matrix.database-name }}"
       it-database-type: "${{ matrix.it-database-type }}"
+      use-shared-distball: true
 
   history-tests:
     name: "History Integration Tests / ${{ matrix.name }}"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes, generate-db-versions ]
+    needs: [ detect-changes, generate-db-versions, build-distball ]
+    permissions:
+      contents: read
+      id-token: write  # granted through to the reusable workflow's WIF GCS auth
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-db-versions.outputs.ci-database-matrix) }}
@@ -1201,11 +1209,15 @@ jobs:
       test-type: "history-tests"
       test-type-label: "History"
       runs-on: "gcp-perf-core-8-default"
+      use-shared-distball: true
 
   identity-tests:
     name: "Identity Integration Tests / ${{ matrix.name }}"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes, generate-db-versions ]
+    needs: [ detect-changes, generate-db-versions, build-distball ]
+    permissions:
+      contents: read
+      id-token: write  # granted through to the reusable workflow's WIF GCS auth
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-db-versions.outputs.ci-database-matrix) }}
@@ -1220,6 +1232,7 @@ jobs:
       maven-profiles: "identity-tests"
       test-type: "identity-tests"
       test-type-label: "Identity"
+      use-shared-distball: true
 
   physical-tenant-acceptance-tests:
     name: "Physical Tenant Acceptance Tests / H2"
@@ -2040,35 +2053,44 @@ jobs:
   tasklist-ci:
     if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
     name: "Tasklist"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, build-distball ]
     uses: ./.github/workflows/ci-tasklist.yml
     secrets: inherit
-    permissions: { }
+    permissions:
+      contents: read
+      id-token: write  # granted through to the reusable back-end UT's WIF GCS auth
     with:
       runFeTests: ${{ needs.detect-changes.outputs.tasklist-frontend-changes  == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
+      use-shared-distball: true
 
   operate-ci:
     if: needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true'
     name: "Operate"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, build-distball ]
     uses: ./.github/workflows/ci-operate.yml
     secrets: inherit
-    permissions: { }
+    permissions:
+      contents: read
+      id-token: write  # granted through to the reusable back-end UT's WIF GCS auth
     with:
       runFeTests: ${{ needs.detect-changes.outputs.operate-frontend-changes == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.operate-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true'}}
+      use-shared-distball: true
 
   optimize-ci:
     if: ${{ needs.detect-changes.outputs.java-code-changes == 'true' || needs.detect-changes.outputs.frontend-changes == 'true' }}
     name: "Optimize"
-    needs: [ detect-changes ]
+    needs: [ detect-changes, build-distball ]
     uses: ./.github/workflows/ci-optimize.yml
     secrets: inherit
-    permissions: { }
+    permissions:
+      contents: read
+      id-token: write  # granted through to the reusable back-end UT's WIF GCS auth
     with:
       runFeTests: ${{ needs.detect-changes.outputs.optimize-frontend-changes == 'true' }}
       runBeTests: ${{ needs.detect-changes.outputs.optimize-backend-changes == 'true' || needs.detect-changes.outputs.zeebe-changes == 'true' }}
+      use-shared-distball: true
 
   zeebe-ci:
     if: needs.detect-changes.outputs.zeebe-changes == 'true'

--- a/.github/workflows/zeebe-rdbms-integration-tests.yml
+++ b/.github/workflows/zeebe-rdbms-integration-tests.yml
@@ -77,6 +77,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -95,6 +96,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -117,6 +119,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}

--- a/.github/workflows/zeebe-search-integration-tests.yml
+++ b/.github/workflows/zeebe-search-integration-tests.yml
@@ -46,6 +46,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -65,6 +66,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
@@ -88,6 +90,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write  # ci-database-integration-tests-reusable declares it (WIF); required at startup even though this caller leaves use-shared-distball=false
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}


### PR DESCRIPTION
## What

Part of #52693. Closes #54354.

`ci-database-integration-tests-reusable` and `ci-webapp-run-ut-reuseable` each run a full **~2 min `build-zeebe` reactor** purely to install the `io.camunda` SNAPSHOTs to `~/.m2` for their test reactor. The inline `rdbms-integration-tests` job in `ci.yml` does the same. Measured across CI runs:

| Consumer | Invocations/run | Reactor each | Compute/run |
|---|---|---|---|
| `ci-database-integration-tests-reusable` (database + history + identity ×5 DB) | ~15 | ~2.0m | ~30m |
| `ci-webapp-run-ut-reuseable` (operate/tasklist/optimize BE-UT) | 6 | ~2.0m | ~12m |
| `rdbms-integration-tests` (inline `ci.yml` job) | 1 | ~2.0m | ~2m |

**~44 gcp-perf runner-min/run** of redundant reactor builds that collapse to a ~seconds GCS restore of the `m2-installed.tar` **`build-distball` already produces**.

## How

- Both reusable workflows gain an optional `use-shared-distball` input. When **true** (set only by ci.yml, which has a `build-distball` job) they restore the shared m2 from GCS via WIF instead of `build-zeebe`. When **false** they fall back to `build-zeebe`.
- ci.yml: `build-distball.if` widened with `|| frontend-changes || rdbms-integration-tests`; database/history/identity + operate/tasklist/optimize-ci callers get `build-distball` in `needs` and pass `use-shared-distball: true`.
- **Inline `rdbms-integration-tests` job (ci.yml):** dropped its `build-zeebe`, now restores the shared m2 via `restore-shared-m2` from GCS + `setup-build` `gcs-build-cache-auth: true` + `id-token: write`; added `build-distball` to its `needs`. Its change-filter is a superset of `java-code-changes` (adds `rdbms-change`), so `build-distball.if` gained `|| rdbms-integration-tests` to guarantee the producer exists whenever this consumer runs. RDBMS ITs run in-process (no Docker image build) → only the m2 SNAPSHOTs are needed, not the distball tarball.
- `ci-operate/tasklist/optimize.yml` gain the input (default **false**, preserving their standalone `workflow_dispatch`) and forward it.
- `id-token: write` granted through every caller in the chain (were `permissions: { }`/none) so the WIF GCS auth isn't denied.

## Design notes

- **Composite actions:** the GCS auth + m2 restore are extracted into `gcs-build-cache-auth` + `restore-shared-m2` composite actions, shared by ci.yml and the reusables so producer + consumers stay in lockstep (no copy-paste drift).
- **Fallback is for real callers, not dispatch-on-the-reusable:** `ci-database-integration-tests-reusable` is also called by standalone `zeebe-rdbms`/`zeebe-search` workflows (no `build-distball`); `ci-operate/tasklist/optimize.yml` are directly `workflow_dispatch`-able. All default to `build-zeebe`. (The *inline* `rdbms-integration-tests` job, by contrast, lives in ci.yml and is never dispatched standalone → no fallback needed, so it consumes unconditionally.)
- **Transport = GCS** (self-hosted artifact-API cap), same as `build-distball`/`integration-tests`. `github.run_id` is stable across nested `workflow_call`, so the reusable workflow reads the same run-scoped prefix.
- **m2 compat:** database path uses the *identical* `-T1C -PskipFrontendBuild` as `build-distball`; webapp-UT uses `-Dquickly` (superset of installed SNAPSHOTs).
- `ci-webapp-client.yml` has **no `build-zeebe`** → out of scope.

## Measured savings (this PR alone)

All numbers are the compute this PR removes — dropping `build-zeebe` from the **22 consumers** (21 reusable-workflow invocations + the inline `rdbms-integration-tests` job) and replacing it with a GCS m2 restore. Independent of #54583's distball win (different redundant build; they stack).

> **Note:** the tables below were measured on runs that predate the inline `rdbms-integration-tests` migration (commit `f07dabd1d45`). rdbms adds one ~2.0m→0.2m gcp-perf-core-8 consumer on top — additive, confirmed green on the HEAD run (see Validation). The volume/$ figures below therefore slightly *under*-count.

**Headline (on-demand list price, measured volume):**

| Metric | Before | After | Saving |
|---|---:|---:|---:|
| Per consumer job | 2.16 min `build-zeebe` | 0.20 min GCS restore | ~11× faster |
| Per qualifying run (21 reusable consumers) | 45.3 runner-min | 4.2 runner-min | **~41 min/run (91%)** |
| Compute / month (real volume) | — | — | **~43,000 vCPU-hours** |
| **$ / month** (c2 on-demand ~$0.052/vCPU-hr) | — | — | **~$2,250** |
| **$ / year** | — | — | **~$27,000** |

**Cost breakdown by runner** (real job-run volume, BigQuery `ci-30-162810.prod_ci_analytics`, last 30 days, ci.yml-triggered `use-shared-distball=true` consumers only):

| Runner | Consumers | Job-runs/day | vCPU-hr/day saved | $/month (on-demand) |
|---|---|---:|---:|---:|
| gcp-perf-core-16 | database + identity ITs | ~1,685 | ~881 | ~$1,375 |
| gcp-perf-core-8 | history ITs + webapp BE-UT + rdbms IT | ~2,118 | ~554 | ~$865 |
| **Total** | | **~3,800** | **~1,435** | **~$2,250** |

**Sensitivity to price basis:**

| Basis | $/vCPU-hr | $/month |
|---|---|---:|
| On-demand list (c2/c3 compute-optimized) | $0.045–0.055 | ~$1,900–2,400 |
| Preemptible / spot (what `-default` actually is) | $0.013–0.020 | ~$550–900 |

Sources: baseline main run [`28579717371`](https://github.com/camunda/camunda/actions/runs/28579717371) vs green PR run [`28587933931`](https://github.com/camunda/camunda/actions/runs/28587933931) for per-job times; BigQuery for volume. The analytics table has no cost column, so $/vCPU-hr is an external assumption (GCP list pricing).

Producer cost is amortized: `build-distball` already runs for `docker-checks` + `integration-tests` on any java-change run, so on the common path this PR adds consumers to an artifact that already exists.

## Risk — both original concerns now verified green ✅

The two risks that kept this draft are resolved by a live CI run ([`28587933931`](https://github.com/camunda/camunda/actions/runs/28587933931), all commits):
1. **`-Dquickly` webapp-UT reactor resolves against the restored m2** — the 6 Operate/Tasklist/Optimize *Unit - Back End* jobs (DataLayer + CoreFeatures) all passed using the GCS-restored m2 (their `build-zeebe` skipped).
2. **`id-token` flows through the 2-level nested `workflow_call`** — the webapp-UT jobs completed the WIF auth + GCS restore, so the OIDC token propagates ci.yml → ci-operate/tasklist/optimize → ci-webapp-run-ut-reuseable.

A code review also caught and fixed three regressions (all verified on real CI):
- The database reusable callers needed `actions: write` granted (commit `9861854d58d`) — GitHub validates the nested-workflow permission contract at startup.
- The database reusable's `integration-tests` job now declares `id-token: write` unconditionally; the standalone `zeebe-rdbms-integration-tests` / `zeebe-search-integration-tests` callers were granting only `contents`+`actions` → would `startup_failure`. Fixed by granting `id-token: write` on those 6 caller jobs.
- `utils-cleanup-distball` only waited on `[build-distball, docker-checks, integration-tests]`; the new reusable + rdbms consumers pull m2 from the same run-scoped GCS prefix and could restore after cleanup deleted it. Fixed by adding them to `utils-cleanup-distball.needs`.

## Validation

- **ci.yml run [`28587933931`](https://github.com/camunda/camunda/actions/runs/28587933931): completed / success — 119 jobs passed, 30 skipped, 0 failures** (reusable-workflow sharing). Sample consumers restoring m2 from GCS (`Restore … from GCS` ran, `build-zeebe` skipped): [Database IT / RDBMS H2](https://github.com/camunda/camunda/actions/runs/28587933931/job/84766285479) · [Operate / Unit - Back End - Data Layer](https://github.com/camunda/camunda/actions/runs/28587933931/job/84766285695).
- **✅ Inline `rdbms-integration-tests` consumer** (commit `f07dabd1d45`) verified green on HEAD run [`28851333999`](https://github.com/camunda/camunda/actions/runs/28851333999): completed / success. The [RDBMS ITs job](https://github.com/camunda/camunda/actions/runs/28851333999/job/85568095401) ran `restore-shared-m2` (success) with **no `build-zeebe` step** — it consumes the m2 `build-distball` produced, exactly as the reusable consumers do.
- **Standalone [`zeebe-rdbms-integration-tests` `28587933627`](https://github.com/camunda/camunda/actions/runs/28587933627) and [`zeebe-search-integration-tests` `28587933573`](https://github.com/camunda/camunda/actions/runs/28587933573): success** — confirms the `id-token` startup fix and the `use-shared-distball=false` → `build-zeebe` fallback path (these workflows have no `build-distball` producer, so they build by design). Example fallback job (GCS steps skipped, `build-zeebe` ran): [RDBMS Identity Tests / MariaDB 11.8](https://github.com/camunda/camunda/actions/runs/28587933627/job/84767961053).
- actionlint: clean (only pre-existing custom self-hosted runner-label warnings).
- conftest (`--rego-version v0`, `.github` policies): 0 failures across all changed files.
