### PR TITLE
test: fix flaky tests in cluster, batch, and activate-job ITs

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ActivateJobIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ActivateJobIT.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -63,6 +64,10 @@ public class ActivateJobIT {
 
   @BeforeAll
   static void setup() {
+    // The CamundaMultiDBExtension resets RecordingExporter (maximumWaitTime → 5s) in its
+    // beforeAll, which runs before this method. Override to 30s to tolerate slow CI runners
+    // where gateway-issued FAIL commands can take longer to propagate.
+    RecordingExporter.setMaximumWaitTime(Duration.ofSeconds(30).toMillis());
     grpcClient = BROKER.newClientBuilder().preferRestOverGrpc(false).build();
     grpcClient
         .newDeployResourceCommand()

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ClusterMultiplePartitionsBatchOperationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/orchestration/ClusterMultiplePartitionsBatchOperationIT.java
@@ -124,7 +124,11 @@ public class ClusterMultiplePartitionsBatchOperationIT {
     waitForBatchOperationWithCorrectTotalCount(
         camundaClient, batchOperationKey, activeProcessInstances.size());
     waitForBatchOperationCompleted(
-        camundaClient, batchOperationKey, activeProcessInstances.size(), 0);
+        camundaClient,
+        batchOperationKey,
+        activeProcessInstances.size(),
+        0,
+        TIMEOUT_DATA_AVAILABILITY.multipliedBy(3));
 
     // Now wait until all process instances are terminated
     final var activeKeys =

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -644,8 +644,22 @@ public final class TestHelper {
       final String batchOperationKey,
       final int expectedCompletedItems,
       final int expectedFailedItems) {
+    waitForBatchOperationCompleted(
+        camundaClient,
+        batchOperationKey,
+        expectedCompletedItems,
+        expectedFailedItems,
+        TIMEOUT_DATA_AVAILABILITY);
+  }
+
+  public static void waitForBatchOperationCompleted(
+      final CamundaClient camundaClient,
+      final String batchOperationKey,
+      final int expectedCompletedItems,
+      final int expectedFailedItems,
+      final Duration timeout) {
     Awaitility.await("should complete batch operation with correct completed/failed count")
-        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .atMost(timeout)
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {

--- a/qa/testcontainer/src/test/java/io/camunda/container/cluster/CamundaClusterTest.java
+++ b/qa/testcontainer/src/test/java/io/camunda/container/cluster/CamundaClusterTest.java
@@ -13,6 +13,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.Topology;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Network;
@@ -44,21 +46,28 @@ final class CamundaClusterTest {
     cluster.start();
 
     // then
-    final Topology topology;
-    try (final CamundaClient client = cluster.newClientBuilder().build()) {
-      topology = client.newTopologyRequest().send().join();
-    }
+    Awaitility.await("topology is complete")
+        .atMost(Duration.ofMinutes(1))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final Topology topology;
+              try (final CamundaClient client = cluster.newClientBuilder().build()) {
+                topology = client.newTopologyRequest().send().join();
+              }
 
-    assertThat(topology.getPartitionsCount())
-        .as("there is exactly one partition as configured")
-        .isOne();
-    assertThat(topology.getReplicationFactor())
-        .as("there is a replication factor of 1 as configured")
-        .isOne();
-    TopologyAssert.assertThat(topology)
-        .as("the topology is complete for a one broker, one partition cluster")
-        .hasBrokersCount(1)
-        .isComplete(1, 1, 1);
+              assertThat(topology.getPartitionsCount())
+                  .as("there is exactly one partition as configured")
+                  .isOne();
+              assertThat(topology.getReplicationFactor())
+                  .as("there is a replication factor of 1 as configured")
+                  .isOne();
+              TopologyAssert.assertThat(topology)
+                  .as("the topology is complete for a one broker, one partition cluster")
+                  .hasBrokersCount(1)
+                  .isComplete(1, 1, 1);
+            });
   }
 
   @Test
@@ -85,26 +94,33 @@ final class CamundaClusterTest {
 
     // then
     for (final GatewayNode<?> gateway : cluster.getGateways().values()) {
-      final Topology topology;
-      try (final CamundaClient client =
-          cluster
-              .newClientBuilder()
-              .grpcAddress(gateway.getGrpcAddress())
-              .restAddress(gateway.getRestAddress())
-              .build()) {
-        topology = client.newTopologyRequest().send().join();
-      }
+      Awaitility.await("topology is complete")
+          .atMost(Duration.ofMinutes(1))
+          .pollInterval(Duration.ofSeconds(1))
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                final Topology topology;
+                try (final CamundaClient client =
+                    cluster
+                        .newClientBuilder()
+                        .grpcAddress(gateway.getGrpcAddress())
+                        .restAddress(gateway.getRestAddress())
+                        .build()) {
+                  topology = client.newTopologyRequest().send().join();
+                }
 
-      assertThat(topology.getReplicationFactor())
-          .as("there is replication factor of 2 as configured")
-          .isEqualTo(2);
-      assertThat(topology.getPartitionsCount())
-          .as("there are exactly two partitions as configured")
-          .isEqualTo(2);
-      TopologyAssert.assertThat(topology)
-          .as("the topology is complete with 2 partitions and 2 brokers")
-          .hasBrokersCount(2)
-          .isComplete(2, 2, 2);
+                assertThat(topology.getReplicationFactor())
+                    .as("there is replication factor of 2 as configured")
+                    .isEqualTo(2);
+                assertThat(topology.getPartitionsCount())
+                    .as("there are exactly two partitions as configured")
+                    .isEqualTo(2);
+                TopologyAssert.assertThat(topology)
+                    .as("the topology is complete with 2 partitions and 2 brokers")
+                    .hasBrokersCount(2)
+                    .isComplete(2, 2, 2);
+              });
     }
   }
 
@@ -137,21 +153,28 @@ final class CamundaClusterTest {
     cluster.start();
 
     // then
-    final Topology topology;
-    try (final CamundaClient client = cluster.newClientBuilder().build()) {
-      topology = client.newTopologyRequest().send().join();
-    }
+    Awaitility.await("topology is complete")
+        .atMost(Duration.ofMinutes(1))
+        .pollInterval(Duration.ofSeconds(1))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final Topology topology;
+              try (final CamundaClient client = cluster.newClientBuilder().build()) {
+                topology = client.newTopologyRequest().send().join();
+              }
 
-    assertThat(topology.getPartitionsCount())
-        .as("there is exactly one partition as configured")
-        .isOne();
-    assertThat(topology.getReplicationFactor())
-        .as("there is a replication factor of 1 as configured")
-        .isOne();
-    TopologyAssert.assertThat(topology)
-        .as("the topology is complete for a one broker, one partition cluster")
-        .hasBrokersCount(1)
-        .isComplete(1, 1, 1);
+              assertThat(topology.getPartitionsCount())
+                  .as("there is exactly one partition as configured")
+                  .isOne();
+              assertThat(topology.getReplicationFactor())
+                  .as("there is a replication factor of 1 as configured")
+                  .isOne();
+              TopologyAssert.assertThat(topology)
+                  .as("the topology is complete for a one broker, one partition cluster")
+                  .hasBrokersCount(1)
+                  .isComplete(1, 1, 1);
+            });
   }
 
   @Test
@@ -184,23 +207,32 @@ final class CamundaClusterTest {
 
     // then
     for (final GatewayNode<?> gateway : cluster.getGateways().values()) {
-      try (final CamundaClient client =
-          CamundaClient.newClientBuilder()
-              .grpcAddress(gateway.getGrpcAddress())
-              .restAddress(gateway.getRestAddress())
-              .build()) {
-        final Topology topology = client.newTopologyRequest().send().join();
-        assertThat(topology.getPartitionsCount())
-            .as("there is exactly one partition as configured")
-            .isOne();
-        assertThat(topology.getReplicationFactor())
-            .as("there is a replication factor of 1 as configured")
-            .isOne();
-        TopologyAssert.assertThat(topology)
-            .as("the topology is complete for a one broker, one partition cluster")
-            .isComplete(1, 1, 1)
-            .hasBrokersCount(1);
-      }
+      Awaitility.await("topology is complete")
+          .atMost(Duration.ofMinutes(1))
+          .pollInterval(Duration.ofSeconds(1))
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                final Topology topology;
+                try (final CamundaClient client =
+                    CamundaClient.newClientBuilder()
+                        .grpcAddress(gateway.getGrpcAddress())
+                        .restAddress(gateway.getRestAddress())
+                        .build()) {
+                  topology = client.newTopologyRequest().send().join();
+                }
+
+                assertThat(topology.getPartitionsCount())
+                    .as("there is exactly one partition as configured")
+                    .isOne();
+                assertThat(topology.getReplicationFactor())
+                    .as("there is a replication factor of 1 as configured")
+                    .isOne();
+                TopologyAssert.assertThat(topology)
+                    .as("the topology is complete for a one broker, one partition cluster")
+                    .isComplete(1, 1, 1)
+                    .hasBrokersCount(1);
+              });
     }
   }
 }


### PR DESCRIPTION


## Description

CamundaClusterTest: per-container ZeebeTopologyWaitStrategy only checks its own topology, so cross-gateway consistency is not guaranteed after start(). Wrap the per-gateway assertion in an Awaitility loop.

ClusterMultiplePartitionsBatchOperationIT: batch cancel across 3 partitions on heavily-loaded OpenSearch 2/3 CI runners can exceed the default 2-minute TIMEOUT_DATA_AVAILABILITY. Add a timeout-parameterised overload to TestHelper.waitForBatchOperationCompleted and pass 3x the default for this multi-partition test.

ActivateJobIT: CamundaMultiDBExtension.beforeAll() resets RecordingExporter.maximumWaitTime to 5 s. Gateway-issued FAIL commands can take longer to propagate on slow CI runners. Override to 30 s in @BeforeAll after the extension reset.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
