### PR TITLE
refactor: vendor realistic-benchmark load test values locally

### DIFF
--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -28,7 +28,7 @@ ifeq ($(scenario),latency)
 _scenario_load_test_flags := --set starter.rate=1 --set workers.worker.replicas=1
 _scenario_platform_flags  :=
 else ifeq ($(scenario),realistic)
-_scenario_load_test_flags := -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
+_scenario_load_test_flags := -f load-test-values-realistic-benchmark.yaml
 _scenario_platform_flags  :=
 else ifeq ($(scenario),typical)
 _scenario_load_test_flags := --set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn

--- a/load-tests/setup/main/newLoadTest.sh
+++ b/load-tests/setup/main/newLoadTest.sh
@@ -141,6 +141,7 @@ cp -v  "Makefile"                                                "$TARGET_DIRECT
 cp -rv ../charts/                                                "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-override-values.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/load-test-values.yaml"                            "$TARGET_DIRECTORY/"
+cp -v  "../scenarios/load-test-values-realistic-benchmark.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/values-stable.yaml"                               "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-values-defaults.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-values-${secondaryStorage}.yaml" "$TARGET_DIRECTORY/"

--- a/load-tests/setup/newCloudLoadTest.sh
+++ b/load-tests/setup/newCloudLoadTest.sh
@@ -55,6 +55,8 @@ kubectl label namespace "$namespace" camunda.io/purpose=load-test --overwrite
 kubectl label namespace "$namespace" camunda.io/created-by="$git_author" --overwrite
 
 cp -rv saas-default/ $namespace
+# Vendored realistic-benchmark values, shared with the self-managed setups.
+cp -v scenarios/load-test-values-realistic-benchmark.yaml $namespace/
 cd $namespace
 
 

--- a/load-tests/setup/saas-default/Makefile
+++ b/load-tests/setup/saas-default/Makefile
@@ -14,7 +14,7 @@ all: install
 install: install-load-test
 
 .PHONY: realistic
-realistic: additional_load_test_configuration = -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml --set global.image.repository=registry.camunda.cloud/team-zeebe --set global.image.pullSecrets[0].name=harbor-registry
+realistic: additional_load_test_configuration = -f load-test-values-realistic-benchmark.yaml --set global.image.repository=registry.camunda.cloud/team-zeebe --set global.image.pullSecrets[0].name=harbor-registry
 realistic: install-load-test
 
 .PHONY: typical

--- a/load-tests/setup/scenarios/load-test-values-realistic-benchmark.yaml
+++ b/load-tests/setup/scenarios/load-test-values-realistic-benchmark.yaml
@@ -1,0 +1,199 @@
+# Realistic benchmark scenario values, vendored from
+# https://github.com/camunda/camunda-load-tests-helm/blob/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
+# Vendored locally so the realistic load test renders without a network fetch at
+# deploy time. Update this file when the upstream values-realistic-benchmark.yaml changes.
+
+# Workers configuration for the to be deployed worker application
+workers:
+  worker: null
+
+  #####
+  # Request documents from customer
+  customer-notification:
+    # Workers.worker.replicas defines how many replicas of the load test should be deployed
+    replicas: 1
+    # Workers.worker.capacity defines how many jobs the worker should activate and work on
+    capacity: 30
+    # Workers.worker.jobType defines the job type which should be used by the worker
+    jobType: "customer_notification"
+    # Workers.worker.payloadPath defines the path (inside the worker app) to the payload resource
+    # that should be used to complete the corresponding jobs
+    payloadPath: "bpmn/emptyPayload.json"
+    # Workers.worker.payloadPath defines the delay of the worker before completing a job
+    completionDelay: 300ms
+    message:
+      name: "dispute_process_receive_documents"
+      correlationVariable: "correlationKey"
+    # Workers.worker.logLevel defines the logging level for the load test
+    logLevel: "INFO"
+    # Workers.worker.resources defines the resources for the load test
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+
+  #####
+  # Store information and get customer info
+  extract-data-from-document:
+    # Workers.worker.replicas defines how many replicas of the load test should be deployed
+    replicas: 1
+    # Workers.worker.capacity defines how many jobs the worker should activate and work on
+    capacity: 30
+    # Workers.worker.jobType defines the job type which should be used by the worker
+    jobType: "extract_data_from_document"
+    # Workers.worker.payloadPath defines the path (inside the worker app) to the payload resource
+    # that should be used to complete the corresponding jobs
+    payloadPath: "bpmn/emptyPayload.json"
+    # Workers.worker.payloadPath defines the delay of the worker before completing a job
+    completionDelay: 300ms
+    # Workers.worker.logLevel defines the logging level for the load test
+    logLevel: "INFO"
+    # Workers.worker.resources defines the resources for the load test
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+
+  #####
+  # Request proof from vendor
+  dispute-process-request-proof-from-vendor:
+    # Workers.worker.replicas defines how many replicas of the load test should be deployed
+    replicas: 1
+    # Workers.worker.capacity defines how many jobs the worker should activate and work on
+    capacity: 60
+    # Workers.worker.threads defines how many threads the worker can use to work on jobs
+    threads: 30
+    # Workers.worker.jobType defines the job type which should be used by the worker
+    jobType: "dispute_process_request_proof_from_vendor"
+    # Workers.worker.payloadPath defines the path (inside the worker app) to the payload resource
+    # that should be used to complete the corresponding jobs
+    payloadPath: "bpmn/emptyPayload.json"
+    # Workers.worker.payloadPath defines the delay of the worker before completing a job
+    completionDelay: 300ms
+    # Workers.dispute-request-documents.message enables sending a message from a worker
+    message:
+      name: "dispute_process_refund_approved"
+      correlationVariable: "correlationKey"
+    # Workers.worker.logLevel defines the logging level for the load test
+    logLevel: "INFO"
+    # Workers.worker.resources defines the resources for the load test
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+
+  ######
+  # Get vendor info
+  dispute-process-request-get-vendor-info:
+    # Workers.worker.replicas defines how many replicas of the load test should be deployed
+    replicas: 1
+    # Workers.worker.capacity defines how many jobs the worker should activate and work on
+    capacity: 30
+    # Workers.worker.jobType defines the job type which should be used by the worker
+    jobType: "dispute_process_request_get_vendor_info"
+    # Workers.worker.payloadPath defines the path (inside the worker app) to the payload resource
+    # that should be used to complete the corresponding jobs
+    payloadPath: "bpmn/emptyPayload.json"
+    # Workers.worker.payloadPath defines the delay of the worker before completing a job
+    completionDelay: 10ms
+    # Workers.dispute-request-documents.message enables sending a message from a worker
+    # Workers.worker.logLevel defines the logging level for the load test
+    logLevel: "INFO"
+    # Workers.worker.resources defines the resources for the load test
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+
+  #####
+  # Refund payment
+  refunding:
+    # Workers.worker.replicas defines how many replicas of the load test should be deployed
+    replicas: 1
+    # Workers.worker.capacity defines how many jobs the worker should activate and work on
+    capacity: 30
+    # Workers.worker.threads defines how many threads the worker can use to work on jobs
+    threads: 30
+    # Workers.worker.jobType defines the job type which should be used by the worker
+    jobType: "refunding"
+    # Workers.worker.payloadPath defines the path (inside the worker app) to the payload resource
+    # that should be used to complete the corresponding jobs
+    payloadPath: "bpmn/emptyPayload.json"
+    # Workers.worker.payloadPath defines the delay of the worker before completing a job
+    completionDelay: 300ms
+    # Workers.worker.logLevel defines the logging level for the load test
+    logLevel: "INFO"
+    # Workers.worker.resources defines the resources for the load test
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+
+  #####
+  # Inform customer about successful claim
+  inform-about-successful-claim:
+    # Workers.worker.replicas defines how many replicas of the load test should be deployed
+    replicas: 1
+    # Workers.worker.capacity defines how many jobs the worker should activate and work on
+    capacity: 30
+    # Workers.worker.jobType defines the job type which should be used by the worker
+    jobType: "inform_about_successful_claim"
+    # Workers.worker.payloadPath defines the path (inside the worker app) to the payload resource
+    # that should be used to complete the corresponding jobs
+    payloadPath: "bpmn/emptyPayload.json"
+    # Workers.worker.payloadPath defines the delay of the worker before completing a job
+    completionDelay: 300ms
+    # Workers.worker.logLevel defines the logging level for the load test
+    logLevel: "INFO"
+    # Workers.worker.resources defines the resources for the load test
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+
+#################################################################################################
+#################################################################################################
+#################################################################################################
+
+# Starter configuration for the to be deployed starter application
+starter:
+  # Starter.replicas defines how many replicas of the application should be deployed
+  replicas: 1
+  # Starter.rate defines with which rate process instances should be created by the starter
+  rate: 1
+  # Starter.logLevel defines the logging level for the load test starter
+  logLevel: "INFO"
+  # Starter.processId defines the process ID, that should be used for creating new process instances
+  processId: "bankDisputeHandling"
+  # Starter.payloadPath defines the path (inside the starter app) to the payload resource
+  # that should be used to create the corresponding process instance
+  payloadPath: "bpmn/realistic/realisticPayload.json"
+  # Starter.bpmnXmlPath defines the path (inside the starter app) to the main bpmn XML resource that should be deployed
+  bpmnXmlPath: "bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn"
+  # Starter.extraBpmnModels can be used to specify paths (inside the starter app) to extra resources that should be deployed
+  extraResources:
+    [
+      "bpmn/realistic/refundingProcess.bpmn",
+      "bpmn/realistic/determineFraudRatingConfidence.dmn",
+    ]
+  # Starter.businessKey can be used to specify a businessKey variable, inside a unique identifier is stored for
+  # each created process instance
+  businessKey: "customerId"

--- a/load-tests/setup/stable-87/Makefile
+++ b/load-tests/setup/stable-87/Makefile
@@ -29,7 +29,7 @@ ifeq ($(scenario),latency)
 _scenario_load_test_flags := --set starter.rate=1 --set workers.worker.replicas=1
 _scenario_platform_flags  :=
 else ifeq ($(scenario),realistic)
-_scenario_load_test_flags := -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
+_scenario_load_test_flags := -f load-test-values-realistic-benchmark.yaml
 _scenario_platform_flags  :=
 else ifeq ($(scenario),typical)
 _scenario_load_test_flags := --set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn

--- a/load-tests/setup/stable-87/newLoadTest.sh
+++ b/load-tests/setup/stable-87/newLoadTest.sh
@@ -150,6 +150,7 @@ cp -v  "Makefile"                                                "$TARGET_DIRECT
 cp -rv ../charts/                                                "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-override-values.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/load-test-values.yaml"                            "$TARGET_DIRECTORY/"
+cp -v  "../scenarios/load-test-values-realistic-benchmark.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/values-stable.yaml"                               "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-values-defaults.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-values-${secondaryStorage}.yaml" "$TARGET_DIRECTORY/"

--- a/load-tests/setup/stable-88/Makefile
+++ b/load-tests/setup/stable-88/Makefile
@@ -28,7 +28,7 @@ ifeq ($(scenario),latency)
 _scenario_load_test_flags := --set starter.rate=1 --set workers.worker.replicas=1
 _scenario_platform_flags  :=
 else ifeq ($(scenario),realistic)
-_scenario_load_test_flags := -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
+_scenario_load_test_flags := -f load-test-values-realistic-benchmark.yaml
 _scenario_platform_flags  :=
 else ifeq ($(scenario),typical)
 _scenario_load_test_flags := --set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn

--- a/load-tests/setup/stable-88/newLoadTest.sh
+++ b/load-tests/setup/stable-88/newLoadTest.sh
@@ -141,6 +141,7 @@ cp -v  "Makefile"                                                "$TARGET_DIRECT
 cp -rv ../charts/                                                "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-override-values.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/load-test-values.yaml"                            "$TARGET_DIRECTORY/"
+cp -v  "../scenarios/load-test-values-realistic-benchmark.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/values-stable.yaml"                               "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-values-defaults.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-values-${secondaryStorage}.yaml" "$TARGET_DIRECTORY/"

--- a/load-tests/setup/stable-89/Makefile
+++ b/load-tests/setup/stable-89/Makefile
@@ -28,7 +28,7 @@ ifeq ($(scenario),latency)
 _scenario_load_test_flags := --set starter.rate=1 --set workers.worker.replicas=1
 _scenario_platform_flags  :=
 else ifeq ($(scenario),realistic)
-_scenario_load_test_flags := -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
+_scenario_load_test_flags := -f load-test-values-realistic-benchmark.yaml
 _scenario_platform_flags  :=
 else ifeq ($(scenario),typical)
 _scenario_load_test_flags := --set starter.rate=50 --set workers.worker.replicas=6 --set starter.bpmnXmlPath=bpmn/typical_process.bpmn

--- a/load-tests/setup/stable-89/newLoadTest.sh
+++ b/load-tests/setup/stable-89/newLoadTest.sh
@@ -141,6 +141,7 @@ cp -v  "Makefile"                                                "$TARGET_DIRECT
 cp -rv ../charts/                                                "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-override-values.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/load-test-values.yaml"                            "$TARGET_DIRECTORY/"
+cp -v  "../scenarios/load-test-values-realistic-benchmark.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/values-stable.yaml"                               "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-values-defaults.yaml"            "$TARGET_DIRECTORY/"
 cp -v  "values/camunda-platform-values-${secondaryStorage}.yaml" "$TARGET_DIRECTORY/"


### PR DESCRIPTION
## Description

The `realistic` load-test scenario fetched its values file over the network at render time via a `raw.githubusercontent.com` URL:

```makefile
_scenario_load_test_flags := -f https://raw.githubusercontent.com/camunda/camunda-load-tests-helm/refs/heads/main/charts/camunda-load-tests/values-realistic-benchmark.yaml
```

That adds a deploy-time dependency on GitHub being reachable and on the `camunda-load-tests-helm` `main` branch being unchanged. It also makes the golden-file tests network-dependent and non-reproducible. The same remote fetch was used by both the self-managed setups (`main` + `stable-*`) and the SaaS setup.

This vendors the values locally and points every setup at the local copy. The rendered output is byte-identical, so no golden files change.

### What changed

**New file: `load-tests/setup/scenarios/load-test-values-realistic-benchmark.yaml`**

A single shared copy of the upstream realistic-benchmark values (a new `scenarios/` directory shared by all setups, rather than duplicated copies). The filename follows the existing `load-test-` convention (matching `load-test-values.yaml`). Includes a provenance header noting where it came from and to update it when upstream changes. Keys are at the top level, matching what the `camunda-load-tests` chart expects.

**Self-managed setups (`main`, `stable-87`, `stable-88`, `stable-89`)**

- Makefile `realistic` flag now references the local file: `-f load-test-values-realistic-benchmark.yaml`
- `newLoadTest.sh` copies `../scenarios/load-test-values-realistic-benchmark.yaml` into the scaffolded per-namespace directory

**SaaS setup (`saas-default`)**

- Makefile `realistic` target now references the local file instead of the remote URL
- `newCloudLoadTest.sh` copies the shared vendored file into the scaffolded namespace directory

### How to verify

```bash
cd load-tests/setup/test
GOCACHE=/tmp/go-build-cache GOMODCACHE=/tmp/go-mod-cache \
HELM_CACHE_HOME=/tmp/helm-cache HELM_DATA_HOME=/tmp/helm-data HELM_CONFIG_HOME=/tmp/helm-config \
go test ./... -run 'TestGoldenFiles/.*realistic' -parallel 4
```

The realistic scenarios render from the local file and match the existing golden fixtures unchanged (no network fetch).

## Checklist

- [ ] No backports needed; `load-tests/setup/` changes are `main`-only per `.github/instructions/load-tests.instructions.md`.

---

> [!NOTE]
> This PR was prepared with the assistance of Claude Code.