### PR TITLE
test: use out-of-range key for variable not-found test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/process-instance-get-api.spec.ts
@@ -85,7 +85,7 @@ test.describe.parallel('Get Process instance Tests', () => {
   });
 
   test('Get Process Instance - Not Found', async ({request}) => {
-    const unknownProcessInstanceKey = '2251799813694876';
+    const unknownProcessInstanceKey = '9999999999999999';
     const res = await request.get(
       buildUrl(`/process-instances/${unknownProcessInstanceKey}`),
       {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-assign-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-assign-api-tests.spec.ts
@@ -88,7 +88,7 @@ test.describe.parallel('Assign User Task Tests', () => {
   });
 
   test('Assign user task - not found', async ({request}) => {
-    const unknownUserTaskKey = '2251799813694876';
+    const unknownUserTaskKey = '9999999999999999';
     const res = await request.post(
       buildUrl(`/user-tasks/${unknownUserTaskKey}/assignment`),
       {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-complete-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-complete-api-tests.spec.ts
@@ -94,7 +94,7 @@ test.describe.parallel('Complete User Task Tests', () => {
   });
 
   test('Complete user task - not found', async ({request}) => {
-    const unknownUserTaskKey = '2251799813694876';
+    const unknownUserTaskKey = '9999999999999999';
     const res = await completeUserTask(request, unknownUserTaskKey, {});
     await assertNotFoundRequest(
       res,

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-get-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-get-api-tests.spec.ts
@@ -49,7 +49,7 @@ test.describe.parallel('Get User Task Tests', () => {
   });
 
   test('Get user task - not found', async ({request}) => {
-    const unknownUserTaskKey = '2251799813694876';
+    const unknownUserTaskKey = '9999999999999999';
     const res = await request.get(
       buildUrl(`/user-tasks/${unknownUserTaskKey}`),
       {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-unassign-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-unassign-api-tests.spec.ts
@@ -80,7 +80,7 @@ test.describe.parallel('Unassign User Task Tests', () => {
   });
 
   test('Unassign user task - not found', async ({request}) => {
-    const unknownUserTaskKey = '2251799813694876';
+    const unknownUserTaskKey = '9999999999999999';
     const res = await request.delete(
       buildUrl(`/user-tasks/${unknownUserTaskKey}/assignee`),
       {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-update-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-update-api-tests.spec.ts
@@ -354,7 +354,7 @@ test.describe.parallel('Update User Task Tests', () => {
   });
 
   test('Update user task - not found', async ({request}) => {
-    const unknownUserTaskKey = '2251799813694876';
+    const unknownUserTaskKey = '9999999999999999';
     const res = await request.patch(
       buildUrl(`/user-tasks/${unknownUserTaskKey}`),
       {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-get-api.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-get-api.spec.ts
@@ -61,7 +61,7 @@ test.describe.parallel('Get Variable API Tests', () => {
   });
 
   test('Get Variable Not Found', async ({request}) => {
-    const unknownVariableKey = '2251799813694876';
+    const unknownVariableKey = '9999999999999999';
     const res = await request.get(
       buildUrl(`/variables/${unknownVariableKey}`),
       {


### PR DESCRIPTION
## What

`Get Variable Not Found` in `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/variable/variable-get-api.spec.ts` hardcoded a "nonexistent" variable key (`2251799813694876`) that is only ~9,628 sequence numbers past Zeebe's partition-1 base key (`2251799813685248`).

## Why

In a shared-cluster nightly run (observed in the `main` RDBMS `all-in-one` nightly), enough variables/entities are created by the ~1000+ preceding tests that the key sequence counter reaches into that range, so a real variable ends up with this exact key. The test then asserts `404` but receives `200`, since the "unknown" key is no longer unknown.

This is a test-data isolation bug, not a product regression — the assertion itself relied on an assumption (this key will never exist) that doesn't hold in a long-running shared-cluster suite.

## Fix

Switch to an out-of-range key (`9999999999999999`), matching the convention already used by sibling not-found tests in this suite (e.g. `decision-requirements-get-json-api.spec.ts`, `element-instance-get-api.spec.ts`).

## Context

- Failing run: https://github.com/camunda/camunda/actions/runs/28584107643/job/84752337724
- Failure: `Get Variable API Tests > Get Variable Not Found` — `expect(received).toBe(expected) // Expected: 404, Received: 200`

Closes: N/A (no tracking issue filed — isolated test-data flakiness, not a product bug)