### PR TITLE
test: add 403 permission-denied API coverage for user task operations (8.9)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-permission-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/user-task-permission-api-tests.spec.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect, test} from '@playwright/test';
+import {
+  assertForbiddenRequest,
+  buildUrl,
+  encode,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {defaultAssertionOptions} from '../../../../utils/constants';
+import {cleanupUsers} from '../../../../utils/usersCleanup';
+import {
+  createUser,
+  findUserTask,
+  grantUserResourceAuthorization,
+  setupProcessInstanceForTests,
+} from '@requestHelpers';
+
+const READ_FORBIDDEN_DETAIL =
+  "'READ_USER_TASK' on 'PROCESS_DEFINITION' or 'READ' on 'USER_TASK'";
+const UPDATE_USER_TASK_FORBIDDEN_DETAIL =
+  "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION'";
+
+test.describe.serial('User Task Permission API - Forbidden', () => {
+  const {state, beforeAll, beforeEach, afterEach} =
+    setupProcessInstanceForTests('user_task_api_test_process');
+
+  let userWithoutUserTaskPermissions: {
+    username: string;
+    name: string;
+    email: string;
+    password: string;
+  };
+  let userWithoutUserTaskPermissionsToken: string;
+
+  test.beforeAll(async ({request}) => {
+    await beforeAll();
+
+    userWithoutUserTaskPermissions = await createUser(request);
+    await grantUserResourceAuthorization(
+      request,
+      userWithoutUserTaskPermissions,
+    );
+    userWithoutUserTaskPermissionsToken = encode(
+      `${userWithoutUserTaskPermissions.username}:${userWithoutUserTaskPermissions.password}`,
+    );
+  });
+
+  test.beforeEach(beforeEach);
+
+  test.afterEach(afterEach);
+
+  test.afterAll(async ({request}) => {
+    await cleanupUsers(request, [userWithoutUserTaskPermissions.username]);
+  });
+
+  test('Get user task - forbidden without READ permission', async ({
+    request,
+  }) => {
+    const userTaskKey = await findUserTask(
+      request,
+      state['processInstanceKey'] as string,
+      'CREATED',
+    );
+
+    await expect(async () => {
+      const res = await request.get(buildUrl(`/user-tasks/${userTaskKey}`), {
+        headers: jsonHeaders(userWithoutUserTaskPermissionsToken),
+      });
+      await assertForbiddenRequest(res, READ_FORBIDDEN_DETAIL);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Assign user task - forbidden without UPDATE_USER_TASK permission', async ({
+    request,
+  }) => {
+    const userTaskKey = await findUserTask(
+      request,
+      state['processInstanceKey'] as string,
+      'CREATED',
+    );
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(`/user-tasks/${userTaskKey}/assignment`),
+        {
+          headers: jsonHeaders(userWithoutUserTaskPermissionsToken),
+          data: {assignee: userWithoutUserTaskPermissions.username},
+        },
+      );
+      await assertForbiddenRequest(res, UPDATE_USER_TASK_FORBIDDEN_DETAIL);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Unassign user task - forbidden without UPDATE_USER_TASK permission', async ({
+    request,
+  }) => {
+    const userTaskKey = await findUserTask(
+      request,
+      state['processInstanceKey'] as string,
+      'CREATED',
+    );
+
+    await expect(async () => {
+      const res = await request.delete(
+        buildUrl(`/user-tasks/${userTaskKey}/assignee`),
+        {
+          headers: jsonHeaders(userWithoutUserTaskPermissionsToken),
+        },
+      );
+      await assertForbiddenRequest(res, UPDATE_USER_TASK_FORBIDDEN_DETAIL);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Update user task - forbidden without UPDATE_USER_TASK permission', async ({
+    request,
+  }) => {
+    const userTaskKey = await findUserTask(
+      request,
+      state['processInstanceKey'] as string,
+      'CREATED',
+    );
+
+    await expect(async () => {
+      const res = await request.patch(buildUrl(`/user-tasks/${userTaskKey}`), {
+        headers: jsonHeaders(userWithoutUserTaskPermissionsToken),
+        data: {
+          changeset: {priority: 80},
+          action: 'customUpdate',
+        },
+      });
+      await assertForbiddenRequest(res, UPDATE_USER_TASK_FORBIDDEN_DETAIL);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Complete user task - forbidden without UPDATE_USER_TASK permission', async ({
+    request,
+  }) => {
+    const userTaskKey = await findUserTask(
+      request,
+      state['processInstanceKey'] as string,
+      'CREATED',
+    );
+
+    await expect(async () => {
+      const res = await request.post(
+        buildUrl(`/user-tasks/${userTaskKey}/completion`),
+        {
+          headers: jsonHeaders(userWithoutUserTaskPermissionsToken),
+          data: {},
+        },
+      );
+      await assertForbiddenRequest(res, UPDATE_USER_TASK_FORBIDDEN_DETAIL);
+    }).toPass(defaultAssertionOptions);
+  });
+});


### PR DESCRIPTION
## Description

Backport of #56614 to `stable/8.9`.

The API user-task test suite under `qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/user-task/` previously only asserted **401 Unauthorized** (requests sent without authentication). It never covered **403 Forbidden** — the case where a request is properly authenticated but the user lacks the required permission. This PR fills that gap on the 8.9 release line.

## What was added

A new spec `user-task-permission-api-tests.spec.ts` with forbidden-access coverage for the five user-task operations:

| Operation | Endpoint | Expected detail |
|-----------|----------|-----------------|
| Get | `GET /user-tasks/{key}` | `READ_USER_TASK` on `PROCESS_DEFINITION` / `READ` on `USER_TASK` |
| Assign | `POST /user-tasks/{key}/assignment` | `UPDATE_USER_TASK` on `PROCESS_DEFINITION` |
| Unassign | `DELETE /user-tasks/{key}/assignee` | `UPDATE_USER_TASK` on `PROCESS_DEFINITION` |
| Update | `PATCH /user-tasks/{key}` | `UPDATE_USER_TASK` on `PROCESS_DEFINITION` |
| Complete | `POST /user-tasks/{key}/completion` | `UPDATE_USER_TASK` on `PROCESS_DEFINITION` |

## How it works

- Reuses `setupProcessInstanceForTests` to deploy and instantiate the shared `user_task_api_test_process` fixture, matching the existing user-task API specs.
- Creates a dedicated user via `createUser` and grants only the minimal `grantUserResourceAuthorization` needed to reach the endpoints, deliberately withholding the user-task permissions under test.
- Sends each request with that user's token via `jsonHeaders`, then asserts the response with `assertForbiddenRequest`, which checks HTTP 403, `title === 'FORBIDDEN'`, and a substring match on `detail`.
- The detail substrings were confirmed present on `stable/8.9` (`UserTaskAuthorizationIT`, `UserTaskAssignAuthorizationTest`, `UserTaskCompleteAuthorizationTest`) to stay stable against dynamic resource IDs.
- Follows the suite's conventions: license header, `test.describe.serial`, shared before/after hooks, `toPass` retry wrapper, and no inline comments.

## Validation

- `eslint` and `tsc` pass with no errors or warnings on `stable/8.9`.
- Full Playwright execution requires a live Camunda cluster and was not run locally.


Test Rail test cases > Cross component test suite
https://camunda.testrail.com/index.php?/cases/view/3846944&group_by=cases:section_id&group_order=asc&display=tree&display_deleted_cases=0&group_id=123782

Confluence Automated Testing Distributions Overview (https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview)

