### PR TITLE
fix: route post-importer-queue writes by partition id

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
@@ -85,7 +85,9 @@ public class PostImporterQueueFromIncidentHandler
 
   @Override
   public void flush(final PostImporterQueueEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    // Route each entry to a single shard by partition id so that, within a partition, a search can
+    // never observe a higher position without also seeing all lower positions (see #56117)
+    batchRequest.addWithRouting(indexName, entity, String.valueOf(entity.getPartitionId()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -95,12 +95,17 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
     final var request = createPendingIncidentsBatchRequest(size, query);
 
     // Force a refresh of the post-importer-queue write index before reading the batch so that all
-    // of its shards expose their acknowledged writes. The queue is written without routing, so a
-    // single partition's entries are scattered across all shards, which refresh on independent
-    // timers. Without this, a higher-position entry on an already-refreshed shard can be returned
-    // while a lower-position entry on a not-yet-refreshed shard is still invisible; the cursor
-    // would then advance past the lower entry and, because the lower bound is strict, never revisit
-    // it. See https://github.com/camunda/camunda/issues/56117.
+    // of its shards expose their acknowledged writes. New entries are written with routing by
+    // partition id, so a single partition's entries co-locate on one shard and cannot exhibit
+    // refresh skew. This refresh remains load-bearing for the unrouted tail — legacy documents
+    // predating this change, restored backups, and entries written by older brokers during a
+    // rolling upgrade — which are still scattered across shards that refresh on independent
+    // timers. Without
+    // it, for those unrouted entries a higher-position entry on an already-refreshed shard could be
+    // returned while a lower-position entry on a not-yet-refreshed shard is still invisible; the
+    // cursor would then advance past the lower entry and, because the lower bound is strict, never
+    // revisit it. See https://github.com/camunda/camunda/issues/56117. Expected to become removable
+    // once routed writes are the norm.
     return refreshPostImporterQueueIndex()
         .thenComposeAsync(ignored -> client.search(request, PendingIncidentUpdate.class), executor)
         .thenApplyAsync(this::createPendingIncidentBatch, executor);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -94,12 +94,17 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   public CompletionStage<PendingIncidentUpdateBatch> getPendingIncidentsBatch(
       final long fromPosition, final int size) {
     // Force a refresh of the post-importer-queue write index before reading the batch so that all
-    // of its shards expose their acknowledged writes. The queue is written without routing, so a
-    // single partition's entries are scattered across all shards, which refresh on independent
-    // timers. Without this, a higher-position entry on an already-refreshed shard can be returned
-    // while a lower-position entry on a not-yet-refreshed shard is still invisible; the cursor
-    // would then advance past the lower entry and, because the lower bound is strict, never revisit
-    // it. See https://github.com/camunda/camunda/issues/56117.
+    // of its shards expose their acknowledged writes. New entries are written with routing by
+    // partition id, so a single partition's entries co-locate on one shard and cannot exhibit
+    // refresh skew. This refresh remains load-bearing for the unrouted tail — legacy documents
+    // predating this change, restored backups, and entries written by older brokers during a
+    // rolling upgrade — which are still scattered across shards that refresh on independent
+    // timers. Without
+    // it, for those unrouted entries a higher-position entry on an already-refreshed shard could be
+    // returned while a lower-position entry on a not-yet-refreshed shard is still invisible; the
+    // cursor would then advance past the lower entry and, because the lower bound is strict, never
+    // revisit it. See https://github.com/camunda/camunda/issues/56117. Expected to become removable
+    // once routed writes are the norm.
     return refreshPostImporterQueueIndex()
         .thenComposeAsync(ignored -> searchPendingIncidents(fromPosition, size), executor)
         .thenApplyAsync(this::createPendingIncidentBatch, executor);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
@@ -124,16 +124,19 @@ public class PostImporterQueueFromIncidentHandlerTest {
   }
 
   @Test
-  void shouldAddEntityOnFlush() {
+  void shouldAddEntityWithPartitionRoutingOnFlush() {
     // given
-    final PostImporterQueueEntity inputEntity = new PostImporterQueueEntity().setId("111");
+    final int partitionId = 3;
+    final PostImporterQueueEntity inputEntity =
+        new PostImporterQueueEntity().setId("111").setPartitionId(partitionId);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1))
+        .addWithRouting(indexName, inputEntity, String.valueOf(partitionId));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.tasks.incident;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.FieldValue;
@@ -73,6 +75,31 @@ final class ElasticsearchIncidentUpdateRepositoryIT extends IncidentUpdateReposi
     return client.search(s -> s.index(index).query(query), documentType).hits().hits().stream()
         .map(Hit::source)
         .toList();
+  }
+
+  @Override
+  protected Collection<RoutedDocument> searchWithRouting(
+      final String index, final String field, final List<String> terms) throws IOException {
+    final var client = new ElasticsearchClient(transport);
+    final var values = terms.stream().map(FieldValue::of).toList();
+    final var query = QueryBuilders.terms(t -> t.field(field).terms(v -> v.value(values)));
+    return client.search(s -> s.index(index).query(query), Object.class).hits().hits().stream()
+        .map(hit -> new RoutedDocument(hit.id(), hit.routing()))
+        .toList();
+  }
+
+  @Override
+  protected void assertRoutedEntriesAreColocatedOnSingleShard(
+      final String index, final String routing, final String field, final int expectedHits)
+      throws IOException {
+    final var client = new ElasticsearchClient(transport);
+    final var query = QueryBuilders.term(t -> t.field(field).value(routing));
+    final var response =
+        client.search(s -> s.index(index).routing(routing).query(query), Object.class);
+    // a routed search is directed to exactly one shard...
+    assertThat(response.shards().total().intValue()).isEqualTo(1);
+    // ...and that single shard holds all of the partition's entries, proving co-location
+    assertThat(response.hits().hits()).hasSize(expectedHits);
   }
 
   private RestClientTransport createTransport() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -18,6 +18,7 @@ import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
@@ -136,6 +137,29 @@ abstract class IncidentUpdateRepositoryIT {
       final String index, final String field, final List<String> terms, final Class<T> documentType)
       throws IOException;
 
+  /**
+   * Runs an <em>unrouted</em> search (as the incident consumer does) and returns, for each matching
+   * hit, its id together with the {@code _routing} value it was stored with (null when the document
+   * was indexed without routing). Used to assert that entries are persisted with routing by
+   * partition id.
+   */
+  protected abstract Collection<RoutedDocument> searchWithRouting(
+      final String index, final String field, final List<String> terms) throws IOException;
+
+  /**
+   * Asserts, for backends that support it, that the entries for {@code routing} physically
+   * co-locate on a single shard: a routed search for that value is served by exactly one shard and
+   * still returns all {@code expectedHits} matching documents. Only Elasticsearch implements this;
+   * the OpenSearch client does not expose the shard statistics needed, so there it is a no-op and
+   * co-location is instead relied upon as the guaranteed "same routing value maps to the same
+   * shard" invariant.
+   */
+  protected void assertRoutedEntriesAreColocatedOnSingleShard(
+      final String index, final String routing, final String field, final int expectedHits)
+      throws IOException {
+    // no-op by default (see javadoc)
+  }
+
   private IncidentEntity newIncident(final long key) {
     final var incident = new IncidentEntity();
     final var id = String.valueOf(key);
@@ -157,6 +181,8 @@ abstract class IncidentUpdateRepositoryIT {
     batchRequest.add(incidentTemplate.getFullQualifiedName(), incident);
     batchRequest.executeWithRefresh();
   }
+
+  protected record RoutedDocument(String id, String routing) {}
 
   @DisabledIfSystemProperty(
       named = SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL,
@@ -578,6 +604,98 @@ abstract class IncidentUpdateRepositoryIT {
       } else {
         batchRequest.execute();
       }
+    }
+  }
+
+  @DisabledIfSystemProperty(
+      named = SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL,
+      matches = "^(?=\\s*\\S).*$",
+      disabledReason = "Excluding from AWS OS IT CI")
+  @Nested
+  final class PostImporterQueueRoutingIT {
+    // The queue index is created with multiple shards, as in production. The handler routes each
+    // entry by its partition id, so all entries of a single partition share the same routing value
+    // and therefore co-locate on a single shard. That co-location is what removes the cross-shard
+    // refresh skew of https://github.com/camunda/camunda/issues/56117 by construction: within one
+    // shard a search can never observe a higher position without also seeing all lower positions.
+    // This test verifies the write side end to end via the real handler: entries are persisted with
+    // routing == partition id, and the incident consumer's unrouted read still sees them.
+    private static final int QUEUE_SHARDS = 3;
+    private static final int OTHER_PARTITION_ID = 2;
+
+    @RegressionTest("https://github.com/camunda/camunda/issues/56117")
+    void shouldRouteEntriesByPartitionIdAndKeepThemReadableByUnroutedConsumer() throws Exception {
+      // given - a multi-shard queue index and the real handler writing into it
+      createQueueIndexWithShards();
+      final var handler =
+          new PostImporterQueueFromIncidentHandler(
+              postImporterQueueTemplate.getFullQualifiedName());
+      final var batchRequest = clientAdapter.createBatchRequest();
+
+      // when - the handler flushes several entries for two partitions across many positions
+      // partition 1 (the consumer's partition): positions 1..5, keys 1..5
+      for (long position = 1; position <= 5; position++) {
+        handler.flush(newQueueEntry(position, position, PARTITION_ID), batchRequest);
+      }
+      // partition 2: positions 1..3, keys offset so they do not collide with partition 1
+      for (long position = 1; position <= 3; position++) {
+        handler.flush(newQueueEntry(100 + position, position, OTHER_PARTITION_ID), batchRequest);
+      }
+      batchRequest.executeWithRefresh();
+
+      // then - every entry is stored with routing equal to its partition id, so a partition's
+      // entries share a routing value and co-locate on a single shard
+      assertThat(
+              searchWithRouting(
+                  postImporterQueueTemplate.getFullQualifiedName(),
+                  PostImporterQueueTemplate.PARTITION_ID,
+                  List.of(String.valueOf(PARTITION_ID))))
+          .hasSize(5)
+          .allSatisfy(doc -> assertThat(doc.routing()).isEqualTo(String.valueOf(PARTITION_ID)));
+      assertThat(
+              searchWithRouting(
+                  postImporterQueueTemplate.getFullQualifiedName(),
+                  PostImporterQueueTemplate.PARTITION_ID,
+                  List.of(String.valueOf(OTHER_PARTITION_ID))))
+          .hasSize(3)
+          .allSatisfy(
+              doc -> assertThat(doc.routing()).isEqualTo(String.valueOf(OTHER_PARTITION_ID)));
+
+      // and (Elasticsearch only) - the partition's entries physically co-locate: a routed search is
+      // served by a single shard and still returns all of the partition's entries
+      assertRoutedEntriesAreColocatedOnSingleShard(
+          postImporterQueueTemplate.getFullQualifiedName(),
+          String.valueOf(PARTITION_ID),
+          PostImporterQueueTemplate.PARTITION_ID,
+          5);
+
+      // and - the consumer's unrouted read still sees the routed entries of its partition and
+      // advances the watermark to the highest position without skipping any
+      final var repository = createRepository();
+      final var batch = repository.getPendingIncidentsBatch(-1L, 10).toCompletableFuture().join();
+      assertThat(batch.highestPosition()).isEqualTo(5L);
+      assertThat(batch.newIncidentStates())
+          .containsOnlyKeys(1L, 2L, 3L, 4L, 5L)
+          .allSatisfy((key, state) -> assertThat(state).isEqualTo(IncidentState.ACTIVE));
+    }
+
+    private PostImporterQueueEntity newQueueEntry(
+        final long key, final long position, final int partitionId) {
+      return new PostImporterQueueEntity()
+          .setId(key + "-" + IncidentIntent.CREATED)
+          .setActionType(PostImporterActionType.INCIDENT)
+          .setIntent(IncidentIntent.CREATED.name())
+          .setKey(key)
+          .setPartitionId(partitionId)
+          .setProcessInstanceKey(key)
+          .setPosition(position);
+    }
+
+    private void createQueueIndexWithShards() {
+      final var config = new IndexConfiguration();
+      config.setNumberOfShards(QUEUE_SHARDS);
+      config.setNumberOfReplicas(0);
+      engineClient.createIndex(postImporterQueueTemplate, config);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
@@ -73,6 +73,23 @@ final class OpensearchIncidentUpdateRepositoryIT extends IncidentUpdateRepositor
         .toList();
   }
 
+  @Override
+  protected Collection<RoutedDocument> searchWithRouting(
+      final String index, final String field, final List<String> terms) throws IOException {
+    final var client = new OpenSearchClient(transport);
+    final var values =
+        terms.stream().map(org.opensearch.client.opensearch._types.FieldValue::of).toList();
+    final var query =
+        org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.terms()
+            .field(field)
+            .terms(v -> v.value(values))
+            .build()
+            .toQuery();
+    return client.search(s -> s.index(index).query(query), Object.class).hits().hits().stream()
+        .map(hit -> new RoutedDocument(hit.id(), hit.routing()))
+        .toList();
+  }
+
   private OpenSearchTransport createTransport() {
     try {
       return ApacheHttpClient5TransportBuilder.builder(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
@@ -16,6 +16,9 @@ import org.junit.jupiter.api.AutoClose;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 import org.opensearch.testcontainers.OpenSearchContainer;
@@ -60,16 +63,11 @@ final class OpensearchIncidentUpdateRepositoryIT extends IncidentUpdateRepositor
       final String index, final String field, final List<String> terms, final Class<T> documentType)
       throws IOException {
     final var client = new OpenSearchClient(transport);
-    final var values =
-        terms.stream().map(org.opensearch.client.opensearch._types.FieldValue::of).toList();
+    final var values = terms.stream().map(FieldValue::of).toList();
     final var query =
-        org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.terms()
-            .field(field)
-            .terms(v -> v.value(values))
-            .build()
-            .toQuery();
+        QueryBuilders.terms().field(field).terms(v -> v.value(values)).build().toQuery();
     return client.search(s -> s.index(index).query(query), documentType).hits().hits().stream()
-        .map(org.opensearch.client.opensearch.core.search.Hit::source)
+        .map(Hit::source)
         .toList();
   }
 
@@ -77,14 +75,9 @@ final class OpensearchIncidentUpdateRepositoryIT extends IncidentUpdateRepositor
   protected Collection<RoutedDocument> searchWithRouting(
       final String index, final String field, final List<String> terms) throws IOException {
     final var client = new OpenSearchClient(transport);
-    final var values =
-        terms.stream().map(org.opensearch.client.opensearch._types.FieldValue::of).toList();
+    final var values = terms.stream().map(FieldValue::of).toList();
     final var query =
-        org.opensearch.client.opensearch._types.query_dsl.QueryBuilders.terms()
-            .field(field)
-            .terms(v -> v.value(values))
-            .build()
-            .toQuery();
+        QueryBuilders.terms().field(field).terms(v -> v.value(values)).build().toQuery();
     return client.search(s -> s.index(index).query(query), Object.class).hits().hits().stream()
         .map(hit -> new RoutedDocument(hit.id(), hit.routing()))
         .toList();


### PR DESCRIPTION
Closes #56117

## What

`PostImporterQueueFromIncidentHandler.flush` now writes each `operate-post-importer-queue` entry with `routing = partitionId` (`addWithRouting`) instead of an unrouted `add`. One handler change covers both Elasticsearch and OpenSearch because `addWithRouting` is implemented in both batch-request stores. Reads are deliberately left unrouted.

## Why

`IncidentUpdateTask` consumes the queue with a strict forward-only position watermark per partition. On a multi-shard index with unrouted writes, a single partition's entries scatter across all shards, which refresh on independent timers. A higher-position entry on an already-refreshed shard can be returned while a lower-position entry on a not-yet-refreshed shard is still invisible; the strict cursor then advances past the lower entry and never revisits it, leaving its incident stuck `PENDING` forever (#56117).

With `routing = partitionId`, all entries of one partition land on a single shard. Within a shard, visibility is prefix-consistent in indexing order, and the handler writes each partition's entries in ascending position order — so a search (even an unrouted fan-out) can never observe position N of a partition without also seeing every position M < N of the same partition. The refresh-skew trigger disappears by construction for routed documents. Shard unavailability becomes all-or-nothing per partition and is caught by `allowPartialSearchResults(false)` regardless. Hot-spotting is a non-concern: routing cardinality = partition count, and this low-volume index would be fine even on a single shard.

## Relationship to #56179 (the read-path refresh)

#56179 (merged, not yet rolled out) hardened the read path: force-refresh of the write index before each batch read + `allowPartialSearchResults(false)`. That refresh is **kept**. It remains load-bearing for the *unrouted tail*: pre-upgrade documents, restored backups, stalled watermarks, and rolling-upgrade interleaving (partition leadership bouncing between old brokers writing unrouted and new brokers writing routed for the whole rollout). Removal was considered and rejected for now — reversibility is asymmetric: removing the refresh later, once the unrouted tail drains, is a trivial patch; a skipped entry in production requires manual watermark surgery. The refresh is **expected to become removable after this release has been out for a cycle** (a follow-up issue will track this). The read-path comments in both repositories are updated to reflect this.

Reads stay unrouted — routed reads would make legacy unrouted documents invisible.

## Safety analysis: same document indexed twice with different routing

After a broker restart the exporter replays records since the last acknowledged position, so the same incident record can be re-exported.

- **Same version (both writes routed, or both unrouted):** same routing → same shard → idempotent overwrite by `_id` (`<key>-<intent>`). No duplicates. Common case.
- **Upgrade boundary (first write unrouted, replay routed) — and symmetrically on downgrade/rollback:** the unrouted copy sits on the `_id`-hash shard, the routed copy on the `partitionId`-hash shard. If they differ, two live documents with the same `_id` coexist (ES/OS do not enforce `_id` uniqueness across shards). One-off, confined to the replay window of the upgrade restart.
- **Duplicate pair content:** identical in every field consumers use (`key`, `position`, `intent`, `partitionId`, `actionType`, `processInstanceKey`, `rootProcessInstanceKey`); only `creationTime` differs, and nothing reads it.

Consumer-by-consumer verdict (all verified on `main`; the handler is the only writer — the old `importer-8_7` writer is gone):

1. **`IncidentUpdateTask` / `*IncidentUpdateRepository.getPendingIncidentsBatch`** — unrouted search on the alias, filters by `partitionId` field, sorts by position. A duplicate pair returns as two adjacent hits with the same position; `createPendingIncidentBatch` collapses hits into a `Map<Long, IncidentState>` keyed by incident key → idempotent. `highestPosition` unchanged. Position ties can only occur between copies of the *same* logical entry (each queue entry comes from a distinct record position per partition), so truncating a tied pair at the `size` boundary never drops a distinct entry. The task never reads/updates/deletes the queue by `_id`.
2. **`ProcessInstanceArchiverJob` (query-based mode)** — archives the queue via `moveDocuments` = `reindexDocuments` + `deleteDocuments`, both query-based on `processInstanceKey`/`rootProcessInstanceKey` → fan out to all shards, find routed/unrouted/duplicate docs alike. Reindex preserves source routing; duplicates in the dated index are content-identical and nothing reads archived queue entries by `_id`. No orphans.
3. **`ProcessInstanceByIdArchiverJob` (by-id mode)** — routing-safe by design: `getArchiveDocIdsBatch` captures each hit's actual routing (`new IdWithRouting(h.id(), h.routing())`), `reindexDocumentsById` uses an `ids` query (fan-out), and `deleteDocumentsById` propagates the hit's routing into each bulk delete (null routing = `_id`-hash fallback for legacy docs). ES and OS repositories are symmetric. A duplicate pair yields two delete ops, each landing on its correct shard.

Known-benign artifacts:

- **Cross-shard duplicate pair** (above): inert, cleaned up at archival.
- **Pagination tie-skip orphan** (by-id mode only): `search_after` sorts on the `id` field; a duplicate pair ties on the sort key; if a page boundary splits the tied pair, the second copy is skipped in that run and its parent PI is never re-batched → one inert doc left in the write index permanently. Its position is already below the watermark, so no consumer ever sees it; reprocessing would be idempotent anyway. Probability ≈ (duplicate pairs from the replay window) × 1/batch-size.

Residual gap **out of scope** (neither refresh nor routing closes it): during the archiver's move there is a window between delete-from-write-index and the dated index's next refresh where a still-pending entry is invisible to the alias while higher-position write-index entries are visible. Practical risk is low (the archiver moves only past the ~1h archiving timepoint; the incident task usually lags by seconds).

## Tests

- `PostImporterQueueFromIncidentHandlerTest` — asserts `flush` calls `addWithRouting` with the partition id.
- `IncidentUpdateRepositoryIT.PostImporterQueueRoutingIT` (ES + OS) — drives the real handler against a multi-shard (3) queue index and asserts (a) every entry is persisted with `_routing == partitionId`, and (b) the consumer's unrouted read still sees the routed entries and advances the watermark without skipping. On Elasticsearch it additionally asserts co-location behaviorally: a routed search for the partition is served by a single shard (`_shards.total == 1`) and still returns all of the partition's entries. OpenSearch relies on the guaranteed "same routing value → same shard" invariant, since its client does not expose the shard statistics needed.
- `IncidentUpdateRepositoryIT.PendingIncidentWatermarkSkipRegressionIT` (from #56179) still passes — it writes unrouted directly and is unaffected.

## Backport

Bug fix — backport labels to be added by the author as appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



## Update (2026-07-22): possible edge case

A later review found a narrow edge case in the by-id archiving path: when a duplicate post-importer-queue document (same `_id` on two different shards) is archived and its two copies fall into two different reindex batches, the by-id archiver's strict count check copies both copies while the paginated batch found only one, and the archive run fails with a `BatchCountMismatchException`.

Workarounds:
- Enable the legacy archiving mode.
- Or manually delete the duplicate post-importer-queue document.

We assess that this scenario is very unlikely to happen at all, as it requires all of the following to coincide:
- Incidents present in the record stream during the upgrade to the version containing the fix (so they are replayed).
- The replayed incident is written to a new shard of the post-importer-queue index (i.e. a multi-shard / legacy queue index).
- The duplicate post-importer-queue documents are archived in two different batches.
