### PR TITLE
Emit AGENT_HISTORY:COMMIT on agentic job completion

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/AgentInstanceAuthorizationIT.java
@@ -126,6 +126,9 @@ class AgentInstanceAuthorizationIT {
         .content(List.of(AgentInstanceHistoryContent.text("hello")))
         .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
         .execute();
+    // Complete job1 so JobCompleteProcessor emits AGENT_HISTORY:COMMIT, transitioning
+    // the history item to COMMITTED so it becomes searchable.
+    adminClient.newCompleteCommand(jobKey1).execute();
 
     agentInstanceKey2 = createAgentInstance(adminClient, PROCESS_ID_2).agentInstanceKey();
     final var result3 = createAgentInstance(adminClient, PROCESS_ID_3);

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
+import static io.camunda.it.util.TestHelper.waitForElementInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
+import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
+import io.camunda.client.api.search.response.AgentInstanceHistory;
+import io.camunda.qa.util.compatibility.CompatibilityTest;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+@MultiDbTest
+@CompatibilityTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
+public class AgentHistoryCommitLifecycleIT {
+
+  private static final String SERVICE_TASK_ID = "agentTask";
+  private static final String PROCESS_ID = "agentHistoryCommitLifecycleProcess";
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void shouldTransitionHistoryItemsFromPendingToCommittedOnJobCompletion() {
+    // --- setup: deploy, start, get element instance ---
+    final var processModel =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                SERVICE_TASK_ID,
+                t -> t.zeebeJobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX))
+            .endEvent()
+            .done();
+
+    final var process =
+        deployProcessAndWaitForIt(
+            camundaClient, processModel, "agent-history-commit-lifecycle.bpmn");
+
+    final var pi = startProcessInstance(camundaClient, process.getBpmnProcessId());
+    final long processInstanceKey = pi.getProcessInstanceKey();
+
+    waitForElementInstances(
+        camundaClient, f -> f.elementId(SERVICE_TASK_ID).processInstanceKey(processInstanceKey), 1);
+
+    final long elementInstanceKey =
+        camundaClient
+            .newElementInstanceSearchRequest()
+            .filter(f -> f.elementId(SERVICE_TASK_ID).processInstanceKey(processInstanceKey))
+            .execute()
+            .items()
+            .getFirst()
+            .getElementInstanceKey();
+
+    // --- create agent instance ---
+    final long agentInstanceKey =
+        camundaClient
+            .newCreateAgentInstanceCommand()
+            .elementInstanceKey(elementInstanceKey)
+            .model("gpt-4o")
+            .provider("openai")
+            .systemPrompt("You are a helpful assistant.")
+            .send()
+            .join()
+            .getAgentInstanceKey();
+
+    waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey);
+
+    // --- activate the agentic job ---
+    final var activatedJobs =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX)
+            .maxJobsToActivate(1)
+            .timeout(Duration.ofMinutes(5))
+            .send()
+            .join()
+            .getJobs();
+    assertThat(activatedJobs)
+        .as("expected to activate one agent job for process instance %d", processInstanceKey)
+        .isNotEmpty();
+    final long jobKey = activatedJobs.get(0).getKey();
+
+    // --- create two history items ---
+    final long historyItemKey1 =
+        camundaClient
+            .newCreateAgentHistoryItemCommand(agentInstanceKey)
+            .elementInstanceKey(elementInstanceKey)
+            .jobKey(jobKey)
+            .role(AgentInstanceHistoryRole.USER)
+            .content(List.of(AgentInstanceHistoryContent.text("Hello, what can you do?")))
+            .producedAt(OffsetDateTime.parse("2025-06-01T10:00:00Z"))
+            .send()
+            .join()
+            .getHistoryItemKey();
+
+    final long historyItemKey2 =
+        camundaClient
+            .newCreateAgentHistoryItemCommand(agentInstanceKey)
+            .elementInstanceKey(elementInstanceKey)
+            .jobKey(jobKey)
+            .role(AgentInstanceHistoryRole.ASSISTANT)
+            .content(List.of(AgentInstanceHistoryContent.text("I can help with many tasks.")))
+            .producedAt(OffsetDateTime.parse("2025-06-01T10:01:00Z"))
+            .send()
+            .join()
+            .getHistoryItemKey();
+
+    // --- verify items are PENDING before job completion ---
+    // Filter by all statuses so that any spurious item of any commit status is visible;
+    // an all-status filter is needed because the search API returns COMMITTED items by default.
+    Awaitility.await("history items indexed as PENDING")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+                      .filter(
+                          f ->
+                              f.commitStatus(
+                                  s ->
+                                      s.in(
+                                          AgentInstanceHistoryCommitStatus.PENDING,
+                                          AgentInstanceHistoryCommitStatus.COMMITTED,
+                                          AgentInstanceHistoryCommitStatus.DISCARDED)))
+                      .execute()
+                      .items();
+              assertThat(items)
+                  .hasSize(2)
+                  .allSatisfy(
+                      item ->
+                          assertThat(item.getCommitStatus())
+                              .isEqualTo(AgentInstanceHistoryCommitStatus.PENDING));
+            });
+
+    final var pendingItems =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .filter(f -> f.commitStatus(AgentInstanceHistoryCommitStatus.PENDING))
+            .execute()
+            .items();
+    assertThat(pendingItems)
+        .extracting(AgentInstanceHistory::getHistoryItemKey)
+        .containsExactlyInAnyOrder(historyItemKey1, historyItemKey2);
+
+    // --- complete the job → engine emits COMMIT → items become COMMITTED ---
+    camundaClient.newCompleteCommand(jobKey).execute();
+
+    // --- verify items are COMMITTED after job completion ---
+    // Filter by all statuses to confirm no items remain in PENDING or DISCARDED state.
+    Awaitility.await("history items transitioned to COMMITTED")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var items =
+                  camundaClient
+                      .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+                      .filter(
+                          f ->
+                              f.commitStatus(
+                                  s ->
+                                      s.in(
+                                          AgentInstanceHistoryCommitStatus.PENDING,
+                                          AgentInstanceHistoryCommitStatus.COMMITTED,
+                                          AgentInstanceHistoryCommitStatus.DISCARDED)))
+                      .execute()
+                      .items();
+              assertThat(items)
+                  .hasSize(2)
+                  .allSatisfy(
+                      item ->
+                          assertThat(item.getCommitStatus())
+                              .isEqualTo(AgentInstanceHistoryCommitStatus.COMMITTED));
+            });
+
+    final var committedItems =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .filter(f -> f.commitStatus(AgentInstanceHistoryCommitStatus.COMMITTED))
+            .execute()
+            .items();
+    assertThat(committedItems)
+        .extracting(AgentInstanceHistory::getHistoryItemKey)
+        .containsExactlyInAnyOrder(historyItemKey1, historyItemKey2);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -27,11 +27,9 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @CompatibilityTest
-@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 public class AgentHistoryCommitLifecycleIT {
 
   private static final String SERVICE_TASK_ID = "agentTask";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -12,6 +12,7 @@ import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForAgentInstanceToBeIndexed;
 import static io.camunda.it.util.TestHelper.waitForElementInstances;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
@@ -144,22 +145,13 @@ public class AgentHistoryCommitLifecycleIT {
                       .execute()
                       .items();
               assertThat(items)
-                  .hasSize(2)
-                  .allSatisfy(
-                      item ->
-                          assertThat(item.getCommitStatus())
-                              .isEqualTo(AgentInstanceHistoryCommitStatus.PENDING));
+                  .extracting(
+                      AgentInstanceHistory::getHistoryItemKey,
+                      AgentInstanceHistory::getCommitStatus)
+                  .containsExactlyInAnyOrder(
+                      tuple(historyItemKey1, AgentInstanceHistoryCommitStatus.PENDING),
+                      tuple(historyItemKey2, AgentInstanceHistoryCommitStatus.PENDING));
             });
-
-    final var pendingItems =
-        camundaClient
-            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
-            .filter(f -> f.commitStatus(AgentInstanceHistoryCommitStatus.PENDING))
-            .execute()
-            .items();
-    assertThat(pendingItems)
-        .extracting(AgentInstanceHistory::getHistoryItemKey)
-        .containsExactlyInAnyOrder(historyItemKey1, historyItemKey2);
 
     // --- complete the job → engine emits COMMIT → items become COMMITTED ---
     camundaClient.newCompleteCommand(jobKey).execute();
@@ -185,21 +177,12 @@ public class AgentHistoryCommitLifecycleIT {
                       .execute()
                       .items();
               assertThat(items)
-                  .hasSize(2)
-                  .allSatisfy(
-                      item ->
-                          assertThat(item.getCommitStatus())
-                              .isEqualTo(AgentInstanceHistoryCommitStatus.COMMITTED));
+                  .extracting(
+                      AgentInstanceHistory::getHistoryItemKey,
+                      AgentInstanceHistory::getCommitStatus)
+                  .containsExactlyInAnyOrder(
+                      tuple(historyItemKey1, AgentInstanceHistoryCommitStatus.COMMITTED),
+                      tuple(historyItemKey2, AgentInstanceHistoryCommitStatus.COMMITTED));
             });
-
-    final var committedItems =
-        camundaClient
-            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
-            .filter(f -> f.commitStatus(AgentInstanceHistoryCommitStatus.COMMITTED))
-            .execute()
-            .items();
-    assertThat(committedItems)
-        .extracting(AgentInstanceHistory::getHistoryItemKey)
-        .containsExactlyInAnyOrder(historyItemKey1, historyItemKey2);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -138,6 +138,10 @@ public class AgentInstanceHistorySearchIT {
             .join()
             .getHistoryItemKey();
 
+    // Complete the job so JobCompleteProcessor emits AGENT_HISTORY:COMMIT,
+    // causing history items to transition to COMMITTED and become searchable.
+    camundaClient.newCompleteCommand(jobKey).execute();
+
     waitForHistoryItemsToBeIndexed(camundaClient, agentInstanceKey, 3);
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/tenancy/AgentInstanceTenancyIT.java
@@ -106,6 +106,8 @@ public class AgentInstanceTenancyIT {
         .content(List.of(AgentInstanceHistoryContent.text("Hello from " + TENANT_A)))
         .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
         .execute();
+    // Complete job A so JobCompleteProcessor emits AGENT_HISTORY:COMMIT for its items.
+    adminClient.newCompleteCommand(jobKeyA).execute();
 
     final var resultB = createAgentInstanceWithResult(adminClient, TENANT_B);
     agentInstanceKeyB = resultB.agentInstanceKey();
@@ -121,6 +123,8 @@ public class AgentInstanceTenancyIT {
         .content(List.of(AgentInstanceHistoryContent.text("Hello from " + TENANT_B)))
         .producedAt(OffsetDateTime.parse("2025-06-01T12:00:00Z"))
         .execute();
+    // Complete job B so its history items also transition to COMMITTED.
+    adminClient.newCompleteCommand(jobKeyB).execute();
 
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyA);
     waitForAgentInstanceToBeIndexed(adminClient, agentInstanceKeyB);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateProcessor.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -29,7 +28,6 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<AgentHistoryRecord> {
 
   private final StateWriter stateWriter;
-  private final TypedCommandWriter commandWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final AgentInstanceState agentInstanceState;
@@ -43,7 +41,6 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
       final AuthorizationCheckBehavior authCheckBehavior,
       final KeyGenerator keyGenerator) {
     stateWriter = writers.state();
-    commandWriter = writers.command();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     agentInstanceState = processingState.getAgentInstanceState();
@@ -141,15 +138,6 @@ public final class AgentHistoryCreateProcessor implements TypedRecordProcessor<A
 
     stateWriter.appendFollowUpEvent(historyKey, AgentHistoryIntent.CREATED, event);
     responseWriter.writeEventOnCommand(historyKey, AgentHistoryIntent.CREATED, event, command);
-    // TODO (#55033): COMMIT is emitted immediately after each item is created as an
-    // intermediate step; once the pending-commit lifecycle is wired to job
-    // completion/failure events, this follow-up command will be moved there instead.
-    commandWriter.appendFollowUpCommand(
-        historyKey,
-        AgentHistoryIntent.COMMIT,
-        new AgentHistoryRecord()
-            .setJobKey(commandValue.getJobKey())
-            .setJobLease(commandValue.getJobLease()));
   }
 
   private void writeRejection(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -31,11 +31,13 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.encoding.AgentInfo;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessInstructionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResultActivateElement;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
@@ -201,6 +203,13 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
 
     stateWriter.appendFollowUpEvent(command.getKey(), JobIntent.COMPLETED, job);
     responseWriter.writeEventOnCommand(command.getKey(), JobIntent.COMPLETED, job, command);
+
+    if (job.isAgentic()) {
+      commandWriter.appendFollowUpCommand(
+          command.getKey(),
+          AgentHistoryIntent.COMMIT,
+          new AgentHistoryRecord().setJobKey(command.getKey()).setJobLease(""));
+    }
 
     jobMetrics.countJobEvent(JobAction.COMPLETED, job.getJobKind(), job.getType());
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCreateTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -33,6 +34,7 @@ public class AgentHistoryCreateTest {
 
   private static final String PROCESS_ID = "process";
   private static final String SERVICE_TASK_ID = "agent-task";
+  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
 
   @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
 
@@ -63,13 +65,6 @@ public class AgentHistoryCreateTest {
     assertThat(created.getValue().getJobKey()).isEqualTo(jobKey);
     assertThat(created.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
     assertThat(created.getValue().getBpmnProcessId()).isEqualTo(PROCESS_ID);
-
-    final var committed =
-        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
-            .withAgentInstanceKey(agentInstanceKey)
-            .getFirst();
-    assertThat(committed.getRecordType()).isEqualTo(RecordType.EVENT);
-    assertThat(committed.getKey()).isEqualTo(created.getKey());
   }
 
   @Test
@@ -190,7 +185,7 @@ public class AgentHistoryCreateTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(PROCESS_ID)
                 .startEvent()
-                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType("agent"))
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
                 .endEvent()
                 .done())
         .deploy();
@@ -203,10 +198,10 @@ public class AgentHistoryCreateTest {
   }
 
   private static long activateJobForProcessInstance(final long processInstanceKey) {
-    ENGINE.jobs().withType("agent").activate();
+    ENGINE.jobs().withType(JOB_TYPE).activate();
     return RecordingExporter.jobRecords(JobIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
-        .withType("agent")
+        .withType(JOB_TYPE)
         .getFirst()
         .getKey();
   }


### PR DESCRIPTION
## Summary

- Move the `AGENT_HISTORY:COMMIT` follow-up command from `AgentHistoryCreateProcessor` to `JobCompleteProcessor` so agent history items stay `PENDING` until the job completes rather than being committed immediately after creation
- Update `AgentHistoryCreateTest` to use `IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX` job type, matching the type `JobCompleteProcessor` routes to `AgentHistoryCommitProcessor`
- Add integration test (`AgentHistoryCommitLifecycleIT`) verifying the end-to-end `PENDING→COMMITTED` lifecycle via the Camunda client

## Test plan

- [x] `AgentHistoryCreateTest` — 5 unit tests pass (happy path no longer asserts an inline COMMITTED event)
- [x] `AgentHistoryCommitTest` — 3 unit tests pass (commit triggered separately, no stop/replay needed)
- [x] `AgentHistoryCommitLifecycleIT` — integration test verifies PENDING→COMMITTED transition on job completion

## Related issues

Closes #56162.
Depends on #56161 / PR #56308.

🤖 Generated with [Claude Code](https://claude.com/claude-code)