### PR TITLE
deps: reset library-parent Spring Boot to public 3.4.13 on stable/8.7

### DIFF
--- a/library-parent/pom.xml
+++ b/library-parent/pom.xml
@@ -27,7 +27,7 @@
     <!-- The Spring Boot version is managed explicitly here to avoid inheriting
     Spring Boot version from the parent pom.xml, which is the reference for internal modules.
     This allows decoupled control of the Spring Boot version for this user facing artifact. -->
-    <version.spring-boot>3.4.13-spring-boot-3.4.20</version.spring-boot>
+    <version.spring-boot>3.4.13</version.spring-boot>
   </properties>
 
   <profiles>


### PR DESCRIPTION
## Description

Renovate previously bumped `version.spring-boot` in the customer-facing `library-parent` to the HeroDevs NES tag `3.4.13-spring-boot-3.4.20`, which only resolves from the private HeroDevs repo. Customers building against Maven Central can't resolve it, so their builds break.

- Reset it to the immediate pre-bump public value `3.4.13`.
- Config-side prevention (so Renovate won't re-introduce this) lands via #56532 on `main`; its rules apply to all stable base branches.

Merge #56532 first (or confirm it's queued) so Renovate doesn't re-bump this on its next run.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #56520

[Slack thread](https://camunda.slack.com/archives/C0A6SDRAMDL/p1782986305706539)