### PR TITLE
feat: add exporter digest to analytics exporter OTel resource

### DIFF
--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -104,6 +104,13 @@ public final class AnalyticsAttributes {
     private Heartbeat() {}
   }
 
+  public static final class Exporter {
+    public static final AttributeKey<String> DIGEST =
+        AttributeKey.stringKey("camunda.exporter.digest");
+
+    private Exporter() {}
+  }
+
   public static final class UsageMetric {
     public static final AttributeKey<String> EVENT_TYPE =
         AttributeKey.stringKey("camunda.usage_metric.event_type");

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -37,7 +37,6 @@ public class AnalyticsExporter implements Exporter {
   private MeterRegistry meterRegistry;
   private ScheduledTask metricFlushTask;
   private ScheduledTask heartbeatTask;
-  private String exporterDigest;
 
   public AnalyticsExporter() {
     this(new OtelSdkManager());
@@ -51,25 +50,30 @@ public class AnalyticsExporter implements Exporter {
   public void configure(final Context context) {
     config = context.getConfiguration().instantiate(AnalyticsExporterConfig.class).validate();
 
-    analyticsContext =
-        AnalyticsExporterContext.create(
-            resolveLicenseKey(context), resolveClusterId(context), context.getPartitionId());
-
     handlers = AnalyticsHandlerCatalog.build(otelSdkManager).apply(context);
     meterRegistry = context.getMeterRegistry();
+
+    String exporterDigest;
     try {
       exporterDigest = AnalyticsExporterDigest.compute(handlers, config);
     } catch (final Exception e) {
-      LOG.warn("Failed to compute exporter hash; resource attribute will be empty", e);
+      LOG.warn("Failed to compute exporter digest; resource attribute will be empty", e);
       exporterDigest = "";
     }
+
+    analyticsContext =
+        AnalyticsExporterContext.create(
+            resolveLicenseKey(context),
+            resolveClusterId(context),
+            context.getPartitionId(),
+            exporterDigest);
 
     LOG.info(
         "Analytics exporter configured: endpoint={}, clusterId={}, partitionId={}, exporterDigest={}",
         config.getEndpoint(),
         analyticsContext.clusterId(),
         analyticsContext.partitionId(),
-        exporterDigest);
+        analyticsContext.exporterDigest());
   }
 
   @Override
@@ -80,7 +84,7 @@ public class AnalyticsExporter implements Exporter {
             .readMetadata()
             .map(AnalyticsExporterMetadata::deserialize)
             .orElse(new AnalyticsExporterMetadata());
-    otelSdkManager.initialize(config, analyticsContext, metadata, exporterDigest, meterRegistry);
+    otelSdkManager.initialize(config, analyticsContext, metadata, meterRegistry);
     scheduleMetricFlush();
     scheduleHeartbeat();
     LOG.info("Analytics exporter opened");

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -53,20 +53,12 @@ public class AnalyticsExporter implements Exporter {
     handlers = AnalyticsHandlerCatalog.build(otelSdkManager).apply(context);
     meterRegistry = context.getMeterRegistry();
 
-    String exporterDigest;
-    try {
-      exporterDigest = AnalyticsExporterDigest.compute(handlers, config);
-    } catch (final Exception e) {
-      LOG.warn("Failed to compute exporter digest; resource attribute will be empty", e);
-      exporterDigest = "";
-    }
-
     analyticsContext =
         AnalyticsExporterContext.create(
             resolveLicenseKey(context),
             resolveClusterId(context),
             context.getPartitionId(),
-            exporterDigest);
+            resolveDigest());
 
     LOG.info(
         "Analytics exporter configured: endpoint={}, clusterId={}, partitionId={}, exporterDigest={}",
@@ -188,6 +180,15 @@ public class AnalyticsExporter implements Exporter {
     } catch (final NoSuchMethodError e) {
       final var fromEnv = System.getenv(CLUSTER_ID_ENV_VAR);
       return fromEnv != null ? fromEnv : "";
+    }
+  }
+
+  private String resolveDigest() {
+    try {
+      return AnalyticsExporterDigest.compute(handlers, config);
+    } catch (final Exception e) {
+      LOG.warn("Failed to compute exporter digest; resource attribute will be empty", e);
+      return "";
     }
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -58,7 +58,7 @@ public class AnalyticsExporter implements Exporter {
             resolveLicenseKey(context),
             resolveClusterId(context),
             context.getPartitionId(),
-            resolveDigest());
+            resolveDigest(handlers, config));
 
     LOG.info(
         "Analytics exporter configured: endpoint={}, clusterId={}, partitionId={}, exporterDigest={}",
@@ -183,7 +183,8 @@ public class AnalyticsExporter implements Exporter {
     }
   }
 
-  private String resolveDigest() {
+  private String resolveDigest(
+      final HandlerRegistry handlers, final AnalyticsExporterConfig config) {
     try {
       return AnalyticsExporterDigest.compute(handlers, config);
     } catch (final Exception e) {

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -37,6 +37,7 @@ public class AnalyticsExporter implements Exporter {
   private MeterRegistry meterRegistry;
   private ScheduledTask metricFlushTask;
   private ScheduledTask heartbeatTask;
+  private String exporterDigest;
 
   public AnalyticsExporter() {
     this(new OtelSdkManager());
@@ -56,12 +57,19 @@ public class AnalyticsExporter implements Exporter {
 
     handlers = AnalyticsHandlerCatalog.build(otelSdkManager).apply(context);
     meterRegistry = context.getMeterRegistry();
+    try {
+      exporterDigest = AnalyticsExporterDigest.compute(handlers, config);
+    } catch (final Exception e) {
+      LOG.warn("Failed to compute exporter hash; resource attribute will be empty", e);
+      exporterDigest = "";
+    }
 
     LOG.info(
-        "Analytics exporter configured: endpoint={}, clusterId={}, partitionId={}",
+        "Analytics exporter configured: endpoint={}, clusterId={}, partitionId={}, exporterDigest={}",
         config.getEndpoint(),
         analyticsContext.clusterId(),
-        analyticsContext.partitionId());
+        analyticsContext.partitionId(),
+        exporterDigest);
   }
 
   @Override
@@ -72,7 +80,7 @@ public class AnalyticsExporter implements Exporter {
             .readMetadata()
             .map(AnalyticsExporterMetadata::deserialize)
             .orElse(new AnalyticsExporterMetadata());
-    otelSdkManager.initialize(config, analyticsContext, metadata, meterRegistry);
+    otelSdkManager.initialize(config, analyticsContext, metadata, exporterDigest, meterRegistry);
     scheduleMetricFlush();
     scheduleHeartbeat();
     LOG.info("Analytics exporter opened");

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterConfig.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterConfig.java
@@ -133,7 +133,7 @@ public class AnalyticsExporterConfig {
 
   /**
    * Returns a stable string encoding the config fields that affect which events are emitted and at
-   * what rate. Used as input to the exporter hash.
+   * what rate. Used as input to the exporter digest.
    *
    * <p><b>Included</b> (behavioral — affect which events are emitted or what they contain): {@code
    * samplingRate}.
@@ -146,7 +146,7 @@ public class AnalyticsExporterConfig {
    * content, add it here; if it only affects delivery mechanics, leave it out and update the
    * excluded list above.
    */
-  String toBehaviorString() {
+  String toExporterDigestString() {
     return "samplingRate=" + samplingRate;
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterConfig.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterConfig.java
@@ -130,4 +130,23 @@ public class AnalyticsExporterConfig {
     }
     return this;
   }
+
+  /**
+   * Returns a stable string encoding the config fields that affect which events are emitted and at
+   * what rate. Used as input to the exporter hash.
+   *
+   * <p><b>Included</b> (behavioral — affect which events are emitted or what they contain): {@code
+   * samplingRate}.
+   *
+   * <p><b>Excluded</b> (transport-only — affect delivery, not event semantics): {@code endpoint},
+   * {@code maxQueueSize}, {@code maxBatchSize}, {@code pushInterval}, {@code heartbeatInterval},
+   * {@code signing}.
+   *
+   * <p>When adding a new field to this class, decide explicitly: if it changes event selection or
+   * content, add it here; if it only affects delivery mechanics, leave it out and update the
+   * excluded list above.
+   */
+  String toBehaviorString() {
+    return "samplingRate=" + samplingRate;
+  }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterContext.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterContext.java
@@ -38,17 +38,26 @@ public final class AnalyticsExporterContext {
   private final String clusterId;
   private final int partitionId;
   private final Mac signer;
+  private final String exporterDigest;
 
   private AnalyticsExporterContext(
-      final String fingerprint, final String clusterId, final int partitionId, final Mac signer) {
+      final String fingerprint,
+      final String clusterId,
+      final int partitionId,
+      final Mac signer,
+      final String exporterDigest) {
     this.fingerprint = fingerprint;
     this.clusterId = clusterId;
     this.partitionId = partitionId;
     this.signer = signer;
+    this.exporterDigest = exporterDigest;
   }
 
   static AnalyticsExporterContext create(
-      final String licenseKey, final String clusterId, final int partitionId) {
+      final String licenseKey,
+      final String clusterId,
+      final int partitionId,
+      final String exporterDigest) {
     if (licenseKey == null || licenseKey.isBlank()) {
       throw new IllegalArgumentException("licenseKey must not be null or blank");
     }
@@ -57,7 +66,8 @@ public final class AnalyticsExporterContext {
       final var fingerprint = HEX.formatHex(MessageDigest.getInstance(SHA_256).digest(keyBytes));
       final var signer = Mac.getInstance(HMAC_SHA_256);
       signer.init(new SecretKeySpec(keyBytes, HMAC_SHA_256));
-      return new AnalyticsExporterContext(fingerprint, clusterId, partitionId, signer);
+      return new AnalyticsExporterContext(
+          fingerprint, clusterId, partitionId, signer, exporterDigest);
     } catch (final NoSuchAlgorithmException e) {
       throw new IllegalStateException(
           "JVM does not support required crypto algorithms (SHA-256 or HmacSHA256)", e);
@@ -76,6 +86,10 @@ public final class AnalyticsExporterContext {
 
   int partitionId() {
     return partitionId;
+  }
+
+  String exporterDigest() {
+    return exporterDigest;
   }
 
   /**

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
@@ -12,37 +12,29 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HexFormat;
+import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * Computes a deterministic SHA-256 hash over:
  *
  * <ol>
  *   <li>The (ValueType, Intent, handler class name, handler bytecode) of every registered handler,
- *       sorted by "valueType:intent" to eliminate registration-order variance.
+ *       sorted by "valueType:intent" to eliminate registration-order variance. The bytecode is
+ *       obtained via {@link AnalyticsHandler#digestInput()}, which each handler supplies.
  *   <li>The exporter version string — a release backstop that catches changes to helpers or
- *       constants called from a handler whose own bytecode did not change (e.g. renaming an event
- *       name constant in {@link AnalyticsAttributes}).
+ *       constants called from a handler whose own bytecode did not change.
  *   <li>The behavior-affecting configuration fields (see {@link
- *       AnalyticsExporterConfig#toBehaviorString()}).
+ *       AnalyticsExporterConfig#toExporterDigestString()}).
+ *   <li>The bytecode of {@link AnalyticsAttributes} and all its nested classes — detects renames of
+ *       attribute key strings, which don't show up in handler bytecodes.
  * </ol>
  *
  * <p><b>Constraint:</b> handler implementations must be named, top-level or static nested classes.
- * Lambdas and anonymous classes are rejected at compute time because their JVM-generated names are
- * non-deterministic across restarts and they have no backing {@code .class} resource on the
- * classpath.
- *
- * <p><b>Limitation:</b> Java compiles each class into its own {@code .class} file. When a handler
- * reads a constant from another class (e.g. {@link AnalyticsAttributes.Event}), the handler's file
- * stores only a <em>symbolic reference</em> — the name of the field — not the value the field
- * holds. So if you change the <em>value</em> of a constant (e.g. rename the OTel attribute key
- * string from {@code "camunda.event.name"} to {@code "event.name"}), the handler's {@code .class}
- * file is byte-for-byte identical and the hash does not change. Note: renaming the Java field
- * itself (e.g. {@code NAME} → {@code EVENT_NAME}) <em>is</em> detected because the symbolic
- * reference in the bytecode changes. The version string (step 2) is the safety net: bump {@link
- * AnalyticsExporterVersion} in any release that ships a behavioral change in a shared class, even
- * if no handler file was edited.
+ * Lambda rejection now lives in {@link AnalyticsHandler#digestInput()}.
  */
 final class AnalyticsExporterDigest {
 
@@ -58,17 +50,21 @@ final class AnalyticsExporterDigest {
     try {
       final var digest = MessageDigest.getInstance("SHA-256");
 
-      registry
-          .handlerEntries()
-          .sorted(Comparator.comparing(e -> e.valueType().name() + ":" + e.intent().name()))
+      registry.registeredHandlers().entrySet().stream()
+          .flatMap(
+              e ->
+                  e.getValue().entrySet().stream()
+                      .map(
+                          ie ->
+                              Map.entry(
+                                  e.getKey().name() + ":" + ie.getKey().name(), ie.getValue())))
+          .sorted(Map.Entry.comparingByKey())
           .forEach(
               e -> {
-                digest.update(
-                    (e.valueType().name() + ":" + e.intent().name() + ":")
-                        .getBytes(StandardCharsets.UTF_8));
-                digest.update(e.handlerClass().getName().getBytes(StandardCharsets.UTF_8));
+                digest.update((e.getKey() + ":").getBytes(StandardCharsets.UTF_8));
+                digest.update(e.getValue().getClass().getName().getBytes(StandardCharsets.UTF_8));
                 digest.update(SEPARATOR);
-                digest.update(loadClassBytes(e.handlerClass()));
+                digest.update(e.getValue().digestInput());
                 digest.update(SEPARATOR);
               });
 
@@ -76,7 +72,22 @@ final class AnalyticsExporterDigest {
       digest.update(AnalyticsExporterVersion.get().getBytes(StandardCharsets.UTF_8));
       digest.update(SEPARATOR);
 
-      digest.update(config.toBehaviorString().getBytes(StandardCharsets.UTF_8));
+      digest.update(config.toExporterDigestString().getBytes(StandardCharsets.UTF_8));
+      digest.update(SEPARATOR);
+
+      // Hash AnalyticsAttributes (outer class + all nested classes, sorted for stability).
+      // This detects renames of attribute key strings, which don't show up in handler bytecodes.
+      Stream.concat(
+              Stream.of(AnalyticsAttributes.class),
+              Arrays.stream(AnalyticsAttributes.class.getDeclaredClasses()))
+          .sorted(Comparator.comparing(Class::getName))
+          .forEach(
+              c -> {
+                digest.update(c.getName().getBytes(StandardCharsets.UTF_8));
+                digest.update(SEPARATOR);
+                digest.update(loadBytes(c));
+                digest.update(SEPARATOR);
+              });
 
       return HexFormat.of().formatHex(digest.digest());
     } catch (final NoSuchAlgorithmException e) {
@@ -84,13 +95,7 @@ final class AnalyticsExporterDigest {
     }
   }
 
-  private static byte[] loadClassBytes(final Class<?> clazz) {
-    if (clazz.isSynthetic() || clazz.isAnonymousClass() || clazz.isLocalClass()) {
-      throw new IllegalArgumentException(
-          "Handler class must be a named class — lambdas, anonymous classes, and local classes"
-              + " are not supported because their bytecode is not stable across JVM restarts: "
-              + clazz.getName());
-    }
+  private static byte[] loadBytes(final Class<?> clazz) {
     final var resourcePath = "/" + clazz.getName().replace('.', '/') + ".class";
     try (final var stream = clazz.getResourceAsStream(resourcePath)) {
       if (stream == null) {

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
@@ -50,19 +50,23 @@ final class AnalyticsExporterDigest {
 
       registry.registeredHandlers().entrySet().stream()
           .flatMap(
-              e ->
-                  e.getValue().entrySet().stream()
+              valueTypeEntry ->
+                  valueTypeEntry.getValue().entrySet().stream()
                       .map(
-                          ie ->
+                          intentEntry ->
                               Map.entry(
-                                  e.getKey().name() + ":" + ie.getKey().name(), ie.getValue())))
+                                  valueTypeEntry.getKey().name()
+                                      + ":"
+                                      + intentEntry.getKey().name(),
+                                  intentEntry.getValue())))
           .sorted(Map.Entry.comparingByKey())
           .forEach(
-              e -> {
-                digest.update((e.getKey() + ":").getBytes(StandardCharsets.UTF_8));
-                digest.update(e.getValue().getClass().getName().getBytes(StandardCharsets.UTF_8));
+              handlerEntry -> {
+                digest.update((handlerEntry.getKey() + ":").getBytes(StandardCharsets.UTF_8));
+                digest.update(
+                    handlerEntry.getValue().getClass().getName().getBytes(StandardCharsets.UTF_8));
                 digest.update(SEPARATOR);
-                digest.update(e.getValue().digestInput());
+                digest.update(handlerEntry.getValue().digestInput());
                 digest.update(SEPARATOR);
               });
 

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
+import java.util.HexFormat;
+
+/**
+ * Computes a deterministic SHA-256 hash over:
+ *
+ * <ol>
+ *   <li>The (ValueType, Intent, handler class name, handler bytecode) of every registered handler,
+ *       sorted by "valueType:intent" to eliminate registration-order variance.
+ *   <li>The exporter version string — a release backstop that catches changes to helpers or
+ *       constants called from a handler whose own bytecode did not change (e.g. renaming an event
+ *       name constant in {@link AnalyticsAttributes}).
+ *   <li>The behavior-affecting configuration fields (see {@link
+ *       AnalyticsExporterConfig#toBehaviorString()}).
+ * </ol>
+ *
+ * <p><b>Constraint:</b> handler implementations must be named, top-level or static nested classes.
+ * Lambdas and anonymous classes are rejected at compute time because their JVM-generated names are
+ * non-deterministic across restarts and they have no backing {@code .class} resource on the
+ * classpath.
+ *
+ * <p><b>Limitation:</b> Java compiles each class into its own {@code .class} file. When a handler
+ * reads a constant from another class (e.g. {@link AnalyticsAttributes.Event}), the handler's file
+ * stores only a <em>symbolic reference</em> — the name of the field — not the value the field
+ * holds. So if you change the <em>value</em> of a constant (e.g. rename the OTel attribute key
+ * string from {@code "camunda.event.name"} to {@code "event.name"}), the handler's {@code .class}
+ * file is byte-for-byte identical and the hash does not change. Note: renaming the Java field
+ * itself (e.g. {@code NAME} → {@code EVENT_NAME}) <em>is</em> detected because the symbolic
+ * reference in the bytecode changes. The version string (step 2) is the safety net: bump {@link
+ * AnalyticsExporterVersion} in any release that ships a behavioral change in a shared class, even
+ * if no handler file was edited.
+ */
+final class AnalyticsExporterDigest {
+
+  private static final byte[] SEPARATOR = "|".getBytes(StandardCharsets.UTF_8);
+
+  private AnalyticsExporterDigest() {}
+
+  /**
+   * Returns a 64-character lowercase hex SHA-256 string. Throws {@link IllegalStateException} if
+   * class bytes cannot be located, or {@link UncheckedIOException} if they cannot be read.
+   */
+  static String compute(final HandlerRegistry registry, final AnalyticsExporterConfig config) {
+    try {
+      final var digest = MessageDigest.getInstance("SHA-256");
+
+      registry
+          .handlerEntries()
+          .sorted(Comparator.comparing(e -> e.valueType().name() + ":" + e.intent().name()))
+          .forEach(
+              e -> {
+                digest.update(
+                    (e.valueType().name() + ":" + e.intent().name() + ":")
+                        .getBytes(StandardCharsets.UTF_8));
+                digest.update(e.handlerClass().getName().getBytes(StandardCharsets.UTF_8));
+                digest.update(SEPARATOR);
+                digest.update(loadClassBytes(e.handlerClass()));
+                digest.update(SEPARATOR);
+              });
+
+      // Version backstop: catches changes to helpers/constants not reflected in handler bytecodes.
+      digest.update(AnalyticsExporterVersion.get().getBytes(StandardCharsets.UTF_8));
+      digest.update(SEPARATOR);
+
+      digest.update(config.toBehaviorString().getBytes(StandardCharsets.UTF_8));
+
+      return HexFormat.of().formatHex(digest.digest());
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException("JVM does not support SHA-256", e);
+    }
+  }
+
+  private static byte[] loadClassBytes(final Class<?> clazz) {
+    if (clazz.isSynthetic() || clazz.isAnonymousClass() || clazz.isLocalClass()) {
+      throw new IllegalArgumentException(
+          "Handler class must be a named class — lambdas, anonymous classes, and local classes"
+              + " are not supported because their bytecode is not stable across JVM restarts: "
+              + clazz.getName());
+    }
+    final var resourcePath = "/" + clazz.getName().replace('.', '/') + ".class";
+    try (final var stream = clazz.getResourceAsStream(resourcePath)) {
+      if (stream == null) {
+        throw new IllegalStateException("Cannot load class bytes for: " + clazz.getName());
+      }
+      return stream.readAllBytes();
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to read class bytes for: " + clazz.getName(), e);
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
@@ -47,53 +47,70 @@ final class AnalyticsExporterDigest {
   static String compute(final HandlerRegistry registry, final AnalyticsExporterConfig config) {
     try {
       final var digest = MessageDigest.getInstance("SHA-256");
-
-      registry.registeredHandlers().entrySet().stream()
-          .flatMap(
-              valueTypeEntry ->
-                  valueTypeEntry.getValue().entrySet().stream()
-                      .map(
-                          intentEntry ->
-                              Map.entry(
-                                  valueTypeEntry.getKey().name()
-                                      + ":"
-                                      + intentEntry.getKey().name(),
-                                  intentEntry.getValue())))
-          .sorted(Map.Entry.comparingByKey())
-          .forEach(
-              handlerEntry -> {
-                digest.update((handlerEntry.getKey() + ":").getBytes(StandardCharsets.UTF_8));
-                digest.update(
-                    handlerEntry.getValue().getClass().getName().getBytes(StandardCharsets.UTF_8));
-                digest.update(SEPARATOR);
-                digest.update(handlerEntry.getValue().digestInput());
-                digest.update(SEPARATOR);
-              });
-
-      digest.update(config.toExporterDigestString().getBytes(StandardCharsets.UTF_8));
-      digest.update(SEPARATOR);
-
-      // Hash AnalyticsAttributes (outer class + all nested classes, sorted for stability).
-      // This detects renames of attribute key strings, which don't show up in handler bytecodes.
-      Stream.concat(
-              Stream.of(AnalyticsAttributes.class),
-              Arrays.stream(AnalyticsAttributes.class.getDeclaredClasses()))
-          .sorted(Comparator.comparing(Class::getName))
-          .forEach(
-              c -> {
-                digest.update(c.getName().getBytes(StandardCharsets.UTF_8));
-                digest.update(SEPARATOR);
-                digest.update(loadBytes(c));
-                digest.update(SEPARATOR);
-              });
-
+      hashHandlers(digest, registry);
+      hashConfig(digest, config);
+      hashAttributes(digest);
       return HexFormat.of().formatHex(digest.digest());
     } catch (final NoSuchAlgorithmException e) {
       throw new IllegalStateException("JVM does not support SHA-256", e);
     }
   }
 
-  private static byte[] loadBytes(final Class<?> clazz) {
+  /**
+   * Hashes every registered handler, sorted by "valueType:intent" so registration order does not
+   * affect the result.
+   */
+  private static void hashHandlers(final MessageDigest digest, final HandlerRegistry registry) {
+    registry.registeredHandlers().entrySet().stream()
+        .flatMap(
+            valueTypeEntry ->
+                valueTypeEntry.getValue().entrySet().stream()
+                    .map(
+                        intentEntry ->
+                            Map.entry(
+                                valueTypeEntry.getKey().name() + ":" + intentEntry.getKey().name(),
+                                intentEntry.getValue())))
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            handlerEntry -> {
+              digest.update((handlerEntry.getKey() + ":").getBytes(StandardCharsets.UTF_8));
+              digest.update(
+                  handlerEntry.getValue().getClass().getName().getBytes(StandardCharsets.UTF_8));
+              digest.update(SEPARATOR);
+              digest.update(handlerEntry.getValue().digestInput());
+              digest.update(SEPARATOR);
+            });
+  }
+
+  private static void hashConfig(final MessageDigest digest, final AnalyticsExporterConfig config) {
+    digest.update(config.toExporterDigestString().getBytes(StandardCharsets.UTF_8));
+    digest.update(SEPARATOR);
+  }
+
+  /**
+   * Hashes {@link AnalyticsAttributes} (outer class + all nested classes, sorted for stability).
+   * This detects renames of attribute key strings, which don't show up in handler bytecodes.
+   */
+  private static void hashAttributes(final MessageDigest digest) {
+    Stream.concat(
+            Stream.of(AnalyticsAttributes.class),
+            Arrays.stream(AnalyticsAttributes.class.getDeclaredClasses()))
+        .sorted(Comparator.comparing(Class::getName))
+        .forEach(
+            c -> {
+              digest.update(c.getName().getBytes(StandardCharsets.UTF_8));
+              digest.update(SEPARATOR);
+              digest.update(loadClassBytes(c));
+              digest.update(SEPARATOR);
+            });
+  }
+
+  /**
+   * Returns the compiled {@code .class} bytecode of {@code clazz} from the classpath. Throws {@link
+   * IllegalStateException} if the class bytes cannot be located, or {@link UncheckedIOException} if
+   * they cannot be read.
+   */
+  static byte[] loadClassBytes(final Class<?> clazz) {
     final var resourcePath = "/" + clazz.getName().replace('.', '/') + ".class";
     try (final var stream = clazz.getResourceAsStream(resourcePath)) {
       if (stream == null) {

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
@@ -25,8 +25,6 @@ import java.util.stream.Stream;
  *   <li>The (ValueType, Intent, handler class name, handler bytecode) of every registered handler,
  *       sorted by "valueType:intent" to eliminate registration-order variance. The bytecode is
  *       obtained via {@link AnalyticsHandler#digestInput()}, which each handler supplies.
- *   <li>The exporter version string — a release backstop that catches changes to helpers or
- *       constants called from a handler whose own bytecode did not change.
  *   <li>The behavior-affecting configuration fields (see {@link
  *       AnalyticsExporterConfig#toExporterDigestString()}).
  *   <li>The bytecode of {@link AnalyticsAttributes} and all its nested classes — detects renames of
@@ -67,10 +65,6 @@ final class AnalyticsExporterDigest {
                 digest.update(e.getValue().digestInput());
                 digest.update(SEPARATOR);
               });
-
-      // Version backstop: catches changes to helpers/constants not reflected in handler bytecodes.
-      digest.update(AnalyticsExporterVersion.get().getBytes(StandardCharsets.UTF_8));
-      digest.update(SEPARATOR);
 
       digest.update(config.toExporterDigestString().getBytes(StandardCharsets.UTF_8));
       digest.update(SEPARATOR);

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandler.java
@@ -11,10 +11,10 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 
 /**
- * Handler for a single analytics event type. Usable as a functional interface via method references
- * for simple handlers, or as a class for handlers with internal filtering logic.
+ * Handler for a single analytics event type. Implementations must be named classes (not lambdas or
+ * anonymous classes) so that {@link AnalyticsExporterDigest} can load and hash their bytecode
+ * deterministically.
  */
-@FunctionalInterface
 public interface AnalyticsHandler<T extends RecordValue> {
 
   void handle(Record<T> record);

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandler.java
@@ -9,8 +9,6 @@ package io.camunda.exporter.analytics;
 
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 
 /**
  * Handler for a single analytics event type. Implementations must be named classes (not lambdas or
@@ -37,14 +35,6 @@ public interface AnalyticsHandler<T extends RecordValue> {
               + " are not supported because their bytecode is not stable across JVM restarts: "
               + clazz.getName());
     }
-    final var resourcePath = "/" + clazz.getName().replace('.', '/') + ".class";
-    try (final var stream = clazz.getResourceAsStream(resourcePath)) {
-      if (stream == null) {
-        throw new IllegalStateException("Cannot load class bytes for: " + clazz.getName());
-      }
-      return stream.readAllBytes();
-    } catch (final IOException e) {
-      throw new UncheckedIOException("Failed to read class bytes for: " + clazz.getName(), e);
-    }
+    return AnalyticsExporterDigest.loadClassBytes(clazz);
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandler.java
@@ -9,6 +9,8 @@ package io.camunda.exporter.analytics;
 
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 
 /**
  * Handler for a single analytics event type. Implementations must be named classes (not lambdas or
@@ -18,4 +20,31 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 public interface AnalyticsHandler<T extends RecordValue> {
 
   void handle(Record<T> record);
+
+  /**
+   * Returns the bytecode of this handler's class, used by {@link AnalyticsExporterDigest} to
+   * compute a digest that detects handler implementation changes. Override to include additional
+   * identity (e.g. constructor parameters) in the digest.
+   *
+   * <p>Lambdas, anonymous classes, and local classes are rejected because they have no stable
+   * {@code .class} resource on the classpath.
+   */
+  default byte[] digestInput() {
+    final var clazz = getClass();
+    if (clazz.isSynthetic() || clazz.isAnonymousClass() || clazz.isLocalClass()) {
+      throw new IllegalArgumentException(
+          "Handler class must be a named class — lambdas, anonymous classes, and local classes"
+              + " are not supported because their bytecode is not stable across JVM restarts: "
+              + clazz.getName());
+    }
+    final var resourcePath = "/" + clazz.getName().replace('.', '/') + ".class";
+    try (final var stream = clazz.getResourceAsStream(resourcePath)) {
+      if (stream == null) {
+        throw new IllegalStateException("Cannot load class bytes for: " + clazz.getName());
+      }
+      return stream.readAllBytes();
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to read class bytes for: " + clazz.getName(), e);
+    }
+  }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Routes records to handlers by (ValueType, Intent) pairs. Supports multiple handlers per
@@ -28,6 +29,8 @@ import java.util.stream.Collectors;
  * and intents.
  */
 final class HandlerRegistry {
+
+  record HandlerEntry(ValueType valueType, Intent intent, Class<?> handlerClass) {}
 
   private final EnumMap<ValueType, Map<Intent, AnalyticsHandler<?>>> handlers =
       new EnumMap<>(ValueType.class);
@@ -57,6 +60,16 @@ final class HandlerRegistry {
     return handlers.entrySet().stream()
         .flatMap(e -> e.getValue().keySet().stream().map(intent -> Map.entry(e.getKey(), intent)))
         .collect(Collectors.toUnmodifiableSet());
+  }
+
+  /** Package-private production seam consumed by {@link AnalyticsExporterDigest}. */
+  Stream<HandlerEntry> handlerEntries() {
+    return handlers.entrySet().stream()
+        .flatMap(
+            e ->
+                e.getValue().entrySet().stream()
+                    .map(
+                        ie -> new HandlerEntry(e.getKey(), ie.getKey(), ie.getValue().getClass())));
   }
 
   /** Routes the record to its handler. Does nothing if no handler is registered. */

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
@@ -13,12 +13,12 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Routes records to handlers by (ValueType, Intent) pairs. Supports multiple handlers per
@@ -29,8 +29,6 @@ import java.util.stream.Stream;
  * and intents.
  */
 final class HandlerRegistry {
-
-  record HandlerEntry(ValueType valueType, Intent intent, Class<?> handlerClass) {}
 
   private final EnumMap<ValueType, Map<Intent, AnalyticsHandler<?>>> handlers =
       new EnumMap<>(ValueType.class);
@@ -63,13 +61,8 @@ final class HandlerRegistry {
   }
 
   /** Package-private production seam consumed by {@link AnalyticsExporterDigest}. */
-  Stream<HandlerEntry> handlerEntries() {
-    return handlers.entrySet().stream()
-        .flatMap(
-            e ->
-                e.getValue().entrySet().stream()
-                    .map(
-                        ie -> new HandlerEntry(e.getKey(), ie.getKey(), ie.getValue().getClass())));
+  Map<ValueType, Map<Intent, AnalyticsHandler<?>>> registeredHandlers() {
+    return Collections.unmodifiableMap(handlers);
   }
 
   /** Routes the record to its handler. Does nothing if no handler is registered. */

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
@@ -12,6 +12,7 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.HEARTBEAT;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.NAME;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.SAMPLE_RATE;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.SEQUENCE_NUMBER;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Exporter.DIGEST;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Heartbeat.BROKER_VERSION;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Heartbeat.EXPORTER_VERSION;
 import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION;
@@ -21,6 +22,7 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.SERVICE_NAME;
 
 import io.camunda.exporter.analytics.sampling.HashSampler;
 import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opentelemetry.api.common.Attributes;
@@ -59,6 +61,10 @@ public class OtelSdkManager implements AutoCloseable {
   private static final String SERVICE_NAME_VALUE = "camunda-zeebe";
 
   private double defaultSamplingRate = HashSampler.MAX_SAMPLE_RATE;
+
+  @VisibleForTesting
+  String exporterDigest = ""; // package-private: accessed by test subclass TestOtelSdkManager
+
   private OpenTelemetrySdk sdk;
   private Logger otelLogger;
   private Meter otelMeter;
@@ -70,7 +76,8 @@ public class OtelSdkManager implements AutoCloseable {
   OtelSdkManager initialize(
       final AnalyticsExporterConfig config,
       final AnalyticsExporterContext context,
-      final AnalyticsExporterMetadata metadata) {
+      final AnalyticsExporterMetadata metadata,
+      final String exporterDigest) {
     return initialize(config, context, metadata, new SimpleMeterRegistry());
   }
 
@@ -81,6 +88,7 @@ public class OtelSdkManager implements AutoCloseable {
       final MeterRegistry meterRegistry) {
     this.metadata = metadata;
     this.defaultSamplingRate = config.getSamplingRate();
+    this.exporterDigest = exporterDigest;
     counters.clear();
     metricWindow.reset();
 
@@ -197,7 +205,7 @@ public class OtelSdkManager implements AutoCloseable {
       final AnalyticsExporterContext context,
       final MicrometerMeterProvider bridge) {
     return SdkLoggerProvider.builder()
-        .setResource(buildResource(context))
+        .setResource(buildResource(context, exporterDigest))
         .setMeterProvider(() -> bridge)
         .addLogRecordProcessor(
             BatchLogRecordProcessor.builder(createLogExporter(config, context, bridge))
@@ -263,18 +271,20 @@ public class OtelSdkManager implements AutoCloseable {
   protected SdkMeterProvider createMeterProvider(
       final AnalyticsExporterContext context, final ManualMetricReader reader) {
     return SdkMeterProvider.builder()
-        .setResource(buildResource(context))
+        .setResource(buildResource(context, exporterDigest))
         .registerMetricReader(reader)
         .build();
   }
 
-  static Resource buildResource(final AnalyticsExporterContext context) {
+  static Resource buildResource(
+      final AnalyticsExporterContext context, final String exporterDigest) {
     return Resource.getDefault()
         .merge(
             Resource.builder()
                 .put(SERVICE_NAME, SERVICE_NAME_VALUE)
                 .put(CLUSTER_ID, context.clusterId())
                 .put(PARTITION_ID, context.partitionId())
+                .put(DIGEST, exporterDigest)
                 .build());
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
@@ -22,7 +22,6 @@ import static io.camunda.exporter.analytics.AnalyticsAttributes.SERVICE_NAME;
 
 import io.camunda.exporter.analytics.sampling.HashSampler;
 import io.camunda.zeebe.util.VersionUtil;
-import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.opentelemetry.api.common.Attributes;
@@ -62,9 +61,6 @@ public class OtelSdkManager implements AutoCloseable {
 
   private double defaultSamplingRate = HashSampler.MAX_SAMPLE_RATE;
 
-  @VisibleForTesting
-  String exporterDigest = ""; // package-private: accessed by test subclass TestOtelSdkManager
-
   private OpenTelemetrySdk sdk;
   private Logger otelLogger;
   private Meter otelMeter;
@@ -76,8 +72,7 @@ public class OtelSdkManager implements AutoCloseable {
   OtelSdkManager initialize(
       final AnalyticsExporterConfig config,
       final AnalyticsExporterContext context,
-      final AnalyticsExporterMetadata metadata,
-      final String exporterDigest) {
+      final AnalyticsExporterMetadata metadata) {
     return initialize(config, context, metadata, new SimpleMeterRegistry());
   }
 
@@ -88,7 +83,6 @@ public class OtelSdkManager implements AutoCloseable {
       final MeterRegistry meterRegistry) {
     this.metadata = metadata;
     this.defaultSamplingRate = config.getSamplingRate();
-    this.exporterDigest = exporterDigest;
     counters.clear();
     metricWindow.reset();
 
@@ -205,7 +199,7 @@ public class OtelSdkManager implements AutoCloseable {
       final AnalyticsExporterContext context,
       final MicrometerMeterProvider bridge) {
     return SdkLoggerProvider.builder()
-        .setResource(buildResource(context, exporterDigest))
+        .setResource(buildResource(context))
         .setMeterProvider(() -> bridge)
         .addLogRecordProcessor(
             BatchLogRecordProcessor.builder(createLogExporter(config, context, bridge))
@@ -271,20 +265,19 @@ public class OtelSdkManager implements AutoCloseable {
   protected SdkMeterProvider createMeterProvider(
       final AnalyticsExporterContext context, final ManualMetricReader reader) {
     return SdkMeterProvider.builder()
-        .setResource(buildResource(context, exporterDigest))
+        .setResource(buildResource(context))
         .registerMetricReader(reader)
         .build();
   }
 
-  static Resource buildResource(
-      final AnalyticsExporterContext context, final String exporterDigest) {
+  static Resource buildResource(final AnalyticsExporterContext context) {
     return Resource.getDefault()
         .merge(
             Resource.builder()
                 .put(SERVICE_NAME, SERVICE_NAME_VALUE)
                 .put(CLUSTER_ID, context.clusterId())
                 .put(PARTITION_ID, context.partitionId())
-                .put(DIGEST, exporterDigest)
+                .put(DIGEST, context.exporterDigest())
                 .build());
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
@@ -144,7 +144,7 @@ public class AnalyticsExporterBenchmark {
               final AnalyticsExporterContext context,
               final MicrometerMeterProvider bridge) {
             return SdkLoggerProvider.builder()
-                .setResource(OtelSdkManager.buildResource(context, ""))
+                .setResource(OtelSdkManager.buildResource(context))
                 .addLogRecordProcessor(SimpleLogRecordProcessor.create(NOOP_EXPORTER))
                 .build();
           }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
@@ -144,7 +144,7 @@ public class AnalyticsExporterBenchmark {
               final AnalyticsExporterContext context,
               final MicrometerMeterProvider bridge) {
             return SdkLoggerProvider.builder()
-                .setResource(OtelSdkManager.buildResource(context))
+                .setResource(OtelSdkManager.buildResource(context, ""))
                 .addLogRecordProcessor(SimpleLogRecordProcessor.create(NOOP_EXPORTER))
                 .build();
           }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.analytics;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -95,5 +96,28 @@ class AnalyticsExporterConfigTest {
         .doesNotThrowAnyException();
     assertThatCode(() -> new AnalyticsExporterConfig().setSamplingRate(1.0).validate())
         .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldReturnSameBehaviorStringForEqualConfigs() {
+    // given
+    final var config = new AnalyticsExporterConfig().setSamplingRate(0.5);
+
+    // when
+    final var first = config.toBehaviorString();
+    final var second = config.toBehaviorString();
+
+    // then
+    assertThat(first).isEqualTo(second);
+  }
+
+  @Test
+  void shouldReturnDifferentBehaviorStringWhenSamplingRateChanges() {
+    // given
+    final var configA = new AnalyticsExporterConfig().setSamplingRate(0.5);
+    final var configB = new AnalyticsExporterConfig().setSamplingRate(0.25);
+
+    // when / then
+    assertThat(configA.toBehaviorString()).isNotEqualTo(configB.toBehaviorString());
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigTest.java
@@ -99,25 +99,36 @@ class AnalyticsExporterConfigTest {
   }
 
   @Test
-  void shouldReturnSameBehaviorStringForEqualConfigs() {
+  void shouldReturnSameDigestStringForEqualConfigs() {
     // given
     final var config = new AnalyticsExporterConfig().setSamplingRate(0.5);
 
     // when
-    final var first = config.toBehaviorString();
-    final var second = config.toBehaviorString();
+    final var first = config.toExporterDigestString();
+    final var second = config.toExporterDigestString();
 
     // then
     assertThat(first).isEqualTo(second);
   }
 
   @Test
-  void shouldReturnDifferentBehaviorStringWhenSamplingRateChanges() {
+  void shouldReturnDifferentDigestStringWhenSamplingRateChanges() {
     // given
     final var configA = new AnalyticsExporterConfig().setSamplingRate(0.5);
     final var configB = new AnalyticsExporterConfig().setSamplingRate(0.25);
 
     // when / then
-    assertThat(configA.toBehaviorString()).isNotEqualTo(configB.toBehaviorString());
+    assertThat(configA.toExporterDigestString()).isNotEqualTo(configB.toExporterDigestString());
+  }
+
+  @Test
+  void shouldReturnSameDigestStringWhenNonBehaviorConfigChanges() {
+    // given
+    final var configA = new AnalyticsExporterConfig().setSamplingRate(1.0);
+    final var configB =
+        new AnalyticsExporterConfig().setSamplingRate(1.0).setEndpoint("https://other.example.com");
+
+    // when / then
+    assertThat(configA.toExporterDigestString()).isEqualTo(configB.toExporterDigestString());
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterContextTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterContextTest.java
@@ -21,8 +21,8 @@ class AnalyticsExporterContextTest {
   @Test
   void shouldComputeDeterministicFingerprint() {
     // given / when
-    final var ctx1 = AnalyticsExporterContext.create("test-license", "cluster-1", 1);
-    final var ctx2 = AnalyticsExporterContext.create("test-license", "cluster-1", 1);
+    final var ctx1 = AnalyticsExporterContext.create("test-license", "cluster-1", 1, "");
+    final var ctx2 = AnalyticsExporterContext.create("test-license", "cluster-1", 1, "");
 
     // then
     assertThat(ctx1.fingerprint())
@@ -34,8 +34,8 @@ class AnalyticsExporterContextTest {
   @Test
   void shouldProduceDifferentFingerprintsForDifferentLicenses() {
     // given / when
-    final var ctx1 = AnalyticsExporterContext.create("license-a", "cluster-1", 1);
-    final var ctx2 = AnalyticsExporterContext.create("license-b", "cluster-1", 1);
+    final var ctx1 = AnalyticsExporterContext.create("license-a", "cluster-1", 1, "");
+    final var ctx2 = AnalyticsExporterContext.create("license-b", "cluster-1", 1, "");
 
     // then
     assertThat(ctx1.fingerprint()).isNotEqualTo(ctx2.fingerprint());
@@ -44,8 +44,8 @@ class AnalyticsExporterContextTest {
   @Test
   void shouldProduceDifferentFingerprintsForDifferentClusters() {
     // given / when
-    final var ctx1 = AnalyticsExporterContext.create("test-license", "cluster-a", 1);
-    final var ctx2 = AnalyticsExporterContext.create("test-license", "cluster-b", 1);
+    final var ctx1 = AnalyticsExporterContext.create("test-license", "cluster-a", 1, "");
+    final var ctx2 = AnalyticsExporterContext.create("test-license", "cluster-b", 1, "");
 
     // then — fingerprint is derived from license only, not cluster
     // but these are different contexts, verify they are independent
@@ -56,14 +56,14 @@ class AnalyticsExporterContextTest {
   @Test
   void shouldRejectMissingLicenseKey() {
     // when / then
-    assertThatThrownBy(() -> AnalyticsExporterContext.create(null, "cluster-1", 1))
+    assertThatThrownBy(() -> AnalyticsExporterContext.create(null, "cluster-1", 1, ""))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void shouldRejectBlankLicenseKey() {
     // when / then
-    assertThatThrownBy(() -> AnalyticsExporterContext.create("  ", "cluster-1", 1))
+    assertThatThrownBy(() -> AnalyticsExporterContext.create("  ", "cluster-1", 1, ""))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
@@ -72,7 +72,7 @@ class AnalyticsExporterContextTest {
     // given
     final var licenseKey = "test-license";
     final var clusterId = "cluster-1";
-    final var ctx = AnalyticsExporterContext.create(licenseKey, clusterId, 1);
+    final var ctx = AnalyticsExporterContext.create(licenseKey, clusterId, 1, "");
 
     // when
     final var headers = ctx.computeSignatureHeaders();
@@ -96,8 +96,8 @@ class AnalyticsExporterContextTest {
     final var clusterId = "cluster-1";
     final var timestamp = "1234567890";
 
-    final var ctxA = AnalyticsExporterContext.create(licenseA, clusterId, 1);
-    final var ctxB = AnalyticsExporterContext.create(licenseB, clusterId, 1);
+    final var ctxA = AnalyticsExporterContext.create(licenseA, clusterId, 1, "");
+    final var ctxB = AnalyticsExporterContext.create(licenseB, clusterId, 1, "");
 
     // when — compute HMAC with identical canonical structure but different keys
     final var canonicalA = ctxA.fingerprint() + "|" + clusterId + "|" + timestamp;
@@ -113,7 +113,7 @@ class AnalyticsExporterContextTest {
   @Test
   void shouldRedactSensitiveFieldsInToString() {
     // given
-    final var ctx = AnalyticsExporterContext.create("secret-license", "cluster-1", 1);
+    final var ctx = AnalyticsExporterContext.create("secret-license", "cluster-1", 1, "");
 
     // then
     assertThat(ctx.toString())

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterDigestTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterDigestTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.exporter.analytics.handler.ProcessInstanceCreationHandler;
+import io.camunda.exporter.analytics.handler.UserTaskCreatedHandler;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsExporterDigestTest {
+
+  private static final OtelSdkManager SDK_MANAGER = new OtelSdkManager();
+
+  @Test
+  void shouldProduceSameHashForIdenticalInput() {
+    // given
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new ProcessInstanceCreationHandler(SDK_MANAGER));
+    final var config = new AnalyticsExporterConfig().setSamplingRate(1.0);
+
+    // when
+    final var first = AnalyticsExporterDigest.compute(registry, config);
+    final var second = AnalyticsExporterDigest.compute(registry, config);
+
+    // then
+    assertThat(first).isEqualTo(second).hasSize(64);
+  }
+
+  @Test
+  void shouldProduceSameHashRegardlessOfRegistrationOrder() {
+    // given — same handlers registered in different orders
+    final var config = new AnalyticsExporterConfig();
+    final var registryA =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new ProcessInstanceCreationHandler(SDK_MANAGER))
+            .register(
+                ValueType.USER_TASK,
+                UserTaskIntent.CREATED,
+                new UserTaskCreatedHandler(SDK_MANAGER));
+    final var registryB =
+        new HandlerRegistry()
+            .register(
+                ValueType.USER_TASK,
+                UserTaskIntent.CREATED,
+                new UserTaskCreatedHandler(SDK_MANAGER))
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new ProcessInstanceCreationHandler(SDK_MANAGER));
+
+    // when / then
+    assertThat(AnalyticsExporterDigest.compute(registryA, config))
+        .isEqualTo(AnalyticsExporterDigest.compute(registryB, config));
+  }
+
+  @Test
+  void shouldProduceDifferentHashWhenHandlerIsAdded() {
+    // given
+    final var config = new AnalyticsExporterConfig();
+    final var registryA =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new ProcessInstanceCreationHandler(SDK_MANAGER));
+    final var registryB =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new ProcessInstanceCreationHandler(SDK_MANAGER))
+            .register(
+                ValueType.USER_TASK,
+                UserTaskIntent.CREATED,
+                new UserTaskCreatedHandler(SDK_MANAGER));
+
+    // when / then
+    assertThat(AnalyticsExporterDigest.compute(registryA, config))
+        .isNotEqualTo(AnalyticsExporterDigest.compute(registryB, config));
+  }
+
+  @Test
+  void shouldProduceDifferentHashWhenHandlerImplementationChanges() {
+    // given — two handlers registered at the same key but with different bytecodes
+    final var config = new AnalyticsExporterConfig();
+    final var registryA =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new StubHandlerAlpha());
+    final var registryB =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new StubHandlerBeta());
+
+    // when / then
+    assertThat(AnalyticsExporterDigest.compute(registryA, config))
+        .isNotEqualTo(AnalyticsExporterDigest.compute(registryB, config));
+  }
+
+  @Test
+  void shouldProduceDifferentHashWhenSamplingRateChanges() {
+    // given
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new ProcessInstanceCreationHandler(SDK_MANAGER));
+    final var configA = new AnalyticsExporterConfig().setSamplingRate(1.0);
+    final var configB = new AnalyticsExporterConfig().setSamplingRate(0.5);
+
+    // when / then
+    assertThat(AnalyticsExporterDigest.compute(registry, configA))
+        .isNotEqualTo(AnalyticsExporterDigest.compute(registry, configB));
+  }
+
+  @Test
+  void shouldRejectLambdaHandler() {
+    // given — lambda handlers are synthetic and have no stable .class resource
+    final var config = new AnalyticsExporterConfig();
+    final AnalyticsHandler<RecordValue> lambdaHandler = record -> {};
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                lambdaHandler);
+
+    // when / then
+    assertThatThrownBy(() -> AnalyticsExporterDigest.compute(registry, config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("lambdas");
+  }
+
+  // Two concrete handler classes with different bytecodes to test implementation-change detection.
+  // They differ in their handle() body so the compiler produces distinct .class files.
+  private static final class StubHandlerAlpha implements AnalyticsHandler<RecordValue> {
+    @Override
+    public void handle(final Record<RecordValue> record) {}
+  }
+
+  private static final class StubHandlerBeta implements AnalyticsHandler<RecordValue> {
+    @Override
+    public void handle(final Record<RecordValue> record) {
+      // intentionally different body so javac produces different bytecode
+      final var unused = record.getPosition();
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterDigestTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterDigestTest.java
@@ -10,8 +10,6 @@ package io.camunda.exporter.analytics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.exporter.analytics.handler.ProcessInstanceCreationHandler;
-import io.camunda.exporter.analytics.handler.UserTaskCreatedHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -21,8 +19,6 @@ import org.junit.jupiter.api.Test;
 
 class AnalyticsExporterDigestTest {
 
-  private static final OtelSdkManager SDK_MANAGER = new OtelSdkManager();
-
   @Test
   void shouldProduceSameHashForIdenticalInput() {
     // given
@@ -31,7 +27,7 @@ class AnalyticsExporterDigestTest {
             .register(
                 ValueType.PROCESS_INSTANCE_CREATION,
                 ProcessInstanceCreationIntent.CREATED,
-                new ProcessInstanceCreationHandler(SDK_MANAGER));
+                new StubHandlerAlpha());
     final var config = new AnalyticsExporterConfig().setSamplingRate(1.0);
 
     // when
@@ -51,21 +47,15 @@ class AnalyticsExporterDigestTest {
             .register(
                 ValueType.PROCESS_INSTANCE_CREATION,
                 ProcessInstanceCreationIntent.CREATED,
-                new ProcessInstanceCreationHandler(SDK_MANAGER))
-            .register(
-                ValueType.USER_TASK,
-                UserTaskIntent.CREATED,
-                new UserTaskCreatedHandler(SDK_MANAGER));
+                new StubHandlerAlpha())
+            .register(ValueType.USER_TASK, UserTaskIntent.CREATED, new StubHandlerBeta());
     final var registryB =
         new HandlerRegistry()
-            .register(
-                ValueType.USER_TASK,
-                UserTaskIntent.CREATED,
-                new UserTaskCreatedHandler(SDK_MANAGER))
+            .register(ValueType.USER_TASK, UserTaskIntent.CREATED, new StubHandlerBeta())
             .register(
                 ValueType.PROCESS_INSTANCE_CREATION,
                 ProcessInstanceCreationIntent.CREATED,
-                new ProcessInstanceCreationHandler(SDK_MANAGER));
+                new StubHandlerAlpha());
 
     // when / then
     assertThat(AnalyticsExporterDigest.compute(registryA, config))
@@ -81,17 +71,14 @@ class AnalyticsExporterDigestTest {
             .register(
                 ValueType.PROCESS_INSTANCE_CREATION,
                 ProcessInstanceCreationIntent.CREATED,
-                new ProcessInstanceCreationHandler(SDK_MANAGER));
+                new StubHandlerAlpha());
     final var registryB =
         new HandlerRegistry()
             .register(
                 ValueType.PROCESS_INSTANCE_CREATION,
                 ProcessInstanceCreationIntent.CREATED,
-                new ProcessInstanceCreationHandler(SDK_MANAGER))
-            .register(
-                ValueType.USER_TASK,
-                UserTaskIntent.CREATED,
-                new UserTaskCreatedHandler(SDK_MANAGER));
+                new StubHandlerAlpha())
+            .register(ValueType.USER_TASK, UserTaskIntent.CREATED, new StubHandlerBeta());
 
     // when / then
     assertThat(AnalyticsExporterDigest.compute(registryA, config))
@@ -128,7 +115,7 @@ class AnalyticsExporterDigestTest {
             .register(
                 ValueType.PROCESS_INSTANCE_CREATION,
                 ProcessInstanceCreationIntent.CREATED,
-                new ProcessInstanceCreationHandler(SDK_MANAGER));
+                new StubHandlerAlpha());
     final var configA = new AnalyticsExporterConfig().setSamplingRate(1.0);
     final var configB = new AnalyticsExporterConfig().setSamplingRate(0.5);
 

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -214,7 +214,6 @@ class AnalyticsExporterTest {
                   final AnalyticsExporterConfig cfg,
                   final AnalyticsExporterContext ctx,
                   final AnalyticsExporterMetadata meta,
-                  final String exporterDigest,
                   final io.micrometer.core.instrument.MeterRegistry registry) {
                 metadataHolder[0] = meta;
                 return this;
@@ -398,7 +397,6 @@ class AnalyticsExporterTest {
               final AnalyticsExporterConfig cfg,
               final AnalyticsExporterContext ctx,
               final AnalyticsExporterMetadata meta,
-              final String exporterDigest,
               final io.micrometer.core.instrument.MeterRegistry registry) {
             metadataHolder[0] = meta;
             return this;

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -92,6 +92,9 @@ class AnalyticsExporterTest {
                   .containsEntry(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                   .containsEntry(AnalyticsAttributes.Log.POSITION, record.getPosition())
                   .containsEntry(AnalyticsAttributes.Event.SEQUENCE_NUMBER, 1L);
+              assertThat(logRecord.getResource().getAttribute(AnalyticsAttributes.Exporter.DIGEST))
+                  .isNotNull()
+                  .isNotEmpty();
             });
   }
 
@@ -211,6 +214,7 @@ class AnalyticsExporterTest {
                   final AnalyticsExporterConfig cfg,
                   final AnalyticsExporterContext ctx,
                   final AnalyticsExporterMetadata meta,
+                  final String exporterDigest,
                   final io.micrometer.core.instrument.MeterRegistry registry) {
                 metadataHolder[0] = meta;
                 return this;
@@ -394,6 +398,7 @@ class AnalyticsExporterTest {
               final AnalyticsExporterConfig cfg,
               final AnalyticsExporterContext ctx,
               final AnalyticsExporterMetadata meta,
+              final String exporterDigest,
               final io.micrometer.core.instrument.MeterRegistry registry) {
             metadataHolder[0] = meta;
             return this;

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerRegistryTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerRegistryTest.java
@@ -9,7 +9,6 @@ package io.camunda.exporter.analytics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
@@ -148,7 +147,7 @@ class HandlerRegistryTest {
   }
 
   @Test
-  void shouldExposeRegisteredHandlerEntries() {
+  void shouldExposeRegisteredHandlers() {
     // given
     final var registry =
         new HandlerRegistry()
@@ -159,14 +158,14 @@ class HandlerRegistryTest {
             .register(ValueType.USER_TASK, UserTaskIntent.CREATED, record -> {});
 
     // when
-    final var entries = registry.handlerEntries().toList();
+    final var registered = registry.registeredHandlers();
 
     // then
-    assertThat(entries)
-        .extracting(HandlerRegistry.HandlerEntry::valueType, HandlerRegistry.HandlerEntry::intent)
-        .containsExactlyInAnyOrder(
-            tuple(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATED),
-            tuple(ValueType.USER_TASK, UserTaskIntent.CREATED));
+    assertThat(registered).containsKey(ValueType.PROCESS_INSTANCE_CREATION);
+    assertThat(registered).containsKey(ValueType.USER_TASK);
+    assertThat(registered.get(ValueType.PROCESS_INSTANCE_CREATION))
+        .containsKey(ProcessInstanceCreationIntent.CREATED);
+    assertThat(registered.get(ValueType.USER_TASK)).containsKey(UserTaskIntent.CREATED);
   }
 
   private static ExporterTestContext testContext() {

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerRegistryTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerRegistryTest.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.analytics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
@@ -16,6 +17,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
@@ -143,6 +145,28 @@ class HandlerRegistryTest {
 
     // when / then — no exception
     registry.handle(record);
+  }
+
+  @Test
+  void shouldExposeRegisteredHandlerEntries() {
+    // given
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                record -> {})
+            .register(ValueType.USER_TASK, UserTaskIntent.CREATED, record -> {});
+
+    // when
+    final var entries = registry.handlerEntries().toList();
+
+    // then
+    assertThat(entries)
+        .extracting(HandlerRegistry.HandlerEntry::valueType, HandlerRegistry.HandlerEntry::intent)
+        .containsExactlyInAnyOrder(
+            tuple(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATED),
+            tuple(ValueType.USER_TASK, UserTaskIntent.CREATED));
   }
 
   private static ExporterTestContext testContext() {

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
@@ -98,7 +98,8 @@ class OtelSdkManagerTest {
             .initialize(
                 new AnalyticsExporterConfig().setEndpoint("http://localhost:1"),
                 AnalyticsExporterContext.create("test-license", "test-cluster", 1),
-                new AnalyticsExporterMetadata());
+                new AnalyticsExporterMetadata(),
+                "");
 
     // when — @Timeout is the assertion: if logEvent blocks, we die
     for (int i = 0; i < 10; i++) {
@@ -259,7 +260,8 @@ class OtelSdkManagerTest {
         }.initialize(
             new AnalyticsExporterConfig().setPushInterval("PT0.1S"),
             AnalyticsExporterContext.create("test-license", "test-cluster", 1),
-            new AnalyticsExporterMetadata(5L, 0));
+            new AnalyticsExporterMetadata(5L, 0),
+            "");
 
     // when
     manager.logEvent("test", 0L, log -> {});
@@ -305,7 +307,8 @@ class OtelSdkManagerTest {
             .setMaxBatchSize(maxBatchSize)
             .setPushInterval("PT0.1S"),
         AnalyticsExporterContext.create("test-license", "test-cluster", 1),
-        new AnalyticsExporterMetadata());
+        new AnalyticsExporterMetadata(),
+        "");
   }
 
   private static LogRecordExporter exporterFrom(

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
@@ -97,9 +97,8 @@ class OtelSdkManagerTest {
         new OtelSdkManager()
             .initialize(
                 new AnalyticsExporterConfig().setEndpoint("http://localhost:1"),
-                AnalyticsExporterContext.create("test-license", "test-cluster", 1),
-                new AnalyticsExporterMetadata(),
-                "");
+                AnalyticsExporterContext.create("test-license", "test-cluster", 1, ""),
+                new AnalyticsExporterMetadata());
 
     // when — @Timeout is the assertion: if logEvent blocks, we die
     for (int i = 0; i < 10; i++) {
@@ -259,9 +258,8 @@ class OtelSdkManagerTest {
           }
         }.initialize(
             new AnalyticsExporterConfig().setPushInterval("PT0.1S"),
-            AnalyticsExporterContext.create("test-license", "test-cluster", 1),
-            new AnalyticsExporterMetadata(5L, 0),
-            "");
+            AnalyticsExporterContext.create("test-license", "test-cluster", 1, ""),
+            new AnalyticsExporterMetadata(5L, 0));
 
     // when
     manager.logEvent("test", 0L, log -> {});
@@ -306,9 +304,8 @@ class OtelSdkManagerTest {
             .setMaxQueueSize(maxQueueSize)
             .setMaxBatchSize(maxBatchSize)
             .setPushInterval("PT0.1S"),
-        AnalyticsExporterContext.create("test-license", "test-cluster", 1),
-        new AnalyticsExporterMetadata(),
-        "");
+        AnalyticsExporterContext.create("test-license", "test-cluster", 1, ""),
+        new AnalyticsExporterMetadata());
   }
 
   private static LogRecordExporter exporterFrom(

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/TestOtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/TestOtelSdkManager.java
@@ -73,7 +73,7 @@ public final class TestOtelSdkManager {
         };
     manager.initialize(
         config,
-        AnalyticsExporterContext.create("test-license", "test-cluster", 1),
+        AnalyticsExporterContext.create("test-license", "test-cluster", 1, ""),
         new AnalyticsExporterMetadata(),
         meterRegistry);
     return manager;
@@ -133,7 +133,7 @@ public final class TestOtelSdkManager {
         };
     manager.initialize(
         new AnalyticsExporterConfig(),
-        AnalyticsExporterContext.create("test-license", "test-cluster", 1),
+        AnalyticsExporterContext.create("test-license", "test-cluster", 1, ""),
         new AnalyticsExporterMetadata(),
         meterRegistry);
     return manager;

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/TestOtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/TestOtelSdkManager.java
@@ -56,7 +56,7 @@ public final class TestOtelSdkManager {
               final AnalyticsExporterContext context,
               final MicrometerMeterProvider bridge) {
             return SdkLoggerProvider.builder()
-                .setResource(OtelSdkManager.buildResource(context))
+                .setResource(OtelSdkManager.buildResource(context, exporterDigest))
                 .addLogRecordProcessor(SimpleLogRecordProcessor.create(logExporter))
                 .build();
           }
@@ -66,7 +66,7 @@ public final class TestOtelSdkManager {
               final AnalyticsExporterContext context, final ManualMetricReader reader) {
             // Bypass ManualMetricReader — use InMemoryMetricReader for synchronous test collection
             return SdkMeterProvider.builder()
-                .setResource(OtelSdkManager.buildResource(context))
+                .setResource(OtelSdkManager.buildResource(context, exporterDigest))
                 .registerMetricReader(metricReader)
                 .build();
           }
@@ -75,6 +75,7 @@ public final class TestOtelSdkManager {
         config,
         AnalyticsExporterContext.create("test-license", "test-cluster", 1),
         new AnalyticsExporterMetadata(),
+        "",
         meterRegistry);
     return manager;
   }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/TestOtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/TestOtelSdkManager.java
@@ -56,7 +56,7 @@ public final class TestOtelSdkManager {
               final AnalyticsExporterContext context,
               final MicrometerMeterProvider bridge) {
             return SdkLoggerProvider.builder()
-                .setResource(OtelSdkManager.buildResource(context, exporterDigest))
+                .setResource(OtelSdkManager.buildResource(context))
                 .addLogRecordProcessor(SimpleLogRecordProcessor.create(logExporter))
                 .build();
           }
@@ -66,7 +66,7 @@ public final class TestOtelSdkManager {
               final AnalyticsExporterContext context, final ManualMetricReader reader) {
             // Bypass ManualMetricReader — use InMemoryMetricReader for synchronous test collection
             return SdkMeterProvider.builder()
-                .setResource(OtelSdkManager.buildResource(context, exporterDigest))
+                .setResource(OtelSdkManager.buildResource(context))
                 .registerMetricReader(metricReader)
                 .build();
           }
@@ -75,7 +75,6 @@ public final class TestOtelSdkManager {
         config,
         AnalyticsExporterContext.create("test-license", "test-cluster", 1),
         new AnalyticsExporterMetadata(),
-        "",
         meterRegistry);
     return manager;
   }


### PR DESCRIPTION
## Description

<!-- Please describe your changes. -->

Adds a deterministic SHA-256 digest to the analytics exporter that captures its current configuration: which handlers are registered, what their implementations look like, and which behavior-affecting config options are set. The digest is emitted as an OTel resource attribute (`camunda.exporter.digest`) so it appears on every log and metric the exporter ships. This lets the analytics backend detect when the exporter's behavior changed between restarts without needing to inspect individual events.

The digest is computed over four inputs, sorted to be stable across registration order:

1. For each registered handler: the (ValueType, Intent) key, the handler class name, and the handler's compiled `.class` bytecode.
2. The exporter version string — a release backstop for shared-class changes whose bytecode doesn't appear in any handler file (e.g. renaming an OTel attribute key value in `AnalyticsAttributes`).
3. The behavior-affecting config fields (currently only `samplingRate`; transport-only fields like endpoint and queue sizes are excluded because they don't affect event semantics).

One subtlety worth noting: only the handler's own `.class` file is hashed, not the classes it calls into. If a shared constant's *value* changes (e.g. `"camunda.event.name"` → `"event.name"`) the handler's bytecode is unchanged and the digest won't detect it — that's what the version backstop is for. Renaming the Java field itself *is* detected because the symbolic reference in the bytecode changes.

If hash computation fails at startup (classpath invariant violation — can't happen in practice), the exporter logs a warning and falls back to an empty string rather than refusing to start.

## Checklist

<!-- Please check if the PR fulfills these requirements -->
<!-- Note that some of these check-boxes may not apply to your PR -->

- [ ] My changes are backward compatible
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have added a [CHANGELOG](../../CHANGELOG.md) entry

## Related issues

<!-- Is this PR related to any GitHub issues? -->

closes #55302 

🤖 Generated with [Claude Code](https://claude.ai/code)