### PR TITLE
ci: keep shared distball in GCS when a consumer fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,10 +539,11 @@ jobs:
     # exempts it from the check-results gate; artifacts self-expire (retention-days: 1)
     # and the bucket TTL covers runs cancelled/failed before this fires.
     needs: [ build-distball, docker-checks, integration-tests ]
-    # Only clean up when every consumer succeeded. If any failed or was cancelled, keep the
-    # GCS objects so "Re-run failed jobs" can re-fetch the distball -- build-distball won't
-    # re-run (it already succeeded) so it won't re-upload. Orphaned objects on failed runs are
-    # reaped by the bucket TTL (Infra-owned).
+    # Clean up only when build-distball succeeded and no consumer failed or was cancelled
+    # (skipped consumers -- both are conditional -- don't block cleanup). If any failed or was
+    # cancelled, keep the GCS objects so "Re-run failed jobs" can re-fetch the distball --
+    # build-distball won't re-run (it already succeeded) so it won't re-upload. Orphaned objects
+    # on failed runs are reaped by the bucket TTL (Infra-owned).
     if: >-
       always()
       && needs.build-distball.result == 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,9 +537,17 @@ jobs:
     name: "Cleanup / Distribution Tarball Artifact"
     # Delete the run-scoped GCS objects after consumers finish. The `utils-` prefix
     # exempts it from the check-results gate; artifacts self-expire (retention-days: 1)
-    # and the bucket TTL covers runs cancelled before this fires.
+    # and the bucket TTL covers runs cancelled/failed before this fires.
     needs: [ build-distball, docker-checks, integration-tests ]
-    if: always() && needs.build-distball.result != 'skipped'
+    # Only clean up when every consumer succeeded. If any failed or was cancelled, keep the
+    # GCS objects so "Re-run failed jobs" can re-fetch the distball -- build-distball won't
+    # re-run (it already succeeded) so it won't re-upload. Orphaned objects on failed runs are
+    # reaped by the bucket TTL (Infra-owned).
+    if: >-
+      always()
+      && needs.build-distball.result == 'success'
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-slim  # short auth-and-delete job; no need for a full runner
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
## Problem

`utils-cleanup-distball` ran on `if: always()`, deleting the run-scoped GCS
distball (and `m2-installed.tar`) as soon as the consumers finished —
**even when an integration-test shard failed or was cancelled**.

Because `build-distball` had already succeeded, GitHub's *Re-run failed jobs*
does not re-run it, so the distball is never re-uploaded. The rerun of the
failed shard then can't fetch it and dies — forcing a full workflow re-run.

Real occurrence: run [`28596079001`](https://github.com/camunda/camunda/actions/runs/28596079001) —
`Zeebe Cluster ScaleUp QA ITs (1)` was **cancelled** on attempt 1 (spot-runner
preemption); the attempt-2 rerun [failed](https://github.com/camunda/camunda/actions/runs/28596079001/job/84801787280?pr=56551)
because the distball was already gone.

## Fix

Gate cleanup on **every consumer succeeding**:

```yaml
if: >-
  always()
  && needs.build-distball.result == 'success'
  && !contains(needs.*.result, 'failure')
  && !contains(needs.*.result, 'cancelled')
```

- Any consumer `failure`/`cancelled` → cleanup **skipped** → distball stays in
  GCS → the targeted rerun fetches it.
- `utils-cleanup-distball` is a **downstream dependent** of the consumers, so
  *Re-run failed jobs* re-triggers it. Once the rerun goes green the gate
  passes and the prefix is deleted — **no manual cleanup**, self-healing.

### Verified

Throwaway fail-then-rerun workflow (`producer → consumer → cleanup`, same gate):

| | producer | consumer | cleanup |
|---|---|---|---|
| Attempt 1 | success | **failure** | **skipped** (distball kept) |
| Attempt 2 (rerun failed) | success | success | **success** (`CLEANUP RAN`, deleted) |

### Pile-up backstop

Runs abandoned without ever going green leak their prefix. Reaped by the
bucket lifecycle TTL on `camunda-monorepo-ci-artifacts` (**Delete at age 7d**,
Infra-owned) — reruns are same-day, well inside the window. No change needed.

Refs #52693
