### PR TITLE
ci: exclude client-facing poms from HeroDevs NES Spring routing

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -79,6 +79,25 @@
       ]
     },
     {
+      "description": "Keep Spring versions in client-facing poms resolvable from Maven Central. Must stay after the HeroDevs NES rule above, since registryUrls replaces (not merges) and last match wins. See https://github.com/camunda/camunda/issues/56520.",
+      "matchDatasources": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "/^org\\.springframework(\\..+)?:/"
+      ],
+      "matchFileNames": [
+        "library-parent/pom.xml",
+        "clients/camunda-spring-boot-3-starter/pom.xml",
+        "clients/camunda-spring-boot-4-starter/pom.xml",
+        "testing/camunda-process-test-spring-boot-3/pom.xml",
+        "testing/camunda-process-test-spring-boot-4/pom.xml"
+      ],
+      "registryUrls": [
+        "https://maven-central.storage-download.googleapis.com/maven2"
+      ]
+    },
+    {
       "description": "Enable separateMinorPatch so updates to latest patch are not ignored in maintenance branches.",
       "separateMinorPatch": true,
       "matchBaseBranches": [


### PR DESCRIPTION
## Description

Renovate routes all `org.springframework*` lookups through the private HeroDevs NES repo. That routing also hit the customer-facing poms, so NES-only patch versions (e.g. `3.4.13-spring-boot-3.4.20`) could leak into artifacts customers resolve from Maven Central — breaking their builds.

- Add a `packageRule` scoping the client-facing poms (`library-parent`, the Spring Boot starters, the CPT Spring Boot modules) back to Maven Central only.
- Placed right after the HeroDevs NES rule on purpose: `registryUrls` replaces (not merges) and the last matching rule wins.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related issue #56520
[Slack thread](https://camunda.slack.com/archives/C0A6SDRAMDL/p1782986305706539)