### PR TITLE
test: end-to-end coverage for call activity businessId propagation (engine → exporter → search API)

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
@@ -53,7 +53,8 @@ public class CallActivityBusinessIdIT {
         deployParentWithChild("literal", c -> c.zeebeBusinessId("child-literal"));
 
     // when - the parent starts without a Business ID of its own
-    final var parent = startParent(parentProcessId, null, Map.of());
+    final var parent =
+        client.newCreateInstanceCommand().bpmnProcessId(parentProcessId).latestVersion().execute();
 
     // then
     assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
@@ -67,7 +68,13 @@ public class CallActivityBusinessIdIT {
     final String parentProcessId = deployParentWithChild("inherit", c -> {});
 
     // when - the parent carries a Business ID
-    final var parent = startParent(parentProcessId, "order-inherit", Map.of());
+    final var parent =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(parentProcessId)
+            .latestVersion()
+            .businessId("order-inherit")
+            .execute();
 
     // then
     assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
@@ -81,7 +88,13 @@ public class CallActivityBusinessIdIT {
     final String parentProcessId = deployParentWithChild("empty", c -> c.zeebeBusinessId(""));
 
     // when - the parent carries a Business ID
-    final var parent = startParent(parentProcessId, "order-empty", Map.of());
+    final var parent =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(parentProcessId)
+            .latestVersion()
+            .businessId("order-empty")
+            .execute();
 
     // then
     assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
@@ -96,8 +109,14 @@ public class CallActivityBusinessIdIT {
         deployParentWithChild("feel-var", c -> c.zeebeBusinessId("=orderCode"));
 
     // when - the variable is provided at parent creation
-    final Map<String, Object> variables = Map.of("orderCode", "feel-child-42");
-    final var parent = startParent(parentProcessId, "order-feel", variables);
+    final var parent =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(parentProcessId)
+            .latestVersion()
+            .businessId("order-feel")
+            .variables(Map.of("orderCode", "feel-child-42"))
+            .execute();
 
     // then
     assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
@@ -115,7 +134,13 @@ public class CallActivityBusinessIdIT {
             c -> c.zeebeBusinessId("=camunda.processInstance.businessId + \"-child\""));
 
     // when - the parent carries a Business ID
-    final var parent = startParent(parentProcessId, "order-parent", Map.of());
+    final var parent =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(parentProcessId)
+            .latestVersion()
+            .businessId("order-parent")
+            .execute();
 
     // then
     assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
@@ -226,18 +251,6 @@ public class CallActivityBusinessIdIT {
             .done();
     return deployProcessAndWaitForIt(client, parent, parentProcessId + ".bpmn")
         .getProcessDefinitionKey();
-  }
-
-  private static ProcessInstanceEvent startParent(
-      final String parentProcessId, final String businessId, final Map<String, Object> variables) {
-    var command = client.newCreateInstanceCommand().bpmnProcessId(parentProcessId).latestVersion();
-    if (businessId != null) {
-      command = command.businessId(businessId);
-    }
-    if (!variables.isEmpty()) {
-      command = command.variables(variables);
-    }
-    return command.execute();
   }
 
   private static ProcessInstance awaitChild(final long parentProcessInstanceKey) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
@@ -36,6 +36,10 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Each test uses its own parent/child process ids and locates the child by {@code
  * parentProcessInstanceKey}, so tests never observe each other's instances.
+ *
+ * <p>Intentionally a plain {@code @MultiDbTest} (not {@code @CompatibilityTest}): the call activity
+ * {@code businessId} is new in 8.10, so it cannot be asserted against an older broker that does not
+ * resolve or emit it.
  */
 @MultiDbTest
 public class CallActivityBusinessIdIT {
@@ -51,8 +55,9 @@ public class CallActivityBusinessIdIT {
     // when - the parent starts without a Business ID of its own
     final var parent = startParent(parentProcessId, null, Map.of());
 
-    // then - the child instance carries the literal, not the (absent) parent value
+    // then
     assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .describedAs("the child instance carries the literal, not the (absent) parent value")
         .isEqualTo("child-literal");
   }
 
@@ -64,8 +69,9 @@ public class CallActivityBusinessIdIT {
     // when - the parent carries a Business ID
     final var parent = startParent(parentProcessId, "order-inherit", Map.of());
 
-    // then - the child inherits the parent's Business ID
+    // then
     assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .describedAs("the child inherits the parent's Business ID")
         .isEqualTo("order-inherit");
   }
 
@@ -77,8 +83,10 @@ public class CallActivityBusinessIdIT {
     // when - the parent carries a Business ID
     final var parent = startParent(parentProcessId, "order-empty", Map.of());
 
-    // then - the child does not inherit; its Business ID is null
-    assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId()).isNull();
+    // then
+    assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .describedAs("the child does not inherit; its Business ID is null")
+        .isNull();
   }
 
   @Test
@@ -91,8 +99,9 @@ public class CallActivityBusinessIdIT {
     final Map<String, Object> variables = Map.of("orderCode", "feel-child-42");
     final var parent = startParent(parentProcessId, "order-feel", variables);
 
-    // then - the child Business ID is the resolved expression value
+    // then
     assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .describedAs("the child Business ID is the resolved expression value")
         .isEqualTo("feel-child-42");
   }
 
@@ -108,8 +117,9 @@ public class CallActivityBusinessIdIT {
     // when - the parent carries a Business ID
     final var parent = startParent(parentProcessId, "order-parent", Map.of());
 
-    // then - the child Business ID is the parent's with the suffix appended
+    // then
     assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .describedAs("the child Business ID is the parent's with the suffix appended")
         .isEqualTo("order-parent-child");
   }
 
@@ -179,6 +189,8 @@ public class CallActivityBusinessIdIT {
 
     // then - the child is created with the Business ID re-evaluated from the migrated definition
     assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .describedAs(
+            "the child is created with the Business ID re-evaluated from the migrated definition")
         .isEqualTo("migrated-business-id");
   }
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage that a call activity's {@code businessId} is resolved when the child instance
+ * is created and is then observable through the process instance search API across all backends.
+ *
+ * <p>Engine unit tests already assert the resolution semantics against the internal record stream;
+ * these tests add the missing cross-component leg (engine → exporter → search index → client) and
+ * confirm the child instance is queryable by its resolved Business ID.
+ *
+ * <p>Each test uses its own parent/child process ids and locates the child by {@code
+ * parentProcessInstanceKey}, so tests never observe each other's instances.
+ */
+@MultiDbTest
+public class CallActivityBusinessIdIT {
+
+  private static CamundaClient client;
+
+  @Test
+  void shouldOverrideChildBusinessIdWithLiteral() {
+    // given - a call activity that assigns a literal child Business ID
+    final String parentProcessId =
+        deployParentWithChild("literal", c -> c.zeebeBusinessId("child-literal"));
+
+    // when - the parent starts without a Business ID of its own
+    final var parent = startParent(parentProcessId, null, Map.of());
+
+    // then - the child instance carries the literal, not the (absent) parent value
+    assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .isEqualTo("child-literal");
+  }
+
+  @Test
+  void shouldInheritParentBusinessIdWhenAttributeIsAbsent() {
+    // given - a call activity without a businessId attribute
+    final String parentProcessId = deployParentWithChild("inherit", c -> {});
+
+    // when - the parent carries a Business ID
+    final var parent = startParent(parentProcessId, "order-inherit", Map.of());
+
+    // then - the child inherits the parent's Business ID
+    assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .isEqualTo("order-inherit");
+  }
+
+  @Test
+  void shouldResolveEmptyChildBusinessIdToNull() {
+    // given - a call activity that explicitly clears the child Business ID
+    final String parentProcessId = deployParentWithChild("empty", c -> c.zeebeBusinessId(""));
+
+    // when - the parent carries a Business ID
+    final var parent = startParent(parentProcessId, "order-empty", Map.of());
+
+    // then - the child does not inherit; its Business ID is null
+    assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId()).isNull();
+  }
+
+  @Test
+  void shouldResolveFeelChildBusinessIdFromVariable() {
+    // given - a call activity whose businessId is a FEEL expression over a process variable
+    final String parentProcessId =
+        deployParentWithChild("feel-var", c -> c.zeebeBusinessId("=orderCode"));
+
+    // when - the variable is provided at parent creation
+    final Map<String, Object> variables = Map.of("orderCode", "feel-child-42");
+    final var parent = startParent(parentProcessId, "order-feel", variables);
+
+    // then - the child Business ID is the resolved expression value
+    assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .isEqualTo("feel-child-42");
+  }
+
+  @Test
+  void shouldAppendSuffixToParentBusinessIdViaExpressionContext() {
+    // given - a call activity that derives the child Business ID from the parent's, using the
+    // camunda.processInstance.businessId context expression
+    final String parentProcessId =
+        deployParentWithChild(
+            "ctx-suffix",
+            c -> c.zeebeBusinessId("=camunda.processInstance.businessId + \"-child\""));
+
+    // when - the parent carries a Business ID
+    final var parent = startParent(parentProcessId, "order-parent", Map.of());
+
+    // then - the child Business ID is the parent's with the suffix appended
+    assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .isEqualTo("order-parent-child");
+  }
+
+  private static String deployParentWithChild(
+      final String suffix, final Consumer<CallActivityBuilder> callActivityCustomizer) {
+    final String childProcessId = "child-" + suffix;
+    final String parentProcessId = "parent-" + suffix;
+
+    final BpmnModelInstance child =
+        Bpmn.createExecutableProcess(childProcessId).startEvent().endEvent().done();
+    final BpmnModelInstance parent =
+        Bpmn.createExecutableProcess(parentProcessId)
+            .startEvent()
+            .callActivity(
+                "call",
+                c -> {
+                  c.zeebeProcessId(childProcessId);
+                  callActivityCustomizer.accept(c);
+                })
+            .endEvent()
+            .done();
+
+    deployProcessAndWaitForIt(client, child, childProcessId + ".bpmn");
+    deployProcessAndWaitForIt(client, parent, parentProcessId + ".bpmn");
+    return parentProcessId;
+  }
+
+  private static ProcessInstanceEvent startParent(
+      final String parentProcessId, final String businessId, final Map<String, Object> variables) {
+    var command = client.newCreateInstanceCommand().bpmnProcessId(parentProcessId).latestVersion();
+    if (businessId != null) {
+      command = command.businessId(businessId);
+    }
+    if (!variables.isEmpty()) {
+      command = command.variables(variables);
+    }
+    return command.execute();
+  }
+
+  private static ProcessInstance awaitChild(final long parentProcessInstanceKey) {
+    final AtomicReference<ProcessInstance> child = new AtomicReference<>();
+    Awaitility.await("child process instance is exported to the search index")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var items =
+                  client
+                      .newProcessInstanceSearchRequest()
+                      .filter(f -> f.parentProcessInstanceKey(parentProcessInstanceKey))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+              child.set(items.getFirst());
+            });
+    return child.get();
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
@@ -11,6 +11,7 @@ import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.MigrationPlan;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
@@ -111,13 +113,63 @@ public class CallActivityBusinessIdIT {
         .isEqualTo("order-parent-child");
   }
 
+  @Test
+  void shouldResolveBusinessIdIncidentAfterMigratingToFixedVersion() {
+    // given - a source version whose call activity Business ID references a variable that is
+    // never provided (raising an incident), and a target version that resolves it from an
+    // available variable
+    final String childProcessId = "child-migrate";
+    deployChild(childProcessId);
+    final long sourceDefinitionKey =
+        deployParent(
+            "parent-migrate-source", childProcessId, c -> c.zeebeBusinessId("=missingVar"));
+    final long targetDefinitionKey =
+        deployParent("parent-migrate-target", childProcessId, c -> c.zeebeBusinessId("=orderId"));
+
+    final ProcessInstanceEvent parent =
+        client
+            .newCreateInstanceCommand()
+            .processDefinitionKey(sourceDefinitionKey)
+            .variables(Map.of("orderId", "migrated-business-id"))
+            .execute();
+    final long incidentKey = awaitIncidentKey(parent.getProcessInstanceKey());
+
+    // when - the instance is migrated to the fixed version and the incident is resolved
+    client
+        .newMigrateProcessInstanceCommand(parent.getProcessInstanceKey())
+        .migrationPlan(
+            MigrationPlan.newBuilder()
+                .withTargetProcessDefinitionKey(targetDefinitionKey)
+                .addMappingInstruction("call", "call")
+                .build())
+        .send()
+        .join();
+    client.newResolveIncidentCommand(incidentKey).send().join();
+
+    // then - the child is created with the Business ID re-evaluated from the migrated definition
+    assertThat(awaitChild(parent.getProcessInstanceKey()).getBusinessId())
+        .isEqualTo("migrated-business-id");
+  }
+
   private static String deployParentWithChild(
       final String suffix, final Consumer<CallActivityBuilder> callActivityCustomizer) {
     final String childProcessId = "child-" + suffix;
     final String parentProcessId = "parent-" + suffix;
+    deployChild(childProcessId);
+    deployParent(parentProcessId, childProcessId, callActivityCustomizer);
+    return parentProcessId;
+  }
 
+  private static void deployChild(final String childProcessId) {
     final BpmnModelInstance child =
         Bpmn.createExecutableProcess(childProcessId).startEvent().endEvent().done();
+    deployProcessAndWaitForIt(client, child, childProcessId + ".bpmn");
+  }
+
+  private static long deployParent(
+      final String parentProcessId,
+      final String childProcessId,
+      final Consumer<CallActivityBuilder> callActivityCustomizer) {
     final BpmnModelInstance parent =
         Bpmn.createExecutableProcess(parentProcessId)
             .startEvent()
@@ -129,10 +181,8 @@ public class CallActivityBusinessIdIT {
                 })
             .endEvent()
             .done();
-
-    deployProcessAndWaitForIt(client, child, childProcessId + ".bpmn");
-    deployProcessAndWaitForIt(client, parent, parentProcessId + ".bpmn");
-    return parentProcessId;
+    return deployProcessAndWaitForIt(client, parent, parentProcessId + ".bpmn")
+        .getProcessDefinitionKey();
   }
 
   private static ProcessInstanceEvent startParent(
@@ -165,5 +215,25 @@ public class CallActivityBusinessIdIT {
               child.set(items.getFirst());
             });
     return child.get();
+  }
+
+  private static long awaitIncidentKey(final long processInstanceKey) {
+    final AtomicLong incidentKey = new AtomicLong();
+    Awaitility.await("incident is exported to the search index")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var items =
+                  client
+                      .newIncidentSearchRequest()
+                      .filter(f -> f.processInstanceKey(processInstanceKey))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+              incidentKey.set(items.getFirst().getIncidentKey());
+            });
+    return incidentKey.get();
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/CallActivityBusinessIdIT.java
@@ -114,6 +114,37 @@ public class CallActivityBusinessIdIT {
   }
 
   @Test
+  void shouldQueryChildInstanceByResolvedBusinessId() {
+    // given - a call activity that assigns a literal child Business ID
+    final String parentProcessId =
+        deployParentWithChild("query-by-bid", c -> c.zeebeBusinessId("queryable-child-id"));
+
+    // when - the parent starts without a Business ID of its own
+    final var parent =
+        client.newCreateInstanceCommand().bpmnProcessId(parentProcessId).latestVersion().execute();
+
+    // then - the child is retrievable by filtering the search API on its resolved Business ID
+    // (scoped by parentProcessInstanceKey so an inherited id could never match the parent instead)
+    Awaitility.await("child instance is queryable by its business id")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var items =
+                  client
+                      .newProcessInstanceSearchRequest()
+                      .filter(
+                          f ->
+                              f.parentProcessInstanceKey(parent.getProcessInstanceKey())
+                                  .businessId("queryable-child-id"))
+                      .send()
+                      .join()
+                      .items();
+              assertThat(items).hasSize(1);
+            });
+  }
+
+  @Test
   void shouldResolveBusinessIdIncidentAfterMigratingToFixedVersion() {
     // given - a source version whose call activity Business ID references a variable that is
     // never provided (raising an incident), and a target version that resolves it from an

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityBusinessIdTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.activity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.processing.processinstance.BusinessIdValidator;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -146,6 +147,25 @@ public final class CallActivityBusinessIdTest {
 
     // then - the expression is evaluated at the call-activity scope and assigned to the child
     Assertions.assertThat(childProcessInstance(parentKey).getValue()).hasBusinessId("child-xyz");
+  }
+
+  @Test
+  public void shouldAcceptFeelBusinessIdAtMaxLength() {
+    // given - a FEEL businessId that resolves to exactly the maximum allowed length
+    deploy(parentProcess(c -> c.zeebeBusinessId("=businessIdVar")));
+    final String maxLengthBusinessId = "a".repeat(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH);
+
+    // when
+    final long parentKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PARENT_PROCESS_ID)
+            .withVariable("businessIdVar", maxLengthBusinessId)
+            .create();
+
+    // then - the value at the boundary is accepted (no incident) and assigned to the child
+    Assertions.assertThat(childProcessInstance(parentKey).getValue())
+        .hasBusinessId(maxLengthBusinessId);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityBusinessIdTest.java
@@ -169,6 +169,24 @@ public final class CallActivityBusinessIdTest {
   }
 
   @Test
+  public void shouldEvaluateFeelBusinessIdReferencingInputMappedVariable() {
+    // given - a call activity whose input mapping produces a local variable that the businessId
+    // expression references; input mappings are applied before the businessId is resolved
+    deploy(
+        parentProcess(
+            c ->
+                c.zeebeBusinessId("=mappedId")
+                    .zeebeInputExpression("\"from-input-mapping\"", "mappedId")));
+
+    // when
+    final long parentKey = ENGINE.processInstance().ofBpmnProcessId(PARENT_PROCESS_ID).create();
+
+    // then - the businessId resolves from the input-mapped variable
+    Assertions.assertThat(childProcessInstance(parentKey).getValue())
+        .hasBusinessId("from-input-mapping");
+  }
+
+  @Test
   public void shouldKeepChildBusinessIdImmutableAcrossLifecycle() {
     // given
     deploy(parentProcess(c -> c.zeebeBusinessId("child-123")));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.incident;
 
 import static io.camunda.zeebe.engine.processing.incident.IncidentHelper.assertIncidentCreated;
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.processing.processinstance.BusinessIdValidator;
@@ -612,6 +613,59 @@ public final class CallActivityIncidentTest {
     // then - the child is created with the now-resolvable business id
     Assertions.assertThat(getChildProcessInstance(processInstanceKey).getValue())
         .hasBusinessId("resolved-business-id");
+  }
+
+  @Test
+  public void shouldResolveBusinessIdIncidentAfterMigratingToFixedVersion() {
+    // given - a source version whose call activity business id references a variable that is
+    // never provided, and a target version whose call activity resolves it from an available one
+    final String sourceProcessId = Strings.newRandomValidBpmnId();
+    final String targetProcessId = Strings.newRandomValidBpmnId();
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                "wf-child.bpmn",
+                Bpmn.createExecutableProcess(childProcessId).startEvent().endEvent().done())
+            .withXmlResource(
+                "wf-source.bpmn",
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .callActivity(
+                        "call",
+                        c -> c.zeebeProcessId(childProcessId).zeebeBusinessId("=businessIdVar"))
+                    .done())
+            .withXmlResource(
+                "wf-target.bpmn",
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .callActivity(
+                        "call", c -> c.zeebeProcessId(childProcessId).zeebeBusinessId("=orderId"))
+                    .done())
+            .deploy();
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(sourceProcessId)
+            .withVariable("orderId", "migrated-business-id")
+            .create();
+    final Record<IncidentRecordValue> incident = getIncident(processInstanceKey);
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    // when - the instance is migrated to the fixed version and the incident is resolved
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("call", "call")
+        .migrate();
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // then - the child is created with the business id re-evaluated from the migrated definition
+    Assertions.assertThat(getChildProcessInstance(processInstanceKey).getValue())
+        .hasBusinessId("migrated-business-id");
   }
 
   private void deployParentWithChildBusinessId(final String businessId) {


### PR DESCRIPTION
## Description

Adds end-to-end test coverage for `businessId` propagation through call activities, spanning the full stack from the engine through the exporter to the search index and client API.

### What's covered

**New acceptance test: `CallActivityBusinessIdIT`** (`qa/acceptance-tests`)
A new `@MultiDbTest` that verifies the child process instance's `businessId` is correctly resolved and queryable via the search API across all supported backends. 

Scenarios covered:
- Literal override: child receives a static literal Business ID
- Inheritance: child inherits the parent's Business ID when no `businessId` attribute is set on the call activity
- Empty value: explicit empty string results in a `null` child Business ID (no inheritance)
- FEEL expression from variable: `businessId` is resolved from a process variable at child creation time
- FEEL expression from context (`camunda.processInstance.businessId`): child derives its ID by appending a suffix to the parent's Business ID
- Incident + migration: a Business ID incident (unresolvable expression) is raised, the instance is migrated to a fixed version, the incident is resolved, and the child is created with the correct re-evaluated Business ID

**Extended engine unit test: `CallActivityBusinessIdTest`**
- `shouldAcceptFeelBusinessIdAtMaxLength`: verifies that a FEEL-resolved Business ID at the exact maximum allowed length is accepted without raising an incident
- `shouldEvaluateFeelBusinessIdReferencingInputMappedVariable`: verifies that input mappings are applied before the `businessId` expression is evaluated, allowing the expression to reference locally mapped variables

**Extended incident test: `CallActivityIncidentTest`**
- `shouldResolveBusinessIdIncidentAfterMigratingToFixedVersion`: engine-level coverage for the incident → migrate → resolve flow, complementing the acceptance test above

### Related issues

Closes #56169