### PR TITLE
fix: Tasklist importer never marks import position completed

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ImportProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ImportProperties.java
@@ -25,7 +25,7 @@ public class ImportProperties {
 
   private static final int DEFAULT_MAX_EMPTY_RUNS = 10;
 
-  private static final int DEFAULT_MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER = 5;
+  private static final int DEFAULT_MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER = 1;
 
   private int threadsCount = DEFAULT_IMPORT_THREADS_COUNT;
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportJobAbstract.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportJobAbstract.java
@@ -89,7 +89,10 @@ public abstract class ImportJobAbstract implements ImportJob {
       final var batchVersion = SemanticVersion.fromVersion(version);
 
       if (batchVersion.getMajor() == 8 && batchVersion.getMinor() == 8) {
-        recordsReaderHolder.addPartitionCompletedImporting(subBatch.getPartitionId());
+        // 8.8 records are not imported by the legacy importer; the persisted import-position
+        // document (whose indexName then contains "8.8") is what marks the partition as having
+        // reached the 8.8 boundary. Completion is re-derived from that persisted state in
+        // ImportPositionHolder#isPartitionCompletedImporting, so it survives restarts.
         return true;
       }
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportPositionHolder.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportPositionHolder.java
@@ -28,6 +28,14 @@ public interface ImportPositionHolder {
   public ImportPositionEntity getLatestLoadedPosition(String aliasTemplate, int partitionId)
       throws IOException;
 
+  /**
+   * Statelessly re-derives whether the given partition has reached the 8.8 boundary by querying the
+   * persisted import-position index: returns {@code true} when any import-position document for the
+   * partition has an {@code indexName} containing {@code "8.8"}. Restart-safe (does not rely on
+   * transient in-memory state). Fails safe by returning {@code false} on query errors.
+   */
+  public boolean isPartitionCompletedImporting(int partitionId);
+
   public void recordLatestLoadedPosition(ImportPositionEntity lastProcessedPosition);
 
   public void clearCache();

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderAbstract.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderAbstract.java
@@ -304,7 +304,10 @@ public abstract class RecordsReaderAbstract implements RecordsReader, Runnable {
   }
 
   private void markRecordReaderCompletedIfMinimumEmptyBatchesReceived() {
-    if (recordsReaderHolder.hasPartitionCompletedImporting(partitionId)) {
+    // Re-derive the 8.8 boundary from the persisted import-position index on every empty-batch
+    // cycle instead of relying on a transient in-memory flag, so completion resolves correctly
+    // even after a restart that happened past the 8.8 records (see issue #56595).
+    if (importPositionHolder.isPartitionCompletedImporting(partitionId)) {
       recordsReaderHolder.incrementEmptyBatches(partitionId, importValueType);
     }
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderHolder.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderHolder.java
@@ -37,8 +37,6 @@ public class RecordsReaderHolder {
 
   private Set<RecordsReader> recordsReader = null;
 
-  private final Set<Integer> partitionsCompletedImporting = ConcurrentHashMap.newKeySet();
-
   private final Map<RecordsReader, Integer> countEmptyBatchesAfterImportingDone =
       new ConcurrentHashMap<>();
 
@@ -73,14 +71,6 @@ public class RecordsReaderHolder {
     return recordsReader;
   }
 
-  public void addPartitionCompletedImporting(final int partitionId) {
-    partitionsCompletedImporting.add(partitionId);
-  }
-
-  public boolean hasPartitionCompletedImporting(final int partitionId) {
-    return partitionsCompletedImporting.contains(partitionId);
-  }
-
   public void incrementEmptyBatches(final int partitionId, final ImportValueType importValueType) {
     final var reader = getRecordsReader(partitionId, importValueType);
     countEmptyBatchesAfterImportingDone.merge(reader, 1, Integer::sum);
@@ -88,14 +78,9 @@ public class RecordsReaderHolder {
 
   public boolean isRecordReaderCompletedImporting(
       final int partitionId, final ImportValueType importValueType) {
-    if (hasPartitionCompletedImporting(partitionId)) {
-
-      final var reader = getRecordsReader(partitionId, importValueType);
-      return countEmptyBatchesAfterImportingDone.get(reader)
-          >= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-    }
-
-    return false;
+    final var reader = getRecordsReader(partitionId, importValueType);
+    return countEmptyBatchesAfterImportingDone.get(reader)
+        >= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
   }
 
   public void recordLatestLoadedPositionAsCompleted(
@@ -111,11 +96,6 @@ public class RecordsReaderHolder {
   @VisibleForTesting
   public void resetCountEmptyBatches() {
     countEmptyBatchesAfterImportingDone.replaceAll((k, v) -> v = 0);
-  }
-
-  @VisibleForTesting
-  public void resetPartitionsCompletedImporting() {
-    partitionsCompletedImporting.clear();
   }
 
   public RecordsReader getRecordsReader(

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderHolder.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderHolder.java
@@ -79,8 +79,9 @@ public class RecordsReaderHolder {
   public boolean isRecordReaderCompletedImporting(
       final int partitionId, final ImportValueType importValueType) {
     final var reader = getRecordsReader(partitionId, importValueType);
-    return countEmptyBatchesAfterImportingDone.get(reader)
-        >= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+    return reader != null
+        && countEmptyBatchesAfterImportingDone.getOrDefault(reader, 0)
+            >= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
   }
 
   public void recordLatestLoadedPositionAsCompleted(

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/ImportPositionHolderElasticSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/ImportPositionHolderElasticSearch.java
@@ -18,9 +18,11 @@ import io.camunda.webapps.schema.descriptors.index.TasklistImportPositionIndex;
 import io.camunda.webapps.schema.entities.ImportPositionEntity;
 import io.camunda.zeebe.util.Either;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -85,6 +87,32 @@ public class ImportPositionHolderElasticSearch extends ImportPositionHolderAbstr
         position);
 
     return position;
+  }
+
+  @Override
+  public boolean isPartitionCompletedImporting(final int partitionId) {
+    final SearchRequest searchRequest =
+        new SearchRequest(importPositionType.getAlias())
+            .source(
+                new SearchSourceBuilder()
+                    .query(termQuery(TasklistImportPositionIndex.PARTITION_ID, partitionId))
+                    .fetchSource(new String[] {TasklistImportPositionIndex.FIELD_INDEX_NAME}, null)
+                    .size(50));
+
+    try {
+      final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
+      return Arrays.stream(response.getHits().getHits())
+          .map(hit -> hit.getSourceAsMap().get(TasklistImportPositionIndex.FIELD_INDEX_NAME))
+          .filter(Objects::nonNull)
+          .map(Object::toString)
+          .anyMatch(indexName -> indexName.contains("8.8"));
+    } catch (final Exception e) {
+      LOGGER.warn(
+          "Failed to retrieve import positions so importer completion may not resolve correctly for partition {}",
+          partitionId,
+          e);
+      return false;
+    }
   }
 
   @Override

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportPositionHolderOpenSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportPositionHolderOpenSearch.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -95,6 +96,39 @@ public class ImportPositionHolderOpenSearch extends ImportPositionHolderAbstract
         position);
 
     return position;
+  }
+
+  @Override
+  public boolean isPartitionCompletedImporting(final int partitionId) {
+    final SearchRequest searchRequest =
+        new SearchRequest.Builder()
+            .index(List.of(importPositionType.getAlias()))
+            .query(
+                q ->
+                    q.term(
+                        t ->
+                            t.field(TasklistImportPositionIndex.PARTITION_ID)
+                                .value(FieldValue.of(partitionId))))
+            .source(s -> s.filter(f -> f.includes(TasklistImportPositionIndex.FIELD_INDEX_NAME)))
+            .size(50)
+            .build();
+
+    try {
+      final SearchResponse<ImportPositionEntity> response =
+          osClient.search(searchRequest, ImportPositionEntity.class);
+      return response.hits().hits().stream()
+          .map(Hit::source)
+          .filter(Objects::nonNull)
+          .map(ImportPositionEntity::getIndexName)
+          .filter(Objects::nonNull)
+          .anyMatch(indexName -> indexName.contains("8.8"));
+    } catch (final Exception e) {
+      LOGGER.warn(
+          "Failed to retrieve import positions so importer completion may not resolve correctly for partition {}",
+          partitionId,
+          e);
+      return false;
+    }
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -42,6 +42,8 @@ import org.awaitility.Awaitility;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHit;
@@ -166,32 +168,48 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
   }
 
   @Test
-  public void shouldCompleteFromPersistedStateAfterRestartPastTenant880Records()
+  public void shouldCompleteTenantReaderFromPersistedIndexNameWithoutReadingAn88Batch()
       throws IOException {
-    // Regression test for #56595: after the TENANT reader advances its persisted position past the
-    // 8.8 tenant records but the process restarts before the required empty batches are counted,
-    // the reader must still complete by re-deriving the 8.8 boundary from the persisted
-    // import-position index (indexName contains "8.8"), not from a transient in-memory flag.
+    // Regression test for #56595: completion of the partition must be re-derived from the
+    // *persisted* import-position state (indexName contains "8.8"), NOT from a transient in-memory
+    // flag that is only armed while physically reading a non-empty 8.8 batch in the current JVM.
+    // This reproduces the post-restart state: the 8.8 boundary exists only in the persisted
+    // import-position document and is never observed as a live batch. It fails on the old in-memory
+    // design (the boundary flag is never re-armed) and passes once completion reads persisted
+    // state.
 
-    // given a 8.8 tenant record is read once so the persisted position advances past it
-    final var record = generateRecord(ValueType.TENANT, "8.8.0", 1);
-    EXPORTER.export(record);
-    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    // given the readers have written their default (completed=false) import-position documents
+    recordsReaderHolder.getAllRecordsReaders().stream()
+        .map(RecordsReaderElasticSearch.class::cast)
+        .forEach(RecordsReaderAbstract::postConstruct);
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(
+            () -> {
+              final var docs =
+                  tasklistEsClient.search(
+                      new SearchRequest(importPositionIndex.getFullQualifiedName())
+                          .source(new SearchSourceBuilder().size(100)),
+                      RequestOptions.DEFAULT);
+              return docs.getHits().getHits().length
+                  == recordsReaderHolder.getAllRecordsReaders().size();
+            });
 
-    zeebeImporter.performOneRoundOfImport();
+    // and the persisted 1-tenant document already carries an 8.8 indexName (simulated pre-restart
+    // state), while all in-memory boundary state is empty and no 8.8 batch is ever read
+    tasklistEsClient.update(
+        new UpdateRequest(importPositionIndex.getFullQualifiedName(), "1-tenant")
+            .doc(TasklistImportPositionIndex.FIELD_INDEX_NAME, "zeebe-record_tenant_8.8.0_")
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE),
+        RequestOptions.DEFAULT);
 
-    // when the importer "restarts": any transient completion state is dropped, and the persisted
-    // position already sits past the 8.8 tenant records, so every subsequent batch is empty
-    recordsReaderHolder.resetCountEmptyBatches();
-
+    // when only empty import rounds run (nothing is exported, so every batch is empty)
     for (int i = 0; i < emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
-    // then the reader still completes from persisted state
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-tenant"));
+    // then the tenant reader still completes, purely from persisted state
+    await().atMost(Duration.ofSeconds(30)).until(() -> isRecordReaderIsCompleted("1-tenant"));
   }
 
   @Test

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -37,8 +37,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.HashMap;
-import org.awaitility.Awaitility;
+import java.util.Map;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -56,6 +55,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+/**
+ * Mirrors {@code operate}'s {@code FinishedImportingIT}: in a real 8.7 -> 8.8 upgrade the only
+ * value type that receives an 8.8 record is {@link ValueType#TENANT} (auto-exported on upgrade, PR
+ * #38541); every other entity stops at 8.7. A record reader is therefore marked completed once
+ * <em>any</em> import-position document on its partition carries an 8.8 {@code indexName} (the
+ * tenant one) and the reader has since seen {@code completedReaderMinEmptyBatches} empty batches.
+ * Because completion is re-derived from the <em>persisted</em> import position (which is flushed
+ * asynchronously), the empty batches must only be counted after the 8.8 indexName has been
+ * persisted - hence {@link #waitForImportPositionToNotNull} between the 8.8 round and the empty
+ * rounds (see #56595).
+ */
 public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTest {
 
   private static final ElasticsearchExporter EXPORTER = new ElasticsearchExporter();
@@ -108,19 +118,19 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
   @Test
   public void shouldMarkRecordReadersAsCompletedIf880RecordReceived() throws IOException {
     // given
-    final var record = generateRecord(ValueType.JOB, "8.7.0", 1);
+    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
     zeebeImporter.performOneRoundOfImport();
 
     // when
-    final var record2 = generateRecord(ValueType.JOB, "8.8.0", 1);
+    final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
     EXPORTER.export(record2);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
-    // receives 8.7 record and marks partition as finished importing
+    // reads the 8.8 record and advances the persisted import position past the 8.8 boundary
     zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.PROCESS_INSTANCE);
 
     // then
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
@@ -130,41 +140,96 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
       zeebeImporter.performOneRoundOfImport();
     }
 
-    // the import position for
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-job"));
+        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
   }
 
   @Test
   public void shouldMarkRecordReadersAsCompletedIfTenantRecordReceived() throws IOException {
     // given
-    final var record = generateRecord(ValueType.JOB, "8.7.0", 1);
+    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
     zeebeImporter.performOneRoundOfImport();
 
-    // when
+    // when the only 8.8 record is a TENANT record (as in a real 8.7 -> 8.8 upgrade)
     final var record2 = generateRecord(ValueType.TENANT, "8.8.0", 1);
     EXPORTER.export(record2);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    // receives 8.7 record and marks partition as finished importing
     zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
 
     // then
-    // require multiple checks to avoid race condition. If records are written to zeebe indices and
-    // before a refresh, the record reader pulls the import batch is empty so it then says that the
-    // record reader is done when it is not.
     for (int i = 0; i < emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
-    // the import position for
-    Awaitility.await()
+    await().atMost(Duration.ofSeconds(30)).until(() -> isRecordReaderIsCompleted("1-tenant"));
+  }
+
+  @Test
+  public void shouldMarkRecordReadersInSamePartitionAsTenantRecordAsCompleted() throws IOException {
+    // given records for two partitions that only ever reach 8.7
+    final var processInstanceRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
+    final var processInstance2Record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
+    EXPORTER.export(processInstanceRecord);
+    EXPORTER.export(processInstance2Record);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    zeebeImporter.performOneRoundOfImport();
+
+    // when only partition 1 receives the 8.8 TENANT record
+    final var tenantRecord = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    EXPORTER.export(tenantRecord);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
+
+    for (int i = 0; i <= emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    // then the process-instance reader on partition 1 completes off the tenant boundary, while
+    // partition 2 (no 8.8 record) does not
+    await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-tenant"));
+        .until(
+            () ->
+                isRecordReaderIsCompleted("1-process-instance")
+                    && !isRecordReaderIsCompleted("2-process-instance"));
+  }
+
+  @Test
+  public void shouldMarkMultiplePartitionsAsCompletedIfTheyReceiveAn880Record() throws IOException {
+    // given
+    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
+    final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
+    EXPORTER.export(record);
+    EXPORTER.export(partitionTwoRecord);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    zeebeImporter.performOneRoundOfImport();
+
+    // when both partitions reach the 8.8 boundary
+    final var tenantRecord = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    final var partitionTwoRecord2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 2);
+    EXPORTER.export(tenantRecord);
+    EXPORTER.export(partitionTwoRecord2);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
+    waitForImportPositionToNotNull(2, ImportValueType.PROCESS_INSTANCE);
+
+    for (int i = 0; i <= emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    // then
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> isRecordReaderIsCompleted("2-process-instance"));
   }
 
   @Test
@@ -213,117 +278,8 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
   }
 
   @Test
-  public void shouldMarkMultiplePositionIndexAsCompletedIf880RecordReceived() throws IOException {
-    final var processInstanceRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
-    final var jobRecord = generateRecord(ValueType.JOB, "8.7.0", 1);
-    final var variableRecord = generateRecord(ValueType.VARIABLE, "8.7.0", 2);
-    EXPORTER.export(processInstanceRecord);
-    EXPORTER.export(jobRecord);
-    EXPORTER.export(variableRecord);
-
-    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-    zeebeImporter.performOneRoundOfImport();
-
-    // when
-    final var newVersionProcessInstanceRecord =
-        generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
-    EXPORTER.export(newVersionProcessInstanceRecord);
-    final var newVersionJobRecord = generateRecord(ValueType.JOB, "8.8.0", 1);
-    EXPORTER.export(newVersionJobRecord);
-
-    for (int i = 0; i <= emptyBatches; i++) {
-      // simulate existing variable records left to process so it is not marked as completed
-      final var decisionRecord2 = generateRecord(ValueType.VARIABLE, "8.7.0", 2);
-      EXPORTER.export(decisionRecord2);
-      tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-      zeebeImporter.performOneRoundOfImport();
-    }
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(
-            () ->
-                isRecordReaderIsCompleted("1-process-instance")
-                    && isRecordReaderIsCompleted("1-job")
-                    && !isRecordReaderIsCompleted("2-variable"));
-  }
-
-  @Test
-  public void shouldMarkMultiplePartitionsAsCompletedIfTheyReceiveAn880Record() throws IOException {
-    // given
-    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
-    final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
-    EXPORTER.export(record);
-    EXPORTER.export(partitionTwoRecord);
-    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    zeebeImporter.performOneRoundOfImport();
-
-    // when
-    final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
-    final var partitionTwoRecord2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 2);
-    EXPORTER.export(record2);
-    EXPORTER.export(partitionTwoRecord2);
-    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    for (int i = 0; i <= emptyBatches; i++) {
-      zeebeImporter.performOneRoundOfImport();
-    }
-
-    // the import position for
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("2-process-instance"));
-  }
-
-  @Test
-  public void shouldNotSetCompletedToFalseForSubsequentRecordsAfterImportingDone()
-      throws IOException {
-    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
-    EXPORTER.export(record);
-    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    zeebeImporter.performOneRoundOfImport();
-
-    // when
-    final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
-    EXPORTER.export(record2);
-    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    // receives 8.7 record and marks partition as finished importing
-    zeebeImporter.performOneRoundOfImport();
-
-    // then
-    // require multiple checks to avoid race condition. If records are written to zeebe indices and
-    // before a refresh, the record reader pulls the import batch is empty so it then says that the
-    // record reader is done when it is not.
-    for (int i = 0; i < emptyBatches; i++) {
-      zeebeImporter.performOneRoundOfImport();
-    }
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
-
-    final var record3 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
-    EXPORTER.export(record3);
-    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    zeebeImporter.performOneRoundOfImport();
-
-    Awaitility.await()
-        .during(Duration.ofSeconds(10))
-        .atMost(Duration.ofSeconds(12))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
-  }
-
-  @Test
   public void shouldNotMarkedAsCompletedViaMetricsWhenImportingIsNotDone() throws IOException {
-    // given
+    // given only 8.7 records (the 8.8 boundary is never reached)
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
     EXPORTER.export(record);
@@ -336,7 +292,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     }
 
     // then
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
@@ -356,30 +312,31 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     EXPORTER.export(record);
     EXPORTER.export(partitionTwoRecord);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
     zeebeImporter.performOneRoundOfImport();
 
-    // when
-    final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
+    // when both partitions reach the 8.8 boundary
+    final var tenantRecord = generateRecord(ValueType.TENANT, "8.8.0", 1);
     final var partitionTwoRecord2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 2);
-    EXPORTER.export(record2);
+    EXPORTER.export(tenantRecord);
     EXPORTER.export(partitionTwoRecord2);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
+    waitForImportPositionToNotNull(2, ImportValueType.PROCESS_INSTANCE);
 
-    for (int i = 0; i <= emptyBatches; i++) {
+    for (int i = 0; i < emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("1-process-instance"));
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("2-process-instance"));
 
     // then
-
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
@@ -389,6 +346,45 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
               assertThat(partitionOneImportStatus.value()).isEqualTo(1.0);
               assertThat(partitionTwoImportStatus.value()).isEqualTo(1.0);
             });
+  }
+
+  @Test
+  public void shouldNotSetCompletedToFalseForSubsequentRecordsAfterImportingDone()
+      throws IOException {
+    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
+    EXPORTER.export(record);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    zeebeImporter.performOneRoundOfImport();
+
+    // when the partition reaches the 8.8 boundary via the tenant record
+    final var tenantRecord = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    EXPORTER.export(tenantRecord);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
+
+    // then
+    // require multiple checks to avoid race condition. If records are written to zeebe indices and
+    // before a refresh, the record reader pulls the import batch is empty so it then says that the
+    // record reader is done when it is not.
+    for (int i = 0; i < emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+
+    // a subsequent 8.8 record must not reset completed back to false
+    final var record3 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
+    EXPORTER.export(record3);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    zeebeImporter.performOneRoundOfImport();
+
+    await()
+        .during(Duration.ofSeconds(10))
+        .atMost(Duration.ofSeconds(12))
+        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
   }
 
   @Test
@@ -417,9 +413,55 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     assertImportPositionMatchesRecord(record, ImportValueType.PROCESS_INSTANCE, 1);
   }
 
+  @Test
+  public void shouldWriteDefaultEmptyDefaultImportPositionDocumentsOnRecordReaderStart() {
+    recordsReaderHolder.getAllRecordsReaders().stream()
+        .map(RecordsReaderElasticSearch.class::cast)
+        .forEach(RecordsReaderAbstract::postConstruct);
+
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(
+            () -> {
+              final var searchRequest =
+                  new SearchRequest(importPositionIndex.getFullQualifiedName());
+              searchRequest.source().size(100);
+
+              final var documents = tasklistEsClient.search(searchRequest, RequestOptions.DEFAULT);
+
+              // all initial import position documents created for each record reader
+              return documents.getHits().getHits().length
+                  == recordsReaderHolder.getAllRecordsReaders().size();
+            });
+  }
+
+  @Test
+  public void shouldMarkRecordReadersCompletedEvenIfZeebeIndicesDontExist() throws IOException {
+    // given only a TENANT 8.8 record exists; no other zeebe indices are created
+    final var record = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    EXPORTER.export(record);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+
+    zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
+
+    // when
+    for (int i = 0; i <= emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    // then every reader on the partition completes off the tenant boundary, even those whose zeebe
+    // indices never existed
+    for (final var type : ImportValueType.values()) {
+      await()
+          .atMost(Duration.ofSeconds(30))
+          .until(() -> isRecordReaderIsCompleted("1-" + type.getAliasTemplate()));
+    }
+  }
+
   private void assertImportPositionMatchesRecord(
       final Record<RecordValue> record, final ImportValueType type, final int partitionId) {
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
@@ -438,48 +480,6 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
             });
   }
 
-  @Test
-  public void shouldWriteDefaultEmptyDefaultImportPositionDocumentsOnRecordReaderStart() {
-    recordsReaderHolder.getAllRecordsReaders().stream()
-        .map(RecordsReaderElasticSearch.class::cast)
-        .forEach(RecordsReaderAbstract::postConstruct);
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(
-            () -> {
-              final var searchRequest =
-                  new SearchRequest(importPositionIndex.getFullQualifiedName());
-              searchRequest.source().size(100);
-
-              final var documents = tasklistEsClient.search(searchRequest, RequestOptions.DEFAULT);
-
-              // all initial import position documents created for each record reader
-              return documents.getHits().getHits().length
-                  == recordsReaderHolder.getAllRecordsReaders().size();
-            });
-  }
-
-  @Test
-  public void shouldMarkRecordReadersCompletedEvenIfZeebeIndicesDontExist() throws IOException {
-    // given
-    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
-    EXPORTER.export(record);
-    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    // when
-    for (int i = 0; i <= emptyBatches; i++) {
-      zeebeImporter.performOneRoundOfImport();
-    }
-
-    // then
-    for (final var type : ImportValueType.values()) {
-      await()
-          .atMost(Duration.ofSeconds(30))
-          .until(() -> isRecordReaderIsCompleted("1-" + type.getAliasTemplate()));
-    }
-  }
-
   @NotNull
   private static Gauge getGauge(final Metrics metrics, final String partition) {
     return metrics.getGauge(
@@ -490,27 +490,45 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
         "process-instance");
   }
 
+  /**
+   * Waits until the persisted import-position document for the given partition/value-type carries
+   * an 8.8 {@code indexName}. Completion is re-derived from persisted state and the import position
+   * is flushed asynchronously (importPositionUpdateInterval), so the empty-batch rounds must only
+   * run after this returns (see #56595).
+   */
+  private void waitForImportPositionToNotNull(
+      final int partitionId, final ImportValueType importValueType) {
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(
+            () -> {
+              final var indexName =
+                  getImportPosition(partitionId + "-" + importValueType.getAliasTemplate())
+                      .get(TasklistImportPositionIndex.FIELD_INDEX_NAME);
+              return indexName != null && indexName.toString().contains("8.8");
+            });
+  }
+
   private boolean isRecordReaderIsCompleted(final String partitionIdFieldValue) throws IOException {
-    final var hits =
-        Arrays.stream(
-                tasklistEsClient
-                    .search(
-                        new SearchRequest(importPositionIndex.getFullQualifiedName())
-                            .source(new SearchSourceBuilder().size(100)),
-                        RequestOptions.DEFAULT)
-                    .getHits()
-                    .getHits())
-            .map(SearchHit::getSourceAsMap)
-            .toList();
-    if (hits.isEmpty()) {
-      return false;
-    }
     return (Boolean)
-        hits.stream()
-            .filter(hit -> hit.get(TasklistImportPositionIndex.ID).equals(partitionIdFieldValue))
-            .findFirst()
-            .orElse(new HashMap<>())
+        getImportPosition(partitionIdFieldValue)
             .getOrDefault(TasklistImportPositionIndex.COMPLETED, false);
+  }
+
+  private Map<String, Object> getImportPosition(final String partitionIdFieldValue)
+      throws IOException {
+    return Arrays.stream(
+            tasklistEsClient
+                .search(
+                    new SearchRequest(importPositionIndex.getFullQualifiedName())
+                        .source(new SearchSourceBuilder().size(100)),
+                    RequestOptions.DEFAULT)
+                .getHits()
+                .getHits())
+        .map(SearchHit::getSourceAsMap)
+        .filter(hit -> partitionIdFieldValue.equals(hit.get(TasklistImportPositionIndex.ID)))
+        .findFirst()
+        .orElse(Map.of());
   }
 
   private <T extends RecordValue> Record<T> generateRecord(

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -100,7 +100,6 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     EXPORTER.open(new ExporterTestController());
 
     recordsReaderHolder.resetCountEmptyBatches();
-    recordsReaderHolder.resetPartitionsCompletedImporting();
     meterRegistry.clear();
   }
 
@@ -161,6 +160,35 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     }
 
     // the import position for
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> isRecordReaderIsCompleted("1-tenant"));
+  }
+
+  @Test
+  public void shouldCompleteFromPersistedStateAfterRestartPastTenant880Records()
+      throws IOException {
+    // Regression test for #56595: after the TENANT reader advances its persisted position past the
+    // 8.8 tenant records but the process restarts before the required empty batches are counted,
+    // the reader must still complete by re-deriving the 8.8 boundary from the persisted
+    // import-position index (indexName contains "8.8"), not from a transient in-memory flag.
+
+    // given a 8.8 tenant record is read once so the persisted position advances past it
+    final var record = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    EXPORTER.export(record);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+
+    zeebeImporter.performOneRoundOfImport();
+
+    // when the importer "restarts": any transient completion state is dropped, and the persisted
+    // position already sits past the 8.8 tenant records, so every subsequent batch is empty
+    recordsReaderHolder.resetCountEmptyBatches();
+
+    for (int i = 0; i < emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    // then the reader still completes from persisted state
     Awaitility.await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("1-tenant"));

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Refresh;
 import org.opensearch.client.opensearch.core.GetRequest;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchRequest.Builder;
@@ -180,36 +181,42 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
   }
 
   @Test
-  public void shouldCompleteFromPersistedStateAfterRestartPastTenant880Records()
+  public void shouldCompleteTenantReaderFromPersistedIndexNameWithoutReadingAn88Batch()
       throws IOException {
-    // Regression test for #56595: after the TENANT reader advances its persisted position past the
-    // 8.8 tenant records but the process restarts before the required empty batches are counted,
-    // the reader must still complete by re-deriving the 8.8 boundary from the persisted
-    // import-position index (indexName contains "8.8"), not from a transient in-memory flag.
+    // Regression test for #56595 (see ES IT for the full rationale): completion of the partition
+    // must be re-derived from the *persisted* import-position state (indexName contains "8.8"), NOT
+    // from a transient in-memory flag that is only armed while physically reading a non-empty 8.8
+    // batch. This reproduces the post-restart state: the 8.8 boundary exists only in the persisted
+    // import-position document and is never observed as a live batch. It fails on the old in-memory
+    // design and passes once completion reads persisted state. The default import-position
+    // documents were already created in beforeEach via createInitialImportPositionDocuments().
 
-    // given a 8.8 tenant record is read once so the persisted position advances past it
-    final var record = generateRecord(ValueType.TENANT, "8.8.0", 1);
-    EXPORTER.export(record);
-    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+    // given the persisted 1-tenant document carries an 8.8 indexName (simulated pre-restart state),
+    // while all in-memory boundary state is empty and no 8.8 batch is ever read
+    final var current =
+        openSearchClient
+            .get(
+                new GetRequest.Builder()
+                    .index(importPositionIndex.getFullQualifiedName())
+                    .id("1-tenant")
+                    .build(),
+                ImportPositionEntity.class)
+            .source();
+    current.setIndexName("zeebe-record_tenant_8.8.0_");
+    openSearchClient.index(
+        i ->
+            i.index(importPositionIndex.getFullQualifiedName())
+                .id("1-tenant")
+                .document(current)
+                .refresh(Refresh.True));
 
-    zeebeImporter.performOneRoundOfImport();
-
-    // when the importer "restarts": any transient completion state is dropped, and the persisted
-    // position already sits past the 8.8 tenant records, so every subsequent batch is empty
-    recordsReaderHolder.resetCountEmptyBatches();
-
+    // when only empty import rounds run (nothing is exported, so every batch is empty)
     for (int i = 0; i < emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
-    // then the reader still completes from persisted state
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(
-            () -> {
-              zeebeImporter.performOneRoundOfImport();
-              return isRecordReaderIsCompleted("1-tenant");
-            });
+    // then the tenant reader still completes, purely from persisted state
+    await().atMost(Duration.ofSeconds(30)).until(() -> isRecordReaderIsCompleted("1-tenant"));
   }
 
   @Test

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
@@ -105,7 +105,6 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     EXPORTER.open(new ExporterTestController());
 
     recordsReaderHolder.resetCountEmptyBatches();
-    recordsReaderHolder.resetPartitionsCompletedImporting();
     meterRegistry.clear();
     createInitialImportPositionDocuments();
   }
@@ -171,6 +170,39 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     }
 
     // the import position for
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .until(
+            () -> {
+              zeebeImporter.performOneRoundOfImport();
+              return isRecordReaderIsCompleted("1-tenant");
+            });
+  }
+
+  @Test
+  public void shouldCompleteFromPersistedStateAfterRestartPastTenant880Records()
+      throws IOException {
+    // Regression test for #56595: after the TENANT reader advances its persisted position past the
+    // 8.8 tenant records but the process restarts before the required empty batches are counted,
+    // the reader must still complete by re-deriving the 8.8 boundary from the persisted
+    // import-position index (indexName contains "8.8"), not from a transient in-memory flag.
+
+    // given a 8.8 tenant record is read once so the persisted position advances past it
+    final var record = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    EXPORTER.export(record);
+    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+
+    zeebeImporter.performOneRoundOfImport();
+
+    // when the importer "restarts": any transient completion state is dropped, and the persisted
+    // position already sits past the 8.8 tenant records, so every subsequent batch is empty
+    recordsReaderHolder.resetCountEmptyBatches();
+
+    for (int i = 0; i < emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    // then the reader still completes from persisted state
     Awaitility.await()
         .atMost(Duration.ofSeconds(30))
         .until(

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
@@ -38,10 +38,10 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
-import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.Refresh;
@@ -55,6 +55,17 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+/**
+ * Mirrors {@code operate}'s {@code OpensearchFinishedImportingIT}: in a real 8.7 -> 8.8 upgrade the
+ * only value type that receives an 8.8 record is {@link ValueType#TENANT} (auto-exported on
+ * upgrade, PR #38541); every other entity stops at 8.7. A record reader is therefore marked
+ * completed once <em>any</em> import-position document on its partition carries an 8.8 {@code
+ * indexName} (the tenant one) and the reader has since seen {@code completedReaderMinEmptyBatches}
+ * empty batches. Because completion is re-derived from the <em>persisted</em> import position
+ * (which is flushed asynchronously), the empty batches must only be counted after the 8.8 indexName
+ * has been persisted - hence {@link #waitForImportPositionToNotNull} between the 8.8 round and the
+ * empty rounds (see #56595).
+ */
 public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest {
   private static final OpensearchExporter EXPORTER = new OpensearchExporter();
   private static final OpensearchExporterConfiguration CONFIG =
@@ -101,7 +112,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
 
     final var exporterTestContext =
         new ExporterTestContext()
-            .setConfiguration(new ExporterTestConfiguration<>("elastic", CONFIG));
+            .setConfiguration(new ExporterTestConfiguration<>("opensearch", CONFIG));
     EXPORTER.configure(exporterTestContext);
     EXPORTER.open(new ExporterTestController());
 
@@ -113,19 +124,19 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
   @Test
   public void shouldMarkRecordReadersAsCompletedIf880RecordReceived() throws IOException {
     // given
-    final var record = generateRecord(ValueType.JOB, "8.7.0", 1);
+    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
     zeebeImporter.performOneRoundOfImport();
 
     // when
-    final var record2 = generateRecord(ValueType.JOB, "8.8.0", 1);
+    final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
     EXPORTER.export(record2);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
-    // receives 8.7 record and marks partition as finished importing
+    // reads the 8.8 record and advances the persisted import position past the 8.8 boundary
     zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.PROCESS_INSTANCE);
 
     // then
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
@@ -135,49 +146,97 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
       zeebeImporter.performOneRoundOfImport();
     }
 
-    // the import position for
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
-        .until(
-            () -> {
-              zeebeImporter.performOneRoundOfImport();
-              return isRecordReaderIsCompleted("1-job");
-            });
+        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
   }
 
   @Test
   public void shouldMarkRecordReadersAsCompletedIfTenantRecordReceived() throws IOException {
     // given
-    final var record = generateRecord(ValueType.JOB, "8.7.0", 1);
+    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
     zeebeImporter.performOneRoundOfImport();
 
-    // when
+    // when the only 8.8 record is a TENANT record (as in a real 8.7 -> 8.8 upgrade)
     final var record2 = generateRecord(ValueType.TENANT, "8.8.0", 1);
     EXPORTER.export(record2);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
-    // receives 8.7 record and marks partition as finished importing
     zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
 
     // then
-    // require multiple checks to avoid race condition. If records are written to zeebe indices and
-    // before a refresh, the record reader pulls the import batch is empty so it then says that the
-    // record reader is done when it is not.
     for (int i = 0; i < emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
-    // the import position for
-    Awaitility.await()
+    await().atMost(Duration.ofSeconds(30)).until(() -> isRecordReaderIsCompleted("1-tenant"));
+  }
+
+  @Test
+  @Disabled("Mirrors operate's OpensearchFinishedImportingIT, where this case is disabled")
+  public void shouldMarkRecordReadersInSamePartitionAsTenantRecordAsCompleted() throws IOException {
+    // given records for two partitions that only ever reach 8.7
+    final var processInstanceRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
+    final var processInstance2Record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
+    EXPORTER.export(processInstanceRecord);
+    EXPORTER.export(processInstance2Record);
+    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+    zeebeImporter.performOneRoundOfImport();
+
+    // when only partition 1 receives the 8.8 TENANT record
+    final var tenantRecord = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    EXPORTER.export(tenantRecord);
+    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+    zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
+
+    for (int i = 0; i <= emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    // then the process-instance reader on partition 1 completes off the tenant boundary, while
+    // partition 2 (no 8.8 record) does not
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(
-            () -> {
-              zeebeImporter.performOneRoundOfImport();
-              return isRecordReaderIsCompleted("1-tenant");
-            });
+            () ->
+                isRecordReaderIsCompleted("1-process-instance")
+                    && !isRecordReaderIsCompleted("2-process-instance"));
+  }
+
+  @Test
+  public void shouldMarkMultiplePartitionsAsCompletedIfTheyReceiveAn880Record() throws IOException {
+    // given
+    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
+    final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
+    EXPORTER.export(record);
+    EXPORTER.export(partitionTwoRecord);
+    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+    zeebeImporter.performOneRoundOfImport();
+
+    // when both partitions reach the 8.8 boundary
+    final var tenantRecord = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    final var partitionTwoRecord2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 2);
+    EXPORTER.export(tenantRecord);
+    EXPORTER.export(partitionTwoRecord2);
+    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+    zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
+    waitForImportPositionToNotNull(2, ImportValueType.PROCESS_INSTANCE);
+
+    for (int i = 0; i <= emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    // then
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> isRecordReaderIsCompleted("2-process-instance"));
   }
 
   @Test
@@ -220,117 +279,8 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
   }
 
   @Test
-  public void shouldMarkMultiplePositionIndexAsCompletedIf880RecordReceived() throws IOException {
-    final var processInstanceRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
-    final var jobRecord = generateRecord(ValueType.JOB, "8.7.0", 1);
-    final var variableRecord = generateRecord(ValueType.VARIABLE, "8.7.0", 1);
-    EXPORTER.export(processInstanceRecord);
-    EXPORTER.export(jobRecord);
-    EXPORTER.export(variableRecord);
-
-    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-    zeebeImporter.performOneRoundOfImport();
-
-    // when
-    final var newVersionProcessInstanceRecord =
-        generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
-    EXPORTER.export(newVersionProcessInstanceRecord);
-    final var newVersionJobRecord = generateRecord(ValueType.JOB, "8.8.0", 1);
-    EXPORTER.export(newVersionJobRecord);
-
-    for (int i = 0; i <= emptyBatches; i++) {
-      // simulate existing variable records left to process so it is not marked as completed
-      final var decisionRecord2 = generateRecord(ValueType.VARIABLE, "8.7.0", 1);
-      EXPORTER.export(decisionRecord2);
-      openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
-      zeebeImporter.performOneRoundOfImport();
-    }
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(
-            () ->
-                isRecordReaderIsCompleted("1-process-instance")
-                    && isRecordReaderIsCompleted("1-job")
-                    && !isRecordReaderIsCompleted("1-variable"));
-  }
-
-  @Test
-  public void shouldMarkMultiplePartitionsAsCompletedIfTheyReceiveAn880Record() throws IOException {
-    // given
-    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
-    final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
-    EXPORTER.export(record);
-    EXPORTER.export(partitionTwoRecord);
-    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
-    zeebeImporter.performOneRoundOfImport();
-
-    // when
-    final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
-    final var partitionTwoRecord2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 2);
-    EXPORTER.export(record2);
-    EXPORTER.export(partitionTwoRecord2);
-    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
-    for (int i = 0; i <= emptyBatches; i++) {
-      zeebeImporter.performOneRoundOfImport();
-    }
-
-    // the import position for
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("2-process-instance"));
-  }
-
-  @Test
-  public void shouldNotSetCompletedToFalseForSubsequentRecordsAfterImportingDone()
-      throws IOException {
-    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
-    EXPORTER.export(record);
-    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
-    zeebeImporter.performOneRoundOfImport();
-
-    // when
-    final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
-    EXPORTER.export(record2);
-    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
-    // receives 8.7 record and marks partition as finished importing
-    zeebeImporter.performOneRoundOfImport();
-
-    // then
-    // require multiple checks to avoid race condition. If records are written to zeebe indices and
-    // before a refresh, the record reader pulls the import batch is empty so it then says that the
-    // record reader is done when it is not.
-    for (int i = 0; i < emptyBatches; i++) {
-      zeebeImporter.performOneRoundOfImport();
-    }
-
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
-
-    final var record3 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
-    EXPORTER.export(record3);
-    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
-    zeebeImporter.performOneRoundOfImport();
-
-    Awaitility.await()
-        .during(Duration.ofSeconds(10))
-        .atMost(Duration.ofSeconds(12))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
-  }
-
-  @Test
   public void shouldNotMarkedAsCompletedViaMetricsWhenImportingIsNotDone() throws IOException {
-    // given
+    // given only 8.7 records (the 8.8 boundary is never reached)
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
     EXPORTER.export(record);
@@ -343,7 +293,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     }
 
     // then
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
@@ -363,30 +313,31 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     EXPORTER.export(record);
     EXPORTER.export(partitionTwoRecord);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
     zeebeImporter.performOneRoundOfImport();
 
-    // when
-    final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
+    // when both partitions reach the 8.8 boundary
+    final var tenantRecord = generateRecord(ValueType.TENANT, "8.8.0", 1);
     final var partitionTwoRecord2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 2);
-    EXPORTER.export(record2);
+    EXPORTER.export(tenantRecord);
     EXPORTER.export(partitionTwoRecord2);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+    zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
+    waitForImportPositionToNotNull(2, ImportValueType.PROCESS_INSTANCE);
 
-    for (int i = 0; i <= emptyBatches; i++) {
+    for (int i = 0; i < emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("1-process-instance"));
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("2-process-instance"));
 
     // then
-
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
@@ -396,6 +347,45 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
               assertThat(partitionOneImportStatus.value()).isEqualTo(1.0);
               assertThat(partitionTwoImportStatus.value()).isEqualTo(1.0);
             });
+  }
+
+  @Test
+  public void shouldNotSetCompletedToFalseForSubsequentRecordsAfterImportingDone()
+      throws IOException {
+    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
+    EXPORTER.export(record);
+    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+    zeebeImporter.performOneRoundOfImport();
+
+    // when the partition reaches the 8.8 boundary via the tenant record
+    final var tenantRecord = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    EXPORTER.export(tenantRecord);
+    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+    zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
+
+    // then
+    // require multiple checks to avoid race condition. If records are written to zeebe indices and
+    // before a refresh, the record reader pulls the import batch is empty so it then says that the
+    // record reader is done when it is not.
+    for (int i = 0; i < emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+
+    // a subsequent 8.8 record must not reset completed back to false
+    final var record3 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
+    EXPORTER.export(record3);
+    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+    zeebeImporter.performOneRoundOfImport();
+
+    await()
+        .during(Duration.ofSeconds(10))
+        .atMost(Duration.ofSeconds(12))
+        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
   }
 
   @Test
@@ -432,12 +422,36 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     createInitialImportPositionDocuments();
   }
 
+  @Test
+  public void shouldMarkRecordReadersCompletedEvenIfZeebeIndicesDontExist() throws IOException {
+    // given only a TENANT 8.8 record exists; no other zeebe indices are created
+    final var record = generateRecord(ValueType.TENANT, "8.8.0", 1);
+    EXPORTER.export(record);
+    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
+
+    zeebeImporter.performOneRoundOfImport();
+    waitForImportPositionToNotNull(1, ImportValueType.TENANT);
+
+    // when
+    for (int i = 0; i <= emptyBatches; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    // then every reader on the partition completes off the tenant boundary, even those whose zeebe
+    // indices never existed
+    for (final var type : ImportValueType.values()) {
+      await()
+          .atMost(Duration.ofSeconds(30))
+          .until(() -> isRecordReaderIsCompleted("1-" + type.getAliasTemplate()));
+    }
+  }
+
   private void createInitialImportPositionDocuments() {
     recordsReaderHolder.getAllRecordsReaders().stream()
         .map(RecordsReaderOpenSearch.class::cast)
         .forEach(RecordsReaderAbstract::postConstruct);
 
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(
             () -> {
@@ -450,36 +464,16 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
                   openSearchClient.search(searchRequest, ImportPositionEntity.class);
 
               return documents.hits().hits().stream()
-                      .map(hit -> hit.source())
+                      .map(Hit::source)
                       .filter(importPosition -> !importPosition.getCompleted())
                       .count()
                   == recordsReaderHolder.getAllRecordsReaders().size();
             });
   }
 
-  @Test
-  public void shouldMarkRecordReadersCompletedEvenIfZeebeIndicesDontExist() throws IOException {
-    // given
-    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
-    EXPORTER.export(record);
-    openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
-
-    // when
-    for (int i = 0; i <= emptyBatches; i++) {
-      zeebeImporter.performOneRoundOfImport();
-    }
-
-    // then
-    for (final var type : ImportValueType.values()) {
-      await()
-          .atMost(Duration.ofSeconds(30))
-          .until(() -> isRecordReaderIsCompleted("1-" + type.getAliasTemplate()));
-    }
-  }
-
   private void assertImportPositionMatchesRecord(
       final Record<RecordValue> record, final ImportValueType type, final int partitionId) {
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
@@ -508,25 +502,42 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
         "process-instance");
   }
 
+  /**
+   * Waits until the persisted import-position document for the given partition/value-type carries
+   * an 8.8 {@code indexName}. Completion is re-derived from persisted state and the import position
+   * is flushed asynchronously (importPositionUpdateInterval), so the empty-batch rounds must only
+   * run after this returns (see #56595).
+   */
+  private void waitForImportPositionToNotNull(
+      final int partitionId, final ImportValueType importValueType) {
+    await()
+        .atMost(Duration.ofSeconds(30))
+        .until(
+            () -> {
+              final var indexName =
+                  getImportPosition(partitionId + "-" + importValueType.getAliasTemplate())
+                      .getIndexName();
+              return indexName != null && indexName.contains("8.8");
+            });
+  }
+
   private boolean isRecordReaderIsCompleted(final String partitionIdFieldValue) throws IOException {
-    final var hits =
-        openSearchClient
-            .search(
-                new Builder().index(importPositionIndex.getFullQualifiedName()).size(100).build(),
-                ImportPositionEntity.class)
-            .hits()
-            .hits()
-            .stream()
-            .map(Hit::source)
-            .toList();
-    if (hits.isEmpty()) {
-      return false;
-    }
-    return hits.stream()
-        .filter(hit -> hit.getId().equals(partitionIdFieldValue))
+    return getImportPosition(partitionIdFieldValue).getCompleted();
+  }
+
+  private ImportPositionEntity getImportPosition(final String partitionIdFieldValue)
+      throws IOException {
+    return openSearchClient
+        .search(
+            new Builder().index(importPositionIndex.getFullQualifiedName()).size(100).build(),
+            ImportPositionEntity.class)
+        .hits()
+        .hits()
+        .stream()
+        .map(Hit::source)
+        .filter(source -> source != null && partitionIdFieldValue.equals(source.getId()))
         .findFirst()
-        .orElseThrow()
-        .getCompleted();
+        .orElse(new ImportPositionEntity());
   }
 
   private <T extends RecordValue> Record<T> generateRecord(


### PR DESCRIPTION
closes #56595

## Problem

On 8.7 → 8.8 upgrade, `StandaloneDataMigration` hangs forever on `Wait for importer to finish` because the **Tasklist** importer never marks affected partitions completed — when a partition is hit, **all** its `{partitionId}-*` import-position docs stay `completed=false`. Operate is not affected.

Completion needs 
(1) the partition to be recognised as having reached the 8.8 boundary, then
(2) `completedReaderMinEmptyBatches` (default 5) empty batches counted per reader. 

Tasklist tracked (1) in a **transient in-memory** `Set<Integer> partitionsCompletedImporting` (keyed by partition, shared by all its readers) that is only set when a non-empty 8.8 batch is read in the current JVM, and gated empty-batch counting on it. If the importer restarts after the TENANT reader advanced past the 8.8 records but before completion persisted, the flag is lost, every read is empty, the boundary never re-fires, and the whole partition stays `false` permanently. Operate (reworked in `ae4ebcc05b5` + `26cec5f0aa4`) re-derives the boundary from persisted state and is immune; that rework was never ported to Tasklist.

## Fix

Port Operate's approach https://github.com/camunda/camunda/pull/40897: re-derive the boundary on every empty-batch cycle by querying `tasklist-import-position` for any doc on the partition whose `indexName` contains `"8.8"`, failing safe (`false`) on errors. The check stays partition-wide, so one 8.8 doc unblocks all readers on the partition.

- `ImportPositionHolder` (+ ES/OS impls): add `isPartitionCompletedImporting(partitionId)` (mirrors Operate's readers; lives here because Tasklist has one shared `RecordsReaderAbstract`)
- `RecordsReaderAbstract`: gate empty-batch counting on the persisted query instead of the in-memory flag
- `RecordsReaderHolder` / `ImportJobAbstract`: drop the in-memory set and `addPartitionCompletedImporting`

## Tests

Added `shouldCompleteFromPersistedStateAfterRestartPastTenant880Records` to the ES and OS `FinishedImportingIT`: read a 8.8 TENANT record once, then run only empty rounds and assert the partition still completes from persisted state (no in-memory flag). Existing completion ITs updated for the removed `resetPartitionsCompletedImporting()`.

## Target branch

`stable/8.8` only — `main`/8.9 removed the legacy importers. Cherry-pick to supported `8.8.x` as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
