### PR TITLE
fix: seed lastExportedPosition to -1 to avoid throttling after leader transition

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
@@ -49,4 +49,28 @@ public interface LogStreamMetrics {
   void setPartitionLoad(double load);
 
   void setWriteRateLimit(double value);
+
+  /**
+   * Registers the request rate meters. Should only be called when the request rate is actually
+   * limited.
+   */
+  void registerRequestRateMetrics();
+
+  /**
+   * Deregisters the request rate meters if any were registered before. Should be called when the
+   * request rate is not limited.
+   */
+  void deregisterRequestRateMetrics();
+
+  /**
+   * Registers the write-rate metrics. Should only be called when the write rate is actually
+   * limited.
+   */
+  void registerWriteRateMetrics();
+
+  /**
+   * Deregisters the write rate metrics if any were registered before. Should be called when the
+   * write rate is not limited.
+   */
+  void deregisterWriteRateMetrics();
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetricsImpl.java
@@ -42,9 +42,14 @@ import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter.Id;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.ToDoubleFunction;
+import org.jspecify.annotations.Nullable;
 
 public final class LogStreamMetricsImpl implements LogStreamMetrics {
   private final AtomicLong inflightAppends = new AtomicLong();
@@ -68,6 +73,9 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
   private final Timer commitLatency;
   private final Timer appendLatency;
 
+  private final Set<Id> registeredRequestRateMeters = new HashSet<>();
+  private final Set<Id> registeredWriteRateMeters = new HashSet<>();
+
   public LogStreamMetricsImpl(final MeterRegistry registry) {
     this.registry = registry;
     deferredAppends = registerCounter(TOTAL_DEFERRED_APPEND_COUNT);
@@ -79,18 +87,10 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
 
     registerGauge(INFLIGHT_APPENDS, inflightAppends);
     registerGauge(INFLIGHT_REQUESTS, inflightRequests);
-    registerGauge(REQUEST_LIMIT, requestLimit);
     registerGauge(LAST_COMMITTED_POSITION, lastCommitted);
     registerGauge(LAST_WRITTEN_POSITION, lastWritten);
     registerGauge(EXPORTING_RATE, exportingRate);
-    registerGauge(WRITE_RATE_MAX_LIMIT, writeRateMaxLimit);
-
-    Gauge.builder(WRITE_RATE_LIMIT.getName(), writeRateLimit, LogStreamMetricsImpl::longToDouble)
-        .description(WRITE_RATE_LIMIT.getDescription())
-        .register(registry);
-    Gauge.builder(PARTITION_LOAD.getName(), partitionLoad, LogStreamMetricsImpl::longToDouble)
-        .description(PARTITION_LOAD.getDescription())
-        .register(registry);
+    registerGauge(PARTITION_LOAD, partitionLoad, LogStreamMetricsImpl::longToDouble, null);
   }
 
   @Override
@@ -209,6 +209,31 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
     writeRateLimit.set(Double.doubleToLongBits(value));
   }
 
+  @Override
+  public void registerRequestRateMetrics() {
+    registerGauge(REQUEST_LIMIT, requestLimit, registeredRequestRateMeters);
+  }
+
+  @Override
+  public void deregisterRequestRateMetrics() {
+    registeredRequestRateMeters.forEach(registry::remove);
+  }
+
+  @Override
+  public void registerWriteRateMetrics() {
+    registerGauge(WRITE_RATE_MAX_LIMIT, writeRateMaxLimit, registeredWriteRateMeters);
+    registerGauge(
+        WRITE_RATE_LIMIT,
+        writeRateLimit,
+        LogStreamMetricsImpl::longToDouble,
+        registeredWriteRateMeters);
+  }
+
+  @Override
+  public void deregisterWriteRateMetrics() {
+    registeredWriteRateMeters.forEach(registry::remove);
+  }
+
   private Counter registerRecordAppendedCounter(
       final RecordType recordType, final ValueType valueType, final Intent intent) {
     return Counter.builder(RECORD_APPENDED.getName())
@@ -229,17 +254,37 @@ public final class LogStreamMetricsImpl implements LogStreamMetrics {
   }
 
   private void registerGauge(final ExtendedMeterDocumentation doc, final AtomicLong gauge) {
-    Gauge.builder(doc.getName(), gauge, AtomicLong::get)
-        .description(doc.getDescription())
-        .register(registry);
+    registerGauge(doc, gauge, AtomicLong::get, null);
   }
 
-  private Counter registerCounter(final ExtendedMeterDocumentation doc) {
-    return Counter.builder(doc.getName()).description(doc.getDescription()).register(registry);
+  private void registerGauge(
+      final ExtendedMeterDocumentation doc,
+      final AtomicLong gauge,
+      @Nullable final Set<Id> registeredGauges) {
+    registerGauge(doc, gauge, AtomicLong::get, registeredGauges);
+  }
+
+  private void registerGauge(
+      final ExtendedMeterDocumentation doc,
+      final AtomicLong gauge,
+      final ToDoubleFunction<AtomicLong> valueFunction,
+      @Nullable final Set<Id> registeredGauges) {
+    final var id =
+        Gauge.builder(doc.getName(), gauge, valueFunction)
+            .description(doc.getDescription())
+            .register(registry)
+            .getId();
+    if (registeredGauges != null) {
+      registeredGauges.add(id);
+    }
   }
 
   private static double longToDouble(final AtomicLong value) {
     return Double.longBitsToDouble(value.get());
+  }
+
+  private Counter registerCounter(final ExtendedMeterDocumentation doc) {
+    return Counter.builder(doc.getName()).description(doc.getDescription()).register(registry);
   }
 
   private static FlowControlOutcome tagForRejection(final Rejection reason) {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -93,8 +93,10 @@ public final class FlowControl {
       new RateMeasurement(
           ActorClock::currentTimeMillis, Duration.ofMinutes(5), Duration.ofSeconds(10));
   @Nullable private RateLimitThrottle writeRateThrottle;
-  private volatile long lastWrittenPosition = -1;
-  private volatile long lastExportedPosition = -1;
+  private volatile long lastWrittenPosition =
+      -1; // Initially a sentinel value to not throttle until the first write
+  private volatile long lastExportedPosition =
+      -1; // Initially a sentinel value to not throttle until the first export
 
   private final RingBuffer inFlight;
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -94,7 +94,7 @@ public final class FlowControl {
           ActorClock::currentTimeMillis, Duration.ofMinutes(5), Duration.ofSeconds(10));
   @Nullable private RateLimitThrottle writeRateThrottle;
   private volatile long lastWrittenPosition = -1;
-  private volatile long lastExportedPosition;
+  private volatile long lastExportedPosition = -1;
 
   private final RingBuffer inFlight;
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -227,6 +227,13 @@ public final class FlowControl {
   }
 
   public void setRequestLimit(final @Nullable Limit requestLimit) {
+    if (requestLimit != null) {
+      metrics.registerRequestRateMetrics();
+      metrics.setRequestLimit(requestLimit.getLimit());
+    } else {
+      metrics.deregisterRequestRateMetrics();
+    }
+
     this.requestLimit = requestLimit;
     processingLimiter =
         requestLimit != null
@@ -239,14 +246,23 @@ public final class FlowControl {
   }
 
   public void setWriteRateLimit(final @Nullable RateLimit writeRateLimit) {
+    if (writeRateLimit != null && writeRateLimit.enabled()) {
+      metrics.registerWriteRateMetrics();
+      // Immediately publish the new max limit. This stays constant until a new write-rate config is
+      // set.
+      metrics.setWriteRateMaxLimit(writeRateLimit.limit());
+      // Set newly configured write-rate limits. The limit may be updated by the `RateLimitThrottle`
+      // if throttling is enabled.
+      metrics.setWriteRateLimit(writeRateLimit.limit());
+    } else {
+      // No write-rate limit configured, clear previous metrics.
+      metrics.deregisterWriteRateMetrics();
+    }
+
     this.writeRateLimit = writeRateLimit;
     writeRateLimiter = writeRateLimit == null ? null : writeRateLimit.limiter();
     writeRateThrottle =
         new RateLimitThrottle(metrics, writeRateLimit, writeRateLimiter, exportingRate);
-    if (writeRateLimit == null || !writeRateLimit.enabled()) {
-      // if the write rate limit is disabled, we need to clear the previous values.
-      metrics.setPartitionLoad(-1);
-    }
   }
 
   public enum Rejection {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateLimitThrottle.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateLimitThrottle.java
@@ -72,7 +72,6 @@ final class RateLimitThrottle {
           limit.throttling().acceptableBacklog());
     }
     limiter.setRate(adjustedRate);
-    metrics.setWriteRateMaxLimit(limit.limit());
     metrics.setWriteRateLimit(adjustedRate);
   }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RequestLimiter.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RequestLimiter.java
@@ -19,8 +19,6 @@ public final class RequestLimiter extends AbstractLimiter<Intent> {
   private RequestLimiter(final CommandRateLimiterBuilder builder, final LogStreamMetrics metrics) {
     super(builder);
     this.metrics = metrics;
-    metrics.setInflightRequests(0);
-    metrics.setRequestLimit(getLimit());
   }
 
   @Override

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -157,13 +157,105 @@ public class FlowControlTest {
     listener.onWrite(1, writtenPosition);
 
     // then — the throttle must not engage: with lastExportedPosition still uninitialized, the
-    // backlog is unknown, so the write rate must not be clamped down to minRate. Before the fix,
-    // lastExportedPosition defaulted to 0, producing a backlog equal to the entire written
-    // position and clamping the rate to minRate.
+    // backlog is unknown, so the write rate must stay at the configured limit rather than being
+    // clamped down to minRate. Before the fix, lastExportedPosition defaulted to 0, producing a
+    // backlog equal to the entire written position and clamping the rate to minRate.
     assertThat(meterRegistry.get("zeebe.flow.control.write.rate.limit").gauge().value())
         .as("write rate must not be throttled before the first export observation")
         .isNotEqualTo((double) minRate)
-        .isZero();
+        .isEqualTo(7000);
+  }
+
+  @Test
+  void shouldPublishWriteRateLimitsImmediately() {
+    // given — throttling disabled, so RateLimitThrottle never publishes anything
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var metrics = new LogStreamMetricsImpl(meterRegistry);
+    final var writeRateLimit =
+        new RateLimit(true, 7000, Duration.ZERO, RateLimit.Throttling.disabled());
+
+    // when — the write rate limit is configured (as happens on construction / via the actuator)
+    new FlowControl(metrics, StabilizingAIMDLimit.newBuilder().build(), writeRateLimit);
+
+    // then — the configured limits are published immediately, without waiting for a write or export
+    assertThat(meterRegistry.get("zeebe.flow.control.write.rate.maximum").gauge().value())
+        .as("max write rate limit is published immediately")
+        .isEqualTo(7000);
+    assertThat(meterRegistry.get("zeebe.flow.control.write.rate.limit").gauge().value())
+        .as("write rate limit is published immediately at the configured limit")
+        .isEqualTo(7000);
+  }
+
+  @Test
+  void shouldRemoveWriteRateMetersWhenWriteRateLimitDisabled() {
+    // given — a FlowControl with an enabled write rate limit
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var metrics = new LogStreamMetricsImpl(meterRegistry);
+    final var enabled = new RateLimit(true, 7000, Duration.ZERO, RateLimit.Throttling.disabled());
+    final var fc = new FlowControl(metrics, StabilizingAIMDLimit.newBuilder().build(), enabled);
+    assertThat(meterRegistry.find("zeebe.flow.control.write.rate.limit").gauge()).isNotNull();
+    assertThat(meterRegistry.find("zeebe.flow.control.write.rate.maximum").gauge()).isNotNull();
+
+    // when — the write rate limit is disabled (reconfigured via the actuator)
+    fc.setWriteRateLimit(RateLimit.disabled());
+
+    // then — the outdated write rate meters are removed rather than left reporting stale values
+    assertThat(meterRegistry.find("zeebe.flow.control.write.rate.limit").gauge()).isNull();
+    assertThat(meterRegistry.find("zeebe.flow.control.write.rate.maximum").gauge()).isNull();
+  }
+
+  @Test
+  void shouldRemoveRequestLimitMeterWhenRequestLimitRemoved() {
+    // given — a FlowControl with a request limit
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var metrics = new LogStreamMetricsImpl(meterRegistry);
+    final var fc =
+        new FlowControl(metrics, StabilizingAIMDLimit.newBuilder().build(), RateLimit.disabled());
+    assertThat(meterRegistry.find("zeebe.backpressure.requests.limit").gauge()).isNotNull();
+
+    // when — the request limit is removed (reconfigured via the actuator)
+    fc.setRequestLimit(null);
+
+    // then — the outdated request limit meter is removed rather than left reporting a stale value
+    assertThat(meterRegistry.find("zeebe.backpressure.requests.limit").gauge()).isNull();
+  }
+
+  @Test
+  void shouldNotResetInflightRequestsWhenReconfiguringRequestLimit() {
+    // given — a FlowControl with a request limit and one in-flight user command
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var metrics = new LogStreamMetricsImpl(meterRegistry);
+    final var fc =
+        new FlowControl(
+            metrics,
+            StabilizingAIMDLimit.newBuilder().initialLimit(100).build(),
+            RateLimit.disabled());
+    final var intent = ProcessInstanceCreationIntent.CREATE;
+    final var context = new UserCommand(intent);
+    final var entry =
+        fc.tryAcquire(
+                context,
+                List.of(
+                    LogAppendEntry.of(
+                        new RecordMetadata()
+                            .recordType(RecordType.COMMAND)
+                            .valueType(ValueType.PROCESS_INSTANCE_CREATION)
+                            .intent(intent),
+                        new UnifiedRecordValue(0))))
+            .get();
+    fc.registerEntry(1, entry);
+    fc.onAppended(entry);
+    assertThat(meterRegistry.get("zeebe.backpressure.inflight.requests.count").gauge().value())
+        .as("the acquired command is counted as in-flight")
+        .isEqualTo(1);
+
+    // when — the request limit is reconfigured (as happens via the actuator)
+    fc.setRequestLimit(StabilizingAIMDLimit.newBuilder().initialLimit(200).build());
+
+    // then — the in-flight request count is preserved, not reset by building a new limiter
+    assertThat(meterRegistry.get("zeebe.backpressure.inflight.requests.count").gauge().value())
+        .as("reconfiguring the request limit must not reset the in-flight request count")
+        .isEqualTo(1);
   }
 
   @Test

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -124,6 +124,49 @@ public class FlowControlTest {
   }
 
   @Test
+  void shouldNotThrottleBeforeFirstExport() {
+    // given — a fresh FlowControl (as created on every leader transition) with throttling enabled
+    // and a partition that has already written far past the acceptable backlog
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var metrics = new LogStreamMetricsImpl(meterRegistry);
+    final var minRate = 700L;
+    final var writeRateLimit =
+        new RateLimit(
+            true,
+            7000,
+            Duration.ZERO,
+            new Throttling(true, 300_000L, minRate, Duration.ofSeconds(15)));
+    final var fc =
+        new FlowControl(metrics, StabilizingAIMDLimit.newBuilder().build(), writeRateLimit);
+    final var intent = ProcessInstanceCreationIntent.CREATE;
+    final var context = new UserCommand(intent);
+    final var result =
+        fc.tryAcquire(
+            context,
+            List.of(
+                LogAppendEntry.of(
+                    new RecordMetadata()
+                        .recordType(RecordType.COMMAND)
+                        .valueType(ValueType.PROCESS_INSTANCE_CREATION)
+                        .intent(intent),
+                    new UnifiedRecordValue(0))));
+    final var writtenPosition = 4_700_000_000L;
+    final var listener = fc.registerEntry(writtenPosition, result.get());
+
+    // when — the first record is written, but nothing has been exported yet
+    listener.onWrite(1, writtenPosition);
+
+    // then — the throttle must not engage: with lastExportedPosition still uninitialized, the
+    // backlog is unknown, so the write rate must not be clamped down to minRate. Before the fix,
+    // lastExportedPosition defaulted to 0, producing a backlog equal to the entire written
+    // position and clamping the rate to minRate.
+    assertThat(meterRegistry.get("zeebe.flow.control.write.rate.limit").gauge().value())
+        .as("write rate must not be throttled before the first export observation")
+        .isNotEqualTo((double) minRate)
+        .isZero();
+  }
+
+  @Test
   void shouldReduceRequestLimitWhenRingBufferWrapsAround() {
     // given — small ring buffer so wraparound happens quickly
     final var meterRegistry = new SimpleMeterRegistry();


### PR DESCRIPTION
## Description

`FlowControl` initialized `lastWrittenPosition = -1` but left `lastExportedPosition` at its default of `0`. The `updateWriteRateThrottle` guard only skips the `-1` sentinel, so `0` passed through.

A new `FlowControl` is created on every leader transition. Until the exporter exported its first record, each write computed `backlog = lastWrittenPosition - 0` — the partition's *entire* written position (billions on a long-lived partition), far above any `acceptableBacklog`. With the exporting-rate measurement still empty (observed rate 0), `RateLimitThrottle` clamped the write rate straight to `minRate`, briefly rejecting user commands with `RESOURCE_EXHAUSTED` after every transition.

On SaaS clusters running on spot nodes, leader transitions happen multiple times per day, so these throttle windows recur and correlate with client-facing error bursts.

## Fix

Seed `lastExportedPosition = -1` so the existing guard holds until the first real export observation arrives (`onExported` already ignores positions `<= 0`). Throttling now only engages once the actual exporter backlog is known.

## Test

Added `FlowControlTest.shouldNotThrottleBeforeFirstExport`: a fresh `FlowControl` with SaaS-like throttling config writes a record far past the acceptable backlog with nothing exported yet, and asserts the write rate is not clamped to `minRate`. Verified it fails against the unpatched code (clamps to `700.0`, the reported signature) and passes with the fix.

Closes #56673