### PR TITLE
Broaden OBJECT content type to accept any JSON value

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryContent.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AgentInstanceHistoryContent.java
@@ -16,7 +16,6 @@
 package io.camunda.client.api.command;
 
 import io.camunda.client.api.response.DocumentReferenceResponse;
-import java.util.Map;
 
 /**
  * A content block in an agent instance history item. Use the static factory methods to create
@@ -43,10 +42,11 @@ public interface AgentInstanceHistoryContent {
   /**
    * Creates an arbitrary-object content block.
    *
-   * @param object the key-value map. Must not be null.
+   * @param object any valid JSON value (object, array, number, boolean, or string). Must not be
+   *     null.
    * @return an {@link AgentInstanceHistoryContent} of type OBJECT
    */
-  static AgentInstanceHistoryContent object(final Map<String, Object> object) {
+  static AgentInstanceHistoryContent object(final Object object) {
     if (object == null) {
       throw new IllegalArgumentException("object must not be null");
     }
@@ -87,9 +87,9 @@ public interface AgentInstanceHistoryContent {
 
   /** Arbitrary structured content block ({@code contentType = "OBJECT"}). */
   final class ObjectContent implements AgentInstanceHistoryContent {
-    private final Map<String, Object> object;
+    private final Object object;
 
-    public ObjectContent(final Map<String, Object> object) {
+    public ObjectContent(final Object object) {
       this.object = object;
     }
 
@@ -98,7 +98,7 @@ public interface AgentInstanceHistoryContent {
       return "OBJECT";
     }
 
-    public Map<String, Object> getObject() {
+    public Object getObject() {
       return object;
     }
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AgentInstanceHistoryImpl.java
@@ -150,10 +150,7 @@ public class AgentInstanceHistoryImpl implements AgentInstanceHistory {
       return new DocumentContent(
           ref != null ? new DocumentReferenceResponseImpl((DocumentReference) ref) : null);
     } else if (proto instanceof AgentInstanceObjectContent) {
-      @SuppressWarnings("unchecked")
-      final Map<String, Object> obj =
-          (Map<String, Object>) ((AgentInstanceObjectContent) proto).getObject();
-      return new ObjectContent(obj);
+      return new ObjectContent(((AgentInstanceObjectContent) proto).getObject());
     }
     return null;
   }

--- a/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
+++ b/clients/java/src/test/java/io/camunda/client/agentinstance/SearchAgentInstanceHistoryTest.java
@@ -30,6 +30,7 @@ import io.camunda.client.api.command.AgentInstanceHistoryToolCall;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryCommitStatus;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
+import io.camunda.client.api.search.response.SearchResponse;
 import io.camunda.client.protocol.rest.AgentInstanceDocumentContent;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryCommitStatusEnum;
 import io.camunda.client.protocol.rest.AgentInstanceHistoryItemMetrics;
@@ -48,7 +49,9 @@ import io.camunda.client.protocol.rest.SortOrderEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.instancio.Instancio;
 import org.junit.jupiter.api.Test;
@@ -290,7 +293,7 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
             .items(Collections.singletonList(provided)));
 
     // when
-    final io.camunda.client.api.search.response.SearchResponse<AgentInstanceHistory> result =
+    final SearchResponse<AgentInstanceHistory> result =
         client.newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY).send().join();
 
     // then
@@ -359,7 +362,7 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
                                         .documentReference(ref))))));
 
     // when
-    final io.camunda.client.api.search.response.SearchResponse<AgentInstanceHistory> result =
+    final SearchResponse<AgentInstanceHistory> result =
         client.newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY).send().join();
 
     // then
@@ -393,12 +396,91 @@ class SearchAgentInstanceHistoryTest extends ClientRestTest {
                                         ._object(obj))))));
 
     // when
-    final io.camunda.client.api.search.response.SearchResponse<AgentInstanceHistory> result =
+    final SearchResponse<AgentInstanceHistory> result =
         client.newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY).send().join();
 
     // then
     final AgentInstanceHistoryContent content = result.items().get(0).getContent().get(0);
     assertThat(content).isInstanceOf(ObjectContent.class);
-    assertThat(((ObjectContent) content).getObject()).containsEntry("key", "value");
+    assertThat(((ObjectContent) content).getObject()).isEqualTo(obj);
+  }
+
+  @Test
+  void shouldMapArrayObjectContent() {
+    // given — OBJECT content with a JSON array value
+    final List<Integer> arr = Arrays.asList(10, 20, 30);
+    gatewayService.onAgentInstanceHistorySearchRequest(
+        AGENT_INSTANCE_KEY,
+        Instancio.create(AgentInstanceHistorySearchQueryResult.class)
+            .items(
+                Collections.singletonList(
+                    Instancio.create(AgentInstanceHistoryItemResult.class)
+                        .historyItemKey("1")
+                        .agentInstanceKey("1")
+                        .elementInstanceKey("1")
+                        .jobKey("1")
+                        .producedAt(null)
+                        .content(
+                            Collections.singletonList(
+                                (AgentInstanceMessageContent)
+                                    new AgentInstanceObjectContent()
+                                        .contentType("OBJECT")
+                                        ._object(arr))))));
+
+    // when
+    final SearchResponse<AgentInstanceHistory> result =
+        client.newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY).send().join();
+
+    // then
+    assertThat(result.items())
+        .first()
+        .satisfies(
+            item ->
+                assertThat(item.getContent())
+                    .first()
+                    .satisfies(
+                        c -> {
+                          assertThat(c).isInstanceOf(ObjectContent.class);
+                          assertThat(((ObjectContent) c).getObject()).isEqualTo(arr);
+                        }));
+  }
+
+  @Test
+  void shouldMapScalarObjectContent() {
+    // given — OBJECT content with a scalar integer value
+    gatewayService.onAgentInstanceHistorySearchRequest(
+        AGENT_INSTANCE_KEY,
+        Instancio.create(AgentInstanceHistorySearchQueryResult.class)
+            .items(
+                Collections.singletonList(
+                    Instancio.create(AgentInstanceHistoryItemResult.class)
+                        .historyItemKey("1")
+                        .agentInstanceKey("1")
+                        .elementInstanceKey("1")
+                        .jobKey("1")
+                        .producedAt(null)
+                        .content(
+                            Collections.singletonList(
+                                (AgentInstanceMessageContent)
+                                    new AgentInstanceObjectContent()
+                                        .contentType("OBJECT")
+                                        ._object(42))))));
+
+    // when
+    final SearchResponse<AgentInstanceHistory> result =
+        client.newAgentInstanceHistorySearchRequest(AGENT_INSTANCE_KEY).send().join();
+
+    // then
+    assertThat(result.items())
+        .first()
+        .satisfies(
+            item ->
+                assertThat(item.getContent())
+                    .first()
+                    .satisfies(
+                        c -> {
+                          assertThat(c).isInstanceOf(ObjectContent.class);
+                          assertThat(((ObjectContent) c).getObject()).isEqualTo(42);
+                        }));
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -39,7 +39,6 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.jspecify.annotations.NullMarked;
@@ -226,8 +225,8 @@ public class AgentInstanceMapper {
     return result;
   }
 
-  private DirectBuffer toMsgPackBuffer(final Map<String, Object> map) {
-    return BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(map));
+  private DirectBuffer toMsgPackBuffer(final Object value) {
+    return BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(value));
   }
 
   private void fillDocumentReferenceMetadata(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2210,7 +2210,7 @@ public final class SearchQueryResponseMapper {
       case OBJECT ->
           AgentInstanceObjectContent.Builder.create()
               .contentType(item.contentType().name())
-              .object(requireNonNullElse(item.object(), Collections.emptyMap()))
+              .object(item.object())
               .build();
     };
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
+import io.camunda.client.api.command.AgentInstanceHistoryContent.ObjectContent;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
@@ -23,7 +24,9 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -132,7 +135,14 @@ public class AgentInstanceHistorySearchIT {
             .elementInstanceKey(elementInstanceKey)
             .jobKey(jobKey)
             .role(AgentInstanceHistoryRole.TOOL_RESULT)
-            .content(List.of(AgentInstanceHistoryContent.text("Search results: ...")))
+            .content(
+                List.of(
+                    AgentInstanceHistoryContent.object(
+                        Arrays.asList(Map.of("id", 1), Map.of("id", 2))),
+                    AgentInstanceHistoryContent.object(Arrays.asList(10, 20, 30)),
+                    AgentInstanceHistoryContent.object(42),
+                    AgentInstanceHistoryContent.object(true),
+                    AgentInstanceHistoryContent.object("search-complete")))
             .producedAt(OffsetDateTime.parse("2025-06-01T10:02:00Z"))
             .send()
             .join()
@@ -231,6 +241,33 @@ public class AgentInstanceHistorySearchIT {
     final var page2Keys =
         page2.items().stream().map(AgentInstanceHistory::getHistoryItemKey).toList();
     assertThat(page1Keys).doesNotContainAnyElementsOf(page2Keys);
+  }
+
+  @Test
+  void shouldReturnObjectContentForAllJsonValueTypes() {
+    // when
+    final var response =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .filter(f -> f.historyItemKey(historyItemKey3))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.getContent())
+                  .allSatisfy(c -> assertThat(c).isInstanceOf(ObjectContent.class));
+              assertThat(item.getContent())
+                  .extracting(c -> ((ObjectContent) c).getObject())
+                  .containsExactly(
+                      Arrays.asList(Map.of("id", 1), Map.of("id", 2)),
+                      Arrays.asList(10, 20, 30),
+                      42,
+                      true,
+                      "search-complete");
+            });
   }
 
   private static void waitForHistoryItemsToBeIndexed(

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformerTest.java
@@ -149,7 +149,7 @@ class AgentHistoryEntityTransformerTest {
     assertThat(item.contentType()).isEqualTo(ContentType.TEXT);
     assertThat(item.text()).isEqualTo("some text");
     assertThat(item.documentReference()).isNull();
-    assertThat(item.object()).isEmpty();
+    assertThat(item.object()).isNull();
   }
 
   @Test

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
@@ -80,11 +80,10 @@ public record AgentInstanceHistoryEntity(
       ContentType contentType,
       @Nullable String text,
       @Nullable DocumentReference documentReference,
-      @Nullable Map<String, Object> object) {
+      @Nullable Object object) {
 
     public ContentItem {
       Objects.requireNonNull(contentType, "contentType");
-      object = object != null ? new HashMap<>(object) : new HashMap<>();
     }
 
     public enum ContentType {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
@@ -405,7 +405,7 @@ public final class AgentHistoryEntity
       AgentHistoryContentType contentType,
       String text,
       DocumentReferenceEntity documentReference,
-      Map<String, Object> object) {
+      Object object) {
 
     public static AgentHistoryContentValue text(final String text) {
       return new AgentHistoryContentValue(AgentHistoryContentType.TEXT, text, null, null);
@@ -417,7 +417,7 @@ public final class AgentHistoryEntity
           AgentHistoryContentType.DOCUMENT, null, documentReference, null);
     }
 
-    public static AgentHistoryContentValue object(final Map<String, Object> object) {
+    public static AgentHistoryContentValue object(final Object object) {
       return new AgentHistoryContentValue(AgentHistoryContentType.OBJECT, null, null, object);
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -360,6 +360,42 @@ final class AgentHistoryHandlerTest {
   }
 
   @Test
+  void shouldMapNonMapObjectContent() {
+    // given — OBJECT content with a non-map value (array of scalars)
+    final var arrayValue = List.of(10, 20, 30);
+    final var contentItem =
+        ImmutableAgentHistoryMessageContentValue.builder()
+            .withContentType(io.camunda.zeebe.protocol.record.value.AgentHistoryContentType.OBJECT)
+            .withText("")
+            .withObject(arrayValue)
+            .build();
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildMinimalRecordValue(1L, 1))
+            .withContent(List.of(contentItem))
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withValue(recordValue));
+    final var entity = new AgentHistoryEntity().setId("1");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getContent())
+        .singleElement()
+        .satisfies(
+            content -> {
+              assertThat(content.contentType()).isEqualTo(AgentHistoryContentType.OBJECT);
+              assertThat(content.text()).isNull();
+              assertThat(content.documentReference()).isNull();
+              assertThat(content.object()).isEqualTo(arrayValue);
+            });
+  }
+
+  @Test
   void shouldThrowOnUnspecifiedContentType() {
     // given — UNSPECIFIED is the protocol sentinel; it cannot occur for a real exported record
     final var unspecifiedItem =

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
@@ -508,6 +508,37 @@ class AgentHistoryExportHandlerTest {
     assertThat(mappedRef.metadata().processDefinitionId()).isEqualTo("my-process");
   }
 
+  @Test
+  void shouldMapNonMapObjectContent() {
+    // given — OBJECT content with a non-map value (array of scalars)
+    final var arrayValue = List.of(10, 20, 30);
+    final var content =
+        ImmutableAgentHistoryMessageContentValue.builder()
+            .withContentType(AgentHistoryContentType.OBJECT)
+            .withObject(arrayValue)
+            .build();
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withContent(List.of(content))
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(62L).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final var mappedItem = modelCaptor.getValue().contentItems().getFirst();
+    assertThat(mappedItem.contentType()).isEqualTo(ContentType.OBJECT);
+    assertThat(mappedItem.text()).isNull();
+    assertThat(mappedItem.documentReference()).isNull();
+    assertThat(mappedItem.object()).isEqualTo(arrayValue);
+  }
+
   /**
    * Builds a fully-populated record value that will not throw during export. In particular: - role
    * is non-UNSPECIFIED - metrics is populated - content has a TEXT item (no UNSPECIFIED content

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -1060,7 +1060,11 @@ components:
     AgentInstanceObjectContent:
       type: object
       title: Object content
-      description: An arbitrary structured content block.
+      description: |
+        An arbitrary structured content block. Accepts any valid JSON value:
+        objects, arrays, numbers, booleans, or strings.
+        Use TEXT content for human-readable natural language;
+        use OBJECT content for machine-readable structured data.
       additionalProperties: false
       required:
         - contentType
@@ -1071,9 +1075,7 @@ components:
           type: string
           example: OBJECT
         object:
-          description: Arbitrary structured content.
-          type: object
-          additionalProperties: true
+          description: Arbitrary structured content — any valid JSON value (object, array, number, boolean, or string).
 
     AgentInstanceMessageContentTypeEnum:
       description: The content type discriminator for a history item content block.

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryReco
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -927,6 +928,58 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(meta.getProcessDefinitionId()).isEqualTo("invoice-process");
                   assertThat(meta.getProcessInstanceKey()).isEqualTo(ELEMENT_INSTANCE_KEY);
                   assertThat(meta.getCustomProperties()).containsEntry("source", "email");
+                }),
+            any());
+  }
+
+  @Test
+  void shouldCreateAgentHistoryItemWithNonMapObjectContent() {
+    // given
+    final var responseRecord = new AgentHistoryRecord();
+    responseRecord.setAgentHistoryKey(HISTORY_ITEM_KEY);
+    when(agentHistoryServices.createAgentHistoryItem(any(AgentHistoryRecord.class), any()))
+        .thenReturn(CompletableFuture.completedFuture(responseRecord));
+
+    final var requestBody =
+        """
+        {
+          "elementInstanceKey": "%d",
+          "jobKey": "%d",
+          "jobLease": "lease-abc",
+          "role": "TOOL_RESULT",
+          "content": [
+            { "contentType": "OBJECT", "object": [10, 20, 30] },
+            { "contentType": "OBJECT", "object": 42 }
+          ],
+          "producedAt": "2025-06-01T12:00:00Z"
+        }
+        """
+            .formatted(ELEMENT_INSTANCE_KEY, JOB_KEY);
+
+    // when / then
+    webClient
+        .post()
+        .uri(AGENT_INSTANCES_URL + "/%d/history".formatted(AGENT_INSTANCE_KEY))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(requestBody)
+        .exchange()
+        .expectStatus()
+        .isCreated();
+
+    verify(agentHistoryServices)
+        .createAgentHistoryItem(
+            assertArg(
+                record -> {
+                  assertThat(record.getContent()).hasSize(2);
+                  final var arrayContent = record.getContent().get(0);
+                  assertThat(arrayContent.getContentType())
+                      .isEqualTo(AgentHistoryContentType.OBJECT);
+                  assertThat(arrayContent.getObject()).isEqualTo(List.of(10, 20, 30));
+                  final var scalarContent = record.getContent().get(1);
+                  assertThat(scalarContent.getContentType())
+                      .isEqualTo(AgentHistoryContentType.OBJECT);
+                  assertThat(scalarContent.getObject()).isEqualTo(42);
                 }),
             any());
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
@@ -250,7 +250,8 @@ public final class MsgPackConverter {
     try {
       return MESSSAGE_PACK_OBJECT_MAPPER.readValue(msgpackBytes, clazz);
     } catch (final IOException e) {
-      throw new RuntimeException("Failed to deserialize MessagePack to Map", e);
+      throw new RuntimeException(
+          "Failed to deserialize MessagePack to " + clazz.getSimpleName(), e);
     }
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryMessageContent.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryMessageContent.java
@@ -9,22 +9,25 @@ package io.camunda.zeebe.protocol.impl.record.value.agenthistory;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.document.DocumentReference;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryMessageContentValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.Map;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 @JsonIgnoreProperties({"encodedLength", "empty"})
 public final class AgentHistoryMessageContent extends ObjectValue
     implements AgentHistoryMessageContentValue {
+
+  private static final DirectBuffer NIL_OBJECT = new UnsafeBuffer(MsgPackHelper.NIL);
 
   private final EnumProperty<AgentHistoryContentType> contentTypeProp =
       new EnumProperty<>(
@@ -32,7 +35,7 @@ public final class AgentHistoryMessageContent extends ObjectValue
   private final StringProperty textProp = new StringProperty("text", "");
   private final ObjectProperty<DocumentReference> documentReferenceProp =
       new ObjectProperty<>("documentReference", new DocumentReference());
-  private final DocumentProperty objectProp = new DocumentProperty("object");
+  private final BinaryProperty objectProp = new BinaryProperty("object", NIL_OBJECT);
 
   public AgentHistoryMessageContent() {
     super(4);
@@ -68,8 +71,8 @@ public final class AgentHistoryMessageContent extends ObjectValue
   }
 
   @Override
-  public Map<String, Object> getObject() {
-    return MsgPackConverter.convertToMap(objectProp.getValue());
+  public Object getObject() {
+    return MsgPackConverter.convertToObject(objectProp.getValue(), Object.class);
   }
 
   public AgentHistoryMessageContent setObject(final DirectBuffer object) {
@@ -86,6 +89,11 @@ public final class AgentHistoryMessageContent extends ObjectValue
     setContentType(other.getContentType());
     setText(other.getText());
     getDocumentReference().copy(other.getDocumentReference());
-    setObject(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(other.getObject())));
+    final var obj = other.getObject();
+    if (obj != null) {
+      setObject(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(obj)));
+    } else {
+      setObject(NIL_OBJECT);
+    }
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5066,19 +5066,19 @@ final class JsonSerializableToJsonTest {
               "contentType": "TEXT",
               "text": "I will extract the line items from the invoice.",
               "documentReference": { "documentId": "", "storeId": "", "contentHash": "", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
-              "object": {}
+              "object": null
             },
             {
               "contentType": "DOCUMENT",
               "text": "",
               "documentReference": { "documentId": "doc-001", "storeId": "gcs-store", "contentHash": "sha256-doc001", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
-              "object": {}
+              "object": null
             },
             {
               "contentType": "DOCUMENT",
               "text": "",
               "documentReference": { "documentId": "doc-002", "storeId": "s3-store", "contentHash": "sha256-doc002", "metadata": { "contentType": "application/pdf", "fileName": "invoice.pdf", "expiresAt": 1748860800000, "size": 10240, "processDefinitionId": "order-process", "processInstanceKey": 2251799813685249, "customProperties": { "region": "eu-west", "version": 2, "active": true } } },
-              "object": {}
+              "object": null
             },
             {
               "contentType": "OBJECT",
@@ -5100,6 +5100,89 @@ final class JsonSerializableToJsonTest {
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
           "bpmnProcessId": "process",
+          "processDefinitionKey": -1
+        }
+        """
+      },
+      {
+        "AgentHistoryRecord OBJECT content types",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final AgentHistoryRecord record = new AgentHistoryRecord();
+              record.addContent(
+                  new AgentHistoryMessageContent()
+                      .setContentType(AgentHistoryContentType.OBJECT)
+                      .setObject(
+                          wrapArray(
+                              MsgPackConverter.convertToMsgPack(
+                                  List.of(Map.of("id", 1), Map.of("id", 2))))));
+              record.addContent(
+                  new AgentHistoryMessageContent()
+                      .setContentType(AgentHistoryContentType.OBJECT)
+                      .setObject(
+                          wrapArray(MsgPackConverter.convertToMsgPack(List.of(10, 20, 30)))));
+              record.addContent(
+                  new AgentHistoryMessageContent()
+                      .setContentType(AgentHistoryContentType.OBJECT)
+                      .setObject(wrapArray(MsgPackConverter.convertToMsgPack(42))));
+              record.addContent(
+                  new AgentHistoryMessageContent()
+                      .setContentType(AgentHistoryContentType.OBJECT)
+                      .setObject(wrapArray(MsgPackConverter.convertToMsgPack(true))));
+              record.addContent(
+                  new AgentHistoryMessageContent()
+                      .setContentType(AgentHistoryContentType.OBJECT)
+                      .setObject(wrapArray(MsgPackConverter.convertToMsgPack((Object) "hello"))));
+              return record;
+            },
+        """
+        {
+          "agentHistoryKey": -1,
+          "agentInstanceKey": -1,
+          "elementInstanceKey": -1,
+          "jobKey": -1,
+          "jobLease": "",
+          "iteration": 0,
+          "role": "UNSPECIFIED",
+          "producedAt": -1,
+          "content": [
+            {
+              "contentType": "OBJECT",
+              "text": "",
+              "documentReference": { "documentId": "", "storeId": "", "contentHash": "", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
+              "object": [{"id": 1}, {"id": 2}]
+            },
+            {
+              "contentType": "OBJECT",
+              "text": "",
+              "documentReference": { "documentId": "", "storeId": "", "contentHash": "", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
+              "object": [10, 20, 30]
+            },
+            {
+              "contentType": "OBJECT",
+              "text": "",
+              "documentReference": { "documentId": "", "storeId": "", "contentHash": "", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
+              "object": 42
+            },
+            {
+              "contentType": "OBJECT",
+              "text": "",
+              "documentReference": { "documentId": "", "storeId": "", "contentHash": "", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
+              "object": true
+            },
+            {
+              "contentType": "OBJECT",
+              "text": "",
+              "documentReference": { "documentId": "", "storeId": "", "contentHash": "", "metadata": { "contentType": "", "fileName": "", "expiresAt": -1, "size": -1, "processDefinitionId": "", "processInstanceKey": -1, "customProperties": {} } },
+              "object": "hello"
+            }
+          ],
+          "toolCalls": [],
+          "metrics": { "inputTokens": 0, "outputTokens": 0, "durationMs": 0 },
+          "tenantId": "<default>",
+          "processInstanceKey": -1,
+          "rootProcessInstanceKey": -1,
+          "bpmnProcessId": "",
           "processDefinitionKey": -1
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverterTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverterTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.encoding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+import org.junit.jupiter.api.Test;
+
+class MsgPackConverterTest {
+
+  @Test
+  void shouldConvertMapToObject() {
+    // given
+    final Map<String, Object> value = Map.of("key", "value", "count", 42);
+    final DirectBuffer buffer = BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(value));
+
+    // when
+    final Object result = MsgPackConverter.convertToObject(buffer, Object.class);
+
+    // then
+    assertThat(result).isInstanceOf(Map.class).isEqualTo(value);
+  }
+
+  @Test
+  void shouldConvertArrayToObject() {
+    // given
+    final List<Object> value = List.of(Map.of("id", 1), Map.of("id", 2));
+    final DirectBuffer buffer = BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(value));
+
+    // when
+    final Object result = MsgPackConverter.convertToObject(buffer, Object.class);
+
+    // then
+    assertThat(result).isInstanceOf(List.class).isEqualTo(value);
+  }
+
+  @Test
+  void shouldConvertScalarNumberToObject() {
+    // given
+    final DirectBuffer buffer = BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(42));
+
+    // when
+    final Object result = MsgPackConverter.convertToObject(buffer, Object.class);
+
+    // then
+    assertThat(result).isInstanceOf(Integer.class).isEqualTo(42);
+  }
+
+  @Test
+  void shouldConvertScalarBooleanToObject() {
+    // given
+    final DirectBuffer buffer = BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(true));
+
+    // when
+    final Object result = MsgPackConverter.convertToObject(buffer, Object.class);
+
+    // then
+    assertThat(result).isInstanceOf(Boolean.class).isEqualTo(true);
+  }
+
+  @Test
+  void shouldConvertScalarStringToObject() {
+    // given — cast to Object forces the value-serialisation overload, not the JSON-text overload
+    final DirectBuffer buffer =
+        BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack((Object) "hello"));
+
+    // when
+    final Object result = MsgPackConverter.convertToObject(buffer, Object.class);
+
+    // then
+    assertThat(result).isInstanceOf(String.class).isEqualTo("hello");
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -16,7 +16,12 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 final class AgentHistoryRecordTest {
 
@@ -152,6 +157,44 @@ final class AgentHistoryRecordTest {
     final var object = content.get(2);
     assertThat(object.getContentType()).isEqualTo(AgentHistoryContentType.OBJECT);
     assertThat(object.getObject()).isEqualTo(objectData);
+  }
+
+  static Stream<Arguments> objectContentValues() {
+    return Stream.of(
+        Arguments.of(Named.named("map", Map.of("key", "value")), Map.class),
+        Arguments.of(
+            Named.named("array of objects", List.of(Map.of("id", 1), Map.of("id", 2))), List.class),
+        Arguments.of(Named.named("array of scalars", List.of(10, 20, 30)), List.class),
+        Arguments.of(Named.named("number", 42), Integer.class),
+        Arguments.of(Named.named("boolean", true), Boolean.class),
+        Arguments.of(Named.named("string scalar", "hello"), String.class));
+  }
+
+  @ParameterizedTest(name = "shouldRoundTripObjectContent [{0}]")
+  @MethodSource("objectContentValues")
+  void shouldRoundTripObjectContentViaMsgPack(final Object value, final Class<?> expectedType) {
+    // given
+    final var content =
+        new AgentHistoryMessageContent()
+            .setContentType(AgentHistoryContentType.OBJECT)
+            .setObject(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(value)));
+
+    // when
+    final var copy = new AgentHistoryMessageContent();
+    copy.copy(content);
+
+    // then
+    assertThat(copy.getObject()).isInstanceOf(expectedType).isEqualTo(value);
+  }
+
+  @Test
+  void shouldReturnNullObjectForUnsetProperty() {
+    // given
+    final var content =
+        new AgentHistoryMessageContent().setContentType(AgentHistoryContentType.TEXT);
+
+    // then
+    assertThat(content.getObject()).isNull();
   }
 
   @Test

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryMessageContent.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryMessageContent.golden
@@ -9,22 +9,25 @@ package io.camunda.zeebe.protocol.impl.record.value.agenthistory;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.document.DocumentReference;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHistoryMessageContentValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.Map;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 @JsonIgnoreProperties({"encodedLength", "empty"})
 public final class AgentHistoryMessageContent extends ObjectValue
     implements AgentHistoryMessageContentValue {
+
+  private static final DirectBuffer NIL_OBJECT = new UnsafeBuffer(MsgPackHelper.NIL);
 
   private final EnumProperty<AgentHistoryContentType> contentTypeProp =
       new EnumProperty<>(
@@ -32,7 +35,7 @@ public final class AgentHistoryMessageContent extends ObjectValue
   private final StringProperty textProp = new StringProperty("text", "");
   private final ObjectProperty<DocumentReference> documentReferenceProp =
       new ObjectProperty<>("documentReference", new DocumentReference());
-  private final DocumentProperty objectProp = new DocumentProperty("object");
+  private final BinaryProperty objectProp = new BinaryProperty("object", NIL_OBJECT);
 
   public AgentHistoryMessageContent() {
     super(4);
@@ -68,8 +71,8 @@ public final class AgentHistoryMessageContent extends ObjectValue
   }
 
   @Override
-  public Map<String, Object> getObject() {
-    return MsgPackConverter.convertToMap(objectProp.getValue());
+  public Object getObject() {
+    return MsgPackConverter.convertToObject(objectProp.getValue(), Object.class);
   }
 
   public AgentHistoryMessageContent setObject(final DirectBuffer object) {
@@ -86,6 +89,11 @@ public final class AgentHistoryMessageContent extends ObjectValue
     setContentType(other.getContentType());
     setText(other.getText());
     getDocumentReference().copy(other.getDocumentReference());
-    setObject(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(other.getObject())));
+    final var obj = other.getObject();
+    if (obj != null) {
+      setObject(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(obj)));
+    } else {
+      setObject(NIL_OBJECT);
+    }
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -95,8 +95,13 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
     /** Returns the document reference; populated when contentType is DOCUMENT. */
     DocumentReferenceValue getDocumentReference();
 
-    /** Returns the structured object payload; populated when contentType is OBJECT. */
-    Map<String, Object> getObject();
+    /**
+     * Returns the JSON value payload when contentType is OBJECT; {@code null} otherwise. The value
+     * may be any JSON type: a {@link java.util.Map} for objects, {@link java.util.List} for arrays,
+     * or a scalar ({@link Integer}, {@link Long}, {@link Float}, {@link Double}, {@link Boolean},
+     * {@link String}).
+     */
+    Object getObject();
   }
 
   /** Represents a tool call embedded in this history entry. */

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -614,7 +614,7 @@ public class CompactRecordLogger {
           }
           case OBJECT -> {
             final var object = block.getObject();
-            if (object != null && !object.isEmpty()) {
+            if (object != null) {
               result.append(indent).append(StringUtils.abbreviate(object.toString(), 50));
             }
           }

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/CompactRecordLoggerTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValu
 import io.camunda.zeebe.protocol.record.value.ImmutableUsageMetricRecordValue;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.EventType;
 import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue.IntervalType;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -201,7 +202,7 @@ class CompactRecordLoggerTest {
     }
 
     @Test
-    void shouldSummarizeAgentHistoryToolResultRecord() {
+    void shouldSummarizeAgentHistoryWithMultipleObjectContentTypes() {
       // given
       final var logger = new CompactRecordLogger(List.of());
       final var record =
@@ -218,7 +219,27 @@ class CompactRecordLoggerTest {
                       .addContent(
                           ImmutableAgentHistoryMessageContentValue.builder()
                               .withContentType(AgentHistoryContentType.OBJECT)
-                              .withObject(Map.of("orderId", "12345"))
+                              .withObject(Arrays.asList(Map.of("id", 1), Map.of("id", 2)))
+                              .build())
+                      .addContent(
+                          ImmutableAgentHistoryMessageContentValue.builder()
+                              .withContentType(AgentHistoryContentType.OBJECT)
+                              .withObject(Arrays.asList(10, 20, 30))
+                              .build())
+                      .addContent(
+                          ImmutableAgentHistoryMessageContentValue.builder()
+                              .withContentType(AgentHistoryContentType.OBJECT)
+                              .withObject(42)
+                              .build())
+                      .addContent(
+                          ImmutableAgentHistoryMessageContentValue.builder()
+                              .withContentType(AgentHistoryContentType.OBJECT)
+                              .withObject(true)
+                              .build())
+                      .addContent(
+                          ImmutableAgentHistoryMessageContentValue.builder()
+                              .withContentType(AgentHistoryContentType.OBJECT)
+                              .withObject("search-complete")
                               .build())
                       .build())
               .build();
@@ -231,7 +252,11 @@ class CompactRecordLoggerTest {
           .isEqualTo(
               """
               K1#3 TOOL_RESULT @K2 K3#1
-                     {orderId=12345}""");
+                     [{id=1}, {id=2}]
+                     [10, 20, 30]
+                     42
+                     true
+                     search-complete""");
     }
 
     @Test


### PR DESCRIPTION
## Description

Agent history entries support an `OBJECT` content block for passing arbitrary structured data alongside text and document references. The original implementation constrained this block to JSON objects only (`Map<String, Object>`), which was unnecessarily restrictive — LLM integrations commonly produce arrays (e.g. a list of tool results) or scalar values (numbers, booleans, strings) as top-level outputs.

This PR broadens the `OBJECT` content type to accept any valid JSON value.

**Why `BinaryProperty` and not `DocumentProperty` or `PackedProperty`?**

`DocumentProperty` rejects anything that is not a MsgPack MAP at the codec level, which is exactly what we are trying to work around. `PackedProperty` (used for `customHeaders` in `JobRecord`) embeds bytes without a binary envelope, meaning it would silently change the wire format for existing data. `BinaryProperty` stores raw MsgPack bytes in a BIN envelope — the same codec already used by `VariableRecord` for variable values, which have the same "any JSON value" semantics. It preserves the wire format contract and has the most established precedent for open-ended JSON storage in this codebase.

The protocol interface's `getObject()` return type changes from `Map<String, Object>` to `Object`; deserialization via `MsgPackConverter` returns `LinkedHashMap`, `ArrayList`, or a scalar depending on the MsgPack type tag.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56083