### PR TITLE
refactor: pass load-tester author and zone as Helm values instead of sed

### DIFF
--- a/load-tests/setup/main/newLoadTest.sh
+++ b/load-tests/setup/main/newLoadTest.sh
@@ -190,9 +190,7 @@ deadlineDate: "$deadline_date"
 # Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
 # Propagated to the camunda-load-tests (load-tester) subchart via Helm global
-# coalescing. These replace the former __AUTHOR__ / __AVAILABILITY_ZONE__ sed
-# placeholders and deep-merge with the static keys in
-# load-tester-values-defaults.yaml.
+# coalescing.
 global:
   commonLabels:
     camunda.io/created-by: "$git_author"

--- a/load-tests/setup/main/newLoadTest.sh
+++ b/load-tests/setup/main/newLoadTest.sh
@@ -189,6 +189,15 @@ author: "$git_author"
 deadlineDate: "$deadline_date"
 # Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
+# Propagated to the camunda-load-tests (load-tester) subchart via Helm global
+# coalescing. These replace the former __AUTHOR__ / __AVAILABILITY_ZONE__ sed
+# placeholders and deep-merge with the static keys in
+# load-tester-values-defaults.yaml.
+global:
+  commonLabels:
+    camunda.io/created-by: "$git_author"
+  nodeSelector:
+    topology.kubernetes.io/zone: $availability_zone
 EOF
 
 # Add/update helm repositories

--- a/load-tests/setup/newCloudLoadTest.sh
+++ b/load-tests/setup/newCloudLoadTest.sh
@@ -66,10 +66,9 @@ cd $namespace
 # Update Makefile to use the namespace
 sed_inplace "s/__NAMESPACE__/$namespace/" Makefile
 
-# Inject the author as a real Helm value (replacing the former __AUTHOR__ sed
-# placeholder). The Makefile passes this via -f alongside load-test-values.yaml,
-# so it deep-merges into global.commonLabels rather than being baked into a
-# committed file.
+# Inject the author as a real Helm value. The Makefile passes this via -f alongside
+# load-test-values.yaml, so it deep-merges into global.commonLabels rather than
+# being baked into a committed file.
 cat <<EOF > load-test-values-generated.yaml
 global:
   commonLabels:

--- a/load-tests/setup/newCloudLoadTest.sh
+++ b/load-tests/setup/newCloudLoadTest.sh
@@ -65,4 +65,13 @@ cd $namespace
 
 # Update Makefile to use the namespace
 sed_inplace "s/__NAMESPACE__/$namespace/" Makefile
-sed_inplace "s/__AUTHOR__/$git_author/" *.yaml
+
+# Inject the author as a real Helm value (replacing the former __AUTHOR__ sed
+# placeholder). The Makefile passes this via -f alongside load-test-values.yaml,
+# so it deep-merges into global.commonLabels rather than being baked into a
+# committed file.
+cat <<EOF > load-test-values-generated.yaml
+global:
+  commonLabels:
+    camunda.io/created-by: "$git_author"
+EOF

--- a/load-tests/setup/saas-default/Makefile
+++ b/load-tests/setup/saas-default/Makefile
@@ -39,6 +39,7 @@ install-load-test:
 		--set saas.credentials.zeebeGrpcAddress="$${ZEEBE_GRPC_ADDRESS}" \
 		--set saas.credentials.authorizationAudience="$${ZEEBE_TOKEN_AUDIENCE}" \
 		-f load-test-values.yaml \
+		-f load-test-values-generated.yaml \
 		$(additional_load_test_configuration)
 
 .PHONY: clean

--- a/load-tests/setup/saas-default/load-test-values.yaml
+++ b/load-tests/setup/saas-default/load-test-values.yaml
@@ -1,4 +1,6 @@
 global:
   commonLabels:
-    camunda.io/created-by: __AUTHOR__
+    # camunda.io/created-by is injected at scaffold time as a real Helm value via
+    # the generated load-test-values-generated.yaml (see newCloudLoadTest.sh), so
+    # it is not baked into this committed file.
     camunda.io/purpose: load-test

--- a/load-tests/setup/saas-default/load-test-values.yaml
+++ b/load-tests/setup/saas-default/load-test-values.yaml
@@ -1,6 +1,3 @@
 global:
   commonLabels:
-    # camunda.io/created-by is injected at scaffold time as a real Helm value via
-    # the generated load-test-values-generated.yaml (see newCloudLoadTest.sh), so
-    # it is not baked into this committed file.
     camunda.io/purpose: load-test

--- a/load-tests/setup/scenarios/load-tester-values-defaults.yaml
+++ b/load-tests/setup/scenarios/load-tester-values-defaults.yaml
@@ -1,6 +1,8 @@
 global:
   commonLabels:
-    camunda.io/created-by: __AUTHOR__
+    # camunda.io/created-by is injected at scaffold time as a real Helm value via
+    # the generated load-test-setup-values.yaml (see newLoadTest.sh), so it is
+    # not baked into this committed file.
     camunda.io/purpose: load-test
   image:
     repository: registry.camunda.cloud/team-zeebe
@@ -12,7 +14,8 @@ global:
 
   nodeSelector:
     component: benchmark-n2-standard-4
-    topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
+    # topology.kubernetes.io/zone is injected at scaffold time as a real Helm
+    # value via the generated load-test-setup-values.yaml (see newLoadTest.sh).
 
   tolerations:
     - key: nodepool

--- a/load-tests/setup/scenarios/load-tester-values-defaults.yaml
+++ b/load-tests/setup/scenarios/load-tester-values-defaults.yaml
@@ -1,8 +1,5 @@
 global:
   commonLabels:
-    # camunda.io/created-by is injected at scaffold time as a real Helm value via
-    # the generated load-test-setup-values.yaml (see newLoadTest.sh), so it is
-    # not baked into this committed file.
     camunda.io/purpose: load-test
   image:
     repository: registry.camunda.cloud/team-zeebe
@@ -14,8 +11,6 @@ global:
 
   nodeSelector:
     component: benchmark-n2-standard-4
-    # topology.kubernetes.io/zone is injected at scaffold time as a real Helm
-    # value via the generated load-test-setup-values.yaml (see newLoadTest.sh).
 
   tolerations:
     - key: nodepool

--- a/load-tests/setup/stable-87/newLoadTest.sh
+++ b/load-tests/setup/stable-87/newLoadTest.sh
@@ -191,9 +191,7 @@ deadlineDate: "$deadline_date"
 # Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
 # Propagated to the camunda-load-tests (load-tester) subchart via Helm global
-# coalescing. These replace the former __AUTHOR__ / __AVAILABILITY_ZONE__ sed
-# placeholders and deep-merge with the static keys in
-# load-tester-values-defaults.yaml.
+# coalescing.
 global:
   commonLabels:
     camunda.io/created-by: "$git_author"

--- a/load-tests/setup/stable-87/newLoadTest.sh
+++ b/load-tests/setup/stable-87/newLoadTest.sh
@@ -190,6 +190,15 @@ author: "$git_author"
 deadlineDate: "$deadline_date"
 # Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
+# Propagated to the camunda-load-tests (load-tester) subchart via Helm global
+# coalescing. These replace the former __AUTHOR__ / __AVAILABILITY_ZONE__ sed
+# placeholders and deep-merge with the static keys in
+# load-tester-values-defaults.yaml.
+global:
+  commonLabels:
+    camunda.io/created-by: "$git_author"
+  nodeSelector:
+    topology.kubernetes.io/zone: $availability_zone
 camundaManagementUrl: "http://zeebe-gateway:9600"
 
 loadTest:

--- a/load-tests/setup/stable-88/newLoadTest.sh
+++ b/load-tests/setup/stable-88/newLoadTest.sh
@@ -181,9 +181,7 @@ deadlineDate: "$deadline_date"
 # Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
 # Propagated to the camunda-load-tests (load-tester) subchart via Helm global
-# coalescing. These replace the former __AUTHOR__ / __AVAILABILITY_ZONE__ sed
-# placeholders and deep-merge with the static keys in
-# load-tester-values-defaults.yaml.
+# coalescing.
 global:
   commonLabels:
     camunda.io/created-by: "$git_author"

--- a/load-tests/setup/stable-88/newLoadTest.sh
+++ b/load-tests/setup/stable-88/newLoadTest.sh
@@ -180,6 +180,15 @@ author: "$git_author"
 deadlineDate: "$deadline_date"
 # Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
+# Propagated to the camunda-load-tests (load-tester) subchart via Helm global
+# coalescing. These replace the former __AUTHOR__ / __AVAILABILITY_ZONE__ sed
+# placeholders and deep-merge with the static keys in
+# load-tester-values-defaults.yaml.
+global:
+  commonLabels:
+    camunda.io/created-by: "$git_author"
+  nodeSelector:
+    topology.kubernetes.io/zone: $availability_zone
 EOF
 
 # Add/update helm repositories

--- a/load-tests/setup/stable-89/newLoadTest.sh
+++ b/load-tests/setup/stable-89/newLoadTest.sh
@@ -190,9 +190,7 @@ deadlineDate: "$deadline_date"
 # Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
 # Propagated to the camunda-load-tests (load-tester) subchart via Helm global
-# coalescing. These replace the former __AUTHOR__ / __AVAILABILITY_ZONE__ sed
-# placeholders and deep-merge with the static keys in
-# load-tester-values-defaults.yaml.
+# coalescing.
 global:
   commonLabels:
     camunda.io/created-by: "$git_author"

--- a/load-tests/setup/stable-89/newLoadTest.sh
+++ b/load-tests/setup/stable-89/newLoadTest.sh
@@ -189,6 +189,15 @@ author: "$git_author"
 deadlineDate: "$deadline_date"
 # Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
+# Propagated to the camunda-load-tests (load-tester) subchart via Helm global
+# coalescing. These replace the former __AUTHOR__ / __AVAILABILITY_ZONE__ sed
+# placeholders and deep-merge with the static keys in
+# load-tester-values-defaults.yaml.
+global:
+  commonLabels:
+    camunda.io/created-by: "$git_author"
+  nodeSelector:
+    topology.kubernetes.io/zone: $availability_zone
 EOF
 
 # Add/update helm repositories


### PR DESCRIPTION
## Description

`newLoadTest.sh` and `newCloudLoadTest.sh` no longer `sed`-substitute the `__AUTHOR__` / `__AVAILABILITY_ZONE__` placeholders into the committed load-tester values files. The author and zone are now passed as real Helm values through the generated values files, removing another slice of bash-based Helm templating (part of #54151).

- **Self-managed:** folded into the already-generated `load-test-setup-values.yaml` (no Makefile change — it is already passed with `-f`).
- **SaaS:** written to a generated `load-test-values-generated.yaml` overlay, added as a `-f` in the `saas-default` Makefile.

This is the camunda-side of camunda/camunda-load-tests-helm#58, which adds `global.commonLabels` support to the chart. With the currently pinned chart (`0.1.12`) the rendered output is unchanged; once #58 ships and the pin is bumped, `created-by` renders on all resources.

Golden-file tests render byte-identical (no regeneration needed).

## Checklist

- [ ] Enable backports when necessary (not needed — load-test setup tooling lives only on `main`).

## Related issues

closes #56641

<sub>🤖 Authored with [Claude Code](https://claude.com/claude-code)</sub>