### PR TITLE
fix: case-insensitive Slack message lookup in stale backport tracker

### DIFF
--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -340,7 +340,7 @@ jobs:
           message_ts=$(echo "$response" | jq -r '
             [(.messages // [])[] | select(
               .bot_id != null and
-              (.blocks[]?.text?.text? // "" | test("Stale Backport PRs"))
+              (.blocks[]?.text?.text? // "" | test("Stale Backport PRs"; "i"))
             )] | first | .ts // ""')
 
           if [[ -n "$message_ts" ]]; then
@@ -420,7 +420,7 @@ jobs:
             [(.items // [])[] | select(
               .type == "message" and
               .message.bot_id != null and
-              (.message.blocks[]?.text?.text? // "" | test("Stale Backport PRs"))
+              (.message.blocks[]?.text?.text? // "" | test("Stale Backport PRs"; "i"))
             ) | .message.ts] | .[]' | while read -r ts; do
             echo "Unpinning old message: $ts" >&2
             resp=$(curl -s -X POST "https://slack.com/api/pins.remove" \


### PR DESCRIPTION
## Summary

- `test("Stale Backport PRs")` in jq is case-sensitive
- The \"no stale\" block text is `"✅ *No stale backport PRs*"` (lowercase `s`/`b`) — doesn't match
- Result: every \"no stale\" run posted a new message instead of updating the existing one; when stale PRs appeared next, a third new message was posted instead of updating again
- Fix: add `"i"` flag (`test("Stale Backport PRs"; "i")`) in both `find-message` and `Unpin previous day` steps