### PR TITLE
fix: await document visibility before executing archiver job in AuditLogArchiverJobIT

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobIT.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestTemplate;
@@ -79,6 +80,24 @@ public class AuditLogArchiverJobIT extends ArchiverJobIT<AuditLogArchiverJob> {
           store(auditLogTemplate, client, auditLog);
           store(auditLogTemplate, client, unrelatedAuditLog);
           client.refresh();
+
+          // explicit wait after store() calls and client.refresh(). This is needed to keep nudging
+          // OpenSearch until the documents are provably visible before the job runs.
+          Awaitility.await()
+              .atMost(Duration.ofSeconds(30))
+              .pollInterval(Duration.ofMillis(200))
+              .untilAsserted(
+                  () -> {
+                    client.refresh();
+                    assertThat(
+                            client.searchAll(
+                                cleanupIndex.getFullQualifiedName(), AuditLogCleanupEntity.class))
+                        .hasSize(1);
+                    assertThat(
+                            client.searchAll(
+                                auditLogTemplate.getFullQualifiedName(), AuditLogEntity.class))
+                        .hasSize(2);
+                  });
 
           // when
           final var archived = job.execute();


### PR DESCRIPTION
Target test:
shouldArchiveAuditLogsAndDeleteCleanupMetadata

Run:
https://github.com/camunda/camunda/actions/runs/28673151200

Job run:
https://github.com/camunda/camunda/actions/runs/28673151200/job/85041163501

## Description

<!-- Describe the goal and purpose of this PR. -->
The archiver job integration test was flaky against AWS OpenSearch because client.refresh() does not guarantee that indexed documents are immediately visible to subsequent searches — network and shard latency mean the refresh can return before all documents are queryable.
The fix adds an Awaitility poll after the store calls that keeps refreshing and asserting document counts until all three documents are confirmed visible, before the archiver job executes. No changes to shared infrastructure were needed.

## Checklist
[x] test shouldArchiveAuditLogsAndDeleteCleanupMetadata is no longer failing

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
