### PR TITLE
Expose `zeebe.active.tenants.count` Prometheus gauge

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -141,6 +141,36 @@ public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
     }
   },
 
+  /** Number of distinct active tenants seen since last broker start */
+  ACTIVE_TENANTS {
+    private static final KeyName[] KEY_NAMES = new KeyName[] {EngineKeyNames.ORGANIZATION_ID};
+
+    @Override
+    public String getDescription() {
+      return "Number of distinct active tenants seen since last broker start";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.active.tenants.count";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
   /** Number of banned instances */
   BANNED_INSTANCES {
     @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/TenantMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/TenantMetrics.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.EngineKeyNames;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public final class TenantMetrics {
+
+  private static final String ORGANIZATION_ID =
+      System.getenv().getOrDefault("CAMUNDA_CLOUD_ORGANIZATION_ID", "null");
+
+  // Accumulates every distinct tenant ID seen across export intervals since broker start.
+  // Access is single-threaded: only the stream-processor thread writes or reads this set.
+  // In SaaS the cardinality is bounded by the number of tenants in an organization (typically
+  // in the tens to low hundreds), so unbounded growth is not a practical concern.
+  private final Set<String> cumulativeTenants = new HashSet<>();
+  // Mirrors cumulativeTenants.size() as a volatile value so the Prometheus scrape thread can
+  // read it safely. AtomicInteger.set() volatile-write happens-before AtomicInteger.get(),
+  // guaranteeing the scrape thread never sees a stale or partially-written count.
+  // cumulativeTenants itself is never read by the scrape thread.
+  private final AtomicInteger activeTenantCount = new AtomicInteger(0);
+
+  public TenantMetrics(final MeterRegistry registry) {
+    final var meterDoc = EngineMetricsDoc.ACTIVE_TENANTS;
+    Gauge.builder(meterDoc.getName(), activeTenantCount, AtomicInteger::get)
+        .description(meterDoc.getDescription())
+        .tag(EngineKeyNames.ORGANIZATION_ID.asString(), ORGANIZATION_ID)
+        .register(registry);
+  }
+
+  /**
+   * Records all tenant IDs seen in a completed export interval. Must be called from the
+   * stream-processor thread only.
+   */
+  public void tenantsSeen(final Collection<String> tenantIds) {
+    final int before = cumulativeTenants.size();
+    cumulativeTenants.addAll(tenantIds);
+    if (cumulativeTenants.size() != before) {
+      activeTenantCount.set(cumulativeTenants.size());
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/TenantMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/TenantMetrics.java
@@ -20,15 +20,20 @@ public final class TenantMetrics {
   private static final String ORGANIZATION_ID =
       System.getenv().getOrDefault("CAMUNDA_CLOUD_ORGANIZATION_ID", "null");
 
-  // Accumulates every distinct tenant ID seen across export intervals since broker start.
-  // Access is single-threaded: only the stream-processor thread writes or reads this set.
-  // In SaaS the cardinality is bounded by the number of tenants in an organization (typically
-  // in the tens to low hundreds), so unbounded growth is not a practical concern.
+  /**
+   * Accumulates every distinct tenant ID seen across export intervals since broker start. Access is
+   * single-threaded: only the stream-processor thread writes or reads this set. In SaaS the
+   * cardinality is bounded by the number of tenants in an organization (typically in the tens to
+   * low hundreds), so unbounded growth is not a practical concern.
+   */
   private final Set<String> cumulativeTenants = new HashSet<>();
-  // Mirrors cumulativeTenants.size() as a volatile value so the Prometheus scrape thread can
-  // read it safely. AtomicInteger.set() volatile-write happens-before AtomicInteger.get(),
-  // guaranteeing the scrape thread never sees a stale or partially-written count.
-  // cumulativeTenants itself is never read by the scrape thread.
+
+  /**
+   * Mirrors {@link #cumulativeTenants}'s size as a volatile value so the Prometheus scrape thread
+   * can read it safely. {@code AtomicInteger.set()} is a volatile write that happens-before {@code
+   * AtomicInteger.get()}, guaranteeing the scrape thread never sees a stale or partially-written
+   * count. {@link #cumulativeTenants} itself is never read by the scrape thread.
+   */
   private final AtomicInteger activeTenantCount = new AtomicInteger(0);
 
   public TenantMetrics(final MeterRegistry registry) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.metrics.DistributionMetrics;
 import io.camunda.zeebe.engine.metrics.IncidentMetrics;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.metrics.TenantMetrics;
 import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationSetupProcessors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
@@ -135,6 +136,7 @@ public final class EngineProcessors {
     final ExpressionLanguageMetricsImpl expressionLanguageMetrics =
         new ExpressionLanguageMetricsImpl(typedRecordProcessorContext.getMeterRegistry());
     final var incidentMetrics = new IncidentMetrics(typedRecordProcessorContext.getMeterRegistry());
+    final var tenantMetrics = new TenantMetrics(typedRecordProcessorContext.getMeterRegistry());
 
     subscriptionCommandSender.setWriters(writers);
 
@@ -376,7 +378,13 @@ public final class EngineProcessors {
         config);
 
     UsageMetricsProcessors.addUsageMetricsProcessors(
-        typedRecordProcessors, config, clock, processingState, writers, keyGenerator);
+        typedRecordProcessors,
+        config,
+        clock,
+        processingState,
+        writers,
+        keyGenerator,
+        tenantMetrics);
 
     HistoryDeletionProcessors.addHistoryDeletionProcessors(
         typedRecordProcessors, writers, processingState, authCheckBehavior);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricExportProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricExportProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.metrics.usage;
 
+import io.camunda.zeebe.engine.metrics.TenantMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -19,6 +20,8 @@ import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.time.InstantSource;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,16 +35,19 @@ public class UsageMetricExportProcessor implements TypedRecordProcessor<UsageMet
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
   private final InstantSource clock;
+  private final TenantMetrics tenantMetrics;
 
   public UsageMetricExportProcessor(
       final UsageMetricState usageMetricState,
       final Writers writers,
       final KeyGenerator keyGenerator,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final TenantMetrics tenantMetrics) {
     this.usageMetricState = usageMetricState;
     stateWriter = writers.state();
     this.keyGenerator = keyGenerator;
     this.clock = clock;
+    this.tenantMetrics = tenantMetrics;
   }
 
   @Override
@@ -59,6 +65,13 @@ public class UsageMetricExportProcessor implements TypedRecordProcessor<UsageMet
     // Additionally, ensure the fromTime is set. This can happen if metrics were recorded before the
     // first applier.
     final PersistedUsageMetrics finalBucket = bucket.close(now);
+
+    // Accumulate all tenant IDs seen in this interval into the broker-lifetime set
+    final Set<String> tenantIds = new HashSet<>();
+    tenantIds.addAll(finalBucket.getTenantRPIMap().keySet());
+    tenantIds.addAll(finalBucket.getTenantEDIMap().keySet());
+    tenantIds.addAll(finalBucket.getTenantTUMap().keySet());
+    tenantMetrics.tenantsSeen(tenantIds);
 
     // export usage metric events if there is data
     Stream.of(EventType.RPI, EventType.EDI, EventType.TU)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricsProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricsProcessors.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.metrics.usage;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.TenantMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -24,13 +25,14 @@ public class UsageMetricsProcessors {
       final InstantSource clock,
       final MutableProcessingState processingState,
       final Writers writers,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final TenantMetrics tenantMetrics) {
     typedRecordProcessors
         .onCommand(
             ValueType.USAGE_METRIC,
             UsageMetricIntent.EXPORT,
             new UsageMetricExportProcessor(
-                processingState.getUsageMetricState(), writers, keyGenerator, clock))
+                processingState.getUsageMetricState(), writers, keyGenerator, clock, tenantMetrics))
         .withListener(
             new UsageMetricsCheckScheduler(config.getUsageMetricsExportInterval(), clock));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/TenantMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/TenantMetricsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class TenantMetricsTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCountDistinctTenants() {
+    engine.deployment().withXmlResource(simpleProcess()).withTenantId(TENANT_A).deploy();
+    engine.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT_A).create();
+
+    engine.deployment().withXmlResource(simpleProcess()).withTenantId(TENANT_B).deploy();
+    engine.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT_B).create();
+
+    engine.usageMetrics().export();
+
+    assertThat(activeTenantGaugeValue()).isEqualTo(2.0);
+  }
+
+  @Test
+  public void shouldNotDoubleCountTenantSeenInMultipleIntervals() {
+    engine.deployment().withXmlResource(simpleProcess()).withTenantId(TENANT_A).deploy();
+    engine.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT_A).create();
+    engine.usageMetrics().export();
+
+    engine.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT_A).create();
+    engine.usageMetrics().export();
+
+    assertThat(activeTenantGaugeValue()).isEqualTo(1.0);
+  }
+
+  @Test
+  public void shouldAccumulateNewTenantsAcrossExportIntervals() {
+    engine.deployment().withXmlResource(simpleProcess()).withTenantId(TENANT_A).deploy();
+    engine.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT_A).create();
+    engine.usageMetrics().export();
+    assertThat(activeTenantGaugeValue()).isEqualTo(1.0);
+
+    engine.deployment().withXmlResource(simpleProcess()).withTenantId(TENANT_B).deploy();
+    engine.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(TENANT_B).create();
+    engine.usageMetrics().export();
+
+    assertThat(activeTenantGaugeValue()).isEqualTo(2.0);
+  }
+
+  private double activeTenantGaugeValue() {
+    return engine.getMeterRegistry().get("zeebe.active.tenants.count").gauge().value();
+  }
+
+  private static BpmnModelInstance simpleProcess() {
+    return Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricExportProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/metrics/usage/UsageMetricExportProcessorTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.metrics.TenantMetrics;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.metrics.PersistedUsageMetrics;
@@ -26,21 +27,25 @@ import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalTyp
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.InstantSource;
 import java.util.Map;
 import java.util.Set;
 import org.agrona.DirectBuffer;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class UsageMetricExportProcessorTest {
   private static final long ASSIGNEE_HASH_1 = getStringHashValue("assignee1");
   private static final String TENANT_1 = "tenant1";
+  private static final String TENANT_2 = "tenant2";
   private MutableUsageMetricState state;
   private StateWriter stateWriter;
   private UsageMetricExportProcessor processor;
   private TypedRecord<UsageMetricRecord> record;
   private InstantSource clock;
+  private SimpleMeterRegistry meterRegistry;
 
   @BeforeEach
   void setUp() {
@@ -48,6 +53,7 @@ class UsageMetricExportProcessorTest {
     state = mock(MutableUsageMetricState.class);
     record = mock(TypedRecord.class);
     clock = mock(InstantSource.class);
+    meterRegistry = new SimpleMeterRegistry();
     final UsageMetricRecord recordValue = new UsageMetricRecord();
     final var keyGenerator = mock(KeyGenerator.class);
     final var writers = mock(Writers.class);
@@ -58,7 +64,13 @@ class UsageMetricExportProcessorTest {
     when(record.getValue()).thenReturn(recordValue);
     when(clock.millis()).thenReturn(2L);
 
-    processor = new UsageMetricExportProcessor(state, writers, keyGenerator, clock);
+    processor =
+        new UsageMetricExportProcessor(
+            state, writers, keyGenerator, clock, new TenantMetrics(meterRegistry));
+  }
+
+  private double activeTenantGaugeValue() {
+    return meterRegistry.get("zeebe.active.tenants.count").gauge().value();
   }
 
   private DirectBuffer toDirectBuffer(final Object data) {
@@ -237,6 +249,87 @@ class UsageMetricExportProcessorTest {
                 .setCounterValues(toDirectBuffer(Map.of()))
                 .setSetValues(toDirectBuffer(Map.of(TENANT_1, Set.of(ASSIGNEE_HASH_1)))));
     verifyAppendFollowUpNoneEvent(2);
+  }
+
+  @Test
+  void shouldInitializeActiveTenantGaugeAtZero() {
+    Assertions.assertThat(activeTenantGaugeValue()).isZero();
+  }
+
+  @Test
+  void shouldIncrementGaugeWhenNewTenantsSeenViaRPI() {
+    when(state.getActiveBucket())
+        .thenReturn(
+            new PersistedUsageMetrics().setFromTime(1).setTenantRPIMap(Map.of(TENANT_1, 5L)));
+
+    processor.processRecord(record);
+
+    Assertions.assertThat(activeTenantGaugeValue()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldIncrementGaugeWhenNewTenantsSeenViaEDI() {
+    when(state.getActiveBucket())
+        .thenReturn(
+            new PersistedUsageMetrics().setFromTime(1).setTenantEDIMap(Map.of(TENANT_1, 3L)));
+
+    processor.processRecord(record);
+
+    Assertions.assertThat(activeTenantGaugeValue()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldIncrementGaugeWhenNewTenantsSeenViaTU() {
+    when(state.getActiveBucket())
+        .thenReturn(
+            new PersistedUsageMetrics()
+                .setFromTime(1)
+                .setTenantTUMap(Map.of(TENANT_1, Set.of(ASSIGNEE_HASH_1))));
+
+    processor.processRecord(record);
+
+    Assertions.assertThat(activeTenantGaugeValue()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldAccumulateTenantsAcrossMultipleExportIntervals() {
+    when(state.getActiveBucket())
+        .thenReturn(
+            new PersistedUsageMetrics().setFromTime(1).setTenantRPIMap(Map.of(TENANT_1, 1L)));
+    processor.processRecord(record);
+
+    when(state.getActiveBucket())
+        .thenReturn(
+            new PersistedUsageMetrics().setFromTime(2).setTenantRPIMap(Map.of(TENANT_2, 1L)));
+    processor.processRecord(record);
+
+    Assertions.assertThat(activeTenantGaugeValue()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldNotDoubleCountTenantsSeenInMultipleIntervals() {
+    when(state.getActiveBucket())
+        .thenReturn(
+            new PersistedUsageMetrics().setFromTime(1).setTenantRPIMap(Map.of(TENANT_1, 1L)));
+    processor.processRecord(record);
+    processor.processRecord(record);
+
+    Assertions.assertThat(activeTenantGaugeValue()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldCountDistinctTenantsAcrossRPIEDIAndTU() {
+    when(state.getActiveBucket())
+        .thenReturn(
+            new PersistedUsageMetrics()
+                .setFromTime(1)
+                .setTenantRPIMap(Map.of(TENANT_1, 1L))
+                .setTenantEDIMap(Map.of(TENANT_1, 1L, TENANT_2, 1L))
+                .setTenantTUMap(Map.of(TENANT_2, Set.of(ASSIGNEE_HASH_1))));
+
+    processor.processRecord(record);
+
+    Assertions.assertThat(activeTenantGaugeValue()).isEqualTo(2);
   }
 
   private void verifyAppendFollowUpNoneEvent(final long resetTime) {


### PR DESCRIPTION
## Summary
Exposes a new Prometheus gauge `zeebe.active.tenants.count` that tracks the number of distinct logical tenants seen since the last broker start. This allows HDP to scrape tenant activity data without relying on `GET /v2/system/usage-metrics`, which currently has authorization issues on SaaS.
- `TenantMetrics` owns gauge registration and state, following the `ProcessDefinitionMetrics` pattern
- Updated at each usage metric export interval (default 5 min) by `UsageMetricExportProcessor`, which passes the union of tenant IDs across the three tracked event types: root process instances (RPI), evaluated decision instances (EDI), and unique task assignees (TU)
- Accumulates across the entire broker lifetime rather than resetting each export interval. This was requested in the issue and improves accuracy: a single export interval may only capture a subset of active tenants (e.g. if some tenants have no activity that interval), whereas over a full broker lifetime each partition is very likely to have observed all tenants at least once
- Tagged with `organizationId` (from `CAMUNDA_CLOUD_ORGANIZATION_ID`); partition tags injected automatically as common tags by `MetricsStep`

**Known limitation**: the gauge is per-partition. Because the same tenant can be active on multiple partitions simultaneously, standard Prometheus aggregations are approximate — `sum()` overcounts, `max()` may undercount when activity is skewed. Use `max()`: it may under-report but will never over-report, which is the correct bias for billing. The authoritative tenant count remains `GET /v2/system/usage-metrics`, which aggregates data from all partitions.

## Test plan
- [ ] `TenantMetricsTest` — integration test using `EngineRule`: deploys processes for multiple tenants, creates instances, triggers export via `UsageMetricClient`, asserts gauge value; covers distinct count, deduplication across intervals, and accumulation of new tenants
- [ ] `UsageMetricExportProcessorTest` — unit test covering processor record-writing behaviour (exported event structure per event type, NONE reset event)

## Related issues
Closes #53817