### PR TITLE
fix: use PASS_THROUGH + MVC urlDecode=false to preserve %2F in group IDs

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -215,21 +215,6 @@ public class WebSecurityConfig {
   private static final KeyValues CAMUNDA_AUTHENTICATION_OBSERVATION_DOMAIN_IDENTITY_TAGS =
       KeyValues.of("domain", "identity");
 
-  /**
-   * Allows encoded slashes ({@code %2F}) in request URIs. Required for entity IDs containing
-   * forward slashes (e.g., OIDC group IDs like {@code /myGroup} from Keycloak). Without this, the
-   * default {@link StrictHttpFirewall} rejects any request whose URI contains {@code %2F} with a
-   * 400 error before it reaches any controller.
-   *
-   * @see <a href="https://github.com/camunda/camunda/issues/45215">Issue #45215</a>
-   */
-  @Bean
-  public WebSecurityCustomizer encodedSlashFirewallCustomizer() {
-    final var firewall = new StrictHttpFirewall();
-    firewall.setAllowUrlEncodedSlash(true);
-    return web -> web.httpFirewall(firewall);
-  }
-
   @Bean
   @Order(ORDER_UNPROTECTED)
   public SecurityFilterChain unprotectedPathsSecurityFilterChain(

--- a/dist/src/main/java/io/camunda/application/commons/rest/EncodedSlashMvcConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/EncodedSlashMvcConfig.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rest;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.util.UrlPathHelper;
+
+/**
+ * Configures Spring MVC's {@link UrlPathHelper} to not pre-decode the request URI before path
+ * matching. This is required so that {@code %2F} (an encoded forward slash) in a path segment is
+ * treated as an opaque segment token rather than decoded to {@code /} (which would introduce an
+ * extra path separator and cause the path normalizer to collapse {@code //myGroup} → {@code
+ * myGroup}, silently stripping the leading slash).
+ *
+ * <p>With {@code urlDecode=false}:
+ *
+ * <ol>
+ *   <li>The path {@code /roles/admin/groups/%2FmyGroup} is matched as-is by {@code AntPathMatcher},
+ *       binding {@code {groupId}} to the raw value {@code %2FmyGroup}.
+ *   <li>{@link UrlPathHelper#decodePathVariables(jakarta.servlet.http.HttpServletRequest,
+ *       java.util.Map)} then decodes each path variable individually, so {@code @PathVariable
+ *       String groupId} receives {@code /myGroup} (with the slash preserved).
+ * </ol>
+ *
+ * <p>All other percent-encoded path variable values (e.g., {@code %40} for {@code @}) are decoded
+ * by the same {@code decodePathVariables()} call, so the change is transparent to callers.
+ *
+ * @see TomcatEncodedSlashConfig
+ * @see <a href="https://github.com/camunda/camunda/issues/45215">Issue #45215</a>
+ */
+@Configuration
+public class EncodedSlashMvcConfig implements WebMvcConfigurer {
+
+  @Override
+  public void configurePathMatch(final PathMatchConfigurer configurer) {
+    final UrlPathHelper urlPathHelper = new UrlPathHelper();
+    urlPathHelper.setUrlDecode(false);
+    configurer.setUrlPathHelper(urlPathHelper);
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rest/EncodedSlashMvcConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/EncodedSlashMvcConfig.java
@@ -7,36 +7,54 @@
  */
 package io.camunda.application.commons.rest;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.util.UrlPathHelper;
 
 /**
- * Configures Spring MVC's {@link UrlPathHelper} to not pre-decode the request URI before path
- * matching. This is required so that {@code %2F} (an encoded forward slash) in a path segment is
- * treated as an opaque segment token rather than decoded to {@code /} (which would introduce an
- * extra path separator and cause the path normalizer to collapse {@code //myGroup} → {@code
- * myGroup}, silently stripping the leading slash).
+ * Configures the three layers required to handle {@code %2F} (encoded forward slash) in URL path
+ * segments — Tomcat connector, Spring Security firewall, and Spring MVC path matching — so that
+ * entity IDs containing forward slashes (e.g., OIDC group IDs like {@code /myGroup} from Keycloak)
+ * round-trip correctly through the REST layer.
  *
- * <p>With {@code urlDecode=false}:
+ * <p>This class is unconditional (no {@code @Profile}) so it applies regardless of the active
+ * authentication profile. The three cooperating layers are:
  *
  * <ol>
- *   <li>The path {@code /roles/admin/groups/%2FmyGroup} is matched as-is by {@code AntPathMatcher},
- *       binding {@code {groupId}} to the raw value {@code %2FmyGroup}.
- *   <li>{@link UrlPathHelper#decodePathVariables(jakarta.servlet.http.HttpServletRequest,
- *       java.util.Map)} then decodes each path variable individually, so {@code @PathVariable
- *       String groupId} receives {@code /myGroup} (with the slash preserved).
+ *   <li>{@link TomcatEncodedSlashConfig}: {@code PASS_THROUGH} — keeps {@code %2F} in the URI so
+ *       Tomcat's path normalizer never sees a literal {@code /} from the encoded slash.
+ *   <li>{@link #encodedSlashFirewallCustomizer()} below: {@code allowUrlEncodedSlash(true)} —
+ *       prevents Spring Security's {@link StrictHttpFirewall} from rejecting {@code %2F} with 400.
+ *       This bean is defined here (not in a profile-specific {@code WebSecurityConfig}) so it is
+ *       always registered.
+ *   <li>{@link #configurePathMatch} below: {@code urlDecode=false} — prevents Spring MVC's {@link
+ *       UrlPathHelper} from decoding {@code %2F} to {@code /} before path matching (which would
+ *       introduce {@code //} and cause the path sanitizer to collapse it to {@code /}, stripping
+ *       the leading slash). After matching, {@code decodePathVariables()} decodes the raw {@code
+ *       %2FmyGroup} → {@code /myGroup} for the {@code @PathVariable}.
  * </ol>
- *
- * <p>All other percent-encoded path variable values (e.g., {@code %40} for {@code @}) are decoded
- * by the same {@code decodePathVariables()} call, so the change is transparent to callers.
  *
  * @see TomcatEncodedSlashConfig
  * @see <a href="https://github.com/camunda/camunda/issues/45215">Issue #45215</a>
  */
 @Configuration
 public class EncodedSlashMvcConfig implements WebMvcConfigurer {
+
+  /**
+   * Allows {@code %2F} through Spring Security's {@link StrictHttpFirewall}. Without this, the
+   * firewall rejects any request whose URI contains {@code %2F} with a 400 before it reaches any
+   * controller.
+   */
+  @Bean
+  public WebSecurityCustomizer encodedSlashFirewallCustomizer() {
+    final var firewall = new StrictHttpFirewall();
+    firewall.setAllowUrlEncodedSlash(true);
+    return web -> web.httpFirewall(firewall);
+  }
 
   @Override
   public void configurePathMatch(final PathMatchConfigurer configurer) {

--- a/dist/src/main/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfig.java
@@ -14,18 +14,26 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Configures Tomcat to decode encoded slashes ({@code %2F}) instead of rejecting them with a 400
- * error. This is required to support entity IDs that contain forward slashes (e.g., OIDC group IDs
- * like {@code /myGroup} from Keycloak).
+ * Configures Tomcat to pass encoded slashes ({@code %2F}) through to Spring MVC instead of
+ * rejecting them with a 400 error. This is required to support entity IDs that contain forward
+ * slashes (e.g., OIDC group IDs like {@code /myGroup} from Keycloak).
  *
- * <p>Uses {@link EncodedSolidusHandling#DECODE} rather than {@code PASS_THROUGH} because Tomcat
- * 10.1+ rejects {@code %2F} during path normalization even in {@code PASS_THROUGH} mode. {@code
- * DECODE} converts {@code %2F} → {@code /} at the connector level, before the normalization check.
+ * <p>Uses {@link EncodedSolidusHandling#PASS_THROUGH} so that {@code %2F} reaches Spring MVC as-is.
+ * Spring MVC path matching (configured via {@link EncodedSlashMvcConfig} with {@code
+ * urlDecode=false}) then treats {@code %2FmyGroup} as a single path segment rather than a path
+ * separator. After the route is matched, Spring's {@code UrlPathHelper.decodePathVariables()}
+ * decodes {@code %2F} → {@code /}, so {@code @PathVariable} parameters receive {@code /myGroup}
+ * (with the slash intact).
+ *
+ * <p>Note: {@code DECODE} mode (used in an earlier fix attempt) converted {@code %2F} → {@code /}
+ * at the Tomcat level, which caused Tomcat's path normalizer to collapse {@code //myGroup} → {@code
+ * myGroup}, silently stripping the leading slash before Spring MVC ever saw it.
  *
  * <p>Note: Spring Security's {@code StrictHttpFirewall} also rejects {@code %2F} independently. The
  * firewall fix lives in {@code WebSecurityConfig.encodedSlashFirewallCustomizer()} (authentication
  * module), configured via {@code WebSecurityCustomizer}.
  *
+ * @see EncodedSlashMvcConfig
  * @see <a href="https://github.com/camunda/camunda/issues/45215">Issue #45215</a>
  */
 @Configuration
@@ -36,6 +44,7 @@ public class TomcatEncodedSlashConfig {
     return factory ->
         factory.addConnectorCustomizers(
             connector ->
-                connector.setEncodedSolidusHandling(EncodedSolidusHandling.DECODE.getValue()));
+                connector.setEncodedSolidusHandling(
+                    EncodedSolidusHandling.PASS_THROUGH.getValue()));
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfigTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rest/TomcatEncodedSlashConfigTest.java
@@ -21,7 +21,7 @@ import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 class TomcatEncodedSlashConfigTest {
 
   @Test
-  void shouldConfigureDecodeForEncodedSlashes() {
+  void shouldConfigurePassThroughForEncodedSlashes() {
     // given
     final var config = new TomcatEncodedSlashConfig();
     final WebServerFactoryCustomizer<TomcatServletWebServerFactory> customizer =
@@ -37,6 +37,6 @@ class TomcatEncodedSlashConfigTest {
 
     final var connector = mock(Connector.class);
     captor.getValue().customize(connector);
-    verify(connector).setEncodedSolidusHandling(EncodedSolidusHandling.DECODE.getValue());
+    verify(connector).setEncodedSolidusHandling(EncodedSolidusHandling.PASS_THROUGH.getValue());
   }
 }

--- a/dist/src/test/java/io/camunda/application/it/EncodedSlashIntegrationIT.java
+++ b/dist/src/test/java/io/camunda/application/it/EncodedSlashIntegrationIT.java
@@ -9,6 +9,7 @@ package io.camunda.application.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.application.commons.rest.EncodedSlashMvcConfig;
 import io.camunda.application.commons.rest.TomcatEncodedSlashConfig;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -28,9 +29,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -50,10 +49,10 @@ import org.springframework.web.bind.annotation.RestController;
  * <ol>
  *   <li>{@link TomcatEncodedSlashConfig}: {@code PASS_THROUGH} — keeps {@code %2F} in the URI so
  *       Tomcat's path normalizer never sees a literal {@code /} from the encoded slash.
- *   <li>{@code WebSecurityConfig.encodedSlashFirewallCustomizer()}: {@code
+ *   <li>{@link EncodedSlashMvcConfig#encodedSlashFirewallCustomizer()}: {@code
  *       allowUrlEncodedSlash(true)} — prevents Spring Security's {@link
  *       org.springframework.security.web.firewall.StrictHttpFirewall} from rejecting {@code %2F}
- *       with 400.
+ *       with 400. Defined unconditionally so it applies across all auth profiles.
  *   <li>{@link EncodedSlashMvcConfig}: {@code urlDecode=false} — prevents Spring MVC's {@link
  *       org.springframework.web.util.UrlPathHelper} from decoding {@code %2F} to {@code /} before
  *       path matching (which would introduce {@code //} and cause the path sanitizer to collapse it
@@ -61,10 +60,10 @@ import org.springframework.web.bind.annotation.RestController;
  *       decodes the raw {@code %2FmyGroup} → {@code /myGroup} for the {@code @PathVariable}.
  * </ol>
  *
- * <p><b>Scope:</b> this fix targets the {@code consolidated-auth} profile's {@code
- * WebSecurityConfig}. Optimize defines independent Spring Security configurations running in their
- * own application contexts; an equivalent customizer would be needed there if Optimize ever exposes
- * path-variable entity IDs sourced from OIDC.
+ * <p><b>Scope:</b> the Tomcat, firewall, and MVC configs live in the {@code dist} module without a
+ * profile condition, so they apply to all auth profiles. Optimize defines independent Spring
+ * Security configurations running in their own application contexts; an equivalent customizer would
+ * be needed there if Optimize ever exposes path-variable entity IDs sourced from OIDC.
  */
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,
@@ -81,8 +80,12 @@ class EncodedSlashIntegrationIT {
 
     // then — neither Tomcat nor Spring Security's StrictHttpFirewall rejects the request with 400
     assertThat(response.statusCode())
-        .as("Tomcat (DECODE) and StrictHttpFirewall (allowUrlEncodedSlash) should let %2F through")
+        .as(
+            "Tomcat (PASS_THROUGH) and StrictHttpFirewall (allowUrlEncodedSlash) should let %2F through")
         .isNotEqualTo(400);
+    assertThat(response.body())
+        .as("@PathVariable should receive the decoded value with the slash intact")
+        .isEqualTo("/myGroup");
   }
 
   @Test
@@ -135,15 +138,15 @@ class EncodedSlashIntegrationIT {
 
   /**
    * Minimal Spring Boot context: embedded Tomcat + Spring Security + test controller. Mirrors the
-   * two production beans that must cooperate for encoded slashes to work:
+   * three production beans that must cooperate for encoded slashes to work:
    *
    * <ol>
-   *   <li>{@link TomcatEncodedSlashConfig} — Tomcat connector layer
-   *   <li>{@code WebSecurityConfig.encodedSlashFirewallCustomizer()} — Spring Security layer
+   *   <li>{@link TomcatEncodedSlashConfig} — Tomcat connector layer (PASS_THROUGH)
+   *   <li>{@link EncodedSlashMvcConfig} — Spring Security firewall + Spring MVC path matching
    * </ol>
    *
-   * <p>We don't import the full {@code WebSecurityConfig} because it requires the entire Camunda
-   * service layer. Instead we replicate just the firewall customizer bean inline.
+   * <p>The firewall customizer is no longer inline here; it lives in {@link EncodedSlashMvcConfig}
+   * so it applies unconditionally across all auth profiles.
    */
   @SpringBootConfiguration
   @EnableAutoConfiguration
@@ -156,20 +159,15 @@ class EncodedSlashIntegrationIT {
       return factory ->
           factory.addConnectorCustomizers(
               (TomcatConnectorCustomizer)
-                  connector -> {
-                    // DECODE converts %2F → / at the Tomcat level (before Spring MVC).
-                    // PASS_THROUGH keeps %2F in the URI but Tomcat 10.1+ still rejects it during
-                    // path normalization. DECODE avoids this by decoding before the check.
-                    connector.setEncodedSolidusHandling(EncodedSolidusHandling.DECODE.getValue());
-                  });
+                  connector ->
+                      connector.setEncodedSolidusHandling(
+                          EncodedSolidusHandling.PASS_THROUGH.getValue()));
     }
 
-    /** Spring Security layer: allow %2F through the firewall. */
+    /** Spring MVC layer: don't pre-decode the URI before path matching. */
     @Bean
-    public WebSecurityCustomizer encodedSlashFirewallCustomizer() {
-      final var firewall = new StrictHttpFirewall();
-      firewall.setAllowUrlEncodedSlash(true);
-      return web -> web.httpFirewall(firewall);
+    public EncodedSlashMvcConfig encodedSlashMvcConfig() {
+      return new EncodedSlashMvcConfig();
     }
 
     @Bean

--- a/dist/src/test/java/io/camunda/application/it/EncodedSlashIntegrationIT.java
+++ b/dist/src/test/java/io/camunda/application/it/EncodedSlashIntegrationIT.java
@@ -38,28 +38,33 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Integration test for <a href="https://github.com/camunda/camunda/issues/45215">#45215</a>.
- * Verifies the two backend layers this PR changes — the Tomcat connector and the Spring Security
- * firewall — accept requests whose URI contains {@code %2F}, instead of rejecting them with 400.
+ * Verifies the full stack — Tomcat connector, Spring Security firewall, and Spring MVC path
+ * matching — correctly handles {@code %2F} in URL path segments: the request reaches the controller
+ * AND the {@code @PathVariable} receives the decoded value with the slash intact.
  *
  * <p>This boots a real embedded Tomcat with Spring Security enabled — NOT a MockMvc test, because
  * MockMvc bypasses Tomcat's {@code EncodedSolidusHandling} check.
  *
- * <p>The Tomcat layer is configured via a {@link WebServerFactoryCustomizer} bean (mirroring
- * production wiring in {@link TomcatEncodedSlashConfig}), not via the {@code
- * server.tomcat.encoded-solidus-handling} property.
+ * <p>The three production beans that must cooperate are:
+ *
+ * <ol>
+ *   <li>{@link TomcatEncodedSlashConfig}: {@code PASS_THROUGH} — keeps {@code %2F} in the URI so
+ *       Tomcat's path normalizer never sees a literal {@code /} from the encoded slash.
+ *   <li>{@code WebSecurityConfig.encodedSlashFirewallCustomizer()}: {@code
+ *       allowUrlEncodedSlash(true)} — prevents Spring Security's {@link
+ *       org.springframework.security.web.firewall.StrictHttpFirewall} from rejecting {@code %2F}
+ *       with 400.
+ *   <li>{@link EncodedSlashMvcConfig}: {@code urlDecode=false} — prevents Spring MVC's {@link
+ *       org.springframework.web.util.UrlPathHelper} from decoding {@code %2F} to {@code /} before
+ *       path matching (which would introduce {@code //} and cause the path sanitizer to collapse it
+ *       to {@code /}, stripping the leading slash). After matching, {@code decodePathVariables()}
+ *       decodes the raw {@code %2FmyGroup} → {@code /myGroup} for the {@code @PathVariable}.
+ * </ol>
  *
  * <p><b>Scope:</b> this fix targets the {@code consolidated-auth} profile's {@code
- * WebSecurityConfig}. Optimize defines independent Spring Security configurations ({@code
- * CCSaaSSecurityConfigurerAdapter}, {@code CCSMSecurityConfigurerAdapter}) running in their own
- * application contexts; an equivalent customizer would be needed there if Optimize ever exposes
+ * WebSecurityConfig}. Optimize defines independent Spring Security configurations running in their
+ * own application contexts; an equivalent customizer would be needed there if Optimize ever exposes
  * path-variable entity IDs sourced from OIDC.
- *
- * <p><b>What this test does NOT assert:</b> the exact value of {@code @PathVariable} after binding.
- * On stable/8.8 the production matching strategy is {@code AntPathMatcher} (set in {@code
- * application.properties}), which collapses {@code //} during URI normalization and may strip the
- * leading {@code /} from the path-bound entity ID. End-to-end behavior on 8.8 — including the value
- * Camunda stores for the assigned group — must be verified manually with the reproduction script in
- * PR #52064.
  */
 @SpringBootTest(
     webEnvironment = WebEnvironment.RANDOM_PORT,


### PR DESCRIPTION
DECODE mode converted %2F → / at the Tomcat connector level, causing the path normalizer to collapse //myGroup → myGroup and strip the leading slash. Switch to PASS_THROUGH and add EncodedSlashMvcConfig (urlDecode=false) so %2F is treated as an opaque segment during path matching; Spring's decodePathVariables() then decodes it to / for the @PathVariable.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
