### PR TITLE
refactor: migrate Group, Role, MappingRule to AuthorizationCheckPort (Inc 4b)

### DIFF
--- a/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/zeebe/engine/processing/AuthorizationArchTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
@@ -112,6 +113,21 @@ public class AuthorizationArchTest {
                     "isAuthorized",
                     TypedRecord.class,
                     PermissionType.class))
+            .or(
+                ArchConditions.callMethod(
+                    PermissionsBehavior.class,
+                    "isAuthorized",
+                    TypedRecord.class,
+                    AuthorizationResourceType.class,
+                    PermissionType.class))
+            .or(
+                ArchConditions.callMethod(
+                    PermissionsBehavior.class,
+                    "isAuthorized",
+                    TypedRecord.class,
+                    AuthorizationResourceType.class,
+                    PermissionType.class,
+                    String.class))
             .or(
                 ArchConditions.callMethod(
                     ProcessInstanceCreationHelper.class,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -354,14 +354,6 @@ public final class EngineProcessors {
         commandDistributionBehavior,
         securityConfig);
 
-    MappingRuleProcessors.addMappingRuleProcessors(
-        typedRecordProcessors,
-        processingState,
-        authCheckBehavior,
-        keyGenerator,
-        writers,
-        commandDistributionBehavior);
-
     IdentitySetupProcessors.addIdentitySetupProcessors(
         keyGenerator, typedRecordProcessors, writers, securityConfig, config);
 
@@ -496,6 +488,16 @@ public final class EngineProcessors {
         securityConfig);
 
     RoleProcessors.addRoleProcessors(
+        typedRecordProcessors,
+        processingState,
+        authzService,
+        claimsConverter,
+        keyGenerator,
+        writers,
+        commandDistributionBehavior,
+        securityConfig);
+
+    MappingRuleProcessors.addMappingRuleProcessors(
         typedRecordProcessors,
         processingState,
         authzService,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -346,15 +346,6 @@ public final class EngineProcessors {
         commandDistributionBehavior,
         securityConfig);
 
-    GroupProcessors.addGroupProcessors(
-        typedRecordProcessors,
-        processingState,
-        authCheckBehavior,
-        keyGenerator,
-        writers,
-        commandDistributionBehavior,
-        securityConfig);
-
     ScalingProcessors.addScalingProcessors(
         commandDistributionBehavior,
         bpmnBehaviors,
@@ -502,6 +493,16 @@ public final class EngineProcessors {
         authCheckBehavior,
         securityConfig,
         authorizationScopeStateAdapter);
+
+    GroupProcessors.addGroupProcessors(
+        typedRecordProcessors,
+        processingState,
+        authzService,
+        claimsConverter,
+        keyGenerator,
+        writers,
+        commandDistributionBehavior,
+        securityConfig);
   }
 
   private static TypedRecordProcessor<UserTaskRecord> createUserTaskProcessor(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -337,15 +337,6 @@ public final class EngineProcessors {
         securityConfig,
         config);
 
-    RoleProcessors.addRoleProcessors(
-        typedRecordProcessors,
-        processingState,
-        authCheckBehavior,
-        keyGenerator,
-        writers,
-        commandDistributionBehavior,
-        securityConfig);
-
     ScalingProcessors.addScalingProcessors(
         commandDistributionBehavior,
         bpmnBehaviors,
@@ -495,6 +486,16 @@ public final class EngineProcessors {
         authorizationScopeStateAdapter);
 
     GroupProcessors.addGroupProcessors(
+        typedRecordProcessors,
+        processingState,
+        authzService,
+        claimsConverter,
+        keyGenerator,
+        writers,
+        commandDistributionBehavior,
+        securityConfig);
+
+    RoleProcessors.addRoleProcessors(
         typedRecordProcessors,
         processingState,
         authzService,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -29,7 +29,9 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
   private static final String ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE =
       "Expected to add entity with ID '%s' to group with ID '%s', but the entity is already assigned to this group.";

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -9,8 +9,6 @@ package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -40,7 +38,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
   private final MappingRuleState mappingRuleState;
   private final UserState userState;
   private final MembershipState membershipState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -50,14 +48,14 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
 
   public GroupAddEntityProcessor(
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
       final EngineSecurityConfig securityConfig) {
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.keyGenerator = keyGenerator;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     groupState = processingState.getGroupState();
     membershipState = processingState.getMembershipState();
     mappingRuleState = processingState.getMappingRuleState();
@@ -71,13 +69,9 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
   @Override
   public void processNewCommand(final TypedRecord<GroupRecord> command) {
     final var record = command.getValue();
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.GROUP)
-            .permissionType(PermissionType.UPDATE)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.GROUP, PermissionType.UPDATE);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -22,7 +22,9 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class GroupCreateProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
 
   public static final String GROUP_ALREADY_EXISTS_ERROR_MESSAGE =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -30,7 +28,7 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
   public static final String GROUP_ALREADY_EXISTS_ERROR_MESSAGE =
       "Expected to create group with ID '%s', but a group with this ID already exists.";
   private final GroupState groupState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -39,12 +37,12 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
 
   public GroupCreateProcessor(
       final GroupState groupState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     this.groupState = groupState;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     this.commandDistributionBehavior = commandDistributionBehavior;
     stateWriter = writers.state();
@@ -54,13 +52,9 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
 
   @Override
   public void processNewCommand(final TypedRecord<GroupRecord> command) {
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.GROUP)
-            .permissionType(PermissionType.CREATE)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.GROUP, PermissionType.CREATE);
 
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
@@ -30,7 +30,9 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
 
   private static final String GROUP_NOT_FOUND_ERROR_MESSAGE =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupDeleteProcessor.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -40,7 +38,7 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
   private final GroupState groupState;
   private final AuthorizationState authorizationState;
   private final MembershipState membershipState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -49,14 +47,14 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
 
   public GroupDeleteProcessor(
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     groupState = processingState.getGroupState();
     authorizationState = processingState.getAuthorizationState();
     membershipState = processingState.getMembershipState();
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -68,14 +66,9 @@ public class GroupDeleteProcessor implements DistributedTypedRecordProcessor<Gro
   public void processNewCommand(final TypedRecord<GroupRecord> command) {
     final var record = command.getValue();
     final var groupId = record.getGroupId();
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.GROUP)
-            .permissionType(PermissionType.DELETE)
-            .addResourceId(groupId)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.GROUP, PermissionType.DELETE, groupId);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
@@ -17,7 +17,9 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class GroupProcessors {
   public static void addGroupProcessors(
       final TypedRecordProcessors typedRecordProcessors,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
@@ -8,8 +8,9 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -21,17 +22,20 @@ public class GroupProcessors {
   public static void addGroupProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final AuthorizationCheckPort authCheckPort,
+      final LazyTokenClaimsConverter claimsConverter,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
       final EngineSecurityConfig securityConfig) {
+    final var permissionsBehavior =
+        new PermissionsBehavior(processingState, authCheckPort, claimsConverter, securityConfig);
     typedRecordProcessors.onCommand(
         ValueType.GROUP,
         GroupIntent.CREATE,
         new GroupCreateProcessor(
             processingState.getGroupState(),
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior));
@@ -41,7 +45,7 @@ public class GroupProcessors {
         new GroupUpdateProcessor(
             processingState.getGroupState(),
             keyGenerator,
-            authCheckBehavior,
+            permissionsBehavior,
             writers,
             commandDistributionBehavior));
     typedRecordProcessors.onCommand(
@@ -49,7 +53,7 @@ public class GroupProcessors {
         GroupIntent.ADD_ENTITY,
         new GroupAddEntityProcessor(
             processingState,
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior,
@@ -59,7 +63,7 @@ public class GroupProcessors {
         GroupIntent.REMOVE_ENTITY,
         new GroupRemoveEntityProcessor(
             processingState,
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior));
@@ -68,7 +72,7 @@ public class GroupProcessors {
         GroupIntent.DELETE,
         new GroupDeleteProcessor(
             processingState,
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -36,7 +34,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
   private final GroupState groupState;
   private final MappingRuleState mappingRuleState;
   private final MembershipState membershipState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -45,14 +43,14 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
 
   public GroupRemoveEntityProcessor(
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     groupState = processingState.getGroupState();
     mappingRuleState = processingState.getMappingRuleState();
     membershipState = processingState.getMembershipState();
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -65,14 +63,9 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
     final var record = command.getValue();
     final var groupId = record.getGroupId();
 
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.GROUP)
-            .permissionType(PermissionType.UPDATE)
-            .addResourceId(groupId)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.GROUP, PermissionType.UPDATE, groupId);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -27,7 +27,9 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
   private static final String ENTITY_NOT_ASSIGNED_ERROR_MESSAGE =
       "Expected to remove entity with ID '%s' from group with ID '%s', but the entity is not assigned to this group.";

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -30,7 +28,7 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
 
   private final GroupState groupState;
   private final KeyGenerator keyGenerator;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
@@ -39,12 +37,12 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
   public GroupUpdateProcessor(
       final GroupState groupState,
       final KeyGenerator keyGenerator,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     this.groupState = groupState;
     this.keyGenerator = keyGenerator;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.commandDistributionBehavior = commandDistributionBehavior;
     stateWriter = writers.state();
     responseWriter = writers.response();
@@ -56,14 +54,9 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
     final var record = command.getValue();
     final var groupId = record.getGroupId();
 
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.GROUP)
-            .permissionType(PermissionType.UPDATE)
-            .addResourceId(groupId)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.GROUP, PermissionType.UPDATE, groupId);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -23,7 +23,9 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
 
   private final GroupState groupState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleCreateProcessor.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -24,7 +22,9 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class MappingRuleCreateProcessor
     implements DistributedTypedRecordProcessor<MappingRuleRecord> {
 
@@ -36,7 +36,7 @@ public class MappingRuleCreateProcessor
       "Expected to create mapping rule with id '%s', but a mapping rule with this id already exists.";
 
   private final MappingRuleState mappingRuleState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -45,12 +45,12 @@ public class MappingRuleCreateProcessor
 
   public MappingRuleCreateProcessor(
       final MappingRuleState mappingRuleState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     this.mappingRuleState = mappingRuleState;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -60,13 +60,9 @@ public class MappingRuleCreateProcessor
 
   @Override
   public void processNewCommand(final TypedRecord<MappingRuleRecord> command) {
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.MAPPING_RULE)
-            .permissionType(PermissionType.CREATE)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.MAPPING_RULE, PermissionType.CREATE);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleDeleteProcessor.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -43,7 +41,9 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class MappingRuleDeleteProcessor
     implements DistributedTypedRecordProcessor<MappingRuleRecord> {
 
@@ -55,7 +55,7 @@ public class MappingRuleDeleteProcessor
   private final GroupState groupState;
   private final AuthorizationState authorizationState;
   private final MembershipState membershipState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -64,7 +64,7 @@ public class MappingRuleDeleteProcessor
 
   public MappingRuleDeleteProcessor(
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
@@ -74,7 +74,7 @@ public class MappingRuleDeleteProcessor
     groupState = processingState.getGroupState();
     authorizationState = processingState.getAuthorizationState();
     membershipState = processingState.getMembershipState();
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -94,13 +94,9 @@ public class MappingRuleDeleteProcessor
       return;
     }
 
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.MAPPING_RULE)
-            .permissionType(PermissionType.DELETE)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.MAPPING_RULE, PermissionType.DELETE);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleProcessors.java
@@ -7,29 +7,37 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class MappingRuleProcessors {
   public static void addMappingRuleProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final AuthorizationCheckPort authCheckPort,
+      final LazyTokenClaimsConverter claimsConverter,
       final KeyGenerator keyGenerator,
       final Writers writers,
-      final CommandDistributionBehavior commandDistributionBehavior) {
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final EngineSecurityConfig securityConfig) {
+    final var permissionsBehavior =
+        new PermissionsBehavior(processingState, authCheckPort, claimsConverter, securityConfig);
     typedRecordProcessors.onCommand(
         ValueType.MAPPING_RULE,
         MappingRuleIntent.CREATE,
         new MappingRuleCreateProcessor(
             processingState.getMappingRuleState(),
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior));
@@ -38,7 +46,7 @@ public class MappingRuleProcessors {
         MappingRuleIntent.DELETE,
         new MappingRuleDeleteProcessor(
             processingState,
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior));
@@ -47,7 +55,7 @@ public class MappingRuleProcessors {
         MappingRuleIntent.UPDATE,
         new MappingRuleUpdateProcessor(
             processingState.getMappingRuleState(),
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingRuleUpdateProcessor.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -24,7 +22,9 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class MappingRuleUpdateProcessor
     implements DistributedTypedRecordProcessor<MappingRuleRecord> {
   private static final String MAPPING_RULE_NULL_VALUE_ERROR_MESSAGE =
@@ -35,7 +35,7 @@ public class MappingRuleUpdateProcessor
       "Expected to update mapping rule with id '%s', but a mapping rule with this id does not exist.";
 
   private final MappingRuleState mappingRuleState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -44,12 +44,12 @@ public class MappingRuleUpdateProcessor
 
   public MappingRuleUpdateProcessor(
       final MappingRuleState mappingRuleState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     this.mappingRuleState = mappingRuleState;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -90,14 +90,9 @@ public class MappingRuleUpdateProcessor
       return;
     }
 
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.MAPPING_RULE)
-            .permissionType(PermissionType.UPDATE)
-            .addResourceId(mappingRuleId)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.MAPPING_RULE, PermissionType.UPDATE, mappingRuleId);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.mapper.AuthzModelMapper;
@@ -67,6 +68,21 @@ public class PermissionsBehavior {
 
   public Either<Rejection, AuthorizationRecord> isAuthorized(
       final TypedRecord<AuthorizationRecord> command, final PermissionType permissionType) {
+    return isAuthorized(command, AuthorizationResourceType.AUTHORIZATION, permissionType);
+  }
+
+  public <R extends UnifiedRecordValue> Either<Rejection, R> isAuthorized(
+      final TypedRecord<R> command,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType) {
+    return isAuthorized(command, resourceType, permissionType, "*");
+  }
+
+  public <R extends UnifiedRecordValue> Either<Rejection, R> isAuthorized(
+      final TypedRecord<R> command,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final String resourceId) {
     if (command.isInternalCommand()) {
       LOG.trace("Skipping authorization check for internal command {}", command.getIntent());
       return Either.right(command.getValue());
@@ -80,41 +96,35 @@ public class PermissionsBehavior {
     if (!securityConfig.isAuthorizationsEnabled()
         && !securityConfig.isMultiTenancyChecksEnabled()) {
       LOG.trace(
-          "Skipping authorization check for command {}: security disabled (authz={}, multiTenancy={})",
-          command.getIntent(),
-          securityConfig.isAuthorizationsEnabled(),
-          securityConfig.isMultiTenancyChecksEnabled());
+          "Skipping authorization check for command {}: security disabled", command.getIntent());
       return Either.right(command.getValue());
     }
     if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
         && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
-      // No principal identity present: the CSL claims converter would throw. Mirror main's
-      // non-throwing contract — authorize when authorization checks are disabled (authorization
-      // commands are not tenant-owned, so the multi-tenancy check is a no-op), otherwise reject.
       if (!securityConfig.isAuthorizationsEnabled()) {
         return Either.right(command.getValue());
       }
       LOG.debug(
           "Rejecting command {}: neither username nor clientId claim is present",
           command.getIntent());
-      return Either.left(
-          AuthorizationRejectionMapper.forbidden(
-              permissionType, AuthorizationResourceType.AUTHORIZATION));
+      return Either.left(AuthorizationRejectionMapper.forbidden(permissionType, resourceType));
     }
     LOG.trace(
-        "Checking {} permission on AUTHORIZATION resource for command {}",
+        "Checking {} permission on {} resource for command {}",
         permissionType,
+        resourceType,
         command.getIntent());
     final var auth = claimsConverter.convert(authorizations);
     final var cslPermType = AuthzModelMapper.fromProtocol(permissionType);
+    final var cslResourceType = AuthzModelMapper.fromProtocol(resourceType);
     final var result =
         authCheckPort.check(
             auth,
             RequiredAuthorization.of(
                 b ->
-                    b.authorization()
+                    b.resourceType(cslResourceType)
                         .permissionType(cslPermType)
-                        .resourceId(AuthorizationScope.WILDCARD_CHAR)));
+                        .resourceId(resourceId)));
     if (result.isLeft()) {
       LOG.debug(
           "Authorization check rejected for command {}: {}",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -75,7 +75,7 @@ public class PermissionsBehavior {
       final TypedRecord<R> command,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType) {
-    return isAuthorized(command, resourceType, permissionType, "*");
+    return isAuthorized(command, resourceType, permissionType, AuthorizationScope.WILDCARD_CHAR);
   }
 
   public <R extends UnifiedRecordValue> Either<Rejection, R> isAuthorized(
@@ -101,6 +101,9 @@ public class PermissionsBehavior {
     }
     if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
         && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
+      // No principal identity present: the CSL claims converter would throw. Mirror main's
+      // non-throwing contract — authorize when authorization checks are disabled (these identity
+      // resources are not tenant-owned, so the multi-tenancy check is a no-op), otherwise reject.
       if (!securityConfig.isAuthorizationsEnabled()) {
         return Either.right(command.getValue());
       }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -9,8 +9,6 @@ package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -32,7 +30,9 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
   public static final String ROLE_NOT_FOUND_ERROR_MESSAGE =
@@ -46,7 +46,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
   private final MembershipState membershipState;
   private final GroupState groupState;
   private final UserState userState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -56,7 +56,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
 
   public RoleAddEntityProcessor(
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
@@ -66,7 +66,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
     membershipState = processingState.getMembershipState();
     groupState = processingState.getGroupState();
     userState = processingState.getUserState();
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -78,14 +78,10 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
   @Override
   public void processNewCommand(final TypedRecord<RoleRecord> command) {
     final var record = command.getValue();
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.ROLE)
-            .permissionType(PermissionType.UPDATE)
-            .addResourceId(record.getRoleId())
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var roleId = record.getRoleId();
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.ROLE, PermissionType.UPDATE, roleId);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -24,13 +22,15 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class RoleCreateProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
   private static final String ROLE_ALREADY_EXISTS_ERROR_MESSAGE =
       "Expected to create role with ID '%s', but a role with this ID already exists";
   private final RoleState roleState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -39,12 +39,12 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
 
   public RoleCreateProcessor(
       final RoleState roleState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     this.roleState = roleState;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -54,13 +54,9 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
 
   @Override
   public void processNewCommand(final TypedRecord<RoleRecord> command) {
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.ROLE)
-            .permissionType(PermissionType.CREATE)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.ROLE, PermissionType.CREATE);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -9,8 +9,6 @@ package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.security.api.model.authz.DefaultRole;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -33,7 +31,9 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
   public static final String ROLE_NOT_FOUND_ERROR_MESSAGE =
@@ -43,7 +43,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
   private final RoleState roleState;
   private final AuthorizationState authorizationState;
   private final MembershipState membershipState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -52,14 +52,14 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
 
   public RoleDeleteProcessor(
       final ProcessingState state,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     roleState = state.getRoleState();
     authorizationState = state.getAuthorizationState();
     membershipState = state.getMembershipState();
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -71,15 +71,10 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
   public void processNewCommand(final TypedRecord<RoleRecord> command) {
     final var record = command.getValue();
     final String roleId = record.getRoleId();
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.ROLE)
-            .permissionType(PermissionType.DELETE)
-            .addResourceId(roleId)
-            .build();
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.ROLE, PermissionType.DELETE, roleId);
 
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleProcessors.java
@@ -8,30 +8,36 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.security.core.authz.LazyTokenClaimsConverter;
+import io.camunda.security.core.port.in.AuthorizationCheckPort;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class RoleProcessors {
   public static void addRoleProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final AuthorizationCheckPort authCheckPort,
+      final LazyTokenClaimsConverter claimsConverter,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
       final EngineSecurityConfig securityConfig) {
+    final var permissionsBehavior =
+        new PermissionsBehavior(processingState, authCheckPort, claimsConverter, securityConfig);
     typedRecordProcessors.onCommand(
         ValueType.ROLE,
         RoleIntent.CREATE,
         new RoleCreateProcessor(
             processingState.getRoleState(),
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior));
@@ -41,7 +47,7 @@ public class RoleProcessors {
         new RoleUpdateProcessor(
             processingState.getRoleState(),
             keyGenerator,
-            authCheckBehavior,
+            permissionsBehavior,
             writers,
             commandDistributionBehavior));
     typedRecordProcessors.onCommand(
@@ -49,7 +55,7 @@ public class RoleProcessors {
         RoleIntent.ADD_ENTITY,
         new RoleAddEntityProcessor(
             processingState,
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior,
@@ -59,7 +65,7 @@ public class RoleProcessors {
         RoleIntent.REMOVE_ENTITY,
         new RoleRemoveEntityProcessor(
             processingState,
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior));
@@ -68,7 +74,7 @@ public class RoleProcessors {
         RoleIntent.DELETE,
         new RoleDeleteProcessor(
             processingState,
-            authCheckBehavior,
+            permissionsBehavior,
             keyGenerator,
             writers,
             commandDistributionBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -31,7 +29,9 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Map;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
   public static final String ROLE_NOT_FOUND_ERROR_MESSAGE =
@@ -44,7 +44,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
   private final MappingRuleState mappingRuleState;
   private final GroupState groupState;
   private final MembershipState membershipState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -53,7 +53,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
 
   public RoleRemoveEntityProcessor(
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
@@ -61,7 +61,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
     mappingRuleState = processingState.getMappingRuleState();
     groupState = processingState.getGroupState();
     membershipState = processingState.getMembershipState();
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -72,14 +72,10 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
   @Override
   public void processNewCommand(final TypedRecord<RoleRecord> command) {
     final var record = command.getValue();
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.ROLE)
-            .permissionType(PermissionType.UPDATE)
-            .addResourceId(record.getRoleId())
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var roleId = record.getRoleId();
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.ROLE, PermissionType.UPDATE, roleId);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
@@ -9,8 +9,6 @@ package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.security.api.model.authz.DefaultRole;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -25,7 +23,9 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.jspecify.annotations.NullMarked;
 
+@NullMarked
 public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
   public static final String ROLE_NOT_FOUND_ERROR_MESSAGE =
@@ -34,7 +34,7 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
       "Expected to update role with ID '%s', which is a default role and cannot be modified.";
   private final RoleState roleState;
   private final KeyGenerator keyGenerator;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
@@ -43,12 +43,12 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
   public RoleUpdateProcessor(
       final RoleState roleState,
       final KeyGenerator keyGenerator,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     this.roleState = roleState;
     this.keyGenerator = keyGenerator;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
@@ -58,14 +58,10 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
   @Override
   public void processNewCommand(final TypedRecord<RoleRecord> command) {
     final var record = command.getValue();
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.ROLE)
-            .permissionType(PermissionType.UPDATE)
-            .addResourceId(record.getRoleId())
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    final var roleId = record.getRoleId();
+    final var isAuthorized =
+        permissionsBehavior.isAuthorized(
+            command, AuthorizationResourceType.ROLE, PermissionType.UPDATE, roleId);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
@@ -73,7 +69,6 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
       return;
     }
 
-    final String roleId = record.getRoleId();
     if (roleId != null && DefaultRole.ids().contains(roleId)) {
       final var errorMessage = ROLE_PROTECTED_ERROR_MESSAGE.formatted(record.getRoleId());
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, errorMessage);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupDeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupDeleteAuthorizationTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jspecify.annotations.NullMarked;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+@NullMarked
+public class GroupDeleteAuthorizationTest {
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg -> {
+                final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
+                defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getInitialization().setDefaultRoles(defaultRoles);
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBeAuthorizedToDeleteGroupWithScopedPermission() {
+    // given
+    final var allowedGroupId = Strings.newRandomValidIdentityId();
+    final var deniedGroupId = Strings.newRandomValidIdentityId();
+    final var user = createUser();
+    engine.group().newGroup(allowedGroupId).withName("allowed").create(DEFAULT_USER.getUsername());
+    engine.group().newGroup(deniedGroupId).withName("denied").create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.DELETE)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.GROUP)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(allowedGroupId)
+        .create(DEFAULT_USER.getUsername());
+
+    // when - the specifically-granted group is deleted
+    engine.group().deleteGroup(allowedGroupId).delete(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.groupRecords(GroupIntent.DELETED)
+                .withGroupId(allowedGroupId)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedToDeleteGroupWithScopedPermissionOnDifferentGroup() {
+    // given
+    final var allowedGroupId = Strings.newRandomValidIdentityId();
+    final var deniedGroupId = Strings.newRandomValidIdentityId();
+    final var user = createUser();
+    engine.group().newGroup(allowedGroupId).withName("allowed").create(DEFAULT_USER.getUsername());
+    engine.group().newGroup(deniedGroupId).withName("denied").create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.DELETE)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.GROUP)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(allowedGroupId)
+        .create(DEFAULT_USER.getUsername());
+
+    // when - a different group ID is rejected
+    final var rejection =
+        engine.group().deleteGroup(deniedGroupId).expectRejection().delete(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'DELETE' on resource 'GROUP'");
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupUpdateAuthorizationTest.java
@@ -86,7 +86,7 @@ public class GroupUpdateAuthorizationTest {
   }
 
   @Test
-  public void shouldBeUnAuthorizedToUpdateGroupWithScopedPermissionOnDifferentGroup() {
+  public void shouldBeUnauthorizedToUpdateGroupWithScopedPermissionOnDifferentGroup() {
     // given
     final var allowedGroupId = Strings.newRandomValidIdentityId();
     final var deniedGroupId = Strings.newRandomValidIdentityId();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupUpdateAuthorizationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class GroupUpdateAuthorizationTest {
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg -> {
+                final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
+                defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getInitialization().setDefaultRoles(defaultRoles);
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBeAuthorizedToUpdateGroupWithScopedPermission() {
+    // given
+    final var allowedGroupId = Strings.newRandomValidIdentityId();
+    final var deniedGroupId = Strings.newRandomValidIdentityId();
+    final var user = createUser();
+    engine.group().newGroup(allowedGroupId).withName("allowed").create(DEFAULT_USER.getUsername());
+    engine.group().newGroup(deniedGroupId).withName("denied").create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.GROUP)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(allowedGroupId)
+        .create(DEFAULT_USER.getUsername());
+
+    // when - the specifically-granted group is updated
+    engine.group().updateGroup(allowedGroupId).withName("updated").update(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.groupRecords(GroupIntent.UPDATED)
+                .withGroupId(allowedGroupId)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeUnAuthorizedToUpdateGroupWithScopedPermissionOnDifferentGroup() {
+    // given
+    final var allowedGroupId = Strings.newRandomValidIdentityId();
+    final var deniedGroupId = Strings.newRandomValidIdentityId();
+    final var user = createUser();
+    engine.group().newGroup(allowedGroupId).withName("allowed").create(DEFAULT_USER.getUsername());
+    engine.group().newGroup(deniedGroupId).withName("denied").create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.GROUP)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(allowedGroupId)
+        .create(DEFAULT_USER.getUsername());
+
+    // when - a different group ID is rejected
+    final var rejection =
+        engine
+            .group()
+            .updateGroup(deniedGroupId)
+            .withName("updated")
+            .expectRejection()
+            .update(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'UPDATE' on resource 'GROUP'");
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupUpdateAuthorizationTest.java
@@ -26,10 +26,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.jspecify.annotations.NullMarked;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 
+@NullMarked
 public class GroupUpdateAuthorizationTest {
   private static final ConfiguredUser DEFAULT_USER =
       new ConfiguredUser(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mappingrule/MappingRuleUpdateAuthorizationTest.java
@@ -160,9 +160,7 @@ public class MappingRuleUpdateAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'UPDATE' on resource 'MAPPING_RULE', required resource identifiers are one of '[*, "
-                + id
-                + "]'");
+            "Insufficient permissions to perform operation 'UPDATE' on resource 'MAPPING_RULE'");
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleDeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleDeleteAuthorizationTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jspecify.annotations.NullMarked;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+@NullMarked
+public class RoleDeleteAuthorizationTest {
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg -> {
+                final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
+                defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getInitialization().setDefaultRoles(defaultRoles);
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBeAuthorizedToDeleteRoleWithScopedPermission() {
+    // given
+    final var allowedRoleId = Strings.newRandomValidIdentityId();
+    final var deniedRoleId = Strings.newRandomValidIdentityId();
+    final var user = createUser();
+    engine.role().newRole(allowedRoleId).withName("allowed").create(DEFAULT_USER.getUsername());
+    engine.role().newRole(deniedRoleId).withName("denied").create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.DELETE)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.ROLE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(allowedRoleId)
+        .create(DEFAULT_USER.getUsername());
+
+    // when - the specifically-granted role is deleted
+    engine.role().deleteRole(allowedRoleId).delete(user.getUsername());
+
+    // then
+    assertThat(RecordingExporter.roleRecords(RoleIntent.DELETED).withRoleId(allowedRoleId).exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedToDeleteRoleWithScopedPermissionOnDifferentRole() {
+    // given
+    final var allowedRoleId = Strings.newRandomValidIdentityId();
+    final var deniedRoleId = Strings.newRandomValidIdentityId();
+    final var user = createUser();
+    engine.role().newRole(allowedRoleId).withName("allowed").create(DEFAULT_USER.getUsername());
+    engine.role().newRole(deniedRoleId).withName("denied").create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.DELETE)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.ROLE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(allowedRoleId)
+        .create(DEFAULT_USER.getUsername());
+
+    // when - a different role ID is rejected
+    final var rejection =
+        engine.role().deleteRole(deniedRoleId).expectRejection().delete(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'DELETE' on resource 'ROLE'");
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleUpdateAuthorizationTest.java
@@ -83,7 +83,7 @@ public class RoleUpdateAuthorizationTest {
   }
 
   @Test
-  public void shouldBeUnAuthorizedToUpdateRoleWithScopedPermissionOnDifferentRole() {
+  public void shouldBeUnauthorizedToUpdateRoleWithScopedPermissionOnDifferentRole() {
     // given
     final var allowedRoleId = Strings.newRandomValidIdentityId();
     final var deniedRoleId = Strings.newRandomValidIdentityId();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleUpdateAuthorizationTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jspecify.annotations.NullMarked;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+@NullMarked
+public class RoleUpdateAuthorizationTest {
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg -> {
+                final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
+                defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.getUsername())));
+                cfg.getInitialization().setDefaultRoles(defaultRoles);
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldBeAuthorizedToUpdateRoleWithScopedPermission() {
+    // given
+    final var allowedRoleId = Strings.newRandomValidIdentityId();
+    final var deniedRoleId = Strings.newRandomValidIdentityId();
+    final var user = createUser();
+    engine.role().newRole(allowedRoleId).withName("allowed").create(DEFAULT_USER.getUsername());
+    engine.role().newRole(deniedRoleId).withName("denied").create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.ROLE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(allowedRoleId)
+        .create(DEFAULT_USER.getUsername());
+
+    // when - the specifically-granted role is updated
+    engine.role().updateRole(allowedRoleId).withName("updated").update(user.getUsername());
+
+    // then
+    assertThat(RecordingExporter.roleRecords(RoleIntent.UPDATED).withRoleId(allowedRoleId).exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeUnAuthorizedToUpdateRoleWithScopedPermissionOnDifferentRole() {
+    // given
+    final var allowedRoleId = Strings.newRandomValidIdentityId();
+    final var deniedRoleId = Strings.newRandomValidIdentityId();
+    final var user = createUser();
+    engine.role().newRole(allowedRoleId).withName("allowed").create(DEFAULT_USER.getUsername());
+    engine.role().newRole(deniedRoleId).withName("denied").create(DEFAULT_USER.getUsername());
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(PermissionType.UPDATE)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(AuthorizationResourceType.ROLE)
+        .withResourceMatcher(AuthorizationResourceMatcher.ID)
+        .withResourceId(allowedRoleId)
+        .create(DEFAULT_USER.getUsername());
+
+    // when - a different role ID is rejected
+    final var rejection =
+        engine
+            .role()
+            .updateRole(deniedRoleId)
+            .withName("updated")
+            .expectRejection()
+            .update(user.getUsername());
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'UPDATE' on resource 'ROLE'");
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+}


### PR DESCRIPTION
## Summary

Migrates Group, Role, and MappingRule domain processors from the engine-local `AuthorizationCheckBehavior` to the CSL `AuthorizationCheckPort`, completing Inc 4b of the security-library migration (camunda/camunda-security-library#452).

**Changes:**
- Generalized `PermissionsBehavior.isAuthorized()` with generic overloads supporting any `AuthorizationResourceType` and optional resource ID scoping
- Replaced `AuthorizationCheckBehavior` with `PermissionsBehavior` in all 13 leaf processors (5 Group, 5 Role, 3 MappingRule)
- Moved all three registrar calls into `addIdentityProcessors()` to receive CSL-constructed service objects
- Added `GroupUpdateAuthorizationTest` and `RoleUpdateAuthorizationTest` for scoped-ID authorization coverage
- Updated `MappingRuleUpdateAuthorizationTest` rejection message to CSL format

**Base branch:** `security-lib-402` (Inc 4a, not yet merged to main)

## Test plan
- [x] All Group authorization tests pass
- [x] All Role authorization tests pass (`RoleTest`, `RoleCreateAuthorizationTest`, `RoleUpdateAuthorizationTest`)
- [x] All MappingRule authorization tests pass (`MappingRuleTest`, `MappingRuleCreateAuthorizationTest`, `MappingRuleUpdateAuthorizationTest`)
- [x] Full `zeebe/engine` module verify passes
- [x] Full repo compile (`./mvnw install -Dquickly`) passes
- [x] Local manual smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)