### PR TITLE
fix: do not block scheduler thread on Optimize import errors

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/PositionBasedImportMediator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/PositionBasedImportMediator.java
@@ -35,12 +35,18 @@ public abstract class PositionBasedImportMediator<
   protected BackoffCalculator idleBackoffCalculator;
   protected T importIndexHandler;
   protected ImportService<DTO> importService;
-  private final BackoffCalculator errorBackoffCalculator = new BackoffCalculator(10, 1000);
 
   @Override
   public CompletableFuture<Void> runImport() {
     final CompletableFuture<Void> importCompleted = new CompletableFuture<>();
-    final boolean pageIsPresent = importNextPageWithRetries(importCompleted);
+    boolean pageIsPresent;
+    try {
+      pageIsPresent = importNextPage(() -> importCompleted.complete(null));
+    } catch (final Exception e) {
+      logger.error("Was not able to import next page, skipping this round.", e);
+      importCompleted.complete(null);
+      pageIsPresent = false;
+    }
     if (pageIsPresent) {
       idleBackoffCalculator.resetBackoff();
     } else {
@@ -81,33 +87,6 @@ public abstract class PositionBasedImportMediator<
   }
 
   protected abstract boolean importNextPage(Runnable importCompleteCallback);
-
-  private boolean importNextPageWithRetries(final CompletableFuture<Void> importCompleteCallback) {
-    Boolean result = null;
-    while (result == null) {
-      try {
-        result = importNextPage(() -> importCompleteCallback.complete(null));
-      } catch (final Exception e) {
-        if (errorBackoffCalculator.isMaximumBackoffReached()) {
-          // if max back-off is reached abort retrying and return true to indicate there is new data
-          logger.error(
-              "Was not able to import next page and reached max backoff, aborting this run.", e);
-          importCompleteCallback.complete(null);
-          result = true;
-        } else {
-          final long timeToSleep = errorBackoffCalculator.calculateSleepTime();
-          logger.error(
-              "Was not able to import next page, retrying after sleeping for {}ms.",
-              timeToSleep,
-              e);
-          sleep(timeToSleep);
-        }
-      }
-    }
-    errorBackoffCalculator.resetBackoff();
-
-    return result;
-  }
 
   protected boolean importNextPagePositionBased(
       final List<DTO> entitiesNextPage, final Runnable importCompleteCallback) {
@@ -168,14 +147,5 @@ public abstract class PositionBasedImportMediator<
     }
     final long sleepTime = idleBackoffCalculator.calculateSleepTime();
     logger.debug("Was not able to produce a new job, sleeping for [{}] ms", sleepTime);
-  }
-
-  private void sleep(final long timeToSleep) {
-    try {
-      Thread.sleep(timeToSleep);
-    } catch (final InterruptedException e) {
-      logger.error("Was interrupted from sleep.", e);
-      Thread.currentThread().interrupt();
-    }
   }
 }


### PR DESCRIPTION
## Description

`PositionBasedImportMediator.importNextPageWithRetries()` called `Thread.sleep()` inside its error retry loop. Because all Zeebe record-type mediators share a single scheduler thread, any one mediator hitting a fetch error (e.g. an ES shard becoming unavailable) would block every other mediator for the full backoff cycle (growing from 1 s up to 10 s per retry). Unrelated record types stopped importing entirely until the error resolved.

### Before — scheduler thread blocked by one failing mediator

```mermaid
flowchart LR
    subgraph ES_Z["Elasticsearch — Zeebe record indices"]
        PI["zeebe_record_process_instance"]
        VAR["zeebe_record_variable\n(primary shard UNAVAILABLE)"]
        INC["zeebe_record_incident"]
        UT["zeebe_record_user_task"]
        PD["zeebe_record_process"]
    end

    subgraph SCHED["Optimize Importer — single scheduler thread BLOCKED"]
        direction TB
        ROUND["runImportRound()"]
        M1["ProcessInstanceMediator.runImport()\n✅ succeeds"]
        M2["VariableMediator.runImport()\n❌ fetch fails → exception"]
        SLEEP["Thread.sleep(errorBackoff)\n~1s, grows to 10s+\nBLOCKS entire scheduler thread"]
        RETRY["retry loop\n(up to max backoff)"]
        M3["IncidentMediator.runImport()\n⏸ unrelated — never reached"]
        M4["UserTaskMediator.runImport()\n⏸ unrelated — never reached"]
        M5["ProcessDefinitionMediator.runImport()\n⏸ unrelated — never reached"]
        ROUND --> M1
        M1 --> M2
        M2 --> SLEEP
        SLEEP -->|"sleep expires"| RETRY
        RETRY -->|"still failing"| SLEEP
        RETRY -->|"max backoff reached"| M3
        M3 --> M4
        M4 --> M5
    end

    PI -->|"fetch ok"| M1
    VAR -->|"fetch fails"| M2
    INC -..->|"blocked — unrelated to variable"| M3
    UT -..->|"blocked — unrelated to variable"| M4
    PD -..->|"blocked — unrelated to variable"| M5
```

### After — failing mediator backs off without touching the thread

The fix removes the blocking retry loop. On a fetch exception the mediator catches the error, completes the future, and returns `false` immediately. The `false` return flows into the existing idle-backoff path (`calculateNewDateUntilIsBlocked`), which advances the `BackoffCalculator` and gates `canImport()` — so the mediator is automatically skipped on the next scheduler rounds until the backoff expires. The hardcoded `errorBackoffCalculator` (1 s–10 s ramp) is removed entirely; the configurable idle backoff handles pacing for both the no-data and error cases.

```mermaid
flowchart LR
    subgraph ES_Z["Elasticsearch — Zeebe record indices"]
        PI["zeebe_record_process_instance"]
        VAR["zeebe_record_variable\n(primary shard UNAVAILABLE)"]
        INC["zeebe_record_incident"]
        UT["zeebe_record_user_task"]
        PD["zeebe_record_process"]
    end

    subgraph SCHED["Optimize Importer — scheduler thread UNBLOCKED"]
        direction TB
        ROUND["runImportRound()"]
        M1["ProcessInstanceMediator.runImport()\n✅ succeeds"]
        M2["VariableMediator.runImport()\n❌ fetch fails → caught\n→ returns false immediately\n→ idle backoff advances"]
        M3["IncidentMediator.runImport()\n✅ continues normally"]
        M4["UserTaskMediator.runImport()\n✅ continues normally"]
        M5["ProcessDefinitionMediator.runImport()\n✅ continues normally"]
        ROUND --> M1
        M1 --> M2
        M2 -->|"no sleep — thread released"| M3
        M3 --> M4
        M4 --> M5
    end

    subgraph NEXT["Subsequent scheduler rounds"]
        SKIP["canImport() = false\n(idle backoff not expired)\n→ VariableMediator skipped"]
        RETRY["canImport() = true\n(idle backoff expired)\n→ VariableMediator retries"]
        SKIP -->|"backoff expires"| RETRY
    end

    PI -->|"fetch ok"| M1
    VAR -->|"fetch fails"| M2
    INC -->|"fetch ok"| M3
    UT -->|"fetch ok"| M4
    PD -->|"fetch ok"| M5
    M2 --> SKIP
    RETRY -->|"ES recovers"| M2
```

## Checklist

- [x] Enable backports when necessary — adding `backport stable/8.7`, `backport stable/8.8`, `backport stable/8.9` (issue affects 8.7–8.10).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56668

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)