### PR TITLE
fix: scope ISM policy names to test run and limit cleanup to owned policies

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -49,6 +49,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.agrona.CloseHelper;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,6 +76,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
   protected CamundaExporterMetrics exporterMetrics;
   protected ExecutorService executor;
   protected Context context;
+  private String testPrefix;
 
   private final List<AutoCloseable> resourcesToClose = new ArrayList<>();
   private LifecyclePolicyNameVerifier lifecyclePolicyNameVerifier;
@@ -86,6 +88,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
     exporterMetrics = new CamundaExporterMetrics(context.getMeterRegistry());
     executor = Executors.newSingleThreadExecutor();
     lifecyclePolicyNameVerifier = new LifecyclePolicyNameVerifier();
+    testPrefix = RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
   }
 
   @AfterEach
@@ -125,6 +128,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
   void withArchiverJob(final ExporterConfiguration config, final ArchiveJobConsumer<T> jobConsumer)
       throws Exception {
     config.getHistory().getRetention().setEnabled(true);
+    config.getHistory().getRetention().setPolicyName(testPrefix + "-camunda-retention-policy");
     config.getIndex().setNumberOfShards(3);
     createSchemas(config);
 
@@ -240,7 +244,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
   }
 
   protected String getExpectedLifecyclePolicyName() {
-    return "camunda-retention-policy";
+    return testPrefix + "-camunda-retention-policy";
   }
 
   private ExporterResourceProvider exporterResourceProvider(final ExporterConfiguration config) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -58,7 +58,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hc.core5.http.HttpHost;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -107,11 +106,12 @@ final class OpenSearchArchiverRepositoryIT {
   private final RetentionConfiguration retention = new RetentionConfiguration();
   private final OpenSearchClient testClient = createOpenSearchClient();
   @AutoClose private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+  private final String testUniqueId = UUID.randomUUID().toString();
   private final String zeebeIndexPrefix = "zeebe-record";
-  private final String zeebeIndex = zeebeIndexPrefix + "-" + UUID.randomUUID();
+  private final String zeebeIndex = zeebeIndexPrefix + "-" + testUniqueId;
 
   private TestExporterResourceProvider resourceProvider;
-  private String testPrefix;
   private HistoryConfiguration config;
   private String processInstanceIndex;
   private String batchOperationIndex;
@@ -126,15 +126,14 @@ final class OpenSearchArchiverRepositoryIT {
 
   @BeforeEach
   void beforeEach() {
-    testPrefix = RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
     config = new HistoryConfiguration();
 
     // Scope policy names to this test run so cleanup doesn't affect other tests
-    retention.setPolicyName(testPrefix + "-default-policy");
-    retention.setUsageMetricsPolicyName(testPrefix + "-usage-metrics-policy");
+    retention.setPolicyName(testUniqueId + "-default-policy");
+    retention.setUsageMetricsPolicyName(testUniqueId + "-usage-metrics-policy");
     config.setRetention(retention);
 
-    resourceProvider = new TestExporterResourceProvider(testPrefix, false);
+    resourceProvider = new TestExporterResourceProvider(testUniqueId, false);
     processInstanceIndex =
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName();
     batchOperationIndex =
@@ -358,7 +357,7 @@ final class OpenSearchArchiverRepositoryIT {
       disabledReason = "Excluding from AWS OS IT CI - policy modification not allowed")
   void shouldSetIndexLifeCycleOnAllValidIndexes(final boolean withPrefix) throws IOException {
     // given
-    final var prefix = withPrefix ? testPrefix : "";
+    final var prefix = withPrefix ? testUniqueId : "";
     resourceProvider = new TestExporterResourceProvider(prefix, true);
     processInstanceIndex =
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName();
@@ -396,10 +395,10 @@ final class OpenSearchArchiverRepositoryIT {
     indices.addAll(untouchedIndices);
 
     final String customPolicyName =
-        withPrefix ? testPrefix + "-custom-default-policy" : "custom-default-policy";
+        withPrefix ? testUniqueId + "-custom-default-policy" : "custom-default-policy";
 
     final String customUsageMetricsPolicyName =
-        withPrefix ? testPrefix + "-custom-usage-metrics-policy" : "custom-usage-metrics-policy";
+        withPrefix ? testUniqueId + "-custom-usage-metrics-policy" : "custom-usage-metrics-policy";
 
     retention.setEnabled(true);
     retention.setPolicyName(customPolicyName);
@@ -1684,7 +1683,7 @@ final class OpenSearchArchiverRepositoryIT {
   private void startupSchema() {
     final var searchEngineClient = new OpensearchEngineClient(testClient, MAPPER);
     final var connectConfig = new ConnectConfiguration();
-    connectConfig.setIndexPrefix(testPrefix);
+    connectConfig.setIndexPrefix(testUniqueId);
     connectConfig.setUrl(SEARCH_DB.esUrl());
     connectConfig.setType(DatabaseType.OPENSEARCH.toString());
     final var schemaManagerConfig = new SchemaManagerConfiguration();
@@ -2020,7 +2019,7 @@ final class OpenSearchArchiverRepositoryIT {
               .indices()
               .get(
                   g ->
-                      g.index(testPrefix + "*", zeebeIndexPrefix + "*", ARCHIVER_IDX_PREFIX + "*")
+                      g.index(testUniqueId + "*", zeebeIndexPrefix + "*", ARCHIVER_IDX_PREFIX + "*")
                           .ignoreUnavailable(true)
                           .allowNoIndices(true))
               .result()
@@ -2062,7 +2061,7 @@ final class OpenSearchArchiverRepositoryIT {
           final var policyId = policy.get("_id");
           if (policyId != null) {
             final var policyName = policyId.asText();
-            if (!policyName.startsWith(testPrefix)) {
+            if (!policyName.startsWith(testUniqueId)) {
               continue;
             }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -100,20 +100,22 @@ final class OpenSearchArchiverRepositoryIT {
       LoggerFactory.getLogger(OpenSearchArchiverRepositoryIT.class);
   @RegisterExtension private static final SearchDBExtension SEARCH_DB = create();
   private static final ObjectMapper MAPPER = TestObjectMapper.objectMapper();
+
   @AutoClose private final OpenSearchTransport transport = createTransport();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final ConnectConfiguration connectConfiguration = new ConnectConfiguration();
   private final RetentionConfiguration retention = new RetentionConfiguration();
+  private final OpenSearchClient testClient = createOpenSearchClient();
+  @AutoClose private final ExecutorService executor = Executors.newSingleThreadExecutor();
+  private final String zeebeIndexPrefix = "zeebe-record";
+  private final String zeebeIndex = zeebeIndexPrefix + "-" + UUID.randomUUID();
+
+  private TestExporterResourceProvider resourceProvider;
+  private String testPrefix;
   private HistoryConfiguration config;
   private String processInstanceIndex;
   private String batchOperationIndex;
   private String auditLogIndex;
-  private final OpenSearchClient testClient = createOpenSearchClient();
-  private final String zeebeIndexPrefix = "zeebe-record";
-  private final String zeebeIndex = zeebeIndexPrefix + "-" + UUID.randomUUID();
-  private TestExporterResourceProvider resourceProvider;
-  private String indexPrefix;
-  @AutoClose private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
   @AfterEach
   void afterEach() {
@@ -124,10 +126,15 @@ final class OpenSearchArchiverRepositoryIT {
 
   @BeforeEach
   void beforeEach() {
+    testPrefix = RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
     config = new HistoryConfiguration();
+
+    // Scope policy names to this test run so cleanup doesn't affect other tests
+    retention.setPolicyName(testPrefix + "-default-policy");
+    retention.setUsageMetricsPolicyName(testPrefix + "-usage-metrics-policy");
     config.setRetention(retention);
-    indexPrefix = RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
-    resourceProvider = new TestExporterResourceProvider(indexPrefix, false);
+
+    resourceProvider = new TestExporterResourceProvider(testPrefix, false);
     processInstanceIndex =
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName();
     batchOperationIndex =
@@ -351,7 +358,7 @@ final class OpenSearchArchiverRepositoryIT {
       disabledReason = "Excluding from AWS OS IT CI - policy modification not allowed")
   void shouldSetIndexLifeCycleOnAllValidIndexes(final boolean withPrefix) throws IOException {
     // given
-    final var prefix = withPrefix ? indexPrefix : "";
+    final var prefix = withPrefix ? testPrefix : "";
     resourceProvider = new TestExporterResourceProvider(prefix, true);
     processInstanceIndex =
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class).getFullQualifiedName();
@@ -388,9 +395,15 @@ final class OpenSearchArchiverRepositoryIT {
     indices.addAll(usageMetricsIndices);
     indices.addAll(untouchedIndices);
 
+    final String customPolicyName =
+        withPrefix ? testPrefix + "-custom-default-policy" : "custom-default-policy";
+
+    final String customUsageMetricsPolicyName =
+        withPrefix ? testPrefix + "-custom-usage-metrics-policy" : "custom-usage-metrics-policy";
+
     retention.setEnabled(true);
-    retention.setPolicyName("default-policy");
-    retention.setUsageMetricsPolicyName("custom-usage-metrics-policy");
+    retention.setPolicyName(customPolicyName);
+    retention.setUsageMetricsPolicyName(customUsageMetricsPolicyName);
 
     createLifeCyclePolicies();
     for (final var index : indices) {
@@ -405,16 +418,16 @@ final class OpenSearchArchiverRepositoryIT {
     // verify that the usage metrics policy was applied to all usage metric indices
     for (final var index : usageMetricsIndices) {
       assertThat(fetchPolicyForIndexWithAwait(index))
-          .as("Expected 'custom-usage-metrics-policy' policy to be applied for %s", index)
+          .as("Expected '%s' policy to be applied for %s", customUsageMetricsPolicyName, index)
           .isNotNull()
-          .isEqualTo("custom-usage-metrics-policy");
+          .isEqualTo(customUsageMetricsPolicyName);
     }
     // verify that the default policy was applied to all other indices
     for (final var index : historicalIndices) {
       assertThat(fetchPolicyForIndexWithAwait(index))
-          .as("Expected 'default-policy' policy to be applied for %s", index)
+          .as("Expected '%s' policy to be applied for %s", customPolicyName, index)
           .isNotNull()
-          .isEqualTo("default-policy");
+          .isEqualTo(customPolicyName);
     }
 
     for (final var index : untouchedIndices) {
@@ -1671,7 +1684,7 @@ final class OpenSearchArchiverRepositoryIT {
   private void startupSchema() {
     final var searchEngineClient = new OpensearchEngineClient(testClient, MAPPER);
     final var connectConfig = new ConnectConfiguration();
-    connectConfig.setIndexPrefix(indexPrefix);
+    connectConfig.setIndexPrefix(testPrefix);
     connectConfig.setUrl(SEARCH_DB.esUrl());
     connectConfig.setType(DatabaseType.OPENSEARCH.toString());
     final var schemaManagerConfig = new SchemaManagerConfiguration();
@@ -1997,8 +2010,8 @@ final class OpenSearchArchiverRepositoryIT {
 
   private void deleteTestIndices() {
     // Delete only indices that were created by this test class. Criteria:
-    //  - start with dynamic indexPrefix (runtime & historical indices created via templates)
-    //  - start with zeebeIndexPrefix (simulated existing zeebe indices used in tests)
+    //  - start with dynamic testPrefix (runtime & historical indices created via templates)
+    //  - start with ZEEBE_INDEX_PREFIX (simulated existing zeebe indices used in tests)
     //  - start with ARCHIVER_IDX_PREFIX (ad‑hoc indices for generic operations tests)
     final var indicesToDelete = new ArrayList<String>();
     try {
@@ -2007,7 +2020,7 @@ final class OpenSearchArchiverRepositoryIT {
               .indices()
               .get(
                   g ->
-                      g.index(indexPrefix + "*", zeebeIndexPrefix + "*", ARCHIVER_IDX_PREFIX + "*")
+                      g.index(testPrefix + "*", zeebeIndexPrefix + "*", ARCHIVER_IDX_PREFIX + "*")
                           .ignoreUnavailable(true)
                           .allowNoIndices(true))
               .result()
@@ -2042,13 +2055,17 @@ final class OpenSearchArchiverRepositoryIT {
       final var jsonString = listResponse.getBody().orElseThrow().bodyAsString();
       final var json = MAPPER.readTree(jsonString);
 
-      // Extract policy names and delete each one
+      // Extract policy names and delete each one that start with the test prefix
       final var policies = json.get("policies");
       if (policies != null && policies.isArray()) {
         for (final var policy : policies) {
           final var policyId = policy.get("_id");
           if (policyId != null) {
             final var policyName = policyId.asText();
+            if (!policyName.startsWith(testPrefix)) {
+              continue;
+            }
+
             try {
               final var deleteRequest =
                   Requests.builder()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR aims at solving the problem where a policy is being deleted by test X while being used by test Y (race condition). NOTE: There are other, different errors. Those will be tackled in different PRs.

Sample log:
```
[INFO] Running io.camunda.exporter.tasks.archiver.OpensearchAuditLogArchiverRepositoryIT
[INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.83 s -- in io.camunda.exporter.tasks.archiver.OpensearchAuditLogArchiverRepositoryIT
```

Main run:
https://github.com/camunda/camunda/actions/runs/28663394716

Job run:
https://github.com/camunda/camunda/actions/runs/28663394716/job/85009361282

In general, the string "Failed to add" does not appear in the logs at all, so it seems like it worked fine.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
