### PR TITLE
build: extract assertj-assertions-generator version in parent/pom

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -41,6 +41,7 @@
     <version.agrona>2.4.1</version.agrona>
     <version.animal-sniffer>1.27</version.animal-sniffer>
     <version.assertj>3.27.7</version.assertj>
+    <version.assertj-assertions-generator>2.2.0</version.assertj-assertions-generator>
     <version.awaitility>4.3.0</version.awaitility>
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>

--- a/zeebe/protocol-asserts/pom.xml
+++ b/zeebe/protocol-asserts/pom.xml
@@ -46,7 +46,7 @@
       <plugin>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
-        <version>2.2.0</version>
+        <version>${version.assertj-assertions-generator}</version>
         <configuration>
           <packages>
             <param>io.camunda.zeebe.protocol.record</param>


### PR DESCRIPTION
## Description
Move the version of into the `parent/pom.xml` as all other dependencies. 
Just noticed with the gradle build that it's not following the same pattern as others
