### PR TITLE
feat: mark legacy JOB_ACTIVATABLE CF as drained to skip Phase 2

### DIFF
--- a/zeebe/engine/spotbugs/spotbugs-exclude.xml
+++ b/zeebe/engine/spotbugs/spotbugs-exclude.xml
@@ -15,4 +15,8 @@
     <Class name="io.camunda.zeebe.engine.processing.scheduled.DueDateCheckScheduler"/>
     <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
   </Match>
+  <Match>
+    <Class name="io.camunda.zeebe.engine.state.instance.DbJobState"/>
+    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
+  </Match>
 </FindBugsFilter>

--- a/zeebe/engine/spotbugs/spotbugs-exclude.xml
+++ b/zeebe/engine/spotbugs/spotbugs-exclude.xml
@@ -15,8 +15,4 @@
     <Class name="io.camunda.zeebe.engine.processing.scheduled.DueDateCheckScheduler"/>
     <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
   </Match>
-  <Match>
-    <Class name="io.camunda.zeebe.engine.state.instance.DbJobState"/>
-    <Bug pattern="AT_STALE_THREAD_WRITE_OF_PRIMITIVE"/>
-  </Match>
 </FindBugsFilter>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.util.EnsureUtil;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -91,6 +92,9 @@ public final class DbJobState implements JobState, MutableJobState {
   private final ColumnFamily<DbCompositeKey<DbLong, DbForeignKey<DbLong>>, DbNil>
       backoffColumnFamily;
   private long nextBackOffDueDate;
+
+  // In-memory, per-partition memory that the legacy JOB_ACTIVATABLE CF is globally drained.
+  private boolean legacyCfDrained = false;
 
   public DbJobState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -562,7 +566,7 @@ public final class DbJobState implements JobState, MutableJobState {
     // Each phase returns true if the batch still wants more jobs. Subsequent phases are skipped
     // when the batch is full to avoid redundant state reads.
     if (visitHighPriorityJobs(tenantIds, callback)
-        && visitLegacyActivatableJobs(tenantIds, callback)) {
+        && (legacyCfDrained || visitLegacyActivatableJobs(tenantIds, callback))) {
       visitNonPositivePriorityJobs(tenantIds, callback);
     }
   }
@@ -654,14 +658,22 @@ public final class DbJobState implements JobState, MutableJobState {
    * <p>The {@code deleteIfExists} call in {@link #makeJobNotActivatable} ensures that a legacy job
    * is removed from this CF the first time it is deactivated after the upgrade.
    *
+   * <p>If this type's prefix yields no entries, a global emptiness check is performed. The check
+   * uses a tenant-agnostic {@link ColumnFamily#isEmpty()} seek run <b>after</b> the prefix scan
+   * returns. If the CF is empty for every type and tenant, {@link #legacyCfDrained} is set so
+   * subsequent activations skip this phase entirely. A per-type empty result alone must never set
+   * the flag:
+   *
    * @return {@code true} if the batch still wants more jobs; {@code false} if the batch is full
    */
   private boolean visitLegacyActivatableJobs(
       final List<String> tenantIds, final BiFunction<Long, JobRecord, Boolean> callback) {
     final var batchNotFull = new boolean[] {true};
+    final var visitedAny = new boolean[] {false};
     activatableColumnFamily.whileEqualPrefix(
         jobTypeKey,
         entry -> {
+          visitedAny[0] = true; // an entry exists for this type prefix => CF is not globally empty
           if (!tenantIds.contains(entry.tenantKey().toString())) {
             return true;
           }
@@ -669,6 +681,20 @@ public final class DbJobState implements JobState, MutableJobState {
               visitJob(entry.wrappedKey().second().inner().getValue(), callback::apply);
           return batchNotFull[0];
         });
+    // Global confirmation runs AFTER the prefix scan returns. Only worth checking when this type
+    // yielded nothing; isEmpty() is the authoritative global gate.
+    if (batchNotFull[0] && !visitedAny[0]) {
+      // isEmpty() scans the whole CF regardless of type, and its visitor wraps the shared
+      // jobTypeKey field with the first entry it finds (of any type) before reporting non-empty.
+      // Phase 3 (visitNonPositivePriorityJobs) relies on jobTypeKey still holding the type
+      // queried by this call, so it must be restored before returning.
+      final DirectBuffer queriedType = BufferUtil.cloneBuffer(jobTypeKey.getBuffer());
+      final boolean globallyEmpty = activatableColumnFamily.isEmpty();
+      jobTypeKey.wrapBuffer(queriedType);
+      if (globallyEmpty) {
+        legacyCfDrained = true;
+      }
+    }
     return batchNotFull[0];
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.util.EnsureUtil;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -60,7 +59,7 @@ public final class DbJobState implements JobState, MutableJobState {
       tenantAwareTypeJobKey;
   private final ColumnFamily<
           DbTenantAwareKey<DbCompositeKey<DbString, DbForeignKey<DbLong>>>, DbNil>
-      activatableColumnFamily;
+      deprecatedActivatableColumnFamily;
 
   // invertedPriority = Integer.MAX_VALUE - priority so higher-priority entries sort first
   // under RocksDB's unsigned byte comparator. For negative priorities the subtraction
@@ -93,8 +92,8 @@ public final class DbJobState implements JobState, MutableJobState {
       backoffColumnFamily;
   private long nextBackOffDueDate;
 
-  // In-memory, per-partition memory that the legacy JOB_ACTIVATABLE CF is globally drained.
-  private boolean legacyCfDrained = false;
+  /** In-memory, per-partition memory that the legacy JOB_ACTIVATABLE CF is globally drained. */
+  private boolean isLegacyCfDrained = false;
 
   public DbJobState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -113,7 +112,7 @@ public final class DbJobState implements JobState, MutableJobState {
     tenantIdKey = new DbString();
     typeJobKey = new DbCompositeKey<>(jobTypeKey, fkJob);
     tenantAwareTypeJobKey = new DbTenantAwareKey<>(tenantIdKey, typeJobKey, PlacementType.SUFFIX);
-    activatableColumnFamily =
+    deprecatedActivatableColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.JOB_ACTIVATABLE,
             transactionContext,
@@ -566,7 +565,7 @@ public final class DbJobState implements JobState, MutableJobState {
     // Each phase returns true if the batch still wants more jobs. Subsequent phases are skipped
     // when the batch is full to avoid redundant state reads.
     if (visitHighPriorityJobs(tenantIds, callback)
-        && (legacyCfDrained || visitLegacyActivatableJobs(tenantIds, callback))) {
+        && (isLegacyCfDrained || visitLegacyActivatableJobs(type, tenantIds, callback))) {
       visitNonPositivePriorityJobs(tenantIds, callback);
     }
   }
@@ -660,17 +659,19 @@ public final class DbJobState implements JobState, MutableJobState {
    *
    * <p>If this type's prefix yields no entries, a global emptiness check is performed. The check
    * uses a tenant-agnostic {@link ColumnFamily#isEmpty()} seek run <b>after</b> the prefix scan
-   * returns. If the CF is empty for every type and tenant, {@link #legacyCfDrained} is set so
+   * returns. If the CF is empty for every type and tenant, {@link #isLegacyCfDrained} is set so
    * subsequent activations skip this phase entirely. A per-type empty result alone must never set
-   * the flag:
+   * the flag.
    *
    * @return {@code true} if the batch still wants more jobs; {@code false} if the batch is full
    */
   private boolean visitLegacyActivatableJobs(
-      final List<String> tenantIds, final BiFunction<Long, JobRecord, Boolean> callback) {
+      final DirectBuffer type,
+      final List<String> tenantIds,
+      final BiFunction<Long, JobRecord, Boolean> callback) {
     final var batchNotFull = new boolean[] {true};
     final var visitedAny = new boolean[] {false};
-    activatableColumnFamily.whileEqualPrefix(
+    deprecatedActivatableColumnFamily.whileEqualPrefix(
         jobTypeKey,
         entry -> {
           visitedAny[0] = true; // an entry exists for this type prefix => CF is not globally empty
@@ -681,18 +682,17 @@ public final class DbJobState implements JobState, MutableJobState {
               visitJob(entry.wrappedKey().second().inner().getValue(), callback::apply);
           return batchNotFull[0];
         });
-    // Global confirmation runs AFTER the prefix scan returns. Only worth checking when this type
-    // yielded nothing; isEmpty() is the authoritative global gate.
+    // Only worth checking globally when this type's own prefix was empty; isEmpty() is the
+    // authoritative global gate.
     if (!visitedAny[0]) {
-      // isEmpty() scans the whole CF regardless of type, and its visitor wraps the shared
-      // jobTypeKey field with the first entry it finds (of any type) before reporting non-empty.
-      // Phase 3 (visitNonPositivePriorityJobs) relies on jobTypeKey still holding the type
-      // queried by this call, so it must be restored before returning.
-      final DirectBuffer queriedType = BufferUtil.cloneBuffer(jobTypeKey.getBuffer());
-      final boolean globallyEmpty = activatableColumnFamily.isEmpty();
-      jobTypeKey.wrapBuffer(queriedType);
-      if (globallyEmpty) {
-        legacyCfDrained = true;
+      // isEmpty() finds the first entry in the whole CF regardless of type, and its visitor
+      // wraps the shared jobTypeKey field with that entry before reporting non-empty. Phase 3
+      // (visitNonPositivePriorityJobs) relies on jobTypeKey still holding the type queried by
+      // this call, so it must be restored from the caller's untouched buffer before returning.
+      final boolean isGloballyEmpty = deprecatedActivatableColumnFamily.isEmpty();
+      jobTypeKey.wrapBuffer(type);
+      if (isGloballyEmpty) {
+        isLegacyCfDrained = true;
       }
     }
     return batchNotFull[0];
@@ -774,7 +774,7 @@ public final class DbJobState implements JobState, MutableJobState {
     jobKey.wrapLong(key);
     tenantIdKey.wrapString(tenantId);
     // upsert because a failed job with retries can be made activatable multiple times
-    activatableColumnFamily.upsert(tenantAwareTypeJobKey, DbNil.INSTANCE);
+    deprecatedActivatableColumnFamily.upsert(tenantAwareTypeJobKey, DbNil.INSTANCE);
   }
 
   private void makeJobNotActivatable(
@@ -791,7 +791,7 @@ public final class DbJobState implements JobState, MutableJobState {
     priorityActivatableColumnFamily.deleteIfExists(tenantAwarePriorityKey);
     // Legacy CF cleanup: pre-8.10 jobs live in JOB_ACTIVATABLE; deleteIfExists is a no-op
     // when the key is absent. Do not remove this line!
-    activatableColumnFamily.deleteIfExists(tenantAwareTypeJobKey);
+    deprecatedActivatableColumnFamily.deleteIfExists(tenantAwareTypeJobKey);
   }
 
   private void addJobDeadline(final long job, final long deadline) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -683,7 +683,7 @@ public final class DbJobState implements JobState, MutableJobState {
         });
     // Global confirmation runs AFTER the prefix scan returns. Only worth checking when this type
     // yielded nothing; isEmpty() is the authoritative global gate.
-    if (batchNotFull[0] && !visitedAny[0]) {
+    if (!visitedAny[0]) {
       // isEmpty() scans the whole CF regardless of type, and its visitor wraps the shared
       // jobTypeKey field with the first entry it finds (of any type) before reporting non-empty.
       // Phase 3 (visitNonPositivePriorityJobs) relies on jobTypeKey still holding the type

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -93,7 +93,7 @@ public final class DbJobState implements JobState, MutableJobState {
   private long nextBackOffDueDate;
 
   /** In-memory, per-partition memory that the legacy JOB_ACTIVATABLE CF is globally drained. */
-  private boolean isLegacyCfDrained = false;
+  private volatile boolean isLegacyCfDrained = false;
 
   public DbJobState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
@@ -77,7 +77,7 @@ final class DbJobStateLegacyDrainTest {
   }
 
   @Test
-  void shouldNotSetFlagWhenAnotherTypeStillHasLegacyJobs() {
+  void shouldStillFindLegacyJobWhenAnotherTypeKeepsCfNonEmpty() {
     // given
     final DirectBuffer typeA = wrapString("type-a");
     final DirectBuffer typeB = wrapString("type-b");
@@ -93,7 +93,7 @@ final class DbJobStateLegacyDrainTest {
   }
 
   @Test
-  void shouldSetFlagOnceLegacyCfGloballyEmptyAndSkipPhase2Afterwards() {
+  void shouldSkipPhase2OnceLegacyCfIsGloballyEmpty() {
     // given: legacy CF is empty from the start
     final DirectBuffer type = wrapString("type-a");
     assertThat(activatableKeys(type)).isEmpty(); // flips the flag

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.instance;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbForeignKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.ArrayList;
+import java.util.List;
+import org.agrona.DirectBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class DbJobStateLegacyDrainTest {
+
+  private static final String TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+
+  private ZeebeDb<ZbColumnFamilies> zeebeDb;
+  private TransactionContext transactionContext;
+  private MutableProcessingState processingState;
+
+  private MutableJobState jobState;
+
+  private DbLong seedJobKey;
+  private ColumnFamily<DbLong, JobRecordValue> seedJobsColumnFamily;
+  private DbString seedJobTypeKey;
+  private DbString seedTenantIdKey;
+  private DbTenantAwareKey<DbCompositeKey<DbString, DbForeignKey<DbLong>>>
+      seedTenantAwareTypeJobKey;
+  private ColumnFamily<DbTenantAwareKey<DbCompositeKey<DbString, DbForeignKey<DbLong>>>, DbNil>
+      legacyColumnFamily;
+
+  @BeforeEach
+  void setUp() {
+    jobState = processingState.getJobState();
+
+    seedJobKey = new DbLong();
+    final var seedFkJob = new DbForeignKey<>(seedJobKey, ZbColumnFamilies.JOBS);
+    seedJobsColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.JOBS, transactionContext, seedJobKey, new JobRecordValue());
+
+    seedJobTypeKey = new DbString();
+    seedTenantIdKey = new DbString();
+    final var seedTypeJobKey = new DbCompositeKey<>(seedJobTypeKey, seedFkJob);
+    seedTenantAwareTypeJobKey =
+        new DbTenantAwareKey<>(seedTenantIdKey, seedTypeJobKey, PlacementType.SUFFIX);
+    legacyColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.JOB_ACTIVATABLE,
+            transactionContext,
+            seedTenantAwareTypeJobKey,
+            DbNil.INSTANCE);
+  }
+
+  @Test
+  void shouldNotSetFlagWhenAnotherTypeStillHasLegacyJobs() {
+    // given
+    final DirectBuffer typeA = wrapString("type-a");
+    final DirectBuffer typeB = wrapString("type-b");
+    seedLegacyJob(1L, typeB, TENANT);
+
+    // when: type A's own legacy scan is empty, but the CF is not globally empty (type B remains)
+    assertThat(activatableKeys(typeA)).isEmpty();
+
+    // then: the flag must not have been set — a legacy job seeded for type A afterwards is still
+    // found on the next activation
+    seedLegacyJob(2L, typeA, TENANT);
+    assertThat(activatableKeys(typeA)).containsExactly(2L);
+  }
+
+  @Test
+  void shouldSetFlagOnceLegacyCfGloballyEmptyAndSkipPhase2Afterwards() {
+    // given: legacy CF is empty from the start
+    final DirectBuffer type = wrapString("type-a");
+    assertThat(activatableKeys(type)).isEmpty(); // flips the flag
+
+    // when: a legacy job is seeded directly afterwards (simulating a leftover legacy entry)
+    seedLegacyJob(1L, type, TENANT);
+
+    // then: it is not returned, because Phase 2 is now skipped
+    assertThat(activatableKeys(type)).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyOnFreshClusterWithNoLegacyJobs() {
+    // given
+    final DirectBuffer type = wrapString("type-a");
+
+    // when
+    final List<Long> keys = activatableKeys(type);
+
+    // then
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void shouldPreserveActivationOrderAcrossPhases() {
+    // given
+    final DirectBuffer type = wrapString("type-a");
+    // legacy (pre-8.10) jobs: implicit priority = 0, ordered by job key ascending
+    seedLegacyJob(1L, type, TENANT);
+    seedLegacyJob(2L, type, TENANT);
+    // new jobs with priority > 0
+    createActivatableJob(11L, type, 10);
+    createActivatableJob(10L, type, 5);
+    // new jobs with priority <= 0
+    createActivatableJob(20L, type, 0);
+    createActivatableJob(21L, type, -5);
+
+    // when
+    final List<Long> keys = activatableKeys(type);
+
+    // then: priority > 0 (desc) -> legacy (jobKey asc) -> priority <= 0 (desc)
+    assertThat(keys).containsExactly(11L, 10L, 1L, 2L, 20L, 21L);
+  }
+
+  @Test
+  void shouldNotEnterPhase2WhenPhase1FillsTheBatch() {
+    // given: a priority>0 job (Phase 1) and a legacy job (Phase 2) for the same type
+    final DirectBuffer type = wrapString("type-a");
+    createActivatableJob(10L, type, 5);
+    seedLegacyJob(1L, type, TENANT);
+
+    // when: the callback reports the batch full on the very first (Phase 1) job,
+    // short-circuiting Phase 2 entirely
+    assertThat(activatableKeys(type, 1)).containsExactly(10L);
+
+    // then: the flag was not set by the short-circuited call, so Phase 2 still runs on the next,
+    // unrestricted call and finds the legacy job
+    assertThat(activatableKeys(type)).containsExactly(10L, 1L);
+  }
+
+  @Test
+  void shouldNotSetFlagWhenLegacyJobExistsForSameTypeButDifferentTenant() {
+    // given: a legacy job of the queried type but a tenant outside the queried tenant list
+    final DirectBuffer type = wrapString("type-a");
+    final String otherTenant = "other-tenant";
+    seedLegacyJob(1L, type, otherTenant);
+
+    // when: querying only TENANT finds nothing, because the entry belongs to another tenant
+    assertThat(activatableKeys(type)).isEmpty();
+
+    // then: the flag must not have been set — a legacy job seeded for the queried tenant
+    // afterwards is still found
+    seedLegacyJob(2L, type, TENANT);
+    assertThat(activatableKeys(type)).containsExactly(2L);
+  }
+
+  @Test
+  void shouldResetFlagOnRestart() {
+    // given: drain the flag on the original state instance
+    final DirectBuffer type = wrapString("type-a");
+    assertThat(activatableKeys(type)).isEmpty();
+    seedLegacyJob(1L, type, TENANT);
+    assertThat(activatableKeys(type)).isEmpty(); // Phase 2 skipped: flag was set
+
+    // when: a fresh DbJobState instance is constructed over the same database (restart)
+    final var restarted = new DbJobState(zeebeDb, transactionContext);
+
+    // then: the new instance starts undrained and finds the leftover legacy job
+    assertThat(activatableKeys(restarted, type)).containsExactly(1L);
+  }
+
+  private void createActivatableJob(final long key, final DirectBuffer type, final int priority) {
+    final JobRecord record =
+        new JobRecord().setType(type).setTenantId(TENANT).setPriority(priority).setRetries(1);
+    jobState.create(key, record);
+  }
+
+  private void seedLegacyJob(final long key, final DirectBuffer type, final String tenantId) {
+    final JobRecord record = new JobRecord().setType(type).setTenantId(tenantId).setRetries(1);
+    final var value = new JobRecordValue();
+    value.setRecordWithoutVariables(record);
+    seedJobKey.wrapLong(key);
+    seedJobsColumnFamily.insert(seedJobKey, value);
+
+    seedJobTypeKey.wrapBuffer(type);
+    seedTenantIdKey.wrapString(tenantId);
+    legacyColumnFamily.insert(seedTenantAwareTypeJobKey, DbNil.INSTANCE);
+  }
+
+  // Unlimited batch: all three phases run. Used by most tests.
+  private List<Long> activatableKeys(final DirectBuffer type) {
+    return activatableKeys(jobState, type, Integer.MAX_VALUE);
+  }
+
+  // Batch-limited: simulates a worker whose batch fills after maxResults jobs.
+  // Returning false from the callback short-circuits Phase 2 (legacy CF) and Phase 3,
+  // because each phase gate checks whether the previous phase left the batch not full.
+  private List<Long> activatableKeys(final DirectBuffer type, final int maxResults) {
+    return activatableKeys(jobState, type, maxResults);
+  }
+
+  // Targets an explicit state instance — needed when testing a simulated restart,
+  // where the in-memory legacyCfDrained flag is reset to its initial false value.
+  private List<Long> activatableKeys(final MutableJobState state, final DirectBuffer type) {
+    return activatableKeys(state, type, Integer.MAX_VALUE);
+  }
+
+  private List<Long> activatableKeys(
+      final MutableJobState state, final DirectBuffer type, final int maxResults) {
+    final List<Long> keys = new ArrayList<>();
+    state.forEachActivatableJobs(
+        type,
+        List.of(TENANT),
+        (k, e) -> {
+          keys.add(k);
+          return keys.size() < maxResults;
+        });
+    return keys;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
@@ -185,10 +185,13 @@ final class DbJobStateLegacyDrainTest {
     assertThat(activatableKeys(restarted, type)).containsExactly(1L);
   }
 
+  // Mirrors JobCreatedV3Applier: a genuinely new (post-8.10) job goes through the
+  // priority-aware insertion path, not the deprecated, legacy-only create().
   private void createActivatableJob(final long key, final DirectBuffer type, final int priority) {
     final JobRecord record =
         new JobRecord().setType(type).setTenantId(TENANT).setPriority(priority).setRetries(1);
-    jobState.create(key, record);
+    jobState.insertJobRecordActivatable(key, record);
+    jobState.makeJobActivatableByPriority(type, key, TENANT, priority);
   }
 
   private void seedLegacyJob(final long key, final DirectBuffer type, final String tenantId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
@@ -173,6 +173,35 @@ final class DbJobStateLegacyDrainTest {
   }
 
   @Test
+  void shouldFindOwnTenantsLegacyJobWhileAnotherTenantsLegacyJobCoexists() {
+    // given: two tenants each have their own legacy job of the same type, coexisting in the CF
+    // at the same time
+    final DirectBuffer type = wrapString("type-a");
+    final String otherTenant = "other-tenant";
+    seedLegacyJob(1L, type, TENANT);
+    seedLegacyJob(2L, type, otherTenant);
+
+    // when/then: querying TENANT finds only its own job, not the other tenant's
+    assertThat(activatableKeys(type)).containsExactly(1L);
+  }
+
+  @Test
+  void shouldReturnTypeAsPriorityLeqZeroJobAfterGlobalEmptinessCheckTouchesTypeB() {
+    // given: type A's legacy prefix is empty but type B keeps the legacy CF non-empty, which
+    // forces the isEmpty() global-emptiness check to run — and that check's underlying seek
+    // wraps the shared jobTypeKey field with type B's entry as a side effect
+    final DirectBuffer typeA = wrapString("type-a");
+    final DirectBuffer typeB = wrapString("type-b");
+    seedLegacyJob(1L, typeB, TENANT);
+    createActivatableJob(2L, typeA, 0); // priority <= 0, served in Phase 3
+
+    // when: querying type A must still resolve Phase 3 against type A, not type B — if
+    // jobTypeKey were not restored after the isEmpty() call, this would incorrectly come back
+    // empty
+    assertThat(activatableKeys(typeA)).containsExactly(2L);
+  }
+
+  @Test
   void shouldFindAndDrainLegacyJobInsertedByReplayOfPreVersionedCreatedEvent() {
     // given: the real applier version-dispatch used at replay, not a direct CF seed
     final var eventAppliers = new EventAppliers();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
@@ -251,7 +251,7 @@ final class DbJobStateLegacyDrainTest {
   }
 
   // Targets an explicit state instance — needed when testing a simulated restart,
-  // where the in-memory legacyCfDrained flag is reset to its initial false value.
+  // where the in-memory isLegacyCfDrained flag is reset to its initial false value.
   private List<Long> activatableKeys(final MutableJobState state, final DirectBuffer type) {
     return activatableKeys(state, type, Integer.MAX_VALUE);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/DbJobStateLegacyDrainTest.java
@@ -20,11 +20,13 @@ import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
+import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.ArrayList;
 import java.util.List;
@@ -168,6 +170,36 @@ final class DbJobStateLegacyDrainTest {
     // afterwards is still found
     seedLegacyJob(2L, type, TENANT);
     assertThat(activatableKeys(type)).containsExactly(2L);
+  }
+
+  @Test
+  void shouldFindAndDrainLegacyJobInsertedByReplayOfPreVersionedCreatedEvent() {
+    // given: the real applier version-dispatch used at replay, not a direct CF seed
+    final var eventAppliers = new EventAppliers();
+    eventAppliers.registerEventAppliers(processingState);
+    final DirectBuffer type = wrapString("type-a");
+    final JobRecord createdRecord =
+        new JobRecord().setType(type).setTenantId(TENANT).setRetries(3).setDeadline(-1L);
+
+    // when: a CREATED event as persisted by a pre-#53724 broker (recordVersion=2) is replayed
+    // through the real dispatch path, which must land the job in the legacy JOB_ACTIVATABLE CF
+    eventAppliers.applyState(1L, JobIntent.CREATED, createdRecord, 2);
+
+    // then: forEachActivatableJobs finds it via Phase 2 — the flag must not be set while a
+    // replay-inserted legacy entry still exists
+    assertThat(activatableKeys(type)).containsExactly(1L);
+
+    // when: the job is activated, which removes it from the legacy CF the same way
+    // makeJobNotActivatable does for any other deactivation
+    final JobRecord activateRecord =
+        new JobRecord().setType(type).setTenantId(TENANT).setRetries(3).setDeadline(1_000L);
+    jobState.activate(1L, activateRecord);
+
+    // then: the legacy CF is now globally empty, so the flag is set on this scan and a legacy
+    // entry seeded afterwards is never found again
+    assertThat(activatableKeys(type)).isEmpty();
+    seedLegacyJob(2L, type, TENANT);
+    assertThat(activatableKeys(type)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Description

Added an in-memory `legacyCfDrained` boolean flag to `DbJobState` that short-circuits Phase 2 of `forEachActivatableJobs` once the legacy `JOB_ACTIVATABLE` column family is globally empty. On clusters upgraded from 8.9 long ago, this eliminates the perpetual prefix-seek overhead from every job activation. Activation ordering and correctness are unchanged from M1-5; the flag is lazy-set on read and in-memory (resets on restart). Verification identified and fixed a critical jobTypeKey clobbering bug in the isEmpty() path and added tests for batch-full and cross-tenant edge cases.

## Checklist

<!--- Please delete options that are not relevant. -->

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #52504
