### PR TITLE
deps: Update version.tomcat to v10.1.56 (stable/optimize-8.7)

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -56,7 +56,7 @@
     <opentelemetry.version>1.62.0</opentelemetry.version>
     <spring.version>6.2.19</spring.version>
     <spring.security.version>6.5.11</spring.security.version>
-    <version.tomcat>10.1.55</version.tomcat>
+    <version.tomcat>10.1.56</version.tomcat>
     <httpclient.version>4.5.14</httpclient.version>
     <quartz.version>2.3.2</quartz.version>
     <kotlin-stdlib.version>2.1.0</kotlin-stdlib.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -106,7 +106,7 @@
     <spring-security.version>${version.spring-security}</spring-security.version>
     <version.spring-boot>3.5.15</version.spring-boot>
     <version.logback>1.5.37</version.logback>
-    <version.tomcat>10.1.55</version.tomcat>
+    <version.tomcat>10.1.56</version.tomcat>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.0</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>


### PR DESCRIPTION
## Description

Fixes the following CVEs:

- CVE-2026-53404
- CVE-2026-55276
- CVE-2026-55956
- CVE-2026-53434
- CVE-2026-55955

---

| Package | Change |
|---|---|
| [org.apache.tomcat.embed:tomcat-embed-websocket](https://tomcat.apache.org/) | `10.1.55` → `10.1.56` |
| [org.apache.tomcat.embed:tomcat-embed-el](https://tomcat.apache.org/) | `10.1.55` → `10.1.56` |
| [org.apache.tomcat.embed:tomcat-embed-core](https://tomcat.apache.org/) | `10.1.55` → `10.1.56` |


## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56663
