### PR TITLE
feat: POC engine feasibility for process instance suspend/resume

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -29,6 +29,8 @@ import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreatio
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceModificationModifyProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceResumeProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceSuspendProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -85,7 +87,12 @@ public final class BpmnProcessors {
     final var keyGenerator = processingState.getKeyGenerator();
 
     addProcessInstanceCommandProcessor(
-        writers, typedRecordProcessors, processingState, asyncRequestBehavior, authCheckBehavior);
+        writers,
+        typedRecordProcessors,
+        processingState,
+        asyncRequestBehavior,
+        authCheckBehavior,
+        timerChecker);
 
     final var bpmnStreamProcessor =
         new BpmnStreamProcessor(
@@ -157,12 +164,30 @@ public final class BpmnProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
       final AsyncRequestBehavior asyncRequestBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final DueDateTimerCheckScheduler timerChecker) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE,
         ProcessInstanceIntent.CANCEL,
         new ProcessInstanceCancelProcessor(
             processingState, writers, asyncRequestBehavior, authCheckBehavior));
+
+    // process instance suspend/resume (POC #56552); no authz in the POC
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE,
+        ProcessInstanceIntent.SUSPEND,
+        new ProcessInstanceSuspendProcessor(
+            processingState.getElementInstanceState(),
+            processingState.getSuspensionState(),
+            writers));
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE,
+        ProcessInstanceIntent.RESUME,
+        new ProcessInstanceResumeProcessor(
+            processingState.getElementInstanceState(),
+            processingState.getSuspensionState(),
+            writers,
+            timerChecker));
   }
 
   private static void addBpmnStepProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -24,11 +24,13 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutionListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -37,10 +39,13 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -49,6 +54,18 @@ import org.slf4j.Logger;
 public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessInstanceRecord> {
 
   private static final Logger LOGGER = Loggers.PROCESS_PROCESSOR_LOGGER;
+
+  /**
+   * Forward-progress BPMN element commands (POC #56552): diverted into the suspend buffer instead
+   * of being processed while the target process instance is suspended. {@code TERMINATE_ELEMENT}
+   * and {@code CONTINUE_TERMINATING_ELEMENT} are intentionally excluded so cancellation still works
+   * on a suspended instance.
+   */
+  private static final Set<ProcessInstanceIntent> BUFFERABLE_ON_SUSPEND =
+      EnumSet.of(
+          ProcessInstanceIntent.ACTIVATE_ELEMENT,
+          ProcessInstanceIntent.COMPLETE_ELEMENT,
+          ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER);
 
   private final BpmnElementContextImpl context = new BpmnElementContextImpl();
 
@@ -63,6 +80,9 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
   private final EventTriggerBehavior eventTriggerBehavior;
   private final VariableBehavior variableBehavior;
   private final EventScopeInstanceState eventScopeInstanceState;
+  private final SuspensionState suspensionState;
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
 
   public BpmnStreamProcessor(
       final BpmnBehaviors bpmnBehaviors,
@@ -73,6 +93,9 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
     processState = processingState.getProcessState();
 
     rejectionWriter = writers.rejection();
+    stateWriter = writers.state();
+    suspensionState = processingState.getSuspensionState();
+    keyGenerator = processingState.getKeyGenerator();
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     stateTransitionGuard = bpmnBehaviors.stateTransitionGuard();
     stateTransitionBehavior =
@@ -107,6 +130,25 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
     // initialize
     final var intent = (ProcessInstanceIntent) record.getIntent();
     final var recordValue = record.getValue();
+
+    // process instance suspend/resume (POC #56552): divert forward-progress element commands
+    // into the buffer instead of processing them while the target instance is suspended.
+    // TERMINATE_ELEMENT/CONTINUE_TERMINATING_ELEMENT are not in BUFFERABLE_ON_SUSPEND, so
+    // cancellation still proceeds on a suspended instance.
+    if (BUFFERABLE_ON_SUSPEND.contains(intent)
+        && suspensionState.isSuspended(recordValue.getProcessInstanceKey())) {
+      bufferCommand(record.getKey(), intent, recordValue);
+      return;
+    }
+
+    // process instance suspend/resume (POC #56552): cancelling a suspended instance still
+    // discards its buffer — reuses the RESUMED event's applier semantics (clear flag + buffer)
+    // since the instance is being torn down and the buffered commands would otherwise leak.
+    if (intent == ProcessInstanceIntent.TERMINATE_ELEMENT
+        && recordValue.getBpmnElementType() == BpmnElementType.PROCESS
+        && suspensionState.isSuspended(recordValue.getProcessInstanceKey())) {
+      stateWriter.appendFollowUpEvent(record.getKey(), ProcessInstanceIntent.RESUMED, recordValue);
+    }
 
     context.init(record.getKey(), recordValue, intent);
 
@@ -420,6 +462,29 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
                   context.getElementInstanceKey(),
                   eventTrigger.getElementId());
             });
+  }
+
+  /**
+   * Diverts a forward-progress element command into the suspend buffer (POC #56552). A key is
+   * generated via {@code KeyGenerator} to serve as the buffering event's own record key, which
+   * doubles as the FIFO sequence in {@code SuspensionState} — monotonic per partition and
+   * deterministically recovered on replay. The original command's key (the element instance key)
+   * and intent travel on the record's internal {@code bufferedOriginalKey} / {@code
+   * bufferedElementIntent} fields so {@code ProcessInstanceResumeProcessor} can replay the command
+   * verbatim on resume.
+   */
+  private void bufferCommand(
+      final long originalKey,
+      final ProcessInstanceIntent originalIntent,
+      final ProcessInstanceRecord recordValue) {
+    final var bufferedRecord = new ProcessInstanceRecord();
+    bufferedRecord.copyFrom(recordValue);
+    bufferedRecord.setBufferedOriginalKey(originalKey);
+    bufferedRecord.setBufferedElementIntent(originalIntent.value());
+
+    final long bufferEventKey = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(
+        bufferEventKey, ProcessInstanceIntent.ELEMENT_COMMAND_BUFFERED, bufferedRecord);
   }
 
   private ExecutableFlowElement getElement(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/SuspendedInstanceCommandCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/SuspendedInstanceCommandCheck.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
+import io.camunda.zeebe.util.Either;
+
+/**
+ * A reusable validation check (POC #56552) that rejects commands targeting a suspended process
+ * instance's "no side effects while paused" guarantee — e.g. job completion/failure and message
+ * correlation. Modeled on {@link BannedInstanceCommandCheck}.
+ */
+public class SuspendedInstanceCommandCheck {
+
+  private static final String SUSPENDED_MESSAGE =
+      "Expected to process a command for process instance '%d', but it is suspended";
+
+  private final SuspensionState suspensionState;
+
+  public SuspendedInstanceCommandCheck(final SuspensionState suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  public <T extends ProcessInstanceRelated> Either<Rejection, T> check(final T record) {
+    final long processInstanceKey = record.getProcessInstanceKey();
+
+    if (suspensionState.isSuspended(processInstanceKey)) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_STATE, SUSPENDED_MESSAGE.formatted(processInstanceKey)));
+    }
+
+    return Either.right(record);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessUtils;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.common.SuspendedInstanceCommandCheck;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
@@ -133,6 +134,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
   private final TypedRejectionWriter rejectionWriter;
 
   private final boolean includeVariablesInJobCompletedEvent;
+  private final SuspendedInstanceCommandCheck suspendedInstanceCheck;
 
   public JobCompleteProcessor(
       final ProcessingState state,
@@ -151,6 +153,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
     this.includeVariablesInJobCompletedEvent = includeVariablesInJobCompletedEvent;
+    suspendedInstanceCheck = new SuspendedInstanceCommandCheck(state.getSuspensionState());
     preconditionChecker =
         new JobCommandPreconditionValidator(
             state.getJobState(),
@@ -158,6 +161,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
             "complete",
             List.of(State.ACTIVATABLE, State.ACTIVATED),
             List.of(
+                this::checkProcessInstanceNotSuspended,
                 this::checkAdHocSubprocessActivationTargetsAreValid,
                 this::checkAdHocSubprocessInstanceIsActive,
                 this::checkAdHocSubProcessCompletionConditionNotFulfilledForElementActivation,
@@ -335,6 +339,11 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
         targetAdHocSubProcessInstanceValue.getBpmnProcessIdBuffer(),
         targetAdHocSubProcessInstanceValue.getTenantId(),
         completingJobRecord.getVariablesBuffer());
+  }
+
+  private Either<Rejection, JobRecord> checkProcessInstanceNotSuspended(
+      final TypedRecord<JobRecord> command, final JobRecord job) {
+    return suspendedInstanceCheck.check(job);
   }
 
   private Either<Rejection, JobRecord>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
+import io.camunda.zeebe.engine.processing.common.SuspendedInstanceCommandCheck;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -66,6 +67,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
   private final ElementInstanceState elementInstanceState;
   private final ProcessState processState;
   private final IncidentMetrics incidentMetrics;
+  private final SuspendedInstanceCommandCheck suspendedInstanceCheck;
 
   public JobFailProcessor(
       final ProcessingState state,
@@ -86,12 +88,14 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
     variableBehavior = bpmnBehaviors.variableBehavior();
     jobActivationBehavior = bpmnBehaviors.jobActivationBehavior();
     this.authCheckBehavior = authCheckBehavior;
+    suspendedInstanceCheck = new SuspendedInstanceCommandCheck(state.getSuspensionState());
     preconditionChecker =
         new JobCommandPreconditionValidator(
             jobState,
             state.getBannedInstanceState(),
             "fail",
             List.of(State.ACTIVATABLE, State.ACTIVATED),
+            List.of(this::checkProcessInstanceNotSuspended),
             authCheckBehavior);
     this.keyGenerator = keyGenerator;
     this.jobBackoffChecker = jobBackoffChecker;
@@ -205,6 +209,11 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
       case JobKind.TASK_LISTENER -> ErrorType.TASK_LISTENER_NO_RETRIES;
       case JobKind.AD_HOC_SUB_PROCESS -> ErrorType.AD_HOC_SUB_PROCESS_NO_RETRIES;
     };
+  }
+
+  private Either<Rejection, JobRecord> checkProcessInstanceNotSuspended(
+      final TypedRecord<JobRecord> command, final JobRecord job) {
+    return suspendedInstanceCheck.check(job);
   }
 
   private Either<Rejection, JobRecord> checkAuthorization(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.common.SuspendedInstanceCommandCheck;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -46,6 +47,9 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   private static final String ALREADY_CLOSING_MESSAGE =
       "Expected to correlate process message subscription with element key '%d' and message name '%s', "
           + "but it is already closing";
+  private static final String PROCESS_INSTANCE_SUSPENDED_MESSAGE =
+      "Expected to correlate process message subscription with element key '%d' and message name '%s', "
+          + "but the process instance is suspended";
 
   private final ProcessMessageSubscriptionState subscriptionState;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
@@ -57,6 +61,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
   private final SideEffectWriter sideEffectWriter;
 
   private final EventHandle eventHandle;
+  private final SuspendedInstanceCommandCheck suspendedInstanceCheck;
 
   public ProcessMessageSubscriptionCorrelateProcessor(
       final ProcessMessageSubscriptionState subscriptionState,
@@ -81,6 +86,8 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
             processState,
             bpmnBehaviors.eventTriggerBehavior(),
             bpmnBehaviors.stateBehavior());
+    suspendedInstanceCheck =
+        new SuspendedInstanceCommandCheck(processingState.getSuspensionState());
   }
 
   @Override
@@ -96,6 +103,11 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
 
     if (subscription == null) {
       rejectCommand(command, RejectionType.NOT_FOUND, NO_SUBSCRIPTION_FOUND_MESSAGE);
+      return;
+
+    } else if (suspendedInstanceCheck.check(record).isLeft()) {
+      // process instance suspend/resume (POC #56552): no side effects while suspended
+      rejectCommand(command, RejectionType.INVALID_STATE, PROCESS_INSTANCE_SUSPENDED_MESSAGE);
       return;
 
     } else if (subscription.isClosing()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceResumeProcessor.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Resumes a suspended process instance (POC #56552): drains the FIFO buffer of diverted
+ * forward-progress element commands, re-appending each as a follow-up command in original order,
+ * then marks the instance resumed.
+ */
+public final class ProcessInstanceResumeProcessor
+    implements TypedRecordProcessor<ProcessInstanceRecord> {
+
+  private static final String MESSAGE_PREFIX =
+      "Expected to resume a process instance with key '%d', but ";
+  private static final String NOT_SUSPENDED_MESSAGE = MESSAGE_PREFIX + "it is not suspended";
+  private static final String PROCESS_NOT_FOUND_MESSAGE =
+      MESSAGE_PREFIX + "no such process was found";
+
+  private final ElementInstanceState elementInstanceState;
+  private final SuspensionState suspensionState;
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final SideEffectWriter sideEffectWriter;
+  private final DueDateTimerCheckScheduler timerChecker;
+
+  public ProcessInstanceResumeProcessor(
+      final ElementInstanceState elementInstanceState,
+      final SuspensionState suspensionState,
+      final Writers writers,
+      final DueDateTimerCheckScheduler timerChecker) {
+    this.elementInstanceState = elementInstanceState;
+    this.suspensionState = suspensionState;
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    sideEffectWriter = writers.sideEffect();
+    this.timerChecker = timerChecker;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceRecord> command) {
+    final var elementInstance = elementInstanceState.getInstance(command.getKey());
+    if (elementInstance == null) {
+      reject(command, RejectionType.NOT_FOUND, PROCESS_NOT_FOUND_MESSAGE);
+      return;
+    }
+
+    if (!suspensionState.isSuspended(command.getKey())) {
+      reject(command, RejectionType.INVALID_STATE, NOT_SUSPENDED_MESSAGE);
+      return;
+    }
+
+    // Collect buffered commands first: the visitor's ProcessInstanceRecord is backed by a shared,
+    // mutable buffer that is overwritten on the next state read, so each entry must be copied out
+    // before we can safely re-append it as a follow-up command.
+    final List<ProcessInstanceRecord> bufferedCommands = new ArrayList<>();
+    suspensionState.forEachBufferedCommand(
+        command.getKey(),
+        record -> {
+          final var copy = new ProcessInstanceRecord();
+          copy.copyFrom(record);
+          bufferedCommands.add(copy);
+        });
+
+    for (final ProcessInstanceRecord bufferedCommand : bufferedCommands) {
+      final var originalIntent =
+          ProcessInstanceIntent.from((short) bufferedCommand.getBufferedElementIntent());
+      // Each buffered command targets its own element instance, not the RESUME command's key.
+      commandWriter.appendFollowUpCommand(
+          bufferedCommand.getBufferedOriginalKey(), originalIntent, bufferedCommand);
+    }
+
+    final var value = elementInstance.getValue();
+    stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.RESUMED, value);
+    responseWriter.writeEventOnCommand(
+        command.getKey(), ProcessInstanceIntent.RESUMED, value, command);
+
+    // nudge the due-date checker so any timer that became due while suspended fires immediately
+    // rather than waiting for the next periodic scan (POC #56552)
+    final long nudgeAt = command.getTimestamp();
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          timerChecker.scheduleTimer(nudgeAt);
+          return true;
+        });
+  }
+
+  private void reject(
+      final TypedRecord<ProcessInstanceRecord> command,
+      final RejectionType type,
+      final String message) {
+    final String formatted = String.format(message, command.getKey());
+    rejectionWriter.appendRejection(command, type, formatted);
+    responseWriter.writeRejectionOnCommand(command, type, formatted);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendProcessor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+/**
+ * Suspends a (root) process instance (POC #56552): forward-progress BPMN element commands are
+ * diverted into a buffer by the gate in {@code BpmnStreamProcessor} until the instance is resumed.
+ */
+public final class ProcessInstanceSuspendProcessor
+    implements TypedRecordProcessor<ProcessInstanceRecord> {
+
+  private static final String MESSAGE_PREFIX =
+      "Expected to suspend a process instance with key '%d', but ";
+  private static final String PROCESS_NOT_FOUND_MESSAGE =
+      MESSAGE_PREFIX + "no such process was found";
+  private static final String NOT_ROOT_MESSAGE =
+      MESSAGE_PREFIX
+          + "it is created by a parent process instance. Suspend the root process instance '%d' instead.";
+  private static final String ALREADY_SUSPENDED_MESSAGE =
+      MESSAGE_PREFIX + "it is already suspended";
+
+  private final ElementInstanceState elementInstanceState;
+  private final SuspensionState suspensionState;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+
+  public ProcessInstanceSuspendProcessor(
+      final ElementInstanceState elementInstanceState,
+      final SuspensionState suspensionState,
+      final Writers writers) {
+    this.elementInstanceState = elementInstanceState;
+    this.suspensionState = suspensionState;
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceRecord> command) {
+    final var elementInstance = elementInstanceState.getInstance(command.getKey());
+
+    if (elementInstance == null || elementInstance.getParentKey() > 0) {
+      reject(command, RejectionType.NOT_FOUND, PROCESS_NOT_FOUND_MESSAGE);
+      return;
+    }
+
+    final var value = elementInstance.getValue();
+    if (value.getParentProcessInstanceKey() > 0) {
+      reject(
+          command,
+          RejectionType.INVALID_STATE,
+          String.format(NOT_ROOT_MESSAGE, command.getKey(), value.getParentProcessInstanceKey()));
+      return;
+    }
+
+    if (suspensionState.isSuspended(command.getKey())) {
+      reject(command, RejectionType.INVALID_STATE, ALREADY_SUSPENDED_MESSAGE);
+      return;
+    }
+
+    stateWriter.appendFollowUpEvent(command.getKey(), ProcessInstanceIntent.SUSPENDED, value);
+    responseWriter.writeEventOnCommand(
+        command.getKey(), ProcessInstanceIntent.SUSPENDED, value, command);
+  }
+
+  private void reject(
+      final TypedRecord<ProcessInstanceRecord> command,
+      final RejectionType type,
+      final String message) {
+    final String formatted =
+        message.contains("%d") ? String.format(message, command.getKey()) : message;
+    rejectionWriter.appendRejection(command, type, formatted);
+    responseWriter.writeRejectionOnCommand(command, type, formatted);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.model.bpmn.util.time.Interval;
@@ -45,12 +46,15 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
       "Expected to find a process definition with key '%d', but no such definition was found";
   private static final String NO_ACTIVE_TIMER_MESSAGE =
       "Expected to trigger a timer with key '%d', but the timer is not active anymore";
+  private static final String PROCESS_INSTANCE_SUSPENDED_MESSAGE =
+      "Expected to trigger a timer with key '%d', but the process instance is suspended";
   private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
 
   private final CatchEventBehavior catchEventBehavior;
   private final ProcessState processState;
   private final ElementInstanceState elementInstanceState;
   private final MutableTimerInstanceState timerInstanceState;
+  private final SuspensionState suspensionState;
   private final ExpressionProcessor expressionProcessor;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -70,6 +74,7 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
     processState = processingState.getProcessState();
     elementInstanceState = processingState.getElementInstanceState();
     timerInstanceState = processingState.getTimerState();
+    suspensionState = processingState.getSuspensionState();
     keyGenerator = processingState.getKeyGenerator();
     eventHandle =
         new EventHandle(
@@ -103,6 +108,17 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
           record,
           RejectionType.NOT_FOUND,
           NO_PROCESS_DEFINITION_FOUND_MESSAGE.formatted(processDefinitionKey));
+      return;
+    }
+
+    // process instance suspend/resume (POC #56552): leave the timer scheduled (do not consume the
+    // TRIGGER command) so the periodic due-date check keeps re-attempting it until resume.
+    if (!isStartEvent(elementInstanceKey)
+        && suspensionState.isSuspended(timer.getProcessInstanceKey())) {
+      rejectionWriter.appendRejection(
+          record,
+          RejectionType.INVALID_STATE,
+          PROCESS_INSTANCE_SUSPENDED_MESSAGE.formatted(record.getKey()));
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -93,6 +93,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableResourceState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
 import io.camunda.zeebe.engine.state.mutable.MutableSignalSubscriptionState;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableUsageMetricState;
@@ -102,6 +103,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.engine.state.routing.DbRoutingState;
 import io.camunda.zeebe.engine.state.signal.DbSignalSubscriptionState;
+import io.camunda.zeebe.engine.state.suspension.DbSuspensionState;
 import io.camunda.zeebe.engine.state.tenant.DbTenantState;
 import io.camunda.zeebe.engine.state.user.DbUserState;
 import io.camunda.zeebe.engine.state.variable.DbVariableState;
@@ -134,6 +136,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final DbMessageCorrelationState messageCorrelationState;
   private final MutableIncidentState incidentState;
   private final MutableBannedInstanceState bannedInstanceState;
+  private final MutableSuspensionState suspensionState;
   private final MutableMigrationState mutableMigrationState;
   private final MutableDecisionState decisionState;
   private final MutableFormState formState;
@@ -204,6 +207,7 @@ public class ProcessingDbState implements MutableProcessingState {
     messageCorrelationState = new DbMessageCorrelationState(zeebeDb, transactionContext);
     incidentState = new DbIncidentState(zeebeDb, transactionContext);
     bannedInstanceState = new DbBannedInstanceState(zeebeDb, transactionContext);
+    suspensionState = new DbSuspensionState(zeebeDb, transactionContext);
     decisionState = new DbDecisionState(zeebeDb, transactionContext, config);
     formState = new DbFormState(zeebeDb, transactionContext, config);
     resourceState = new DbResourceState(zeebeDb, transactionContext, config);
@@ -303,6 +307,11 @@ public class ProcessingDbState implements MutableProcessingState {
   @Override
   public MutableBannedInstanceState getBannedInstanceState() {
     return bannedInstanceState;
+  }
+
+  @Override
+  public MutableSuspensionState getSuspensionState() {
+    return suspensionState;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -397,6 +397,14 @@ public final class EventAppliers implements EventApplier {
         RuntimeInstructionIntent.INTERRUPTED,
         new RuntimeInstructionInterruptedApplier(elementInstanceState));
     register(ProcessInstanceIntent.CANCELING, NOOP_EVENT_APPLIER);
+
+    // process instance suspend/resume (POC #56552)
+    final var suspensionState = state.getSuspensionState();
+    register(ProcessInstanceIntent.SUSPENDED, new ProcessInstanceSuspendedApplier(suspensionState));
+    register(ProcessInstanceIntent.RESUMED, new ProcessInstanceResumedApplier(suspensionState));
+    register(
+        ProcessInstanceIntent.ELEMENT_COMMAND_BUFFERED,
+        new ProcessInstanceElementCommandBufferedApplier(suspensionState));
   }
 
   private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCommandBufferedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementCommandBufferedApplier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/**
+ * Applies {@link ProcessInstanceIntent#ELEMENT_COMMAND_BUFFERED}: appends the diverted
+ * forward-progress element command to the FIFO buffer.
+ *
+ * <p>The event's own record key (generated via {@code KeyGenerator} by the gate in {@code
+ * BpmnStreamProcessor} at the time of buffering) is used as the FIFO sequence — it is monotonic per
+ * partition and deterministically recovered on replay, giving the same ordering guarantee as a raw
+ * log position without needing to plumb position through the applier interface.
+ */
+public final class ProcessInstanceElementCommandBufferedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableSuspensionState suspensionState;
+
+  public ProcessInstanceElementCommandBufferedApplier(
+      final MutableSuspensionState suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    suspensionState.bufferCommand(value.getProcessInstanceKey(), key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceResumedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceResumedApplier.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/**
+ * Applies {@link ProcessInstanceIntent#RESUMED}: removes the suspended marker and clears any
+ * buffered commands. The drain of buffered commands into follow-up {@code ACTIVATE_ELEMENT} /
+ * {@code COMPLETE_ELEMENT} / {@code COMPLETE_EXECUTION_LISTENER} commands happens in {@code
+ * ResumeProcessor} before this event is appended — this applier only clears the now-drained buffer
+ * state.
+ */
+public final class ProcessInstanceResumedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableSuspensionState suspensionState;
+
+  public ProcessInstanceResumedApplier(final MutableSuspensionState suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    suspensionState.resume(value.getProcessInstanceKey());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceSuspendedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceSuspendedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/** Applies {@link ProcessInstanceIntent#SUSPENDED}: marks the process instance as suspended. */
+public final class ProcessInstanceSuspendedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableSuspensionState suspensionState;
+
+  public ProcessInstanceSuspendedApplier(final MutableSuspensionState suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    suspensionState.suspend(value.getProcessInstanceKey());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -38,6 +38,8 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
 
   BannedInstanceState getBannedInstanceState();
 
+  SuspensionState getSuspensionState();
+
   VariableState getVariableState();
 
   ClusterVariableState getClusterVariableState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/SuspensionState.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import java.util.function.Consumer;
+
+/**
+ * Read access to the process-instance suspend/resume state (POC #56552).
+ *
+ * <p>A process instance is "suspended" when a marker exists for its key. While suspended,
+ * forward-progress BPMN element commands are diverted into a FIFO buffer keyed by {@code
+ * (processInstanceKey, logPosition)} and replayed in order on resume.
+ */
+public interface SuspensionState {
+
+  /** Returns {@code true} if the given process instance is currently suspended. */
+  boolean isSuspended(long processInstanceKey);
+
+  /**
+   * Visits the buffered element commands for the given process instance in FIFO (insertion) order.
+   * The visited {@link ProcessInstanceRecord} is backed by a shared buffer — consume it within the
+   * visitor, do not cache it. The original element-command intent is available via {@link
+   * ProcessInstanceRecord#getBufferedElementIntent()}.
+   */
+  void forEachBufferedCommand(long processInstanceKey, Consumer<ProcessInstanceRecord> visitor);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -50,6 +50,9 @@ public interface MutableProcessingState extends ProcessingState {
   MutableBannedInstanceState getBannedInstanceState();
 
   @Override
+  MutableSuspensionState getSuspensionState();
+
+  @Override
   MutableVariableState getVariableState();
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableSuspensionState.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.mutable;
+
+import io.camunda.zeebe.engine.state.immutable.SuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+
+/** Write access to the process-instance suspend/resume state (POC #56552). */
+public interface MutableSuspensionState extends SuspensionState {
+
+  /** Marks the process instance as suspended. */
+  void suspend(long processInstanceKey);
+
+  /** Removes the suspended marker and discards any buffered commands for the process instance. */
+  void resume(long processInstanceKey);
+
+  /**
+   * Appends a diverted forward-progress element command to the FIFO buffer. {@code seq} must be
+   * monotonically increasing per process instance and deterministic on replay (e.g. a key issued by
+   * {@code KeyGenerator} for the buffering event) to provide FIFO ordering. The {@code record} must
+   * carry the original element-command intent via {@link
+   * ProcessInstanceRecord#setBufferedElementIntent(int)}.
+   */
+  void bufferCommand(long processInstanceKey, long seq, ProcessInstanceRecord record);
+
+  /** Discards all buffered commands for the process instance without removing the marker. */
+  void clearBuffer(long processInstanceKey);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/BufferedCommand.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/BufferedCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.suspension;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+
+/**
+ * Column-family value wrapping a buffered forward-progress element command (POC #56552). The
+ * embedded {@link ProcessInstanceRecord} carries the original element-command intent via its
+ * internal {@code bufferedElementIntent} field.
+ */
+public final class BufferedCommand extends UnpackedObject implements DbValue {
+
+  private static final StringValue RECORD_KEY = new StringValue("record");
+
+  private final ObjectProperty<ProcessInstanceRecord> recordProp =
+      new ObjectProperty<>(RECORD_KEY, new ProcessInstanceRecord());
+
+  public BufferedCommand() {
+    super(1);
+    declareProperty(recordProp);
+  }
+
+  public ProcessInstanceRecord getRecord() {
+    return recordProp.getValue();
+  }
+
+  public BufferedCommand setRecord(final ProcessInstanceRecord record) {
+    // Full property copy (not the partial ProcessInstanceRecord#wrap) so that array properties
+    // (elementInstancePath, processDefinitionPath, callingElementPath, tags) and the
+    // bufferedElementIntent are preserved for exact replay on resume.
+    recordProp.getValue().copyFrom(record);
+    return this;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/suspension/DbSuspensionState.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.suspension;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Persists process-instance suspend/resume state (POC #56552).
+ *
+ * <ul>
+ *   <li>{@code SUSPENDED_PROCESS_INSTANCES}: {@code processInstanceKey -> ∅}. Presence ==
+ *       suspended.
+ *   <li>{@code BUFFERED_PROCESS_INSTANCE_COMMANDS}: {@code (processInstanceKey, seq) ->
+ *       BufferedCommand}. The wrapped record carries the original element-command intent via its
+ *       internal {@code bufferedElementIntent} field. {@code seq} is the KeyGenerator-issued record
+ *       key of the buffering event, which is monotonic per partition and deterministically
+ *       recovered on replay, giving replay-deterministic FIFO ordering with no separate counter.
+ * </ul>
+ */
+public final class DbSuspensionState implements MutableSuspensionState {
+
+  private final DbLong processInstanceKey = new DbLong();
+  private final ColumnFamily<DbLong, DbNil> suspendedColumnFamily;
+
+  private final DbLong bufferPosition = new DbLong();
+  private final DbCompositeKey<DbLong, DbLong> bufferKey =
+      new DbCompositeKey<>(processInstanceKey, bufferPosition);
+  private final BufferedCommand bufferedCommand = new BufferedCommand();
+  private final ColumnFamily<DbCompositeKey<DbLong, DbLong>, BufferedCommand>
+      bufferedCommandColumnFamily;
+
+  public DbSuspensionState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    suspendedColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.SUSPENDED_PROCESS_INSTANCES,
+            transactionContext,
+            processInstanceKey,
+            DbNil.INSTANCE);
+    bufferedCommandColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.BUFFERED_PROCESS_INSTANCE_COMMANDS,
+            transactionContext,
+            bufferKey,
+            bufferedCommand);
+  }
+
+  @Override
+  public boolean isSuspended(final long processInstanceKey) {
+    this.processInstanceKey.wrapLong(processInstanceKey);
+    return suspendedColumnFamily.exists(this.processInstanceKey);
+  }
+
+  @Override
+  public void forEachBufferedCommand(
+      final long processInstanceKey, final Consumer<ProcessInstanceRecord> visitor) {
+    this.processInstanceKey.wrapLong(processInstanceKey);
+    final BiConsumer<DbCompositeKey<DbLong, DbLong>, BufferedCommand> onEntry =
+        (key, value) -> visitor.accept(value.getRecord());
+    bufferedCommandColumnFamily.whileEqualPrefix(this.processInstanceKey, onEntry);
+  }
+
+  @Override
+  public void suspend(final long processInstanceKey) {
+    this.processInstanceKey.wrapLong(processInstanceKey);
+    suspendedColumnFamily.upsert(this.processInstanceKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void resume(final long processInstanceKey) {
+    this.processInstanceKey.wrapLong(processInstanceKey);
+    suspendedColumnFamily.deleteExisting(this.processInstanceKey);
+    clearBuffer(processInstanceKey);
+  }
+
+  @Override
+  public void bufferCommand(
+      final long processInstanceKey, final long position, final ProcessInstanceRecord record) {
+    this.processInstanceKey.wrapLong(processInstanceKey);
+    bufferPosition.wrapLong(position);
+    bufferedCommand.setRecord(record);
+    bufferedCommandColumnFamily.upsert(bufferKey, bufferedCommand);
+  }
+
+  @Override
+  public void clearBuffer(final long processInstanceKey) {
+    this.processInstanceKey.wrapLong(processInstanceKey);
+    // Collect positions first — mutating the column family while iterating it is unsafe.
+    final List<Long> positions = new ArrayList<>();
+    final BiConsumer<DbCompositeKey<DbLong, DbLong>, BufferedCommand> onEntry =
+        (key, value) -> positions.add(key.second().getValue());
+    bufferedCommandColumnFamily.whileEqualPrefix(this.processInstanceKey, onEntry);
+    for (final Long position : positions) {
+      this.processInstanceKey.wrapLong(processInstanceKey);
+      bufferPosition.wrapLong(position);
+      bufferedCommandColumnFamily.deleteExisting(bufferKey);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendResumeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceSuspendResumeTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Smoke tests for the process instance suspend/resume POC (#56552): verifies the core mechanism —
+ * forward-progress element commands are diverted into the buffer while suspended, and drained in
+ * order on resume — before layering the auxiliary gates and cancel/variable behavior on top.
+ */
+public final class ProcessInstanceSuspendResumeTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String JOB_TYPE = "test";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Test
+  public void shouldBufferForwardProgressCommandWhileSuspendedAndDrainOnResume() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var taskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+    final long taskElementInstanceKey = taskActivated.getKey();
+
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when: simulate a forward-progress command arriving while suspended (e.g. what job
+    // completion would eventually trigger) by writing it directly
+    final var completeElementCommand =
+        new ProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .setProcessInstanceKey(processInstanceKey)
+            .setProcessDefinitionKey(taskActivated.getValue().getProcessDefinitionKey())
+            .setElementId("task")
+            .setFlowScopeKey(taskActivated.getValue().getFlowScopeKey())
+            .setBpmnProcessId(PROCESS_ID)
+            .setVersion(taskActivated.getValue().getVersion());
+    engine.writeRecords(
+        RecordToWrite.command()
+            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, completeElementCommand)
+            .key(taskElementInstanceKey));
+
+    // then: the command is buffered, not processed — no ELEMENT_COMPLETING is produced yet
+    final var buffered =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMMAND_BUFFERED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(buffered).isNotNull();
+    RecordingExporter.expectNoMatchingRecords(
+        records ->
+            records
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETING)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .findFirst());
+
+    // when: resume — the buffered COMPLETE_ELEMENT drains and the task completes normally
+    engine.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then: the drained COMPLETE_ELEMENT (SERVICE_TASK) leads to the process completing normally,
+    // proving the buffer->resume->drain path reproduces ordinary forward progress
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withElementType(BpmnElementType.PROCESS))
+        .extracting(Record::getIntent)
+        .containsSubsequence(
+            ProcessInstanceIntent.SUSPENDED,
+            ProcessInstanceIntent.RESUMED,
+            ProcessInstanceIntent.ELEMENT_COMPLETED);
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldRejectJobCompleteWhileSuspended() {
+    // given
+    final long processInstanceKey = createServiceTaskProcessInstance();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final var rejection = engine.job().withKey(jobKey).expectRejection().complete();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    RecordingExporter.expectNoMatchingRecords(
+        records ->
+            records.jobRecords().withIntent(JobIntent.COMPLETED).withRecordKey(jobKey).findFirst());
+  }
+
+  @Test
+  public void shouldRejectJobFailWhileSuspended() {
+    // given
+    final long processInstanceKey = createServiceTaskProcessInstance();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final var rejection = engine.job().withKey(jobKey).expectRejection().fail();
+
+    // then
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    RecordingExporter.expectNoMatchingRecords(
+        records ->
+            records.jobRecords().withIntent(JobIntent.FAILED).withRecordKey(jobKey).findFirst());
+  }
+
+  @Test
+  public void shouldNotFireTimerWhileSuspendedAndFireOnResume() {
+    // given: a genuinely short-lived timer so the real due-date checker (not a simulated command)
+    // drives both the rejection-while-suspended and the fire-on-resume paths
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .intermediateCatchEvent("timer", i -> i.timerWithDuration("PT0.2S"))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var timerCreated =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when: the due-date checker naturally re-attempts TRIGGER once the timer becomes due —
+    // rejected because the instance is suspended; the timer stays scheduled (not consumed)
+    final var rejection =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGER)
+            .onlyCommandRejections()
+            .withRecordKey(timerCreated.getKey())
+            .getFirst();
+    assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    RecordingExporter.expectNoMatchingRecords(
+        records ->
+            records
+                .timerRecords()
+                .withIntent(TimerIntent.TRIGGERED)
+                .withRecordKey(timerCreated.getKey())
+                .findFirst());
+
+    // when: resume — the nudge re-checks the (already past) real due date and fires immediately
+    engine.processInstance().withInstanceKey(processInstanceKey).resume();
+
+    // then
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+                .withRecordKey(timerCreated.getKey())
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldRejectMessageCorrelationWhileSuspended() {
+    // given
+    final String correlationKey = "order-1";
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .intermediateCatchEvent(
+                    "msg",
+                    i ->
+                        i.message(
+                            m -> m.name("order-placed").zeebeCorrelationKeyExpression("orderId")))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("orderId", correlationKey)
+            .create();
+
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when: publishing succeeds (that step is unrelated to suspension) — correlation is the step
+    // that is rejected
+    engine.message().withName("order-placed").withCorrelationKey(correlationKey).publish();
+
+    // then: correlation is rejected — no side effects while suspended, catch event never completes
+    final var correlateRejection =
+        RecordingExporter.processMessageSubscriptionRecords(
+                ProcessMessageSubscriptionIntent.CORRELATE)
+            .onlyCommandRejections()
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    assertThat(correlateRejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
+    RecordingExporter.expectNoMatchingRecords(
+        records ->
+            records
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("msg")
+                .findFirst());
+  }
+
+  @Test
+  public void shouldTerminateAndDiscardBufferWhenCancellingSuspendedInstance() {
+    // given
+    final long processInstanceKey = createServiceTaskProcessInstance();
+    final var taskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferServiceTaskCompleteCommand(processInstanceKey, taskActivated);
+
+    // when: cancel proceeds even though the instance is suspended and has a buffered command
+    engine.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then: the instance terminates cleanly and the buffered command never drains
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+    RecordingExporter.expectNoMatchingRecords(
+        records ->
+            records
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETING)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .findFirst());
+  }
+
+  @Test
+  public void shouldAllowVariableUpdateWhileSuspended() {
+    // given
+    final long processInstanceKey = createServiceTaskProcessInstance();
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+
+    // when
+    final var updated =
+        engine
+            .variables()
+            .ofScope(processInstanceKey)
+            .withDocument(Map.of("approved", true))
+            .update();
+
+    // then
+    assertThat(updated.getIntent()).isEqualTo(VariableDocumentIntent.UPDATED);
+  }
+
+  @Test
+  public void shouldRecoverSuspensionAndBufferAfterRestartAndReplayIdentically() {
+    // given
+    final long processInstanceKey = createServiceTaskProcessInstance();
+    final var taskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+
+    engine.processInstance().withInstanceKey(processInstanceKey).suspend();
+    bufferServiceTaskCompleteCommand(processInstanceKey, taskActivated);
+
+    // when: restart and replay the log — suspended flag and buffer must be rebuilt purely from
+    // the SUSPENDED/ELEMENT_COMMAND_BUFFERED events, proving the determinism guarantee
+    engine.reprocess();
+
+    // then: resume still drains the buffer and completes the process, exactly as before restart
+    engine.processInstance().withInstanceKey(processInstanceKey).resume();
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .isTrue();
+  }
+
+  private long createServiceTaskProcessInstance() {
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent()
+                .done())
+        .deploy();
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+  }
+
+  private void bufferServiceTaskCompleteCommand(
+      final long processInstanceKey, final Record<ProcessInstanceRecordValue> taskActivated) {
+    final var taskActivatedValue = taskActivated.getValue();
+    final var completeElementCommand =
+        new ProcessInstanceRecord()
+            .setBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .setProcessInstanceKey(processInstanceKey)
+            .setProcessDefinitionKey(taskActivatedValue.getProcessDefinitionKey())
+            .setElementId("task")
+            .setFlowScopeKey(taskActivatedValue.getFlowScopeKey())
+            .setBpmnProcessId(PROCESS_ID)
+            .setVersion(taskActivatedValue.getVersion());
+    engine.writeRecords(
+        RecordToWrite.command()
+            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, completeElementCommand)
+            .key(taskActivated.getKey()));
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMMAND_BUFFERED)
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -392,6 +392,59 @@ public final class ProcessInstanceClient {
       return this;
     }
 
+    public Record<ProcessInstanceRecordValue> suspend() {
+      writeSuspendResumeCommand(ProcessInstanceIntent.SUSPEND);
+      return RecordingExporter.processInstanceRecords()
+          .withRecordKey(processInstanceKey)
+          .withIntent(ProcessInstanceIntent.SUSPENDED)
+          .withProcessInstanceKey(processInstanceKey)
+          .getFirst();
+    }
+
+    public Record<ProcessInstanceRecordValue> suspendExpectRejection() {
+      writeSuspendResumeCommand(ProcessInstanceIntent.SUSPEND);
+      return RecordingExporter.processInstanceRecords()
+          .onlyCommandRejections()
+          .withIntent(ProcessInstanceIntent.SUSPEND)
+          .withRecordKey(processInstanceKey)
+          .getFirst();
+    }
+
+    public Record<ProcessInstanceRecordValue> resume() {
+      writeSuspendResumeCommand(ProcessInstanceIntent.RESUME);
+      return RecordingExporter.processInstanceRecords()
+          .withRecordKey(processInstanceKey)
+          .withIntent(ProcessInstanceIntent.RESUMED)
+          .withProcessInstanceKey(processInstanceKey)
+          .getFirst();
+    }
+
+    public Record<ProcessInstanceRecordValue> resumeExpectRejection() {
+      writeSuspendResumeCommand(ProcessInstanceIntent.RESUME);
+      return RecordingExporter.processInstanceRecords()
+          .onlyCommandRejections()
+          .withIntent(ProcessInstanceIntent.RESUME)
+          .withRecordKey(processInstanceKey)
+          .getFirst();
+    }
+
+    private void writeSuspendResumeCommand(final ProcessInstanceIntent intent) {
+      if (partition == DEFAULT_PARTITION) {
+        partition =
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getPartitionId();
+      }
+
+      writer.writeCommandOnPartition(
+          partition,
+          processInstanceKey,
+          intent,
+          new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey),
+          authorizedTenants);
+    }
+
     public ProcessInstanceModificationClient modification() {
       return new ProcessInstanceModificationClient(writer, processInstanceKey, authorizedTenants);
     }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_COMMAND_BUFFERED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_ELEMENT_COMMAND_BUFFERED_v1.golden
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/**
+ * Applies {@link ProcessInstanceIntent#ELEMENT_COMMAND_BUFFERED}: appends the diverted
+ * forward-progress element command to the FIFO buffer.
+ *
+ * <p>The event's own record key (generated via {@code KeyGenerator} by the gate in {@code
+ * BpmnStreamProcessor} at the time of buffering) is used as the FIFO sequence — it is monotonic
+ * per partition and deterministically recovered on replay, giving the same ordering guarantee as a
+ * raw log position without needing to plumb position through the applier interface.
+ */
+public final class ProcessInstanceElementCommandBufferedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableSuspensionState suspensionState;
+
+  public ProcessInstanceElementCommandBufferedApplier(
+      final MutableSuspensionState suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    suspensionState.bufferCommand(value.getProcessInstanceKey(), key, value);
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_RESUMED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_RESUMED_v1.golden
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/**
+ * Applies {@link ProcessInstanceIntent#RESUMED}: removes the suspended marker and clears any
+ * buffered commands. The drain of buffered commands into follow-up {@code ACTIVATE_ELEMENT} /
+ * {@code COMPLETE_ELEMENT} / {@code COMPLETE_EXECUTION_LISTENER} commands happens in {@code
+ * ResumeProcessor} before this event is appended — this applier only clears the now-drained buffer
+ * state.
+ */
+public final class ProcessInstanceResumedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableSuspensionState suspensionState;
+
+  public ProcessInstanceResumedApplier(final MutableSuspensionState suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    suspensionState.resume(value.getProcessInstanceKey());
+  }
+}

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_SUSPENDED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstance_SUSPENDED_v1.golden
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableSuspensionState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+/** Applies {@link ProcessInstanceIntent#SUSPENDED}: marks the process instance as suspended. */
+public final class ProcessInstanceSuspendedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableSuspensionState suspensionState;
+
+  public ProcessInstanceSuspendedApplier(final MutableSuspensionState suspensionState) {
+    this.suspensionState = suspensionState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceRecord value) {
+    suspensionState.suspend(value.getProcessInstanceKey());
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -59,6 +59,17 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   public static final StringValue ROOT_PROCESS_INSTANCE_KEY =
       new StringValue("rootProcessInstanceKey");
   public static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  // Internal-only (POC #56552): carries the original element-command intent when this record is
+  // used as the value of an ELEMENT_COMMAND_BUFFERED event, so the command can be replayed on
+  // resume. Not part of the public ProcessInstanceRecordValue interface and excluded from JSON
+  // export.
+  public static final StringValue BUFFERED_ELEMENT_INTENT_KEY =
+      new StringValue("bufferedElementIntent");
+  // Internal-only (POC #56552): carries the original command's record key (the element instance
+  // key) alongside bufferedElementIntent, since the record itself has no elementInstanceKey field
+  // — the BpmnStreamProcessor relies on the command's record key for that.
+  public static final StringValue BUFFERED_ORIGINAL_KEY_KEY =
+      new StringValue("bufferedOriginalKey");
 
   private final StringProperty bpmnProcessIdProp = new StringProperty(BPMN_PROCESS_ID_KEY, "");
   private final IntegerProperty versionProp = new IntegerProperty(VERSION_KEY, -1);
@@ -99,8 +110,15 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   private final StringProperty businessIdProp = new StringProperty(BUSINESS_ID_KEY, "");
 
+  // Internal-only (POC #56552). Default -1 == "not a buffered command".
+  private final IntegerProperty bufferedElementIntentProp =
+      new IntegerProperty(BUFFERED_ELEMENT_INTENT_KEY, -1);
+  // Internal-only (POC #56552). Default -1 == "not a buffered command".
+  private final LongProperty bufferedOriginalKeyProp =
+      new LongProperty(BUFFERED_ORIGINAL_KEY_KEY, -1L);
+
   public ProcessInstanceRecord() {
-    super(17);
+    super(19);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)
@@ -117,7 +135,9 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(callingElementPathProp)
         .declareProperty(tagsProp)
         .declareProperty(rootProcessInstanceKeyProp)
-        .declareProperty(businessIdProp);
+        .declareProperty(businessIdProp)
+        .declareProperty(bufferedElementIntentProp)
+        .declareProperty(bufferedOriginalKeyProp);
   }
 
   public void wrap(final ProcessInstanceRecord record) {
@@ -383,6 +403,34 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  /**
+   * Internal-only (POC #56552): the original element-command intent value that was buffered while
+   * the process instance is suspended, or {@code -1} if this record is not a buffered command.
+   */
+  @JsonIgnore
+  public int getBufferedElementIntent() {
+    return bufferedElementIntentProp.getValue();
+  }
+
+  public ProcessInstanceRecord setBufferedElementIntent(final int intentValue) {
+    bufferedElementIntentProp.setValue(intentValue);
+    return this;
+  }
+
+  /**
+   * Internal-only (POC #56552): the original command's record key (the element instance key), or
+   * {@code -1} if this record is not a buffered command.
+   */
+  @JsonIgnore
+  public long getBufferedOriginalKey() {
+    return bufferedOriginalKeyProp.getValue();
+  }
+
+  public ProcessInstanceRecord setBufferedOriginalKey(final long originalKey) {
+    bufferedOriginalKeyProp.setValue(originalKey);
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -328,7 +328,14 @@ public enum ZbColumnFamilies implements EnumValue, ScopedColumnFamily {
   AGENT_HISTORY(150, PARTITION_LOCAL),
   // secondary index: (jobKey, jobLease, historyItemKey) → ∅; supports prefix iteration by job key
   // or job key + lease
-  AGENT_HISTORY_BY_JOB_KEY(151, PARTITION_LOCAL);
+  AGENT_HISTORY_BY_JOB_KEY(151, PARTITION_LOCAL),
+
+  // process instance suspend/resume (POC #56552)
+  // marker CF: presence of processInstanceKey → instance is suspended
+  SUSPENDED_PROCESS_INSTANCES(152, PARTITION_LOCAL),
+  // FIFO buffer of forward-progress element commands diverted while suspended, keyed by
+  // (processInstanceKey, logPosition) so iteration by PI prefix drains in original order
+  BUFFERED_PROCESS_INSTANCE_COMMANDS(153, PARTITION_LOCAL);
 
   private final int value;
   private final ColumnFamilyScope columnFamilyScope;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -67,9 +67,27 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
    *
    * <p>This event is not applied to the state, but is used for auditing reasons.
    */
-  CANCELING((short) 16);
+  CANCELING((short) 16),
 
-  private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS = EnumSet.of(CANCEL);
+  // --- Process instance suspend/resume (POC #56552) ---
+
+  /** Command to suspend a (root) process instance, freezing its forward progression. */
+  SUSPEND((short) 17, false),
+  /** Event marking that a process instance has been suspended. */
+  SUSPENDED((short) 18, false),
+  /** Command to resume a previously suspended process instance. */
+  RESUME((short) 19, false),
+  /** Event marking that a process instance has been resumed; drains buffered commands. */
+  RESUMED((short) 20, false),
+  /**
+   * Event capturing a forward-progress BPMN element command that was diverted into the buffer while
+   * the process instance is suspended. The original element command intent travels on the record's
+   * internal {@code bufferedElementIntent} field so it can be replayed verbatim on resume.
+   */
+  ELEMENT_COMMAND_BUFFERED((short) 21, false);
+
+  private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS =
+      EnumSet.of(CANCEL, SUSPEND, RESUME);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
       EnumSet.of(
           ACTIVATE_ELEMENT,
@@ -130,6 +148,16 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return SEQUENCE_FLOW_DELETED;
       case 16:
         return CANCELING;
+      case 17:
+        return SUSPEND;
+      case 18:
+        return SUSPENDED;
+      case 19:
+        return RESUME;
+      case 20:
+        return RESUMED;
+      case 21:
+        return ELEMENT_COMMAND_BUFFERED;
       default:
         return Intent.UNKNOWN;
     }
@@ -154,6 +182,9 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
       case ANCESTOR_MIGRATED:
       case SEQUENCE_FLOW_DELETED:
       case CANCELING:
+      case SUSPENDED:
+      case RESUMED:
+      case ELEMENT_COMMAND_BUFFERED:
         return true;
       default:
         return false;


### PR DESCRIPTION
## Description

POC proving engine feasibility for process instance suspend/resume: freezing a running process instance by diverting forward-progress BPMN element commands into a buffer, and replaying them in order on resume — with the suspended flag and buffer surviving restart/replay.

Engine-only scope (no REST/gateway/exporter/Operate/Tasklist/batch/authz). See the [issue](https://github.com/camunda/camunda/issues/56552) for the full breakdown and the [findings comment](https://github.com/camunda/camunda/issues/56552#issuecomment-4873157317) for the feasibility verdict (**GO**) and design deviations discovered during implementation.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #56552
