### PR TITLE
Carry a lease token on the job record

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -60,6 +60,7 @@ final class BulkIndexRequest {
   private static final String PRIORITY_PROPERTY = "priority";
   private static final String ELEMENT_TYPE_PROPERTY = "elementType";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
+  private static final String LEASE_TOKEN_PROPERTY = "leaseToken";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -179,7 +180,12 @@ final class BulkIndexRequest {
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
   private static final class CommandDistributionMixin {}
 
-  @JsonIgnoreProperties({PRIORITY_PROPERTY, ELEMENT_TYPE_PROPERTY, BUSINESS_ID_PROPERTY})
+  @JsonIgnoreProperties({
+    PRIORITY_PROPERTY,
+    ELEMENT_TYPE_PROPERTY,
+    BUSINESS_ID_PROPERTY,
+    LEASE_TOKEN_PROPERTY
+  })
   private static final class JobMixin {}
 
   /** Shared by record values that only need to strip {@code businessId} for previous versions. */

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
@@ -172,6 +172,9 @@
                 },
                 "businessId": {
                   "type": "keyword"
+                },
+                "leaseToken": {
+                  "type": "keyword"
                 }
               }
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-template.json
@@ -153,6 +153,9 @@
             },
             "businessId": {
               "type": "keyword"
+            },
+            "leaseToken": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -471,10 +471,10 @@ final class BulkIndexRequestTest {
           .hasSize(1)
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("businessId"))
           .describedAs(
               "Expect that job records are NOT serialized with businessId on previous version")
-          .containsExactly(new Object[] {null});
+          .allSatisfy(
+              value -> assertThat((Map<String, Object>) value).doesNotContainKey("businessId"));
     }
 
     @Test
@@ -522,10 +522,10 @@ final class BulkIndexRequestTest {
           .hasSize(1)
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("leaseToken"))
           .describedAs(
               "Expect that job records are NOT serialized with leaseToken on previous version")
-          .containsExactly(new Object[] {null});
+          .allSatisfy(
+              value -> assertThat((Map<String, Object>) value).doesNotContainKey("leaseToken"));
     }
 
     @Test

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -503,6 +503,57 @@ final class BulkIndexRequestTest {
     }
 
     @Test
+    void shouldIndexJobRecordWithoutLeaseTokenOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new JobRecord().setLeaseToken("lease-abc-123")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("leaseToken"))
+          .describedAs(
+              "Expect that job records are NOT serialized with leaseToken on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithLeaseTokenOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new JobRecord().setLeaseToken("lease-abc-123")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("leaseToken"))
+          .describedAs("Expect that job records are serialized with leaseToken on current version")
+          .containsExactly("lease-abc-123");
+    }
+
+    @Test
     void shouldIndexUserTaskRecordWithoutBusinessIdOnPreviousVersion() {
       // given
       final var record =

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -60,6 +60,7 @@ final class BulkIndexRequest {
   private static final String PRIORITY_PROPERTY = "priority";
   private static final String ELEMENT_TYPE_PROPERTY = "elementType";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
+  private static final String LEASE_TOKEN_PROPERTY = "leaseToken";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -179,7 +180,12 @@ final class BulkIndexRequest {
   @JsonIgnoreProperties({AUTH_INFO_PROPERTY})
   private static final class CommandDistributionMixin {}
 
-  @JsonIgnoreProperties({PRIORITY_PROPERTY, ELEMENT_TYPE_PROPERTY, BUSINESS_ID_PROPERTY})
+  @JsonIgnoreProperties({
+    PRIORITY_PROPERTY,
+    ELEMENT_TYPE_PROPERTY,
+    BUSINESS_ID_PROPERTY,
+    LEASE_TOKEN_PROPERTY
+  })
   private static final class JobMixin {}
 
   /** Shared by record values that only need to strip {@code businessId} for previous versions. */

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
@@ -178,6 +178,9 @@
                 },
                 "businessId": {
                   "type": "keyword"
+                },
+                "leaseToken": {
+                  "type": "keyword"
                 }
               }
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-template.json
@@ -159,6 +159,9 @@
             },
             "businessId": {
               "type": "keyword"
+            },
+            "leaseToken": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -516,6 +516,57 @@ final class BulkIndexRequestTest {
     }
 
     @Test
+    void shouldIndexJobRecordWithoutLeaseTokenOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new JobRecord().setLeaseToken("lease-abc-123")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("leaseToken"))
+          .describedAs(
+              "Expect that job records are NOT serialized with leaseToken on previous version")
+          .containsExactly(new Object[] {null});
+    }
+
+    @Test
+    void shouldIndexJobRecordWithLeaseTokenOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new JobRecord().setLeaseToken("lease-abc-123")));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("leaseToken"))
+          .describedAs("Expect that job records are serialized with leaseToken on current version")
+          .containsExactly("lease-abc-123");
+    }
+
+    @Test
     void shouldIndexUserTaskRecordWithoutBusinessIdOnPreviousVersion() throws IOException {
       // given
       final var record =

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -484,10 +484,10 @@ final class BulkIndexRequestTest {
           .hasSize(1)
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("businessId"))
           .describedAs(
               "Expect that job records are NOT serialized with businessId on previous version")
-          .containsExactly(new Object[] {null});
+          .allSatisfy(
+              value -> assertThat((Map<String, Object>) value).doesNotContainKey("businessId"));
     }
 
     @Test
@@ -535,10 +535,10 @@ final class BulkIndexRequestTest {
           .hasSize(1)
           .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
           .extracting(source -> source.get("value"))
-          .extracting(source -> ((Map<String, Object>) source).get("leaseToken"))
           .describedAs(
               "Expect that job records are NOT serialized with leaseToken on previous version")
-          .containsExactly(new Object[] {null});
+          .allSatisfy(
+              value -> assertThat((Map<String, Object>) value).doesNotContainKey("leaseToken"));
     }
 
     @Test

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -91,6 +91,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringValue("rootProcessInstanceKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue PRIORITY_KEY = new StringValue(PRIORITY);
+  private static final StringValue LEASE_TOKEN_KEY = new StringValue("leaseToken");
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
@@ -138,9 +139,10 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, EMPTY_STRING);
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
+  private final StringProperty leaseTokenProp = new StringProperty(LEASE_TOKEN_KEY, EMPTY_STRING);
 
   public JobRecord() {
-    super(27);
+    super(28);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -168,7 +170,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(isJobToUserTaskMigrationProp)
         .declareProperty(rootProcessInstanceKeyProp)
         .declareProperty(priorityProp)
-        .declareProperty(businessIdProp);
+        .declareProperty(businessIdProp)
+        .declareProperty(leaseTokenProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -201,6 +204,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     rootProcessInstanceKeyProp.setValue(record.getRootProcessInstanceKey());
     priorityProp.setValue(record.getPriority());
     businessIdProp.setValue(record.getBusinessIdBuffer());
+    leaseTokenProp.setValue(record.getLeaseTokenBuffer());
   }
 
   public void wrap(final JobRecord record) {
@@ -424,6 +428,21 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @JsonIgnore
   public DirectBuffer getBusinessIdBuffer() {
     return businessIdProp.getValue();
+  }
+
+  @Override
+  public String getLeaseToken() {
+    return bufferAsString(leaseTokenProp.getValue());
+  }
+
+  public JobRecord setLeaseToken(final String leaseToken) {
+    leaseTokenProp.setValue(leaseToken);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getLeaseTokenBuffer() {
+    return leaseTokenProp.getValue();
   }
 
   public JobRecord setElementInstanceKey(final long elementInstanceKey) {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -887,6 +887,7 @@ final class JsonSerializableToJsonTest {
                       "retries": 3,
                       "priority": 0,
                       "businessId": "",
+                      "leaseToken": "",
                       "jobKind": "BPMN_ELEMENT",
                       "jobListenerEventType": "UNSPECIFIED",
                       "retryBackoff": 1002,
@@ -1056,7 +1057,8 @@ final class JsonSerializableToJsonTest {
                       .setRootProcessInstanceKey(rootProcessInstanceKey)
                       .setIsJobToUserTaskMigration(true)
                       .setPriority(42)
-                      .setBusinessId("biz-42");
+                      .setBusinessId("biz-42")
+                      .setLeaseToken("lease-abc-123");
 
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
               return record;
@@ -1078,6 +1080,7 @@ final class JsonSerializableToJsonTest {
                   "retries": 12,
                   "priority": 42,
                   "businessId": "biz-42",
+                  "leaseToken": "lease-abc-123",
                   "jobKind": "BPMN_ELEMENT",
                   "jobListenerEventType": "UNSPECIFIED",
                   "retryBackoff": 1003,
@@ -1158,6 +1161,7 @@ final class JsonSerializableToJsonTest {
                   "retries": -1,
                   "priority": 0,
                   "businessId": "",
+                  "leaseToken": "",
                   "jobKind": "BPMN_ELEMENT",
                   "jobListenerEventType": "UNSPECIFIED",
                   "retryBackoff": 0,
@@ -1223,6 +1227,7 @@ final class JsonSerializableToJsonTest {
                   "retries": -1,
                   "priority": 0,
                   "businessId": "",
+                  "leaseToken": "",
                   "jobKind": "BPMN_ELEMENT",
                   "jobListenerEventType": "UNSPECIFIED",
                   "retryBackoff": 0,

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobRecord.golden
@@ -80,6 +80,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringValue("rootProcessInstanceKey");
   private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
   private static final StringValue PRIORITY_KEY = new StringValue(PRIORITY);
+  private static final StringValue LEASE_TOKEN_KEY = new StringValue("leaseToken");
   private final StringProperty typeProp = new StringProperty(TYPE_KEY, EMPTY_STRING);
   private final StringProperty workerProp = new StringProperty(WORKER_KEY, EMPTY_STRING);
   private final LongProperty deadlineProp = new LongProperty(DEADLINE_KEY, -1);
@@ -127,6 +128,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1L);
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, EMPTY_STRING);
   private final IntegerProperty priorityProp = new IntegerProperty(PRIORITY_KEY, 0);
+  private final StringProperty leaseTokenProp = new StringProperty(LEASE_TOKEN_KEY, EMPTY_STRING);
 
   public JobRecord() {
     super(26);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -141,14 +141,14 @@ public interface JobRecordValue
   String getBusinessId();
 
   /**
-   * Returns the lease token identifying the activation that currently holds this job. The token is
-   * an opaque, engine-generated value handed to a worker that activates the job with a lease; it
-   * lets the engine distinguish items produced by a particular activation from those of superseded
-   * activations.
+   * Returns the current lease token of this job. The token is an opaque, engine-generated value
+   * handed to a worker when the job is activated with a lease; it lets the engine distinguish items
+   * produced by a particular activation from those of superseded activations.
    *
-   * <p>A leased job can only be completed and failed using the token. The token is valid until the
-   * job is activated again, not on job timeout. Updating the job timeout of a leased job also
-   * requires the lease token, except when updated through a batch operation.
+   * <p>The lease token persists on the job across timeouts and retries and is only advanced by a
+   * subsequent leased activation. Mutating a leased job (complete, fail, throw an error, or update
+   * the timeout) requires providing the matching lease token, except when the timeout is updated
+   * through a batch operation.
    *
    * @return the current lease token, or an empty string when the job has no active lease
    */

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -141,6 +141,20 @@ public interface JobRecordValue
   String getBusinessId();
 
   /**
+   * Returns the lease token identifying the activation that currently holds this job. The token is
+   * an opaque, engine-generated value handed to a worker that activates the job with a lease; it
+   * lets the engine distinguish items produced by a particular activation from those of superseded
+   * activations.
+   *
+   * <p>A leased job can only be completed and failed using the token. The token is valid until the
+   * job is activated again, not on job timeout. Updating the job timeout of a leased job also
+   * requires the lease token, except when updated through a batch operation.
+   *
+   * @return the current lease token, or an empty string when the job has no active lease
+   */
+  String getLeaseToken();
+
+  /**
    * @return the bpmn process id of the corresponding process definition
    */
   @Override


### PR DESCRIPTION
## Description

Adds a `leaseToken` field to `JobRecord` and the `JobRecordValue` interface — the foundational schema change for the job-lease mechanism (epic #54840). The token identifies the activation that currently holds a job, allowing the engine to verify that a completion, failure, or timeout comes from the holder and not a stale client. The empty string is the no-lease sentinel (record fields are never null).

This PR is **schema only** — it adds and (de)serializes the field. Lease generation, the `withLease` activation opt-in, and command enforcement follow separately.

The field is carried on `JobRecord` / `JobRecordValue` with a full MsgPack round-trip and golden-file snapshot. The four strict raw-record ES/OS templates (job + job-batch) are updated alongside it — `dynamic: strict` would otherwise reject the newly-serialized attribute. A `JobMixin` exclusion is added to the ES/OS bulk-index path so that, during a rolling upgrade, the current broker does not write the field into re-serialized previous-minor records that the old strict index would reject. This mirrors the `businessId` precedent (67ce8f71d0c).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #54841