### PR TITLE
ci: add Claude component auto-labeler as issue-labeler fallback

### DIFF
--- a/.github/prompts/component-auto-label.md
+++ b/.github/prompts/component-auto-label.md
@@ -1,0 +1,88 @@
+# Component auto-labeling
+
+You are labeling a single GitHub issue in `camunda/camunda` that may be missing a `component/*` label. You run automatically right after the regex-based issue labeler, as a fallback for issues it could not assign a component to.
+
+Process issue number `$ISSUE_NUMBER` in repo `$REPO`. Use the `gh` CLI for all GitHub actions (`gh issue view`, `gh issue edit`, `gh issue comment`); `GH_TOKEN` is already set with write access. Do not touch any other issue.
+
+## Step 1 — read and check idempotency
+Run: `gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json number,title,body,labels,comments`
+
+If `$FORCE` is NOT `true`:
+- If the issue already has ANY label whose name starts with `component/`: STOP — do nothing (no label, no comment). This is the normal case where the regex labeler already handled it.
+- If any existing comment body contains the marker `<!-- auto-project-label -->`: STOP — it has already been processed.
+
+## Step 2 — determine the best-fit component
+Choose EXACTLY ONE label from the list at the bottom. Signal priority:
+1. Template markers in the body (e.g. `Zeebe-`, `Operate-`, `Identity-`, `Data Layer-`, `Optimize-`, `Tasklist-`, `C8-API-`, `Clients-`, `Feel-`, `Load Tests-`, `Spring Boot Starter-`, `Management Identity-`, `Camunda Process Test-`).
+2. Existing `area/*` and other labels on the issue.
+3. A referenced parent issue's component label — if the body references a parent (`Part of #N`, `Parent: #N`, `Tracked by #N`, sub-issue of `#N`), run `gh issue view N --repo "$REPO" --json labels` and use its `component/*` label as a strong signal.
+4. Title + body content and general knowledge of the Camunda 8 codebase.
+
+Be opinionated: apply your best-fit even when confidence is low — the comment invites the author to correct it. Only decline to label when there is essentially ZERO signal (e.g. an empty body and an uninformative title with nothing to reason from).
+
+## Step 3a — you can choose a component
+1. Apply the label and remove the stale tag in one command (include `--remove-label` ONLY if the issue currently has `needs component label`):
+   `gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "component/CHOSEN" --remove-label "needs component label"`
+2. Post a comment with `gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "..."`. Choose wording by confidence.
+
+If confidence is High or Medium, use exactly:
+
+**🏷️ Component auto-labeling**
+
+This issue had no `component/*` label, so I assessed the best fit and applied one.
+
+**Assessment:** `component/CHOSEN`
+**Confidence:** High
+**Reasoning:**
+- <concrete signal 1>
+- <concrete signal 2>
+
+<sub>Automated suggestion, assessed once. If it's off, just change the label — I won't re-comment.</sub>
+
+<!-- auto-project-label -->
+
+If confidence is Low, use exactly:
+
+**🏷️ Component auto-labeling**
+
+This issue had no `component/*` label. My best-fit read is below, but I'm not highly confident, so if it's wrong please relabel — I won't re-comment.
+
+**Assessment:** `component/CHOSEN`
+**Confidence:** Low
+**Reasoning:**
+- <concrete signal or why it's ambiguous>
+
+<sub>Automated suggestion, assessed once. Change the label freely if it's off.</sub>
+
+<!-- auto-project-label -->
+
+## Step 3b — you genuinely cannot choose (zero signal)
+1. Do NOT apply a component label.
+2. Ensure `needs component label` is present (add it only if the issue doesn't already have it): `gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs component label"`
+3. Post exactly this comment:
+
+**🏷️ Component auto-labeling**
+
+I couldn't confidently determine a component for this issue from its title and description, so I've left `needs component label` for manual triage. A bit more detail about the affected area would help — or just apply the right `component/*` label directly.
+
+<sub>Automated triage note, posted once.</sub>
+
+<!-- auto-project-label -->
+
+## Rules
+- Assess ONCE. Every comment you post MUST end with the hidden marker `<!-- auto-project-label -->`.
+- Only ever add one `component/*` label and (optionally) remove `needs component label`. Never add, remove, or change any other label.
+- Exactly one component label.
+
+## The 44 component/* labels (choose one, verbatim)
+<!-- Keep this list in sync with the component/* labels in camunda/camunda. Update manually when labels are added or removed. -->
+- component/camunda — affects the complete monorepo / cross-cutting (only for genuinely repo-wide work)
+- component/backend, component/frontend — broad; prefer something more specific when possible
+- component/zeebe, component/engine, component/broker, component/gateway, component/gossip, component/raft, component/journal, component/snapshot, component/state, component/scheduler, component/stream-platform, component/partition-transitions, component/protocol, component/transport, component/exporter, component/batch-operation — Zeebe engine / distributed-system internals
+- component/operate, component/optimize, component/tasklist — the respective apps
+- component/identity — Identity UI, auth, authorization library; component/management-identity — the old/management Identity
+- component/webapp — Orchestration Cluster Webapp (unified frontend)
+- component/c8-api — unified C8 API / C8 REST; component/c8run — Camunda 8 Run; component/clients — client libraries; component/connectors — connectors; component/camunda-process-test — CPT; component/spring-boot-starter — Spring Boot Starter
+- component/data-layer — Data Layer team: search/query APIs, indices, secondary storage; component/rdbms — RDBMS support; component/db — database; component/document-handling — document storage/handling; component/schema-manager — schema management
+- component/feel-js, component/feel-scala — FEEL engines; component/mcp — OC MCP gateways
+- component/monitor — metrics/prometheus/grafana; component/load-tests — load tests; component/qa — QA infrastructure; component/build-pipeline — CI/build pipeline; component/release — monorepo release process; component/backup — backup

--- a/.github/prompts/component-auto-label.md
+++ b/.github/prompts/component-auto-label.md
@@ -35,7 +35,7 @@ If confidence is High or Medium, use exactly:
 This issue had no `component/*` label, so I assessed the best fit and applied one.
 
 **Assessment:** `component/CHOSEN`
-**Confidence:** High
+**Confidence:** <High or Medium>
 **Reasoning:**
 - <concrete signal 1>
 - <concrete signal 2>

--- a/.github/prompts/component-auto-label.md
+++ b/.github/prompts/component-auto-label.md
@@ -5,6 +5,7 @@ You are labeling a single GitHub issue in `camunda/camunda` that may be missing 
 Process issue number `$ISSUE_NUMBER` in repo `$REPO`. Use the `gh` CLI for all GitHub actions (`gh issue view`, `gh issue edit`, `gh issue comment`); `GH_TOKEN` is already set with write access. Do not touch any other issue.
 
 ## Step 1 — read and check idempotency
+
 Run: `gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json number,title,body,labels,comments`
 
 If `$FORCE` is NOT `true`:
@@ -12,6 +13,7 @@ If `$FORCE` is NOT `true`:
 - If any existing comment body contains the marker `<!-- auto-project-label -->`: STOP — it has already been processed.
 
 ## Step 2 — determine the best-fit component
+
 Choose EXACTLY ONE label from the list at the bottom. Signal priority:
 1. Template markers in the body (e.g. `Zeebe-`, `Operate-`, `Identity-`, `Data Layer-`, `Optimize-`, `Tasklist-`, `C8-API-`, `Clients-`, `Feel-`, `Load Tests-`, `Spring Boot Starter-`, `Management Identity-`, `Camunda Process Test-`).
 2. Existing `area/*` and other labels on the issue.
@@ -21,6 +23,7 @@ Choose EXACTLY ONE label from the list at the bottom. Signal priority:
 Be opinionated: apply your best-fit even when confidence is low — the comment invites the author to correct it. Only decline to label when there is essentially ZERO signal (e.g. an empty body and an uninformative title with nothing to reason from).
 
 ## Step 3a — you can choose a component
+
 1. Apply the label and remove the stale tag in one command (include `--remove-label` ONLY if the issue currently has `needs component label`):
    `gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "component/CHOSEN" --remove-label "needs component label"`
 2. Post a comment with `gh issue comment "$ISSUE_NUMBER" --repo "$REPO" --body "..."`. Choose wording by confidence.
@@ -57,6 +60,7 @@ This issue had no `component/*` label. My best-fit read is below, but I'm not hi
 <!-- auto-project-label -->
 
 ## Step 3b — you genuinely cannot choose (zero signal)
+
 1. Do NOT apply a component label.
 2. Ensure `needs component label` is present (add it only if the issue doesn't already have it): `gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "needs component label"`
 3. Post exactly this comment:
@@ -70,11 +74,13 @@ I couldn't confidently determine a component for this issue from its title and d
 <!-- auto-project-label -->
 
 ## Rules
+
 - Assess ONCE. Every comment you post MUST end with the hidden marker `<!-- auto-project-label -->`.
 - Only ever add one `component/*` label and (optionally) remove `needs component label`. Never add, remove, or change any other label.
 - Exactly one component label.
 
 ## The 44 component/* labels (choose one, verbatim)
+
 <!-- Keep this list in sync with the component/* labels in camunda/camunda. Update manually when labels are added or removed. -->
 - component/camunda — affects the complete monorepo / cross-cutting (only for genuinely repo-wide work)
 - component/backend, component/frontend — broad; prefer something more specific when possible
@@ -86,3 +92,4 @@ I couldn't confidently determine a component for this issue from its title and d
 - component/data-layer — Data Layer team: search/query APIs, indices, secondary storage; component/rdbms — RDBMS support; component/db — database; component/document-handling — document storage/handling; component/schema-manager — schema management
 - component/feel-js, component/feel-scala — FEEL engines; component/mcp — OC MCP gateways
 - component/monitor — metrics/prometheus/grafana; component/load-tests — load tests; component/qa — QA infrastructure; component/build-pipeline — CI/build pipeline; component/release — monorepo release process; component/backup — backup
+

--- a/.github/prompts/component-auto-label.md
+++ b/.github/prompts/component-auto-label.md
@@ -79,7 +79,7 @@ I couldn't confidently determine a component for this issue from its title and d
 - Only ever add one `component/*` label and (optionally) remove `needs component label`. Never add, remove, or change any other label.
 - Exactly one component label.
 
-## The 44 component/* labels (choose one, verbatim)
+## The 45 component/* labels (choose one, verbatim)
 
 <!-- Keep this list in sync with the component/* labels in camunda/camunda. Update manually when labels are added or removed. -->
 - component/camunda — affects the complete monorepo / cross-cutting (only for genuinely repo-wide work)

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -184,8 +184,11 @@ jobs:
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Install Claude Code CLI
+        env:
+          # renovate: datasource=npm depName=@anthropic-ai/claude-code
+          CLAUDE_CODE_VERSION: '2.1.198'
         run: |
-          npm install -g @anthropic-ai/claude-code@2.1.156
+          npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
           claude --version
 
       - name: Compute workspace name

--- a/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-nightly-fix.yml
@@ -188,7 +188,7 @@ jobs:
           # renovate: datasource=npm depName=@anthropic-ai/claude-code
           CLAUDE_CODE_VERSION: '2.1.198'
         run: |
-          npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+          npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
           claude --version
 
       - name: Compute workspace name

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -71,9 +71,6 @@ jobs:
         roleId: ${{ secrets.VAULT_ROLE_ID }}
         secretId: ${{ secrets.VAULT_SECRET_ID }}
         exportEnv: false
-        # Reuses the QA-path Claude API key already used by the nightly-fix workflow.
-        # Alternative if QA-path access is ever restricted: add CLAUDE_API_KEY under
-        # secret/data/products/camunda/ci/camunda and read it here instead.
         secrets: |
           secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
     - name: Set up Node
@@ -85,7 +82,7 @@ jobs:
         # renovate: datasource=npm depName=@anthropic-ai/claude-code
         CLAUDE_CODE_VERSION: '2.1.198'
       run: |
-        npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+        npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
         claude --version
     - name: Run component auto-labeler
       env:

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -4,6 +4,12 @@ name: "Opened Issue Labeler"
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to (re)run the component auto-labeler against"
+        required: false
+        type: string
 
 permissions:
   issues: write
@@ -11,6 +17,7 @@ permissions:
 
 jobs:
   triage:
+    if: ${{ github.event_name == 'issues' }}
     runs-on: ubuntu-latest
     steps:
     - name: Generate GitHub token
@@ -30,3 +37,62 @@ jobs:
         configuration-path: .github/opened_issue_labeler.yml
         enable-versioned-regex: 0
         repo-token: ${{ steps.github-token.outputs.token }}
+
+  # Fallback labeler: runs after the regex-based triage job and, for issues it
+  # could not assign a component/* label to, asks Claude to read the issue and
+  # apply a best-fit component/* label (or leave a triage note when it can't).
+  component-auto-label:
+    needs: [triage]
+    if: ${{ always() && (github.event.issue.number || inputs.issue_number) }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Generate GitHub token
+      id: github-token
+      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+      with:
+        github-app-id-vault-key: PROJECT_BOARD_AUTOMATION_APP_ID
+        github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+        github-app-private-key-vault-key: PROJECT_BOARD_AUTOMATION_APP_PRIVATE_KEY
+        github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+        vault-auth-method: approle
+        vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+        vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+        vault-url: ${{ secrets.VAULT_ADDR }}
+    - name: Import Vault secrets
+      id: secrets
+      uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        exportEnv: false
+        # Reuses the QA-path Claude API key already used by the nightly-fix workflow.
+        # Alternative if QA-path access is ever restricted: add CLAUDE_API_KEY under
+        # secret/data/products/camunda/ci/camunda and read it here instead.
+        secrets: |
+          secret/data/products/qa/ci/common CLAUDE_API_KEY | ANTHROPIC_API_KEY ;
+    - name: Set up Node
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      with:
+        node-version: 20
+    - name: Install Claude Code CLI
+      env:
+        # renovate: datasource=npm depName=@anthropic-ai/claude-code
+        CLAUDE_CODE_VERSION: '2.1.198'
+      run: |
+        npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+        claude --version
+    - name: Run component auto-labeler
+      env:
+        GH_TOKEN: ${{ steps.github-token.outputs.token }}
+        ANTHROPIC_API_KEY: ${{ steps.secrets.outputs.ANTHROPIC_API_KEY }}
+        ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
+        REPO: ${{ github.repository }}
+        FORCE: ${{ github.event_name == 'workflow_dispatch' && 'true' || 'false' }}
+      run: |
+        claude -p "$(cat .github/prompts/component-auto-label.md)" --dangerously-skip-permissions


### PR DESCRIPTION
## Description

**What / why**

New issues that the regex-based issue labeler can't assign a `component/*` label to get a Claude fallback step. Claude reads the issue and applies the best-fit `component/*` label with a short explanatory comment. When it assigns a label it also removes `needs component label`; it keeps that tag (with an author-nudge comment) only when it genuinely can't decide from the issue content.

**How**

- New downstream `component-auto-label` job in `.github/workflows/opened_issue_labeler.yml`, gated with `needs: triage` so it runs strictly after the regex labeler — no race, skips whenever a `component/*` label already exists.
- Isolated with `continue-on-error: true` and `timeout-minutes: 15`; can never affect or block regex labeling.
- Reuses the `PROJECT_BOARD_AUTOMATION` app token and the QA-path Claude API key (`secret/data/products/qa/ci/common`) already used by the nightly-fix workflow.
- Labeling rules live in `.github/prompts/component-auto-label.md` — edit to tune behavior (signal priority, comment wording, the 44 valid `component/*` labels). No CI edits needed.
- Existing `triage` job guarded with `if: ${{ github.event_name == 'issues' }}` so it's skipped on manual dispatch; regex config is untouched.
- `workflow_dispatch` with optional `issue_number` for manual re-runs; `FORCE=true` bypasses the idempotency guard on dispatch.
- Adds Renovate annotation for the Claude Code CLI version pin in both this workflow and `c8-orchestration-cluster-e2e-nightly-fix.yml`; bumps `2.1.156` → `2.1.198`.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).