### PR TITLE
refactor: rename leftover recovery references to mode change

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
@@ -30,7 +30,7 @@ public interface ClusterConfigurationService extends AsyncClosable {
 
   void removePartitionChangeExecutor();
 
-  void registerModeChangeExecutor(ModeChangeExecutor recoveryModeChangeExecutor);
+  void registerModeChangeExecutor(ModeChangeExecutor modeChangeExecutor);
 
   void removeModeChangeExecutor();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -62,9 +62,9 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
   }
 
   @Override
-  public void registerModeChangeExecutor(final ModeChangeExecutor recoveryModeChangeExecutor) {
+  public void registerModeChangeExecutor(final ModeChangeExecutor modeChangeExecutor) {
     if (clusterConfigurationManagerService != null) {
-      clusterConfigurationManagerService.registerModeChangeExecutor(recoveryModeChangeExecutor);
+      clusterConfigurationManagerService.registerModeChangeExecutor(modeChangeExecutor);
     } else {
       throw new IllegalStateException(
           "Cannot register mode change executor before the topology manager is started");

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -81,8 +81,7 @@ public interface ClusterConfigurationManagementApi {
   ActorFuture<ClusterConfigurationChangeResponse> enableExporter(
       ExporterEnableRequest enableRequest);
 
-  ActorFuture<ClusterConfigurationChangeResponse> enterRecovery(
-      ModeChangeRequest recoveryModeRequest);
+  ActorFuture<ClusterConfigurationChangeResponse> modeChange(ModeChangeRequest modeChangeRequest);
 
   ActorFuture<ClusterConfiguration> cancelTopologyChange(
       ClusterConfigurationManagementRequest.CancelChangeRequest cancelChangeRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -246,10 +246,10 @@ public final class ClusterConfigurationManagementRequestSender {
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> modeChange(
-      final ModeChangeRequest recoveryModeRequest) {
+      final ModeChangeRequest request) {
     return communicationService.send(
         ClusterConfigurationRequestTopics.MODE_CHANGE.topic(),
-        recoveryModeRequest,
+        request,
         serializer::encodeModeChangeRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -220,10 +220,10 @@ public final class ClusterConfigurationManagementRequestsHandler
   }
 
   @Override
-  public ActorFuture<ClusterConfigurationChangeResponse> enterRecovery(
-      final ModeChangeRequest recoveryModeRequest) {
+  public ActorFuture<ClusterConfigurationChangeResponse> modeChange(
+      final ModeChangeRequest modeChangeRequest) {
     return handleRequest(
-        recoveryModeRequest.dryRun(), new ModeChangeRequestTransformer(recoveryModeRequest.mode()));
+        modeChangeRequest.dryRun(), new ModeChangeRequestTransformer(modeChangeRequest.mode()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -53,7 +53,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerUpdatePartitionDistributionHandler();
     registerForceRemoveBrokersRequestHandler();
     registerPurgeRequestHandler();
-    registerEnterRecoveryHandler();
+    registerModeChangeHandler();
   }
 
   @Override
@@ -226,13 +226,11 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         this::encodeResponse);
   }
 
-  private void registerEnterRecoveryHandler() {
+  private void registerModeChangeHandler() {
     communicationService.replyTo(
         ClusterConfigurationRequestTopics.MODE_CHANGE.topic(),
         serializer::decodeModeChangeRequest,
-        request -> {
-          return mapResponse(clusterConfigurationManagementApi.enterRecovery(request));
-        },
+        request -> mapResponse(clusterConfigurationManagementApi.modeChange(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -36,19 +36,19 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
   private final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor;
   private final PartitionScalingChangeExecutor partitionScalingChangeExecutor;
   private final ClusterChangeExecutor clusterChangeExecutor;
-  private final ModeChangeExecutor recoveryModeChangeExecutor;
+  private final ModeChangeExecutor modeChangeExecutor;
 
   public ConfigurationChangeAppliersImpl(
       final PartitionChangeExecutor partitionChangeExecutor,
       final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor,
       final PartitionScalingChangeExecutor partitionScalingChangeExecutor,
       final ClusterChangeExecutor clusterChangeExecutor,
-      final ModeChangeExecutor recoveryModeChangeExecutor) {
+      final ModeChangeExecutor modeChangeExecutor) {
     this.partitionChangeExecutor = partitionChangeExecutor;
     this.clusterMembershipChangeExecutor = clusterMembershipChangeExecutor;
     this.partitionScalingChangeExecutor = partitionScalingChangeExecutor;
     this.clusterChangeExecutor = clusterChangeExecutor;
-    this.recoveryModeChangeExecutor = recoveryModeChangeExecutor;
+    this.modeChangeExecutor = modeChangeExecutor;
   }
 
   @Override
@@ -142,13 +142,12 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
       case final ModeChangeOperation modeChangeOperation ->
           switch (modeChangeOperation.mode()) {
             case RECOVERING ->
-                new EnterRecoveryApplier(
-                    modeChangeOperation.memberId(), recoveryModeChangeExecutor);
+                new EnterRecoveryApplier(modeChangeOperation.memberId(), modeChangeExecutor);
             case PROCESSING ->
-                new ExitRecoveryApplier(modeChangeOperation.memberId(), recoveryModeChangeExecutor);
+                new ExitRecoveryApplier(modeChangeOperation.memberId(), modeChangeExecutor);
           };
       case final AwaitModeChangeOperation awaitModeChangeOperation ->
-          new AwaitModeChangeApplier(awaitModeChangeOperation.mode(), recoveryModeChangeExecutor);
+          new AwaitModeChangeApplier(awaitModeChangeOperation.mode(), modeChangeExecutor);
     };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/EnterRecoveryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/EnterRecoveryApplier.java
@@ -21,12 +21,12 @@ public class EnterRecoveryApplier implements MemberOperationApplier {
   private static final String TRANSITION_ERROR_MESSAGE =
       "Expected to enter recovery for member %s, but the member is not part of the cluster";
   private final MemberId memberId;
-  private final ModeChangeExecutor recoveryModeChangeExecutor;
+  private final ModeChangeExecutor modeChangeExecutor;
 
   public EnterRecoveryApplier(
-      final MemberId memberId, final ModeChangeExecutor recoveryModeChangeExecutor) {
+      final MemberId memberId, final ModeChangeExecutor modeChangeExecutor) {
     this.memberId = memberId;
-    this.recoveryModeChangeExecutor = recoveryModeChangeExecutor;
+    this.modeChangeExecutor = modeChangeExecutor;
   }
 
   @Override
@@ -59,7 +59,7 @@ public class EnterRecoveryApplier implements MemberOperationApplier {
   public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
     final CompletableActorFuture<UnaryOperator<MemberState>> result =
         new CompletableActorFuture<>();
-    recoveryModeChangeExecutor
+    modeChangeExecutor
         .enterRecovery()
         .onComplete(
             (ignore, error) -> {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ExitRecoveryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ExitRecoveryApplier.java
@@ -21,12 +21,11 @@ public class ExitRecoveryApplier implements MemberOperationApplier {
   private static final String TRANSITION_ERROR_MESSAGE =
       "Expected to exit recovery for member %s, but the member is not part of the cluster";
   private final MemberId memberId;
-  private final ModeChangeExecutor recoveryModeChangeExecutor;
+  private final ModeChangeExecutor modeChangeExecutor;
 
-  public ExitRecoveryApplier(
-      final MemberId memberId, final ModeChangeExecutor recoveryModeChangeExecutor) {
+  public ExitRecoveryApplier(final MemberId memberId, final ModeChangeExecutor modeChangeExecutor) {
     this.memberId = memberId;
-    this.recoveryModeChangeExecutor = recoveryModeChangeExecutor;
+    this.modeChangeExecutor = modeChangeExecutor;
   }
 
   @Override
@@ -60,7 +59,7 @@ public class ExitRecoveryApplier implements MemberOperationApplier {
   public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
     final CompletableActorFuture<UnaryOperator<MemberState>> result =
         new CompletableActorFuture<>();
-    recoveryModeChangeExecutor
+    modeChangeExecutor
         .exitRecovery()
         .onComplete(
             (ignore, error) -> {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -118,7 +118,7 @@ public interface ClusterConfigurationRequestsSerializer {
   UpdatePartitionDistributorConfigRequest decodeUpdatePartitionDistributorConfigRequest(
       byte[] bytes);
 
-  byte[] encodeModeChangeRequest(ModeChangeRequest recoveryModeRequest);
+  byte[] encodeModeChangeRequest(ModeChangeRequest modeChangeRequest);
 
   ModeChangeRequest decodeModeChangeRequest(byte[] encodedRequest);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1389,10 +1389,10 @@ public class ProtoBufSerializer
   }
 
   @Override
-  public byte[] encodeModeChangeRequest(final ModeChangeRequest recoveryModeRequest) {
+  public byte[] encodeModeChangeRequest(final ModeChangeRequest modeChangeRequest) {
     return Requests.ModeChangeRequest.newBuilder()
-        .setMode(toProtoRequestMode(recoveryModeRequest.mode()))
-        .setDryRun(recoveryModeRequest.dryRun())
+        .setMode(toProtoRequestMode(modeChangeRequest.mode()))
+        .setDryRun(modeChangeRequest.dryRun())
         .build()
         .toByteArray();
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Rename leftover references of `recovery` operations to `mode`  as the more generalized Member state.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
