### PR TITLE
Raise incidents at the call activity for invalid runtime `businessId` values

### DIFF
--- a/zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md
+++ b/zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md
@@ -50,16 +50,17 @@ Business ID to null (matching 8.9 engine behaviour for an absent Business ID). A
 literal Business ID.
 
 **D4. Invalid runtime values raise a resolvable incident; discards do not.** A child `businessId`
-defined with an invalid FEEL expression rejects the process on deployment. At runtime,
-when the child instance is created:
+defined with an invalid FEEL expression, or a **static literal that exceeds the maximum length** (256
+characters), rejects the process on deployment — both are statically knowable, so they fail fast. At
+runtime, when the child instance is created:
 
 - an **explicit `=null`**, an **empty literal** (`businessId=""`), and a **FEEL expression that
   evaluates to null or an empty string** all **discard** the child Business ID — the child starts with
   no Business ID and **no incident** is raised (consistent with the engine-wide "empty string = not
   set" convention);
 - an incident is raised only when a **FEEL expression references a missing/unresolvable variable**
-  (coerced to null, reported via a `NO_VARIABLE_FOUND` warning), when a resolved value (**FEEL or
-  literal**) **exceeds the maximum length** (256 characters), or when a **FEEL expression resolves to
+  (coerced to null, reported via a `NO_VARIABLE_FOUND` warning), when a **FEEL expression evaluates to
+  a value that exceeds the maximum length** (256 characters), or when a **FEEL expression resolves to
   a non-string, non-null type** (e.g. number, boolean, list).
 
 Incidents are resolvable: correcting the variables or the expression and retrying activation creates

--- a/zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md
+++ b/zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md
@@ -58,10 +58,11 @@ runtime, when the child instance is created:
   evaluates to null or an empty string** all **discard** the child Business ID — the child starts with
   no Business ID and **no incident** is raised (consistent with the engine-wide "empty string = not
   set" convention);
-- an incident is raised only when a **FEEL expression references a missing/unresolvable variable**
-  (coerced to null, reported via a `NO_VARIABLE_FOUND` warning), when a **FEEL expression evaluates to
-  a value that exceeds the maximum length** (256 characters), or when a **FEEL expression resolves to
-  a non-string, non-null type** (e.g. number, boolean, list).
+- an incident is raised when a **FEEL expression evaluates to null but reports evaluation warnings**
+  (i.e. the null was coerced from a failure such as a missing variable, function, or property, as
+  opposed to an intentional `=null`), when a **FEEL expression evaluates to a value that exceeds the
+  maximum length** (256 characters), or when a **FEEL expression resolves to a non-string, non-null
+  type** (e.g. number, boolean, list).
 
 Incidents are resolvable: correcting the variables or the expression and retrying activation creates
 the child with the intended Business ID.

--- a/zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md
+++ b/zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md
@@ -49,11 +49,21 @@ expression, evaluated by the engine at child instance creation. An empty string 
 Business ID to null (matching 8.9 engine behaviour for an absent Business ID). Any other value is a
 literal Business ID.
 
-**D4. Invalid configuration is rejected at deploy or raised as an incident at runtime.** A child
-`businessId` defined with an invalid FEEL expression rejects the process on deployment. At runtime, a
-FEEL expression that evaluates to null, to an empty string, or to an invalid value (e.g. longer than
-256 characters), and a literal that violates Business ID constraints (e.g. longer than 256
-characters), raise an incident at the call activity.
+**D4. Invalid runtime values raise a resolvable incident; discards do not.** A child `businessId`
+defined with an invalid FEEL expression rejects the process on deployment. At runtime,
+when the child instance is created:
+
+- an **explicit `=null`**, an **empty literal** (`businessId=""`), and a **FEEL expression that
+  evaluates to null or an empty string** all **discard** the child Business ID — the child starts with
+  no Business ID and **no incident** is raised (consistent with the engine-wide "empty string = not
+  set" convention);
+- an incident is raised only when a **FEEL expression references a missing/unresolvable variable**
+  (coerced to null, reported via a `NO_VARIABLE_FOUND` warning), when a resolved value (**FEEL or
+  literal**) **exceeds the maximum length** (256 characters), or when a **FEEL expression resolves to
+  a non-string, non-null type** (e.g. number, boolean, list).
+
+Incidents are resolvable: correcting the variables or the expression and retrying activation creates
+the child with the intended Business ID.
 
 ## Alternatives considered
 
@@ -74,11 +84,11 @@ characters), raise an incident at the call activity.
 - A single attribute carries four distinct behaviours (propagate / literal / FEEL / null) selected by
   value form; modeling tools must surface this so the absent-vs-empty-vs-`=` distinction is clear to
   authors.
-- FEEL evaluation happens at child instance creation, so propagation failures (null/empty/oversized
-  results) surface as runtime incidents at the call activity rather than at deploy time.
+- FEEL evaluation happens at child instance creation, so a null or empty result discards the Business
+  ID, while a missing-variable reference, an over-long value, or a non-string/non-null result surfaces
+  as a resolvable runtime incident at the call activity rather than at deploy time.
 - Future extensions — deriving the child Business ID from the parent's (e.g. `=businessId + "-suffix"`)
-  or a literal fallback when a FEEL expression yields null — are accommodated by the FEEL form but are
-  not part of this decision.
+  — are accommodated by the FEEL form but are not part of this decision.
 
 ## Source
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -47,9 +47,6 @@ public final class CallActivityProcessor
   private static final String UNABLE_TO_TERMINATE_FROM_STATE_MESSAGE =
       "Expected to terminate call activity after child terminated, but call activity cannot be terminated from state '%s'";
 
-  /** The FEEL evaluation warning type signaling that a referenced variable could not be found. */
-  private static final String NO_VARIABLE_FOUND_WARNING = "NO_VARIABLE_FOUND";
-
   private final ExpressionProcessor expressionProcessor;
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
   private final BpmnStateBehavior stateBehavior;
@@ -302,8 +299,8 @@ public final class CallActivityProcessor
     return switch (result.getType()) {
       // An empty string is a valid discard, a non-empty one is used (subject to the length check).
       case STRING -> validateBusinessId(result.getString(), context);
-      // A null result is either an intentional discard ('=null') or a coerced null from an
-      // unresolvable variable — only the latter is an incident.
+      // A null result is either an intentional discard ('=null') or a coerced null from a failed
+      // evaluation — only the latter is an incident.
       case NULL -> resolveNullBusinessId(result, context);
       default -> Either.left(nonStringBusinessIdFailure(result, context));
     };
@@ -311,10 +308,10 @@ public final class CallActivityProcessor
 
   private Either<Failure, String> resolveNullBusinessId(
       final EvaluationResult result, final BpmnElementContext context) {
-    final var coercedFromMissingVariable =
-        result.getWarnings().stream()
-            .anyMatch(warning -> NO_VARIABLE_FOUND_WARNING.equals(warning.getType()));
-    if (coercedFromMissingVariable) {
+    // A null accompanied by evaluation warnings was coerced from a failure (e.g. a missing
+    // variable, function, or property), so it is an incident; an intentional '=null' reports no
+    // warnings and discards the Business ID.
+    if (!result.getWarnings().isEmpty()) {
       return Either.left(
           new Failure(
               "Expected to resolve the business id for the call activity from expression '%s', but it evaluated to null.%s"

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -289,7 +289,7 @@ public final class CallActivityProcessor
       return Either.right(context.getBusinessId());
     }
     if (businessIdExpression.isStatic()) {
-      return validateBusinessIdLength(businessIdExpression.getExpression(), context);
+      return validateBusinessId(businessIdExpression.getExpression(), context);
     }
     return expressionProcessor
         .evaluateAnyExpression(
@@ -301,7 +301,7 @@ public final class CallActivityProcessor
       final EvaluationResult result, final BpmnElementContext context) {
     return switch (result.getType()) {
       // An empty string is a valid discard, a non-empty one is used (subject to the length check).
-      case STRING -> validateBusinessIdLength(result.getString(), context);
+      case STRING -> validateBusinessId(result.getString(), context);
       // A null result is either an intentional discard ('=null') or a coerced null from an
       // unresolvable variable — only the latter is an incident.
       case NULL -> resolveNullBusinessId(result, context);
@@ -326,17 +326,16 @@ public final class CallActivityProcessor
     return Either.right("");
   }
 
-  private Either<Failure, String> validateBusinessIdLength(
+  private Either<Failure, String> validateBusinessId(
       final String businessId, final BpmnElementContext context) {
-    if (BusinessIdValidator.exceedsMaxLength(businessId)) {
-      return Either.left(
-          new Failure(
-              "Expected to resolve a valid business id for the call activity, but it exceeds the max length of %d."
-                  .formatted(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH),
-              ErrorType.EXTRACT_VALUE_ERROR,
-              context.getElementInstanceKey()));
-    }
-    return Either.right(businessId);
+    return BusinessIdValidator.validate(businessId)
+        .mapLeft(
+            reason ->
+                new Failure(
+                    "Expected to resolve a valid business id for the call activity, but it %s."
+                        .formatted(reason),
+                    ErrorType.EXTRACT_VALUE_ERROR,
+                    context.getElementInstanceKey()));
   }
 
   private Failure nonStringBusinessIdFailure(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.container;
 
+import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContainerProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
@@ -21,12 +22,14 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehav
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
+import io.camunda.zeebe.engine.processing.processinstance.BusinessIdValidator;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 public final class CallActivityProcessor
@@ -43,6 +46,9 @@ public final class CallActivityProcessor
       "Expected to complete call activity after child completed, but call activity cannot be completed from state '%s'";
   private static final String UNABLE_TO_TERMINATE_FROM_STATE_MESSAGE =
       "Expected to terminate call activity after child terminated, but call activity cannot be terminated from state '%s'";
+
+  /** The FEEL evaluation warning type signaling that a referenced variable could not be found. */
+  private static final String NO_VARIABLE_FOUND_WARNING = "NO_VARIABLE_FOUND";
 
   private final ExpressionProcessor expressionProcessor;
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
@@ -262,18 +268,19 @@ public final class CallActivityProcessor
   }
 
   /**
-   * Resolves the Business ID to assign to the child process instance, per ADR 0003-810 (D2/D3):
+   * Resolves the Business ID to assign to the child process instance, per ADR 0003-810 (D2/D3/D4):
    *
    * <ul>
    *   <li><b>inherit</b> (no configuration) — keep the parent's Business ID, preserving the 8.9
    *       behavior;
-   *   <li><b>literal/empty</b> (static expression) — use the configured value verbatim, so a
-   *       numeric or reserved-word literal is not coerced and an empty value yields no Business ID;
-   *   <li><b>FEEL</b> (dynamic expression) — evaluate at the call-activity element-instance scope.
+   *   <li><b>literal/empty</b> (static expression) — use the configured value verbatim (subject to
+   *       the length constraint), so a numeric or reserved-word literal is not coerced and an empty
+   *       value yields no Business ID;
+   *   <li><b>FEEL</b> (dynamic expression) — evaluate the raw result at the call-activity
+   *       element-instance scope and interpret it: an explicit null or an empty string discards the
+   *       Business ID (no incident), while an unresolvable variable, a non-string/non-null type, or
+   *       an over-long value raises a resolvable incident.
    * </ul>
-   *
-   * <p>The evaluation is threaded through the {@link Either} chain so that a FEEL failure can
-   * surface as an incident (handled in a follow-up feature).
    */
   private Either<Failure, String> resolveChildBusinessId(
       final BpmnElementContext context, final ExecutableCallActivity element) {
@@ -282,10 +289,74 @@ public final class CallActivityProcessor
       return Either.right(context.getBusinessId());
     }
     if (businessIdExpression.isStatic()) {
-      return Either.right(businessIdExpression.getExpression());
+      return validateBusinessIdLength(businessIdExpression.getExpression(), context);
     }
-    return expressionProcessor.evaluateStringExpression(
-        businessIdExpression, context.getElementInstanceKey(), context.getTenantId());
+    return expressionProcessor
+        .evaluateAnyExpression(
+            businessIdExpression, context.getElementInstanceKey(), context.getTenantId())
+        .flatMap(result -> resolveBusinessIdFromResult(result, context));
+  }
+
+  private Either<Failure, String> resolveBusinessIdFromResult(
+      final EvaluationResult result, final BpmnElementContext context) {
+    return switch (result.getType()) {
+      // An empty string is a valid discard, a non-empty one is used (subject to the length check).
+      case STRING -> validateBusinessIdLength(result.getString(), context);
+      // A null result is either an intentional discard ('=null') or a coerced null from an
+      // unresolvable variable — only the latter is an incident.
+      case NULL -> resolveNullBusinessId(result, context);
+      default -> Either.left(nonStringBusinessIdFailure(result, context));
+    };
+  }
+
+  private Either<Failure, String> resolveNullBusinessId(
+      final EvaluationResult result, final BpmnElementContext context) {
+    final var coercedFromMissingVariable =
+        result.getWarnings().stream()
+            .anyMatch(warning -> NO_VARIABLE_FOUND_WARNING.equals(warning.getType()));
+    if (coercedFromMissingVariable) {
+      return Either.left(
+          new Failure(
+              "Expected to resolve the business id for the call activity from expression '%s', but it evaluated to null.%s"
+                  .formatted(result.getExpression(), formatWarnings(result)),
+              ErrorType.EXTRACT_VALUE_ERROR,
+              context.getElementInstanceKey()));
+    }
+    // Explicit null (e.g. '=null'): intentionally discard the Business ID.
+    return Either.right("");
+  }
+
+  private Either<Failure, String> validateBusinessIdLength(
+      final String businessId, final BpmnElementContext context) {
+    if (BusinessIdValidator.exceedsMaxLength(businessId)) {
+      return Either.left(
+          new Failure(
+              "Expected to resolve a valid business id for the call activity, but it exceeds the max length of %d."
+                  .formatted(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH),
+              ErrorType.EXTRACT_VALUE_ERROR,
+              context.getElementInstanceKey()));
+    }
+    return Either.right(businessId);
+  }
+
+  private Failure nonStringBusinessIdFailure(
+      final EvaluationResult result, final BpmnElementContext context) {
+    return new Failure(
+        "Expected the business id for the call activity to resolve to a string, but expression '%s' evaluated to '%s'."
+            .formatted(result.getExpression(), result.getType()),
+        ErrorType.EXTRACT_VALUE_ERROR,
+        context.getElementInstanceKey());
+  }
+
+  private static String formatWarnings(final EvaluationResult result) {
+    final var warnings = result.getWarnings();
+    if (warnings.isEmpty()) {
+      return "";
+    }
+    return " The evaluation reported the following warnings:\n"
+        + warnings.stream()
+            .map(warning -> "[%s] %s".formatted(warning.getType(), warning.getMessage()))
+            .collect(Collectors.joining("\n"));
   }
 
   private Either<Failure, DeployedProcess> getCalledProcess(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.validation;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.validation.ZeebeExpressionValidator.ExpressionVerification;
+import io.camunda.zeebe.engine.processing.processinstance.BusinessIdValidator;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.Condition;
 import io.camunda.zeebe.model.bpmn.instance.ConditionExpression;
@@ -88,7 +89,16 @@ public final class ZeebeRuntimeValidators {
             .hasValidExpression(
                 ZeebeCalledElement::getProcessId, ExpressionVerification::isMandatory)
             .hasValidExpression(
-                ZeebeCalledElement::getBusinessId, ExpressionVerification::isOptional)
+                ZeebeCalledElement::getBusinessId,
+                expression ->
+                    expression
+                        .isOptional()
+                        .satisfiesIfStatic(
+                            staticExpression ->
+                                !BusinessIdValidator.exceedsMaxLength(
+                                    staticExpression.getExpression()),
+                            "be no longer than %d characters"
+                                .formatted(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH)))
             .build(expressionLanguage),
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(TimerEventDefinition.class)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -95,8 +95,8 @@ public final class ZeebeRuntimeValidators {
                         .isOptional()
                         .satisfiesIfStatic(
                             staticExpression ->
-                                !BusinessIdValidator.exceedsMaxLength(
-                                    staticExpression.getExpression()),
+                                BusinessIdValidator.validate(staticExpression.getExpression())
+                                    .isRight(),
                             "be no longer than %d characters"
                                 .formatted(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH)))
             .build(expressionLanguage),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BusinessIdValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BusinessIdValidator.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.util.Either;
+
 /**
- * Central definition of the Business ID length constraint, shared by the process-instance creation
+ * Central definition of the Business ID validation rules, shared by the process-instance creation
  * path (which turns a violation into a command rejection), the call-activity resolution path (which
  * turns it into a runtime incident), and the deployment validation path (which rejects a static
  * literal that violates the rule at deploy time). Callers adapt the outcome to their own result
- * type; this class owns only the rule.
+ * type; this class owns the rules and the reason describing a violation, so a future rule change
+ * only has to happen here.
  */
 public final class BusinessIdValidator {
 
@@ -22,11 +25,20 @@ public final class BusinessIdValidator {
   private BusinessIdValidator() {}
 
   /**
-   * @param businessId the Business ID to check, may be {@code null}
-   * @return {@code true} if the Business ID is non-null and longer than {@link
-   *     #MAX_BUSINESS_ID_LENGTH}
+   * Validates the given Business ID against all Business ID rules.
+   *
+   * @param businessId the Business ID to validate, may be {@code null}
+   * @return a {@link Either#left(Object) left} with the reason the Business ID is invalid, or a
+   *     {@link Either#right(Object) right} with the validated Business ID
    */
-  public static boolean exceedsMaxLength(final String businessId) {
+  public static Either<String, String> validate(final String businessId) {
+    if (exceedsMaxLength(businessId)) {
+      return Either.left("exceeds the max length of %d".formatted(MAX_BUSINESS_ID_LENGTH));
+    }
+    return Either.right(businessId);
+  }
+
+  private static boolean exceedsMaxLength(final String businessId) {
     return businessId != null && businessId.length() > MAX_BUSINESS_ID_LENGTH;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BusinessIdValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BusinessIdValidator.java
@@ -9,9 +9,10 @@ package io.camunda.zeebe.engine.processing.processinstance;
 
 /**
  * Central definition of the Business ID length constraint, shared by the process-instance creation
- * path (which turns a violation into a command rejection) and the call-activity resolution path
- * (which turns it into a runtime incident). Callers adapt the outcome to their own result type;
- * this class owns only the rule.
+ * path (which turns a violation into a command rejection), the call-activity resolution path (which
+ * turns it into a runtime incident), and the deployment validation path (which rejects a static
+ * literal that violates the rule at deploy time). Callers adapt the outcome to their own result
+ * type; this class owns only the rule.
  */
 public final class BusinessIdValidator {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BusinessIdValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/BusinessIdValidator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+/**
+ * Central definition of the Business ID length constraint, shared by the process-instance creation
+ * path (which turns a violation into a command rejection) and the call-activity resolution path
+ * (which turns it into a runtime incident). Callers adapt the outcome to their own result type;
+ * this class owns only the rule.
+ */
+public final class BusinessIdValidator {
+
+  /** The maximum allowed length of a Business ID. */
+  public static final int MAX_BUSINESS_ID_LENGTH = 256;
+
+  private BusinessIdValidator() {}
+
+  /**
+   * @param businessId the Business ID to check, may be {@code null}
+   * @return {@code true} if the Business ID is non-null and longer than {@link
+   *     #MAX_BUSINESS_ID_LENGTH}
+   */
+  public static boolean exceedsMaxLength(final String businessId) {
+    return businessId != null && businessId.length() > MAX_BUSINESS_ID_LENGTH;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -62,7 +62,6 @@ public class ProcessInstanceCreationHelper {
           BpmnElementType.BOUNDARY_EVENT,
           BpmnElementType.UNSPECIFIED);
   private static final Either<Rejection, Object> VALID = Either.right(null);
-  private static final int MAX_BUSINESS_ID_LENGTH = 256;
   private static final int MAX_REPORTED_INVALID_ELEMENT_IDS = 5;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final ProcessState processState;
@@ -441,10 +440,7 @@ public class ProcessInstanceCreationHelper {
   }
 
   private Either<Rejection, ?> validateBusinessIdFormat(final String businessId) {
-    if (businessId == null) {
-      return VALID;
-    }
-    if (businessId.length() <= MAX_BUSINESS_ID_LENGTH) {
+    if (!BusinessIdValidator.exceedsMaxLength(businessId)) {
       return VALID;
     }
     return Either.left(
@@ -453,7 +449,7 @@ public class ProcessInstanceCreationHelper {
             """
             Expected to create instance of process with a valid business id, \
             but the business id exceeds the max length of %d."""
-                .formatted(MAX_BUSINESS_ID_LENGTH)));
+                .formatted(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH)));
   }
 
   private Either<Rejection, ?> validateBusinessIdUniqueness(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -440,16 +440,13 @@ public class ProcessInstanceCreationHelper {
   }
 
   private Either<Rejection, ?> validateBusinessIdFormat(final String businessId) {
-    if (!BusinessIdValidator.exceedsMaxLength(businessId)) {
-      return VALID;
-    }
-    return Either.left(
-        new Rejection(
-            RejectionType.INVALID_ARGUMENT,
-            """
-            Expected to create instance of process with a valid business id, \
-            but the business id exceeds the max length of %d."""
-                .formatted(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH)));
+    return BusinessIdValidator.validate(businessId)
+        .mapLeft(
+            reason ->
+                new Rejection(
+                    RejectionType.INVALID_ARGUMENT,
+                    "Expected to create instance of process with a valid business id, but the business id %s."
+                        .formatted(reason)));
   }
 
   private Either<Rejection, ?> validateBusinessIdUniqueness(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/CallActivityBusinessIdValidationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/CallActivityBusinessIdValidationTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
 import static io.camunda.zeebe.engine.processing.deployment.model.validation.ExpectedValidationResult.expect;
 
+import io.camunda.zeebe.engine.processing.processinstance.BusinessIdValidator;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
@@ -21,6 +22,9 @@ final class CallActivityBusinessIdValidationTest {
   private static final String INVALID_FEEL_EXPRESSION = "=a & b";
   private static final String INVALID_FEEL_EXPRESSION_MESSAGE =
       "failed to parse expression 'a & b'";
+  private static final String TOO_LONG_LITERAL_MESSAGE =
+      "Expected static value to be no longer than %d characters, but found '"
+          .formatted(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH);
 
   private static BpmnModelInstance processWithCallActivity(
       final Consumer<CallActivityBuilder> modifier) {
@@ -75,6 +79,29 @@ final class CallActivityBusinessIdValidationTest {
   void shouldAcceptAbsentBusinessId() {
     // given
     final var process = processWithCallActivity(c -> c.zeebeProcessId("child"));
+
+    // when / then
+    ProcessValidationUtil.validateProcess(process);
+  }
+
+  @Test
+  void shouldRejectLiteralBusinessIdExceedingMaxLength() {
+    // given
+    final var tooLongLiteral = "a".repeat(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH + 1);
+    final var process =
+        processWithCallActivity(c -> c.zeebeProcessId("child").zeebeBusinessId(tooLongLiteral));
+
+    // when / then
+    ProcessValidationUtil.validateProcess(
+        process, expect(ZeebeCalledElement.class, TOO_LONG_LITERAL_MESSAGE));
+  }
+
+  @Test
+  void shouldAcceptLiteralBusinessIdAtMaxLength() {
+    // given
+    final var maxLengthLiteral = "a".repeat(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH);
+    final var process =
+        processWithCallActivity(c -> c.zeebeProcessId("child").zeebeBusinessId(maxLengthLiteral));
 
     // when / then
     ProcessValidationUtil.validateProcess(process);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -548,6 +548,28 @@ public final class CallActivityIncidentTest {
   }
 
   @Test
+  public void shouldCreateIncidentWhenBusinessIdFeelEvaluatesToNullWithNonVariableWarning() {
+    // given - a FEEL expression that coerces to null through a failure other than a missing
+    // variable (here: an unknown function)
+    deployParentWithChildBusinessId("=unknownFunction()");
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
+
+    // then - any null accompanied by evaluation warnings is an incident, not an intentional discard
+    final Record<IncidentRecordValue> incident = getIncident(processInstanceKey);
+    final Record<ProcessInstanceRecordValue> elementInstance =
+        getCallActivityInstance(processInstanceKey);
+
+    assertIncidentCreated(incident, elementInstance).hasErrorType(ErrorType.EXTRACT_VALUE_ERROR);
+    assertThat(incident.getValue().getErrorMessage())
+        .contains(
+            "Expected to resolve the business id for the call activity from expression 'unknownFunction()', but it evaluated to null.")
+        .contains("The evaluation reported the following warnings:");
+  }
+
+  @Test
   public void shouldCreateIncidentWhenBusinessIdFeelResolvesToTooLongValue() {
     // given - a FEEL expression whose variable resolves to a value longer than the maximum
     deployParentWithChildBusinessId("=businessIdVar");

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -10,10 +10,12 @@ package io.camunda.zeebe.engine.processing.incident;
 import static io.camunda.zeebe.engine.processing.incident.IncidentHelper.assertIncidentCreated;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.processing.processinstance.BusinessIdValidator;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -27,6 +29,7 @@ import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -485,6 +488,174 @@ public final class CallActivityIncidentTest {
         .containsExactly(
             List.of(parentProcessInstanceKey, callActivityInstanceKey),
             List.of(childProcessInstanceKey, failingElementInstanceKey));
+  }
+
+  @Test
+  public void shouldNotCreateIncidentWhenBusinessIdIsExplicitNull() {
+    // given - an explicit null discards the business id
+    deployParentWithChildBusinessId("=null");
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(parentProcessId)
+            .withBusinessId("parent-business-id")
+            .create();
+
+    // then - no incident; the child is created with no business id
+    Assertions.assertThat(getChildProcessInstance(processInstanceKey).getValue()).hasBusinessId("");
+  }
+
+  @Test
+  public void shouldNotCreateIncidentWhenBusinessIdFeelEvaluatesToEmptyString() {
+    // given - a FEEL expression evaluating to an empty string is treated like '=null'
+    deployParentWithChildBusinessId("=\"\"");
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(parentProcessId)
+            .withBusinessId("parent-business-id")
+            .create();
+
+    // then - no incident; the child is created with no business id
+    Assertions.assertThat(getChildProcessInstance(processInstanceKey).getValue()).hasBusinessId("");
+  }
+
+  @Test
+  public void shouldCreateIncidentWhenBusinessIdVariableNotExists() {
+    // given - a FEEL expression referencing a variable that is never provided
+    deployParentWithChildBusinessId("=businessIdVar");
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
+
+    // then
+    final Record<IncidentRecordValue> incident = getIncident(processInstanceKey);
+    final Record<ProcessInstanceRecordValue> elementInstance =
+        getCallActivityInstance(processInstanceKey);
+
+    assertIncidentCreated(incident, elementInstance)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            """
+            Expected to resolve the business id for the call activity from expression 'businessIdVar', but it evaluated to null. \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'businessIdVar'""");
+  }
+
+  @Test
+  public void shouldCreateIncidentWhenBusinessIdExceedsMaxLength() {
+    // given - a literal business id longer than the allowed maximum
+    deployParentWithChildBusinessId("b".repeat(257));
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
+
+    // then
+    final Record<IncidentRecordValue> incident = getIncident(processInstanceKey);
+    final Record<ProcessInstanceRecordValue> elementInstance =
+        getCallActivityInstance(processInstanceKey);
+
+    assertIncidentCreated(incident, elementInstance)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Expected to resolve a valid business id for the call activity, but it exceeds the max length of 256.");
+  }
+
+  @Test
+  public void shouldCreateIncidentWhenBusinessIdFeelResolvesToTooLongValue() {
+    // given - a FEEL expression whose variable resolves to a value longer than the maximum
+    deployParentWithChildBusinessId("=businessIdVar");
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(parentProcessId)
+            .withVariable(
+                "businessIdVar", "b".repeat(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH + 1))
+            .create();
+
+    // then
+    final Record<IncidentRecordValue> incident = getIncident(processInstanceKey);
+    final Record<ProcessInstanceRecordValue> elementInstance =
+        getCallActivityInstance(processInstanceKey);
+
+    assertIncidentCreated(incident, elementInstance)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Expected to resolve a valid business id for the call activity, but it exceeds the max length of %d."
+                .formatted(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH));
+  }
+
+  @Test
+  public void shouldCreateIncidentWhenBusinessIdResolvesToNonString() {
+    // given - a FEEL expression that resolves to a number
+    deployParentWithChildBusinessId("=42");
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
+
+    // then
+    final Record<IncidentRecordValue> incident = getIncident(processInstanceKey);
+    final Record<ProcessInstanceRecordValue> elementInstance =
+        getCallActivityInstance(processInstanceKey);
+
+    assertIncidentCreated(incident, elementInstance)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Expected the business id for the call activity to resolve to a string, but expression '42' evaluated to 'NUMBER'.");
+  }
+
+  @Test
+  public void shouldResolveIncidentAfterProvidingBusinessIdVariable() {
+    // given - a missing-variable incident at the call activity
+    deployParentWithChildBusinessId("=businessIdVar");
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
+    final Record<IncidentRecordValue> incident = getIncident(processInstanceKey);
+
+    // when - the variable is provided and the incident is resolved
+    ENGINE
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Map.of("businessIdVar", "resolved-business-id"))
+        .update();
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // then - the child is created with the now-resolvable business id
+    Assertions.assertThat(getChildProcessInstance(processInstanceKey).getValue())
+        .hasBusinessId("resolved-business-id");
+  }
+
+  private void deployParentWithChildBusinessId(final String businessId) {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            "wf-parent.bpmn",
+            Bpmn.createExecutableProcess(parentProcessId)
+                .startEvent()
+                .callActivity(
+                    "call", c -> c.zeebeProcessId(childProcessId).zeebeBusinessId(businessId))
+                .done())
+        .withXmlResource(
+            "wf-child.bpmn",
+            Bpmn.createExecutableProcess(childProcessId).startEvent().endEvent().done())
+        .deploy();
+  }
+
+  private Record<ProcessInstanceRecordValue> getChildProcessInstance(
+      final long parentProcessInstanceKey) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withParentProcessInstanceKey(parentProcessInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst();
   }
 
   private Record<ProcessInstanceRecordValue> getCallActivityInstance(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -548,26 +548,6 @@ public final class CallActivityIncidentTest {
   }
 
   @Test
-  public void shouldCreateIncidentWhenBusinessIdExceedsMaxLength() {
-    // given - a literal business id longer than the allowed maximum
-    deployParentWithChildBusinessId("b".repeat(257));
-
-    // when
-    final long processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
-
-    // then
-    final Record<IncidentRecordValue> incident = getIncident(processInstanceKey);
-    final Record<ProcessInstanceRecordValue> elementInstance =
-        getCallActivityInstance(processInstanceKey);
-
-    assertIncidentCreated(incident, elementInstance)
-        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
-        .hasErrorMessage(
-            "Expected to resolve a valid business id for the call activity, but it exceeds the max length of 256.");
-  }
-
-  @Test
   public void shouldCreateIncidentWhenBusinessIdFeelResolvesToTooLongValue() {
     // given - a FEEL expression whose variable resolves to a value longer than the maximum
     deployParentWithChildBusinessId("=businessIdVar");


### PR DESCRIPTION
## Description

Raises a resolvable incident at the call activity when the child `businessId` cannot be resolved to a valid value at runtime, per [ADR 0003-810](https://github.com/camunda/camunda/blob/main/zeebe/docs/adr/0003-810-business-id-call-activity-propagation.md) (D4). 
### What changed

**`CallActivityProcessor`** — replaced the `evaluateStringExpression` call, which collapsed every non-STRING FEEL result into the same failure, with raw-result evaluation (`evaluateAnyExpression`) and explicit branching:

| FEEL result | Behavior |
|---|---|
| Explicit `=null` | Discard — child gets no Business ID, no incident |
| Empty string (literal or FEEL) | Discard — child gets no Business ID, no incident |
| `NULL` from a missing/unresolvable variable (`NO_VARIABLE_FOUND` warning) | Resolvable incident |
| `STRING` exceeding 256 characters | Resolvable incident |
| Non-string, non-null type (e.g. `NUMBER`, `BOOLEAN`) | Resolvable incident |

The discriminator between an intentional `=null` and an incident-worthy coerced null is the `NO_VARIABLE_FOUND` evaluation warning.

**`BusinessIdValidator`** (new) — extracts the 256-character max-length constraint into a single shared source of truth, used by both the process-instance creation path (command rejection) and the call-activity path (incident).

**`ProcessInstanceCreationHelper`** — refactored to delegate to `BusinessIdValidator` instead of privately owning the length constant.

**`ZeebeRuntimeValidators`** — rejects a literal `businessId` exceeding the max length at deployment time, since a literal's length is statically knowable (previously this only surfaced as a runtime incident).

**ADR 0003-810 (D4)** — updated to describe the discard-vs-incident semantics implemented here, replacing the previous text that treated any null/empty FEEL result as an incident.

### Tests

- No incident for explicit `=null`, a FEEL expression evaluating to an empty string, or an empty literal — all discard the Business ID.
- Incident when the FEEL expression references a missing variable.
- Incident when the resolved value exceeds 256 characters.
- Incident when the FEEL expression resolves to a non-string, non-null type.
- Incident is resolvable: correcting the variable/expression and retrying activation creates the child with the expected Business ID.
- Deploy-time rejection of an over-length literal `businessId`, and acceptance at exactly the max length.

## Related issues

closes #56168