### PR TITLE
ci: cache Go builds and fix too-tight unit test timeout in c8run-build workflow

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GO_VERSION}}
-          cache: false # disabling since not working anyways without a cache-dependency-path specified
+          cache-dependency-path: c8run/go.sum
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
@@ -76,7 +76,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
     name: C8Run Unit Tests ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 2
+    timeout-minutes: 5
     defaults:
       run:
         working-directory: ./c8run
@@ -86,7 +86,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GO_VERSION}}
-          cache: false
+          cache-dependency-path: c8run/go.sum
 
       - name: Download dependencies
         run: go mod download
@@ -270,7 +270,7 @@ jobs:
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: ${{ env.GO_VERSION}}
-          cache: false # disabling since not working anyways without a cache-dependency-path specified
+          cache-dependency-path: c8run/go.sum
 
       - name: Setup Java 21
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0


### PR DESCRIPTION
## Description

Fixes INC-6272: the `test_c8run_unittests` job has `timeout-minutes: 2` while healthy runs take 62–119s on `macos-15-intel`/`windows-latest`, because every run compiles cold with the setup-go cache disabled. The slow tail of normal runs crosses the 2-minute budget and gets cancelled; in the alerting run all tests passed and the job was killed right after the last test finished. Same signature in 7 of the last 50 runs on `main`.

- Enable the setup-go cache in all three `actions/setup-go` steps via `cache-dependency-path: c8run/go.sum`.
- Raise the unit test job timeout from 2 to 5 minutes to cover the cold-cache tail (worst observed: 2m48s).

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

INC-6272