### PR TITLE
fix: make optional document metadata fields optional in zod schema

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
-		"@camunda/camunda-api-zod-schemas": "0.0.79",
+		"@camunda/camunda-api-zod-schemas": "0.0.80",
 		"@camunda/camunda-composite-components": "0.24.0",
 		"@carbon/react": "1.109.0",
 		"@carbon/type": "11.61.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -28,7 +28,7 @@
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
-				"@camunda/camunda-api-zod-schemas": "0.0.79",
+				"@camunda/camunda-api-zod-schemas": "0.0.80",
 				"@camunda/camunda-composite-components": "0.24.0",
 				"@carbon/react": "1.109.0",
 				"@carbon/type": "11.61.0",
@@ -11140,13 +11140,13 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.79",
+				"@camunda/camunda-api-zod-schemas": "0.0.80",
 				"typescript": "6.0.3"
 			}
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.79",
+			"version": "0.0.80",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "25.9.3",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.79",
+		"@camunda/camunda-api-zod-schemas": "0.0.80",
 		"typescript": "6.0.3"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.0.80
+
+### 🩹 Fixes
+
+- Make optional `DocumentMetadata` fields (`expiresAt`, `processDefinitionId`, `processInstanceKey`, `customProperties`) optional in the 8.10 document schema, so connector-produced document references that omit these keys are recognized as documents ([#56657](https://github.com/camunda/camunda/issues/56657))
+
+### ❤️ Contributors
+
+- Omran Abazid ([@OmranAbazid](https://github.com/OmranAbazid))
+
 ## v0.0.79
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/document.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/document.ts
@@ -16,7 +16,7 @@ const documentMetadataSchema = z.object({
 	size: z.number(),
 	processDefinitionId: z.string().nullish(),
 	processInstanceKey: z.string().nullish(),
-	customProperties: z.record(z.string(), z.unknown()).optional(),
+	customProperties: z.record(z.string(), z.unknown()).nullish(),
 });
 type DocumentMetadata = z.infer<typeof documentMetadataSchema>;
 

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/document.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/document.ts
@@ -12,11 +12,11 @@ import {API_VERSION, type Endpoint} from './common';
 const documentMetadataSchema = z.object({
 	contentType: z.string(),
 	fileName: z.string(),
-	expiresAt: z.string().nullable(),
+	expiresAt: z.string().nullish(),
 	size: z.number(),
-	processDefinitionId: z.string().nullable(),
-	processInstanceKey: z.string().nullable(),
-	customProperties: z.record(z.string(), z.unknown()),
+	processDefinitionId: z.string().nullish(),
+	processInstanceKey: z.string().nullish(),
+	customProperties: z.record(z.string(), z.unknown()).optional(),
 });
 type DocumentMetadata = z.infer<typeof documentMetadataSchema>;
 

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.79",
+	"version": "0.0.80",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

Connector-produced document references (e.g. REST connector "Store Response", AI Agent) may omit optional metadata fields. The 8.10 `documentMetadataSchema` declared `expiresAt`, `processDefinitionId`, `processInstanceKey`, and `customProperties` as **required keys** (via `.nullable()` / `z.record`). In Zod, `.nullable()` requires the key to be present, so `documentReferenceSchema.safeParse` rejected valid references that omit those keys — and Operate silently failed to recognize them as documents.

This aligns the schema with the protocol `DocumentMetadata` contract (`zeebe/gateway-protocol/src/main/proto/v2/documents.yaml`), which declares **no required fields**, and with the connectors SDK, which detects a document solely by the `camunda.document.type` discriminator and treats all other fields as nullable/absent.

Only the 8.10 schema is affected — this metadata shape was introduced in the current `8.10-snapshot`, so 8.8 needs no change.

## Changes

- `lib/8.10/document.ts`: `expiresAt`, `processDefinitionId`, `processInstanceKey` → `.nullish()`; `customProperties` → `.optional()`.
- Bump `@camunda/camunda-api-zod-schemas` version `0.0.79` → `0.0.80`.

Download and preview are unaffected: the download link uses top-level `contentHash`/`documentId`/`storeId`, and preview uses `contentType`/`fileName`/`size` — all still required. Nested-document detection is intentionally out of scope.

Follow-up (separate change): update the `isExpired` guard in `parseDocumentVariable.ts` to a loose `!= null` check and add a regression test for references with missing metadata fields.

Closes #56657
