### PR TITLE
test: enforce backup priority on all webapps-schema index descriptors

### DIFF
--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -176,6 +176,7 @@
             <dep>com.fasterxml.jackson.core:jackson-databind</dep>
             <dep>jakarta.validation:jakarta.validation-api</dep>
             <dep>org.springframework.ai:spring-ai-mcp-annotations</dep>
+            <dep>io.camunda:webapps-schema</dep>
           </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>

--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -169,6 +169,7 @@
             <dep>io.camunda:camunda-security-protocol</dep>
             <dep>io.camunda:zeebe-stream-platform</dep>
             <dep>io.camunda:zeebe-workflow-engine</dep>
+            <dep>io.camunda:webapps-schema</dep>
             <dep>org.springframework:spring-beans</dep>
             <dep>org.springframework:spring-context</dep>
             <dep>org.springframework:spring-web</dep>
@@ -176,7 +177,6 @@
             <dep>com.fasterxml.jackson.core:jackson-databind</dep>
             <dep>jakarta.validation:jakarta.validation-api</dep>
             <dep>org.springframework.ai:spring-ai-mcp-annotations</dep>
-            <dep>io.camunda:webapps-schema</dep>
           </ignoredUsedUndeclaredDependencies>
         </configuration>
       </plugin>

--- a/qa/archunit-tests/src/test/java/io/camunda/webapps/schema/descriptors/BackupPriorityDescriptorArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/webapps/schema/descriptors/BackupPriorityDescriptorArchTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors;
+
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.assignableTo;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
+import io.camunda.webapps.schema.descriptors.backup.BackupPriority;
+
+/**
+ * Enforces that every concrete ES/OS index descriptor in webapps-schema declares a backup priority
+ * tier. Descriptors that do not implement {@link BackupPriority} are silently excluded from backup
+ * and cause data loss on restore.
+ *
+ * @see <a href="https://github.com/camunda/camunda/issues/55578">Issue #55578</a>
+ */
+@AnalyzeClasses(
+    packages = "io.camunda.webapps.schema.descriptors",
+    importOptions = DoNotIncludeTestsOrTestJars.class)
+public final class BackupPriorityDescriptorArchTest {
+
+  @ArchTest
+  static final ArchRule ALL_DESCRIPTORS_MUST_IMPLEMENT_BACKUP_PRIORITY =
+      ArchRuleDefinition.classes()
+          .that(
+              assignableTo(IndexDescriptor.class)
+                  .and(
+                      new DescribedPredicate<JavaClass>("are not abstract and not interfaces") {
+                        @Override
+                        public boolean test(final JavaClass input) {
+                          return !input.getModifiers().contains(JavaModifier.ABSTRACT)
+                              && !input.isInterface();
+                        }
+                      }))
+          .should()
+          .implement(BackupPriority.class)
+          .because(
+              "every ES/OS index descriptor in webapps-schema must declare a backup priority"
+                  + " tier (Prio1Backup-Prio4Backup); descriptors missing this contract are"
+                  + " silently excluded from backup and cause data loss on restore");
+}


### PR DESCRIPTION
## Summary

- Adds an ArchUnit rule in `qa/archunit-tests` that fails the build if any concrete `IndexDescriptor` subclass in `webapps-schema` does not implement `BackupPriority` (`Prio1Backup`–`Prio4Backup`)
- Closes the silent data-loss gap: previously a developer could add a new index descriptor without assigning a backup tier and it would be excluded from backup with no warning
- Complements the existing `BackupPrioritiesTest` (which checks that `BackupPriority` implementors are registered in `BackupPriorityConfiguration`), forming a complete enforcement chain

Closes #55578