### PR TITLE
feat: integrate wait state statistics endpoint in Operate

### DIFF
--- a/operate/client/e2e-playwright/docs-screenshots/wait-states.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/wait-states.spec.ts
@@ -36,6 +36,7 @@ test.describe('wait states', () => {
         variables: waitStateProcessInstance.variables,
         xml: waitStateProcessInstance.xml,
         waitStates: waitStateProcessInstance.waitStates,
+        waitStateStatistics: waitStateProcessInstance.waitStateStatistics,
       }),
     );
 

--- a/operate/client/e2e-playwright/mocks/processInstance/index.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/index.ts
@@ -17,6 +17,7 @@ import type {
   QueryElementInstancesResponseBody,
   QueryAuditLogsResponseBody,
   QueryElementInstanceInspectionResponseBody,
+  GetProcessInstanceWaitStateStatisticsResponseBody,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 
 type InstanceMock = {
@@ -29,6 +30,7 @@ type InstanceMock = {
   variables: Variable[];
   incidents?: QueryProcessInstanceIncidentsResponseBody;
   waitStates?: QueryElementInstanceInspectionResponseBody;
+  waitStateStatistics?: GetProcessInstanceWaitStateStatisticsResponseBody;
 };
 
 function mockResponses({
@@ -42,6 +44,7 @@ function mockResponses({
   incidents,
   auditLogs,
   waitStates,
+  waitStateStatistics,
 }: {
   processInstanceDetail?: ProcessInstance;
   callHierarchy?: GetProcessInstanceCallHierarchyResponseBody;
@@ -53,6 +56,7 @@ function mockResponses({
   incidents?: QueryProcessInstanceIncidentsResponseBody;
   auditLogs?: QueryAuditLogsResponseBody;
   waitStates?: QueryElementInstanceInspectionResponseBody;
+  waitStateStatistics?: GetProcessInstanceWaitStateStatisticsResponseBody;
 }) {
   return (route: Route) => {
     if (route.request().url().includes('/v2/authentication/me')) {
@@ -162,6 +166,16 @@ function mockResponses({
       return route.fulfill({
         status: 200,
         body: JSON.stringify({items: [], page: {totalItems: 0}}),
+        headers: {
+          'content-type': 'application/json',
+        },
+      });
+    }
+
+    if (route.request().url().includes('statistics/wait-states')) {
+      return route.fulfill({
+        status: 200,
+        body: JSON.stringify(waitStateStatistics ?? {items: []}),
         headers: {
           'content-type': 'application/json',
         },

--- a/operate/client/e2e-playwright/mocks/processInstance/waitStateProcessInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/waitStateProcessInstance.mocks.ts
@@ -315,6 +315,12 @@ const waitStateProcessInstance: InstanceMock = {
       hasMoreTotalItems: false,
     },
   },
+  waitStateStatistics: {
+    items: [
+      {elementId: 'approveOrder', waitingCount: 1},
+      {elementId: 'chargePayment', waitingCount: 1},
+    ],
+  },
 };
 
 export {waitStateProcessInstance};

--- a/operate/client/e2e-playwright/mocks/processInstance/waitStateRunningInstance.mocks.ts
+++ b/operate/client/e2e-playwright/mocks/processInstance/waitStateRunningInstance.mocks.ts
@@ -14,28 +14,9 @@ const PROCESS_INSTANCE_KEY = '2251799813687144';
 const USER_TASK_INSTANCE_KEY = '2251799813687150';
 const SERVICE_TASK_INSTANCE_KEY = '2251799813687170';
 
-// Generate `count` SIGNAL wait states for a (narrow) signal catch event so the
-// diagram label renders e.g. "5 waiting" / "333 waiting" without hand-writing
-// hundreds of entries.
-function signalWaitStates(
-  elementId: string,
-  count: number,
-): ElementInstanceInspection[] {
-  return Array.from({length: count}, (_, index) => ({
-    rootProcessInstanceKey: null,
-    processInstanceKey: PROCESS_INSTANCE_KEY,
-    elementInstanceKey: `${elementId}-${index}`,
-    elementId,
-    elementType: 'INTERMEDIATE_CATCH_EVENT',
-    tenantId: '<default>',
-    bpmnProcessId: 'signalEventProcess',
-    details: {
-      waitStateType: 'SIGNAL',
-      signalName: 'startSignal1',
-    },
-  }));
-}
-
+// Only the elements whose details panel is opened by the test need search
+// items; the diagram waiting-badge counts come from the wait state statistics
+// endpoint (waitStateStatistics) instead.
 const waitStateItems: ElementInstanceInspection[] = [
   {
     rootProcessInstanceKey: null,
@@ -85,14 +66,6 @@ const waitStateItems: ElementInstanceInspection[] = [
       retries: 3,
     },
   },
-  // Four narrow signal catch events exercising 1-, 2- and 3-digit label widths
-  // ("Waiting", "5 waiting", "11 waiting", "333 waiting") and the narrow-element
-  // centering offset. Total stays below the 1000 cap so labels are not
-  // truncated ("N+ waiting").
-  ...signalWaitStates('Event_signal_1', 1),
-  ...signalWaitStates('Event_signal_5', 5),
-  ...signalWaitStates('Event_signal_11', 11),
-  ...signalWaitStates('Event_signal_333', 333),
 ];
 
 // A running instance with a Camunda user task (2 tokens, 2 wait states), a
@@ -333,6 +306,19 @@ const waitStateRunningInstance: InstanceMock = {
       endCursor: null,
       hasMoreTotalItems: false,
     },
+  },
+  // Diagram waiting-badge counts: exercises 1-, 2- and 3-digit label widths
+  // ("Waiting", "2 waiting", "5 waiting", "11 waiting", "333 waiting") and the
+  // narrow-element centering offset on the signal catch events.
+  waitStateStatistics: {
+    items: [
+      {elementId: 'Activity_0dex012', waitingCount: 2},
+      {elementId: 'Activity_charge', waitingCount: 1},
+      {elementId: 'Event_signal_1', waitingCount: 1},
+      {elementId: 'Event_signal_5', waitingCount: 5},
+      {elementId: 'Event_signal_11', waitingCount: 11},
+      {elementId: 'Event_signal_333', waitingCount: 333},
+    ],
   },
 };
 

--- a/operate/client/e2e-playwright/visual/processInstance.spec.ts
+++ b/operate/client/e2e-playwright/visual/processInstance.spec.ts
@@ -120,6 +120,7 @@ test.describe('process instance page', () => {
         xml: waitStateRunningInstance.xml,
         incidents: waitStateRunningInstance.incidents,
         waitStates: waitStateRunningInstance.waitStates,
+        waitStateStatistics: waitStateRunningInstance.waitStateStatistics,
       }),
     );
 

--- a/operate/client/package-lock.json
+++ b/operate/client/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@axe-core/playwright": "4.11.3",
         "@bpmn-io/element-template-icon-renderer": "1.0.0",
-        "@camunda/camunda-api-zod-schemas": "0.0.78",
+        "@camunda/camunda-api-zod-schemas": "0.0.79",
         "@camunda/camunda-composite-components": "0.25.0",
         "@carbon/elements": "11.90.0",
         "@carbon/react": "1.108.0",
@@ -459,9 +459,9 @@
       "license": "LicenseRef-Camunda-1.0"
     },
     "node_modules/@camunda/camunda-api-zod-schemas": {
-      "version": "0.0.78",
-      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.78.tgz",
-      "integrity": "sha512-GjRD4dMI8RAB+cTXRSL/XdJYT0VBKEbJNm36iV3SkLF8Z8rI42swvgByQKM80as2D/H1422ht+3lbKlxbTE6nw==",
+      "version": "0.0.79",
+      "resolved": "https://registry.npmjs.org/@camunda/camunda-api-zod-schemas/-/camunda-api-zod-schemas-0.0.79.tgz",
+      "integrity": "sha512-hQmiTuKf0uRtj0RnUMk1k+ZUzrCw/YTYrVw9Bz4KCRCpS5JuRiFyk16AtOd8w7WHdKWGKbxd5ZyWmnWSC1q2pQ==",
       "license": "LicenseRef-Camunda-1.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@axe-core/playwright": "4.11.3",
     "@bpmn-io/element-template-icon-renderer": "1.0.0",
-    "@camunda/camunda-api-zod-schemas": "0.0.78",
+    "@camunda/camunda-api-zod-schemas": "0.0.79",
     "@camunda/camunda-composite-components": "0.25.0",
     "@carbon/elements": "11.90.0",
     "@carbon/react": "1.108.0",

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -462,9 +462,9 @@ describe('TopPanel', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should add an active overlay for an element that is waiting but missing from element-instances statistics', async () => {
+  it('should add an active overlay for a waiting multi-instance body missing from element-instances statistics', async () => {
     mockFetchProcessInstanceWaitStateStatistics().withSuccess({
-      items: [{elementId: 'multi-instance-task', waitingCount: 1}],
+      items: [{elementId: 'multi-instance-service-task', waitingCount: 1}],
     });
 
     render(<TopPanel />, {wrapper: getWrapper()});
@@ -476,14 +476,15 @@ describe('TopPanel', () => {
       expect(
         diagramOverlaysStore.state.overlays.find(
           ({elementId, type}) =>
-            elementId === 'multi-instance-task' && type === 'elementState',
+            elementId === 'multi-instance-service-task' &&
+            type === 'elementState',
         ),
       ).toBeDefined();
     });
 
     const activeOverlay = diagramOverlaysStore.state.overlays.find(
       ({elementId, type}) =>
-        elementId === 'multi-instance-task' && type === 'elementState',
+        elementId === 'multi-instance-service-task' && type === 'elementState',
     );
 
     const payload = activeOverlay?.payload as {
@@ -492,5 +493,26 @@ describe('TopPanel', () => {
     };
     expect(payload?.elementState).toBe('active');
     expect(payload?.count).toBeUndefined();
+  });
+
+  it('should not add an active overlay for a waiting non-multi-instance element missing from statistics', async () => {
+    // service-task-3 is a plain task absent from element-instances stats; a
+    // waiting count alone must not synthesize an active overlay for it.
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({
+      items: [{elementId: 'service-task-3', waitingCount: 1}],
+    });
+
+    render(<TopPanel />, {wrapper: getWrapper()});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('diagram-spinner'),
+    );
+
+    expect(
+      diagramOverlaysStore.state.overlays.find(
+        ({elementId, type}) =>
+          elementId === 'service-task-3' && type === 'elementState',
+      ),
+    ).toBeUndefined();
   });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -515,4 +515,31 @@ describe('TopPanel', () => {
       ),
     ).toBeUndefined();
   });
+
+  it('should render a waiting overlay with a count label for a waiting element', async () => {
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({
+      items: [
+        {elementId: 'service-task-7', waitingCount: 5},
+        {elementId: 'service-task-1', waitingCount: 1},
+      ],
+    });
+
+    render(<TopPanel />, {wrapper: getWrapper()});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('diagram-spinner'),
+    );
+
+    await waitFor(() => {
+      expect(
+        diagramOverlaysStore.state.overlays.some(
+          ({elementId, type}) =>
+            elementId === 'service-task-7' && type === 'waitingState',
+        ),
+      ).toBe(true);
+    });
+
+    expect(await screen.findByText('5 waiting')).toBeInTheDocument();
+    expect(screen.getByText('Waiting')).toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -37,7 +37,7 @@ import {mockSearchDecisionInstances} from 'modules/mocks/api/v2/decisionInstance
 import {mockSearchProcessInstances} from 'modules/mocks/api/v2/processInstances/searchProcessInstances';
 import {mockSearchMessageSubscriptions} from 'modules/mocks/api/v2/messageSubscriptions/searchMessageSubscriptions';
 import {mockSearchAgentInstances} from 'modules/mocks/api/v2/agentInstances/searchAgentInstances';
-import {mockSearchElementInstanceInspection} from 'modules/mocks/api/v2/elementInstanceInspection/searchElementInstanceInspection';
+import {mockFetchProcessInstanceWaitStateStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstanceWaitStateStatistics';
 import {diagramOverlaysStore} from 'modules/stores/diagramOverlays';
 import {
   SearchParamsUpdater,
@@ -215,7 +215,7 @@ describe('TopPanel', () => {
 
     mockSearchAgentInstances().withSuccess(searchResult([]));
 
-    mockSearchElementInstanceInspection().withSuccess(searchResult([]));
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({items: []});
   });
 
   afterEach(() => {
@@ -462,28 +462,10 @@ describe('TopPanel', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should add an active overlay for a multi-instance body waiting for a beforeAll execution listener', async () => {
-    mockSearchElementInstanceInspection().withSuccess(
-      searchResult([
-        {
-          rootProcessInstanceKey: 'instance_id',
-          processInstanceKey: 'instance_id',
-          elementInstanceKey: '9999',
-          elementId: 'multi-instance-task',
-          elementType: 'MULTI_INSTANCE_BODY',
-          tenantId: '<default>',
-          bpmnProcessId: 'process-def-1',
-          details: {
-            waitStateType: 'JOB',
-            jobKey: '8888',
-            jobType: 'io.camunda:execution-listener:1',
-            jobKind: 'EXECUTION_LISTENER',
-            listenerEventType: 'BEFORE_ALL',
-            retries: null,
-          },
-        },
-      ]),
-    );
+  it('should add an active overlay for an element that is waiting but missing from element-instances statistics', async () => {
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({
+      items: [{elementId: 'multi-instance-task', waitingCount: 1}],
+    });
 
     render(<TopPanel />, {wrapper: getWrapper()});
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -57,6 +57,7 @@ import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusiness
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {isCompensationAssociation} from 'modules/bpmn-js/utils/isCompensationAssociation';
+import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
 import {useProcessSequenceFlows} from 'modules/queries/sequenceFlows/useProcessSequenceFlows';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useWaitStateStatistics} from 'modules/queries/waitStateStatistics/useWaitStateStatistics';
@@ -198,11 +199,15 @@ const TopPanel: React.FC = observer(() => {
       ...subprocessOverlays,
     ];
 
-    // Some wait states (e.g. a BEFORE_ALL execution listener on a multi-instance
-    // body) are missing from element-instances stats; synthesize an active overlay.
+    // A waiting MI body with no active inner instance (BEFORE_ALL listener) is
+    // absent from element-instances stats; synthesize an active overlay for it.
     const elementIdsInStats = new Set(statistics?.map(({id}) => id) ?? []);
     for (const {elementId, waitingCount} of waitStateStatistics ?? []) {
-      if (waitingCount > 0 && !elementIdsInStats.has(elementId)) {
+      if (
+        waitingCount > 0 &&
+        !elementIdsInStats.has(elementId) &&
+        isMultiInstance(businessObjects?.[elementId])
+      ) {
         allElementStateOverlays.push({
           payload: {elementState: 'active' as const},
           type: OVERLAY_TYPE_STATE,

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -59,16 +59,9 @@ import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefi
 import {isCompensationAssociation} from 'modules/bpmn-js/utils/isCompensationAssociation';
 import {useProcessSequenceFlows} from 'modules/queries/sequenceFlows/useProcessSequenceFlows';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
-import {
-  MAX_WAIT_STATES,
-  useElementInstanceInspection,
-} from 'modules/queries/elementInstanceInspection/useElementInstanceInspection';
-import type {ElementInstanceInspection} from '@camunda/camunda-api-zod-schemas/8.10';
+import {useWaitStateStatistics} from 'modules/queries/waitStateStatistics/useWaitStateStatistics';
 import {getSubprocessOverlayFromIncidentElements} from 'modules/utils/elements';
-import {
-  getWaitStateLabel,
-  isBeforeAllExecutionListenerWaitState,
-} from 'modules/utils/waitStates';
+import {getWaitStateLabel} from 'modules/utils/waitStates';
 import type {
   AgentShinePayload,
   AgentStatusPayload,
@@ -89,16 +82,17 @@ const OVERLAY_TYPE_AGENT_STATUS = 'agentStatus';
 const OVERLAY_TYPE_AGENT_SHINE = 'agentShine';
 
 // Gateways and events are narrow (~36px) symbols.
-const NARROW_WAIT_STATE_ELEMENT_TYPES = new Set<string>([
-  'EXCLUSIVE_GATEWAY',
-  'PARALLEL_GATEWAY',
-  'INCLUSIVE_GATEWAY',
-  'EVENT_BASED_GATEWAY',
-  'START_EVENT',
-  'END_EVENT',
-  'INTERMEDIATE_CATCH_EVENT',
-  'INTERMEDIATE_THROW_EVENT',
-  'BOUNDARY_EVENT',
+const NARROW_WAIT_STATE_BPMN_TYPES = new Set<string>([
+  'bpmn:ExclusiveGateway',
+  'bpmn:ParallelGateway',
+  'bpmn:InclusiveGateway',
+  'bpmn:EventBasedGateway',
+  'bpmn:ComplexGateway',
+  'bpmn:StartEvent',
+  'bpmn:EndEvent',
+  'bpmn:IntermediateCatchEvent',
+  'bpmn:IntermediateThrowEvent',
+  'bpmn:BoundaryEvent',
 ]);
 
 const overlayPositions = {
@@ -144,8 +138,7 @@ const TopPanel: React.FC = observer(() => {
       sourceElementIdForMoveOperation || undefined,
     );
   const {data: processInstance} = useProcessInstance();
-  const {data: inspectionData} = useElementInstanceInspection({
-    processInstanceKey: processInstanceId,
+  const {data: waitStateStatistics} = useWaitStateStatistics({
     enabled:
       clientConfig.waitStatesEnabled && processInstance?.state === 'ACTIVE',
   });
@@ -205,20 +198,17 @@ const TopPanel: React.FC = observer(() => {
       ...subprocessOverlays,
     ];
 
-    if (inspectionData?.items?.length) {
-      const elementIdsInStats = new Set(statistics?.map(({id}) => id) ?? []);
-      for (const item of inspectionData.items) {
-        if (
-          isBeforeAllExecutionListenerWaitState(item) &&
-          !elementIdsInStats.has(item.elementId)
-        ) {
-          allElementStateOverlays.push({
-            payload: {elementState: 'active' as const},
-            type: OVERLAY_TYPE_STATE,
-            elementId: item.elementId,
-            position: overlayPositions.active,
-          });
-        }
+    // Some wait states (e.g. a BEFORE_ALL execution listener on a multi-instance
+    // body) are missing from element-instances stats; synthesize an active overlay.
+    const elementIdsInStats = new Set(statistics?.map(({id}) => id) ?? []);
+    for (const {elementId, waitingCount} of waitStateStatistics ?? []) {
+      if (waitingCount > 0 && !elementIdsInStats.has(elementId)) {
+        allElementStateOverlays.push({
+          payload: {elementState: 'active' as const},
+          type: OVERLAY_TYPE_STATE,
+          elementId,
+          position: overlayPositions.active,
+        });
       }
     }
 
@@ -233,20 +223,12 @@ const TopPanel: React.FC = observer(() => {
     statistics,
     businessObjects,
     isExecutionCountVisible,
-    inspectionData?.items,
+    waitStateStatistics,
   ]);
 
   const allWaitingStateOverlays = useMemo(() => {
-    if (!inspectionData?.items?.length) {
+    if (!waitStateStatistics?.length) {
       return [];
-    }
-
-    // Group wait states by elementId (show only 1 label per element)
-    const waitStatesByElement = new Map<string, ElementInstanceInspection[]>();
-    for (const item of inspectionData.items) {
-      const existing = waitStatesByElement.get(item.elementId) ?? [];
-      existing.push(item);
-      waitStatesByElement.set(item.elementId, existing);
     }
 
     const overlays: Array<{
@@ -256,13 +238,11 @@ const TopPanel: React.FC = observer(() => {
       payload: {label: string; centered: boolean};
     }> = [];
 
-    const hasMore = inspectionData.page?.totalItems > MAX_WAIT_STATES;
-
-    for (const [elementId, waitStates] of waitStatesByElement) {
-      const label = getWaitStateLabel(waitStates, hasMore);
+    for (const {elementId, waitingCount} of waitStateStatistics) {
+      const label = getWaitStateLabel(waitingCount);
       if (label) {
-        const isNarrowElement = waitStates.some((waitState) =>
-          NARROW_WAIT_STATE_ELEMENT_TYPES.has(waitState.elementType),
+        const isNarrowElement = NARROW_WAIT_STATE_BPMN_TYPES.has(
+          businessObjects?.[elementId]?.$type ?? '',
         );
         overlays.push({
           elementId,
@@ -274,7 +254,7 @@ const TopPanel: React.FC = observer(() => {
     }
 
     return overlays;
-  }, [inspectionData?.items, inspectionData?.page?.totalItems]);
+  }, [waitStateStatistics, businessObjects]);
 
   const {agentOverlays, elementsWithAgent} = useMemo(() => {
     if (!agentInstancesData?.items?.length) {

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.tsx
@@ -140,8 +140,7 @@ const TopPanel: React.FC = observer(() => {
     );
   const {data: processInstance} = useProcessInstance();
   const {data: waitStateStatistics} = useWaitStateStatistics({
-    enabled:
-      clientConfig.waitStatesEnabled && processInstance?.state === 'ACTIVE',
+    enabled: clientConfig.waitStatesEnabled,
   });
   const {data: agentInstancesData} = useProcessInstanceAgentInstances();
   const modificationsByElement = useModificationsByElement();

--- a/operate/client/src/modules/api/v2/processInstances/fetchProcessInstanceWaitStateStatistics.ts
+++ b/operate/client/src/modules/api/v2/processInstances/fetchProcessInstanceWaitStateStatistics.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  endpoints,
+  type GetProcessInstanceWaitStateStatisticsResponseBody,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import {requestWithThrow} from 'modules/request';
+
+const fetchProcessInstanceWaitStateStatistics = async (
+  processInstanceKey: string,
+  signal?: AbortSignal,
+) => {
+  return requestWithThrow<GetProcessInstanceWaitStateStatisticsResponseBody>({
+    url: endpoints.getProcessInstanceWaitStateStatistics.getUrl({
+      processInstanceKey,
+    }),
+    method: endpoints.getProcessInstanceWaitStateStatistics.method,
+    signal,
+  });
+};
+
+export {fetchProcessInstanceWaitStateStatistics};

--- a/operate/client/src/modules/mocks/api/v2/processInstances/fetchProcessInstanceWaitStateStatistics.ts
+++ b/operate/client/src/modules/mocks/api/v2/processInstances/fetchProcessInstanceWaitStateStatistics.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {mockGetRequest} from '../../mockRequest';
+import {type GetProcessInstanceWaitStateStatisticsResponseBody} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const mockFetchProcessInstanceWaitStateStatistics = () =>
+  mockGetRequest<GetProcessInstanceWaitStateStatisticsResponseBody>(
+    '/v2/process-instances/:processInstanceKey/statistics/wait-states',
+  );
+
+export {mockFetchProcessInstanceWaitStateStatistics};

--- a/operate/client/src/modules/queries/queryKeys.ts
+++ b/operate/client/src/modules/queries/queryKeys.ts
@@ -257,6 +257,12 @@ const queryKeys = {
       processInstanceKey,
     ],
   },
+  waitStateStatistics: {
+    get: (processInstanceKey: string) => [
+      'waitStateStatistics',
+      processInstanceKey,
+    ],
+  },
   callHierarchy: {
     get: (processInstanceKey: string) => ['callHierarchy', processInstanceKey],
   },

--- a/operate/client/src/modules/queries/waitStateStatistics/useWaitStateStatistics.ts
+++ b/operate/client/src/modules/queries/waitStateStatistics/useWaitStateStatistics.ts
@@ -26,7 +26,8 @@ const useWaitStateStatistics = (params: UseWaitStateStatisticsParams = {}) => {
   const {processInstanceId = ''} = useProcessInstancePageParams();
   const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
 
-  const isEnabled = enabled && !!processInstanceId;
+  const isEnabled =
+    enabled && !!processInstanceId && !!isProcessInstanceRunning;
 
   return useQuery<
     GetProcessInstanceWaitStateStatisticsResponseBody,

--- a/operate/client/src/modules/queries/waitStateStatistics/useWaitStateStatistics.ts
+++ b/operate/client/src/modules/queries/waitStateStatistics/useWaitStateStatistics.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery} from '@tanstack/react-query';
+import type {
+  GetProcessInstanceWaitStateStatisticsResponseBody,
+  WaitStateStatistic,
+} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {RequestError} from 'modules/request';
+import {fetchProcessInstanceWaitStateStatistics} from 'modules/api/v2/processInstances/fetchProcessInstanceWaitStateStatistics';
+import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
+import {useIsProcessInstanceRunning} from 'modules/queries/processInstance/useIsProcessInstanceRunning';
+import {queryKeys} from '../queryKeys';
+
+type UseWaitStateStatisticsParams = {
+  enabled?: boolean;
+};
+
+const useWaitStateStatistics = (params: UseWaitStateStatisticsParams = {}) => {
+  const {enabled = true} = params;
+  const {processInstanceId = ''} = useProcessInstancePageParams();
+  const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
+
+  const isEnabled = enabled && !!processInstanceId;
+
+  return useQuery<
+    GetProcessInstanceWaitStateStatisticsResponseBody,
+    RequestError,
+    WaitStateStatistic[]
+  >({
+    queryKey: queryKeys.waitStateStatistics.get(processInstanceId),
+    queryFn: async ({signal}) => {
+      const {response, error} = await fetchProcessInstanceWaitStateStatistics(
+        processInstanceId,
+        signal,
+      );
+      if (response !== null) {
+        return response;
+      }
+      throw error;
+    },
+    enabled: isEnabled,
+    refetchInterval: () => (isProcessInstanceRunning ? 5000 : undefined),
+    select: (data) => (isEnabled ? data.items : []),
+  });
+};
+
+export {useWaitStateStatistics};

--- a/operate/client/src/modules/utils/waitStates.test.ts
+++ b/operate/client/src/modules/utils/waitStates.test.ts
@@ -40,51 +40,21 @@ const jobDetails: WaitStateDetails = {
 };
 
 describe('getWaitStateLabel', () => {
-  it('should return null for an empty wait state list', () => {
-    expect(getWaitStateLabel([])).toBeNull();
+  it('should return null for a zero waiting count', () => {
+    expect(getWaitStateLabel(0)).toBeNull();
   });
 
-  it('should return "Waiting" for a single wait state', () => {
-    expect(getWaitStateLabel([buildWaitState(jobDetails)])).toBe('Waiting');
+  it('should return null for a negative waiting count', () => {
+    expect(getWaitStateLabel(-1)).toBeNull();
   });
 
-  it('should count all wait states, including timers', () => {
-    expect(
-      getWaitStateLabel([
-        buildWaitState({
-          waitStateType: 'TIMER',
-          dueDate: Date.parse('2026-01-01T00:00:00Z'),
-          repetitions: null,
-        }),
-        buildWaitState({
-          waitStateType: 'MESSAGE',
-          messageName: 'foo',
-          correlationKey: null,
-        }),
-      ]),
-    ).toBe('2 waiting');
+  it('should return "Waiting" for a single waiting instance', () => {
+    expect(getWaitStateLabel(1)).toBe('Waiting');
   });
 
-  it('should suffix the count with "+" when more wait states exist than returned', () => {
-    expect(
-      getWaitStateLabel(
-        [
-          buildWaitState(jobDetails),
-          buildWaitState({
-            waitStateType: 'MESSAGE',
-            messageName: 'foo',
-            correlationKey: null,
-          }),
-        ],
-        true,
-      ),
-    ).toBe('2+ waiting');
-  });
-
-  it('should not suffix "+" for a single wait state even when truncated', () => {
-    expect(getWaitStateLabel([buildWaitState(jobDetails)], true)).toBe(
-      'Waiting',
-    );
+  it('should return the count for multiple waiting instances', () => {
+    expect(getWaitStateLabel(2)).toBe('2 waiting');
+    expect(getWaitStateLabel(42)).toBe('42 waiting');
   });
 });
 

--- a/operate/client/src/modules/utils/waitStates.ts
+++ b/operate/client/src/modules/utils/waitStates.ts
@@ -9,18 +9,13 @@
 import type {ElementInstanceInspection} from '@camunda/camunda-api-zod-schemas/8.10';
 import {formatDate} from 'modules/utils/date';
 
-function getWaitStateLabel(
-  waitStates: ElementInstanceInspection[],
-  hasMore = false,
-): string | null {
-  const count = waitStates.length;
-
-  if (count === 0) {
+function getWaitStateLabel(waitingCount: number): string | null {
+  if (waitingCount <= 0) {
     return null;
   }
 
-  if (count > 1) {
-    return `${count}${hasMore ? '+' : ''} waiting`;
+  if (waitingCount > 1) {
+    return `${waitingCount} waiting`;
   }
 
   return 'Waiting';
@@ -121,20 +116,4 @@ function getEarliestTimerDueDate(
   return earliestDueDate;
 }
 
-function isBeforeAllExecutionListenerWaitState(
-  item: ElementInstanceInspection,
-): boolean {
-  return (
-    item.elementType === 'MULTI_INSTANCE_BODY' &&
-    item.details.waitStateType === 'JOB' &&
-    item.details.jobKind === 'EXECUTION_LISTENER' &&
-    item.details.listenerEventType === 'BEFORE_ALL'
-  );
-}
-
-export {
-  getWaitStateLabel,
-  getWaitStateStatusItems,
-  getEarliestTimerDueDate,
-  isBeforeAllExecutionListenerWaitState,
-};
+export {getWaitStateLabel, getWaitStateStatusItems, getEarliestTimerDueDate};


### PR DESCRIPTION
## Description

- Diagram overview now uses the aggregated wait-state statistics endpoint (`GET /process-instances/{key}/statistics/wait-states`, polled every 5s) instead of fetching the full wait-state list; badge label and count come from `waitingCount`.
- Kept a synthetic "active" overlay for multi-instance bodies that are waiting but missing from the element-instances stats (they have no active inner instance yet, e.g. a BEFORE_ALL execution listener); guarded by `isMultiInstance` so no other element gets a spurious active badge. Element detail panel unchanged.
- Bumped `@camunda/camunda-api-zod-schemas` to `0.0.79`; updated tests + added a mock builder.

## Related issues

closes #56258
