### PR TITLE
test: regression coverage for OIDC fetch logout 2xx contract

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerNoEndSessionWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerNoEndSessionWiringTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+/**
+ * Companion to {@link OidcLogoutSuccessHandlerWiringTest} covering the case where the OIDC provider
+ * has no {@code end_session_endpoint} configured (no {@code
+ * camunda.security.authentication.oidc.end-session-endpoint-uri} property here, unlike the sibling
+ * test class). Regression test for camunda/camunda-security-library#484.
+ */
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityOidcTestContext.class,
+      WebSecurityConfig.class
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=example",
+      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com"
+    })
+public class OidcLogoutSuccessHandlerNoEndSessionWiringTest extends AbstractWebSecurityConfigTest {
+
+  @Test
+  public void shouldReturnNoContentForFetchLogoutWhenNoEndSessionEndpointConfigured()
+      throws Exception {
+    // given an OIDC-authenticated fetch()/XHR caller whose registration has no
+    // end_session_endpoint
+
+    // when it POSTs /logout
+    final MvcTestResult result =
+        mockMvcTester
+            .post()
+            .uri("https://localhost/logout")
+            .header("Sec-Fetch-Dest", "empty")
+            .with(oidcLogin())
+            .exchange();
+
+    // then it gets an empty 204, not a 302 redirect to a non-existent end-session endpoint
+    assertThat(result).hasStatus(HttpStatus.NO_CONTENT);
+    assertThat(result.getResponse().getContentAsString()).isEmpty();
+  }
+
+  private org.springframework.test.web.servlet.request.RequestPostProcessor oidcLogin() {
+    final ClientRegistration registration =
+        ClientRegistration.withRegistrationId("oidc")
+            .clientId("example")
+            .clientSecret("secret")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("{baseUrl}/sso-callback")
+            .authorizationUri("https://authorization.example.com")
+            .tokenUri("https://token.example.com")
+            .jwkSetUri("https://jwks.example.com")
+            .userNameAttributeName("sub")
+            .scope("openid")
+            .build();
+
+    return SecurityMockMvcRequestPostProcessors.oidcLogin().clientRegistration(registration);
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerNoEndSessionWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerNoEndSessionWiringTest.java
@@ -14,6 +14,7 @@ import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
@@ -54,6 +55,7 @@ public class OidcLogoutSuccessHandlerNoEndSessionWiringTest extends AbstractWebS
             .post()
             .uri("https://localhost/logout")
             .header("Sec-Fetch-Dest", "empty")
+            .accept(MediaType.APPLICATION_JSON)
             .with(oidcLogin())
             .exchange();
 

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
@@ -99,14 +99,15 @@ public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfi
 
   @Test
   public void shouldReturnFoundRedirectForNonFetchLogoutWhenEndSessionEndpointConfigured() {
-    // given the same OIDC-authenticated user, but performing a full-page navigation (no
-    // Sec-Fetch-Dest, HTML accept) rather than a fetch() call
+    // given the same OIDC-authenticated user, but performing a full-page navigation
+    // (Sec-Fetch-Dest: document, HTML accept) rather than a fetch() call
 
     // when it POSTs /logout
     final MvcTestResult result =
         mockMvcTester
             .post()
             .uri("https://localhost/logout")
+            .header("Sec-Fetch-Dest", "document")
             .accept(MediaType.TEXT_HTML)
             .with(oidcLoginWithLoginHint())
             .exchange();

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
@@ -77,6 +77,7 @@ public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfi
             .post()
             .uri("https://localhost/logout")
             .header("Sec-Fetch-Dest", "empty")
+            .accept(MediaType.APPLICATION_JSON)
             .with(oidcLoginWithLoginHint())
             .exchange();
 

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+/**
+ * Regression test for camunda/camunda-security-library#484: {@code CamundaOidcLogoutSuccessHandler}
+ * used to answer {@code POST /logout} with a 302 redirect to the IdP's {@code
+ * end_session_endpoint}, even for {@code fetch()} callers. The webapps cannot follow a 302 into a
+ * top-level cross-origin navigation from {@code fetch()}, so the IdP session was never terminated
+ * and the user got silently logged back in.
+ *
+ * <p>Boots the real OIDC webapp security chain assembled by {@link WebSecurityConfig} (via
+ * {@code @ImportAutoConfiguration(CamundaSecurityAutoConfiguration.class)}), so this verifies the
+ * actual wiring of the CSL logout handler into the host application, not just the handler in
+ * isolation. The {@code camunda.security.authentication.oidc.end-session-endpoint-uri} property
+ * lets {@link io.camunda.security.spring.oidc.ScopedClientRegistrationFactory} populate the {@code
+ * end_session_endpoint} provider metadata without needing a live IdP for discovery.
+ */
+@SpringBootTest(
+    classes = {
+      WebSecurityConfigTestContext.class,
+      WebSecurityOidcTestContext.class,
+      WebSecurityConfig.class
+    },
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=oidc",
+      "camunda.security.authentication.oidc.client-id=example",
+      "camunda.security.authentication.oidc.redirect-uri=redirect.example.com",
+      "camunda.security.authentication.oidc.authorization-uri=authorization.example.com",
+      "camunda.security.authentication.oidc.token-uri=token.example.com",
+      "camunda.security.authentication.oidc.jwk-set-uri=jwks.example.com",
+      "camunda.security.authentication.oidc.end-session-endpoint-uri=https://idp.example.com/protocol/openid-connect/logout"
+    })
+public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfigTest {
+
+  private static final String LOGIN_HINT = "user@example.com";
+
+  @Test
+  public void shouldReturnJsonEndSessionUrlForFetchLogoutWhenEndSessionEndpointConfigured()
+      throws IOException {
+    // given an OIDC-authenticated fetch()/XHR caller (Sec-Fetch-Dest: empty) whose registration
+    // has an end_session_endpoint
+
+    // when it POSTs /logout
+    final MvcTestResult result =
+        mockMvcTester
+            .post()
+            .uri("https://localhost/logout")
+            .header("Sec-Fetch-Dest", "empty")
+            .with(oidcLoginWithLoginHint())
+            .exchange();
+
+    // then it gets a 200 JSON body with the IdP end-session URL, not a redirect
+    assertThat(result)
+        .hasStatus(HttpStatus.OK)
+        .headers()
+        .doesNotContainHeaders(HttpHeaders.LOCATION);
+    assertThat(result.getResponse().getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
+
+    final JsonNode body = new ObjectMapper().readTree(result.getResponse().getContentAsString());
+    final String url = body.get("url").asText();
+    assertThat(url).contains("https://idp.example.com/protocol/openid-connect/logout");
+    assertThat(url).contains("id_token_hint");
+    assertThat(url).contains("logout_hint=" + LOGIN_HINT);
+  }
+
+  @Test
+  public void shouldReturnFoundRedirectForNonFetchLogoutWhenEndSessionEndpointConfigured() {
+    // given the same OIDC-authenticated user, but performing a full-page navigation (no
+    // Sec-Fetch-Dest, HTML accept) rather than a fetch() call
+
+    // when it POSTs /logout
+    final MvcTestResult result =
+        mockMvcTester
+            .post()
+            .uri("https://localhost/logout")
+            .accept(MediaType.TEXT_HTML)
+            .with(oidcLoginWithLoginHint())
+            .exchange();
+
+    // then backward compatibility is preserved: a 302 redirect to the IdP end-session endpoint
+    assertThat(result).hasStatus(HttpStatus.FOUND).containsHeader(HttpHeaders.LOCATION);
+    final String location = result.getResponse().getHeader(HttpHeaders.LOCATION);
+    assertThat(location).contains("https://idp.example.com/protocol/openid-connect/logout");
+  }
+
+  /**
+   * Builds an OIDC login whose {@code authorizedClientRegistrationId} is {@code "oidc"} — the
+   * registration id the app's real {@link
+   * org.springframework.security.oauth2.client.registration.ClientRegistrationRepository} (built by
+   * CSL from the {@code camunda.security.authentication.oidc.*} properties) uses, so {@code
+   * CamundaOidcLogoutSuccessHandler} looks up the real registration (with its configured
+   * end-session endpoint) rather than the throwaway registration used only to establish the mocked
+   * security context. No {@link
+   * org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository} wiring is
+   * needed here: {@code determineTargetUrl} only reads the {@code Authentication} and the real
+   * {@code ClientRegistrationRepository} bean, not an authorized client.
+   */
+  private RequestPostProcessor oidcLoginWithLoginHint() {
+    final ClientRegistration registration =
+        ClientRegistration.withRegistrationId("oidc")
+            .clientId("example")
+            .clientSecret("secret")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("{baseUrl}/sso-callback")
+            .authorizationUri("https://authorization.example.com")
+            .tokenUri("https://token.example.com")
+            .jwkSetUri("https://jwks.example.com")
+            .userNameAttributeName("sub")
+            .scope("openid")
+            .build();
+
+    return SecurityMockMvcRequestPostProcessors.oidcLogin()
+        .clientRegistration(registration)
+        .idToken(token -> token.claim("login_hint", LOGIN_HINT));
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
@@ -14,6 +14,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import io.camunda.authentication.config.controllers.WebSecurityOidcTestContext;
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
@@ -24,6 +27,9 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 /**
  * Regression test for camunda/camunda-security-library#484: {@code CamundaOidcLogoutSuccessHandler}
@@ -82,10 +88,13 @@ public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfi
     assertThat(result.getResponse().getContentType()).startsWith(MediaType.APPLICATION_JSON_VALUE);
 
     final JsonNode body = new ObjectMapper().readTree(result.getResponse().getContentAsString());
-    final String url = body.get("url").asText();
-    assertThat(url).contains("https://idp.example.com/protocol/openid-connect/logout");
-    assertThat(url).contains("id_token_hint");
-    assertThat(url).contains("logout_hint=" + LOGIN_HINT);
+    final MultiValueMap<String, String> query =
+        queryParams(body.get("url").asText(), "idp.example.com", "/protocol/openid-connect/logout");
+    assertThat(query.getFirst("id_token_hint")).isNotBlank();
+    assertThat(
+            URLDecoder.decode(
+                Objects.requireNonNull(query.getFirst("logout_hint")), StandardCharsets.UTF_8))
+        .isEqualTo(LOGIN_HINT);
   }
 
   @Test
@@ -105,7 +114,18 @@ public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfi
     // then backward compatibility is preserved: a 302 redirect to the IdP end-session endpoint
     assertThat(result).hasStatus(HttpStatus.FOUND).containsHeader(HttpHeaders.LOCATION);
     final String location = result.getResponse().getHeader(HttpHeaders.LOCATION);
-    assertThat(location).contains("https://idp.example.com/protocol/openid-connect/logout");
+    final MultiValueMap<String, String> query =
+        queryParams(location, "idp.example.com", "/protocol/openid-connect/logout");
+    assertThat(query.getFirst("id_token_hint")).isNotBlank();
+  }
+
+  private static MultiValueMap<String, String> queryParams(
+      final String url, final String expectedHost, final String expectedPath) {
+    final UriComponents parsed = UriComponentsBuilder.fromUriString(url).build();
+    assertThat(parsed.getScheme()).isEqualTo("https");
+    assertThat(parsed.getHost()).isEqualTo(expectedHost);
+    assertThat(parsed.getPath()).isEqualTo(expectedPath);
+    return parsed.getQueryParams();
   }
 
   /**

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha40</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha41</version.camunda-security-library>
     <version.checkstyle>13.5.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Description

Adds a regression test for the OIDC webapp logout contract, guarding the bug in #56125 /
camunda/camunda-security-library#484: `CamundaOidcLogoutSuccessHandler` used to answer
`POST /logout` with a **302** redirect to the IdP `end_session_endpoint`. The webapps call `/logout`
via `fetch()` and cannot follow a 302 into a top-level cross-origin navigation, so the IdP session
was never terminated and the user was silently logged back in.

The test boots the **real OIDC webapp security chain** (`WebSecurityConfig` +
`@ImportAutoConfiguration(CamundaSecurityAutoConfiguration.class)`, reusing the existing
`OidcWebSecurityConfigTest` context) and drives `POST /logout` via MockMvc + Spring Security's
`oidcLogin()`, asserting:

- fetch/XHR + `end_session_endpoint` present → **200** + `application/json` `{"url": …}` (IdP
  end-session URL), **no** `Location`;
- fetch/XHR + no `end_session_endpoint` → **204**;
- full-page navigation (`Accept: text/html`) → **302** to the end-session endpoint (backward compat).

It exercises the real bean wiring — i.e. that the OC app's OIDC chain actually uses the fixed CSL
handler — rather than re-testing the handler in isolation.

## Linked issue

Closes #56125 (fix lives in camunda/camunda-security-library#484).

## Validation

Built against a local `0.1.0-alpha41` of CSL #484:

- **`0.1.0-alpha41` (fix present):** all 3 tests green.
- **`0.1.0-alpha39` (pre-fix):** 2 of 3 fail — `expected: 200 but was: 302` and
  `expected: 204 but was: 302` — confirming the test catches the regression; the navigation/302 case
  stays green (no false positive).

