### PR TITLE
Add AGENT_HISTORY DISCARD intent + processor + emit on job destruction

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentHistoryCommitLifecycleIT.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
+import org.assertj.core.groups.Tuple;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +41,88 @@ public class AgentHistoryCommitLifecycleIT {
 
   @Test
   void shouldTransitionHistoryItemsFromPendingToCommittedOnJobCompletion() {
-    // --- setup: deploy, start, get element instance ---
+    // --- setup: two PENDING history items on an activated agentic job ---
+    final long processInstanceKey = deployAndStartProcessInstance();
+    final long elementInstanceKey = getServiceTaskElementInstanceKey(processInstanceKey);
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey);
+    final long jobKey = activateAgenticJob(processInstanceKey);
+    final long historyItemKey1 =
+        createHistoryItem(
+            agentInstanceKey,
+            elementInstanceKey,
+            jobKey,
+            AgentInstanceHistoryRole.USER,
+            "Hello, what can you do?",
+            OffsetDateTime.parse("2025-06-01T10:00:00Z"));
+    final long historyItemKey2 =
+        createHistoryItem(
+            agentInstanceKey,
+            elementInstanceKey,
+            jobKey,
+            AgentInstanceHistoryRole.ASSISTANT,
+            "I can help with many tasks.",
+            OffsetDateTime.parse("2025-06-01T10:01:00Z"));
+    awaitHistoryStatuses(
+        agentInstanceKey,
+        "history items indexed as PENDING",
+        tuple(historyItemKey1, AgentInstanceHistoryCommitStatus.PENDING),
+        tuple(historyItemKey2, AgentInstanceHistoryCommitStatus.PENDING));
+
+    // --- complete the job → engine emits COMMIT → items become COMMITTED ---
+    camundaClient.newCompleteCommand(jobKey).execute();
+
+    // --- verify items are COMMITTED after job completion ---
+    awaitHistoryStatuses(
+        agentInstanceKey,
+        "history items transitioned to COMMITTED",
+        tuple(historyItemKey1, AgentInstanceHistoryCommitStatus.COMMITTED),
+        tuple(historyItemKey2, AgentInstanceHistoryCommitStatus.COMMITTED));
+  }
+
+  @Test
+  void shouldTransitionHistoryItemsFromPendingToDiscardedOnJobCancellation() {
+    // --- setup: two PENDING history items on an activated agentic job ---
+    final long processInstanceKey = deployAndStartProcessInstance();
+    final long elementInstanceKey = getServiceTaskElementInstanceKey(processInstanceKey);
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey);
+    final long jobKey = activateAgenticJob(processInstanceKey);
+    final long historyItemKey1 =
+        createHistoryItem(
+            agentInstanceKey,
+            elementInstanceKey,
+            jobKey,
+            AgentInstanceHistoryRole.USER,
+            "Hello, what can you do?",
+            OffsetDateTime.parse("2025-06-01T10:00:00Z"));
+    final long historyItemKey2 =
+        createHistoryItem(
+            agentInstanceKey,
+            elementInstanceKey,
+            jobKey,
+            AgentInstanceHistoryRole.ASSISTANT,
+            "I can help with many tasks.",
+            OffsetDateTime.parse("2025-06-01T10:01:00Z"));
+    awaitHistoryStatuses(
+        agentInstanceKey,
+        "history items indexed as PENDING",
+        tuple(historyItemKey1, AgentInstanceHistoryCommitStatus.PENDING),
+        tuple(historyItemKey2, AgentInstanceHistoryCommitStatus.PENDING));
+
+    // --- cancel the process instance → the agentic job is destroyed without completing → engine
+    // emits DISCARD → items become DISCARDED instead of leaking as PENDING ---
+    camundaClient.newCancelInstanceCommand(processInstanceKey).send().join();
+
+    // --- verify items are DISCARDED after cancellation ---
+    awaitHistoryStatuses(
+        agentInstanceKey,
+        "history items transitioned to DISCARDED",
+        tuple(historyItemKey1, AgentInstanceHistoryCommitStatus.DISCARDED),
+        tuple(historyItemKey2, AgentInstanceHistoryCommitStatus.DISCARDED));
+  }
+
+  // --- helpers: each step below is called directly from the test bodies above ---
+
+  private long deployAndStartProcessInstance() {
     final var processModel =
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
@@ -60,16 +142,20 @@ public class AgentHistoryCommitLifecycleIT {
     waitForElementInstances(
         camundaClient, f -> f.elementId(SERVICE_TASK_ID).processInstanceKey(processInstanceKey), 1);
 
-    final long elementInstanceKey =
-        camundaClient
-            .newElementInstanceSearchRequest()
-            .filter(f -> f.elementId(SERVICE_TASK_ID).processInstanceKey(processInstanceKey))
-            .execute()
-            .items()
-            .getFirst()
-            .getElementInstanceKey();
+    return processInstanceKey;
+  }
 
-    // --- create agent instance ---
+  private long getServiceTaskElementInstanceKey(final long processInstanceKey) {
+    return camundaClient
+        .newElementInstanceSearchRequest()
+        .filter(f -> f.elementId(SERVICE_TASK_ID).processInstanceKey(processInstanceKey))
+        .execute()
+        .items()
+        .getFirst()
+        .getElementInstanceKey();
+  }
+
+  private long createAgentInstance(final long elementInstanceKey) {
     final long agentInstanceKey =
         camundaClient
             .newCreateAgentInstanceCommand()
@@ -82,8 +168,10 @@ public class AgentHistoryCommitLifecycleIT {
             .getAgentInstanceKey();
 
     waitForAgentInstanceToBeIndexed(camundaClient, agentInstanceKey);
+    return agentInstanceKey;
+  }
 
-    // --- activate the agentic job ---
+  private long activateAgenticJob(final long processInstanceKey) {
     final var activatedJobs =
         camundaClient
             .newActivateJobsCommand()
@@ -96,37 +184,37 @@ public class AgentHistoryCommitLifecycleIT {
     assertThat(activatedJobs)
         .as("expected to activate one agent job for process instance %d", processInstanceKey)
         .isNotEmpty();
-    final long jobKey = activatedJobs.get(0).getKey();
+    return activatedJobs.get(0).getKey();
+  }
 
-    // --- create two history items ---
-    final long historyItemKey1 =
-        camundaClient
-            .newCreateAgentHistoryItemCommand(agentInstanceKey)
-            .elementInstanceKey(elementInstanceKey)
-            .jobKey(jobKey)
-            .role(AgentInstanceHistoryRole.USER)
-            .content(List.of(AgentInstanceHistoryContent.text("Hello, what can you do?")))
-            .producedAt(OffsetDateTime.parse("2025-06-01T10:00:00Z"))
-            .send()
-            .join()
-            .getHistoryItemKey();
+  private long createHistoryItem(
+      final long agentInstanceKey,
+      final long elementInstanceKey,
+      final long jobKey,
+      final AgentInstanceHistoryRole role,
+      final String text,
+      final OffsetDateTime producedAt) {
+    return camundaClient
+        .newCreateAgentHistoryItemCommand(agentInstanceKey)
+        .elementInstanceKey(elementInstanceKey)
+        .jobKey(jobKey)
+        .role(role)
+        .content(List.of(AgentInstanceHistoryContent.text(text)))
+        .producedAt(producedAt)
+        .send()
+        .join()
+        .getHistoryItemKey();
+  }
 
-    final long historyItemKey2 =
-        camundaClient
-            .newCreateAgentHistoryItemCommand(agentInstanceKey)
-            .elementInstanceKey(elementInstanceKey)
-            .jobKey(jobKey)
-            .role(AgentInstanceHistoryRole.ASSISTANT)
-            .content(List.of(AgentInstanceHistoryContent.text("I can help with many tasks.")))
-            .producedAt(OffsetDateTime.parse("2025-06-01T10:01:00Z"))
-            .send()
-            .join()
-            .getHistoryItemKey();
-
-    // --- verify items are PENDING before job completion ---
-    // Filter by all statuses so that any spurious item of any commit status is visible;
-    // an all-status filter is needed because the search API returns COMMITTED items by default.
-    Awaitility.await("history items indexed as PENDING")
+  /**
+   * Awaits until the agent instance's history items match exactly the expected (key, commit-status)
+   * tuples. Filters by all commit statuses so that any spurious item of any status is visible (the
+   * search API returns COMMITTED items by default) and so that leftover PENDING items would fail
+   * the assertion rather than be silently hidden.
+   */
+  private void awaitHistoryStatuses(
+      final long agentInstanceKey, final String description, final Tuple... expected) {
+    Awaitility.await(description)
         .atMost(Duration.ofSeconds(30))
         .ignoreExceptions()
         .untilAsserted(
@@ -148,41 +236,7 @@ public class AgentHistoryCommitLifecycleIT {
                   .extracting(
                       AgentInstanceHistory::getHistoryItemKey,
                       AgentInstanceHistory::getCommitStatus)
-                  .containsExactlyInAnyOrder(
-                      tuple(historyItemKey1, AgentInstanceHistoryCommitStatus.PENDING),
-                      tuple(historyItemKey2, AgentInstanceHistoryCommitStatus.PENDING));
-            });
-
-    // --- complete the job → engine emits COMMIT → items become COMMITTED ---
-    camundaClient.newCompleteCommand(jobKey).execute();
-
-    // --- verify items are COMMITTED after job completion ---
-    // Filter by all statuses to confirm no items remain in PENDING or DISCARDED state.
-    Awaitility.await("history items transitioned to COMMITTED")
-        .atMost(Duration.ofSeconds(30))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              final var items =
-                  camundaClient
-                      .newAgentInstanceHistorySearchRequest(agentInstanceKey)
-                      .filter(
-                          f ->
-                              f.commitStatus(
-                                  s ->
-                                      s.in(
-                                          AgentInstanceHistoryCommitStatus.PENDING,
-                                          AgentInstanceHistoryCommitStatus.COMMITTED,
-                                          AgentInstanceHistoryCommitStatus.DISCARDED)))
-                      .execute()
-                      .items();
-              assertThat(items)
-                  .extracting(
-                      AgentInstanceHistory::getHistoryItemKey,
-                      AgentInstanceHistory::getCommitStatus)
-                  .containsExactlyInAnyOrder(
-                      tuple(historyItemKey1, AgentInstanceHistoryCommitStatus.COMMITTED),
-                      tuple(historyItemKey2, AgentInstanceHistoryCommitStatus.COMMITTED));
+                  .containsExactlyInAnyOrder(expected);
             });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.AgentHistoryState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+// DISCARD is always a follow-up command emitted internally by the engine when an agentic job is
+// destroyed without completing, so there is no user to authorize against.
+@ExcludeAuthorizationCheck
+public final class AgentHistoryDiscardProcessor
+    implements TypedRecordProcessor<AgentHistoryRecord> {
+
+  private final StateWriter stateWriter;
+  private final AgentHistoryState agentHistoryState;
+
+  public AgentHistoryDiscardProcessor(
+      final Writers writers, final ProcessingState processingState) {
+    stateWriter = writers.state();
+    agentHistoryState = processingState.getAgentHistoryState();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<AgentHistoryRecord> command) {
+    final long jobKey = command.getValue().getJobKey();
+    final String jobLease = command.getValue().getJobLease();
+    final AgentHistoryState.AgentHistoryVisitor visitor =
+        item ->
+            stateWriter.appendFollowUpEvent(
+                item.getAgentHistoryKey(), AgentHistoryIntent.DISCARDED, item);
+    if (jobLease.isEmpty()) {
+      // Job destruction: every activation's items are dead — discard all items for the job.
+      agentHistoryState.visitByJobKey(jobKey, visitor);
+    } else {
+      // Supersession: only the given (dead) activation's items are discarded.
+      agentHistoryState.visitByJobLease(jobKey, jobLease, visitor);
+    }
+    // no-op when no items exist — backward-compatible with non-agentic jobs
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryProcessors.java
@@ -33,5 +33,9 @@ public final class AgentHistoryProcessors {
         ValueType.AGENT_HISTORY,
         AgentHistoryIntent.COMMIT,
         new AgentHistoryCommitProcessor(writers, processingState));
+    typedRecordProcessors.onCommand(
+        ValueType.AGENT_HISTORY,
+        AgentHistoryIntent.DISCARD,
+        new AgentHistoryDiscardProcessor(writers, processingState));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.LinkedResourc
 import io.camunda.zeebe.engine.processing.deployment.model.element.TaskListener;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.ExpressionTransformer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import io.camunda.zeebe.engine.state.deployment.PersistedResource;
@@ -39,8 +40,10 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventTyp
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -110,6 +113,7 @@ public final class BpmnJobBehavior {
   private final HeaderEncoder headerEncoder = new HeaderEncoder(LOGGER);
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final JobState jobState;
   private final ExpressionProcessor expressionBehavior;
   private final BpmnStateBehavior stateBehavior;
@@ -136,6 +140,7 @@ public final class BpmnJobBehavior {
     this.jobState = jobState;
     this.expressionBehavior = expressionBehavior;
     stateWriter = writers.state();
+    commandWriter = writers.command();
     this.stateBehavior = stateBehavior;
     this.resourceState = resourceState;
     this.formState = formState;
@@ -723,6 +728,15 @@ public final class BpmnJobBehavior {
       // it there as well.
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
       jobMetrics.countJobEvent(JobAction.CANCELED, job.getJobKind(), job.getType());
+      if (job.isAgentic()) {
+        // The job is destroyed without completing — discard all its pending history items. The
+        // lease is left empty on purpose: the whole job is gone, so every activation's items must
+        // be discarded regardless of the lease they were created with.
+        commandWriter.appendFollowUpCommand(
+            jobKey,
+            AgentHistoryIntent.DISCARD,
+            new AgentHistoryRecord().setJobKey(jobKey).setJobLease(JobRecord.EMPTY_LEASE));
+      }
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -735,7 +735,7 @@ public final class BpmnJobBehavior {
         commandWriter.appendFollowUpCommand(
             jobKey,
             AgentHistoryIntent.DISCARD,
-            new AgentHistoryRecord().setJobKey(jobKey).setJobLease(JobRecord.EMPTY_LEASE));
+            new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -12,13 +12,16 @@ import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
@@ -30,6 +33,7 @@ public final class JobCancelProcessor implements TypedRecordProcessor<JobRecord>
   private final JobState jobState;
   private final JobProcessingMetrics jobMetrics;
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
 
@@ -38,6 +42,7 @@ public final class JobCancelProcessor implements TypedRecordProcessor<JobRecord>
     jobState = state.getJobState();
     this.jobMetrics = jobMetrics;
     stateWriter = writers.state();
+    commandWriter = writers.command();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
   }
@@ -51,6 +56,15 @@ public final class JobCancelProcessor implements TypedRecordProcessor<JobRecord>
       // it there as well.
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
       jobMetrics.countJobEvent(JobAction.CANCELED, job.getJobKind(), job.getType());
+      if (job.isAgentic()) {
+        // The job is destroyed without completing — discard all its pending history items. The
+        // lease is left empty on purpose: the whole job is gone, so every activation's items must
+        // be discarded regardless of the lease they were created with.
+        commandWriter.appendFollowUpCommand(
+            jobKey,
+            AgentHistoryIntent.DISCARD,
+            new AgentHistoryRecord().setJobKey(jobKey).setJobLease(JobRecord.EMPTY_LEASE));
+      }
     } else {
       rejectionWriter.appendRejection(
           record, RejectionType.NOT_FOUND, NO_JOB_FOUND_MESSAGE.formatted(jobKey));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -63,7 +63,7 @@ public final class JobCancelProcessor implements TypedRecordProcessor<JobRecord>
         commandWriter.appendFollowUpCommand(
             jobKey,
             AgentHistoryIntent.DISCARD,
-            new AgentHistoryRecord().setJobKey(jobKey).setJobLease(JobRecord.EMPTY_LEASE));
+            new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
       }
     } else {
       rejectionWriter.appendRejection(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCh
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -33,9 +34,11 @@ import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -81,6 +84,7 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
   private final TypedResponseWriter responseWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final IncidentMetrics incidentMetrics;
 
   public JobThrowErrorProcessor(
@@ -108,6 +112,7 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
 
     stateAnalyzer = new CatchEventAnalyzer(state.getProcessState(), elementInstanceState);
     stateWriter = writers.state();
+    commandWriter = writers.command();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
 
@@ -183,6 +188,15 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
     } else {
       writeThrowErrorEvent(jobKey, job, command);
       eventPublicationBehavior.throwErrorEvent(foundCatchEvent.get(), job.getVariablesBuffer());
+      if (job.isAgentic()) {
+        // The error was caught, so the job is deleted without completing — discard all its pending
+        // history items. The lease is left empty on purpose: the whole job is gone, so every
+        // activation's items must be discarded regardless of the lease they were created with.
+        commandWriter.appendFollowUpCommand(
+            jobKey,
+            AgentHistoryIntent.DISCARD,
+            new AgentHistoryRecord().setJobKey(jobKey).setJobLease(JobRecord.EMPTY_LEASE));
+      }
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -195,7 +195,7 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
         commandWriter.appendFollowUpCommand(
             jobKey,
             AgentHistoryIntent.DISCARD,
-            new AgentHistoryRecord().setJobKey(jobKey).setJobLease(JobRecord.EMPTY_LEASE));
+            new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -119,7 +119,11 @@ public class ProcessInstanceMigrationMigrateProcessor
         new ProcessInstanceMigrationJobBehavior(stateWriter, jobState, incidentState);
     migrationUserTaskBehaviour =
         new ProcessInstanceMigrationUserTaskBehavior(
-            stateWriter, jobState, processingState.getUserTaskState(), bpmnBehaviors);
+            stateWriter,
+            writers.command(),
+            jobState,
+            processingState.getUserTaskState(),
+            bpmnBehaviors);
     migrationSequenceFlowBehaviour =
         new ProcessInstanceMigrationSequenceFlowBehavior(
             keyGenerator, stateWriter, elementInstanceState);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -23,15 +23,19 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUse
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationMigrateProcessor.SafetyCheckFailedException;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationPreconditions.ProcessInstanceMigrationPreconditionFailedException;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -71,16 +75,19 @@ public class ProcessInstanceMigrationUserTaskBehavior {
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
   private final BpmnUserTaskBehavior userTaskBehavior;
   private final JobState jobState;
   private final UserTaskState userTaskState;
 
   public ProcessInstanceMigrationUserTaskBehavior(
       final StateWriter stateWriter,
+      final TypedCommandWriter commandWriter,
       final JobState jobState,
       final UserTaskState userTaskState,
       final BpmnBehaviors bpmnBehaviors) {
     this.stateWriter = stateWriter;
+    this.commandWriter = commandWriter;
     this.jobState = jobState;
     this.userTaskState = userTaskState;
     userTaskBehavior = bpmnBehaviors.userTaskBehavior();
@@ -154,6 +161,17 @@ public class ProcessInstanceMigrationUserTaskBehavior {
     job.setIsJobToUserTaskMigration(true);
     // Cancel previous job worker job
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
+    if (job.isAgentic()) {
+      // The job is destroyed without completing — discard all its pending history items. The lease
+      // is left empty on purpose: the whole job is gone, so every activation's items must be
+      // discarded regardless of the lease they were created with. Today the cancelled job is a
+      // user-task job (never agentic), so this is a no-op; kept to future-proof job-worker user
+      // tasks that carry an associated agent instance.
+      commandWriter.appendFollowUpCommand(
+          jobKey,
+          AgentHistoryIntent.DISCARD,
+          new AgentHistoryRecord().setJobKey(jobKey).setJobLease(JobRecord.EMPTY_LEASE));
+    }
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationUserTaskBehavior.java
@@ -31,7 +31,6 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -170,7 +169,7 @@ public class ProcessInstanceMigrationUserTaskBehavior {
       commandWriter.appendFollowUpCommand(
           jobKey,
           AgentHistoryIntent.DISCARD,
-          new AgentHistoryRecord().setJobKey(jobKey).setJobLease(JobRecord.EMPTY_LEASE));
+          new AgentHistoryRecord().setJobKey(jobKey).ignoreLease());
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -9,11 +9,8 @@ package io.camunda.zeebe.engine.processing.agenthistory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -32,17 +29,6 @@ import org.junit.Test;
 
 public class AgentHistoryCommitTest {
 
-  // Tests use the stop/replay pattern to inject CREATED events directly rather than going through
-  // AgentHistoryCreateProcessor. The CREATE command currently emits a COMMIT follow-up command
-  // (TODO #55033) — using it here would trigger COMMIT inline in the same batch, before the test
-  // can set up the desired state. Once the pending-commit lifecycle is wired to job
-  // completion/failure events, the follow-up command will move there and CREATE can be used
-  // directly in these tests.
-  //
-  // Pattern: pauseProcessing → reserve keys → stop → writeRecords(CREATED events) → start →
-  // ENGINE.agentHistories().commit(). During replay, CREATED event appliers populate state;
-  // COMMIT is then issued as a regular command and processed normally.
-
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   private static final String PROCESS_ID = "process";
@@ -59,32 +45,11 @@ public class AgentHistoryCommitTest {
 
     final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
     final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final var itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
 
-    ENGINE.pauseProcessing(1);
-    final long itemKey =
-        ((MutableProcessingState) ENGINE.getProcessingState()).getKeyGenerator().nextKey();
-    ENGINE.stop();
-
-    ENGINE.writeRecords(
-        RecordToWrite.event()
-            .key(itemKey)
-            .agentHistory(
-                AgentHistoryIntent.CREATED,
-                new AgentHistoryRecord()
-                    .setAgentHistoryKey(itemKey)
-                    .setAgentInstanceKey(agentInstanceKey)
-                    .setJobKey(jobKey)
-                    .setElementInstanceKey(elementInstanceKey)
-                    .setRole(AgentHistoryRole.USER)));
-    ENGINE.start();
-
-    ENGINE.agentHistories().withJobKey(jobKey).commit();
+    final var committed = ENGINE.agentHistories().withJobKey(jobKey).commit();
 
     // AgentHistoryCommitProcessor emits COMMITTED carrying the full stored record
-    final var committed =
-        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.COMMITTED)
-            .withRecordKey(itemKey)
-            .getFirst();
     assertThat(committed.getRecordType()).isEqualTo(RecordType.EVENT);
     assertThat(committed.getKey()).isEqualTo(itemKey);
     assertThat(committed.getValue().getJobKey()).isEqualTo(jobKey);
@@ -97,63 +62,26 @@ public class AgentHistoryCommitTest {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
-
     final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
     final var jobKey = activateJobForProcessInstance(processInstanceKey);
 
-    ENGINE.pauseProcessing(1);
-    final var keyGenerator =
-        ((MutableProcessingState) ENGINE.getProcessingState()).getKeyGenerator();
-    final long firstItemKey = keyGenerator.nextKey();
-    final long secondItemKey = keyGenerator.nextKey();
-    final long otherJobItemKey = keyGenerator.nextKey();
-    final long otherJobKey = keyGenerator.nextKey();
-    ENGINE.stop();
-
     // Two items share jobKey but have different leases — COMMIT with no lease must commit both
-    // regardless of lease. A third item with a different jobKey must not be committed.
-    ENGINE.writeRecords(
-        RecordToWrite.event()
-            .key(firstItemKey)
-            .agentHistory(
-                AgentHistoryIntent.CREATED,
-                new AgentHistoryRecord()
-                    .setAgentHistoryKey(firstItemKey)
-                    .setAgentInstanceKey(agentInstanceKey)
-                    .setJobKey(jobKey)
-                    .setJobLease("lease-a")
-                    .setElementInstanceKey(elementInstanceKey)
-                    .setRole(AgentHistoryRole.USER)),
-        RecordToWrite.event()
-            .key(secondItemKey)
-            .agentHistory(
-                AgentHistoryIntent.CREATED,
-                new AgentHistoryRecord()
-                    .setAgentHistoryKey(secondItemKey)
-                    .setAgentInstanceKey(agentInstanceKey)
-                    .setJobKey(jobKey)
-                    .setJobLease("lease-b")
-                    .setElementInstanceKey(elementInstanceKey)
-                    .setRole(AgentHistoryRole.ASSISTANT)),
-        RecordToWrite.event()
-            .key(otherJobItemKey)
-            .agentHistory(
-                AgentHistoryIntent.CREATED,
-                new AgentHistoryRecord()
-                    .setAgentHistoryKey(otherJobItemKey)
-                    .setAgentInstanceKey(agentInstanceKey)
-                    .setJobKey(otherJobKey)
-                    .setElementInstanceKey(elementInstanceKey)
-                    .setRole(AgentHistoryRole.USER)));
-    ENGINE.start();
+    // regardless of lease.
+    final long firstItemKey =
+        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-a");
+    final long secondItemKey =
+        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-b");
+
+    // An item on an unrelated job must not be committed.
+    createUnrelatedJobHistoryItem("lease-a");
 
     final var firstCommitted = ENGINE.agentHistories().withJobKey(jobKey).commit();
     final long commitPosition = firstCommitted.getSourceRecordPosition();
     final long clockResetKey = ENGINE.clock().reset().getKey();
 
     // COMMIT with no lease → visitByJobKey commits all items for jobKey regardless of lease.
-    // withSourceRecordPosition scopes to events from this COMMIT command only; otherJobItemKey
-    // is not visited by visitByJobKey(jobKey) so no event for it can appear.
+    // withSourceRecordPosition scopes to events from this COMMIT command only; the unrelated job's
+    // item is not visited by visitByJobKey(jobKey) so no event for it can appear.
     assertThat(
             RecordingExporter.records()
                 .limit(r -> r.getKey() == clockResetKey)
@@ -172,86 +100,38 @@ public class AgentHistoryCommitTest {
     final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
     final var jobKey = activateJobForProcessInstance(processInstanceKey);
 
-    ENGINE.pauseProcessing(1);
-    final var keyGenerator =
-        ((MutableProcessingState) ENGINE.getProcessingState()).getKeyGenerator();
-    final long lease1ItemKey = keyGenerator.nextKey();
-    final long lease2ItemKey = keyGenerator.nextKey();
-    final long otherJobItemKey = keyGenerator.nextKey();
-    final long otherJobKey = keyGenerator.nextKey();
-    ENGINE.stop();
-
-    // lease-1 and lease-2 items share jobKey; otherJobItem has lease-1 but a different jobKey —
-    // it must not be affected by the COMMIT, proving the filter is scoped to jobKey.
-    ENGINE.writeRecords(
-        RecordToWrite.event()
-            .key(lease1ItemKey)
-            .agentHistory(
-                AgentHistoryIntent.CREATED,
-                new AgentHistoryRecord()
-                    .setAgentHistoryKey(lease1ItemKey)
-                    .setAgentInstanceKey(agentInstanceKey)
-                    .setJobKey(jobKey)
-                    .setJobLease("lease-1")
-                    .setElementInstanceKey(elementInstanceKey)
-                    .setRole(AgentHistoryRole.USER)),
-        RecordToWrite.event()
-            .key(lease2ItemKey)
-            .agentHistory(
-                AgentHistoryIntent.CREATED,
-                new AgentHistoryRecord()
-                    .setAgentHistoryKey(lease2ItemKey)
-                    .setAgentInstanceKey(agentInstanceKey)
-                    .setJobKey(jobKey)
-                    .setJobLease("lease-2")
-                    .setElementInstanceKey(elementInstanceKey)
-                    .setRole(AgentHistoryRole.ASSISTANT)),
-        RecordToWrite.event()
-            .key(otherJobItemKey)
-            .agentHistory(
-                AgentHistoryIntent.CREATED,
-                new AgentHistoryRecord()
-                    .setAgentHistoryKey(otherJobItemKey)
-                    .setAgentInstanceKey(agentInstanceKey)
-                    .setJobKey(otherJobKey)
-                    .setJobLease("lease-1")
-                    .setElementInstanceKey(elementInstanceKey)
-                    .setRole(AgentHistoryRole.USER)));
-    ENGINE.start();
+    // lease-1 and lease-2 items share jobKey; the unrelated job's item also carries lease-1 — it
+    // must not be affected by the COMMIT, proving the filter is scoped to jobKey.
+    final long lease1ItemKey =
+        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-1");
+    final long lease2ItemKey =
+        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-2");
+    createUnrelatedJobHistoryItem("lease-1");
 
     final var firstCommitted =
         ENGINE.agentHistories().withJobKey(jobKey).withJobLease("lease-1").commit();
     final long commitPosition = firstCommitted.getSourceRecordPosition();
     final long clockResetKey = ENGINE.clock().reset().getKey();
 
-    // withSourceRecordPosition scopes to events from this COMMIT command only, naturally
-    // excluding otherJobItem (different jobKey, not visited by visitByJobKey)
-    final var agentHistoryEventsForCommit =
-        RecordingExporter.records()
-            .limit(r -> r.getKey() == clockResetKey)
-            .withValueType(ValueType.AGENT_HISTORY)
-            .filter(r -> r.getSourceRecordPosition() == commitPosition)
-            .asList();
-
     // visitByJobLease(lease-1) → lease-1 item COMMITTED
     assertThat(
-            agentHistoryEventsForCommit.stream()
-                .filter(r -> r.getIntent() == AgentHistoryIntent.COMMITTED)
-                .map(Record::getKey)
-                .toList())
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.COMMITTED)
+                .filter(r -> r.getSourceRecordPosition() == commitPosition)
+                .map(Record::getKey))
         .containsExactly(lease1ItemKey);
 
     // discard pass (visitByJobKey) → lease-2 item DISCARDED as superseded activation
     assertThat(
-            agentHistoryEventsForCommit.stream()
-                .filter(r -> r.getIntent() == AgentHistoryIntent.DISCARDED)
-                .map(Record::getKey)
-                .toList())
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.DISCARDED)
+                .filter(r -> r.getSourceRecordPosition() == commitPosition)
+                .map(Record::getKey))
         .containsExactly(lease2ItemKey);
-
-    // otherJobItem must not have any event (different jobKey, COMMIT is scoped to jobKey)
-    assertThat(agentHistoryEventsForCommit.stream().map(Record::getKey).toList())
-        .doesNotContain(otherJobItemKey);
   }
 
   // --- helpers ---
@@ -289,5 +169,42 @@ public class AgentHistoryCommitTest {
         .withElementInstanceKey(elementInstanceKey)
         .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
         .create();
+  }
+
+  private static long createHistoryItem(
+      final long agentInstanceKey,
+      final long jobKey,
+      final long elementInstanceKey,
+      final String jobLease) {
+    return ENGINE
+        .agentHistories()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withJobKey(jobKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobLease(jobLease)
+        .withRole(AgentHistoryRole.USER)
+        .create()
+        .getKey();
+  }
+
+  /**
+   * Creates a second, unrelated agentic job (a new process instance of the already-deployed
+   * process) with its own agent instance, and a single history item on it with the given lease.
+   * Used as a control case to prove an operation scoped to one job does not affect another.
+   */
+  private static long createUnrelatedJobHistoryItem(final String jobLease) {
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var serviceTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst();
+    final long elementInstanceKey = serviceTaskInstance.getKey();
+
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final long jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    return createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, jobLease);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardOnJobDestructionTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies that destroying an agentic job (cancel / caught throw-error) emits {@code
+ * AGENT_HISTORY:DISCARD} for the job, so its pending items reach {@code DISCARDED} instead of
+ * leaking as {@code PENDING} forever. Non-agentic job destruction must not emit a discard.
+ */
+public class AgentHistoryDiscardOnJobDestructionTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String SERVICE_TASK_ID = "agent-task";
+  private static final String BOUNDARY_ID = "error-boundary";
+  private static final String ERROR_CODE = "boom";
+  private static final String AGENTIC_JOB_TYPE =
+      JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+  private static final String PLAIN_JOB_TYPE = "plain-service-task";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDiscardPendingItemsWhenAgenticJobCanceledByProcessInstanceCancellation() {
+    // given
+    final var fixture =
+        deployActivateAndCreatePendingItem(process(AGENTIC_JOB_TYPE), AGENTIC_JOB_TYPE);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(fixture.processInstanceKey).cancel();
+
+    // then
+    assertItemDiscarded(fixture.jobKey, fixture.itemKey);
+  }
+
+  @Test
+  public void shouldDiscardPendingItemsWhenAgenticJobCanceledByCancelCommand() {
+    // given
+    final var fixture =
+        deployActivateAndCreatePendingItem(process(AGENTIC_JOB_TYPE), AGENTIC_JOB_TYPE);
+
+    // when — explicit JOB:CANCEL command (JobCancelProcessor path)
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .key(fixture.jobKey)
+            .job(JobIntent.CANCEL, new JobRecord().setType(AGENTIC_JOB_TYPE)));
+
+    // then
+    assertItemDiscarded(fixture.jobKey, fixture.itemKey);
+  }
+
+  @Test
+  public void shouldDiscardPendingItemsWhenAgenticJobThrowsCaughtError() {
+    // given
+    final var fixture =
+        deployActivateAndCreatePendingItem(
+            processWithErrorBoundary(AGENTIC_JOB_TYPE), AGENTIC_JOB_TYPE);
+
+    // when — error is caught by the boundary event, so the job is deleted without completing
+    ENGINE
+        .job()
+        .ofInstance(fixture.processInstanceKey)
+        .withType(AGENTIC_JOB_TYPE)
+        .withErrorCode(ERROR_CODE)
+        .throwError();
+
+    // then
+    assertItemDiscarded(fixture.jobKey, fixture.itemKey);
+  }
+
+  @Test
+  public void shouldNotDiscardWhenNonAgenticJobIsCanceled() {
+    // given
+    final var fixture = deployActivateAndCreatePendingItem(process(PLAIN_JOB_TYPE), PLAIN_JOB_TYPE);
+
+    // when
+    ENGINE.processInstance().withInstanceKey(fixture.processInstanceKey).cancel();
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // then — the job is canceled but no discard is emitted for this non-agentic job. Scope by
+    // jobKey so residual async records from other tests on the shared engine cannot interfere.
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .filter(r -> r.getIntent() == AgentHistoryIntent.DISCARD)
+                .filter(r -> ((AgentHistoryRecordValue) r.getValue()).getJobKey() == fixture.jobKey)
+                .exists())
+        .isFalse();
+  }
+
+  private void assertItemDiscarded(final long jobKey, final long itemKey) {
+    // the DISCARD follow-up command is emitted for the destroyed job
+    final var discardCommand =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARD)
+            .onlyCommands()
+            .withJobKey(jobKey)
+            .getFirst();
+    assertThat(discardCommand.getRecordType()).isEqualTo(RecordType.COMMAND);
+    assertThat(discardCommand.getValue().getJobLease()).isEmpty();
+
+    // and the pending item is discarded
+    final var discarded =
+        RecordingExporter.agentHistoryRecords(AgentHistoryIntent.DISCARDED)
+            .withRecordKey(itemKey)
+            .getFirst();
+    assertThat(discarded.getKey()).isEqualTo(itemKey);
+    assertThat(discarded.getValue().getJobKey()).isEqualTo(jobKey);
+  }
+
+  // --- fixture / helpers ---
+
+  private static BpmnModelInstance process(final String jobType) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(jobType))
+        .endEvent()
+        .done();
+  }
+
+  private static BpmnModelInstance processWithErrorBoundary(final String jobType) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(jobType))
+        .boundaryEvent(BOUNDARY_ID, b -> b.error(ERROR_CODE))
+        .endEvent()
+        .moveToActivity(SERVICE_TASK_ID)
+        .endEvent()
+        .done();
+  }
+
+  private Fixture deployActivateAndCreatePendingItem(
+      final BpmnModelInstance model, final String jobType) {
+    ENGINE.deployment().withXmlResource(model).deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var serviceTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst();
+    final long elementInstanceKey = serviceTaskInstance.getKey();
+
+    ENGINE.jobs().withType(jobType).activate();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(jobType)
+            .getFirst()
+            .getKey();
+
+    final long agentInstanceKey =
+        ENGINE
+            .agentInstances()
+            .withElementInstanceKey(elementInstanceKey)
+            .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+            .create()
+            .getKey();
+
+    final long itemKey =
+        ENGINE
+            .agentHistories()
+            .withAgentInstanceKey(agentInstanceKey)
+            .withJobKey(jobKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withRole(AgentHistoryRole.USER)
+            .create()
+            .getKey();
+
+    return new Fixture(processInstanceKey, elementInstanceKey, jobKey, itemKey);
+  }
+
+  private record Fixture(
+      long processInstanceKey, long elementInstanceKey, long jobKey, long itemKey) {}
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.agenthistory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AgentHistoryDiscardTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String SERVICE_TASK_ID = "agent-task";
+  private static final String JOB_TYPE = JobRecord.IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX;
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDiscardAllItemsForJobKeyOnEmptyLease() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    // Two items share jobKey but have different leases — DISCARD with no lease must discard both
+    // regardless of lease.
+    final long firstItemKey =
+        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-a");
+    final long secondItemKey =
+        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-b");
+
+    // An item on an unrelated job must not be discarded.
+    createUnrelatedJobHistoryItem("");
+
+    final var firstDiscarded = ENGINE.agentHistories().withJobKey(jobKey).discard();
+    final long discardPosition = firstDiscarded.getSourceRecordPosition();
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.DISCARDED)
+                .filter(r -> r.getSourceRecordPosition() == discardPosition)
+                .map(Record::getKey))
+        .containsExactlyInAnyOrder(firstItemKey, secondItemKey);
+  }
+
+  @Test
+  public void shouldDiscardOnlyMatchingLeaseOnLeaseBasedDiscard() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    final long lease1ItemKey =
+        createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-1");
+    createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "lease-2");
+    createUnrelatedJobHistoryItem("lease-1");
+
+    final var firstDiscarded =
+        ENGINE.agentHistories().withJobKey(jobKey).withJobLease("lease-1").discard();
+    final long discardPosition = firstDiscarded.getSourceRecordPosition();
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    // Only the matching-lease item is discarded; the superseding lease-2 item and the unrelated
+    // job's item are left untouched.
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.DISCARDED)
+                .filter(r -> r.getSourceRecordPosition() == discardPosition)
+                .map(Record::getKey))
+        .containsExactly(lease1ItemKey);
+  }
+
+  @Test
+  public void shouldEmitDiscardedEventCarryingStoredRecord() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+    final long itemKey = createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, "");
+
+    final var discarded = ENGINE.agentHistories().withJobKey(jobKey).discard();
+
+    assertThat(discarded.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(discarded.getKey()).isEqualTo(itemKey);
+    assertThat(discarded.getValue().getJobKey()).isEqualTo(jobKey);
+    assertThat(discarded.getValue().getAgentInstanceKey()).isEqualTo(agentInstanceKey);
+    assertThat(discarded.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+  }
+
+  @Test
+  public void shouldNotEmitAnyEventWhenNoItemsExistForJobKey() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    // No CREATED items for the job — DISCARD must be a no-op. The client helper would block
+    // waiting for a follow-up event, which a no-op never produces, so write the command directly.
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .key(jobKey)
+            .agentHistory(AgentHistoryIntent.DISCARD, new AgentHistoryRecord().setJobKey(jobKey)));
+    final long clockResetKey = ENGINE.clock().reset().getKey();
+
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getKey() == clockResetKey)
+                .withValueType(ValueType.AGENT_HISTORY)
+                .withIntent(AgentHistoryIntent.DISCARDED)
+                .exists())
+        .isFalse();
+  }
+
+  // --- helpers ---
+
+  private static Record<ProcessInstanceRecordValue> deployAndCreateProcessInstance() {
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent()
+                .done())
+        .deploy();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.SERVICE_TASK)
+        .withElementId(SERVICE_TASK_ID)
+        .getFirst();
+  }
+
+  private static long activateJobForProcessInstance(final long processInstanceKey) {
+    ENGINE.jobs().withType(JOB_TYPE).activate();
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(JOB_TYPE)
+        .getFirst()
+        .getKey();
+  }
+
+  private static Record<?> createAgentInstance(final long elementInstanceKey) {
+    return ENGINE
+        .agentInstances()
+        .withElementInstanceKey(elementInstanceKey)
+        .withDefinition("gpt-4o", "openai", "You are a helpful agent.")
+        .create();
+  }
+
+  private static long createHistoryItem(
+      final long agentInstanceKey,
+      final long jobKey,
+      final long elementInstanceKey,
+      final String jobLease) {
+    return ENGINE
+        .agentHistories()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withJobKey(jobKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withJobLease(jobLease)
+        .withRole(AgentHistoryRole.USER)
+        .create()
+        .getKey();
+  }
+
+  /**
+   * Creates a second, unrelated agentic job (a new process instance of the already-deployed
+   * process) with its own agent instance, and a single history item on it with the given lease.
+   * Used as a control case to prove an operation scoped to one job does not affect another.
+   */
+  private static long createUnrelatedJobHistoryItem(final String jobLease) {
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var serviceTaskInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withElementId(SERVICE_TASK_ID)
+            .getFirst();
+    final long elementInstanceKey = serviceTaskInstance.getKey();
+
+    final long agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final long jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    return createHistoryItem(agentInstanceKey, jobKey, elementInstanceKey, jobLease);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
@@ -35,7 +35,9 @@ public final class AgentHistoryClient {
                   .withSourceRecordPosition(position)
                   .getFirst();
 
-  private static final Function<Long, Record<AgentHistoryRecordValue>> COMMIT_EXPECTATION =
+  // Shared by commit() and discard(): both wait for the first follow-up event (COMMITTED or
+  // DISCARDED) at the command's source position.
+  private static final Function<Long, Record<AgentHistoryRecordValue>> FOLLOW_UP_EVENT_EXPECTATION =
       (position) ->
           RecordingExporter.agentHistoryRecords()
               .onlyEvents()
@@ -115,6 +117,11 @@ public final class AgentHistoryClient {
 
   public Record<AgentHistoryRecordValue> commit() {
     final long position = writer.writeCommand(AgentHistoryIntent.COMMIT, record);
-    return COMMIT_EXPECTATION.apply(position);
+    return FOLLOW_UP_EVENT_EXPECTATION.apply(position);
+  }
+
+  public Record<AgentHistoryRecordValue> discard() {
+    final long position = writer.writeCommand(AgentHistoryIntent.DISCARD, record);
+    return FOLLOW_UP_EVENT_EXPECTATION.apply(position);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -87,8 +87,8 @@ final class AgentHistoryHandlerTest {
   @ParameterizedTest(name = "[{index}] Should populate all entity fields for ''{0}'' intent")
   @EnumSource(
       value = AgentHistoryIntent.class,
-      names = {"CREATED", "COMMITTED", "DISCARDED"},
-      mode = Mode.INCLUDE)
+      names = {"CREATE", "COMMIT", "DISCARD"},
+      mode = Mode.EXCLUDE)
   void shouldUpdateEntityForAllHandledIntents(final AgentHistoryIntent intent) {
     // given — updateEntity() must populate ALL fields for every handled intent; the partial update
     // (commitStatus-only) is an artefact of flush(), not of updateEntity().
@@ -280,8 +280,8 @@ final class AgentHistoryHandlerTest {
   @ParameterizedTest(name = "[{index}] Intent ''{0}'' should map to the expected commitStatus")
   @EnumSource(
       value = AgentHistoryIntent.class,
-      names = {"CREATED", "COMMITTED", "DISCARDED"},
-      mode = Mode.INCLUDE)
+      names = {"CREATE", "COMMIT", "DISCARD"},
+      mode = Mode.EXCLUDE)
   void shouldMapIntentToExpectedCommitStatus(final AgentHistoryIntent intent) {
     // given
     final Record<AgentHistoryRecordValue> record =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -87,8 +87,8 @@ final class AgentHistoryHandlerTest {
   @ParameterizedTest(name = "[{index}] Should populate all entity fields for ''{0}'' intent")
   @EnumSource(
       value = AgentHistoryIntent.class,
-      names = {"CREATE", "COMMIT"},
-      mode = Mode.EXCLUDE)
+      names = {"CREATED", "COMMITTED", "DISCARDED"},
+      mode = Mode.INCLUDE)
   void shouldUpdateEntityForAllHandledIntents(final AgentHistoryIntent intent) {
     // given — updateEntity() must populate ALL fields for every handled intent; the partial update
     // (commitStatus-only) is an artefact of flush(), not of updateEntity().
@@ -280,8 +280,8 @@ final class AgentHistoryHandlerTest {
   @ParameterizedTest(name = "[{index}] Intent ''{0}'' should map to the expected commitStatus")
   @EnumSource(
       value = AgentHistoryIntent.class,
-      names = {"CREATE", "COMMIT"},
-      mode = Mode.EXCLUDE)
+      names = {"CREATED", "COMMITTED", "DISCARDED"},
+      mode = Mode.INCLUDE)
   void shouldMapIntentToExpectedCommitStatus(final AgentHistoryIntent intent) {
     // given
     final Record<AgentHistoryRecordValue> record =

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -252,5 +253,9 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   @Override
   public AgentHistoryMetrics getMetrics() {
     return metricsProp.getValue();
+  }
+
+  public AgentHistoryRecord ignoreLease() {
+    return setJobLease(JobRecord.EMPTY_LEASE);
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -51,6 +51,14 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   public static final String IO_CAMUNDA_AI_AGENT_JOB_WORKER_TYPE_PREFIX =
       "io.camunda.agenticai:aiagent";
 
+  /**
+   * Sentinel lease token that does not scope to a specific job activation, meaning "apply to every
+   * activation of this job". Used to signal "the whole job is gone" — e.g. when discarding agent
+   * history for a destroyed job, an empty lease discards all items for the job regardless of which
+   * activation produced them.
+   */
+  public static final String EMPTY_LEASE = "";
+
   public static final DirectBuffer NO_HEADERS = new UnsafeBuffer(MsgPackHelper.EMTPY_OBJECT);
   public static final String RETRIES = "retries";
   public static final String TIMEOUT = "timeout";

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentHistoryIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AgentHistoryIntent.java
@@ -20,7 +20,8 @@ public enum AgentHistoryIntent implements Intent {
   CREATED((short) 1, true),
   COMMIT((short) 2, false),
   COMMITTED((short) 3, true),
-  DISCARDED((short) 4, true);
+  DISCARD((short) 4, false),
+  DISCARDED((short) 5, true);
 
   private final short value;
   private final boolean isEvent;
@@ -51,6 +52,8 @@ public enum AgentHistoryIntent implements Intent {
       case 3:
         return COMMITTED;
       case 4:
+        return DISCARD;
+      case 5:
         return DISCARDED;
       default:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AgentHistoryRecordValue.java
@@ -61,7 +61,13 @@ public interface AgentHistoryRecordValue extends RecordValue, TenantOwned, Proce
   /** Returns the key of the job that triggered the agent for this entry. */
   long getJobKey();
 
-  /** Returns the job lease token identifying which job activation produced this history entry. */
+  /**
+   * Returns the job lease token identifying which job activation produced this history entry.
+   *
+   * <p>An empty string means the entry is not scoped to a specific activation and applies to
+   * <b>all</b> pending items of the job, whereas a non-empty lease scopes it to the single
+   * activation holding that lease.
+   */
   String getJobLease();
 
   /** Returns the iteration counter (conversation round with the LLM). */


### PR DESCRIPTION
## Summary

Adds the discard side of the pending-commit lifecycle: every `AGENT_HISTORY` item is created `PENDING` and must reach `COMMITTED` or `DISCARDED` (both appliers delete the item from primary storage). Before this change, an agentic job destroyed without completing left its pending items with no terminal event — a permanent primary-storage leak that shows in secondary storage / Operate as `PENDING` forever.

### What changed

- **`AgentHistoryIntent`**: adds the `DISCARD` command intent at ordinal `5` (`isEvent=false`), mirroring the existing `COMMIT`/`COMMITTED`/`DISCARDED` intents already delivered.
- **`AgentHistoryDiscardProcessor`** (new): handles `AGENT_HISTORY:DISCARD`, mirroring `AgentHistoryCommitProcessor`'s lease handling:
  - empty `jobLease` → `visitByJobKey`, discards **all** items for the job (the whole job is gone, every activation's items are dead);
  - non-empty `jobLease` → `visitByJobLease`, discards only that lease's items (supersession).
  - No-op when no items exist for the `jobKey` — non-agentic jobs are unaffected.
- **`JobRecord.EMPTY_LEASE`** (new constant): sentinel for "no specific activation" — used at every destruction emit site instead of a literal `""`, with a comment explaining why the lease is intentionally empty there.
- **Emit sites**, all guarded by `job.isAgentic()`:
  - `JobCancelProcessor` and `BpmnJobBehavior.writeJobCanceled` — the two `CANCELED` emit sites (explicit cancel command; process-instance cancellation / element termination). `CANCELABLE_STATES` also covers jobs terminated while in `FAILED` or `ERROR_THROWN`.
  - `JobThrowErrorProcessor` — the caught-error branch only (job deleted inline, flow continues at the catch event); the uncaught/incident branch does **not** delete the job and correctly gets no discard.
  - `ProcessInstanceMigrationUserTaskBehavior` — its direct `CANCELED` emit. Today the migrated job is always a user-task job (never agentic), so this is a no-op; added to future-proof job-worker user tasks that might carry an associated agent instance. No refactor of this class.

### Deliberately out of scope

- `TIMED_OUT` is **not** a discard site: `timeout()` returns the job to `ACTIVATABLE` with the lease retained, so the timed-out activation can still legitimately complete — discarding here risks deleting items that are later committed.
- Lease-scoped discard on `FAILED`/re-activation (eager supersession discard) is tracked separately in #56706 as a timeliness optimization; it is not required for correctness since the lease-aware `COMMIT` already discards superseded-lease items at completion.

## Test plan

- `AgentHistoryDiscardTest` — unit tests for `AgentHistoryDiscardProcessor`: empty-lease discards all items for the job (other jobs untouched), lease-scoped discard touches only the matching lease, the `DISCARDED` event carries the stored record, no-op when no items exist.
- `AgentHistoryDiscardOnJobDestructionTest` — integration test asserting a `DISCARD` is emitted and pending items reach `DISCARDED` for all three destruction paths (process-instance cancellation, explicit cancel command, caught throw-error), plus the negative case that a non-agentic job emits none.
- `AgentHistoryCommitLifecycleIT` — extended with an end-to-end case: activate an agentic job, create pending history items, cancel the process instance, assert the items transition `PENDING` → `DISCARDED` via the Camunda client. Shared setup/assertion helpers extracted and reused by the existing commit-lifecycle case.
- Regression: `AgentHistoryCommitTest`, `AgentHistoryCreateTest`, `JobThrowErrorTest`, `MigrateUserTaskTest`, `CancelProcessInstanceTest`, `IntentEncodingDecodingTest` — all green.

## Related issues

- Parent: #55033
- Closes #56163
- Depends on: #56161 / PR #56308, #56162 / PR #56543
- Related (not required for this issue): #56706

🤖 Generated with [Claude Code](https://claude.com/claude-code)