### PR TITLE
feat: add dedicated tool-result message component

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.test.tsx
@@ -128,7 +128,7 @@ describe('<LatestAgentMessage />', () => {
     expect(message.getByText('I will help you with that.')).toBeInTheDocument();
   });
 
-  it('should render tool call buttons for a message with tool calls', async () => {
+  it('should render tool call intents for a message with tool calls', async () => {
     mockSearchAgentInstanceHistory(AGENT_INSTANCE_KEY).withSuccess(
       searchResult([
         mockAgentInstanceHistoryItem({
@@ -167,10 +167,8 @@ describe('<LatestAgentMessage />', () => {
 
     const message = within(screen.getByTestId('conversation-message-msg-2'));
     expect(
-      message.getByRole('button', {
-        name: '"doSomething" tool call. Click to open details.',
-      }),
-    ).toBeEnabled();
+      message.getByRole('button', {name: '"doSomething" tool call.'}),
+    ).toBeDisabled();
     expect(
       message.getByRole('button', {name: '"noElement" tool call.'}),
     ).toBeDisabled();

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.tsx
@@ -8,7 +8,6 @@
 
 import {SkeletonText} from '@carbon/react';
 import {useLatestAgentMessage} from 'modules/queries/agentInstances/useLatestAgentMessage';
-import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
 import {StatusHint} from './styled';
 
@@ -21,7 +20,6 @@ const LatestAgentMessage: React.FC<LatestAgentMessageProps> = ({
   agentInstanceKey,
   enablePeriodicRefetch,
 }) => {
-  const {selectElement} = useProcessInstanceElementSelectActions();
   const {data, status} = useLatestAgentMessage(agentInstanceKey, {
     enablePeriodicRefetch,
   });
@@ -48,11 +46,6 @@ const LatestAgentMessage: React.FC<LatestAgentMessageProps> = ({
       content={data.content}
       toolCalls={data.toolCalls}
       historyItemKey={data.historyItemKey}
-      onToolCallClick={(toolCall) => {
-        if (toolCall.elementId !== null) {
-          selectElement({elementId: toolCall.elementId});
-        }
-      }}
     />
   );
 };

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/LatestAgentMessage.tsx
@@ -36,7 +36,7 @@ const LatestAgentMessage: React.FC<LatestAgentMessageProps> = ({
     return <StatusHint>Failed to load latest agent message.</StatusHint>;
   }
 
-  if (data === null) {
+  if (data === null || data.role !== 'ASSISTANT') {
     return <StatusHint>The agent has not produced a message yet.</StatusHint>;
   }
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -396,7 +396,7 @@ describe('<ConversationHistory />', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render tool calls and enable them when a tool links to an element', async () => {
+  it('should render tool calls', async () => {
     mockSearchAgentInstanceHistory().withSuccess(
       searchResult([
         mockAgentInstanceHistoryItem({
@@ -440,10 +440,8 @@ describe('<ConversationHistory />', () => {
       screen.getByTestId('conversation-message-1'),
     );
     expect(
-      assistantMessage.getByRole('button', {
-        name: '"greet" tool call. Click to open details.',
-      }),
-    ).toBeEnabled();
+      assistantMessage.getByRole('button', {name: '"greet" tool call.'}),
+    ).toBeDisabled();
     expect(
       assistantMessage.getByRole('button', {name: '"search" tool call.'}),
     ).toBeDisabled();

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -53,6 +53,7 @@ describe('<ConversationHistory />', () => {
     render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
@@ -72,6 +73,7 @@ describe('<ConversationHistory />', () => {
     render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
@@ -95,6 +97,7 @@ describe('<ConversationHistory />', () => {
     render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
@@ -125,17 +128,13 @@ describe('<ConversationHistory />', () => {
           role: 'ASSISTANT',
           content: [{contentType: 'TEXT', text: 'Hello, user!'}],
         }),
-        mockAgentInstanceHistoryItem({
-          historyItemKey: '3',
-          role: 'TOOL_RESULT',
-          content: [{contentType: 'TEXT', text: 'Tool output here'}],
-        }),
       ]),
     );
 
     render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
@@ -159,14 +158,6 @@ describe('<ConversationHistory />', () => {
       agentMessage.getByRole('heading', {name: 'Assistant'}),
     ).toBeInTheDocument();
     expect(agentMessage.getByText('Hello, user!')).toBeInTheDocument();
-
-    const toolResultMessage = within(
-      screen.getByTestId('conversation-message-3'),
-    );
-    expect(
-      toolResultMessage.getByRole('heading', {name: 'Tool Result'}),
-    ).toBeInTheDocument();
-    expect(screen.getByText('Tool output here')).toBeInTheDocument();
   });
 
   it('should render conversation items with formatted object content', async () => {
@@ -174,11 +165,11 @@ describe('<ConversationHistory />', () => {
       searchResult([
         mockAgentInstanceHistoryItem({
           historyItemKey: '1',
-          role: 'TOOL_RESULT',
+          role: 'ASSISTANT',
           content: [
             {
               contentType: 'OBJECT',
-              object: {message: 'Tool output here', hello: 'world'},
+              object: {message: 'Some structured content', hello: 'world'},
             },
           ],
         }),
@@ -188,6 +179,54 @@ describe('<ConversationHistory />', () => {
     render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
+        enablePeriodicRefetch={false}
+        isVisible
+        selectedElementInstanceKey={null}
+        agentsElementInstanceKeys={[]}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    const message = within(screen.getByTestId('conversation-message-1'));
+    expect(
+      message.getByRole('heading', {name: 'Assistant'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        '{\n  "message": "Some structured content",\n  "hello": "world"\n}',
+        {normalizer: (text) => text},
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should render tool results in the history', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '1',
+          role: 'TOOL_RESULT',
+          content: [{contentType: 'TEXT', text: 'Tool output here'}],
+          toolCalls: [
+            {
+              toolCallId: 'tc-1',
+              toolName: 'search',
+              elementId: null,
+              arguments: {},
+            },
+          ],
+        }),
+      ]),
+    );
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
@@ -201,19 +240,12 @@ describe('<ConversationHistory />', () => {
     );
 
     const toolResultMessage = within(
-      screen.getByTestId('conversation-message-1'),
+      screen.getByRole('article', {name: 'Result for "search" tool call'}),
     );
     expect(
-      toolResultMessage.getByRole('heading', {name: 'Tool Result'}),
+      toolResultMessage.getByRole('heading', {name: 'search'}),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        '{\n  "message": "Tool output here",\n  "hello": "world"\n}',
-        {
-          normalizer: (text) => text,
-        },
-      ),
-    ).toBeInTheDocument();
+    expect(toolResultMessage.getByText('Tool output here')).toBeInTheDocument();
   });
 
   it('should toggle the history sort order when the sort button is clicked', async () => {
@@ -234,6 +266,7 @@ describe('<ConversationHistory />', () => {
     const {user} = render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
@@ -295,6 +328,7 @@ describe('<ConversationHistory />', () => {
     const {user} = render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
@@ -374,6 +408,7 @@ describe('<ConversationHistory />', () => {
     render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
@@ -424,6 +459,7 @@ describe('<ConversationHistory />', () => {
     render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
@@ -468,6 +504,7 @@ describe('<ConversationHistory />', () => {
     render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey={null}
@@ -511,6 +548,7 @@ describe('<ConversationHistory />', () => {
     const {rerender} = render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey="111"
@@ -530,6 +568,7 @@ describe('<ConversationHistory />', () => {
     rerender(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey="111"
@@ -548,6 +587,7 @@ describe('<ConversationHistory />', () => {
     render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey="111"
@@ -585,6 +625,7 @@ describe('<ConversationHistory />', () => {
     const {user} = render(
       <ConversationHistory
         agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
         enablePeriodicRefetch={false}
         isVisible
         selectedElementInstanceKey="111"

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -98,7 +98,6 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
             item.role === 'TOOL_RESULT' ? (
               <ToolResultMessage
                 key={item.historyItemKey}
-                historyItemKey={item.historyItemKey}
                 availableTools={availableTools}
                 toolCalls={item.toolCalls}
                 result={item.content}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -10,7 +10,6 @@ import {useState} from 'react';
 import {SkeletonText} from '@carbon/react';
 import type {QuerySortOrder} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
-import {useProcessInstanceElementSelectActions} from 'modules/hooks/useProcessInstanceElementSelection';
 import {ConversationMessage} from '../ConversationMessage';
 import {ConversationToggles} from './ConversationToggles';
 import {
@@ -42,7 +41,6 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   const [sortOrder, setSortOrder] = useState<QuerySortOrder>('desc');
   const [isScoped, setIsScoped] = useState(true);
 
-  const {selectElement} = useProcessInstanceElementSelectActions();
   const {
     data,
     status,
@@ -98,11 +96,6 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
               content={item.content}
               toolCalls={item.toolCalls}
               metrics={item.metrics}
-              onToolCallClick={(toolCall) => {
-                if (toolCall.elementId !== null) {
-                  selectElement({elementId: toolCall.elementId});
-                }
-              }}
             />
           ))
         )}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -100,7 +100,7 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
                 key={item.historyItemKey}
                 availableTools={availableTools}
                 toolCalls={item.toolCalls}
-                result={item.content}
+                content={item.content}
               />
             ) : (
               <ConversationMessage

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -8,7 +8,10 @@
 
 import {useState} from 'react';
 import {SkeletonText} from '@carbon/react';
-import type {QuerySortOrder} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {
+  AgentTool,
+  QuerySortOrder,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
 import {ConversationMessage} from '../ConversationMessage';
 import {ConversationToggles} from './ConversationToggles';
@@ -19,9 +22,11 @@ import {
   ShowMoreButton,
 } from './styled';
 import {flattenPaginatedPages} from 'modules/queries/flattenPaginatedPages';
+import {ToolResultMessage} from '../ConversationMessage/ToolResultMessage';
 
 type ConversationHistoryProps = {
   agentInstanceKey: string;
+  availableTools: AgentTool[];
   isVisible: boolean;
   enablePeriodicRefetch: boolean;
   selectedElementInstanceKey: string | null;
@@ -30,6 +35,7 @@ type ConversationHistoryProps = {
 
 const ConversationHistory: React.FC<ConversationHistoryProps> = ({
   agentInstanceKey,
+  availableTools,
   isVisible,
   enablePeriodicRefetch,
   selectedElementInstanceKey,
@@ -88,16 +94,26 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
               : 'No conversation with this agent instance found.'}
           </StatusHint>
         ) : (
-          data.items.map((item) => (
-            <ConversationMessage
-              key={item.historyItemKey}
-              historyItemKey={item.historyItemKey}
-              actor={item.role}
-              content={item.content}
-              toolCalls={item.toolCalls}
-              metrics={item.metrics}
-            />
-          ))
+          data.items.map((item) =>
+            item.role === 'TOOL_RESULT' ? (
+              <ToolResultMessage
+                key={item.historyItemKey}
+                historyItemKey={item.historyItemKey}
+                availableTools={availableTools}
+                toolCalls={item.toolCalls}
+                result={item.content}
+              />
+            ) : (
+              <ConversationMessage
+                key={item.historyItemKey}
+                historyItemKey={item.historyItemKey}
+                actor={item.role}
+                content={item.content}
+                toolCalls={item.toolCalls}
+                metrics={item.metrics}
+              />
+            ),
+          )
         )}
       </Messages>
       {isFetchingNextPage && <SkeletonText paragraph lineCount={2} />}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
@@ -13,7 +13,6 @@ describe('<ToolResultMessage />', () => {
   it('should render nothing without tool call information', () => {
     const {container} = render(
       <ToolResultMessage
-        historyItemKey="1"
         availableTools={[]}
         toolCalls={[]}
         result={[{contentType: 'TEXT', text: 'Tool output here'}]}
@@ -26,7 +25,6 @@ describe('<ToolResultMessage />', () => {
   it('should render the tool name and a result preview', () => {
     render(
       <ToolResultMessage
-        historyItemKey="1"
         availableTools={[]}
         toolCalls={[
           {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
@@ -45,7 +43,6 @@ describe('<ToolResultMessage />', () => {
   it('should render a compact JSON preview for object content', () => {
     render(
       <ToolResultMessage
-        historyItemKey="1"
         availableTools={[]}
         toolCalls={[
           {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
@@ -67,7 +64,6 @@ describe('<ToolResultMessage />', () => {
   it('should show a fallback message when the result has no content', () => {
     render(
       <ToolResultMessage
-        historyItemKey="1"
         availableTools={[]}
         toolCalls={[
           {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
@@ -82,7 +78,6 @@ describe('<ToolResultMessage />', () => {
   it('should show a fallback message for unsupported content types', () => {
     render(
       <ToolResultMessage
-        historyItemKey="1"
         availableTools={[]}
         toolCalls={[
           {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
@@ -15,7 +15,7 @@ describe('<ToolResultMessage />', () => {
       <ToolResultMessage
         availableTools={[]}
         toolCalls={[]}
-        result={[{contentType: 'TEXT', text: 'Tool output here'}]}
+        content={[{contentType: 'TEXT', text: 'Tool output here'}]}
       />,
     );
 
@@ -29,7 +29,7 @@ describe('<ToolResultMessage />', () => {
         toolCalls={[
           {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
         ]}
-        result={[{contentType: 'TEXT', text: 'Tool output here'}]}
+        content={[{contentType: 'TEXT', text: 'Tool output here'}]}
       />,
     );
 
@@ -48,7 +48,7 @@ describe('<ToolResultMessage />', () => {
         toolCalls={[
           {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
         ]}
-        result={[
+        content={[
           {
             contentType: 'OBJECT',
             object: {message: 'Tool output here', hello: 'world'},
@@ -69,7 +69,7 @@ describe('<ToolResultMessage />', () => {
         toolCalls={[
           {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
         ]}
-        result={[
+        content={[
           {
             contentType: 'DOCUMENT',
             documentReference: {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen} from 'modules/testing-library';
+import {render, screen, within} from 'modules/testing-library';
 import {ToolResultMessage} from './index';
 
 describe('<ToolResultMessage />', () => {
@@ -33,11 +33,12 @@ describe('<ToolResultMessage />', () => {
       />,
     );
 
-    expect(screen.getByRole('heading', {name: 'search'})).toBeInTheDocument();
-    expect(screen.getByText('Tool output here')).toBeInTheDocument();
-    expect(
-      screen.getByLabelText('Result for search tool call'),
-    ).toBeInTheDocument();
+    const message = within(
+      screen.getByRole('article', {name: 'Result for "search" tool call'}),
+    );
+
+    expect(message.getByRole('heading', {name: 'search'})).toBeInTheDocument();
+    expect(message.getByText('Tool output here')).toBeInTheDocument();
   });
 
   it('should render a compact JSON preview for object content', () => {
@@ -61,21 +62,7 @@ describe('<ToolResultMessage />', () => {
     ).toBeInTheDocument();
   });
 
-  it('should show a fallback message when the result has no content', () => {
-    render(
-      <ToolResultMessage
-        availableTools={[]}
-        toolCalls={[
-          {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
-        ]}
-        result={[]}
-      />,
-    );
-
-    expect(screen.getByText('Tool result has no content.')).toBeInTheDocument();
-  });
-
-  it('should show a fallback message for unsupported content types', () => {
+  it('should show a fallback message when the result has no TEXT or OBJECT content', () => {
     render(
       <ToolResultMessage
         availableTools={[]}
@@ -106,7 +93,7 @@ describe('<ToolResultMessage />', () => {
     );
 
     expect(
-      screen.getByText('Tool result has no viewable content.'),
+      screen.getByText('The tool call did not return content.'),
     ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {ToolResultMessage} from './index';
+
+describe('<ToolResultMessage />', () => {
+  it('should render nothing without tool call information', () => {
+    const {container} = render(
+      <ToolResultMessage
+        historyItemKey="1"
+        availableTools={[]}
+        toolCalls={[]}
+        result={[{contentType: 'TEXT', text: 'Tool output here'}]}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('should render the tool name and a result preview', () => {
+    render(
+      <ToolResultMessage
+        historyItemKey="1"
+        availableTools={[]}
+        toolCalls={[
+          {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
+        ]}
+        result={[{contentType: 'TEXT', text: 'Tool output here'}]}
+      />,
+    );
+
+    expect(screen.getByRole('heading', {name: 'search'})).toBeInTheDocument();
+    expect(screen.getByText('Tool output here')).toBeInTheDocument();
+    expect(
+      screen.getByLabelText('Result for search tool call'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render a compact JSON preview for object content', () => {
+    render(
+      <ToolResultMessage
+        historyItemKey="1"
+        availableTools={[]}
+        toolCalls={[
+          {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
+        ]}
+        result={[
+          {
+            contentType: 'OBJECT',
+            object: {message: 'Tool output here', hello: 'world'},
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText('{"message":"Tool output here","hello":"world"}'),
+    ).toBeInTheDocument();
+  });
+
+  it('should show a fallback message when the result has no content', () => {
+    render(
+      <ToolResultMessage
+        historyItemKey="1"
+        availableTools={[]}
+        toolCalls={[
+          {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
+        ]}
+        result={[]}
+      />,
+    );
+
+    expect(screen.getByText('Tool result has no content.')).toBeInTheDocument();
+  });
+
+  it('should show a fallback message for unsupported content types', () => {
+    render(
+      <ToolResultMessage
+        historyItemKey="1"
+        availableTools={[]}
+        toolCalls={[
+          {toolCallId: '1', toolName: 'search', elementId: null, arguments: {}},
+        ]}
+        result={[
+          {
+            contentType: 'DOCUMENT',
+            documentReference: {
+              'camunda.document.type': 'camunda',
+              contentHash: 'abc123',
+              documentId: 'doc-1',
+              storeId: 'default',
+              metadata: {
+                contentType: 'text/plain',
+                fileName: 'report.txt',
+                size: 1234,
+                expiresAt: null,
+                processDefinitionId: null,
+                processInstanceKey: null,
+                customProperties: {},
+              },
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText('Tool result has no viewable content.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
@@ -40,12 +40,12 @@ const getResultPreview = (result: ContentItem[]): string => {
 type ToolResultMessageProps = {
   availableTools: AgentTool[];
   toolCalls: AgentInstanceToolCall[];
-  result: ContentItem[];
+  content: ContentItem[];
 };
 
 const ToolResultMessage: React.FC<ToolResultMessageProps> = ({
   toolCalls,
-  result,
+  content,
 }) => {
   // According to the API, the tool call is a single entry in the tool calls list on a TOOL_RESULT message.
   const toolCall = toolCalls[0];
@@ -53,7 +53,7 @@ const ToolResultMessage: React.FC<ToolResultMessageProps> = ({
     return null;
   }
 
-  const resultPreview = getResultPreview(result);
+  const resultPreview = getResultPreview(content);
 
   return (
     <Container

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
@@ -37,14 +37,12 @@ const getResultPreview = (result: ContentItem[]): string => {
 };
 
 type ToolResultMessageProps = {
-  historyItemKey?: string;
   availableTools: AgentTool[];
   toolCalls: AgentInstanceToolCall[];
   result: ContentItem[];
 };
 
 const ToolResultMessage: React.FC<ToolResultMessageProps> = ({
-  historyItemKey,
   toolCalls,
   result,
 }) => {
@@ -59,7 +57,7 @@ const ToolResultMessage: React.FC<ToolResultMessageProps> = ({
   return (
     <Container
       $actor="TOOL_RESULT"
-      data-testid={`conversation-message${historyItemKey ? `-${historyItemKey}` : ''}`}
+      data-testid={`tool-call-result-${toolCall.toolCallId}`}
       aria-label={`Result for "${toolCall.toolName}" tool call`}
     >
       <ToolHeader>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
@@ -60,7 +60,7 @@ const ToolResultMessage: React.FC<ToolResultMessageProps> = ({
     <Container
       $actor="TOOL_RESULT"
       data-testid={`conversation-message${historyItemKey ? `-${historyItemKey}` : ''}`}
-      aria-label={`Result for ${toolCall.toolName} tool call`}
+      aria-label={`Result for "${toolCall.toolName}" tool call`}
     >
       <ToolHeader>
         <Tools size={12} />

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
@@ -24,15 +24,16 @@ import {Button} from '@carbon/react';
 type ContentItem = AgentInstanceHistoryItem['content'][number];
 
 const getResultPreview = (result: ContentItem[]): string => {
-  const entry = result[0];
-  if (!entry) {
-    return 'Tool result has no content.';
-  } else if (entry.contentType === 'TEXT') {
-    return entry.text;
-  } else if (entry.contentType === 'OBJECT') {
-    return JSON.stringify(entry.object);
-  } else {
-    return 'Tool result has no viewable content.';
+  const entry = result.find(
+    (item) => item.contentType === 'TEXT' || item.contentType === 'OBJECT',
+  );
+  switch (entry?.contentType) {
+    case 'TEXT':
+      return entry.text;
+    case 'OBJECT':
+      return JSON.stringify(entry.object);
+    default:
+      return 'The tool call did not return content.';
   }
 };
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {
+  AgentInstanceHistoryItem,
+  AgentInstanceToolCall,
+  AgentTool,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {Maximize, Tools} from '@carbon/react/icons';
+import {
+  Container,
+  ResultPreview,
+  ToolActions,
+  ToolHeader,
+  ToolLabel,
+} from './styled';
+import {Button} from '@carbon/react';
+
+type ContentItem = AgentInstanceHistoryItem['content'][number];
+
+const getResultPreview = (result: ContentItem[]): string => {
+  const entry = result[0];
+  if (!entry) {
+    return 'Tool result has no content.';
+  } else if (entry.contentType === 'TEXT') {
+    return entry.text;
+  } else if (entry.contentType === 'OBJECT') {
+    return JSON.stringify(entry.object);
+  } else {
+    return 'Tool result has no viewable content.';
+  }
+};
+
+type ToolResultMessageProps = {
+  historyItemKey?: string;
+  availableTools: AgentTool[];
+  toolCalls: AgentInstanceToolCall[];
+  result: ContentItem[];
+};
+
+const ToolResultMessage: React.FC<ToolResultMessageProps> = ({
+  historyItemKey,
+  toolCalls,
+  result,
+}) => {
+  // According to the API, the tool call is a single entry in the tool calls list on a TOOL_RESULT message.
+  const toolCall = toolCalls[0];
+  if (!toolCall) {
+    return null;
+  }
+
+  const resultPreview = getResultPreview(result);
+
+  return (
+    <Container
+      $actor="TOOL_RESULT"
+      data-testid={`conversation-message${historyItemKey ? `-${historyItemKey}` : ''}`}
+      aria-label={`Result for ${toolCall.toolName} tool call`}
+    >
+      <ToolHeader>
+        <Tools size={12} />
+        <ToolLabel>{toolCall.toolName}</ToolLabel>
+      </ToolHeader>
+      <ResultPreview>{resultPreview}</ResultPreview>
+      <ToolActions>
+        <Button
+          disabled // disabled until implemented.
+          kind="ghost"
+          size="sm"
+          renderIcon={Maximize}
+          iconDescription="Expand"
+          tooltipAlignment="end"
+          hasIconOnly
+        />
+      </ToolActions>
+    </Container>
+  );
+};
+
+export {ToolResultMessage};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/styled.ts
@@ -60,6 +60,7 @@ const ResultPreview = styled.p`
   overflow: hidden;
   text-overflow: ellipsis;
   color: var(--cds-text-secondary);
+  max-inline-size: 100ch;
 `;
 
 export {Container, ToolHeader, ToolLabel, ToolActions, ResultPreview};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/styled.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {
+  ActorLabel,
+  Container as MessageContainer,
+  MessageHeader,
+} from '../styled';
+
+const ToolActions = styled.div`
+  grid-area: actions;
+  display: flex;
+  opacity: 0;
+
+  &:has(:focus-visible) {
+    opacity: 1;
+  }
+`;
+
+const Container = styled(MessageContainer)`
+  display: grid;
+  align-items: start;
+  column-gap: var(--cds-spacing-03);
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    'header actions'
+    'content actions';
+
+  &:hover ${ToolActions} {
+    opacity: 1;
+  }
+`;
+
+const ToolHeader = styled(MessageHeader)`
+  grid-area: header;
+
+  & > svg {
+    color: var(--cds-icon-secondary);
+  }
+`;
+
+const ToolLabel = styled(ActorLabel)`
+  text-transform: initial;
+`;
+
+const ResultPreview = styled.p`
+  grid-area: content;
+  font-family: var(--cds-code-01-font-family);
+  font-size: var(--cds-code-01-font-size);
+  font-weight: var(--cds-code-01-font-weight);
+  line-height: var(--cds-code-01-line-height);
+  letter-spacing: var(--cds-code-01-letter-spacing);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: var(--cds-text-secondary);
+`;
+
+export {Container, ToolHeader, ToolLabel, ToolActions, ResultPreview};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -8,7 +8,7 @@
 
 import {useReducer} from 'react';
 import {Button, Tag, Tooltip} from '@carbon/react';
-import {Document, Maximize} from '@carbon/react/icons';
+import {Document, Maximize, Tools} from '@carbon/react/icons';
 import type {
   AgentInstanceHistoryItem,
   AgentInstanceHistoryRole,
@@ -158,6 +158,7 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
               aria-label={`"${tc.toolName}" tool call.`}
               disabled
             >
+              <Tools size={12} />
               {tc.toolName}
             </AttachmentButton>
           ))}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -59,7 +59,6 @@ type ConversationMessageProps = {
   historyItemKey?: string;
   metrics?: Metrics | null;
   toolCalls?: ToolCall[];
-  onToolCallClick?: (toolCall: ToolCall) => void;
 };
 
 const ConversationMessage: React.FC<ConversationMessageProps> = ({
@@ -68,7 +67,6 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
   historyItemKey,
   metrics = null,
   toolCalls = [],
-  onToolCallClick,
 }) => {
   const [messageDetails, dispatch] = useReducer(
     messageDetailsReducer,
@@ -154,22 +152,15 @@ const ConversationMessage: React.FC<ConversationMessageProps> = ({
       {toolCalls.length > 0 && (
         <AttachmentsContainer>
           <AttachmentsLabel>Tool calls</AttachmentsLabel>
-          {toolCalls.map((tc) => {
-            const isDisabled = tc.elementId === null;
-            const label = isDisabled
-              ? `"${tc.toolName}" tool call.`
-              : `"${tc.toolName}" tool call. Click to open details.`;
-            return (
-              <AttachmentButton
-                key={tc.toolCallId}
-                aria-label={label}
-                disabled={isDisabled}
-                onClick={() => onToolCallClick?.(tc)}
-              >
-                {tc.toolName}
-              </AttachmentButton>
-            );
-          })}
+          {toolCalls.map((tc) => (
+            <AttachmentButton
+              key={tc.toolCallId}
+              aria-label={`"${tc.toolName}" tool call.`}
+              disabled
+            >
+              {tc.toolName}
+            </AttachmentButton>
+          ))}
         </AttachmentsContainer>
       )}
       {messageDetails.state === 'visible' && (

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/index.tsx
@@ -30,7 +30,7 @@ import {
 import {MarkdownMessage} from './MarkdownMessage';
 import {MessageDetailsModal} from './MessageDetailsModal';
 
-type Actor = AgentInstanceHistoryRole | 'SYSTEM';
+type Actor = Exclude<AgentInstanceHistoryRole, 'TOOL_RESULT'> | 'SYSTEM';
 type ContentItem = AgentInstanceHistoryItem['content'][number];
 type ToolCall = AgentInstanceHistoryItem['toolCalls'][number];
 type Metrics = AgentInstanceHistoryItem['metrics'];
@@ -39,14 +39,12 @@ const readableTitleByActor: Record<Actor, string> = {
   SYSTEM: 'System prompt',
   USER: 'User message',
   ASSISTANT: 'Assistant message',
-  TOOL_RESULT: 'Tool result',
 };
 
 const labelByActor: Record<Actor, string> = {
   SYSTEM: 'System',
   USER: 'User',
   ASSISTANT: 'Assistant',
-  TOOL_RESULT: 'Tool Result',
 };
 
 function formatDuration(ms: number): string {

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/index.tsx
@@ -183,6 +183,7 @@ const AgentDetails: React.FC<AgentDetailsProps> = ({
         >
           <ConversationHistory
             agentInstanceKey={agentInstance.agentInstanceKey}
+            availableTools={agentInstance.tools}
             isVisible={isConversationHistoryOpen}
             enablePeriodicRefetch={isAgentInstanceActive(agentInstance)}
             selectedElementInstanceKey={selectedElementInstanceKey}


### PR DESCRIPTION
## Description

This PR overhauls the `ConversationHistory` and `ConversationMessage` to separate `TOOL_RESULTS` into a dedicated component. This is the first part of updated tool results after the design prototype update (see issue for info).

The new design does not follow the prototype exactly - it is only inspired by it. Overall, the design is bit more aligned with other conversation messages to look more cohesive and scale with more features (e.g. a loop counter).
- Tool name has same design as other message names
- Result preview is in a separate line
- Note: Expand button is disabled until its modal is implemented.
- => `ToolResultMessages` are still compact and only 4px bigger than the prototype.

**Prototype:**
<img width="1237" height="343" alt="Screenshot 2026-07-02 at 15 34 29" src="https://github.com/user-attachments/assets/40b9bc04-dc06-4b8f-b89d-b74c4833956b" />

**Implementation:**
<img width="1200" height="241" alt="Screenshot 2026-07-02 at 15 35 28" src="https://github.com/user-attachments/assets/2740d160-4278-4faf-b6d1-d6e10c01d91b" />

</div>


## Related issues

relates #56089
