### PR TITLE
fix: apply per-physical-tenant configuration to the broker

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -9,6 +9,7 @@ package io.camunda.configuration.beanoverrides;
 
 import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
 import io.camunda.configuration.Azure;
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.CommandApi;
 import io.camunda.configuration.Data;
 import io.camunda.configuration.Export;
@@ -110,46 +111,75 @@ public class BrokerBasedPropertiesOverride {
     final BrokerBasedProperties override = new BrokerBasedProperties();
     BeanUtils.copyProperties(legacyBrokerBasedProperties, override);
 
-    populateFromCluster(override);
+    populateFromCamunda(override, unifiedConfiguration.getCamunda());
 
-    populateFromLongPolling(override);
+    return override;
+  }
 
-    populateFromRestFilters(override);
+  /**
+   * Builds a per-physical-tenant {@link BrokerBasedProperties} entirely from the supplied
+   * per-tenant {@link Camunda} object, using the same population logic as the root {@link
+   * #brokerBasedProperties()} bean.
+   *
+   * <p>The per-tenant {@code Camunda} is produced by {@code PhysicalTenantResolver} via a two-step
+   * bind: it inherits root values for every un-overridden key, so cluster-wide sections come out
+   * identical to the root while per-tenant overrides apply on top.
+   *
+   * <p>Unlike the root bean, no legacy {@code zeebe.broker.*} properties are applied: legacy keys
+   * cannot express per-tenant configuration. The default tenant keeps legacy support by reusing the
+   * root bean directly instead of this method.
+   *
+   * <p>The caller must stamp {@code cluster.nodeId} / {@code cluster.nodeVersion} (from {@code
+   * NodeIdProvider}) and call {@code init()}, just as {@code BrokerBasedConfiguration} does for the
+   * root bean.
+   */
+  public BrokerBasedProperties convert(final Camunda perTenant) {
+    final BrokerBasedProperties props = new BrokerBasedProperties();
+    populateFromCamunda(props, perTenant);
+    return props;
+  }
 
-    populateFromSystem(override);
+  /**
+   * Populates the given {@link BrokerBasedProperties} from a {@link Camunda} object. Single code
+   * path shared by the root bean and the per-tenant build so the two cannot drift.
+   */
+  private void populateFromCamunda(final BrokerBasedProperties override, final Camunda camunda) {
+    populateFromCluster(override, camunda);
 
-    populateFromPrimaryStorage(override);
+    populateFromLongPolling(override, camunda);
 
-    populateFromGrpc(override);
+    populateFromRestFilters(override, camunda);
 
-    populateFromData(override);
+    populateFromSystem(override, camunda);
 
-    if (unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getType()
-        == SecondaryStorageType.rdbms) {
+    populateFromPrimaryStorage(override, camunda);
+
+    populateFromGrpc(override, camunda);
+
+    populateFromData(override, camunda);
+
+    if (camunda.getData().getSecondaryStorage().getType() == SecondaryStorageType.rdbms) {
       populateRdbmsExporter(override);
     } else {
       populateCamundaExporter(override);
     }
 
-    populateFromExporters(override);
+    populateFromExporters(override, camunda);
 
-    populateFromMonitoring(override);
+    populateFromMonitoring(override, camunda);
 
-    populateFromProcessing(override);
+    populateFromProcessing(override, camunda);
 
-    populateFromFlowControl(override);
+    populateFromFlowControl(override, camunda);
 
-    populateFromSecurity(override);
+    populateFromSecurity(override, camunda);
 
-    override.setLicenseKey(unifiedConfiguration.getCamunda().getLicense().getKey());
-
-    return override;
+    override.setLicenseKey(camunda.getLicense().getKey());
   }
 
-  private void populateFromSecurity(final BrokerBasedProperties override) {
+  private void populateFromSecurity(final BrokerBasedProperties override, final Camunda camunda) {
     final var tlsCluster =
-        unifiedConfiguration
-            .getCamunda()
+        camunda
             .getSecurity()
             .getTransportLayerSecurity()
             .getCluster()
@@ -169,8 +199,8 @@ public class BrokerBasedPropertiesOverride {
             tlsCluster.getKeyStore().withBrokerTlsClusterKeyStoreProperties().getPassword());
   }
 
-  private void populateFromProcessing(final BrokerBasedProperties override) {
-    final Processing processing = unifiedConfiguration.getCamunda().getProcessing();
+  private void populateFromProcessing(final BrokerBasedProperties override, final Camunda camunda) {
+    final Processing processing = camunda.getProcessing();
 
     // processing
     override.getProcessing().setMaxCommandsInBatch(processing.getMaxCommandsInBatch());
@@ -213,29 +243,29 @@ public class BrokerBasedPropertiesOverride {
         .getFeatures()
         .setEnableMessageBodyOnExpired(processing.isEnableMessageBodyOnExpired());
 
-    populateFromEngine(override);
+    populateFromEngine(override, camunda);
   }
 
-  private void populateFromEngine(final BrokerBasedProperties override) {
-    populateFromDistribution(override);
-    populateFromBatchOperations(override);
-    populateFromExpression(override);
-    populateFromProcessInstanceCreation(override);
-    populateFromJobs(override);
+  private void populateFromEngine(final BrokerBasedProperties override, final Camunda camunda) {
+    populateFromDistribution(override, camunda);
+    populateFromBatchOperations(override, camunda);
+    populateFromExpression(override, camunda);
+    populateFromProcessInstanceCreation(override, camunda);
+    populateFromJobs(override, camunda);
   }
 
-  private void populateFromDistribution(final BrokerBasedProperties override) {
-    final var distribution =
-        unifiedConfiguration.getCamunda().getProcessing().getEngine().getDistribution();
+  private void populateFromDistribution(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var distribution = camunda.getProcessing().getEngine().getDistribution();
 
     final var distributionCfg = override.getExperimental().getEngine().getDistribution();
     distributionCfg.setMaxBackoffDuration(distribution.getMaxBackoffDuration());
     distributionCfg.setRedistributionInterval(distribution.getRedistributionInterval());
   }
 
-  private void populateFromBatchOperations(final BrokerBasedProperties override) {
-    final var engineBatchOperation =
-        unifiedConfiguration.getCamunda().getProcessing().getEngine().getBatchOperations();
+  private void populateFromBatchOperations(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var engineBatchOperation = camunda.getProcessing().getEngine().getBatchOperations();
     final var batchOperationsCfg = override.getExperimental().getEngine().getBatchOperations();
     batchOperationsCfg.setSchedulerInterval(engineBatchOperation.getSchedulerInterval());
     batchOperationsCfg.setChunkSize(engineBatchOperation.getChunkSize());
@@ -248,19 +278,20 @@ public class BrokerBasedPropertiesOverride {
         engineBatchOperation.getQueryRetryBackoffFactor());
   }
 
-  private void populateFromExpression(final BrokerBasedProperties override) {
-    final var expression = unifiedConfiguration.getCamunda().getExpression();
+  private void populateFromExpression(final BrokerBasedProperties override, final Camunda camunda) {
+    final var expression = camunda.getExpression();
     override.getExperimental().getEngine().getExpression().setTimeout(expression.getTimeout());
   }
 
-  private void populateFromFlowControl(final BrokerBasedProperties override) {
-    populateFromBackpressureLimitRequest(override);
-    populateFromWrite(override);
+  private void populateFromFlowControl(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    populateFromBackpressureLimitRequest(override, camunda);
+    populateFromWrite(override, camunda);
   }
 
-  private void populateFromBackpressureLimitRequest(final BrokerBasedProperties override) {
-    final Limit request =
-        unifiedConfiguration.getCamunda().getProcessing().getFlowControl().getRequest();
+  private void populateFromBackpressureLimitRequest(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Limit request = camunda.getProcessing().getFlowControl().getRequest();
 
     if (request == null) {
       return;
@@ -311,9 +342,8 @@ public class BrokerBasedPropertiesOverride {
     override.getFlowControl().setRequest(limitCfg);
   }
 
-  private void populateFromWrite(final BrokerBasedProperties override) {
-    final Write write =
-        unifiedConfiguration.getCamunda().getProcessing().getFlowControl().getWrite();
+  private void populateFromWrite(final BrokerBasedProperties override, final Camunda camunda) {
+    final Write write = camunda.getProcessing().getFlowControl().getWrite();
 
     if (write == null) {
       return;
@@ -326,12 +356,11 @@ public class BrokerBasedPropertiesOverride {
     rateLimitCfg.setRampUp(write.getRampUp());
     override.getFlowControl().setWrite(rateLimitCfg);
 
-    populateFromThrottle(override);
+    populateFromThrottle(override, camunda);
   }
 
-  private void populateFromThrottle(final BrokerBasedProperties override) {
-    final Throttle throttle =
-        unifiedConfiguration.getCamunda().getProcessing().getFlowControl().getWrite().getThrottle();
+  private void populateFromThrottle(final BrokerBasedProperties override, final Camunda camunda) {
+    final Throttle throttle = camunda.getProcessing().getFlowControl().getWrite().getThrottle();
 
     final ThrottleCfg throttleCfg = override.getFlowControl().getWrite().getThrottling();
     throttleCfg.setEnabled(throttle.isEnabled());
@@ -340,49 +369,42 @@ public class BrokerBasedPropertiesOverride {
     throttleCfg.setResolution(throttle.getResolution());
   }
 
-  private void populateFromGrpc(final BrokerBasedProperties override) {
-    final var grpc =
-        unifiedConfiguration.getCamunda().getApi().getGrpc().withBrokerNetworkProperties();
+  private void populateFromGrpc(final BrokerBasedProperties override, final Camunda camunda) {
+    final var grpc = camunda.getApi().getGrpc().withBrokerNetworkProperties();
 
     final NetworkCfg networkCfg = override.getGateway().getNetwork();
     networkCfg.setHost(grpc.getAddress());
     networkCfg.setPort(grpc.getPort());
     networkCfg.setMinKeepAliveInterval(grpc.getMinKeepAliveInterval());
 
-    populateFromSsl(override);
-    populateFromInterceptors(override);
+    populateFromSsl(override, camunda);
+    populateFromInterceptors(override, camunda);
 
     final io.camunda.zeebe.gateway.impl.configuration.ThreadsCfg threadsCfg =
         override.getGateway().getThreads();
     threadsCfg.setManagementThreads(grpc.getManagementThreads());
   }
 
-  private void populateFromSsl(final BrokerBasedProperties override) {
-    final Ssl ssl =
-        unifiedConfiguration.getCamunda().getApi().getGrpc().getSsl().withBrokerSslProperties();
+  private void populateFromSsl(final BrokerBasedProperties override, final Camunda camunda) {
+    final Ssl ssl = camunda.getApi().getGrpc().getSsl().withBrokerSslProperties();
     final SecurityCfg securityCfg = override.getGateway().getSecurity();
     securityCfg.setEnabled(ssl.isEnabled());
     securityCfg.setCertificateChainPath(ssl.getCertificate());
     securityCfg.setPrivateKeyPath(ssl.getCertificatePrivateKey());
 
-    populateFromKeyStore(override);
+    populateFromKeyStore(override, camunda);
   }
 
-  private void populateFromKeyStore(final BrokerBasedProperties override) {
+  private void populateFromKeyStore(final BrokerBasedProperties override, final Camunda camunda) {
     final KeyStore keyStore =
-        unifiedConfiguration
-            .getCamunda()
-            .getApi()
-            .getGrpc()
-            .getSsl()
-            .getKeyStore()
-            .withBrokerKeyStoreProperties();
+        camunda.getApi().getGrpc().getSsl().getKeyStore().withBrokerKeyStoreProperties();
     final KeyStoreCfg keyStoreCfg = override.getGateway().getSecurity().getKeyStore();
     keyStoreCfg.setFilePath(keyStore.getFilePath());
     keyStoreCfg.setPassword(keyStore.getPassword());
   }
 
-  private void populateFromInterceptors(final BrokerBasedProperties override) {
+  private void populateFromInterceptors(
+      final BrokerBasedProperties override, final Camunda camunda) {
     // Order between legacy and new interceptor props is not guaranteed.
     // Log common interceptors warning instead of using UnifiedConfigurationHelper logging.
     if (!override.getGateway().getInterceptors().isEmpty()) {
@@ -393,8 +415,7 @@ public class BrokerBasedPropertiesOverride {
       LOGGER.warn(warningMessage);
     }
 
-    final List<Interceptor> interceptors =
-        unifiedConfiguration.getCamunda().getApi().getGrpc().getInterceptors();
+    final List<Interceptor> interceptors = camunda.getApi().getGrpc().getInterceptors();
     if (!interceptors.isEmpty()) {
       final List<InterceptorCfg> interceptorCfgList =
           interceptors.stream().map(Interceptor::toInterceptorCfg).toList();
@@ -402,8 +423,8 @@ public class BrokerBasedPropertiesOverride {
     }
   }
 
-  private void populateFromCluster(final BrokerBasedProperties override) {
-    final var cluster = unifiedConfiguration.getCamunda().getCluster().withBrokerProperties();
+  private void populateFromCluster(final BrokerBasedProperties override, final Camunda camunda) {
+    final var cluster = camunda.getCluster().withBrokerProperties();
 
     override.getCluster().setInitialContactPoints(cluster.getInitialContactPoints());
     if (cluster.getNodeIdProvider().getType() == Type.FIXED) {
@@ -416,27 +437,27 @@ public class BrokerBasedPropertiesOverride {
     override.getCluster().setClusterId(cluster.getClusterId());
     override.getCluster().setZone(cluster.getZone());
 
-    populateFromMembership(override);
-    populateFromRaftProperties(override);
-    populateFromClusterMetadata(override);
-    populateFromClusterNetwork(override);
+    populateFromMembership(override, camunda);
+    populateFromRaftProperties(override, camunda);
+    populateFromClusterMetadata(override, camunda);
+    populateFromClusterNetwork(override, camunda);
 
     override
         .getCluster()
         .setMessageCompression(
             CompressionAlgorithm.valueOf(cluster.getCompressionAlgorithm().name()));
 
-    populateFromGlobalListeners(override);
+    populateFromGlobalListeners(override, camunda);
 
-    populateFromPartitioning(override);
+    populateFromPartitioning(override, camunda);
 
     override.getExperimental().setReceiveOnLegacySubject(cluster.isReceiveOnLegacySubject());
   }
 
   @SuppressWarnings("MissingSwitchDefault")
-  private void populateFromPartitioning(final BrokerBasedProperties override) {
-    final Partitioning partitioning =
-        unifiedConfiguration.getCamunda().getCluster().getPartitioning();
+  private void populateFromPartitioning(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Partitioning partitioning = camunda.getCluster().getPartitioning();
 
     // Order between legacy and new partitioning props is not guaranteed.
     // Log common partitioning warning instead of using UnifiedConfigurationHelper logging.
@@ -467,13 +488,9 @@ public class BrokerBasedPropertiesOverride {
     }
   }
 
-  private void populateFromLongPolling(final BrokerBasedProperties override) {
-    final var longPolling =
-        unifiedConfiguration
-            .getCamunda()
-            .getApi()
-            .getLongPolling()
-            .withBrokerLongPollingProperties();
+  private void populateFromLongPolling(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var longPolling = camunda.getApi().getLongPolling().withBrokerLongPollingProperties();
     final var longPollingCfg = override.getGateway().getLongPolling();
     longPollingCfg.setEnabled(longPolling.isEnabled());
     longPollingCfg.setTimeout(longPolling.getTimeout());
@@ -481,13 +498,9 @@ public class BrokerBasedPropertiesOverride {
     longPollingCfg.setMinEmptyResponses(longPolling.getMinEmptyResponses());
   }
 
-  private void populateFromMembership(final BrokerBasedProperties override) {
+  private void populateFromMembership(final BrokerBasedProperties override, final Camunda camunda) {
     final Membership membership =
-        unifiedConfiguration
-            .getCamunda()
-            .getCluster()
-            .getMembership()
-            .withBrokerMembershipProperties();
+        camunda.getCluster().getMembership().withBrokerMembershipProperties();
     final MembershipCfg membershipCfg = override.getCluster().getMembership();
     membershipCfg.setBroadcastUpdates(membership.isBroadcastUpdates());
     membershipCfg.setBroadcastDisputes(membership.isBroadcastDisputes());
@@ -501,8 +514,9 @@ public class BrokerBasedPropertiesOverride {
     membershipCfg.setSyncInterval(membership.getSyncInterval());
   }
 
-  private void populateFromRaftProperties(final BrokerBasedProperties override) {
-    final var raft = unifiedConfiguration.getCamunda().getCluster().getRaft();
+  private void populateFromRaftProperties(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var raft = camunda.getCluster().getRaft();
     override.getCluster().setHeartbeatInterval(raft.getHeartbeatInterval());
     override.getCluster().setElectionTimeout(raft.getElectionTimeout());
     override.getCluster().getRaft().setEnablePriorityElection(raft.isPriorityElectionEnabled());
@@ -545,8 +559,9 @@ public class BrokerBasedPropertiesOverride {
         .setSegmentPreallocationStrategy(raft.getSegmentPreallocationStrategy());
   }
 
-  private void populateFromClusterMetadata(final BrokerBasedProperties override) {
-    final var metadata = unifiedConfiguration.getCamunda().getCluster().getMetadata();
+  private void populateFromClusterMetadata(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var metadata = camunda.getCluster().getMetadata();
     final var syncDelay = metadata.getSyncDelay();
     final var syncTimeout = metadata.getSyncRequestTimeout();
     final var gossipFanout = metadata.getGossipFanout();
@@ -557,9 +572,9 @@ public class BrokerBasedPropertiesOverride {
     override.getCluster().setConfigManager(new ConfigManagerCfg(configManagerGossipConfig));
   }
 
-  private void populateFromClusterNetwork(final BrokerBasedProperties override) {
-    final var network =
-        unifiedConfiguration.getCamunda().getCluster().getNetwork().withBrokerNetworkProperties();
+  private void populateFromClusterNetwork(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var network = camunda.getCluster().getNetwork().withBrokerNetworkProperties();
 
     final var brokerNetwork = override.getNetwork();
     brokerNetwork.setHost(network.getHost());
@@ -571,22 +586,16 @@ public class BrokerBasedPropertiesOverride {
     brokerNetwork.setHeartbeatTimeout(network.getHeartbeatTimeout());
     brokerNetwork.setHeartbeatInterval(network.getHeartbeatInterval());
 
-    final var ucNetwork =
-        unifiedConfiguration.getCamunda().getCluster().getNetwork().withBrokerNetworkProperties();
-    override.getGateway().getNetwork().setMaxMessageSize(ucNetwork.getMaxMessageSize());
+    override.getGateway().getNetwork().setMaxMessageSize(network.getMaxMessageSize());
 
-    populateFromCommandApi(override);
-    populateFromInternalApi(override);
+    populateFromCommandApi(override, camunda);
+    populateFromInternalApi(override, camunda);
   }
 
-  private void populateFromInternalApi(final BrokerBasedProperties override) {
+  private void populateFromInternalApi(
+      final BrokerBasedProperties override, final Camunda camunda) {
     final InternalApi internalApi =
-        unifiedConfiguration
-            .getCamunda()
-            .getCluster()
-            .getNetwork()
-            .getInternalApi()
-            .withBrokerInternalApiProperties();
+        camunda.getCluster().getNetwork().getInternalApi().withBrokerInternalApiProperties();
 
     final SocketBindingCfg socketBindingCfg = override.getNetwork().getInternalApi();
 
@@ -597,9 +606,8 @@ public class BrokerBasedPropertiesOverride {
         .ifPresent(socketBindingCfg::setAdvertisedPort);
   }
 
-  private void populateFromCommandApi(final BrokerBasedProperties override) {
-    final CommandApi commandApi =
-        unifiedConfiguration.getCamunda().getCluster().getNetwork().getCommandApi();
+  private void populateFromCommandApi(final BrokerBasedProperties override, final Camunda camunda) {
+    final CommandApi commandApi = camunda.getCluster().getNetwork().getCommandApi();
     final CommandApiCfg commandApiCfg = override.getNetwork().getCommandApi();
 
     commandApiCfg.setHost(commandApi.getHost());
@@ -608,7 +616,8 @@ public class BrokerBasedPropertiesOverride {
     Optional.ofNullable(commandApi.getAdvertisedPort()).ifPresent(commandApiCfg::setAdvertisedPort);
   }
 
-  private void populateFromRestFilters(final BrokerBasedProperties override) {
+  private void populateFromRestFilters(
+      final BrokerBasedProperties override, final Camunda camunda) {
     // Order between legacy and new filters props is not guaranteed.
     // Log common filters warning instead of using UnifiedConfigurationHelper logging.
     if (!override.getGateway().getFilters().isEmpty()) {
@@ -619,78 +628,57 @@ public class BrokerBasedPropertiesOverride {
       LOGGER.warn(warningMessage);
     }
 
-    final List<Filter> filters = unifiedConfiguration.getCamunda().getApi().getRest().getFilters();
+    final List<Filter> filters = camunda.getApi().getRest().getFilters();
     if (!filters.isEmpty()) {
       final List<FilterCfg> filterCfgList = filters.stream().map(Filter::toFilterCfg).toList();
       override.getGateway().setFilters(filterCfgList);
     }
   }
 
-  private void populateFromSystem(final BrokerBasedProperties override) {
-    final var system = unifiedConfiguration.getCamunda().getSystem();
+  private void populateFromSystem(final BrokerBasedProperties override, final Camunda camunda) {
+    final var system = camunda.getSystem();
 
     final var threadsCfg = new ThreadsCfg();
     threadsCfg.setCpuThreadCount(system.getCpuThreadCount());
     threadsCfg.setIoThreadCount(system.getIoThreadCount());
     override.setThreads(threadsCfg);
 
-    final var enableVersionCheck =
-        unifiedConfiguration.getCamunda().getSystem().getUpgrade().getEnableVersionCheck();
+    final var enableVersionCheck = system.getUpgrade().getEnableVersionCheck();
     override.getExperimental().setVersionCheckRestrictionEnabled(enableVersionCheck);
   }
 
-  private void populateFromData(final BrokerBasedProperties override) {
-    final Data data = unifiedConfiguration.getCamunda().getData();
+  private void populateFromData(final BrokerBasedProperties override, final Camunda camunda) {
+    final Data data = camunda.getData();
     override.getData().setSnapshotPeriod(data.getSnapshotPeriod());
 
-    populateFromExport(override);
-    populateFromBackup(override);
+    populateFromExport(override, camunda);
+    populateFromBackup(override, camunda);
   }
 
-  private void populateFromExport(final BrokerBasedProperties override) {
-    final Export export = unifiedConfiguration.getCamunda().getData().getExport();
+  private void populateFromExport(final BrokerBasedProperties override, final Camunda camunda) {
+    final Export export = camunda.getData().getExport();
     final var exportingCfg =
         new ExportingCfg(export.getSkipRecords(), export.getDistributionInterval());
     override.setExporting(exportingCfg);
   }
 
-  private void populateFromBackup(final BrokerBasedProperties override) {
+  private void populateFromBackup(final BrokerBasedProperties override, final Camunda camunda) {
     final PrimaryStorageBackup primaryStorageBackup =
-        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup();
+        camunda.getData().getPrimaryStorage().getBackup();
     final BackupCfg backupCfg = override.getData().getBackup();
     backupCfg.setStore(BackupStoreType.valueOf(primaryStorageBackup.getStore().name()));
 
-    populateFromS3(override);
-    populateFromGcs(override);
-    populateFromAzure(override);
-    populateFromFilesystem(override);
+    populateFromS3(override, camunda);
+    populateFromGcs(override, camunda);
+    populateFromAzure(override, camunda);
+    populateFromFilesystem(override, camunda);
 
     override.getData().setBackup(backupCfg);
   }
 
-  private void populateFromS3(final BrokerBasedProperties override) {
-    final S3 s3 =
-        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getS3();
-    final S3BackupStoreConfig s3BackupStoreConfig = override.getData().getBackup().getS3();
-    s3BackupStoreConfig.setBucketName(s3.getBucketName());
-    s3BackupStoreConfig.setEndpoint(s3.getEndpoint());
-    s3BackupStoreConfig.setRegion(s3.getRegion());
-    s3BackupStoreConfig.setAccessKey(s3.getAccessKey());
-    s3BackupStoreConfig.setSecretKey(s3.getSecretKey());
-    s3BackupStoreConfig.setApiCallTimeout(s3.getApiCallTimeout());
-    s3BackupStoreConfig.setForcePathStyleAccess(s3.isForcePathStyleAccess());
-    s3BackupStoreConfig.setCompression(s3.getCompression());
-    s3BackupStoreConfig.setMaxConcurrentConnections(s3.getMaxConcurrentConnections());
-    s3BackupStoreConfig.setConnectionAcquisitionTimeout(s3.getConnectionAcquisitionTimeout());
-    s3BackupStoreConfig.setBasePath(s3.getBasePath());
-    s3BackupStoreConfig.setSupportLegacyMd5(s3.isSupportLegacyMd5());
-    s3BackupStoreConfig.setSsecKey(s3.getSsecKey());
-
-    override.getData().getBackup().setS3(s3BackupStoreConfig);
-  }
-
-  private void populateFromPrimaryStorage(final BrokerBasedProperties override) {
-    final var primaryStorage = unifiedConfiguration.getCamunda().getData().getPrimaryStorage();
+  private void populateFromPrimaryStorage(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var primaryStorage = camunda.getData().getPrimaryStorage();
     final var data = override.getData();
     data.setDirectory(primaryStorage.getDirectory());
     data.setRuntimeDirectory(primaryStorage.getRuntimeDirectory());
@@ -709,7 +697,7 @@ public class BrokerBasedPropertiesOverride {
     // Migrate RocksDB configuration from new unified config to old broker config structure
     populateFromRocksDb(override, primaryStorage);
 
-    populateBackupScheduler(override, primaryStorage.getBackup());
+    populateBackupScheduler(override, primaryStorage.getBackup(), camunda);
   }
 
   private void populateFromRocksDb(
@@ -742,9 +730,28 @@ public class BrokerBasedPropertiesOverride {
     brokerRocksDb.setEnableSstPartitioning(unifiedRocksDb.isSstPartitioningEnabled());
   }
 
-  private void populateFromGcs(final BrokerBasedProperties override) {
-    final Gcs gcs =
-        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getGcs();
+  private void populateFromS3(final BrokerBasedProperties override, final Camunda camunda) {
+    final S3 s3 = camunda.getData().getPrimaryStorage().getBackup().getS3();
+    final S3BackupStoreConfig s3BackupStoreConfig = override.getData().getBackup().getS3();
+    s3BackupStoreConfig.setBucketName(s3.getBucketName());
+    s3BackupStoreConfig.setEndpoint(s3.getEndpoint());
+    s3BackupStoreConfig.setRegion(s3.getRegion());
+    s3BackupStoreConfig.setAccessKey(s3.getAccessKey());
+    s3BackupStoreConfig.setSecretKey(s3.getSecretKey());
+    s3BackupStoreConfig.setApiCallTimeout(s3.getApiCallTimeout());
+    s3BackupStoreConfig.setForcePathStyleAccess(s3.isForcePathStyleAccess());
+    s3BackupStoreConfig.setCompression(s3.getCompression());
+    s3BackupStoreConfig.setMaxConcurrentConnections(s3.getMaxConcurrentConnections());
+    s3BackupStoreConfig.setConnectionAcquisitionTimeout(s3.getConnectionAcquisitionTimeout());
+    s3BackupStoreConfig.setBasePath(s3.getBasePath());
+    s3BackupStoreConfig.setSupportLegacyMd5(s3.isSupportLegacyMd5());
+    s3BackupStoreConfig.setSsecKey(s3.getSsecKey());
+
+    override.getData().getBackup().setS3(s3BackupStoreConfig);
+  }
+
+  private void populateFromGcs(final BrokerBasedProperties override, final Camunda camunda) {
+    final Gcs gcs = camunda.getData().getPrimaryStorage().getBackup().getGcs();
     final GcsBackupStoreConfig gcsBackupStoreConfig = override.getData().getBackup().getGcs();
     gcsBackupStoreConfig.setBucketName(gcs.getBucketName());
     gcsBackupStoreConfig.setBasePath(gcs.getBasePath());
@@ -756,9 +763,8 @@ public class BrokerBasedPropertiesOverride {
     override.getData().getBackup().setGcs(gcsBackupStoreConfig);
   }
 
-  private void populateFromAzure(final BrokerBasedProperties override) {
-    final Azure azure =
-        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getAzure();
+  private void populateFromAzure(final BrokerBasedProperties override, final Camunda camunda) {
+    final Azure azure = camunda.getData().getPrimaryStorage().getBackup().getAzure();
     final AzureBackupStoreConfig azureBackupStoreConfig = override.getData().getBackup().getAzure();
     azureBackupStoreConfig.setEndpoint(azure.getEndpoint());
     azureBackupStoreConfig.setAccountName(azure.getAccountName());
@@ -766,20 +772,14 @@ public class BrokerBasedPropertiesOverride {
     azureBackupStoreConfig.setConnectionString(azure.getConnectionString());
     azureBackupStoreConfig.setBasePath(azure.getBasePath());
     azureBackupStoreConfig.setCreateContainer(azure.isCreateContainer());
-    populateFromSasToken(override);
+    populateFromSasToken(override, camunda);
 
     override.getData().getBackup().setAzure(azureBackupStoreConfig);
   }
 
-  private void populateFromSasToken(final BrokerBasedProperties override) {
+  private void populateFromSasToken(final BrokerBasedProperties override, final Camunda camunda) {
     final SasToken sasToken =
-        unifiedConfiguration
-            .getCamunda()
-            .getData()
-            .getPrimaryStorage()
-            .getBackup()
-            .getAzure()
-            .getSasToken();
+        camunda.getData().getPrimaryStorage().getBackup().getAzure().getSasToken();
     final SasTokenConfig sasTokenConfig = override.getData().getBackup().getAzure().getSasToken();
 
     if (sasToken != null) {
@@ -793,9 +793,8 @@ public class BrokerBasedPropertiesOverride {
     }
   }
 
-  private void populateFromFilesystem(final BrokerBasedProperties override) {
-    final Filesystem filesystem =
-        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getFilesystem();
+  private void populateFromFilesystem(final BrokerBasedProperties override, final Camunda camunda) {
+    final Filesystem filesystem = camunda.getData().getPrimaryStorage().getBackup().getFilesystem();
     final FilesystemBackupStoreConfig filesystemBackupStoreConfig =
         override.getData().getBackup().getFilesystem();
     filesystemBackupStoreConfig.setBasePath(filesystem.getBasePath());
@@ -804,9 +803,10 @@ public class BrokerBasedPropertiesOverride {
   }
 
   private void populateBackupScheduler(
-      final BrokerBasedProperties override, final PrimaryStorageBackup primaryStorageBackup) {
-
-    validateSchedulerConfiguration(primaryStorageBackup);
+      final BrokerBasedProperties override,
+      final PrimaryStorageBackup primaryStorageBackup,
+      final Camunda camunda) {
+    validateSchedulerConfiguration(primaryStorageBackup, camunda);
 
     final BackupCfg backupCfg = override.getData().getBackup();
     backupCfg.setRequired(primaryStorageBackup.isRequired());
@@ -817,8 +817,9 @@ public class BrokerBasedPropertiesOverride {
     backupCfg.setRetention(primaryStorageBackup.getRetention());
   }
 
-  private void validateSchedulerConfiguration(final PrimaryStorageBackup primaryStorageBackup) {
-    final var dbType = unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getType();
+  private void validateSchedulerConfiguration(
+      final PrimaryStorageBackup primaryStorageBackup, final Camunda camunda) {
+    final var dbType = camunda.getData().getSecondaryStorage().getType();
 
     final var continuousBackupsEnabledOnDocumentBasedStore =
         (dbType.isElasticSearch() || dbType.isOpenSearch())
@@ -836,6 +837,10 @@ public class BrokerBasedPropertiesOverride {
         && !primaryStorageBackup.getSchedule().isBlank()
         && !primaryStorageBackup.getSchedule().equalsIgnoreCase("none");
   }
+
+  // The auto-configured exporters (camundaexporter / rdbms) are populated from the cluster-wide
+  // unifiedConfiguration: secondary-storage connection details cannot be overridden per physical
+  // tenant, so these methods intentionally do not take a Camunda parameter.
 
   private void populateCamundaExporter(final BrokerBasedProperties override) {
     final Data data = unifiedConfiguration.getCamunda().getData();
@@ -1046,12 +1051,12 @@ public class BrokerBasedPropertiesOverride {
     history.setMaxHistoryCleanupUsage(database.getHistory().getMaxHistoryCleanupUsage());
   }
 
-  private void populateFromMonitoring(final BrokerBasedProperties override) {
-    populateFromMetrics(override);
+  private void populateFromMonitoring(final BrokerBasedProperties override, final Camunda camunda) {
+    populateFromMetrics(override, camunda);
   }
 
-  private void populateFromMetrics(final BrokerBasedProperties override) {
-    final Metrics metrics = unifiedConfiguration.getCamunda().getMonitoring().getMetrics();
+  private void populateFromMetrics(final BrokerBasedProperties override, final Camunda camunda) {
+    final Metrics metrics = camunda.getMonitoring().getMetrics();
     override.getExperimental().getFeatures().setEnableActorMetrics(metrics.isActor());
     override.setExecutionMetricsExporterEnabled(metrics.isEnableExporterExecutionMetrics());
 
@@ -1082,9 +1087,8 @@ public class BrokerBasedPropertiesOverride {
     cursor.put(keys[keys.length - 1], value);
   }
 
-  private void populateFromExporters(final BrokerBasedProperties override) {
-    final Map<String, Exporter> exporters =
-        unifiedConfiguration.getCamunda().getData().getExporters();
+  private void populateFromExporters(final BrokerBasedProperties override, final Camunda camunda) {
+    final Map<String, Exporter> exporters = camunda.getData().getExporters();
 
     // Log common legacy exporters warning instead of using UnifiedConfigurationHelper logging.
     if (!override.getExporters().isEmpty()) {
@@ -1099,16 +1103,17 @@ public class BrokerBasedPropertiesOverride {
         (name, exporter) -> override.getExporters().put(name, exporter.toExporterCfg()));
   }
 
-  private void populateFromGlobalListeners(final BrokerBasedProperties override) {
+  private void populateFromGlobalListeners(
+      final BrokerBasedProperties override, final Camunda camunda) {
     override
         .getExperimental()
         .getEngine()
-        .setGlobalListeners(unifiedConfiguration.getCamunda().getCluster().getGlobalListeners());
+        .setGlobalListeners(camunda.getCluster().getGlobalListeners());
   }
 
-  private void populateFromProcessInstanceCreation(final BrokerBasedProperties override) {
-    final var processInstanceCreation =
-        unifiedConfiguration.getCamunda().getProcessInstanceCreation();
+  private void populateFromProcessInstanceCreation(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var processInstanceCreation = camunda.getProcessInstanceCreation();
     final var processInstanceCreationCfg =
         override.getExperimental().getEngine().getProcessInstanceCreation();
     processInstanceCreationCfg.setBusinessIdUniquenessEnabled(
@@ -1129,17 +1134,12 @@ public class BrokerBasedPropertiesOverride {
         processInstanceCreation.getMessageStartLockReleasePollBatchLimit());
   }
 
-  private void populateFromJobs(final BrokerBasedProperties override) {
+  private void populateFromJobs(final BrokerBasedProperties override, final Camunda camunda) {
     override
         .getExperimental()
         .getEngine()
         .getJobs()
         .setIncludeVariablesInJobCompletedEvent(
-            unifiedConfiguration
-                .getCamunda()
-                .getProcessing()
-                .getEngine()
-                .getJob()
-                .isIncludeVariablesInJobCompletedEvent());
+            camunda.getProcessing().getEngine().getJob().isIncludeVariablesInJobCompletedEvent());
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -10,7 +10,10 @@ package io.camunda.zeebe.broker;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Processing;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
@@ -27,6 +30,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
 import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
@@ -80,6 +84,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final SearchClientsProxy searchClientsProxy;
   private final NodeIdProvider nodeIdProvider;
   private final PhysicalTenantIds physicalTenantIds;
+  private final BrokerBasedPropertiesOverride brokerBasedPropertiesOverride;
+  private final UnifiedConfiguration unifiedConfiguration;
 
   private Broker broker;
 
@@ -94,6 +100,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       final BrokerShutdownHelper shutdownHelper,
       final MeterRegistry meterRegistry,
       final PhysicalTenantResolver physicalTenantResolver,
+      final BrokerBasedPropertiesOverride brokerBasedPropertiesOverride,
+      final UnifiedConfiguration unifiedConfiguration,
       // The ServiceRegistry is not available if you want to start-up the Standalone Broker
       @Autowired(required = false) final ServiceRegistry serviceRegistry,
       final PasswordEncoder passwordEncoder,
@@ -111,8 +119,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.brokerClient = brokerClient;
     this.shutdownHelper = shutdownHelper;
     this.meterRegistry = meterRegistry;
-    this.physicalTenantEngineContexts =
-        physicalTenantResolver.mapValues(this::buildPhysicalTenantEngineContext);
+    this.brokerBasedPropertiesOverride = brokerBasedPropertiesOverride;
+    this.unifiedConfiguration = unifiedConfiguration;
     this.serviceRegistry = serviceRegistry;
     this.passwordEncoder = passwordEncoder;
     this.scopedJwtDecoderFactory = scopedJwtDecoderFactory;
@@ -120,6 +128,9 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.searchClientsProxy = searchClientsProxy;
     this.nodeIdProvider = nodeIdProvider;
     this.physicalTenantIds = physicalTenantIds;
+    // must run after all fields are assigned: buildPhysicalTenantEngineContext reads them
+    physicalTenantEngineContexts =
+        physicalTenantResolver.mapValues(this::buildPhysicalTenantEngineContext);
   }
 
   @Bean
@@ -187,8 +198,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     }
   }
 
-  private PhysicalTenantEngineContext buildPhysicalTenantEngineContext(
-      final io.camunda.configuration.Camunda camunda) {
+  private PhysicalTenantEngineContext buildPhysicalTenantEngineContext(final Camunda camunda) {
     final var s = camunda.getSecurity();
     final var securityConfig =
         new EngineSecurityConfig(
@@ -200,7 +210,26 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             s.getCompiledGroupIdValidationPattern());
     final var authorizationConverter = new BrokerRequestAuthorizationConverter(securityConfig);
     final var featureFlags = buildFeatureFlags(camunda.getProcessing());
-    return new PhysicalTenantEngineContext(securityConfig, authorizationConverter, featureFlags);
+    return new PhysicalTenantEngineContext(
+        securityConfig, authorizationConverter, featureFlags, buildBrokerConfig(camunda));
+  }
+
+  private BrokerCfg buildBrokerConfig(final Camunda tenantConfig) {
+    // The resolver maps the default tenant to the root Camunda object unless it is explicitly
+    // declared under camunda.physical-tenants.default.*. For the root object, reuse the root
+    // BrokerBasedProperties bean directly: it is the exact configuration the broker always ran
+    // with, including legacy zeebe.broker.* properties that per-tenant keys cannot express.
+    if (tenantConfig == unifiedConfiguration.getCamunda()) {
+      return configuration.config();
+    }
+    final var brokerConfig = brokerBasedPropertiesOverride.convert(tenantConfig);
+    // stamp nodeId/nodeVersion and resolve relative paths, mirroring what
+    // BrokerBasedConfiguration does for the root BrokerBasedProperties bean
+    final var nodeInstance = nodeIdProvider.currentNodeInstance();
+    brokerConfig.getCluster().setNodeId(nodeInstance.id());
+    brokerConfig.getCluster().setNodeVersion(nodeInstance.version().version());
+    brokerConfig.init(configuration.workingDirectory().path().toAbsolutePath().toString());
+    return brokerConfig;
   }
 
   private FeatureFlags buildFeatureFlags(final Processing p) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsageMetricsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsageMetricsIT.java
@@ -21,9 +21,12 @@ import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator.AddTimeRequest;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -53,8 +56,13 @@ public class UsageMetricsIT {
           .withMultiTenancyEnabled()
           .withAuthenticatedAccess()
           // set exportInterval via properties because it is not yet supported in unified config
+          // (https://github.com/camunda/camunda/issues/56077). Legacy zeebe.broker.* properties
+          // are not applied to per-physical-tenant configuration, so under physical-tenant mode
+          // the export is triggered by advancing the broker clock instead — see
+          // advanceClockPastExportInterval().
           .withProperty(
-              "zeebe.broker.experimental.engine.usageMetrics.exportInterval", EXPORT_INTERVAL);
+              "zeebe.broker.experimental.engine.usageMetrics.exportInterval", EXPORT_INTERVAL)
+          .withProperty("zeebe.clock.controlled", "true");
 
   private static final String ADMIN = "admin";
   private static final String ASSIGNEE = "bar2";
@@ -69,6 +77,45 @@ public class UsageMetricsIT {
   private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
 
   private static OffsetDateTime exportedTime;
+
+  /**
+   * Advances the broker clock past the default usage-metrics export interval (5 minutes) so the
+   * engine's {@code UsageMetricsCheckScheduler} fires on every partition group.
+   *
+   * <p>Needed because the export interval is only configurable via legacy {@code zeebe.broker.*}
+   * properties, which are not applied to per-physical-tenant configuration — under physical-tenant
+   * mode the tenant's partition group runs with the 5-minute default. Once <a
+   * href="https://github.com/camunda/camunda/issues/56077">#56077</a> adds the property to the
+   * unified configuration, the interval can be set there (inherited by all physical tenants) and
+   * this clock manipulation can be removed.
+   *
+   * <p>No-op when the broker actuator is not reachable (e.g. compatibility-mode runs against a
+   * containerized broker), where the short export interval is configured via environment variable
+   * instead.
+   */
+  private static void advanceClockPastExportInterval() {
+    try {
+      ActorClockActuator.of(BROKER.actuatorUri("clock").toString())
+          .addTime(new AddTimeRequest(Duration.ofMinutes(5).plusSeconds(1).toMillis()));
+    } catch (final Exception e) {
+      // broker actuator not available (compatibility mode); rely on the configured interval
+    }
+  }
+
+  /**
+   * Returns the broker's current (possibly clock-advanced) time, falling back to wall-clock time
+   * when the actuator is not reachable. Metric record timestamps follow the broker clock, so
+   * interval assertions must use it as well.
+   */
+  private static OffsetDateTime currentBrokerTime() {
+    try {
+      return OffsetDateTime.ofInstant(
+          ActorClockActuator.of(BROKER.actuatorUri("clock").toString()).getCurrentClock().instant(),
+          ZoneOffset.UTC);
+    } catch (final Exception e) {
+      return OffsetDateTime.now();
+    }
+  }
 
   private static void waitForUsageMetrics(
       final CamundaClient camundaClient,
@@ -99,6 +146,7 @@ public class UsageMetricsIT {
     deployResource(adminClient, "process/process_with_assigned_user_task.bpmn", TENANT_A);
     startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
     startProcessInstance(adminClient, PROCESS_ID_2, TENANT_A);
+    advanceClockPastExportInterval();
     waitForUsageMetrics(
         adminClient,
         NOW.minusDays(1),
@@ -110,7 +158,7 @@ public class UsageMetricsIT {
         });
 
     // Store first export time & wait 2 export intervals
-    exportedTime = OffsetDateTime.now();
+    exportedTime = currentBrokerTime();
     Thread.sleep(2 * EXPORT_INTERVAL.toMillis());
 
     // Create second batch of metrics
@@ -144,6 +192,7 @@ public class UsageMetricsIT {
     assertDecisionsInstantiated(adminClient);
 
     // Wait for all metrics to be exported
+    advanceClockPastExportInterval();
     waitForUsageMetrics(
         adminClient,
         NOW.minusDays(1),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -63,6 +63,11 @@ public final class Broker implements AutoCloseable {
     this.systemContext = systemContext;
     this.exporterRepository = exporterRepository;
 
+    // at this point the repository contains only predefined (e.g. Spring-injected) descriptors;
+    // buildExporterRepository below merges the configured exporters into the same instance
+    final var predefinedExporterDescriptors =
+        List.copyOf(exporterRepository.getExporters().values());
+
     final ActorScheduler scheduler = this.systemContext.getScheduler();
     final BrokerInfo localBroker = createBrokerInfo(getConfig());
     final var cluster = getConfig().getCluster();
@@ -84,6 +89,7 @@ public final class Broker implements AutoCloseable {
             scheduler,
             healthCheckService,
             buildExporterRepository(getConfig()),
+            predefinedExporterDescriptors,
             new ClusterServicesImpl(systemContext.getCluster()),
             systemContext.getBrokerClient(),
             additionalPartitionListeners,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
@@ -106,6 +107,13 @@ public interface BrokerStartupContext {
   void setDiskSpaceUsageMonitor(DiskSpaceUsageMonitor diskSpaceUsageMonitor);
 
   ExporterRepository getExporterRepository();
+
+  /**
+   * Returns the exporter descriptors that were predefined (e.g. injected as Spring beans) rather
+   * than loaded from the exporter configuration. Per-physical-tenant exporter repositories are
+   * seeded with these, since predefined exporters cannot be re-created by class-name loading.
+   */
+  List<ExporterDescriptor> getPredefinedExporterDescriptors();
 
   /** Returns all currently registered partition managers, keyed by physical tenant ID. */
   Map<String, PartitionManager> getPartitionManagers();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
@@ -64,6 +65,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final ActorSchedulingService actorScheduler;
   private final BrokerHealthCheckService healthCheckService;
   private final ExporterRepository exporterRepository;
+  private final List<ExporterDescriptor> predefinedExporterDescriptors;
   private final ClusterServicesImpl clusterServices;
   private final BrokerClient brokerClient;
   private final List<PartitionListener> partitionListeners = new ArrayList<>();
@@ -102,6 +104,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final ActorSchedulingService actorScheduler,
       final BrokerHealthCheckService healthCheckService,
       final ExporterRepository exporterRepository,
+      final List<ExporterDescriptor> predefinedExporterDescriptors,
       final ClusterServicesImpl clusterServices,
       final BrokerClient brokerClient,
       final List<PartitionListener> additionalPartitionListeners,
@@ -122,6 +125,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.actorScheduler = requireNonNull(actorScheduler);
     this.healthCheckService = requireNonNull(healthCheckService);
     this.exporterRepository = requireNonNull(exporterRepository);
+    this.predefinedExporterDescriptors = List.copyOf(predefinedExporterDescriptors);
     this.clusterServices = requireNonNull(clusterServices);
     this.identityConfiguration = identityConfiguration;
     this.brokerClient = brokerClient;
@@ -275,6 +279,11 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public ExporterRepository getExporterRepository() {
     return exporterRepository;
+  }
+
+  @Override
+  public List<ExporterDescriptor> getPredefinedExporterDescriptors() {
+    return predefinedExporterDescriptors;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -12,9 +12,12 @@ import io.atomix.raft.partition.RaftPartition;
 import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
+import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.jar.ExternalJarLoadException;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
@@ -68,11 +71,19 @@ public interface PartitionManager {
       final String physicalTenantId,
       final TopologyManagerImpl topologyManager) {
     final var engineContext = brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
+    final var perTenantBrokerConfig = engineContext.brokerConfig();
+    // The default tenant's engine context carries the root BrokerCfg itself; reuse the shared
+    // repository already loaded by the Broker (it may also contain predefined descriptors
+    // injected by embedding applications and tests).
+    final var perTenantExporterRepository =
+        perTenantBrokerConfig == brokerStartupContext.getBrokerConfiguration()
+            ? brokerStartupContext.getExporterRepository()
+            : buildExporterRepository(perTenantBrokerConfig);
     return new PartitionManagerImpl(
         physicalTenantId,
         brokerStartupContext.getConcurrencyControl(),
         brokerStartupContext.getActorSchedulingService(),
-        brokerStartupContext.getBrokerConfiguration(),
+        perTenantBrokerConfig,
         brokerStartupContext.getBrokerInfo(),
         brokerStartupContext.getClusterServices(),
         brokerStartupContext.getHealthCheckService(),
@@ -80,7 +91,7 @@ public interface PartitionManager {
         brokerStartupContext.getPartitionListeners(),
         brokerStartupContext.getPartitionRaftListeners(),
         brokerStartupContext.getSnapshotApiRequestHandler(),
-        brokerStartupContext.getExporterRepository(),
+        perTenantExporterRepository,
         brokerStartupContext.getGatewayBrokerTransport(),
         brokerStartupContext.getJobStreamService().jobStreamer(),
         brokerStartupContext.getClusterConfigurationService(),
@@ -92,6 +103,21 @@ public interface PartitionManager {
         engineContext.authorizationConverter(),
         engineContext.featureFlags(),
         topologyManager);
+  }
+
+  private static ExporterRepository buildExporterRepository(
+      final io.camunda.zeebe.broker.system.configuration.BrokerCfg brokerCfg) {
+    final var repository = new ExporterRepository();
+    repository.setLicenseKey(brokerCfg.getLicenseKey());
+    for (final var entry : brokerCfg.getExporters().entrySet()) {
+      try {
+        repository.load(entry.getKey(), entry.getValue());
+      } catch (final ExporterLoadException | ExternalJarLoadException e) {
+        throw new IllegalStateException(
+            "Failed to load per-tenant exporter with configuration: " + entry.getValue(), e);
+      }
+    }
+    return repository;
   }
 
   static RecoveryPartitionManager createRecoveryPartitionManager(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -12,6 +12,7 @@ import io.atomix.raft.partition.RaftPartition;
 import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.jar.ExternalJarLoadException;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 
@@ -78,7 +80,8 @@ public interface PartitionManager {
     final var perTenantExporterRepository =
         perTenantBrokerConfig == brokerStartupContext.getBrokerConfiguration()
             ? brokerStartupContext.getExporterRepository()
-            : buildExporterRepository(perTenantBrokerConfig);
+            : buildExporterRepository(
+                perTenantBrokerConfig, brokerStartupContext.getPredefinedExporterDescriptors());
     return new PartitionManagerImpl(
         physicalTenantId,
         brokerStartupContext.getConcurrencyControl(),
@@ -106,8 +109,12 @@ public interface PartitionManager {
   }
 
   private static ExporterRepository buildExporterRepository(
-      final io.camunda.zeebe.broker.system.configuration.BrokerCfg brokerCfg) {
-    final var repository = new ExporterRepository();
+      final io.camunda.zeebe.broker.system.configuration.BrokerCfg brokerCfg,
+      final List<ExporterDescriptor> predefinedExporterDescriptors) {
+    // seed with predefined (e.g. Spring-injected) descriptors: they cannot be re-created from
+    // configuration by class-name loading, and load() below skips ids that are already present —
+    // mirroring how the shared root repository treats them
+    final var repository = new ExporterRepository(predefinedExporterDescriptors);
     repository.setLicenseKey(brokerCfg.getLicenseKey());
     for (final var entry : brokerCfg.getExporters().entrySet()) {
       try {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/PhysicalTenantEngineContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/PhysicalTenantEngineContext.java
@@ -9,13 +9,18 @@ package io.camunda.zeebe.broker.system;
 
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.util.FeatureFlags;
 
 /**
  * Bundles all per-physical-tenant objects required to bootstrap the engine for a given physical
  * tenant. Passed as a single unit through the broker startup chain instead of three parallel maps.
+ *
+ * <p>BrokerConfig included here contains the configuration for the physical tenant. It differs from
+ * the root BrokerCfg for the properties that are overridden for this physical tenant.
  */
 public record PhysicalTenantEngineContext(
     EngineSecurityConfig securityConfig,
     BrokerRequestAuthorizationConverter authorizationConverter,
-    FeatureFlags featureFlags) {}
+    FeatureFlags featureFlags,
+    BrokerCfg brokerConfig) {}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -378,7 +378,10 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
         physicalTenantId,
         id ->
             new PhysicalTenantEngineContext(
-                securityConfiguration, brokerRequestAuthorizationConverter, featureFlags));
+                securityConfiguration,
+                brokerRequestAuthorizationConverter,
+                featureFlags,
+                brokerConfiguration));
   }
 
   public void setPhysicalTenantEngineContext(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
@@ -267,6 +268,11 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   @Override
   public ExporterRepository getExporterRepository() {
     return exporterRepository;
+  }
+
+  @Override
+  public List<ExporterDescriptor> getPredefinedExporterDescriptors() {
+    return List.of();
   }
 
   public void setExporterRepository(final ExporterRepository exporterRepository) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -224,9 +224,13 @@ class PartitionManagerStepTest {
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
       final var conv = new BrokerRequestAuthorizationConverter(secCfg);
       testBrokerStartupContext.setPhysicalTenantEngineContext(
-          PHYSICAL_TENANT_ID, new PhysicalTenantEngineContext(secCfg, conv, flagsA));
+          PHYSICAL_TENANT_ID,
+          new PhysicalTenantEngineContext(
+              secCfg, conv, flagsA, testBrokerStartupContext.getBrokerConfiguration()));
       testBrokerStartupContext.setPhysicalTenantEngineContext(
-          secondTenantId, new PhysicalTenantEngineContext(secCfg, conv, flagsB));
+          secondTenantId,
+          new PhysicalTenantEngineContext(
+              secCfg, conv, flagsB, testBrokerStartupContext.getBrokerConfiguration()));
 
       final var secondFuture = CONCURRENCY_CONTROL.<BrokerStartupContext>createFuture();
       final var secondStep = new PartitionManagerStep(secondTenantId);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -589,10 +589,11 @@ final class SystemContextTest {
     // given
     final var tenantId = PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
     final var flags = FeatureFlags.createDefaultForTests();
+    final var brokerCfg = new BrokerCfg();
     final var ctx =
         new SystemContext(
             SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
-            new BrokerCfg(),
+            brokerCfg,
             null,
             mock(ActorScheduler.class),
             mock(AtomixCluster.class),
@@ -603,7 +604,8 @@ final class SystemContextTest {
                 new PhysicalTenantEngineContext(
                     EngineSecurityConfigurations.defaultConfig(),
                     mock(BrokerRequestAuthorizationConverter.class),
-                    flags)),
+                    flags,
+                    brokerCfg)),
             ignored -> mock(UserServices.class),
             mock(PasswordEncoder.class),
             authConfig -> mock(JwtDecoder.class),
@@ -672,7 +674,8 @@ final class SystemContextTest {
                     new PhysicalTenantEngineContext(
                         configsByTenant.get(tenantId),
                         convertersByTenant.get(tenantId),
-                        FeatureFlags.createDefaultForTests())));
+                        FeatureFlags.createDefaultForTests(),
+                        brokerCfg)));
     return new SystemContext(
         SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
         brokerCfg,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -108,7 +108,10 @@ public final class SystemContextTestFactory {
         singleValueMap(
             physicalTenantIds,
             new PhysicalTenantEngineContext(
-                securityConfiguration, brokerRequestAuthorizationConverter, featureFlags)),
+                securityConfiguration,
+                brokerRequestAuthorizationConverter,
+                featureFlags,
+                brokerCfg)),
         tenantId -> userServices,
         passwordEncoder,
         authConfig -> jwtDecoder,

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Verifies that per-physical-tenant exporter configuration is applied at the exporter level.
+ *
+ * <p>Supported today: an exporter declared in the <b>root</b> configuration can be redeclared per
+ * physical tenant under {@code camunda.physical-tenants.<tenantId>.data.exporters.<id>.*} with
+ * different properties. The per-tenant declaration must be complete (class-name and all args):
+ * partial overrides do not inherit the root entry's remaining fields (Spring's MapBinder replaces
+ * the whole map entry; a merge strategy is discussed in a separate issue). Each tenant's partition
+ * group then runs the exporter with that tenant's configuration.
+ *
+ * <p>Not yet supported: declaring an exporter <b>only</b> for a physical tenant (absent from the
+ * root config). The initial cluster configuration — which decides which exporter ids are enabled on
+ * a partition — is still generated from the root {@code BrokerCfg} only, so a tenant-only exporter
+ * is never enabled. See the disabled test below; this will be addressed once the
+ * cluster-configuration layer supports per-physical-tenant exporters.
+ */
+@Timeout(120)
+@ZeebeIntegration
+final class PhysicalTenantExporterConfigIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String LOCATION_EXPORTER_ID = "location-exporter";
+  private static final String TARGET_ARG = "target";
+  private static final String ROOT_TARGET = "root-location";
+  private static final String TENANT_A_TARGET = "tenanta-location";
+
+  private static final String TENANT_A_ONLY_EXPORTER_ID = "tenanta-exporter";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  // The exporter is declared in the ROOT config (so it is enabled on every partition group), and
+  // tenantA redeclares it fully with a different "target" arg. The tenantA-only exporter
+  // exercises the not-yet-supported case and is used by the disabled test only.
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS
+          .configure(new TestStandaloneBroker().withUnauthenticatedAccess())
+          .withExporter(
+              LOCATION_EXPORTER_ID,
+              cfg -> {
+                cfg.setClassName(LocationRecordingExporter.class.getName());
+                cfg.setArgs(Map.of(TARGET_ARG, ROOT_TARGET));
+              })
+          .withPtConfig(
+              TENANT_A,
+              camunda -> {
+                final var exporter = new io.camunda.configuration.Exporter();
+                exporter.setClassName(LocationRecordingExporter.class.getName());
+                exporter.setArgs(Map.of(TARGET_ARG, TENANT_A_TARGET));
+                camunda.getData().getExporters().put(LOCATION_EXPORTER_ID, exporter);
+
+                final var tenantOnlyExporter = new io.camunda.configuration.Exporter();
+                tenantOnlyExporter.setClassName(TenantAExporter.class.getName());
+                camunda.getData().getExporters().put(TENANT_A_ONLY_EXPORTER_ID, tenantOnlyExporter);
+              });
+
+  @AutoClose private CamundaClient tenantAClient;
+  @AutoClose private CamundaClient defaultClient;
+
+  @BeforeEach
+  void setUp() {
+    LocationRecordingExporter.reset();
+    TenantAExporter.reset();
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+  }
+
+  /**
+   * Asserts that a root-declared exporter runs on both tenants' partition groups, and that each
+   * partition group sees the exporter args of its own tenant: the default tenant exports to the
+   * root-configured target, while tenantA exports to the target redeclared under {@code
+   * camunda.physical-tenants.tenanta.data.exporters.*}.
+   */
+  @Test
+  void shouldApplyPerTenantExporterArgsOverride() {
+    // given — deploy a process to each tenant so records flow through both partition groups
+    deployAndCreateInstance(defaultClient, "default-process");
+    deployAndCreateInstance(tenantAClient, "tenanta-process");
+
+    // then — the exporter instance on the default partition group was configured with the root
+    // target and received records, and the instance on tenantA's partition group was configured
+    // with tenantA's overridden target and received records.
+    await("exporter receives records under both the root and the tenantA target")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              assertThat(LocationRecordingExporter.RECORDS_BY_TARGET)
+                  .containsKey(ROOT_TARGET)
+                  .containsKey(TENANT_A_TARGET);
+              assertThat(LocationRecordingExporter.RECORDS_BY_TARGET.get(ROOT_TARGET)).isNotEmpty();
+              assertThat(LocationRecordingExporter.RECORDS_BY_TARGET.get(TENANT_A_TARGET))
+                  .isNotEmpty();
+            });
+
+    // and no exporter instance was configured with anything but the two expected targets
+    assertThat(LocationRecordingExporter.RECORDS_BY_TARGET.keySet())
+        .containsOnly(ROOT_TARGET, TENANT_A_TARGET);
+  }
+
+  /**
+   * Asserts that an exporter declared only in {@code tenantA}'s config (absent from the root
+   * config) is opened and receives records from {@code tenantA}'s partition group.
+   *
+   * <p>Disabled: the initial cluster configuration that decides which exporter ids are enabled per
+   * partition is still generated from the root {@code BrokerCfg} only
+   * (StaticConfigurationGenerator), so a tenant-only exporter is never enabled even though it is
+   * present in the tenant's ExporterRepository. To be re-enabled once the cluster-configuration
+   * layer supports per-physical-tenant exporters.
+   */
+  @Disabled(
+      "Tenant-only exporters require per-physical-tenant exporter support in the"
+          + " cluster-configuration layer (initial DynamicPartitionConfig is generated from the"
+          + " root BrokerCfg only); tracked in"
+          + " https://github.com/camunda/camunda/issues/56652")
+  @Test
+  void shouldApplyExporterConfiguredOnlyForPhysicalTenant() {
+    // given — records flow through tenantA's partition group
+    deployAndCreateInstance(tenantAClient, "tenanta-only-process");
+
+    // then — the exporter configured only for tenantA should be opened on tenantA's partition and
+    // should receive exported records
+    await("tenant-only exporter is opened and receives records from tenantA's partition")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> assertThat(TenantAExporter.RECORDS).isNotEmpty());
+  }
+
+  private static void deployAndCreateInstance(final CamundaClient client, final String processId) {
+    final var process = Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+
+    // the tenant's Raft group may need a moment to elect a leader after startup
+    await("deployment succeeds for " + processId)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, processId + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+
+    client.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send().join();
+  }
+
+  /**
+   * A minimal {@link Exporter} that records exported record positions keyed by the {@code target}
+   * arg it was configured with. Static state so assertions can observe it from outside the exporter
+   * lifecycle; call {@link #reset()} in {@code @BeforeEach} to isolate test runs.
+   */
+  public static final class LocationRecordingExporter implements Exporter {
+
+    static final Map<String, CopyOnWriteArrayList<Long>> RECORDS_BY_TARGET =
+        new ConcurrentHashMap<>();
+
+    private String target;
+    private Controller controller;
+
+    static void reset() {
+      RECORDS_BY_TARGET.clear();
+    }
+
+    @Override
+    public void configure(final Context context) {
+      target = String.valueOf(context.getConfiguration().getArguments().get(TARGET_ARG));
+    }
+
+    @Override
+    public void open(final Controller controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      RECORDS_BY_TARGET
+          .computeIfAbsent(target, ignored -> new CopyOnWriteArrayList<>())
+          .add(record.getPosition());
+      controller.updateLastExportedRecordPosition(record.getPosition());
+    }
+  }
+
+  /**
+   * A minimal {@link Exporter} used by the disabled tenant-only test. Records whether it was opened
+   * and collects exported record positions.
+   */
+  public static final class TenantAExporter implements Exporter {
+
+    static final AtomicBoolean OPENED = new AtomicBoolean(false);
+    static final CopyOnWriteArrayList<Long> RECORDS = new CopyOnWriteArrayList<>();
+
+    private Controller controller;
+
+    static void reset() {
+      OPENED.set(false);
+      RECORDS.clear();
+    }
+
+    @Override
+    public void configure(final Context context) {}
+
+    @Override
+    public void open(final Controller controller) {
+      this.controller = controller;
+      OPENED.set(true);
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      RECORDS.add(record.getPosition());
+      controller.updateLastExportedRecordPosition(record.getPosition());
+    }
+  }
+}


### PR DESCRIPTION
## Description

Configuration declared under `camunda.physical-tenants.<tenantId>.*` was silently ignored by the broker: `BrokerBasedPropertiesOverride` converted only the root `Camunda` object into `BrokerCfg`, and all partition groups shared the root `BrokerCfg` and a single `ExporterRepository` built from it.

### Changes

- **`BrokerBasedPropertiesOverride`** now populates `BrokerBasedProperties` through a single `populateFromCamunda(props, camunda)` path used by both the root bean and the new `convert(Camunda)` method, so the two cannot drift when new populate methods are added. All `populateFrom*` methods take the `Camunda` to read from; only the auto-configured exporter methods (camunda/rdbms) keep reading the cluster-wide `UnifiedConfiguration`, since secondary-storage connection details cannot be overridden per tenant.
- **`PhysicalTenantEngineContext`** carries the per-tenant `BrokerCfg` through the broker startup chain. `BrokerModuleConfiguration` builds it per tenant, stamping `nodeId`/`nodeVersion` and calling `init()` as `BrokerBasedConfiguration` does for the root bean.
- **The default tenant reuses the root `BrokerBasedProperties` bean** instead of a rebuilt copy. This preserves legacy `zeebe.broker.*` properties (which per-tenant keys cannot express) and keeps the default partition group's behaviour identical to before.
- **`PartitionManager`** passes the per-tenant `BrokerCfg` and a per-tenant `ExporterRepository` to `PartitionManagerImpl`; the default tenant keeps the shared repository (including predefined descriptors injected by embedding applications and tests).

### Scope and limitations

- Supported: an exporter declared in the root configuration can be redeclared per tenant with different properties; each tenant's partition group runs it with its own tenant's configuration. The per-tenant declaration must be complete (class-name and all args) — partial overrides do not inherit the root entry's remaining fields (a merge strategy is a separate discussion).
- Not yet supported: declaring an exporter *only* for a tenant. The initial `DynamicPartitionConfig` exporter states are still generated from the root `BrokerCfg`, so a tenant-only exporter is never enabled. Tracked in #56652 (depends on #56018); the corresponding IT is included but `@Disabled`.

### Alternatives considered

- Keeping separate root/per-tenant populate paths in the mapper — rejected as drift-prone (a new populate method added to one path would silently not apply to the other).
- Rebuilding the default tenant's `BrokerCfg` like any other tenant — rejected because it drops legacy `zeebe.broker.*` properties and predefined `ExporterDescriptor`s, changing existing behaviour.

Closes #56517
