### PR TITLE
feat: broker per physical tenant job stream services

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerJobStreamService.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerJobStreamService.java
@@ -7,14 +7,12 @@
  */
 package io.camunda.zeebe.broker;
 
-import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamInfo;
-import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import java.util.Collection;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,9 +30,12 @@ final class BrokerJobStreamService implements JobStreamEndpoint.Service {
   @Override
   public Collection<RemoteStreamInfo<JobActivationProperties>> remoteJobStreams() {
     return bridge
-        .getJobStreamService()
-        .map(JobStreamService::remoteStreamService)
-        .map(RemoteStreamService::streams)
+        .getJobStreamServices()
+        .map(
+            services ->
+                services.stream()
+                    .flatMap(svc -> svc.remoteStreamService().streams().stream())
+                    .toList())
         .orElse(Collections.emptyList());
   }
 

--- a/dist/src/test/java/io/camunda/zeebe/broker/SystemContextLoaderTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/SystemContextLoaderTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
+import io.camunda.configuration.UnifiedConfigurationHelper;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.service.UserServices;
@@ -30,8 +31,11 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.mock.env.MockEnvironment;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
@@ -44,6 +48,18 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 final class SystemContextLoaderTest {
 
   @TempDir private Path workingDirectory;
+
+  @BeforeEach
+  void setUpEnvironment() {
+    // Guard against static-field contamination from Spring-context tests that leave a plain
+    // mock(Environment.class), which is not a ConfigurableEnvironment and crashes Binder.get().
+    UnifiedConfigurationHelper.setCustomEnvironment(new MockEnvironment());
+  }
+
+  @AfterEach
+  void resetEnvironment() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
 
   @Test
   void shouldThrowWhenExporterHasNoClassName() {
@@ -84,7 +100,7 @@ final class SystemContextLoaderTest {
     // then - the default tenant reuses the fully-initialized root broker config as-is
     assertThat(
             systemContext
-                .getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .getPhysicalTenantContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .config())
         .isSameAs(rootBrokerCfg);
   }
@@ -110,11 +126,11 @@ final class SystemContextLoaderTest {
     final SystemContext systemContext = loader.createSystemContext();
 
     // then - the non-default tenant gets its own converted config, distinct from the root
-    final var tenantConfig = systemContext.getPhysicalTenantEngineContext("tenanta").config();
+    final var tenantConfig = systemContext.getPhysicalTenantContext("tenanta").config();
     assertThat(tenantConfig).isNotSameAs(rootBrokerCfg);
     assertThat(
             systemContext
-                .getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .getPhysicalTenantContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .config())
         .isSameAs(rootBrokerCfg);
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
@@ -15,9 +15,7 @@ import io.atomix.cluster.BrokerMemberId;
  */
 public interface BrokerTopologyListener {
 
-  default void brokerAdded(final BrokerMemberId memberId) {}
-
-  default void brokerAddedToGroup(final BrokerMemberId memberId, final String physicalTenantId) {}
+  default void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {}
 
   default void brokerRemoved(final BrokerMemberId memberId) {}
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
@@ -17,6 +17,8 @@ public interface BrokerTopologyListener {
 
   default void brokerAdded(final BrokerMemberId memberId) {}
 
+  default void brokerAddedToGroup(final BrokerMemberId memberId, final String physicalTenantId) {}
+
   default void brokerRemoved(final BrokerMemberId memberId) {}
 
   default void completedClusterChange() {}

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
@@ -17,7 +17,7 @@ public interface BrokerTopologyListener {
 
   default void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {}
 
-  default void brokerRemoved(final BrokerMemberId memberId) {}
+  default void brokerRemoved(final BrokerMemberId memberId, final String physicalTenantId) {}
 
   default void completedClusterChange() {}
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -37,9 +37,9 @@ public interface BrokerTopologyManager extends ClusterConfigurationUpdateListene
   ClusterConfiguration getClusterConfiguration();
 
   /**
-   * Adds the topology listener. For each existing brokers, the listener will be notified via {@link
-   * BrokerTopologyListener#brokerAdded(BrokerMemberId)}. After that, the listener gets notified of
-   * every new broker added or removed events.
+   * Adds the topology listener. For each existing broker-group pair, the listener will be notified
+   * via {@link BrokerTopologyListener#brokerAdded(BrokerMemberId, String)}. After that, the
+   * listener gets notified of every new broker added or removed events.
    *
    * @param listener the topology listener
    */

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -78,17 +78,9 @@ public final class BrokerTopologyManagerImpl extends Actor
     actor.run(
         () -> {
           topologyListeners.add(listener);
-          // Backfill listener with all known broker IDs across all groups
-          memberPropertiesPerGroup.values().stream()
-              .flatMap(m -> m.keySet().stream())
-              .distinct()
-              .forEach(listener::brokerAdded);
-          // Backfill group-aware listener per physicalTenantId
           memberPropertiesPerGroup.forEach(
               (physicalTenantId, groupMap) ->
-                  groupMap
-                      .keySet()
-                      .forEach(id -> listener.brokerAddedToGroup(id, physicalTenantId)));
+                  groupMap.keySet().forEach(id -> listener.brokerAdded(id, physicalTenantId)));
         });
   }
 
@@ -123,22 +115,11 @@ public final class BrokerTopologyManagerImpl extends Actor
     final var physicalTenantId = brokerInfo.getPartitionGroup();
     actor.run(
         () -> {
-          // Notify listeners only on the first appearance of this broker across all groups.
-          final boolean isNew =
-              memberPropertiesPerGroup.values().stream()
-                  .noneMatch(m -> m.containsKey(brokerMemberId));
-          if (isNew) {
-            topologyListeners.forEach(l -> l.brokerAdded(brokerMemberId));
-          }
-
           memberPropertiesPerGroup
               .computeIfAbsent(physicalTenantId, id -> new HashMap<>())
               .put(brokerMemberId, brokerInfo);
           rebuildGroupTopology(physicalTenantId);
-
-          // Notify group-aware listeners every time (per physicalTenantId, not just on first
-          // appearance).
-          topologyListeners.forEach(l -> l.brokerAddedToGroup(brokerMemberId, physicalTenantId));
+          topologyListeners.forEach(l -> l.brokerAdded(brokerMemberId, physicalTenantId));
         });
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -145,8 +145,11 @@ public final class BrokerTopologyManagerImpl extends Actor
               });
 
           if (!groupsToRebuild.isEmpty()) {
-            topologyListeners.forEach(l -> l.brokerRemoved(brokerMemberId));
-            groupsToRebuild.forEach(this::rebuildGroupTopology);
+            groupsToRebuild.forEach(
+                physicalTenantId -> {
+                  rebuildGroupTopology(physicalTenantId);
+                  topologyListeners.forEach(l -> l.brokerRemoved(brokerMemberId, physicalTenantId));
+                });
           }
         });
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -83,6 +83,12 @@ public final class BrokerTopologyManagerImpl extends Actor
               .flatMap(m -> m.keySet().stream())
               .distinct()
               .forEach(listener::brokerAdded);
+          // Backfill group-aware listener per physicalTenantId
+          memberPropertiesPerGroup.forEach(
+              (physicalTenantId, groupMap) ->
+                  groupMap
+                      .keySet()
+                      .forEach(id -> listener.brokerAddedToGroup(id, physicalTenantId)));
         });
   }
 
@@ -114,7 +120,7 @@ public final class BrokerTopologyManagerImpl extends Actor
 
   private void addBroker(final BrokerInfo brokerInfo) {
     final var brokerMemberId = BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
-    final var group = brokerInfo.getPartitionGroup();
+    final var physicalTenantId = brokerInfo.getPartitionGroup();
     actor.run(
         () -> {
           // Notify listeners only on the first appearance of this broker across all groups.
@@ -126,9 +132,13 @@ public final class BrokerTopologyManagerImpl extends Actor
           }
 
           memberPropertiesPerGroup
-              .computeIfAbsent(group, g -> new HashMap<>())
+              .computeIfAbsent(physicalTenantId, id -> new HashMap<>())
               .put(brokerMemberId, brokerInfo);
-          rebuildGroupTopology(group);
+          rebuildGroupTopology(physicalTenantId);
+
+          // Notify group-aware listeners every time (per physicalTenantId, not just on first
+          // appearance).
+          topologyListeners.forEach(l -> l.brokerAddedToGroup(brokerMemberId, physicalTenantId));
         });
   }
 
@@ -147,9 +157,9 @@ public final class BrokerTopologyManagerImpl extends Actor
         () -> {
           final Set<String> groupsToRebuild = new HashSet<>();
           memberPropertiesPerGroup.forEach(
-              (group, groupMap) -> {
+              (physicalTenantId, groupMap) -> {
                 if (groupMap.remove(brokerMemberId) != null) {
-                  groupsToRebuild.add(group);
+                  groupsToRebuild.add(physicalTenantId);
                 }
               });
 
@@ -160,18 +170,19 @@ public final class BrokerTopologyManagerImpl extends Actor
         });
   }
 
-  private void rebuildGroupTopology(final String group) {
-    final var groupMembers = memberPropertiesPerGroup.getOrDefault(group, Map.of()).values();
+  private void rebuildGroupTopology(final String physicalTenantId) {
+    final var groupMembers =
+        memberPropertiesPerGroup.getOrDefault(physicalTenantId, Map.of()).values();
     final var configuredState = currentConfiguredState();
     final var newGroupTopology =
         BrokerClientTopologyImpl.fromMemberProperties(groupMembers, configuredState);
 
     final Map<String, BrokerClientTopologyImpl> updated = new HashMap<>(topologyPerGroup);
-    updated.put(group, newGroupTopology);
+    updated.put(physicalTenantId, newGroupTopology);
     topologyPerGroup = Map.copyOf(updated);
 
     // temp: only update metrics for default group until we support group-specific metrics
-    if (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(group)) {
+    if (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
       updateMetrics(newGroupTopology);
     }
   }
@@ -261,13 +272,16 @@ public final class BrokerTopologyManagerImpl extends Actor
     // temp: apply the same configured state to all other known groups. This must be revisited when
     // we add support for group-specific cluster configurations.
     memberPropertiesPerGroup.keySet().stream()
-        .filter(group -> !group.equals(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .filter(
+            physicalTenantId ->
+                !physicalTenantId.equals(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
         .forEach(
-            group -> {
+            physicalTenantId -> {
               final var oldGroup =
-                  topologyPerGroup.getOrDefault(group, BrokerClientTopologyImpl.uninitialized());
+                  topologyPerGroup.getOrDefault(
+                      physicalTenantId, BrokerClientTopologyImpl.uninitialized());
               allGroups.put(
-                  group,
+                  physicalTenantId,
                   new BrokerClientTopologyImpl(oldGroup.liveClusterState(), newConfiguredState));
             });
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -563,7 +563,7 @@ final class BrokerTopologyManagerTest {
     topologyManager.addTopologyListener(
         new BrokerTopologyListener() {
           @Override
-          public void brokerAdded(final BrokerMemberId memberId) {
+          public void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {
             capturedIds.add(memberId);
           }
         });
@@ -581,8 +581,7 @@ final class BrokerTopologyManagerTest {
     addTopologyListener(
         new BrokerTopologyListener() {
           @Override
-          public void brokerAddedToGroup(
-              final BrokerMemberId memberId, final String physicalTenantId) {
+          public void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {
             capturedMembers.add(memberId);
             capturedGroups.add(physicalTenantId);
           }
@@ -612,14 +611,13 @@ final class BrokerTopologyManagerTest {
     addTopologyListener(
         new BrokerTopologyListener() {
           @Override
-          public void brokerAddedToGroup(
-              final BrokerMemberId memberId, final String physicalTenantId) {
+          public void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {
             capturedMembers.add(memberId);
             capturedGroups.add(physicalTenantId);
           }
         });
 
-    // then — backfill fires brokerAddedToGroup with the known group
+    // then — backfill fires brokerAdded with the known group
     assertThat(capturedMembers).containsExactly(brokerId);
     assertThat(capturedGroups).containsExactly("tenant1");
   }
@@ -744,7 +742,7 @@ final class BrokerTopologyManagerTest {
     private final Set<BrokerMemberId> brokers = new CopyOnWriteArraySet<>();
 
     @Override
-    public void brokerAdded(final BrokerMemberId memberId) {
+    public void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {
       brokers.add(memberId);
     }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.BrokerMemberId;
@@ -620,6 +621,62 @@ final class BrokerTopologyManagerTest {
     // then — backfill fires brokerAdded with the known group
     assertThat(capturedMembers).containsExactly(brokerId);
     assertThat(capturedGroups).containsExactly("tenant1");
+  }
+
+  @Test
+  void shouldNotifyListenerWithGroupWhenBrokerRemoved() {
+    // given
+    final var brokerId = BrokerMemberId.from(0);
+    final BrokerInfo broker = createBrokerWithGroup(brokerId, "tenant1");
+    notifyEvent(createMemberAddedEvent(broker));
+
+    final var capturedRemovedGroups = new CopyOnWriteArrayList<String>();
+    final var capturedRemovedMembers = new CopyOnWriteArrayList<BrokerMemberId>();
+    addTopologyListener(
+        new BrokerTopologyListener() {
+          @Override
+          public void brokerRemoved(final BrokerMemberId memberId, final String physicalTenantId) {
+            capturedRemovedMembers.add(memberId);
+            capturedRemovedGroups.add(physicalTenantId);
+          }
+        });
+
+    // when
+    notifyEvent(createMemberRemoveEvent(broker));
+
+    // then
+    assertThat(capturedRemovedMembers).containsExactly(brokerId);
+    assertThat(capturedRemovedGroups).containsExactly("tenant1");
+  }
+
+  @Test
+  void shouldNotifyListenerForEachGroupOnBrokerRemoved() {
+    // given — broker 0 serves both default and tenant1 groups
+    final var brokerId = BrokerMemberId.from(0);
+    final BrokerInfo defaultInfo = createBroker(brokerId);
+    final BrokerInfo tenant1Info = createBrokerWithGroup(brokerId, "tenant1");
+
+    final Member member = new Member(new MemberConfig().setId(defaultInfo.brokerIdStr()));
+    defaultInfo.writeIntoProperties(member.properties());
+    tenant1Info.writeIntoProperties(member.properties());
+    members.add(member);
+    notifyEvent(new ClusterMembershipEvent(Type.MEMBER_ADDED, member));
+
+    final var capturedRemovedGroups = new CopyOnWriteArrayList<String>();
+    addTopologyListener(
+        new BrokerTopologyListener() {
+          @Override
+          public void brokerRemoved(final BrokerMemberId memberId, final String physicalTenantId) {
+            capturedRemovedGroups.add(physicalTenantId);
+          }
+        });
+
+    // when
+    notifyEvent(new ClusterMembershipEvent(Type.MEMBER_REMOVED, member));
+
+    // then — one notification per group
+    assertThat(capturedRemovedGroups)
+        .containsExactlyInAnyOrder(DEFAULT_PHYSICAL_TENANT_ID, "tenant1");
   }
 
   @Test

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -747,7 +747,7 @@ final class BrokerTopologyManagerTest {
     }
 
     @Override
-    public void brokerRemoved(final BrokerMemberId memberId) {
+    public void brokerRemoved(final BrokerMemberId memberId, final String physicalTenantId) {
       brokers.remove(memberId);
     }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -574,6 +574,57 @@ final class BrokerTopologyManagerTest {
   }
 
   @Test
+  void shouldNotifyListenerWithGroupWhenBrokerJoins() {
+    // given
+    final var capturedGroups = new CopyOnWriteArrayList<String>();
+    final var capturedMembers = new CopyOnWriteArrayList<BrokerMemberId>();
+    addTopologyListener(
+        new BrokerTopologyListener() {
+          @Override
+          public void brokerAddedToGroup(
+              final BrokerMemberId memberId, final String physicalTenantId) {
+            capturedMembers.add(memberId);
+            capturedGroups.add(physicalTenantId);
+          }
+        });
+
+    final var brokerId = BrokerMemberId.from(0);
+    final BrokerInfo broker = createBrokerWithGroup(brokerId, "tenant1");
+
+    // when
+    notifyEvent(createMemberAddedEvent(broker));
+
+    // then
+    assertThat(capturedMembers).containsExactly(brokerId);
+    assertThat(capturedGroups).containsExactly("tenant1");
+  }
+
+  @Test
+  void shouldBackfillNewListenerWithGroupInfo() {
+    // given — broker 0 already joined with group "tenant1"
+    final var brokerId = BrokerMemberId.from(0);
+    final BrokerInfo broker = createBrokerWithGroup(brokerId, "tenant1");
+    notifyEvent(createMemberAddedEvent(broker));
+
+    // when — a new listener is registered after the broker is already known
+    final var capturedGroups = new CopyOnWriteArrayList<String>();
+    final var capturedMembers = new CopyOnWriteArrayList<BrokerMemberId>();
+    addTopologyListener(
+        new BrokerTopologyListener() {
+          @Override
+          public void brokerAddedToGroup(
+              final BrokerMemberId memberId, final String physicalTenantId) {
+            capturedMembers.add(memberId);
+            capturedGroups.add(physicalTenantId);
+          }
+        });
+
+    // then — backfill fires brokerAddedToGroup with the known group
+    assertThat(capturedMembers).containsExactly(brokerId);
+    assertThat(capturedGroups).containsExactly("tenant1");
+  }
+
+  @Test
   void shouldAggregateTopologyPerPartitionGroup() {
     // given — broker 0 publishes both a default-group and a tenant1-group BrokerInfo
     final var brokerId = BrokerMemberId.from(0);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -73,7 +73,7 @@ public final class Broker implements AutoCloseable {
             additionalPartitionListeners,
             systemContext.getShutdownTimeout(),
             systemContext.getMeterRegistry(),
-            systemContext.getPhysicalTenantEngineContexts(),
+            systemContext.getPhysicalTenantContexts(),
             systemContext.getUserServicesForTenant(),
             systemContext.getPasswordEncoder(),
             systemContext.getJwtDecoderFactory(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.system.management.BrokerAdminService;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -29,7 +30,7 @@ public class SpringBrokerBridge {
 
   private Supplier<BrokerHealthCheckService> healthCheckServiceSupplier;
   private Supplier<BrokerAdminService> adminServiceSupplier;
-  private Supplier<JobStreamService> jobStreamServiceSupplier;
+  private Supplier<Collection<JobStreamService>> jobStreamServicesSupplier;
   private Supplier<JobStreamClient> jobStreamClientSupplier;
 
   private BiConsumer<Integer, String> shutdownHelper;
@@ -61,13 +62,13 @@ public class SpringBrokerBridge {
     return Optional.ofNullable(jobStreamClientSupplier).map(Supplier::get);
   }
 
-  public void registerJobStreamServiceSupplier(
-      final Supplier<JobStreamService> jobStreamServiceSupplier) {
-    this.jobStreamServiceSupplier = jobStreamServiceSupplier;
+  public void registerJobStreamServicesSupplier(
+      final Supplier<Collection<JobStreamService>> jobStreamServicesSupplier) {
+    this.jobStreamServicesSupplier = jobStreamServicesSupplier;
   }
 
-  public Optional<JobStreamService> getJobStreamService() {
-    return Optional.ofNullable(jobStreamServiceSupplier).map(Supplier::get);
+  public Optional<Collection<JobStreamService>> getJobStreamServices() {
+    return Optional.ofNullable(jobStreamServicesSupplier).map(Supplier::get);
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -57,7 +57,7 @@ public interface BrokerStartupContext {
   /**
    * Return the broker configuration shared across all physical tenants. This should be used only
    * for broker-wide configuration. The components that run per physical tenant must use the
-   * configuration from #getPhysicalTenantEngineContext(String physicalTenantId) instead.
+   * configuration from #getPhysicalTenantContext(String physicalTenantId) instead.
    *
    * @return the broker-wide configuration shared across all physical tenants
    */
@@ -153,7 +153,7 @@ public interface BrokerStartupContext {
    *
    * @throws IllegalArgumentException if the physical tenant id is unknown
    */
-  PhysicalTenantContext getPhysicalTenantEngineContext(String physicalTenantId);
+  PhysicalTenantContext getPhysicalTenantContext(String physicalTenantId);
 
   Function<String, UserServices> getUserServicesForTenant();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
-import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
@@ -128,9 +127,12 @@ public interface BrokerStartupContext {
 
   void setBrokerAdminService(final BrokerAdminServiceImpl brokerAdminService);
 
-  JobStreamService getJobStreamService();
-
-  void setJobStreamService(final JobStreamService jobStreamService);
+  /**
+   * Replaces the {@link PhysicalTenantContext} for the given physical tenant. Throws if the
+   * tenant id is not already registered.
+   */
+  void updatePhysicalTenantEngineContext(
+      String physicalTenantId, PhysicalTenantEngineContext context);
 
   ClusterConfigurationService getClusterConfigurationService();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -18,6 +18,8 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
-import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
@@ -108,6 +107,12 @@ public interface BrokerStartupContext {
 
   void setDiskSpaceUsageMonitor(DiskSpaceUsageMonitor diskSpaceUsageMonitor);
 
+  JobStreamService getJobStreamService(String physicalTenantId);
+
+  void addJobStreamService(String physicalTenantId, JobStreamService service);
+
+  void removeJobStreamService(String physicalTenantId);
+
   /** Returns all currently registered partition managers, keyed by physical tenant ID. */
   Map<String, PartitionManager> getPartitionManagers();
 
@@ -128,13 +133,6 @@ public interface BrokerStartupContext {
   BrokerAdminServiceImpl getBrokerAdminService();
 
   void setBrokerAdminService(final BrokerAdminServiceImpl brokerAdminService);
-
-  /**
-   * Replaces the {@link PhysicalTenantContext} for the given physical tenant. Throws if the
-   * tenant id is not already registered.
-   */
-  void updatePhysicalTenantEngineContext(
-      String physicalTenantId, PhysicalTenantEngineContext context);
 
   ClusterConfigurationService getClusterConfigurationService();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -65,7 +65,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final List<PartitionRaftListener> partitionRaftListeners = new ArrayList<>();
   private final Duration shutdownTimeout;
   private final MeterRegistry meterRegistry;
-  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts;
+  private final Map<String, PhysicalTenantContext> physicalTenantContexts;
   private final Function<String, UserServices> userServicesForTenant;
   private final PasswordEncoder passwordEncoder;
   private final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
@@ -100,7 +100,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final List<PartitionListener> additionalPartitionListeners,
       final Duration shutdownTimeout,
       final MeterRegistry meterRegistry,
-      final Map<String, PhysicalTenantContext> physicalTenantEngineContexts,
+      final Map<String, PhysicalTenantContext> physicalTenantContexts,
       final Function<String, UserServices> userServicesForTenant,
       final PasswordEncoder passwordEncoder,
       final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory,
@@ -118,7 +118,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.brokerClient = brokerClient;
     this.shutdownTimeout = shutdownTimeout;
     this.meterRegistry = requireNonNull(meterRegistry);
-    this.physicalTenantEngineContexts = Map.copyOf(physicalTenantEngineContexts);
+    this.physicalTenantContexts = Map.copyOf(physicalTenantContexts);
     this.userServicesForTenant = userServicesForTenant;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoderFactory = jwtDecoderFactory;
@@ -346,11 +346,11 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public PhysicalTenantContext getPhysicalTenantEngineContext(final String physicalTenantId) {
-    if (!physicalTenantEngineContexts.containsKey(physicalTenantId)) {
+  public PhysicalTenantContext getPhysicalTenantContext(final String physicalTenantId) {
+    if (!physicalTenantContexts.containsKey(physicalTenantId)) {
       throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
     }
-    return physicalTenantEngineContexts.get(physicalTenantId);
+    return physicalTenantContexts.get(physicalTenantId);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -65,7 +65,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final List<PartitionRaftListener> partitionRaftListeners = new ArrayList<>();
   private final Duration shutdownTimeout;
   private final MeterRegistry meterRegistry;
-  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts;
+  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts =
+      new LinkedHashMap<>();
   private final Function<String, UserServices> userServicesForTenant;
   private final PasswordEncoder passwordEncoder;
   private final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
@@ -84,7 +85,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final Map<String, PartitionManager> partitionManagers = new LinkedHashMap<>();
   private RocksDbResources sharedRocksDbResources;
   private BrokerAdminServiceImpl brokerAdminService;
-  private JobStreamService jobStreamService;
   private ClusterConfigurationService clusterConfigurationService;
   private SnapshotApiRequestHandler snapshotApiRequestHandler;
   private CheckpointSchedulingService checkpointSchedulingService;
@@ -118,7 +118,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.brokerClient = brokerClient;
     this.shutdownTimeout = shutdownTimeout;
     this.meterRegistry = requireNonNull(meterRegistry);
-    this.physicalTenantEngineContexts = Map.copyOf(physicalTenantEngineContexts);
+    this.physicalTenantEngineContexts.putAll(physicalTenantEngineContexts);
     this.userServicesForTenant = userServicesForTenant;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoderFactory = jwtDecoderFactory;
@@ -295,13 +295,12 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public JobStreamService getJobStreamService() {
-    return jobStreamService;
-  }
-
-  @Override
-  public void setJobStreamService(final JobStreamService jobStreamService) {
-    this.jobStreamService = jobStreamService;
+  public void updatePhysicalTenantEngineContext(
+      final String physicalTenantId, final PhysicalTenantEngineContext context) {
+    if (!physicalTenantEngineContexts.containsKey(physicalTenantId)) {
+      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
+    }
+    physicalTenantEngineContexts.put(physicalTenantId, context);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -82,6 +82,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private ManagedMessagingService commandApiMessagingService;
   private AdminApiRequestHandler adminApiService;
   private EmbeddedGatewayService embeddedGatewayService;
+  private final Map<String, JobStreamService> jobStreamServices = new LinkedHashMap<>();
   private final Map<String, PartitionManager> partitionManagers = new LinkedHashMap<>();
   private RocksDbResources sharedRocksDbResources;
   private BrokerAdminServiceImpl brokerAdminService;
@@ -259,6 +260,21 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
+  public JobStreamService getJobStreamService(final String physicalTenantId) {
+    return jobStreamServices.get(physicalTenantId);
+  }
+
+  @Override
+  public void addJobStreamService(final String physicalTenantId, final JobStreamService service) {
+    jobStreamServices.put(physicalTenantId, service);
+  }
+
+  @Override
+  public void removeJobStreamService(final String physicalTenantId) {
+    jobStreamServices.remove(physicalTenantId);
+  }
+
+  @Override
   public Map<String, PartitionManager> getPartitionManagers() {
     return Collections.unmodifiableMap(partitionManagers);
   }
@@ -292,15 +308,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public void setBrokerAdminService(final BrokerAdminServiceImpl brokerAdminService) {
     this.brokerAdminService = brokerAdminService;
-  }
-
-  @Override
-  public void updatePhysicalTenantEngineContext(
-      final String physicalTenantId, final PhysicalTenantEngineContext context) {
-    if (!physicalTenantEngineContexts.containsKey(physicalTenantId)) {
-      throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
-    }
-    physicalTenantEngineContexts.put(physicalTenantId, context);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -65,8 +65,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final List<PartitionRaftListener> partitionRaftListeners = new ArrayList<>();
   private final Duration shutdownTimeout;
   private final MeterRegistry meterRegistry;
-  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts =
-      new LinkedHashMap<>();
+  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts;
   private final Function<String, UserServices> userServicesForTenant;
   private final PasswordEncoder passwordEncoder;
   private final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
@@ -119,7 +118,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.brokerClient = brokerClient;
     this.shutdownTimeout = shutdownTimeout;
     this.meterRegistry = requireNonNull(meterRegistry);
-    this.physicalTenantEngineContexts.putAll(physicalTenantEngineContexts);
+    this.physicalTenantEngineContexts = Map.copyOf(physicalTenantEngineContexts);
     this.userServicesForTenant = userServicesForTenant;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoderFactory = jwtDecoderFactory;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
@@ -40,7 +40,7 @@ public class ClusterConfigurationManagerStep
             // This is a temporary solution until we support multiple physical tenants in dynamic
             // cluster config module.
             brokerStartupContext
-                .getPhysicalTenantEngineContext(DEFAULT_PHYSICAL_TENANT_ID)
+                .getPhysicalTenantContext(DEFAULT_PHYSICAL_TENANT_ID)
                 .exporterRepository(),
             brokerStartupContext.getNodeIdProvider(),
             brokerStartupContext.getMeterRegistry(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -46,7 +46,7 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
                     physicalTenantId -> physicalTenantId,
                     physicalTenantId ->
                         brokerStartupContext
-                            .getPhysicalTenantEngineContext(physicalTenantId)
+                            .getPhysicalTenantContext(physicalTenantId)
                             .securityConfig()));
 
     final var embeddedGatewayService =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -32,10 +32,9 @@ import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
 /**
- * Sets up one {@link JobStreamService} per physical tenant and stores it in the tenant's {@link
- * io.camunda.zeebe.broker.system.PhysicalTenantEngineContext}. Each service subscribes on its
- * group's transport topics so that streams registered for one physical tenant are never matched
- * against jobs from another.
+ * Sets up one {@link JobStreamService} per physical tenant and registers it in the broker startup
+ * context's job-stream-service map. Each service subscribes on its group's transport topics so that
+ * streams registered for one physical tenant are never matched against jobs from another.
  */
 public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
 
@@ -60,16 +59,20 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
         futures,
         (services, err) -> {
           if (err != null) {
-            startupFuture.completeExceptionally(err);
+            // Shut down any services that started successfully before completing exceptionally.
+            // shutdownTenantService is a no-op for tenants whose service was never stored.
+            final var cleanupFutures =
+                tenantIds.stream()
+                    .map(id -> shutdownTenantService(brokerStartupContext, id, concurrencyControl))
+                    .collect(new ActorFutureCollector<>(concurrencyControl));
+            concurrencyControl.runOnCompletion(
+                cleanupFutures, (ignored, cleanupErr) -> startupFuture.completeExceptionally(err));
             return;
           }
           brokerStartupContext
               .getSpringBrokerBridge()
               .registerJobStreamServiceSupplier(
-                  () ->
-                      brokerStartupContext
-                          .getPhysicalTenantEngineContext(DEFAULT_PHYSICAL_TENANT_ID)
-                          .jobStreamService());
+                  () -> brokerStartupContext.getJobStreamService(DEFAULT_PHYSICAL_TENANT_ID));
           startupFuture.complete(brokerStartupContext);
         });
   }
@@ -147,11 +150,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
                             new RemoteJobStreamer(streamer, clusterServices.getEventService()),
                             errorHandlerService);
                     clusterServices.getMembershipService().addListener(remoteStreamService);
-                    brokerStartupContext.updatePhysicalTenantEngineContext(
-                        physicalTenantId,
-                        brokerStartupContext
-                            .getPhysicalTenantEngineContext(physicalTenantId)
-                            .withJobStreamService(jobStreamService));
+                    brokerStartupContext.addJobStreamService(physicalTenantId, jobStreamService);
                     result.complete(jobStreamService);
                   });
         });
@@ -164,15 +163,13 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
       final String physicalTenantId,
       final ConcurrencyControl concurrencyControl) {
 
-    final var service = ctx.getPhysicalTenantEngineContext(physicalTenantId).jobStreamService();
+    final var service = ctx.getJobStreamService(physicalTenantId);
     if (service == null) {
       return CompletableActorFuture.completed(null);
     }
 
     ctx.getClusterServices().getMembershipService().removeListener(service.remoteStreamService());
-    ctx.updatePhysicalTenantEngineContext(
-        physicalTenantId,
-        ctx.getPhysicalTenantEngineContext(physicalTenantId).withJobStreamService(null));
+    ctx.removeJobStreamService(physicalTenantId);
 
     final var result = concurrencyControl.<Void>createFuture();
     service

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -18,8 +18,11 @@ import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.TransportFactory;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -29,8 +32,10 @@ import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
 /**
- * Sets up the {@link JobStreamService}, which manages the lifecycle of the job specific stream API
- * remoteStreamService, pusher, and registry.
+ * Sets up one {@link JobStreamService} per physical tenant and stores it in the tenant's {@link
+ * io.camunda.zeebe.broker.system.PhysicalTenantEngineContext}. Each service subscribes on its
+ * group's transport topics so that streams registered for one physical tenant are never matched
+ * against jobs from another.
  */
 public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
 
@@ -39,11 +44,72 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
       final BrokerStartupContext brokerStartupContext,
       final ConcurrencyControl concurrencyControl,
       final ActorFuture<BrokerStartupContext> startupFuture) {
+
+    final var scheduler = brokerStartupContext.getActorSchedulingService();
+    final var tenantIds = brokerStartupContext.getPhysicalTenantIds().known();
+
+    final var futures =
+        tenantIds.stream()
+            .map(
+                tenantId ->
+                    startTenantService(
+                        brokerStartupContext, tenantId, scheduler, concurrencyControl))
+            .collect(new ActorFutureCollector<>(concurrencyControl));
+
+    concurrencyControl.runOnCompletion(
+        futures,
+        (services, err) -> {
+          if (err != null) {
+            startupFuture.completeExceptionally(err);
+            return;
+          }
+          brokerStartupContext
+              .getSpringBrokerBridge()
+              .registerJobStreamServiceSupplier(
+                  () ->
+                      brokerStartupContext
+                          .getPhysicalTenantEngineContext(DEFAULT_PHYSICAL_TENANT_ID)
+                          .jobStreamService());
+          startupFuture.complete(brokerStartupContext);
+        });
+  }
+
+  @Override
+  void shutdownInternal(
+      final BrokerStartupContext brokerShutdownContext,
+      final ConcurrencyControl concurrencyControl,
+      final ActorFuture<BrokerStartupContext> shutdownFuture) {
+
+    final var tenantIds = brokerShutdownContext.getPhysicalTenantIds().known();
+
+    final var futures =
+        tenantIds.stream()
+            .map(
+                tenantId ->
+                    shutdownTenantService(brokerShutdownContext, tenantId, concurrencyControl))
+            .collect(new ActorFutureCollector<>(concurrencyControl));
+
+    concurrencyControl.runOnCompletion(
+        futures,
+        (ok, err) -> {
+          brokerShutdownContext.getSpringBrokerBridge().registerJobStreamServiceSupplier(null);
+          if (err != null) {
+            shutdownFuture.completeExceptionally(err);
+          } else {
+            shutdownFuture.complete(brokerShutdownContext);
+          }
+        });
+  }
+
+  private ActorFuture<JobStreamService> startTenantService(
+      final BrokerStartupContext brokerStartupContext,
+      final String physicalTenantId,
+      final ActorSchedulingService scheduler,
+      final ConcurrencyControl concurrencyControl) {
+
     final var clusterServices = brokerStartupContext.getClusterServices();
     final var errorHandlerService =
         new RemoteJobStreamErrorHandlerService(new YieldingJobStreamErrorHandler());
-
-    final var scheduler = brokerStartupContext.getActorSchedulingService();
     final RemoteStreamService<JobActivationProperties, ActivatedJob> remoteStreamService =
         new TransportFactory(scheduler)
             .createRemoteStreamServer(
@@ -51,13 +117,15 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
                 JobStreamServiceStep::readJobActivationProperties,
                 errorHandlerService,
                 new JobStreamMetrics(brokerStartupContext.getMeterRegistry()),
-                DEFAULT_PHYSICAL_TENANT_ID);
+                physicalTenantId);
+
+    final var result = concurrencyControl.<JobStreamService>createFuture();
     final var errorHandlerStarted = scheduler.submitActor(errorHandlerService);
 
     errorHandlerStarted.onComplete(
         (ok, err) -> {
           if (err != null) {
-            startupFuture.completeExceptionally(err);
+            result.completeExceptionally(err);
             return;
           }
 
@@ -66,7 +134,8 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
               .onComplete(
                   (streamer, error) -> {
                     if (error != null) {
-                      startupFuture.completeExceptionally(error);
+                      errorHandlerService.closeAsync();
+                      result.completeExceptionally(error);
                       return;
                     }
 
@@ -76,49 +145,45 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
                             new RemoteJobStreamer(streamer, clusterServices.getEventService()),
                             errorHandlerService);
                     clusterServices.getMembershipService().addListener(remoteStreamService);
-                    brokerStartupContext.addPartitionListener(errorHandlerService);
-                    brokerStartupContext.setJobStreamService(jobStreamService);
-                    brokerStartupContext
-                        .getSpringBrokerBridge()
-                        .registerJobStreamServiceSupplier(() -> jobStreamService);
-                    startupFuture.complete(brokerStartupContext);
+                    brokerStartupContext.updatePhysicalTenantEngineContext(
+                        physicalTenantId,
+                        brokerStartupContext
+                            .getPhysicalTenantEngineContext(physicalTenantId)
+                            .withJobStreamService(jobStreamService));
+                    result.complete(jobStreamService);
                   });
         });
+
+    return result;
   }
 
-  @Override
-  void shutdownInternal(
-      final BrokerStartupContext brokerShutdownContext,
-      final ConcurrencyControl concurrencyControl,
-      final ActorFuture<BrokerStartupContext> shutdownFuture) {
-    final var service = brokerShutdownContext.getJobStreamService();
+  private ActorFuture<Void> shutdownTenantService(
+      final BrokerStartupContext ctx,
+      final String physicalTenantId,
+      final ConcurrencyControl concurrencyControl) {
 
-    if (service != null) {
-      brokerShutdownContext
-          .getClusterServices()
-          .getMembershipService()
-          .removeListener(service.remoteStreamService());
-      brokerShutdownContext.removePartitionListener(service.errorHandlerService());
-
-      service
-          .closeAsync(concurrencyControl)
-          .onComplete(
-              (ok, error) -> {
-                if (error != null) {
-                  shutdownFuture.completeExceptionally(error);
-                } else {
-                  brokerShutdownContext
-                      .getClusterServices()
-                      .getMembershipService()
-                      .removeListener(service.remoteStreamService());
-                  brokerShutdownContext.setJobStreamService(null);
-                  brokerShutdownContext
-                      .getSpringBrokerBridge()
-                      .registerJobStreamServiceSupplier(null);
-                  shutdownFuture.complete(brokerShutdownContext);
-                }
-              });
+    final var service = ctx.getPhysicalTenantEngineContext(physicalTenantId).jobStreamService();
+    if (service == null) {
+      return CompletableActorFuture.completed(null);
     }
+
+    ctx.getClusterServices().getMembershipService().removeListener(service.remoteStreamService());
+    ctx.updatePhysicalTenantEngineContext(
+        physicalTenantId,
+        ctx.getPhysicalTenantEngineContext(physicalTenantId).withJobStreamService(null));
+
+    final var result = concurrencyControl.<Void>createFuture();
+    service
+        .closeAsync(concurrencyControl)
+        .onComplete(
+            (ignored, err) -> {
+              if (err != null) {
+                result.completeExceptionally(err);
+              } else {
+                result.complete(null);
+              }
+            });
+    return result;
   }
 
   @VisibleForTesting("https://github.com/camunda/camunda/issues/14624")

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-
 import io.camunda.zeebe.broker.jobstream.JobStreamMetrics;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.jobstream.RemoteJobStreamErrorHandlerService;
@@ -28,6 +26,7 @@ import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
@@ -71,8 +70,12 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
           }
           brokerStartupContext
               .getSpringBrokerBridge()
-              .registerJobStreamServiceSupplier(
-                  () -> brokerStartupContext.getJobStreamService(DEFAULT_PHYSICAL_TENANT_ID));
+              .registerJobStreamServicesSupplier(
+                  () ->
+                      tenantIds.stream()
+                          .map(brokerStartupContext::getJobStreamService)
+                          .filter(Objects::nonNull)
+                          .toList());
           startupFuture.complete(brokerStartupContext);
         });
   }
@@ -95,7 +98,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
     concurrencyControl.runOnCompletion(
         futures,
         (ok, err) -> {
-          brokerShutdownContext.getSpringBrokerBridge().registerJobStreamServiceSupplier(null);
+          brokerShutdownContext.getSpringBrokerBridge().registerJobStreamServicesSupplier(null);
           if (err != null) {
             shutdownFuture.completeExceptionally(err);
           } else {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -116,7 +116,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
                 clusterServices.getCommunicationService(),
                 JobStreamServiceStep::readJobActivationProperties,
                 errorHandlerService,
-                new JobStreamMetrics(brokerStartupContext.getMeterRegistry()),
+                new JobStreamMetrics(brokerStartupContext.getMeterRegistry(), physicalTenantId),
                 physicalTenantId);
 
     final var result = concurrencyControl.<JobStreamService>createFuture();
@@ -125,6 +125,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
     errorHandlerStarted.onComplete(
         (ok, err) -> {
           if (err != null) {
+            remoteStreamService.closeAsync(concurrencyControl);
             result.completeExceptionally(err);
             return;
           }
@@ -135,6 +136,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
                   (streamer, error) -> {
                     if (error != null) {
                       errorHandlerService.closeAsync();
+                      remoteStreamService.closeAsync(concurrencyControl);
                       result.completeExceptionally(error);
                       return;
                     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamMetrics.java
@@ -18,15 +18,19 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class JobStreamMetrics implements RemoteStreamMetrics {
+
+  private static final String PHYSICAL_TENANT_ID_TAG = "physicalTenantId";
   private final AtomicInteger streamCount = new AtomicInteger(0);
   private final Map<ErrorCode, Counter> pushTryFailedCount = new EnumMap<>(ErrorCode.class);
 
   private final MeterRegistry registry;
+  private final String physicalTenantId;
   private final Counter pushSuccessCount;
   private final Counter pushFailedCount;
 
-  public JobStreamMetrics(final MeterRegistry registry) {
+  public JobStreamMetrics(final MeterRegistry registry, final String physicalTenantId) {
     this.registry = registry;
+    this.physicalTenantId = physicalTenantId;
 
     pushSuccessCount = registerCounter(JobStreamMetricsDoc.PUSH_SUCCESS_COUNT);
     pushFailedCount = registerCounter(JobStreamMetricsDoc.PUSH_FAILED_COUNT);
@@ -34,11 +38,15 @@ public class JobStreamMetrics implements RemoteStreamMetrics {
     final var streamCountDoc = JobStreamMetricsDoc.STREAM_COUNT;
     Gauge.builder(streamCountDoc.getName(), streamCount, Number::intValue)
         .description(streamCountDoc.getDescription())
+        .tag(PHYSICAL_TENANT_ID_TAG, physicalTenantId)
         .register(registry);
   }
 
   private Counter registerCounter(final JobStreamMetricsDoc doc, final Tag... tags) {
-    final var builder = Counter.builder(doc.getName()).description(doc.getDescription());
+    final var builder =
+        Counter.builder(doc.getName())
+            .description(doc.getDescription())
+            .tag(PHYSICAL_TENANT_ID_TAG, physicalTenantId);
     for (final var tag : tags) {
       builder.tag(tag.getKey(), tag.getValue());
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -11,11 +11,15 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
+import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 
@@ -70,6 +74,14 @@ public interface PartitionManager {
     final var physicalTenantContext =
         brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
 
+    final JobStreamService jobStreamService = null;
+
+    // Combine global listeners with this tenant's error handler so each handler only ever
+    // sees its own group's partitions, resolving the bare-int partition-id aliasing bug.
+    final List<PartitionListener> partitionListeners =
+        new ArrayList<>(brokerStartupContext.getPartitionListeners());
+    partitionListeners.add(jobStreamService.errorHandlerService());
+
     return new PartitionManagerImpl(
         physicalTenantId,
         brokerStartupContext.getConcurrencyControl(),
@@ -81,12 +93,12 @@ public interface PartitionManager {
         brokerStartupContext.getClusterServices(),
         brokerStartupContext.getHealthCheckService(),
         brokerStartupContext.getDiskSpaceUsageMonitor(),
-        brokerStartupContext.getPartitionListeners(),
+        partitionListeners,
         brokerStartupContext.getPartitionRaftListeners(),
         brokerStartupContext.getSnapshotApiRequestHandler(),
         physicalTenantContext.exporterRepository(),
         brokerStartupContext.getGatewayBrokerTransport(),
-        brokerStartupContext.getJobStreamService().jobStreamer(),
+        jobStreamService.jobStreamer(),
         brokerStartupContext.getClusterConfigurationService(),
         brokerStartupContext.getMeterRegistry(),
         brokerStartupContext.getBrokerClient(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -12,7 +12,6 @@ import io.atomix.raft.partition.RaftPartition;
 import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
-import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.future.ActorFuture;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -70,7 +70,7 @@ public interface PartitionManager {
       final String physicalTenantId,
       final TopologyManagerImpl topologyManager) {
     final var physicalTenantContext =
-        brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
+        brokerStartupContext.getPhysicalTenantContext(physicalTenantId);
 
     final var jobStreamService =
         Objects.requireNonNull(
@@ -117,7 +117,7 @@ public interface PartitionManager {
 
     return new RecoveryPartitionManager(
         physicalTenantId,
-        brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId).config(),
+        brokerStartupContext.getPhysicalTenantContext(physicalTenantId).config(),
         brokerStartupContext.getBrokerInfo(),
         brokerStartupContext.getConcurrencyControl(),
         brokerStartupContext.getClusterConfigurationService(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
 
@@ -75,6 +76,7 @@ public interface PartitionManager {
         brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
 
     final JobStreamService jobStreamService = null;
+    final var engineContext = brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
 
     // Combine global listeners with this tenant's error handler so each handler only ever
     // sees its own group's partitions, resolving the bare-int partition-id aliasing bug.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -73,8 +73,10 @@ public interface PartitionManager {
     final var physicalTenantContext =
         brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
 
-    final JobStreamService jobStreamService = null;
-    final var engineContext = brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
+    final var jobStreamService =
+        Objects.requireNonNull(
+            brokerStartupContext.getJobStreamService(physicalTenantId),
+            "JobStreamService not initialized for tenant " + physicalTenantId);
 
     // Combine global listeners with this tenant's error handler so each handler only ever
     // sees its own group's partitions, resolving the bare-int partition-id aliasing bug.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -11,7 +11,6 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.cluster.PartitionId;
 import io.camunda.cluster.PhysicalTenantIds;
-import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
@@ -19,7 +18,6 @@ import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
@@ -80,8 +78,7 @@ public interface PartitionManager {
 
     // Combine global listeners with this tenant's error handler so each handler only ever
     // sees its own group's partitions, resolving the bare-int partition-id aliasing bug.
-    final List<PartitionListener> partitionListeners =
-        new ArrayList<>(brokerStartupContext.getPartitionListeners());
+    final var partitionListeners = new ArrayList<>(brokerStartupContext.getPartitionListeners());
     partitionListeners.add(jobStreamService.errorHandlerService());
 
     return new PartitionManagerImpl(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -129,7 +129,7 @@ public final class SystemContext {
   private final AtomixCluster cluster;
   private final BrokerClient brokerClient;
   private final MeterRegistry meterRegistry;
-  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts;
+  private final Map<String, PhysicalTenantContext> physicalTenantContexts;
   private final Function<String, UserServices> userServicesForTenant;
   private final PasswordEncoder passwordEncoder;
   private final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
@@ -150,7 +150,7 @@ public final class SystemContext {
       final AtomixCluster cluster,
       final BrokerClient brokerClient,
       final MeterRegistry meterRegistry,
-      final Map<String, PhysicalTenantContext> physicalTenantEngineContexts,
+      final Map<String, PhysicalTenantContext> physicalTenantContexts,
       final Function<String, UserServices> userServicesForTenant,
       final PasswordEncoder passwordEncoder,
       final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory,
@@ -164,7 +164,7 @@ public final class SystemContext {
     this.cluster = cluster;
     this.brokerClient = brokerClient;
     this.meterRegistry = meterRegistry;
-    this.physicalTenantEngineContexts = Map.copyOf(physicalTenantEngineContexts);
+    this.physicalTenantContexts = Map.copyOf(physicalTenantContexts);
     this.userServicesForTenant = userServicesForTenant;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoderFactory = jwtDecoderFactory;
@@ -475,7 +475,7 @@ public final class SystemContext {
   // actually initializing the entities will be done in IdentitySetupInitializer.
   // Validation is done here, only to be able to stop the application on error.
   private void validateInitializationConfig() {
-    physicalTenantEngineContexts.forEach(
+    physicalTenantContexts.forEach(
         (physicalTenantId, ctx) ->
             validateInitializationConfigForTenant(physicalTenantId, ctx.securityConfig()));
   }
@@ -697,8 +697,8 @@ public final class SystemContext {
   }
 
   /** Returns the per-physical-tenant engine context map (unmodifiable). */
-  public Map<String, PhysicalTenantContext> getPhysicalTenantEngineContexts() {
-    return physicalTenantEngineContexts;
+  public Map<String, PhysicalTenantContext> getPhysicalTenantContexts() {
+    return physicalTenantContexts;
   }
 
   /**
@@ -706,11 +706,11 @@ public final class SystemContext {
    *
    * @throws IllegalArgumentException if the physical tenant id is unknown
    */
-  public PhysicalTenantContext getPhysicalTenantEngineContext(final String physicalTenantId) {
-    if (!physicalTenantEngineContexts.containsKey(physicalTenantId)) {
+  public PhysicalTenantContext getPhysicalTenantContext(final String physicalTenantId) {
+    if (!physicalTenantContexts.containsKey(physicalTenantId)) {
       throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
     }
-    return physicalTenantEngineContexts.get(physicalTenantId);
+    return physicalTenantContexts.get(physicalTenantId);
   }
 
   /**
@@ -721,7 +721,7 @@ public final class SystemContext {
    *     physical tenant
    */
   public EngineSecurityConfig getSecurityConfiguration() {
-    final var ctx = physicalTenantEngineContexts.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    final var ctx = physicalTenantContexts.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
     if (ctx == null) {
       throw new IllegalStateException(
           "No security configuration registered for the default physical tenant");

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
@@ -7,18 +7,116 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class JobStreamServiceStepTest {
+
+  @Nested
+  final class StartupBehavior {
+    private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
+
+    private final List<CompletableActorFuture<Void>> scheduledActorFutures = new ArrayList<>();
+    private MockBrokerStartupContext ctx;
+    private ActorFuture<BrokerStartupContext> startupFuture;
+    private final JobStreamServiceStep sut = new JobStreamServiceStep();
+
+    @BeforeEach
+    void setUp() {
+      scheduledActorFutures.clear();
+      startupFuture = CONCURRENCY_CONTROL.createFuture();
+      ctx = new MockBrokerStartupContext();
+      ctx.setConcurrencyControl(CONCURRENCY_CONTROL);
+      // Return incomplete futures so ActorFutureCollector's index loop finishes registering all
+      // callbacks before any callback fires and modifies the pending-futures list.
+      final var mockScheduler = mock(ActorSchedulingService.class);
+      when(mockScheduler.submitActor(any()))
+          .thenAnswer(
+              inv -> {
+                final var f = new CompletableActorFuture<Void>();
+                scheduledActorFutures.add(f);
+                return f;
+              });
+      ctx.setActorSchedulingService(mockScheduler);
+    }
+
+    /** Completes all scheduled actor futures, including ones added during completion callbacks. */
+    private void completeAllScheduledActors() {
+      for (int i = 0; i < scheduledActorFutures.size(); i++) {
+        scheduledActorFutures.get(i).complete(null);
+      }
+    }
+
+    @Test
+    void shouldStoreJobStreamServiceInEngineContextAfterStartup() {
+      // given — PhysicalTenantIds.DEFAULT has only DEFAULT_PHYSICAL_TENANT_ID as known tenant
+
+      // when
+      sut.startupInternal(ctx, CONCURRENCY_CONTROL, startupFuture);
+      completeAllScheduledActors();
+
+      // then
+      assertThat(startupFuture.isDone()).as("startup completed").isTrue();
+      assertThat(ctx.getPhysicalTenantEngineContext(DEFAULT_PHYSICAL_TENANT_ID).jobStreamService())
+          .isNotNull();
+    }
+
+    @Test
+    void shouldCreateDistinctServicesForEachPhysicalTenant() {
+      // given — two distinct physical tenants
+      final var secondTenantId = "second";
+      ctx.setPhysicalTenantIds(() -> Set.of(DEFAULT_PHYSICAL_TENANT_ID, secondTenantId));
+
+      // when
+      sut.startupInternal(ctx, CONCURRENCY_CONTROL, startupFuture);
+      completeAllScheduledActors();
+
+      // then — each tenant gets its own isolated service instance
+      assertThat(startupFuture.isDone()).as("startup completed").isTrue();
+      final var defaultService =
+          ctx.getPhysicalTenantEngineContext(DEFAULT_PHYSICAL_TENANT_ID).jobStreamService();
+      final var secondService =
+          ctx.getPhysicalTenantEngineContext(secondTenantId).jobStreamService();
+      assertThat(defaultService).isNotNull();
+      assertThat(secondService).isNotNull();
+      assertThat(defaultService).isNotSameAs(secondService);
+    }
+
+    @Test
+    void shouldNotRegisterErrorHandlerAsGlobalPartitionListener() {
+      // given
+      final var spyCtx = spy(ctx);
+
+      // when
+      sut.startupInternal(spyCtx, CONCURRENCY_CONTROL, startupFuture);
+      completeAllScheduledActors();
+
+      // then — error handler goes into each PartitionManager's listeners, not the global list
+      assertThat(startupFuture.isDone()).as("startup completed").isTrue();
+      verify(spyCtx, never()).addPartitionListener(any());
+    }
+  }
 
   @Nested
   final class ImmutableJobActivationPropertiesTest {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.bootstrap;
 import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -70,7 +71,8 @@ final class JobStreamServiceStepTest {
 
     @Test
     void shouldStoreJobStreamServiceInEngineContextAfterStartup() {
-      // given — PhysicalTenantIds.DEFAULT has only DEFAULT_PHYSICAL_TENANT_ID as known tenant
+      // given — no pre-existing service; a null default makes the step's write observable
+      ctx.setJobStreamService(null);
 
       // when
       sut.startupInternal(ctx, CONCURRENCY_CONTROL, startupFuture);
@@ -78,14 +80,16 @@ final class JobStreamServiceStepTest {
 
       // then
       assertThat(startupFuture.isDone()).as("startup completed").isTrue();
+      assertThat(startupFuture.isCompletedExceptionally()).as("no startup error").isFalse();
       assertThat(ctx.getPhysicalTenantEngineContext(DEFAULT_PHYSICAL_TENANT_ID).jobStreamService())
           .isNotNull();
     }
 
     @Test
     void shouldCreateDistinctServicesForEachPhysicalTenant() {
-      // given — two distinct physical tenants
+      // given — two distinct physical tenants, no pre-existing services
       final var secondTenantId = "second";
+      ctx.setJobStreamService(null);
       ctx.setPhysicalTenantIds(() -> Set.of(DEFAULT_PHYSICAL_TENANT_ID, secondTenantId));
 
       // when
@@ -94,6 +98,7 @@ final class JobStreamServiceStepTest {
 
       // then — each tenant gets its own isolated service instance
       assertThat(startupFuture.isDone()).as("startup completed").isTrue();
+      assertThat(startupFuture.isCompletedExceptionally()).as("no startup error").isFalse();
       final var defaultService =
           ctx.getPhysicalTenantEngineContext(DEFAULT_PHYSICAL_TENANT_ID).jobStreamService();
       final var secondService =
@@ -101,6 +106,21 @@ final class JobStreamServiceStepTest {
       assertThat(defaultService).isNotNull();
       assertThat(secondService).isNotNull();
       assertThat(defaultService).isNotSameAs(secondService);
+    }
+
+    @Test
+    void shouldRegisterDefaultTenantServiceSupplierWithSpringBrokerBridge() {
+      // given
+      ctx.setJobStreamService(null);
+
+      // when
+      sut.startupInternal(ctx, CONCURRENCY_CONTROL, startupFuture);
+      completeAllScheduledActors();
+
+      // then — the bridge supplier is wired to the default physical tenant's service
+      assertThat(startupFuture.isDone()).as("startup completed").isTrue();
+      assertThat(startupFuture.isCompletedExceptionally()).as("no startup error").isFalse();
+      verify(ctx.getSpringBrokerBridge()).registerJobStreamServiceSupplier(notNull());
     }
 
     @Test
@@ -114,6 +134,7 @@ final class JobStreamServiceStepTest {
 
       // then — error handler goes into each PartitionManager's listeners, not the global list
       assertThat(startupFuture.isDone()).as("startup completed").isTrue();
+      assertThat(startupFuture.isCompletedExceptionally()).as("no startup error").isFalse();
       verify(spyCtx, never()).addPartitionListener(any());
     }
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
@@ -96,15 +96,15 @@ final class JobStreamServiceStepTest {
     }
 
     @Test
-    void shouldRegisterDefaultTenantServiceSupplierWithSpringBrokerBridge() {
+    void shouldRegisterAllTenantServicesSupplierWithSpringBrokerBridge() {
       // when
       sut.startupInternal(ctx, CONCURRENCY_CONTROL, startupFuture);
       completeAllScheduledActors();
 
-      // then — the bridge supplier is wired to the default physical tenant's service
+      // then — the bridge supplier exposes all physical tenant services for the actuator
       assertThat(startupFuture.isDone()).as("startup completed").isTrue();
       assertThat(startupFuture.isCompletedExceptionally()).as("no startup error").isFalse();
-      verify(ctx.getSpringBrokerBridge()).registerJobStreamServiceSupplier(notNull());
+      verify(ctx.getSpringBrokerBridge()).registerJobStreamServicesSupplier(notNull());
     }
 
     @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
@@ -26,8 +27,10 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -49,8 +52,6 @@ final class JobStreamServiceStepTest {
       startupFuture = CONCURRENCY_CONTROL.createFuture();
       ctx = new MockBrokerStartupContext();
       ctx.setConcurrencyControl(CONCURRENCY_CONTROL);
-      // Return incomplete futures so ActorFutureCollector's index loop finishes registering all
-      // callbacks before any callback fires and modifies the pending-futures list.
       final var mockScheduler = mock(ActorSchedulingService.class);
       when(mockScheduler.submitActor(any()))
           .thenAnswer(
@@ -62,18 +63,8 @@ final class JobStreamServiceStepTest {
       ctx.setActorSchedulingService(mockScheduler);
     }
 
-    /** Completes all scheduled actor futures, including ones added during completion callbacks. */
-    private void completeAllScheduledActors() {
-      for (int i = 0; i < scheduledActorFutures.size(); i++) {
-        scheduledActorFutures.get(i).complete(null);
-      }
-    }
-
     @Test
-    void shouldStoreJobStreamServiceInEngineContextAfterStartup() {
-      // given — no pre-existing service; a null default makes the step's write observable
-      ctx.setJobStreamService(null);
-
+    void shouldRegisterJobStreamServiceInBrokerContextAfterStartup() {
       // when
       sut.startupInternal(ctx, CONCURRENCY_CONTROL, startupFuture);
       completeAllScheduledActors();
@@ -81,15 +72,13 @@ final class JobStreamServiceStepTest {
       // then
       assertThat(startupFuture.isDone()).as("startup completed").isTrue();
       assertThat(startupFuture.isCompletedExceptionally()).as("no startup error").isFalse();
-      assertThat(ctx.getPhysicalTenantEngineContext(DEFAULT_PHYSICAL_TENANT_ID).jobStreamService())
-          .isNotNull();
+      assertThat(ctx.getJobStreamService(DEFAULT_PHYSICAL_TENANT_ID)).isNotNull();
     }
 
     @Test
     void shouldCreateDistinctServicesForEachPhysicalTenant() {
-      // given — two distinct physical tenants, no pre-existing services
+      // given — two distinct physical tenants
       final var secondTenantId = "second";
-      ctx.setJobStreamService(null);
       ctx.setPhysicalTenantIds(() -> Set.of(DEFAULT_PHYSICAL_TENANT_ID, secondTenantId));
 
       // when
@@ -99,10 +88,8 @@ final class JobStreamServiceStepTest {
       // then — each tenant gets its own isolated service instance
       assertThat(startupFuture.isDone()).as("startup completed").isTrue();
       assertThat(startupFuture.isCompletedExceptionally()).as("no startup error").isFalse();
-      final var defaultService =
-          ctx.getPhysicalTenantEngineContext(DEFAULT_PHYSICAL_TENANT_ID).jobStreamService();
-      final var secondService =
-          ctx.getPhysicalTenantEngineContext(secondTenantId).jobStreamService();
+      final var defaultService = ctx.getJobStreamService(DEFAULT_PHYSICAL_TENANT_ID);
+      final var secondService = ctx.getJobStreamService(secondTenantId);
       assertThat(defaultService).isNotNull();
       assertThat(secondService).isNotNull();
       assertThat(defaultService).isNotSameAs(secondService);
@@ -110,9 +97,6 @@ final class JobStreamServiceStepTest {
 
     @Test
     void shouldRegisterDefaultTenantServiceSupplierWithSpringBrokerBridge() {
-      // given
-      ctx.setJobStreamService(null);
-
       // when
       sut.startupInternal(ctx, CONCURRENCY_CONTROL, startupFuture);
       completeAllScheduledActors();
@@ -136,6 +120,76 @@ final class JobStreamServiceStepTest {
       assertThat(startupFuture.isDone()).as("startup completed").isTrue();
       assertThat(startupFuture.isCompletedExceptionally()).as("no startup error").isFalse();
       verify(spyCtx, never()).addPartitionListener(any());
+    }
+
+    @Test
+    void shouldShutDownAlreadyStartedServicesWhenOnePhysicalTenantFailsToStart() {
+      // given
+      final var secondTenantId = "second";
+      ctx.setPhysicalTenantIds(
+          () -> new LinkedHashSet<>(List.of(DEFAULT_PHYSICAL_TENANT_ID, secondTenantId)));
+
+      final var mockDefaultService = mock(JobStreamService.class);
+      // closeAsync must return a pending future so cleanup's CompletionWaiter finishes
+      // registering all callbacks before any of them fires and shrinks the pending list.
+      when(mockDefaultService.closeAsync(any()))
+          .thenAnswer(
+              inv -> {
+                final var f = new CompletableActorFuture<Void>();
+                scheduledActorFutures.add(f);
+                return f;
+              });
+
+      final var ctxForTest =
+          new MockBrokerStartupContext() {
+            @Override
+            public void addJobStreamService(final String tenantId, final JobStreamService service) {
+              super.addJobStreamService(
+                  tenantId,
+                  DEFAULT_PHYSICAL_TENANT_ID.equals(tenantId) ? mockDefaultService : service);
+            }
+          };
+      ctxForTest.setConcurrencyControl(CONCURRENCY_CONTROL);
+      ctxForTest.setPhysicalTenantIds(
+          () -> new LinkedHashSet<>(List.of(DEFAULT_PHYSICAL_TENANT_ID, secondTenantId)));
+
+      // The second submitActor call (second's errorHandler) fails; all others stay pending
+      // so CompletionWaiter registration loops complete before any callback fires.
+      final var actorIndex = new AtomicInteger();
+      final var mockSched = mock(ActorSchedulingService.class);
+      when(mockSched.submitActor(any()))
+          .thenAnswer(
+              inv -> {
+                final var f = new CompletableActorFuture<Void>();
+                scheduledActorFutures.add(f);
+                if (actorIndex.getAndIncrement() == 1) {
+                  f.completeExceptionally(new RuntimeException("actor start failed"));
+                }
+                return f;
+              });
+      ctxForTest.setActorSchedulingService(mockSched);
+
+      // when
+      sut.startupInternal(ctxForTest, CONCURRENCY_CONTROL, startupFuture);
+      completeAllScheduledActors();
+
+      // then
+      assertThat(startupFuture.isDone()).as("startup future resolved").isTrue();
+      assertThat(startupFuture.isCompletedExceptionally())
+          .as("startup completed exceptionally")
+          .isTrue();
+      assertThat(ctxForTest.getJobStreamService(DEFAULT_PHYSICAL_TENANT_ID))
+          .as("already-started service removed from map on partial failure")
+          .isNull();
+    }
+
+    private void completeAllScheduledActors() {
+      for (int i = 0; i < scheduledActorFutures.size(); i++) {
+        final var f = scheduledActorFutures.get(i);
+        if (!f.isDone()) {
+          f.complete(null);
+        }
+      }
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -367,21 +367,6 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   @Override
-  public void updatePhysicalTenantEngineContext(
-      final String physicalTenantId, final PhysicalTenantContext context) {
-    physicalTenantEngineContexts.put(physicalTenantId, context);
-  }
-
-  public void setPhysicalTenantEngineContext(
-      final String physicalTenantId, final PhysicalTenantContext context) {
-    physicalTenantEngineContexts.put(physicalTenantId, context);
-  }
-
-  public void setSecurityConfiguration(final EngineSecurityConfig securityConfiguration) {
-    this.securityConfiguration = securityConfiguration;
-  }
-
-  @Override
   public Function<String, UserServices> getUserServicesForTenant() {
     return tenantId -> userServices;
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -95,8 +95,7 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter =
       mock(BrokerRequestAuthorizationConverter.class);
   private FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
-  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts =
-      new LinkedHashMap<>();
+  private final Map<String, PhysicalTenantContext> physicalTenantContexts = new LinkedHashMap<>();
   private CheckpointSchedulingService checkpointSchedulingService =
       mock(CheckpointSchedulingService.class);
   private NodeIdProvider nodeIdProvider = mock(NodeIdProvider.class);
@@ -354,8 +353,8 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   @Override
-  public PhysicalTenantContext getPhysicalTenantEngineContext(final String physicalTenantId) {
-    return physicalTenantEngineContexts.computeIfAbsent(
+  public PhysicalTenantContext getPhysicalTenantContext(final String physicalTenantId) {
+    return physicalTenantContexts.computeIfAbsent(
         physicalTenantId,
         id ->
             new PhysicalTenantContext(
@@ -430,9 +429,9 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
     this.physicalTenantIds = physicalTenantIds;
   }
 
-  public void setPhysicalTenantEngineContext(
+  public void setPhysicalTenantContext(
       final String physicalTenantId, final PhysicalTenantContext context) {
-    physicalTenantEngineContexts.put(physicalTenantId, context);
+    physicalTenantContexts.put(physicalTenantId, context);
   }
 
   public void setUserServices(final UserServices userServices) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -74,11 +74,10 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private EmbeddedGatewayService embeddedGatewayService;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor = mock(DiskSpaceUsageMonitor.class);
   private final ExporterRepository exporterRepository = mock(ExporterRepository.class);
+  private final Map<String, JobStreamService> jobStreamServices = new LinkedHashMap<>();
   private final Map<String, PartitionManager> partitionManagers = new LinkedHashMap<>();
   private RocksDbResources sharedRocksDbResources;
   private BrokerAdminServiceImpl brokerAdminService = mock(BrokerAdminServiceImpl.class);
-  // Default service used when auto-creating PhysicalTenantEngineContext entries.
-  private JobStreamService defaultJobStreamService = mock(JobStreamService.class);
   private ClusterConfigurationService clusterConfigurationService =
       mock(ClusterConfigurationService.class);
   private BrokerClient brokerClient = mock(BrokerClient.class);
@@ -291,14 +290,19 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
     this.brokerAdminService = brokerAdminService;
   }
 
-  /** Test helper — not part of {@link BrokerStartupContext}. */
-  public JobStreamService getJobStreamService() {
-    return defaultJobStreamService;
+  @Override
+  public JobStreamService getJobStreamService(final String physicalTenantId) {
+    return jobStreamServices.get(physicalTenantId);
   }
 
-  /** Test helper — sets the default {@link JobStreamService} used when auto-creating contexts. */
-  public void setJobStreamService(final JobStreamService jobStreamService) {
-    this.defaultJobStreamService = jobStreamService;
+  @Override
+  public void addJobStreamService(final String physicalTenantId, final JobStreamService service) {
+    jobStreamServices.put(physicalTenantId, service);
+  }
+
+  @Override
+  public void removeJobStreamService(final String physicalTenantId) {
+    jobStreamServices.remove(physicalTenantId);
   }
 
   @Override
@@ -360,11 +364,6 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
                 featureFlags,
                 brokerConfiguration,
                 exporterRepository));
-            new PhysicalTenantContext(
-                securityConfiguration,
-                brokerRequestAuthorizationConverter,
-                featureFlags,
-                defaultJobStreamService));
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -77,7 +77,8 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private final Map<String, PartitionManager> partitionManagers = new LinkedHashMap<>();
   private RocksDbResources sharedRocksDbResources;
   private BrokerAdminServiceImpl brokerAdminService = mock(BrokerAdminServiceImpl.class);
-  private JobStreamService jobStreamService = mock(JobStreamService.class);
+  // Default service used when auto-creating PhysicalTenantEngineContext entries.
+  private JobStreamService defaultJobStreamService = mock(JobStreamService.class);
   private ClusterConfigurationService clusterConfigurationService =
       mock(ClusterConfigurationService.class);
   private BrokerClient brokerClient = mock(BrokerClient.class);
@@ -290,14 +291,14 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
     this.brokerAdminService = brokerAdminService;
   }
 
-  @Override
+  /** Test helper — not part of {@link BrokerStartupContext}. */
   public JobStreamService getJobStreamService() {
-    return jobStreamService;
+    return defaultJobStreamService;
   }
 
-  @Override
+  /** Test helper — sets the default {@link JobStreamService} used when auto-creating contexts. */
   public void setJobStreamService(final JobStreamService jobStreamService) {
-    this.jobStreamService = jobStreamService;
+    this.defaultJobStreamService = jobStreamService;
   }
 
   @Override
@@ -359,6 +360,26 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
                 featureFlags,
                 brokerConfiguration,
                 exporterRepository));
+            new PhysicalTenantContext(
+                securityConfiguration,
+                brokerRequestAuthorizationConverter,
+                featureFlags,
+                defaultJobStreamService));
+  }
+
+  @Override
+  public void updatePhysicalTenantEngineContext(
+      final String physicalTenantId, final PhysicalTenantContext context) {
+    physicalTenantEngineContexts.put(physicalTenantId, context);
+  }
+
+  public void setPhysicalTenantEngineContext(
+      final String physicalTenantId, final PhysicalTenantContext context) {
+    physicalTenantEngineContexts.put(physicalTenantId, context);
+  }
+
+  public void setSecurityConfiguration(final EngineSecurityConfig securityConfiguration) {
+    this.securityConfiguration = securityConfiguration;
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -228,7 +228,7 @@ class PartitionManagerStepTest {
 
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
       final var conv = new BrokerRequestAuthorizationConverter(secCfg);
-      testBrokerStartupContext.setPhysicalTenantEngineContext(
+      testBrokerStartupContext.setPhysicalTenantContext(
           PHYSICAL_TENANT_ID,
           new PhysicalTenantContext(
               secCfg,
@@ -236,7 +236,7 @@ class PartitionManagerStepTest {
               flagsA,
               testBrokerStartupContext.getBrokerConfiguration(),
               new ExporterRepository()));
-      testBrokerStartupContext.setPhysicalTenantEngineContext(
+      testBrokerStartupContext.setPhysicalTenantContext(
           secondTenantId,
           new PhysicalTenantContext(
               secCfg,
@@ -247,6 +247,8 @@ class PartitionManagerStepTest {
 
       final var secondFuture = CONCURRENCY_CONTROL.<BrokerStartupContext>createFuture();
       final var secondStep = new PartitionManagerStep(secondTenantId);
+
+      testBrokerStartupContext.addJobStreamService(secondTenantId, mock(JobStreamService.class));
 
       // when — start the steps one after the other. They are started sequentially on purpose:
       // both steps build their PartitionManagerImpl on actor threads, and that construction reads
@@ -297,7 +299,7 @@ class PartitionManagerStepTest {
 
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
       final var conv = new BrokerRequestAuthorizationConverter(secCfg);
-      testBrokerStartupContext.setPhysicalTenantEngineContext(
+      testBrokerStartupContext.setPhysicalTenantContext(
           PHYSICAL_TENANT_ID,
           new PhysicalTenantContext(
               secCfg,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -224,6 +224,7 @@ class PartitionManagerStepTest {
 
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
       final var conv = new BrokerRequestAuthorizationConverter(secCfg);
+      final var mockJobStreamService = testBrokerStartupContext.getJobStreamService();
       testBrokerStartupContext.setPhysicalTenantEngineContext(
           PHYSICAL_TENANT_ID,
           new PhysicalTenantContext(
@@ -232,7 +233,11 @@ class PartitionManagerStepTest {
               flagsA,
               testBrokerStartupContext.getBrokerConfiguration(),
               new ExporterRepository()));
+          PHYSICAL_TENANT_ID,
+          new PhysicalTenantContext(secCfg, conv, flagsA, mockJobStreamService));
       testBrokerStartupContext.setPhysicalTenantEngineContext(
+          secondTenantId,
+          new PhysicalTenantContext(secCfg, conv, flagsB, mockJobStreamService));
           secondTenantId,
           new PhysicalTenantContext(
               secCfg,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -22,6 +22,8 @@ import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
+import io.camunda.zeebe.broker.jobstream.RemoteJobStreamErrorHandlerService;
+import io.camunda.zeebe.broker.jobstream.YieldingJobStreamErrorHandler;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.partitioning.RecoveryPartitionManager;
 import io.camunda.zeebe.broker.partitioning.startup.ZeebePartitionFactory;
@@ -41,6 +43,7 @@ import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -286,6 +289,40 @@ class PartitionManagerStepTest {
 
       // then
       assertThat(startupFuture).succeedsWithin(TIME_OUT);
+    }
+
+    @Test
+    void shouldRegisterJobStreamErrorHandlerInPartitionListeners() throws Exception {
+      // given — a job stream service with a real, identifiable error handler
+      final var errorHandler =
+          new RemoteJobStreamErrorHandlerService(new YieldingJobStreamErrorHandler());
+      final var jobStreamService = mock(JobStreamService.class);
+      when(jobStreamService.errorHandlerService()).thenReturn(errorHandler);
+
+      final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
+      final var conv = new BrokerRequestAuthorizationConverter(secCfg);
+      testBrokerStartupContext.setPhysicalTenantEngineContext(
+          PHYSICAL_TENANT_ID,
+          new PhysicalTenantEngineContext(
+              secCfg, conv, FeatureFlags.createDefaultForTests(), jobStreamService));
+
+      // when
+      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      assertThat(startupFuture).succeedsWithin(TIME_OUT);
+
+      // then — the error handler is wired into the partition manager's factory, not the global list
+      final var factoryField = PartitionManagerImpl.class.getDeclaredField("zeebePartitionFactory");
+      factoryField.setAccessible(true);
+      final var listenersField = ZeebePartitionFactory.class.getDeclaredField("partitionListeners");
+      listenersField.setAccessible(true);
+
+      final var manager =
+          (PartitionManagerImpl)
+              testBrokerStartupContext.getPartitionManagers().get(PHYSICAL_TENANT_ID);
+      final var listeners = (List<?>) listenersField.get(factoryField.get(manager));
+      assertThat(listeners).anySatisfy(l -> assertThat(l).isSameAs(errorHandler));
+      assertThat(testBrokerStartupContext.getPartitionListeners())
+          .noneSatisfy(l -> assertThat(l).isSameAs(errorHandler));
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -228,7 +228,6 @@ class PartitionManagerStepTest {
 
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
       final var conv = new BrokerRequestAuthorizationConverter(secCfg);
-      testBrokerStartupContext.addJobStreamService(secondTenantId, mock(JobStreamService.class));
       testBrokerStartupContext.setPhysicalTenantEngineContext(
           PHYSICAL_TENANT_ID,
           new PhysicalTenantContext(
@@ -237,11 +236,7 @@ class PartitionManagerStepTest {
               flagsA,
               testBrokerStartupContext.getBrokerConfiguration(),
               new ExporterRepository()));
-          PHYSICAL_TENANT_ID,
-          new PhysicalTenantContext(secCfg, conv, flagsA, mockJobStreamService));
       testBrokerStartupContext.setPhysicalTenantEngineContext(
-          secondTenantId,
-          new PhysicalTenantContext(secCfg, conv, flagsB, mockJobStreamService));
           secondTenantId,
           new PhysicalTenantContext(
               secCfg,
@@ -304,7 +299,12 @@ class PartitionManagerStepTest {
       final var conv = new BrokerRequestAuthorizationConverter(secCfg);
       testBrokerStartupContext.setPhysicalTenantEngineContext(
           PHYSICAL_TENANT_ID,
-          new PhysicalTenantEngineContext(secCfg, conv, FeatureFlags.createDefaultForTests()));
+          new PhysicalTenantContext(
+              secCfg,
+              conv,
+              FeatureFlags.createDefaultForTests(),
+              testBrokerStartupContext.getBrokerConfiguration(),
+              new ExporterRepository()));
       testBrokerStartupContext.addJobStreamService(PHYSICAL_TENANT_ID, jobStreamService);
 
       // when

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -98,7 +98,8 @@ class PartitionManagerStepTest {
       testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
       testBrokerStartupContext.setAdminApiService(mock(AdminApiRequestHandler.class));
       testBrokerStartupContext.setBrokerAdminService(mock(BrokerAdminServiceImpl.class));
-      testBrokerStartupContext.setJobStreamService(mock(JobStreamService.class));
+      testBrokerStartupContext.addJobStreamService(
+          PHYSICAL_TENANT_ID, mock(JobStreamService.class));
       final ClusterConfigurationService clusterConfigurationService =
           mock(ClusterConfigurationService.class);
       when(clusterConfigurationService.getPartitionDistribution())
@@ -227,7 +228,7 @@ class PartitionManagerStepTest {
 
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
       final var conv = new BrokerRequestAuthorizationConverter(secCfg);
-      final var mockJobStreamService = testBrokerStartupContext.getJobStreamService();
+      testBrokerStartupContext.addJobStreamService(secondTenantId, mock(JobStreamService.class));
       testBrokerStartupContext.setPhysicalTenantEngineContext(
           PHYSICAL_TENANT_ID,
           new PhysicalTenantContext(
@@ -303,8 +304,8 @@ class PartitionManagerStepTest {
       final var conv = new BrokerRequestAuthorizationConverter(secCfg);
       testBrokerStartupContext.setPhysicalTenantEngineContext(
           PHYSICAL_TENANT_ID,
-          new PhysicalTenantEngineContext(
-              secCfg, conv, FeatureFlags.createDefaultForTests(), jobStreamService));
+          new PhysicalTenantEngineContext(secCfg, conv, FeatureFlags.createDefaultForTests()));
+      testBrokerStartupContext.addJobStreamService(PHYSICAL_TENANT_ID, jobStreamService);
 
       // when
       sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
@@ -98,6 +98,56 @@ final class RemoteJobStreamErrorHandlerTest {
         .containsExactly(1L, job.jobRecord());
   }
 
+  @Test
+  void shouldRouteErrorToCorrectTenantHandlerWhenBothManagePartitionWithSameId() {
+    // two instances with the same numeric partition id never share log-stream writers.
+
+    // given — two handler instances, one per physical tenant, both owning partition 1
+    final var tenantAErrors = new TestErrorHandler();
+    final var tenantBErrors = new TestErrorHandler();
+    final var handlerA = new RemoteJobStreamErrorHandler(tenantAErrors);
+    final var handlerB = new RemoteJobStreamErrorHandler(tenantBErrors);
+
+    final var writtenByA = new ArrayList<LogAppendEntry>();
+    final var writtenByB = new ArrayList<LogAppendEntry>();
+    handlerA.addWriter(
+        1,
+        (ctx, entries, ignored) -> {
+          writtenByA.addAll(entries);
+          return Either.right(1L);
+        });
+    handlerB.addWriter(
+        1,
+        (ctx, entries, ignored) -> {
+          writtenByB.addAll(entries);
+          return Either.right(1L);
+        });
+
+    final var jobRecord = new JobRecord();
+    final var job = new TestActivatedJob(Protocol.encodePartitionId(1, 42), jobRecord);
+    final var error = new RuntimeException("push failed");
+
+    // when — a push failure is reported to each tenant handler independently
+    handlerA.handleError(error, job);
+    handlerB.handleError(error, job);
+
+    // then — each tenant's writes land only on its own log stream, not the other's
+    Assertions.assertThat(writtenByA)
+        .as("tenant A writes only to its own stream")
+        .hasSize(1)
+        .first()
+        .extracting(LogAppendEntry::recordValue)
+        .isEqualTo(jobRecord);
+    Assertions.assertThat(writtenByB)
+        .as("tenant B writes only to its own stream")
+        .hasSize(1)
+        .first()
+        .extracting(LogAppendEntry::recordValue)
+        .isEqualTo(jobRecord);
+    Assertions.assertThat(tenantAErrors.errors()).hasSize(1);
+    Assertions.assertThat(tenantBErrors.errors()).hasSize(1);
+  }
+
   // TODO: use actual one if possible
   private record TestActivatedJob(long jobKey, JobRecord jobRecord) implements ActivatedJob {
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -372,7 +372,7 @@ final class SystemContextTest {
     // when / then
     assertThat(ctx.getSecurityConfiguration()).isSameAs(defaultCfg);
     assertThat(
-            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+            ctx.getPhysicalTenantContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .securityConfig())
         .isSameAs(defaultCfg);
   }
@@ -386,7 +386,7 @@ final class SystemContextTest {
             new BrokerCfg(), Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, defaultCfg));
 
     // when / then
-    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("unknown-tenant"))
+    assertThatThrownBy(() -> ctx.getPhysicalTenantContext("unknown-tenant"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown physical tenant id")
         .hasMessageContaining("unknown-tenant");
@@ -420,11 +420,11 @@ final class SystemContextTest {
 
     // when / then
     assertThat(
-            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+            ctx.getPhysicalTenantContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .securityConfig())
         .isSameAs(defaultCfg);
-    assertThat(ctx.getPhysicalTenantEngineContext("pta").securityConfig()).isSameAs(ptaCfg);
-    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("unknown"))
+    assertThat(ctx.getPhysicalTenantContext("pta").securityConfig()).isSameAs(ptaCfg);
+    assertThatThrownBy(() -> ctx.getPhysicalTenantContext("unknown"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown physical tenant id");
   }
@@ -437,10 +437,10 @@ final class SystemContextTest {
     // when / then – the single-config ctor populates every known tenant with the supplied config
     assertThat(ctx.getSecurityConfiguration()).isNotNull();
     assertThat(
-            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+            ctx.getPhysicalTenantContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .securityConfig())
         .isSameAs(ctx.getSecurityConfiguration());
-    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("any-other"))
+    assertThatThrownBy(() -> ctx.getPhysicalTenantContext("any-other"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown physical tenant id");
   }
@@ -466,11 +466,10 @@ final class SystemContextTest {
 
     // when / then
     assertThat(
-            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+            ctx.getPhysicalTenantContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .authorizationConverter())
         .isSameAs(defaultConverter);
-    assertThat(ctx.getPhysicalTenantEngineContext("pta").authorizationConverter())
-        .isSameAs(ptConverter);
+    assertThat(ctx.getPhysicalTenantContext("pta").authorizationConverter()).isSameAs(ptConverter);
   }
 
   @Test
@@ -487,10 +486,10 @@ final class SystemContextTest {
 
     // when / then
     assertThat(
-            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+            ctx.getPhysicalTenantContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .authorizationConverter())
         .isSameAs(defaultConverter);
-    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("unknown"))
+    assertThatThrownBy(() -> ctx.getPhysicalTenantContext("unknown"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown physical tenant id");
   }
@@ -502,10 +501,10 @@ final class SystemContextTest {
 
     // when / then
     assertThat(
-            ctx.getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+            ctx.getPhysicalTenantContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
                 .authorizationConverter())
         .isNotNull();
-    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("any-other"))
+    assertThatThrownBy(() -> ctx.getPhysicalTenantContext("any-other"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Unknown physical tenant id");
   }
@@ -587,7 +586,7 @@ final class SystemContextTest {
             PhysicalTenantIds.DEFAULT);
 
     // when / then
-    assertThat(ctx.getPhysicalTenantEngineContext(tenantId).featureFlags()).isSameAs(flags);
+    assertThat(ctx.getPhysicalTenantContext(tenantId).featureFlags()).isSameAs(flags);
   }
 
   @Test
@@ -596,7 +595,7 @@ final class SystemContextTest {
     final var ctx = initSystemContext(new BrokerCfg());
 
     // when / then
-    assertThatThrownBy(() -> ctx.getPhysicalTenantEngineContext("unknown-tenant"))
+    assertThatThrownBy(() -> ctx.getPhysicalTenantContext("unknown-tenant"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("unknown-tenant");
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -46,15 +46,8 @@ public final class JobStreamClientImpl implements JobStreamClient {
                 clusterCommunicationService, new JobClientStreamMetrics(meterRegistry));
   }
 
-  /**
-   * No-op: group information is required for correct stream routing. Handled by {@link
-   * #brokerAddedToGroup(BrokerMemberId, String)}.
-   */
   @Override
-  public synchronized void brokerAdded(final BrokerMemberId memberId) {}
-
-  @Override
-  public synchronized void brokerAddedToGroup(
+  public synchronized void brokerAdded(
       final BrokerMemberId memberId, final String physicalTenantId) {
     if (!started) {
       return;

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.gateway.impl.stream;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
@@ -45,18 +43,24 @@ public final class JobStreamClientImpl implements JobStreamClient {
     streamService =
         new TransportFactory(schedulingService)
             .createRemoteStreamClient(
-                clusterCommunicationService,
-                new JobClientStreamMetrics(meterRegistry),
-                DEFAULT_PHYSICAL_TENANT_ID);
+                clusterCommunicationService, new JobClientStreamMetrics(meterRegistry));
   }
 
+  /**
+   * No-op: group information is required for correct stream routing. Handled by {@link
+   * #brokerAddedToGroup(BrokerMemberId, String)}.
+   */
   @Override
-  public synchronized void brokerAdded(final BrokerMemberId memberId) {
+  public synchronized void brokerAdded(final BrokerMemberId memberId) {}
+
+  @Override
+  public synchronized void brokerAddedToGroup(
+      final BrokerMemberId memberId, final String physicalTenantId) {
     if (!started) {
       return;
     }
 
-    streamService.onServerJoined(memberId.memberId());
+    streamService.onServerJoinedToGroup(memberId.memberId(), physicalTenantId);
   }
 
   @Override

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -57,7 +57,8 @@ public final class JobStreamClientImpl implements JobStreamClient {
   }
 
   @Override
-  public synchronized void brokerRemoved(final BrokerMemberId memberId) {
+  public synchronized void brokerRemoved(
+      final BrokerMemberId memberId, final String physicalTenantId) {
     if (!started) {
       return;
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -53,7 +53,7 @@ public final class JobStreamClientImpl implements JobStreamClient {
       return;
     }
 
-    streamService.onServerJoinedToGroup(memberId.memberId(), physicalTenantId);
+    streamService.onServerJoined(memberId.memberId(), physicalTenantId);
   }
 
   @Override

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -71,8 +71,7 @@ public final class TransportFactory {
 
   public <M extends BufferWriter> ClientStreamService<M> createRemoteStreamClient(
       final ClusterCommunicationService clusterCommunicationService,
-      final ClientStreamMetrics metrics,
-      final String physicalTenantId) {
-    return new ClientStreamServiceImpl<>(clusterCommunicationService, metrics, physicalTenantId);
+      final ClientStreamMetrics metrics) {
+    return new ClientStreamServiceImpl<>(clusterCommunicationService, metrics);
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
@@ -38,7 +38,7 @@ public interface ClientStreamService<M extends BufferWriter> extends AsyncClosab
    * {@code physicalTenantId} are registered with {@code memberId}. Implementations should be
    * idempotent.
    */
-  void onServerJoinedToGroup(final MemberId memberId, final String physicalTenantId);
+  void onServerJoined(final MemberId memberId, final String physicalTenantId);
 
   /**
    * A callback to be invoked when a new streaming server is removed. Implementations should be

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  * Manages an instance of {@link ClientStreamer}. Intended to be the main entry point when setting
  * up the client side for remote streams, primarily via {@link
  * io.camunda.zeebe.transport.TransportFactory#createRemoteStreamClient(ClusterCommunicationService,
- * ClientStreamMetrics, String)}.
+ * ClientStreamMetrics)}.
  *
  * @param <M> the type of the streaming metadata
  */
@@ -33,10 +33,12 @@ public interface ClientStreamService<M extends BufferWriter> extends AsyncClosab
   ActorFuture<Void> start(final ActorSchedulingService schedulingService);
 
   /**
-   * A callback to be invoked when a new streaming server is added. Implementations should be
+   * A callback to be invoked when a streaming server is confirmed to serve a specific partition
+   * group. Drives group-aware stream registration: only streams whose physical tenant matches
+   * {@code physicalTenantId} are registered with {@code memberId}. Implementations should be
    * idempotent.
    */
-  void onServerJoined(final MemberId memberId);
+  void onServerJoinedToGroup(final MemberId memberId, final String physicalTenantId);
 
   /**
    * A callback to be invoked when a new streaming server is removed. Implementations should be

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
@@ -41,8 +41,7 @@ final class ClientStreamApiHandler {
   }
 
   byte[] handleRestartRequest(final MemberId sender, final byte[] ignored) {
-    clientStreamManager.onServerRemoved(MemberId.from(sender.id()));
-    clientStreamManager.onServerJoined(MemberId.from(sender.id()));
+    clientStreamManager.onServerRestarted(MemberId.from(sender.id()));
     return ArrayUtil.EMPTY_BYTE_ARRAY;
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -55,7 +55,7 @@ final class ClientStreamManager<M extends BufferWriter> {
    * @param serverId the joining server
    * @param physicalTenantId the physical tenant served by this server
    */
-  void onServerJoinedToGroup(final MemberId serverId, final String physicalTenantId) {
+  void onServerJoined(final MemberId serverId, final String physicalTenantId) {
     serversByPhysicalTenantId
         .computeIfAbsent(physicalTenantId, id -> new HashSet<>())
         .add(serverId);

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -15,7 +15,10 @@ import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
@@ -23,7 +26,13 @@ import org.slf4j.LoggerFactory;
 
 final class ClientStreamManager<M extends BufferWriter> {
   private static final Logger LOG = LoggerFactory.getLogger(ClientStreamManager.class);
-  private final Set<MemberId> servers = new HashSet<>();
+
+  /** physicalTenantId → set of broker member IDs serving that physical tenant */
+  private final Map<String, Set<MemberId>> serversByPhysicalTenantId = new HashMap<>();
+
+  /** broker member ID → set of physicalTenantIds it serves (for RESTART lookup) */
+  private final Map<MemberId, Set<String>> physicalTenantsByServer = new HashMap<>();
+
   private final ClientStreamRegistry<M> registry;
   private final ClientStreamRequestManager<M> requestManager;
   private final ClientStreamMetrics metrics;
@@ -40,22 +49,56 @@ final class ClientStreamManager<M extends BufferWriter> {
   }
 
   /**
-   * When a new server is added to the cluster, or an existing server restarted, existing client
-   * streams must be registered (again) with the server.
+   * Called when a server joins the cluster for a specific partition group. Only streams whose
+   * physical tenant matches {@code physicalTenantId} are registered with this server.
    *
-   * @param serverId id of the server that is added or restarted
+   * @param serverId the joining server
+   * @param physicalTenantId the physical tenant served by this server
    */
-  void onServerJoined(final MemberId serverId) {
-    servers.add(serverId);
-    metrics.serverCount(servers.size());
+  void onServerJoinedToGroup(final MemberId serverId, final String physicalTenantId) {
+    serversByPhysicalTenantId
+        .computeIfAbsent(physicalTenantId, id -> new HashSet<>())
+        .add(serverId);
+    physicalTenantsByServer.computeIfAbsent(serverId, id -> new HashSet<>()).add(physicalTenantId);
+    metrics.serverCount(physicalTenantsByServer.size());
 
-    registry.list().forEach(c -> requestManager.add(c, serverId));
+    registry.list().stream()
+        .filter(c -> physicalTenantId.equals(c.physicalTenantId()))
+        .forEach(c -> requestManager.add(c, serverId));
   }
 
   void onServerRemoved(final MemberId serverId) {
-    servers.remove(serverId);
-    metrics.serverCount(servers.size());
+    final var physicalTenantIds = physicalTenantsByServer.remove(serverId);
+    if (physicalTenantIds != null) {
+      physicalTenantIds.forEach(
+          physicalTenantId -> {
+            final var servers = serversByPhysicalTenantId.get(physicalTenantId);
+            if (servers != null) {
+              servers.remove(serverId);
+              if (servers.isEmpty()) {
+                serversByPhysicalTenantId.remove(physicalTenantId);
+              }
+            }
+          });
+    }
+    metrics.serverCount(physicalTenantsByServer.size());
     requestManager.onServerRemoved(serverId);
+  }
+
+  /**
+   * Called when a server that was already in the topology sends a RESTART_STREAMS signal. Resets
+   * its registrations and re-registers all streams belonging to its known physical tenants —
+   * without touching the topology maps.
+   */
+  void onServerRestarted(final MemberId serverId) {
+    requestManager.onServerRemoved(serverId);
+    physicalTenantsByServer
+        .getOrDefault(serverId, Collections.emptySet())
+        .forEach(
+            physicalTenantId ->
+                registry.list().stream()
+                    .filter(c -> physicalTenantId.equals(c.physicalTenantId()))
+                    .forEach(c -> requestManager.add(c, serverId)));
   }
 
   ClientStreamId add(
@@ -67,6 +110,8 @@ final class ClientStreamManager<M extends BufferWriter> {
     final var clientStream =
         registry.addClient(streamType, metadata, clientStreamConsumer, physicalTenantId);
     LOG.debug("Added new client stream [{}]", clientStream.streamId());
+    final var servers =
+        serversByPhysicalTenantId.getOrDefault(physicalTenantId, Collections.emptySet());
     clientStream.serverStream().open(requestManager, servers);
 
     return clientStream.streamId();
@@ -79,13 +124,16 @@ final class ClientStreamManager<M extends BufferWriter> {
         stream -> {
           LOG.debug("Removing aggregated stream [{}]", stream.streamId());
           stream.close();
+          final var servers =
+              serversByPhysicalTenantId.getOrDefault(
+                  stream.physicalTenantId(), Collections.emptySet());
           requestManager.remove(stream, servers);
         });
   }
 
   void close() {
     registry.clear();
-    requestManager.removeAll(servers);
+    requestManager.removeAll(serversByPhysicalTenantId);
   }
 
   public void onPayloadReceived(
@@ -115,7 +163,7 @@ final class ClientStreamManager<M extends BufferWriter> {
           // Stream does not exist. We expect to have already sent remove request to all servers.
           // But just in case that request is lost, we send remove request again. To keep it simple,
           // we do not retry. Otherwise, it is possible that we send it multiple times unnecessary.
-          requestManager.removeUnreliable(streamId, servers);
+          requestManager.removeUnreliable(streamId, serversByPhysicalTenantId);
           LOG.warn("Expected to push payload to stream {}, but no stream found.", streamId);
           responseFuture.completeExceptionally(
               new NoSuchStreamException(

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
@@ -43,6 +43,10 @@ final class ClientStreamRegistration<M extends BufferWriter> {
     return stream.streamId();
   }
 
+  String physicalTenantId() {
+    return stream.physicalTenantId();
+  }
+
   LogicalId<? extends BufferWriter> logicalId() {
     return stream.logicalId();
   }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
@@ -39,6 +40,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Coordinates registering/de-registering {@link AggregatedClientStream} with arbitrary set of
  * servers.
+ *
+ * <p>Each stream carries its own {@code physicalTenantId}; this manager uses that value to form the
+ * correct physicalTenantId-scoped topic for every ADD/REMOVE/REMOVE_ALL message, so that streams
+ * are only registered with brokers that serve their physical tenant.
  *
  * <p>NOTE: all operations are potentially asynchronous as network I/O is involved. To avoid race
  * conditions w.r.t to the stream lifecycle, the manager keeps track of the registration state per
@@ -62,15 +67,11 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
   private final ClusterCommunicationService communicationService;
   private final ConcurrencyControl executor;
-  private final String physicalTenantId;
 
   ClientStreamRequestManager(
-      final ClusterCommunicationService communicationService,
-      final ConcurrencyControl executor,
-      final String physicalTenantId) {
+      final ClusterCommunicationService communicationService, final ConcurrencyControl executor) {
     this.communicationService = communicationService;
     this.executor = executor;
-    this.physicalTenantId = physicalTenantId;
   }
 
   /**
@@ -144,38 +145,45 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   }
 
   /**
-   * Sends a single remove all request to each given server, and closes all pending registrations.
+   * Sends REMOVE_ALL to each broker on its physicalTenantId-scoped topic, and closes all pending
+   * registrations.
    *
-   * @param servers the list of servers to notify
+   * @param serversByPhysicalTenantId physicalTenantId → set of broker member IDs
    */
-  void removeAll(final Collection<MemberId> servers) {
+  void removeAll(final Map<String, Set<MemberId>> serversByPhysicalTenantId) {
     registrations.values().stream()
         .flatMap(m -> m.values().stream())
         .forEach(ClientStreamRegistration::transitionToClosed);
     registrations.clear();
 
-    servers.forEach(this::doRemoveAll);
+    serversByPhysicalTenantId.forEach(
+        (physicalTenantId, servers) ->
+            servers.forEach(brokerId -> doRemoveAll(brokerId, physicalTenantId)));
   }
 
   /**
    * Send remove stream request to servers without waiting for ack and without retry. As this is
    * used to send even when no stream was originally registered, we ignore any existing
-   * registrations.
+   * registrations. Iterates all known physical tenants since the stream's tenant is unknown at this
+   * point.
    */
-  void removeUnreliable(final UUID streamId, final Collection<MemberId> servers) {
+  void removeUnreliable(
+      final UUID streamId, final Map<String, Set<MemberId>> serversByPhysicalTenantId) {
     final var request = new RemoveStreamRequest().streamId(streamId);
     final var payload = BufferUtil.bufferAsArray(request);
 
-    servers.forEach(
-        serverId -> {
-          communicationService.unicast(
-              StreamTopics.REMOVE.topic(physicalTenantId),
-              payload,
-              Function.identity(),
-              serverId,
-              true);
-          purgeRegistration(streamId, serverId);
-        });
+    serversByPhysicalTenantId.forEach(
+        (physicalTenantId, servers) ->
+            servers.forEach(
+                serverId -> {
+                  communicationService.unicast(
+                      StreamTopics.REMOVE.topic(physicalTenantId),
+                      payload,
+                      Function.identity(),
+                      serverId,
+                      true);
+                  purgeRegistration(streamId, serverId);
+                }));
   }
 
   private void add(final ClientStreamRegistration<M> registration) {
@@ -256,7 +264,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
     final var pendingRequest =
         communicationService.send(
-            StreamTopics.ADD.topic(physicalTenantId),
+            StreamTopics.ADD.topic(registration.physicalTenantId()),
             request,
             Function.identity(),
             Function.identity(),
@@ -315,7 +323,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
     final var pendingRequest =
         communicationService.send(
-            StreamTopics.REMOVE.topic(physicalTenantId),
+            StreamTopics.REMOVE.topic(registration.physicalTenantId()),
             request,
             Function.identity(),
             Function.identity(),
@@ -408,8 +416,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     }
   }
 
-  private void doRemoveAll(final MemberId brokerId) {
-    // Do not wait for response, as this is expected to be called while shutting down.
+  private void doRemoveAll(final MemberId brokerId, final String physicalTenantId) {
     communicationService.unicast(
         StreamTopics.REMOVE_ALL.topic(physicalTenantId),
         REMOVE_ALL_REQUEST,

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -25,7 +25,9 @@ import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
 
@@ -41,23 +43,20 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   private final ClusterCommunicationService communicationService;
   private final ClientStreamRegistry<M> registry;
   private final ClientStreamApiHandler apiHandler;
-  private final String physicalTenantId;
+
+  /** Tracks which physicalTenantId topics already have a RESTART_STREAMS listener registered. */
+  private final Set<String> registeredRestartPhysicalTenants = new HashSet<>();
 
   public ClientStreamServiceImpl(
-      final ClusterCommunicationService communicationService,
-      final ClientStreamMetrics metrics,
-      final String physicalTenantId) {
+      final ClusterCommunicationService communicationService, final ClientStreamMetrics metrics) {
     this.communicationService = communicationService;
-    this.physicalTenantId = physicalTenantId;
     registry = new ClientStreamRegistry<>(metrics);
 
     // ClientStreamRequestManager must use same actor as this because it is mutating shared
     // ClientStream objects.
     clientStreamManager =
         new ClientStreamManager<>(
-            registry,
-            new ClientStreamRequestManager<>(communicationService, actor, physicalTenantId),
-            metrics);
+            registry, new ClientStreamRequestManager<>(communicationService, actor), metrics);
     apiHandler = new ClientStreamApiHandler(clientStreamManager, actor);
   }
 
@@ -70,12 +69,9 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
         BufferUtil::bufferAsArray,
         actor::run);
 
-    communicationService.replyTo(
-        StreamTopics.RESTART_STREAMS.topic(physicalTenantId),
-        Function.identity(),
-        apiHandler::handleRestartRequest,
-        Function.identity(),
-        actor::run);
+    // Pre-register the default group's RESTART topic so restarted legacy brokers are handled
+    // even before the first brokerAddedToGroup callback fires.
+    registerRestartHandler(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   @Override
@@ -105,8 +101,12 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   }
 
   @Override
-  public void onServerJoined(final MemberId memberId) {
-    actor.run(() -> clientStreamManager.onServerJoined(memberId));
+  public void onServerJoinedToGroup(final MemberId memberId, final String physicalTenantId) {
+    actor.run(
+        () -> {
+          registerRestartHandler(physicalTenantId);
+          clientStreamManager.onServerJoinedToGroup(memberId, physicalTenantId);
+        });
   }
 
   @Override
@@ -133,5 +133,16 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
                 .flatMap(agg -> agg.list().stream())
                 .map(s -> (ClientStream<M>) s)
                 .toList());
+  }
+
+  private void registerRestartHandler(final String physicalTenantId) {
+    if (registeredRestartPhysicalTenants.add(physicalTenantId)) {
+      communicationService.replyTo(
+          StreamTopics.RESTART_STREAMS.topic(physicalTenantId),
+          Function.identity(),
+          apiHandler::handleRestartRequest,
+          Function.identity(),
+          actor::run);
+    }
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -101,11 +101,11 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   }
 
   @Override
-  public void onServerJoinedToGroup(final MemberId memberId, final String physicalTenantId) {
+  public void onServerJoined(final MemberId memberId, final String physicalTenantId) {
     actor.run(
         () -> {
           registerRestartHandler(physicalTenantId);
-          clientStreamManager.onServerJoinedToGroup(memberId, physicalTenantId);
+          clientStreamManager.onServerJoined(memberId, physicalTenantId);
         });
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -70,7 +70,7 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
         actor::run);
 
     // Pre-register the default group's RESTART topic so restarted legacy brokers are handled
-    // even before the first brokerAddedToGroup callback fires.
+    // even before the first brokerAdded callback fires.
     registerRestartHandler(DEFAULT_PHYSICAL_TENANT_ID);
   }
 

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 
 class ClientStreamManagerTest {
 
+  private static final String OTHER_PHYSICAL_TENANT_ID = "other-tenant";
   private static final ClientStreamConsumer NOOP_CONSUMER =
       p -> CompletableActorFuture.completed(null);
   private final DirectBuffer streamType = BufferUtil.wrapString("foo");
@@ -52,8 +53,7 @@ class ClientStreamManagerTest {
   private final ClientStreamManager<TestMetadata> clientStreamManager =
       new ClientStreamManager<>(
           registry,
-          new ClientStreamRequestManager<>(
-              mockTransport, new TestConcurrencyControl(), DEFAULT_PHYSICAL_TENANT_ID),
+          new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl()),
           metrics);
 
   @BeforeEach
@@ -95,13 +95,13 @@ class ClientStreamManagerTest {
   void shouldAddStreamAfterServerWasRemoved() {
     // given
     final var serverId = MemberId.anonymous();
-    clientStreamManager.onServerJoined(serverId);
+    clientStreamManager.onServerJoinedToGroup(serverId, DEFAULT_PHYSICAL_TENANT_ID);
     final var streamId =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     clientStreamManager.onServerRemoved(serverId);
 
     // when
-    clientStreamManager.onServerJoined(serverId);
+    clientStreamManager.onServerJoinedToGroup(serverId, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(registry.getClient(streamId))
@@ -167,9 +167,9 @@ class ClientStreamManagerTest {
   void shouldOpenStreamToExistingServers() {
     // given
     final MemberId server1 = MemberId.from("1");
-    clientStreamManager.onServerJoined(server1);
+    clientStreamManager.onServerJoinedToGroup(server1, DEFAULT_PHYSICAL_TENANT_ID);
     final MemberId server2 = MemberId.from("2");
-    clientStreamManager.onServerJoined(server2);
+    clientStreamManager.onServerJoinedToGroup(server2, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     final var uuid =
@@ -192,7 +192,7 @@ class ClientStreamManagerTest {
 
     // when
     final MemberId server = MemberId.from("3");
-    clientStreamManager.onServerJoined(server);
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(serverStream.isConnected(server)).isTrue();
@@ -209,9 +209,10 @@ class ClientStreamManagerTest {
             BufferUtil.wrapString("bar"), metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var serverStream1 = registry.get(getServerStreamId(stream1)).orElseThrow();
     final var serverStream2 = registry.get(getServerStreamId(stream2)).orElseThrow();
+
     // when
     final MemberId server = MemberId.from("3");
-    clientStreamManager.onServerJoined(server);
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(serverStream1.isConnected(server)).isTrue();
@@ -326,7 +327,7 @@ class ClientStreamManagerTest {
   void shouldRemoveServerFromClientStream() {
     // given
     final MemberId server = MemberId.from("1");
-    clientStreamManager.onServerJoined(server);
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
     final var uuid =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
@@ -345,7 +346,7 @@ class ClientStreamManagerTest {
     final MemberId server = MemberId.from("1");
 
     // when
-    clientStreamManager.onServerJoined(server);
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(metrics.getServerCount()).isOne();
@@ -355,13 +356,63 @@ class ClientStreamManagerTest {
   void shouldReportServerCountOnRemoved() {
     // given
     final MemberId server = MemberId.from("1");
-    clientStreamManager.onServerJoined(server);
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     clientStreamManager.onServerRemoved(server);
 
     // then
     assertThat(metrics.getServerCount()).isZero();
+  }
+
+  @Test
+  void shouldNotRegisterStreamWithServerFromDifferentGroup() {
+    // given
+    final MemberId defaultServer = MemberId.from("default-1");
+    final MemberId otherServer = MemberId.from("other-1");
+    clientStreamManager.onServerJoinedToGroup(defaultServer, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoinedToGroup(otherServer, OTHER_PHYSICAL_TENANT_ID);
+
+    // when - add a stream for the default group
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
+
+    // then - only registered with the default server, not the other-group server
+    assertThat(stream.isConnected(defaultServer)).isTrue();
+    assertThat(stream.isConnected(otherServer)).isFalse();
+  }
+
+  @Test
+  void shouldOnlyPropagateServerJoinToMatchingGroupStreams() {
+    // given - stream for default group already open
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
+
+    // when - a server from a different group joins
+    final MemberId otherServer = MemberId.from("other-1");
+    clientStreamManager.onServerJoinedToGroup(otherServer, OTHER_PHYSICAL_TENANT_ID);
+
+    // then - stream not registered with that server
+    assertThat(stream.isConnected(otherServer)).isFalse();
+  }
+
+  @Test
+  void shouldRestartOnlyStreamsForKnownGroups() {
+    // given
+    final MemberId server = MemberId.from("1");
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
+    assertThat(stream.isConnected(server)).isTrue();
+
+    // when - server restarts
+    clientStreamManager.onServerRestarted(server);
+
+    // then - stream re-registered with same server
+    assertThat(stream.isConnected(server)).isTrue();
   }
 
   private UUID getServerStreamId(final ClientStreamId clientStreamId) {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -95,13 +95,13 @@ class ClientStreamManagerTest {
   void shouldAddStreamAfterServerWasRemoved() {
     // given
     final var serverId = MemberId.anonymous();
-    clientStreamManager.onServerJoinedToGroup(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
     final var streamId =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     clientStreamManager.onServerRemoved(serverId);
 
     // when
-    clientStreamManager.onServerJoinedToGroup(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(registry.getClient(streamId))
@@ -167,9 +167,9 @@ class ClientStreamManagerTest {
   void shouldOpenStreamToExistingServers() {
     // given
     final MemberId server1 = MemberId.from("1");
-    clientStreamManager.onServerJoinedToGroup(server1, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server1, DEFAULT_PHYSICAL_TENANT_ID);
     final MemberId server2 = MemberId.from("2");
-    clientStreamManager.onServerJoinedToGroup(server2, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server2, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     final var uuid =
@@ -192,7 +192,7 @@ class ClientStreamManagerTest {
 
     // when
     final MemberId server = MemberId.from("3");
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(serverStream.isConnected(server)).isTrue();
@@ -212,7 +212,7 @@ class ClientStreamManagerTest {
 
     // when
     final MemberId server = MemberId.from("3");
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(serverStream1.isConnected(server)).isTrue();
@@ -327,7 +327,7 @@ class ClientStreamManagerTest {
   void shouldRemoveServerFromClientStream() {
     // given
     final MemberId server = MemberId.from("1");
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
     final var uuid =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
@@ -346,7 +346,7 @@ class ClientStreamManagerTest {
     final MemberId server = MemberId.from("1");
 
     // when
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(metrics.getServerCount()).isOne();
@@ -356,7 +356,7 @@ class ClientStreamManagerTest {
   void shouldReportServerCountOnRemoved() {
     // given
     final MemberId server = MemberId.from("1");
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     clientStreamManager.onServerRemoved(server);
@@ -370,8 +370,8 @@ class ClientStreamManagerTest {
     // given
     final MemberId defaultServer = MemberId.from("default-1");
     final MemberId otherServer = MemberId.from("other-1");
-    clientStreamManager.onServerJoinedToGroup(defaultServer, DEFAULT_PHYSICAL_TENANT_ID);
-    clientStreamManager.onServerJoinedToGroup(otherServer, OTHER_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(defaultServer, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(otherServer, OTHER_PHYSICAL_TENANT_ID);
 
     // when - add a stream for the default group
     final var uuid =
@@ -392,7 +392,7 @@ class ClientStreamManagerTest {
 
     // when - a server from a different group joins
     final MemberId otherServer = MemberId.from("other-1");
-    clientStreamManager.onServerJoinedToGroup(otherServer, OTHER_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(otherServer, OTHER_PHYSICAL_TENANT_ID);
 
     // then - stream not registered with that server
     assertThat(stream.isConnected(otherServer)).isFalse();
@@ -402,7 +402,7 @@ class ClientStreamManagerTest {
   void shouldRestartOnlyStreamsForKnownGroups() {
     // given
     final MemberId server = MemberId.from("1");
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
     final var uuid =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -415,6 +415,18 @@ class ClientStreamManagerTest {
     assertThat(stream.isConnected(server)).isTrue();
   }
 
+  @Test
+  void shouldHandleRestartFromUnknownServerGracefully() {
+    // given — a stream exists but this server never joined any group
+    clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final MemberId unknownServer = MemberId.from("never-joined");
+
+    // when / then — no exception, stream stays unregistered with unknown server
+    clientStreamManager.onServerRestarted(unknownServer);
+    final var stream = registry.list().stream().findFirst().orElseThrow();
+    assertThat(stream.isConnected(unknownServer)).isFalse();
+  }
+
   private UUID getServerStreamId(final ClientStreamId clientStreamId) {
     return registry.getClient(clientStreamId).orElseThrow().serverStream().streamId();
   }

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -623,6 +623,71 @@ final class ClientStreamRequestManagerTest {
             anyBoolean());
   }
 
+  @Test
+  void shouldUseGroupScopedTopicForNonDefaultPhysicalTenant() {
+    // given — stream owned by a non-default partition group
+    final String physicalTenantId = "tenant1";
+    final var tenantStream =
+        new AggregatedClientStream<>(
+            UUID.randomUUID(),
+            new LogicalId<>(
+                new UnsafeBuffer(BufferUtil.wrapString("tenant-foo")), new TestMetadata()),
+            physicalTenantId);
+    tenantStream.open(requestManager, Collections.emptySet());
+
+    final var serverId = MemberId.anonymous();
+    when(mockTransport.send(
+            eq(StreamTopics.ADD.topic(physicalTenantId)), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(CompletableFuture.completedFuture(addStreamSuccess));
+    when(mockTransport.send(
+            eq(StreamTopics.REMOVE.topic(physicalTenantId)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
+        .thenReturn(CompletableFuture.completedFuture(removeStreamSuccess));
+
+    // when
+    requestManager.add(tenantStream, serverId);
+
+    // then — ADD uses prefixed topic "tenant1-stream-add", not legacy "stream-add"
+    verify(mockTransport)
+        .send(
+            eq(StreamTopics.ADD.topic(physicalTenantId)), any(), any(), any(), eq(serverId), any());
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    assertThat(tenantStream.isConnected(serverId)).isTrue();
+
+    // when
+    requestManager.remove(tenantStream, serverId);
+
+    // then — REMOVE also uses prefixed topic
+    verify(mockTransport)
+        .send(
+            eq(StreamTopics.REMOVE.topic(physicalTenantId)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    assertThat(tenantStream.isConnected(serverId)).isFalse();
+  }
+
   private static Stream<MessagingException> provideMessagingFailures() {
     return Stream.of(
         new NoSuchMemberException("failed"),

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -53,8 +54,7 @@ final class ClientStreamRequestManagerTest {
   private final ClusterCommunicationService mockTransport = mock(ClusterCommunicationService.class);
   private final TestConcurrencyControl concurrencyControl = spy(new TestConcurrencyControl());
   private final ClientStreamRequestManager<TestMetadata> requestManager =
-      new ClientStreamRequestManager<>(
-          mockTransport, concurrencyControl, DEFAULT_PHYSICAL_TENANT_ID);
+      new ClientStreamRequestManager<>(mockTransport, concurrencyControl);
   private final AggregatedClientStream<TestMetadata> clientStream =
       new AggregatedClientStream<>(
           UUID.randomUUID(),
@@ -484,7 +484,7 @@ final class ClientStreamRequestManagerTest {
 
     // when - remove all, which will close all registrations
     requestManager.remove(clientStream, serverId);
-    requestManager.removeAll(Collections.singleton(serverId));
+    requestManager.removeAll(Map.of(DEFAULT_PHYSICAL_TENANT_ID, Collections.singleton(serverId)));
     pendingRequest.completeExceptionally(new RuntimeException("failed"));
 
     // then
@@ -580,7 +580,7 @@ final class ClientStreamRequestManagerTest {
 
     // when - remove all, which will close all registrations
     requestManager.add(clientStream, serverId);
-    requestManager.removeAll(Collections.singleton(serverId));
+    requestManager.removeAll(Map.of(DEFAULT_PHYSICAL_TENANT_ID, Collections.singleton(serverId)));
     pendingRequest.completeExceptionally(new RuntimeException("failed"));
 
     // then
@@ -600,10 +600,11 @@ final class ClientStreamRequestManagerTest {
     // given
     final MemberId server1 = MemberId.from("1");
     final MemberId server2 = MemberId.from("2");
-    final var servers = Set.of(server1, server2);
+    final var serversByPhysicalTenantId =
+        Map.of(DEFAULT_PHYSICAL_TENANT_ID, Set.of(server1, server2));
 
     // when
-    requestManager.removeAll(servers);
+    requestManager.removeAll(serversByPhysicalTenantId);
 
     // then
     verify(mockTransport)

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -86,9 +86,9 @@ final class StreamIntegrationTest {
     server2.start();
     client.start();
 
-    client.streamService.onServerJoinedToGroup(
+    client.streamService.onServerJoined(
         server1.cluster.getMembershipService().getLocalMember().id(), DEFAULT_PHYSICAL_TENANT_ID);
-    client.streamService.onServerJoinedToGroup(
+    client.streamService.onServerJoined(
         server2.cluster.getMembershipService().getLocalMember().id(), DEFAULT_PHYSICAL_TENANT_ID);
     clientStreamer = client.streamService.streamer();
   }
@@ -345,7 +345,7 @@ final class StreamIntegrationTest {
                   .hasValue(Set.of(server2.memberId())));
 
       // when
-      client.streamService.onServerJoinedToGroup(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
+      client.streamService.onServerJoined(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
 
       // then
       awaitStreamAdded(streamType, streamId, server1, server2);
@@ -414,8 +414,7 @@ final class StreamIntegrationTest {
       try (final var restartedServer =
           new TestServer(createClusterNode(clusterNodes.get(0), clusterNodes))) {
         restartedServer.start();
-        client.streamService.onServerJoinedToGroup(
-            restartedServer.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
+        client.streamService.onServerJoined(restartedServer.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
 
         // then
         awaitStreamAdded(streamType, streamId, restartedServer, server2);

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -86,10 +86,10 @@ final class StreamIntegrationTest {
     server2.start();
     client.start();
 
-    client.streamService.onServerJoined(
-        server1.cluster.getMembershipService().getLocalMember().id());
-    client.streamService.onServerJoined(
-        server2.cluster.getMembershipService().getLocalMember().id());
+    client.streamService.onServerJoinedToGroup(
+        server1.cluster.getMembershipService().getLocalMember().id(), DEFAULT_PHYSICAL_TENANT_ID);
+    client.streamService.onServerJoinedToGroup(
+        server2.cluster.getMembershipService().getLocalMember().id(), DEFAULT_PHYSICAL_TENANT_ID);
     clientStreamer = client.streamService.streamer();
   }
 
@@ -345,7 +345,7 @@ final class StreamIntegrationTest {
                   .hasValue(Set.of(server2.memberId())));
 
       // when
-      client.streamService.onServerJoined(server1.memberId());
+      client.streamService.onServerJoinedToGroup(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
 
       // then
       awaitStreamAdded(streamType, streamId, server1, server2);
@@ -414,7 +414,8 @@ final class StreamIntegrationTest {
       try (final var restartedServer =
           new TestServer(createClusterNode(clusterNodes.get(0), clusterNodes))) {
         restartedServer.start();
-        client.streamService.onServerJoined(restartedServer.memberId());
+        client.streamService.onServerJoinedToGroup(
+            restartedServer.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
 
         // then
         awaitStreamAdded(streamType, streamId, restartedServer, server2);
@@ -483,9 +484,7 @@ final class StreamIntegrationTest {
       final var factory = new TransportFactory(actorScheduler);
       streamService =
           factory.createRemoteStreamClient(
-              cluster.getCommunicationService(),
-              ClientStreamMetrics.noop(),
-              DEFAULT_PHYSICAL_TENANT_ID);
+              cluster.getCommunicationService(), ClientStreamMetrics.noop());
     }
 
     private void start() {


### PR DESCRIPTION
## Description

Previously a single `JobStreamService` was shared across all physical tenants. The job-stream error
handler received callbacks for every partition regardless of which physical tenant owned it.
When multiple physical tenants have overlapping numeric partition IDs this causes aliasing — a
handler for tenant A incorrectly processes events from tenant B's partition with the same number.

## What the PR does

Creates one isolated `JobStreamService` per physical tenant. Each service subscribes only to its
own tenant's transport topics, so stream registration and error handling are fully scoped.

## Key changes

### `JobStreamServiceStep`
- Iterates `physicalTenantIds.known()` and calls `startTenantService` for each tenant concurrently
  via `ActorFutureCollector`.
- Each service gets its own `RemoteStreamService`, `RemoteJobStreamer`, and
  `RemoteJobStreamErrorHandlerService`.
- On partial startup failure: shuts down any already-started services before completing the startup
  future exceptionally (no leaks).

### `PartitionManager.createPartitionManager`
Resolves `jobStreamer` and `errorHandlerService` from the per-tenant service
(`brokerStartupContext.getJobStreamService(physicalTenantId)`) instead of a shared singleton.
Error handler is added to that partition group's listener list only — it never sees another
tenant's partitions.

### `BrokerStartupContext`
Added `getJobStreamService / addJobStreamService / removeJobStreamService` backed by a
`LinkedHashMap<String, JobStreamService>`. Services are registered after startup and cleaned up
during shutdown or on partial failure.

### Metrics
Each `JobStreamService` is tagged with its physical tenant ID so metrics are distinguishable per
tenant.

  Closes #56221


