### PR TITLE
test: abstract test class cannot declare a shared resource as static

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersBaseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersBaseIT.java
@@ -45,7 +45,7 @@ public abstract class SecurityHeadersBaseIT {
   protected static final ElasticsearchContainer CONTAINER =
       TestSearchContainers.createDefaultElasticsearchContainer();
 
-  @AutoClose protected static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  @AutoClose protected final HttpClient httpClient = HttpClient.newHttpClient();
 
   // Abstract methods to be implemented by subclasses
   protected abstract CamundaClient getCamundaClient();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersBasicAuthIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersBasicAuthIT.java
@@ -86,7 +86,7 @@ public class SecurityHeadersBasicAuthIT extends SecurityHeadersBaseIT {
             .uri(createUri(camundaClient, path))
             .header(HttpHeaders.AUTHORIZATION, basicAuthentication())
             .build();
-    return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
   }
 
   @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersOidcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/shared/security/headers/SecurityHeadersOidcIT.java
@@ -148,7 +148,7 @@ public class SecurityHeadersOidcIT extends SecurityHeadersBaseIT {
             .header(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + bearerToken)
             .build();
 
-    return HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
   }
 
   @Override


### PR DESCRIPTION
## Description
SecurityHeadersBaseIT was declaring the HTTP client as static: that was closed when one of the classes completed the tests. This is probably not happening in maven as each test runs in a separate JVM
Found in #52869 (gradle build)

