### PR TITLE
docs: add infos from recent incidents

### DIFF
--- a/docs/monorepo-docs/ci-runbooks.md
+++ b/docs/monorepo-docs/ci-runbooks.md
@@ -19,6 +19,7 @@ incidents affecting the monorepo CI.
 - [GitHub status](https://www.githubstatus.com/) (Actions, PRs, API, Git, etc.)
 - [DockerHub status](https://www.dockerstatus.com/) (Docker image push/pull)
 - [Maven Central status](https://status.maven.org/) (Maven artifact up-/downloads)
+- [Minimus status](https://docs.minimus.io/status) (Minimus Docker registry)
 
 ### Temporarily Disable Tests To Lessen Impact
 
@@ -109,7 +110,7 @@ artifacts might not get built or uploaded to artifact repositories, and indicate
 since we expect only green builds. Unlike merge-queue failures which block PRs, base-branch failures
 affect artifact availability and release readiness.
 
-Each alert instance is grouped by workflow job name and base branch, and includes:
+Each alert instance is grouped by workflow job name and thus spans multiple base branches, and includes:
 
 - Number of unsuccessful runs in the evaluation window
 - Links to failed workflow runs in the evaluation window (useful for root cause analysis)

--- a/docs/monorepo-docs/processes.md
+++ b/docs/monorepo-docs/processes.md
@@ -187,6 +187,11 @@ From [IM - Roles and Responsibilities](https://confluence.camunda.com/display/HA
 - Communications Lead (CL)
 - Operations Lead (OL)
 
+#### Responses
+
+- Mitigation: removing or at least reducing the impact an incident has by temporary means
+- Fixing: addressing the root cause(s) of an incident to entirely remove the impact and future recurrence
+
 ### Steps
 
 Effective incident management is key to limiting the disruption caused by an incident and restoring normal business operations as quickly as possible.


### PR DESCRIPTION
## Description

* add link to Minimus status page for future responders
* update `green-base-branch` alert runbook to reflect that we combine all base branches into the same incident now (fits real world use cases better)
* define what a mitigation is

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to INC-6269
