### PR TITLE
56140 duration heatmap tile

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardService.java
@@ -116,6 +116,9 @@ public class AgenticControlDashboardService {
   public static final String DURATION_STABILITY_NAME = "agenticDurationStabilityName";
   public static final String DURATION_STABILITY_DESCRIPTION = "agenticDurationStabilityDescription";
 
+  public static final String DURATION_HEATMAP_NAME = "agenticDurationHeatmapName";
+  public static final String DURATION_HEATMAP_DESCRIPTION = "agenticDurationHeatmapDescription";
+
   // Deterministic report IDs — derived from fixed seed strings so IDs are stable across restarts
   // and DB reimports. Same seed always produces the same UUID (UUID v3 / name-based).
   public static final String KPI_COMPLETED_REPORT_ID =
@@ -154,6 +157,9 @@ public class AgenticControlDashboardService {
           .toString();
   public static final String TOOL_CALLS_HEATMAP_REPORT_ID =
       UUID.nameUUIDFromBytes("agentic-tool-calls-heatmap".getBytes(StandardCharsets.UTF_8))
+          .toString();
+  public static final String DURATION_HEATMAP_REPORT_ID =
+      UUID.nameUUIDFromBytes("agentic-duration-heatmap".getBytes(StandardCharsets.UTF_8))
           .toString();
 
   private static final long INSTANCE_END_DATE_ROLLING_DAYS = 30L;
@@ -218,6 +224,7 @@ public class AgenticControlDashboardService {
     tiles.add(buildFailureRateByVersionReport());
     tiles.add(buildTotalToolCallsReport());
     tiles.add(buildToolCallsHeatmapReport());
+    tiles.add(buildDurationHeatmapReport());
 
     // Always upsert the dashboard too — tile list can grow across versions and the cold-start
     // guard would leave an existing deployment stuck on the old layout.
@@ -761,6 +768,48 @@ public class AgenticControlDashboardService {
             true,
             TILE_CONFIG_SECTION,
             TILE_SECTION_RELIABILITY_AND_TOOL_CALLS));
+  }
+
+  // Average duration per flow node rendered as a process diagram heat map, so operators can see
+  // which step of an agentic process is slowest. Like the tool-calls heat map it is only visible
+  // once a single process definition is selected (L1): heatmaps need BPMN XML from a concrete
+  // definition, which the dashboard's process-scope filter supplies at render time. Duration is
+  // aggregated across all flow nodes of completed, agent-bearing instances.
+  private DashboardReportTileDto buildDurationHeatmapReport() {
+    final ProcessReportDataDto reportData =
+        ProcessReportDataDto.builder()
+            .definitions(Collections.emptyList())
+            .view(new ProcessViewDto(ProcessViewEntity.FLOW_NODE, ViewProperty.DURATION))
+            .groupBy(new FlowNodesGroupByDto())
+            .distributedBy(new NoneDistributedByDto())
+            .visualization(ProcessVisualization.HEAT)
+            .configuration(
+                SingleReportConfigurationDto.builder()
+                    .aggregationTypes(
+                        new LinkedHashSet<>(
+                            Collections.singletonList(new AggregationDto(AggregationType.AVERAGE))))
+                    .build())
+            .filter(
+                ProcessFilterBuilder.filter()
+                    .completedInstancesOnly()
+                    .add()
+                    .hasAgentInstances()
+                    .add()
+                    .buildList())
+            .agenticControlReport(true)
+            .build();
+    reportWriter.createOrUpdateSingleProcessReport(
+        DURATION_HEATMAP_REPORT_ID,
+        null,
+        reportData,
+        DURATION_HEATMAP_NAME,
+        DURATION_HEATMAP_DESCRIPTION,
+        null);
+    return buildTile(
+        DURATION_HEATMAP_REPORT_ID,
+        new PositionDto(0, 14),
+        new DimensionDto(18, 4),
+        Map.of(TILE_CONFIG_VISIBLE_IN_L1_ONLY, true, TILE_CONFIG_SECTION, TILE_SECTION_DURATION));
   }
 
   private DashboardDefinitionRestDto buildAgentDashboard(final List<DashboardReportTileDto> tiles) {

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -1614,7 +1614,9 @@
       "agenticKpiToolCallsName": "Tool-Aufrufe gesamt",
       "agenticKpiToolCallsDescription": "Gesamtzahl der Tool-Aufrufe durch Agenten in abgeschlossenen agentischen Prozessinstanzen im gewählten Zeitraum.",
       "agenticToolCallsHeatmapName": "Tool-Aufrufe je Prozessknoten",
-      "agenticToolCallsHeatmapDescription": "Gesamtzahl der Tool-Aufrufe je Prozessknoten über abgeschlossene agentische Prozessinstanzen, als Heatmap auf dem Prozessdiagramm dargestellt."
+      "agenticToolCallsHeatmapDescription": "Gesamtzahl der Tool-Aufrufe je Prozessknoten über abgeschlossene agentische Prozessinstanzen, als Heatmap auf dem Prozessdiagramm dargestellt.",
+      "agenticDurationHeatmapName": "Dauer je Prozessknoten",
+      "agenticDurationHeatmapDescription": "Durchschnittliche Dauer je Prozessknoten über abgeschlossene agentische Prozessinstanzen, als Heatmap auf dem Prozessdiagramm dargestellt."
     }
   },
   "managementDashboard": {

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -1614,7 +1614,9 @@
       "agenticKpiToolCallsName": "Total tool calls",
       "agenticKpiToolCallsDescription": "Total number of tool calls made by agents in completed agentic process instances in the selected period.",
       "agenticToolCallsHeatmapName": "Tool calls per flow node",
-      "agenticToolCallsHeatmapDescription": "Total tool calls made per flow node across completed agentic process instances, shown as a heat map overlay on the process diagram."
+      "agenticToolCallsHeatmapDescription": "Total tool calls made per flow node across completed agentic process instances, shown as a heat map overlay on the process diagram.",
+      "agenticDurationHeatmapName": "Duration per flow node",
+      "agenticDurationHeatmapDescription": "Average duration per flow node across completed agentic process instances, shown as a heat map overlay on the process diagram."
     }
   },
   "managementDashboard": {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/dashboard/AgenticControlDashboardServiceTest.java
@@ -94,7 +94,7 @@ public class AgenticControlDashboardServiceTest {
     assertThat(saved.isAgenticControlDashboard()).isTrue();
     assertThat(saved.isManagementDashboard()).isFalse();
     assertThat(saved.getCollectionId()).isNull();
-    assertThat(saved.getTiles()).hasSize(14);
+    assertThat(saved.getTiles()).hasSize(15);
   }
 
   @Test
@@ -182,7 +182,8 @@ public class AgenticControlDashboardServiceTest {
             AgenticControlDashboardService.KPI_DURATION_P95_REPORT_ID,
             AgenticControlDashboardService.FAILURE_RATE_BY_VERSION_REPORT_ID,
             AgenticControlDashboardService.KPI_TOOL_CALLS_REPORT_ID,
-            AgenticControlDashboardService.TOOL_CALLS_HEATMAP_REPORT_ID);
+            AgenticControlDashboardService.TOOL_CALLS_HEATMAP_REPORT_ID,
+            AgenticControlDashboardService.DURATION_HEATMAP_REPORT_ID);
   }
 
   @Test
@@ -243,7 +244,7 @@ public class AgenticControlDashboardServiceTest {
     underTest.reconcile();
 
     // then reports are upserted and dashboard tiles are updated, but dashboard is not recreated
-    verify(reportWriter, times(14))
+    verify(reportWriter, times(15))
         .createOrUpdateSingleProcessReport(any(), any(), any(), any(), any(), any());
     verify(dashboardWriter, never()).saveDashboard(any());
     verify(dashboardWriter).updateDashboard(any(), any());
@@ -352,7 +353,9 @@ public class AgenticControlDashboardServiceTest {
               AgenticControlDashboardService.KPI_TOOL_CALLS_NAME,
               AgenticControlDashboardService.KPI_TOOL_CALLS_DESCRIPTION,
               AgenticControlDashboardService.TOOL_CALLS_HEATMAP_NAME,
-              AgenticControlDashboardService.TOOL_CALLS_HEATMAP_DESCRIPTION);
+              AgenticControlDashboardService.TOOL_CALLS_HEATMAP_DESCRIPTION,
+              AgenticControlDashboardService.DURATION_HEATMAP_NAME,
+              AgenticControlDashboardService.DURATION_HEATMAP_DESCRIPTION);
     }
   }
 
@@ -941,6 +944,100 @@ public class AgenticControlDashboardServiceTest {
     verify(reportWriter, times(2))
         .createOrUpdateSingleProcessReport(
             eq(AgenticControlDashboardService.TOOL_CALLS_HEATMAP_REPORT_ID),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
+  }
+
+  @Test
+  void shouldSeedDurationHeatmapReportWithFlowNodeViewAndGroupBy() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+    final ArgumentCaptor<ProcessReportDataDto> dataCaptor =
+        ArgumentCaptor.forClass(ProcessReportDataDto.class);
+
+    // when
+    underTest.reconcile();
+
+    // then the report is upserted with the deterministic ID and localization keys
+    verify(reportWriter)
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.DURATION_HEATMAP_REPORT_ID),
+            isNull(),
+            dataCaptor.capture(),
+            eq(AgenticControlDashboardService.DURATION_HEATMAP_NAME),
+            eq(AgenticControlDashboardService.DURATION_HEATMAP_DESCRIPTION),
+            isNull());
+
+    final ProcessReportDataDto reportData = dataCaptor.getValue();
+    // view: FLOW_NODE + DURATION, grouped by flow node and rendered as a heat map
+    assertThat(reportData.getView().getEntity()).isEqualTo(ProcessViewEntity.FLOW_NODE);
+    assertThat(reportData.getView().getProperties()).containsExactly(ViewProperty.DURATION);
+    assertThat(reportData.getGroupBy()).isInstanceOf(FlowNodesGroupByDto.class);
+    assertThat(reportData.getVisualization()).isEqualTo(ProcessVisualization.HEAT);
+    // average duration per flow node (a single aggregation, no unused percentiles)
+    assertThat(reportData.getConfiguration().getAggregationTypes())
+        .extracting(AggregationDto::getType)
+        .containsExactly(AggregationType.AVERAGE);
+    // filters: completedInstancesOnly + hasAgentInstances, no fixed definition (scoped by the
+    // frontend's process selection)
+    assertThat(reportData.getFilter())
+        .hasAtLeastOneElementOfType(CompletedInstancesOnlyFilterDto.class);
+    assertThat(reportData.getFilter()).hasAtLeastOneElementOfType(HasAgentInstancesFilterDto.class);
+    assertThat(reportData.getDefinitions()).isEmpty();
+    assertThat(reportData.isAgenticControlReport()).isTrue();
+  }
+
+  @Test
+  void shouldUseDeterministicDurationHeatmapReportId() {
+    // when / then
+    assertThat(AgenticControlDashboardService.DURATION_HEATMAP_REPORT_ID)
+        .isEqualTo(
+            java.util
+                .UUID
+                .nameUUIDFromBytes(
+                    "agentic-duration-heatmap".getBytes(java.nio.charset.StandardCharsets.UTF_8))
+                .toString());
+  }
+
+  @Test
+  void shouldMarkDurationHeatmapTileAsL1OnlyInDurationSectionAtCorrectPositionAndDimensions() {
+    // given
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID)).thenReturn(Optional.empty());
+
+    // when
+    underTest.reconcile();
+
+    // then the tile is L1-only (a heat map needs a single process definition's BPMN XML to render)
+    // and lives in the duration section
+    final DashboardDefinitionRestDto saved = captureSavedDashboard();
+    final DashboardReportTileDto heatmapTile =
+        tileById(saved, AgenticControlDashboardService.DURATION_HEATMAP_REPORT_ID);
+
+    assertThat(heatmapTile.getPosition().getX()).isZero();
+    assertThat(heatmapTile.getPosition().getY()).isEqualTo(14);
+    assertThat(heatmapTile.getDimensions().getWidth()).isEqualTo(18);
+    assertThat(heatmapTile.getDimensions().getHeight()).isEqualTo(4);
+    assertThat(heatmapTile.getConfiguration())
+        .isEqualTo(Map.of("section", "duration", "visibleInL1Only", true));
+  }
+
+  @Test
+  void shouldUpsertDurationHeatmapReportOnWarmRestart() {
+    // given the dashboard already exists (warm restart)
+    when(dashboardReader.getDashboard(AGENTIC_DASHBOARD_ID))
+        .thenReturn(Optional.of(new DashboardDefinitionRestDto()));
+
+    // when
+    underTest.reconcile();
+    underTest.reconcile();
+
+    // then the heatmap report is upserted on every reconcile
+    verify(reportWriter, times(2))
+        .createOrUpdateSingleProcessReport(
+            eq(AgenticControlDashboardService.DURATION_HEATMAP_REPORT_ID),
             any(),
             any(),
             any(),


### PR DESCRIPTION
## Description
Adds a full-width Duration per flow node heatmap tile to the Agentic Control Plane
dashboard. It overlays average per-flow-node duration on the process diagram so operators
can spot slow steps at a glance. Shown only once a single process is selected (L1).

## Screenshot
<img width="2935" height="861" alt="Screenshot 2026-07-03 at 11 14 48 AM" src="https://github.com/user-attachments/assets/5d836f99-f070-4971-b4ac-bc824ec1fbeb" />

closes #56140
