### PR TITLE
[stable/8.8] ci: add Spring Boot 4.1 compatibility job for dedicated SB4 modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1987,7 +1987,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "spring-boot-starter-compatibility/${{ matrix.name }}"
+          job_name: "spring-boot-compatibility-tests/${{ matrix.name }}"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
           detailed_junit_tests: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1918,6 +1918,83 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  spring-boot-compatibility-tests:
+    # Verifies the dedicated Spring Boot 4 modules (camunda-spring-boot-4-starter and
+    # camunda-process-test-spring-boot-4) still build and pass their tests against a
+    # non-default Spring Boot 4 minor version. On this branch the default Spring Boot
+    # version is 3.x, so these dedicated modules pin their own 4.x version; the version
+    # under test is set by the spring-boot-4.1 profile defined in those module poms.
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    name: "Clients / Spring-Boot-Starter / Compatibility ${{ matrix.name }}"
+    needs: [ detect-changes ]
+    runs-on: gcp-perf-core-8-default
+    timeout-minutes: 30
+    permissions: { }  # GITHUB_TOKEN is unused in this job
+    env:
+      TEST_OWNER: '@camunda/camundaex'
+      TEST_PRODUCT: Camunda
+      TEST_TYPE: Integration
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "4.1"
+            profile: "spring-boot-4.1"
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@2fee788847f2b0eedcdd8b324e48ae1fad52fe4f # main
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Print metadata
+        uses: ./.github/actions/print-metadata
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: spring-boot-compatibility
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -Dquickly
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> "$GITHUB_ENV"
+      - name: Maven Test Build
+        shell: bash
+        # We run unit and integration tests here as there aren't that many tests in the modules.
+        # 'clean' forces recompilation against the profile's Spring Boot version rather than
+        # reusing the default-version artifacts produced by build-zeebe.
+        run: >
+          ./mvnw -T2 -B --no-snapshot-updates
+          -D skipChecks
+          -D surefire.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
+          -D failsafe.rerunFailingTestsCount=${{ env.FLAKY_TEST_RERUN_COUNT }}
+          -P skipFrontendBuild,extract-flaky-tests,${{ matrix.profile }}
+          -pl clients/camunda-spring-boot-4-starter,testing/camunda-process-test-spring-boot-4
+          clean verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "Clients / Spring-Boot-Starter / Compatibility ${{ matrix.name }}"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "spring-boot-starter-compatibility/${{ matrix.name }}"
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          detailed_junit_tests: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   check-results:
     # Used by the merge queue to check all tests, including the unit test matrix.
     # New test jobs must be added to the `needs` lists!
@@ -1960,6 +2037,7 @@ jobs:
       - renovatelint
       - setup-tests
       - shell-script-tests
+      - spring-boot-compatibility-tests
       - tasklist-ci
       - validate-pom-metadata
       - zeebe-ci

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -321,4 +321,19 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>spring-boot-4.1</id>
+      <properties>
+        <!-- Tests compatibility against a non-default Spring Boot 4 minor version.
+             Spring Boot 4.1.0 manages Spring Framework 7.0.8 (same as the default 4.0.x
+             pinned above), so version.spring is left unchanged; only the Spring Boot
+             version is overridden here. This profile lives in the module pom (not
+             library-parent) because the module pins version.spring-boot locally, which
+             would shadow a parent-level profile property. -->
+        <version.spring-boot>4.1.0</version.spring-boot>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/testing/camunda-process-test-spring-boot-4/pom.xml
+++ b/testing/camunda-process-test-spring-boot-4/pom.xml
@@ -315,6 +315,18 @@
 
   <profiles>
     <profile>
+      <id>spring-boot-4.1</id>
+      <properties>
+        <!-- Tests compatibility against a non-default Spring Boot 4 minor version.
+             Spring Boot 4.1.0 manages Spring Framework 7.0.8 (same as the default 4.0.x
+             pinned above), so version.spring is left unchanged; only the Spring Boot
+             version is overridden here. This profile lives in the module pom (not
+             library-parent) because the module pins version.spring-boot locally, which
+             would shadow a parent-level profile property. -->
+        <version.spring-boot>4.1.0</version.spring-boot>
+      </properties>
+    </profile>
+    <profile>
       <id>central-sonatype-publish</id>
       <!--
         This profile is typically activated during release builds refer to


### PR DESCRIPTION
## Description

Adds CI coverage that verifies the dedicated **Spring Boot 4 modules** on 8.8 still build and pass their tests against a **non-default Spring Boot 4 minor version** (4.1.0).

This mirrors the Spring-Boot-framework compatibility job added on `stable/8.9` (#56491) and originally on `stable/8.7` for 3.x (#40803), adapting it to a key structural difference on 8.8:

- On 8.9 the **default** Spring Boot version is 4.x, so a single `spring-boot-4.1` profile in `library-parent/pom.xml` propagates to the default modules.
- On 8.8 the **default** Spring Boot version is 3.x. The Spring Boot 4 support lives in dedicated modules (`camunda-spring-boot-4-starter`, `camunda-process-test-spring-boot-4`) that **pin their own** `version.spring-boot` (4.0.7) locally. A profile in `library-parent` would be shadowed by those module-level properties, so the compatibility profile must be defined **in the module poms themselves**.

Note this is a **different axis** from the existing `camunda-spring-boot-starter-compatibility-test.yml` / `camunda-process-test-compatibility.yml` workflows, which test product **client-vs-server version** combinations, not the Spring Boot framework version.

### Changes

- **`clients/camunda-spring-boot-4-starter/pom.xml`** and **`testing/camunda-process-test-spring-boot-4/pom.xml`** — new `spring-boot-4.1` profile overriding `version.spring-boot` to `4.1.0`. Defined per-module (not in `library-parent`) because each module pins its Spring Boot version locally.
- **`.github/workflows/ci.yml`** — new `spring-boot-compatibility-tests` job (matrix `profile: spring-boot-4.1`, displayed as `Clients / Spring-Boot-Starter / Compatibility 4.1`), gated on `java-code-changes` and added to the `check-results` `needs:` list so the merge queue enforces it. It runs `build-zeebe -Dquickly`, then a scoped `clean verify` (with the profile) over the two dedicated SB4 modules.

### Notes

- `version.spring` is intentionally **not** overridden: Spring Boot 4.1.0 manages Spring Framework 7.0.8 (the same as the 4.0.x default pinned in the modules), and Spring Framework 7.1.0 does not exist. Only the Spring Boot version differs.
- There is no virtual-threads module on 8.8, so (unlike 8.9) it is not in scope.

### Verification

Confirmed locally that the `spring-boot-4.1` profile takes effect (`version.spring-boot` resolves to `4.1.0` with the profile vs `4.0.7` by default) and that both modules build and pass their tests under it. Also confirmed in CI by the build log downloading 4.1 artifacts https://github.com/camunda/camunda/actions/runs/28641672085/job/84939102569?pr=56639

🤖 Generated with [Claude Code](https://claude.com/claude-code)
