### PR TITLE
fix: give each Optimize import mediator its own independent scheduler thread

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/EmbeddedOptimizeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/EmbeddedOptimizeExtension.java
@@ -26,6 +26,7 @@ import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.importing.AbstractImportScheduler;
 import io.camunda.optimize.service.importing.ImportIndexHandlerRegistry;
+import io.camunda.optimize.service.importing.ImportMediator;
 import io.camunda.optimize.service.importing.ImportSchedulerManagerService;
 import io.camunda.optimize.service.importing.PositionBasedImportIndexHandler;
 import io.camunda.optimize.service.importing.ingested.mediator.StoreIngestedImportProgressMediator;
@@ -171,12 +172,16 @@ public class EmbeddedOptimizeExtension
   }
 
   public void importAllZeebeEntitiesFromLastIndex() {
+    final List<CompletableFuture<Void>> importFutures =
+        getImportSchedulerManager()
+            .getZeebeImportScheduler()
+            .orElseThrow(() -> new OptimizeIntegrationTestException("No Zeebe Scheduler present"))
+            .getImportMediators()
+            .stream()
+            .map(ImportMediator::runImport)
+            .toList();
     try {
-      getImportSchedulerManager()
-          .getZeebeImportScheduler()
-          .orElseThrow(() -> new OptimizeIntegrationTestException("No Zeebe Scheduler present"))
-          .runImportRound(true)
-          .get();
+      CompletableFuture.allOf(importFutures.toArray(new CompletableFuture[0])).get();
     } catch (final InterruptedException | ExecutionException e) {
       throw new OptimizeRuntimeException(e);
     }

--- a/optimize/backend/src/main/java/io/camunda/optimize/MetricEnum.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/MetricEnum.java
@@ -16,10 +16,6 @@ public enum MetricEnum {
       MetricType.IMPORT,
       "indexingDuration",
       "Records the time spent indexing data from Zeebe into Optimize Elasticsearch indexes"),
-  IMPORT_RECORDS_IMPORTED_METRIC(
-      MetricType.IMPORT,
-      "importedRecordsCount",
-      "Counts Zeebe records successfully written to Optimize per import mediator"),
   IMPORT_CYCLE_DURATION_METRIC(
       MetricType.IMPORT,
       "cycleDuration",

--- a/optimize/backend/src/main/java/io/camunda/optimize/MetricEnum.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/MetricEnum.java
@@ -16,6 +16,18 @@ public enum MetricEnum {
       MetricType.IMPORT,
       "indexingDuration",
       "Records the time spent indexing data from Zeebe into Optimize Elasticsearch indexes"),
+  IMPORT_RECORDS_IMPORTED_METRIC(
+      MetricType.IMPORT,
+      "importedRecordsCount",
+      "Counts Zeebe records successfully written to Optimize per import mediator"),
+  IMPORT_CYCLE_DURATION_METRIC(
+      MetricType.IMPORT,
+      "cycleDuration",
+      "Records the total import cycle time (ES fetch + DB write) per mediator"),
+  IMPORT_MEDIATOR_ERROR_METRIC(
+      MetricType.IMPORT,
+      "mediatorErrors",
+      "Counts import errors per mediator, tagged with record type and partition"),
   NEW_PAGE_FETCH_TIME_METRIC(
       MetricType.IMPORT,
       "newPageFetchTime",

--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeMetrics.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeMetrics.java
@@ -66,6 +66,15 @@ public final class OptimizeMetrics {
         .register(Metrics.globalRegistry);
   }
 
+  public static Counter getCounter(
+      final MetricEnum metric, final String recordType, final Integer partitionId) {
+    return Counter.builder(metric.getName())
+        .description(metric.getDescription())
+        .tag(RECORD_TYPE_TAG, recordType)
+        .tag(PARTITION_ID_TAG, String.valueOf(partitionId))
+        .register(Metrics.globalRegistry);
+  }
+
   /**
    * Registers a timer with the given metric definition and tags. Timers are used to track the
    * duration and frequency of events.

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/AbstractImportScheduler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/AbstractImportScheduler.java
@@ -8,24 +8,21 @@
 package io.camunda.optimize.service.importing;
 
 import io.camunda.optimize.dto.optimize.SchedulerConfig;
-import io.camunda.optimize.service.AbstractScheduledService;
-import java.time.Duration;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
-import org.springframework.scheduling.Trigger;
-import org.springframework.scheduling.support.PeriodicTrigger;
 
-public abstract class AbstractImportScheduler<T extends SchedulerConfig>
-    extends AbstractScheduledService {
+public abstract class AbstractImportScheduler<T extends SchedulerConfig> {
 
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(AbstractImportScheduler.class);
+
   protected final List<ImportMediator> importMediators;
   protected final T dataImportSourceDto;
-  protected volatile boolean isImporting = false;
+  private volatile ScheduledExecutorService mediatorExecutor;
 
   public AbstractImportScheduler(
       final List<ImportMediator> importMediators, final T dataImportSourceDto) {
@@ -33,124 +30,85 @@ public abstract class AbstractImportScheduler<T extends SchedulerConfig>
     this.dataImportSourceDto = dataImportSourceDto;
   }
 
-  @Override
-  public void run() {
-    if (isScheduledToRun()) {
-      LOG.debug("Next round!");
-      try {
-        runImportRound();
-      } catch (final Exception e) {
-        LOG.error("Could not schedule next import round!", e);
-      }
-    }
-  }
-
-  @Override
-  protected Trigger createScheduleTrigger() {
-    return new PeriodicTrigger(Duration.ZERO);
-  }
-
   public synchronized void startImportScheduling() {
     LOG.info("Start scheduling import from {}.", dataImportSourceDto);
-    isImporting = true;
-    startScheduling();
+    if (mediatorExecutor == null || mediatorExecutor.isShutdown()) {
+      final int poolSize = Math.max(1, importMediators.size());
+      mediatorExecutor =
+          Executors.newScheduledThreadPool(
+              poolSize,
+              r -> {
+                final Thread t = new Thread(r, getClass().getSimpleName() + "-importer");
+                t.setDaemon(true);
+                return t;
+              });
+      importMediators.forEach(this::submitMediatorRun);
+    }
   }
 
   public synchronized void stopImportScheduling() {
     LOG.info("Stop scheduling import from {}.", dataImportSourceDto);
-    isImporting = false;
-    stopScheduling();
+    if (mediatorExecutor != null) {
+      mediatorExecutor.shutdown();
+    }
   }
 
   public void shutdown() {
     LOG.debug("Scheduler for {} will shutdown.", dataImportSourceDto);
-    getImportMediators().forEach(ImportMediator::shutdown);
-  }
-
-  public Future<Void> runImportRound() {
-    return runImportRound(false);
-  }
-
-  public Future<Void> runImportRound(final boolean forceImport) {
-    final List<ImportMediator> currentImportRound =
-        importMediators.stream()
-            .filter(mediator -> forceImport || mediator.canImport())
-            .collect(Collectors.toList());
-    if (nothingToBeImported(currentImportRound)) {
-      isImporting = false;
-      if (!forceImport) {
-        doBackoff();
-      }
-      return CompletableFuture.completedFuture(null);
-    } else {
-      isImporting = true;
-      return executeImportRound(currentImportRound);
-    }
-  }
-
-  public Future<Void> executeImportRound(final List<ImportMediator> currentImportRound) {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(
-          "Scheduling import round for {}",
-          currentImportRound.stream()
-              .map(mediator1 -> mediator1.getClass().getSimpleName())
-              .collect(Collectors.joining(",")));
-    }
-
-    final CompletableFuture<?>[] importTaskFutures =
-        currentImportRound.stream()
-            .map(
-                mediator -> {
-                  try {
-                    return mediator.runImport();
-                  } catch (final IllegalStateException e) {
-                    LOG.warn("Got into illegal state, will abort import round.", e);
-                    throw e;
-                  } catch (final Exception e) {
-                    LOG.error(
-                        "Was not able to execute import of [{}]",
-                        mediator.getClass().getSimpleName(),
-                        e);
-                    return CompletableFuture.completedFuture(null);
-                  }
-                })
-            .toArray(CompletableFuture[]::new);
-
-    return CompletableFuture.allOf(importTaskFutures);
+    importMediators.forEach(ImportMediator::shutdown);
   }
 
   public boolean isImporting() {
-    return isImporting || hasActiveImportJobs();
+    return (mediatorExecutor != null && !mediatorExecutor.isShutdown())
+        || importMediators.stream().anyMatch(ImportMediator::hasPendingImportJobs);
   }
 
   public List<ImportMediator> getImportMediators() {
     return importMediators;
   }
 
-  protected boolean hasActiveImportJobs() {
-    return importMediators.stream().anyMatch(ImportMediator::hasPendingImportJobs);
+  public T getDataImportSourceDto() {
+    return dataImportSourceDto;
   }
 
-  protected boolean nothingToBeImported(final List<?> currentImportRound) {
-    return currentImportRound.isEmpty();
-  }
-
-  protected void doBackoff() {
-    final long timeToSleep =
-        importMediators.stream()
-            .map(ImportMediator::getBackoffTimeInMs)
-            .min(Long::compare)
-            .orElse(5000L);
+  private void submitMediatorRun(final ImportMediator mediator) {
+    if (mediatorExecutor == null || mediatorExecutor.isShutdown()) {
+      return;
+    }
     try {
-      LOG.debug("No imports to schedule. Scheduler is sleeping for [{}] ms.", timeToSleep);
-      Thread.sleep(timeToSleep);
-    } catch (final InterruptedException e) {
-      LOG.error("Scheduler was interrupted while sleeping.", e);
-      Thread.currentThread().interrupt();
+      mediatorExecutor.submit(() -> runMediatorAndReschedule(mediator));
+    } catch (final RejectedExecutionException e) {
+      LOG.debug(
+          "Mediator {} not submitted, executor is shutting down.",
+          mediator.getClass().getSimpleName());
     }
   }
 
-  public T getDataImportSourceDto() {
-    return dataImportSourceDto;
+  private void runMediatorAndReschedule(final ImportMediator mediator) {
+    try {
+      mediator.runImport();
+    } catch (final Exception e) {
+      LOG.error("Was not able to execute import of [{}]", mediator.getClass().getSimpleName(), e);
+    }
+    rescheduleMediator(mediator);
+  }
+
+  private void rescheduleMediator(final ImportMediator mediator) {
+    if (mediatorExecutor == null || mediatorExecutor.isShutdown()) {
+      return;
+    }
+    final long delayMs = mediator.getBackoffTimeInMs();
+    try {
+      if (delayMs <= 0) {
+        mediatorExecutor.submit(() -> runMediatorAndReschedule(mediator));
+      } else {
+        mediatorExecutor.schedule(
+            () -> runMediatorAndReschedule(mediator), delayMs, TimeUnit.MILLISECONDS);
+      }
+    } catch (final RejectedExecutionException e) {
+      LOG.debug(
+          "Mediator {} not rescheduled, executor is shutting down.",
+          mediator.getClass().getSimpleName());
+    }
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/AbstractImportScheduler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/AbstractImportScheduler.java
@@ -41,7 +41,8 @@ public abstract class AbstractImportScheduler<T extends SchedulerConfig> {
           Executors.newScheduledThreadPool(
               importMediators.size(),
               r -> {
-                final Thread t = new Thread(r, getClass().getSimpleName() + "-importer");
+                final Thread t = new Thread(r);
+                t.setName(getClass().getSimpleName() + "-importer-" + t.getId());
                 t.setDaemon(true);
                 return t;
               });

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/AbstractImportScheduler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/AbstractImportScheduler.java
@@ -91,7 +91,18 @@ public abstract class AbstractImportScheduler<T extends SchedulerConfig> {
 
   private void runMediatorAndReschedule(final ImportMediator mediator) {
     try {
+      if (!mediator.canImport()) {
+        rescheduleMediator(mediator);
+        return;
+      }
       final CompletableFuture<Void> importFuture = mediator.runImport();
+      if (importFuture == null) {
+        LOG.error(
+            "Import of [{}] returned a null future, skipping this round.",
+            mediator.getClass().getSimpleName());
+        rescheduleMediator(mediator);
+        return;
+      }
       importFuture.whenComplete(
           (result, throwable) -> {
             if (throwable != null) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/AbstractImportScheduler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/AbstractImportScheduler.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service.importing;
 
 import io.camunda.optimize.dto.optimize.SchedulerConfig;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -90,11 +91,21 @@ public abstract class AbstractImportScheduler<T extends SchedulerConfig> {
 
   private void runMediatorAndReschedule(final ImportMediator mediator) {
     try {
-      mediator.runImport();
+      final CompletableFuture<Void> importFuture = mediator.runImport();
+      importFuture.whenComplete(
+          (result, throwable) -> {
+            if (throwable != null) {
+              LOG.error(
+                  "Was not able to execute import of [{}]",
+                  mediator.getClass().getSimpleName(),
+                  throwable);
+            }
+            rescheduleMediator(mediator);
+          });
     } catch (final Exception e) {
       LOG.error("Was not able to execute import of [{}]", mediator.getClass().getSimpleName(), e);
+      rescheduleMediator(mediator);
     }
-    rescheduleMediator(mediator);
   }
 
   private void rescheduleMediator(final ImportMediator mediator) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/AbstractImportScheduler.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/AbstractImportScheduler.java
@@ -32,11 +32,13 @@ public abstract class AbstractImportScheduler<T extends SchedulerConfig> {
 
   public synchronized void startImportScheduling() {
     LOG.info("Start scheduling import from {}.", dataImportSourceDto);
+    if (importMediators.isEmpty()) {
+      return;
+    }
     if (mediatorExecutor == null || mediatorExecutor.isShutdown()) {
-      final int poolSize = Math.max(1, importMediators.size());
       mediatorExecutor =
           Executors.newScheduledThreadPool(
-              poolSize,
+              importMediators.size(),
               r -> {
                 final Thread t = new Thread(r, getClass().getSimpleName() + "-importer");
                 t.setDaemon(true);
@@ -49,7 +51,9 @@ public abstract class AbstractImportScheduler<T extends SchedulerConfig> {
   public synchronized void stopImportScheduling() {
     LOG.info("Stop scheduling import from {}.", dataImportSourceDto);
     if (mediatorExecutor != null) {
-      mediatorExecutor.shutdown();
+      // shutdownNow (rather than shutdown) cancels already-scheduled backoff-delayed reschedule
+      // tasks so a stopped scheduler cannot keep running mediators in the background.
+      mediatorExecutor.shutdownNow();
     }
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/PositionBasedImportMediator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/PositionBasedImportMediator.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.optimize.service.importing;
 
+import static io.camunda.optimize.MetricEnum.IMPORT_CYCLE_DURATION_METRIC;
+import static io.camunda.optimize.MetricEnum.IMPORT_MEDIATOR_ERROR_METRIC;
+import static io.camunda.optimize.MetricEnum.IMPORT_RECORDS_IMPORTED_METRIC;
 import static io.camunda.optimize.MetricEnum.INDEXING_DURATION_METRIC;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -16,6 +19,7 @@ import io.camunda.optimize.service.importing.engine.service.ImportService;
 import io.camunda.optimize.service.security.util.LocalDateUtil;
 import io.camunda.optimize.service.util.BackoffCalculator;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Timer;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -39,10 +43,18 @@ public abstract class PositionBasedImportMediator<
   @Override
   public CompletableFuture<Void> runImport() {
     final CompletableFuture<Void> importCompleted = new CompletableFuture<>();
+    final Timer.Sample cycleSample = Timer.start(Metrics.globalRegistry);
+    importCompleted.whenComplete(
+        (result, throwable) ->
+            cycleSample.stop(
+                OptimizeMetrics.getTimer(
+                    IMPORT_CYCLE_DURATION_METRIC, getRecordType(), getPartitionId())));
     boolean pageIsPresent;
     try {
       pageIsPresent = importNextPage(() -> importCompleted.complete(null));
     } catch (final Exception e) {
+      OptimizeMetrics.getCounter(IMPORT_MEDIATOR_ERROR_METRIC, getRecordType(), getPartitionId())
+          .increment();
       logger.error("Was not able to import next page, skipping this round.", e);
       importCompleted.complete(null);
       pageIsPresent = false;
@@ -111,6 +123,10 @@ public abstract class PositionBasedImportMediator<
                 endTime.toInstant().toEpochMilli() - startTime.toInstant().toEpochMilli();
             final Timer indexingDurationTimer = getIndexingDurationTimer();
             indexingDurationTimer.record(took, MILLISECONDS);
+
+            OptimizeMetrics.getCounter(
+                    IMPORT_RECORDS_IMPORTED_METRIC, getRecordType(), getPartitionId())
+                .increment(entitiesNextPage.size());
 
             importIndexHandler.updateLastPersistedEntityPositionAndSequence(
                 currentPageLastEntityPosition, currentPageLastEntitySequence);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/PositionBasedImportMediator.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/PositionBasedImportMediator.java
@@ -9,7 +9,6 @@ package io.camunda.optimize.service.importing;
 
 import static io.camunda.optimize.MetricEnum.IMPORT_CYCLE_DURATION_METRIC;
 import static io.camunda.optimize.MetricEnum.IMPORT_MEDIATOR_ERROR_METRIC;
-import static io.camunda.optimize.MetricEnum.IMPORT_RECORDS_IMPORTED_METRIC;
 import static io.camunda.optimize.MetricEnum.INDEXING_DURATION_METRIC;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -123,10 +122,6 @@ public abstract class PositionBasedImportMediator<
                 endTime.toInstant().toEpochMilli() - startTime.toInstant().toEpochMilli();
             final Timer indexingDurationTimer = getIndexingDurationTimer();
             indexingDurationTimer.record(took, MILLISECONDS);
-
-            OptimizeMetrics.getCounter(
-                    IMPORT_RECORDS_IMPORTED_METRIC, getRecordType(), getPartitionId())
-                .increment(entitiesNextPage.size());
 
             importIndexHandler.updateLastPersistedEntityPositionAndSequence(
                 currentPageLastEntityPosition, currentPageLastEntitySequence);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessInstanceSubEntityImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessInstanceSubEntityImportService.java
@@ -94,6 +94,11 @@ public abstract class ZeebeProcessInstanceSubEntityImportService<T> implements I
       final Long processInstanceId,
       final Long processDefinitionId,
       final String tenantId) {
+    if (processDefinitionKey == null || processDefinitionKey.isBlank()) {
+      throw new IllegalArgumentException(
+          "Expected Zeebe record for process instance [%s], process definition [%s], tenant [%s] to contain a bpmnProcessId, but it was missing."
+              .formatted(processInstanceId, processDefinitionId, tenantId));
+    }
     final ProcessInstanceDto processInstanceDto = new ProcessInstanceDto();
     processInstanceDto.setProcessDefinitionKey(processDefinitionKey);
     processInstanceDto.setProcessInstanceId(String.valueOf(processInstanceId));

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeVariableImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeVariableImportService.java
@@ -18,8 +18,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
-import io.camunda.optimize.dto.optimize.DefinitionOptimizeResponseDto;
-import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
 import io.camunda.optimize.dto.optimize.query.variable.ProcessVariableDto;
 import io.camunda.optimize.dto.optimize.query.variable.ProcessVariableUpdateDto;
@@ -29,7 +27,6 @@ import io.camunda.optimize.dto.zeebe.variable.ZeebeVariableRecordDto;
 import io.camunda.optimize.service.db.DatabaseClient;
 import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
 import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
-import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.importing.engine.service.ObjectVariableService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
@@ -101,34 +98,11 @@ public class ZeebeVariableImportService
     final ZeebeVariableDataDto firstRecordValue = recordsForInstance.get(0).getValue();
     final ProcessInstanceDto instanceToAdd =
         createSkeletonProcessInstance(
-            getBpmnProcessId(firstRecordValue),
+            firstRecordValue.getBpmnProcessId(),
             firstRecordValue.getProcessInstanceKey(),
             firstRecordValue.getProcessDefinitionKey(),
             firstRecordValue.getTenantId());
     return updateProcessVariables(instanceToAdd, recordsForInstance);
-  }
-
-  private String getBpmnProcessId(final ZeebeVariableDataDto zeebeVariableDataDto) {
-    return Optional.ofNullable(zeebeVariableDataDto.getBpmnProcessId())
-        .orElseGet(
-            () -> {
-              // Zeebe variable records older than 1.4.0 didn't contain the process ID, so we have
-              // to fetch it from the
-              // stored definition. We can remove this handling in future as part of:
-              // https://jira.camunda.com/browse/OPT-6065
-              final String processDefKey =
-                  String.valueOf(zeebeVariableDataDto.getProcessDefinitionKey());
-              final Optional<ProcessDefinitionOptimizeDto> processDefinition =
-                  processDefinitionReader.getProcessDefinition(processDefKey);
-              return processDefinition
-                  .map(DefinitionOptimizeResponseDto::getKey)
-                  .orElseThrow(
-                      () ->
-                          new OptimizeRuntimeException(
-                              "The process definition with id "
-                                  + processDefKey
-                                  + " has not yet been imported to Optimize"));
-            });
   }
 
   private ProcessInstanceDto updateProcessVariables(

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.ZeebeConfigDto;
+import io.camunda.optimize.service.importing.zeebe.ZeebeImportScheduler;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractImportSchedulerTest {
+
+  private ZeebeImportScheduler scheduler;
+
+  @AfterEach
+  void tearDown() {
+    if (scheduler != null) {
+      scheduler.stopImportScheduling();
+    }
+  }
+
+  @Test
+  void shouldRunSlowMediatorWithoutBlockingFastMediator() throws Exception {
+    // given
+    final CountDownLatch fastMediatorRan = new CountDownLatch(1);
+    final CountDownLatch releaseSlowMediator = new CountDownLatch(1);
+
+    final ImportMediator slowMediator = mock(ImportMediator.class);
+    final ImportMediator fastMediator = mock(ImportMediator.class);
+
+    // lenient: whether these get invoked before the test ends is a timing race against the
+    // background reschedule threads, not something this test asserts on.
+    lenient().when(slowMediator.getBackoffTimeInMs()).thenReturn(0L);
+    lenient().when(fastMediator.getBackoffTimeInMs()).thenReturn(0L);
+
+    when(slowMediator.runImport())
+        .thenAnswer(
+            inv -> {
+              releaseSlowMediator.await(5, TimeUnit.SECONDS);
+              return CompletableFuture.completedFuture(null);
+            });
+    when(fastMediator.runImport())
+        .thenAnswer(
+            inv -> {
+              fastMediatorRan.countDown();
+              return CompletableFuture.completedFuture(null);
+            });
+
+    scheduler =
+        new ZeebeImportScheduler(List.of(slowMediator, fastMediator), mock(ZeebeConfigDto.class));
+
+    // when
+    scheduler.startImportScheduling();
+
+    // then: fastMediator completes even though slowMediator is still blocked
+    assertThat(fastMediatorRan.await(2, TimeUnit.SECONDS))
+        .as("fast mediator should complete independently of the blocked slow mediator")
+        .isTrue();
+
+    releaseSlowMediator.countDown();
+  }
+
+  @Test
+  void shouldRescheduleMediatorAutomaticallyAfterCompletion() throws Exception {
+    // given
+    final int expectedRuns = 3;
+    final CountDownLatch runsCompleted = new CountDownLatch(expectedRuns);
+
+    final ImportMediator mediator = mock(ImportMediator.class);
+    when(mediator.getBackoffTimeInMs()).thenReturn(0L);
+    when(mediator.runImport())
+        .thenAnswer(
+            inv -> {
+              runsCompleted.countDown();
+              return CompletableFuture.completedFuture(null);
+            });
+
+    scheduler = new ZeebeImportScheduler(List.of(mediator), mock(ZeebeConfigDto.class));
+
+    // when
+    scheduler.startImportScheduling();
+
+    // then: mediator is invoked repeatedly without any external trigger
+    assertThat(runsCompleted.await(2, TimeUnit.SECONDS))
+        .as("mediator should be rescheduled and run at least " + expectedRuns + " times")
+        .isTrue();
+
+    verify(mediator, atLeast(expectedRuns)).runImport();
+  }
+
+  @Test
+  void shouldApplyMediatorBackoffBeforeRescheduling() throws Exception {
+    // given
+    final long backoffMs = 200L;
+    final AtomicInteger runCount = new AtomicInteger(0);
+    final AtomicInteger backoffCallCount = new AtomicInteger(0);
+    final CountDownLatch firstRunComplete = new CountDownLatch(1);
+
+    final ImportMediator mediator = mock(ImportMediator.class);
+    // return backoff on the first reschedule decision, 0 on subsequent ones. Tracked via a
+    // dedicated counter (rather than runCount) since getBackoffTimeInMs() is evaluated by the
+    // scheduler right after runImport() has already incremented runCount for that run.
+    when(mediator.getBackoffTimeInMs())
+        .thenAnswer(inv -> backoffCallCount.getAndIncrement() == 0 ? backoffMs : 0L);
+    when(mediator.runImport())
+        .thenAnswer(
+            inv -> {
+              runCount.incrementAndGet();
+              firstRunComplete.countDown();
+              return CompletableFuture.completedFuture(null);
+            });
+
+    scheduler = new ZeebeImportScheduler(List.of(mediator), mock(ZeebeConfigDto.class));
+
+    // when
+    scheduler.startImportScheduling();
+    assertThat(firstRunComplete.await(2, TimeUnit.SECONDS)).isTrue();
+
+    // then: immediately after the first run, the mediator should NOT have run again yet
+    // (it's waiting for backoffMs)
+    assertThat(runCount.get())
+        .as("mediator should not have been rescheduled immediately after first run with backoff")
+        .isEqualTo(1);
+
+    // after backoff elapses, it runs again
+    Thread.sleep(backoffMs + 100);
+    assertThat(runCount.get())
+        .as("mediator should have run again after backoff elapsed")
+        .isGreaterThanOrEqualTo(2);
+  }
+
+  @Test
+  void shouldContinueRunningOtherMediatorsWhenOneFails() throws Exception {
+    // given
+    final CountDownLatch successMediatorRan = new CountDownLatch(1);
+
+    final ImportMediator failingMediator = mock(ImportMediator.class);
+    final ImportMediator successMediator = mock(ImportMediator.class);
+
+    // small backoff so the failing mediator retries a few times without spinning in a tight,
+    // zero-delay loop (and flooding the log) for the duration of the test
+    when(failingMediator.getBackoffTimeInMs()).thenReturn(50L);
+    when(successMediator.getBackoffTimeInMs()).thenReturn(0L);
+
+    when(failingMediator.runImport()).thenThrow(new RuntimeException("simulated ES failure"));
+    when(successMediator.runImport())
+        .thenAnswer(
+            inv -> {
+              successMediatorRan.countDown();
+              return CompletableFuture.completedFuture(null);
+            });
+
+    scheduler =
+        new ZeebeImportScheduler(
+            List.of(failingMediator, successMediator), mock(ZeebeConfigDto.class));
+
+    // when
+    scheduler.startImportScheduling();
+
+    // then: success mediator completes despite the other mediator throwing
+    assertThat(successMediatorRan.await(2, TimeUnit.SECONDS))
+        .as("success mediator should run even when another mediator throws")
+        .isTrue();
+  }
+
+  @Test
+  void shouldReportIsImportingWhileExecutorIsRunning() throws Exception {
+    // given
+    final CountDownLatch mediatorRan = new CountDownLatch(1);
+    final ImportMediator mediator = mock(ImportMediator.class);
+    lenient().when(mediator.getBackoffTimeInMs()).thenReturn(60_000L);
+    when(mediator.runImport())
+        .thenAnswer(
+            inv -> {
+              mediatorRan.countDown();
+              return CompletableFuture.completedFuture(null);
+            });
+
+    scheduler = new ZeebeImportScheduler(List.of(mediator), mock(ZeebeConfigDto.class));
+
+    // when
+    scheduler.startImportScheduling();
+
+    // then
+    assertThat(scheduler.isImporting()).isTrue();
+    assertThat(mediatorRan.await(2, TimeUnit.SECONDS))
+        .as("mediator should have run once while the scheduler is active")
+        .isTrue();
+
+    scheduler.stopImportScheduling();
+    assertThat(scheduler.isImporting()).isFalse();
+  }
+
+  @Test
+  void shouldHandleEmptyMediatorListWithoutThrowing() {
+    // given
+    scheduler = new ZeebeImportScheduler(List.of(), mock(ZeebeConfigDto.class));
+
+    // when / then: no exception on start or stop
+    scheduler.startImportScheduling();
+    scheduler.stopImportScheduling();
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -177,6 +178,77 @@ class AbstractImportSchedulerTest {
                 assertThat(runCount.get())
                     .as("mediator should have run again after backoff elapsed")
                     .isGreaterThanOrEqualTo(2));
+  }
+
+  @Test
+  void shouldWaitForMediatorFutureCompletionBeforeRescheduling() {
+    // given
+    final AtomicInteger runCount = new AtomicInteger(0);
+    final AtomicReference<CompletableFuture<Void>> firstRunFuture = new AtomicReference<>();
+
+    final ImportMediator mediator = mock(ImportMediator.class);
+    when(mediator.getBackoffTimeInMs()).thenReturn(0L);
+    when(mediator.runImport())
+        .thenAnswer(
+            inv -> {
+              final CompletableFuture<Void> importFuture = new CompletableFuture<>();
+              firstRunFuture.compareAndSet(null, importFuture);
+              runCount.incrementAndGet();
+              return importFuture;
+            });
+
+    scheduler = new ZeebeImportScheduler(List.of(mediator), mock(ZeebeConfigDto.class));
+
+    // when
+    scheduler.startImportScheduling();
+
+    // then
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(() -> assertThat(runCount.get()).isEqualTo(1));
+    await()
+        .pollDelay(Duration.ZERO)
+        .pollInterval(Duration.ofMillis(10))
+        .during(Duration.ofMillis(50))
+        .atMost(Duration.ofMillis(150))
+        .untilAsserted(() -> assertThat(runCount.get()).isEqualTo(1));
+
+    firstRunFuture.get().complete(null);
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(() -> assertThat(runCount.get()).isEqualTo(2));
+  }
+
+  @Test
+  void shouldRescheduleMediatorAfterFutureCompletesExceptionally() {
+    // given
+    final AtomicInteger runCount = new AtomicInteger(0);
+    final AtomicReference<CompletableFuture<Void>> firstRunFuture = new AtomicReference<>();
+
+    final ImportMediator mediator = mock(ImportMediator.class);
+    when(mediator.getBackoffTimeInMs()).thenReturn(0L);
+    when(mediator.runImport())
+        .thenAnswer(
+            inv -> {
+              final CompletableFuture<Void> importFuture = new CompletableFuture<>();
+              firstRunFuture.compareAndSet(null, importFuture);
+              runCount.incrementAndGet();
+              return importFuture;
+            });
+
+    scheduler = new ZeebeImportScheduler(List.of(mediator), mock(ZeebeConfigDto.class));
+
+    // when
+    scheduler.startImportScheduling();
+
+    // then
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(() -> assertThat(runCount.get()).isEqualTo(1));
+    firstRunFuture.get().completeExceptionally(new RuntimeException("simulated async failure"));
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(() -> assertThat(runCount.get()).isEqualTo(2));
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
@@ -12,6 +12,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -50,8 +51,8 @@ class AbstractImportSchedulerTest {
     final CountDownLatch slowMediatorStarted = new CountDownLatch(1);
     final AtomicBoolean slowMediatorCompleted = new AtomicBoolean(false);
 
-    final ImportMediator slowMediator = mock(ImportMediator.class);
-    final ImportMediator fastMediator = mock(ImportMediator.class);
+    final ImportMediator slowMediator = readyMediator();
+    final ImportMediator fastMediator = readyMediator();
 
     // lenient: whether these get invoked before the test ends is a timing race against the
     // background reschedule threads, not something this test asserts on.
@@ -100,7 +101,7 @@ class AbstractImportSchedulerTest {
     final int expectedRuns = 3;
     final CountDownLatch runsCompleted = new CountDownLatch(expectedRuns);
 
-    final ImportMediator mediator = mock(ImportMediator.class);
+    final ImportMediator mediator = readyMediator();
     when(mediator.getBackoffTimeInMs()).thenReturn(0L);
     when(mediator.runImport())
         .thenAnswer(
@@ -130,7 +131,7 @@ class AbstractImportSchedulerTest {
     final AtomicInteger backoffCallCount = new AtomicInteger(0);
     final CountDownLatch firstRunComplete = new CountDownLatch(1);
 
-    final ImportMediator mediator = mock(ImportMediator.class);
+    final ImportMediator mediator = readyMediator();
     // return backoff on the first reschedule decision, 0 on subsequent ones. Tracked via a
     // dedicated counter (rather than runCount) since getBackoffTimeInMs() is evaluated by the
     // scheduler right after runImport() has already incremented runCount for that run.
@@ -181,12 +182,98 @@ class AbstractImportSchedulerTest {
   }
 
   @Test
+  void shouldWaitUntilMediatorCanImportBeforeRunning() throws Exception {
+    // given
+    final CountDownLatch canImportChecked = new CountDownLatch(1);
+
+    final ImportMediator mediator = mock(ImportMediator.class);
+    when(mediator.canImport())
+        .thenAnswer(
+            inv -> {
+              canImportChecked.countDown();
+              return false;
+            });
+    when(mediator.getBackoffTimeInMs()).thenReturn(60_000L);
+
+    scheduler = new ZeebeImportScheduler(List.of(mediator), mock(ZeebeConfigDto.class));
+
+    // when
+    scheduler.startImportScheduling();
+
+    // then
+    assertThat(canImportChecked.await(2, TimeUnit.SECONDS))
+        .as("scheduler should check mediator readiness")
+        .isTrue();
+    await()
+        .pollDelay(Duration.ZERO)
+        .pollInterval(Duration.ofMillis(10))
+        .during(Duration.ofMillis(50))
+        .atMost(Duration.ofMillis(150))
+        .untilAsserted(() -> verify(mediator, never()).runImport());
+  }
+
+  @Test
+  void shouldRunMediatorAfterCanImportBecomesTrue() throws Exception {
+    // given
+    final CountDownLatch mediatorRan = new CountDownLatch(1);
+    final AtomicInteger canImportChecks = new AtomicInteger(0);
+
+    final ImportMediator mediator = mock(ImportMediator.class);
+    when(mediator.canImport()).thenAnswer(inv -> canImportChecks.getAndIncrement() == 1);
+    when(mediator.getBackoffTimeInMs()).thenReturn(50L, 60_000L);
+    when(mediator.runImport())
+        .thenAnswer(
+            inv -> {
+              mediatorRan.countDown();
+              return CompletableFuture.completedFuture(null);
+            });
+
+    scheduler = new ZeebeImportScheduler(List.of(mediator), mock(ZeebeConfigDto.class));
+
+    // when
+    scheduler.startImportScheduling();
+
+    // then
+    assertThat(mediatorRan.await(2, TimeUnit.SECONDS))
+        .as("mediator should run after its backoff makes it ready")
+        .isTrue();
+  }
+
+  @Test
+  void shouldRescheduleMediatorWhenRunImportReturnsNullFuture() {
+    // given
+    final AtomicInteger runCount = new AtomicInteger(0);
+
+    final ImportMediator mediator = mock(ImportMediator.class);
+    when(mediator.canImport()).thenReturn(true);
+    when(mediator.getBackoffTimeInMs()).thenReturn(0L, 60_000L);
+    when(mediator.runImport())
+        .thenAnswer(
+            inv -> {
+              if (runCount.incrementAndGet() == 1) {
+                return null;
+              }
+              return CompletableFuture.completedFuture(null);
+            });
+
+    scheduler = new ZeebeImportScheduler(List.of(mediator), mock(ZeebeConfigDto.class));
+
+    // when
+    scheduler.startImportScheduling();
+
+    // then
+    await()
+        .atMost(Duration.ofSeconds(2))
+        .untilAsserted(() -> assertThat(runCount.get()).isEqualTo(2));
+  }
+
+  @Test
   void shouldWaitForMediatorFutureCompletionBeforeRescheduling() {
     // given
     final AtomicInteger runCount = new AtomicInteger(0);
     final AtomicReference<CompletableFuture<Void>> firstRunFuture = new AtomicReference<>();
 
-    final ImportMediator mediator = mock(ImportMediator.class);
+    final ImportMediator mediator = readyMediator();
     when(mediator.getBackoffTimeInMs()).thenReturn(0L);
     when(mediator.runImport())
         .thenAnswer(
@@ -225,7 +312,7 @@ class AbstractImportSchedulerTest {
     final AtomicInteger runCount = new AtomicInteger(0);
     final AtomicReference<CompletableFuture<Void>> firstRunFuture = new AtomicReference<>();
 
-    final ImportMediator mediator = mock(ImportMediator.class);
+    final ImportMediator mediator = readyMediator();
     when(mediator.getBackoffTimeInMs()).thenReturn(0L);
     when(mediator.runImport())
         .thenAnswer(
@@ -256,8 +343,8 @@ class AbstractImportSchedulerTest {
     // given
     final CountDownLatch successMediatorRan = new CountDownLatch(1);
 
-    final ImportMediator failingMediator = mock(ImportMediator.class);
-    final ImportMediator successMediator = mock(ImportMediator.class);
+    final ImportMediator failingMediator = readyMediator();
+    final ImportMediator successMediator = readyMediator();
 
     // small backoff so the failing mediator retries a few times without spinning in a tight,
     // zero-delay loop (and flooding the log) for the duration of the test. lenient: the test only
@@ -291,7 +378,7 @@ class AbstractImportSchedulerTest {
   void shouldReportIsImportingWhileExecutorIsRunning() throws Exception {
     // given
     final CountDownLatch mediatorRan = new CountDownLatch(1);
-    final ImportMediator mediator = mock(ImportMediator.class);
+    final ImportMediator mediator = readyMediator();
     lenient().when(mediator.getBackoffTimeInMs()).thenReturn(60_000L);
     when(mediator.runImport())
         .thenAnswer(
@@ -323,5 +410,11 @@ class AbstractImportSchedulerTest {
     // when / then: no exception on start or stop
     scheduler.startImportScheduling();
     scheduler.stopImportScheduling();
+  }
+
+  private ImportMediator readyMediator() {
+    final ImportMediator mediator = mock(ImportMediator.class);
+    when(mediator.canImport()).thenReturn(true);
+    return mediator;
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
@@ -149,11 +149,20 @@ class AbstractImportSchedulerTest {
     scheduler.startImportScheduling();
     assertThat(firstRunComplete.await(2, TimeUnit.SECONDS)).isTrue();
 
-    // then: immediately after the first run, the mediator should NOT have run again yet
-    // (it's waiting for backoffMs)
-    assertThat(runCount.get())
-        .as("mediator should not have been rescheduled immediately after first run with backoff")
-        .isEqualTo(1);
+    // then: the mediator should not be rescheduled before backoff elapses. Checked with
+    // Awaitility's during() (holds continuously for part of the backoff window) rather than a
+    // single point-in-time read, since a stalled/descheduled test thread could otherwise observe
+    // the count after the real reschedule already happened and flake under a loaded CI runner.
+    await()
+        .during(Duration.ofMillis(backoffMs / 2))
+        .atMost(Duration.ofMillis(backoffMs))
+        .untilAsserted(
+            () ->
+                assertThat(runCount.get())
+                    .as(
+                        "mediator should not have been rescheduled immediately after first run"
+                            + " with backoff")
+                    .isEqualTo(1));
 
     // after backoff elapses, it runs again. Polled via Awaitility rather than a fixed
     // Thread.sleep + buffer, so this doesn't flake under a slow/loaded CI runner.

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.optimize.service.importing;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -16,10 +17,12 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.optimize.dto.optimize.ZeebeConfigDto;
 import io.camunda.optimize.service.importing.zeebe.ZeebeImportScheduler;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +46,8 @@ class AbstractImportSchedulerTest {
     // given
     final CountDownLatch fastMediatorRan = new CountDownLatch(1);
     final CountDownLatch releaseSlowMediator = new CountDownLatch(1);
+    final CountDownLatch slowMediatorStarted = new CountDownLatch(1);
+    final AtomicBoolean slowMediatorCompleted = new AtomicBoolean(false);
 
     final ImportMediator slowMediator = mock(ImportMediator.class);
     final ImportMediator fastMediator = mock(ImportMediator.class);
@@ -55,7 +60,9 @@ class AbstractImportSchedulerTest {
     when(slowMediator.runImport())
         .thenAnswer(
             inv -> {
+              slowMediatorStarted.countDown();
               releaseSlowMediator.await(5, TimeUnit.SECONDS);
+              slowMediatorCompleted.set(true);
               return CompletableFuture.completedFuture(null);
             });
     when(fastMediator.runImport())
@@ -71,10 +78,17 @@ class AbstractImportSchedulerTest {
     // when
     scheduler.startImportScheduling();
 
-    // then: fastMediator completes even though slowMediator is still blocked
+    // then: fastMediator completes while slowMediator is confirmed still running (not just
+    // never scheduled), proving genuine concurrency rather than a lucky ordering
+    assertThat(slowMediatorStarted.await(2, TimeUnit.SECONDS))
+        .as("slow mediator should have started running on its own thread")
+        .isTrue();
     assertThat(fastMediatorRan.await(2, TimeUnit.SECONDS))
         .as("fast mediator should complete independently of the blocked slow mediator")
         .isTrue();
+    assertThat(slowMediatorCompleted.get())
+        .as("slow mediator should still be blocked when the fast mediator has already completed")
+        .isFalse();
 
     releaseSlowMediator.countDown();
   }
@@ -141,11 +155,15 @@ class AbstractImportSchedulerTest {
         .as("mediator should not have been rescheduled immediately after first run with backoff")
         .isEqualTo(1);
 
-    // after backoff elapses, it runs again
-    Thread.sleep(backoffMs + 100);
-    assertThat(runCount.get())
-        .as("mediator should have run again after backoff elapsed")
-        .isGreaterThanOrEqualTo(2);
+    // after backoff elapses, it runs again. Polled via Awaitility rather than a fixed
+    // Thread.sleep + buffer, so this doesn't flake under a slow/loaded CI runner.
+    await()
+        .atMost(Duration.ofMillis(backoffMs + 2000))
+        .untilAsserted(
+            () ->
+                assertThat(runCount.get())
+                    .as("mediator should have run again after backoff elapsed")
+                    .isGreaterThanOrEqualTo(2));
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/AbstractImportSchedulerTest.java
@@ -153,9 +153,13 @@ class AbstractImportSchedulerTest {
     // Awaitility's during() (holds continuously for part of the backoff window) rather than a
     // single point-in-time read, since a stalled/descheduled test thread could otherwise observe
     // the count after the real reschedule already happened and flake under a loaded CI runner.
+    // A short, fast poll loop (10ms) with real margin before the real 200ms backoff fires, since
+    // Awaitility's own default poll interval/delay would otherwise eat most of a tight budget.
     await()
-        .during(Duration.ofMillis(backoffMs / 2))
-        .atMost(Duration.ofMillis(backoffMs))
+        .pollDelay(Duration.ZERO)
+        .pollInterval(Duration.ofMillis(10))
+        .during(Duration.ofMillis(50))
+        .atMost(Duration.ofMillis(150))
         .untilAsserted(
             () ->
                 assertThat(runCount.get())
@@ -184,9 +188,11 @@ class AbstractImportSchedulerTest {
     final ImportMediator successMediator = mock(ImportMediator.class);
 
     // small backoff so the failing mediator retries a few times without spinning in a tight,
-    // zero-delay loop (and flooding the log) for the duration of the test
-    when(failingMediator.getBackoffTimeInMs()).thenReturn(50L);
-    when(successMediator.getBackoffTimeInMs()).thenReturn(0L);
+    // zero-delay loop (and flooding the log) for the duration of the test. lenient: the test only
+    // waits on successMediator, so whether failingMediator's background thread has reached its
+    // reschedule decision by the time the test ends is an unasserted timing race.
+    lenient().when(failingMediator.getBackoffTimeInMs()).thenReturn(50L);
+    lenient().when(successMediator.getBackoffTimeInMs()).thenReturn(0L);
 
     when(failingMediator.runImport()).thenThrow(new RuntimeException("simulated ES failure"));
     when(successMediator.runImport())

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessInstanceSubEntityImportServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/importing/engine/service/zeebe/ZeebeProcessInstanceSubEntityImportServiceTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.importing.engine.service.zeebe;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.dto.optimize.ProcessInstanceDto;
+import io.camunda.optimize.service.db.DatabaseClient;
+import io.camunda.optimize.service.db.reader.ProcessDefinitionReader;
+import io.camunda.optimize.service.db.writer.ProcessInstanceWriter;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+class ZeebeProcessInstanceSubEntityImportServiceTest {
+
+  @Test
+  void shouldRejectSkeletonProcessInstancesWithoutBpmnProcessId() {
+    // given
+    final TestProcessInstanceSubEntityImportService underTest = createService();
+
+    // when / then
+    assertThatThrownBy(() -> underTest.createSkeletonProcessInstance(null, 100L, 200L, "tenant-a"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("process instance [100]")
+        .hasMessageContaining("process definition [200]")
+        .hasMessageContaining("bpmnProcessId");
+  }
+
+  @Test
+  void shouldRejectSkeletonProcessInstancesWithBlankBpmnProcessId() {
+    // given
+    final TestProcessInstanceSubEntityImportService underTest = createService();
+
+    // when / then
+    assertThatThrownBy(() -> underTest.createSkeletonProcessInstance(" ", 100L, 200L, "tenant-a"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("bpmnProcessId");
+  }
+
+  private TestProcessInstanceSubEntityImportService createService() {
+    final ConfigurationService configurationService =
+        mock(ConfigurationService.class, Answers.RETURNS_DEEP_STUBS);
+    when(configurationService.getJobExecutorQueueSize()).thenReturn(10);
+    when(configurationService.getJobExecutorThreadCount()).thenReturn(1);
+    return new TestProcessInstanceSubEntityImportService(
+        configurationService,
+        mock(ProcessInstanceWriter.class),
+        1,
+        mock(ProcessDefinitionReader.class),
+        mock(DatabaseClient.class));
+  }
+
+  private static final class TestProcessInstanceSubEntityImportService
+      extends ZeebeProcessInstanceSubEntityImportService<Object> {
+
+    private TestProcessInstanceSubEntityImportService(
+        final ConfigurationService configurationService,
+        final ProcessInstanceWriter processInstanceWriter,
+        final int partitionId,
+        final ProcessDefinitionReader processDefinitionReader,
+        final DatabaseClient databaseClient) {
+      super(
+          configurationService,
+          processInstanceWriter,
+          partitionId,
+          processDefinitionReader,
+          databaseClient,
+          "test-source-index");
+    }
+
+    @Override
+    List<ProcessInstanceDto> filterAndMapZeebeRecordsToOptimizeEntities(
+        final List<Object> records) {
+      return List.of();
+    }
+  }
+}


### PR DESCRIPTION
## Description

Optimize import scheduling no longer runs all mediators through one shared round loop. Each mediator is scheduled independently on a `ScheduledExecutorService`, so a slow or erroring mediator, or one mediator's idle backoff, no longer stalls the rest of the import pipeline.

Each mediator only starts a new import when `canImport()` allows it and its previous `runImport()` future has completed. This preserves per-mediator ordering and backoff while removing cross-mediator blocking. `EmbeddedOptimizeExtension`'s IT helper is updated for the removed synchronous round API.

The old OPT-6065 fallback for pre-1.4.0 variable records is removed. Records missing `bpmnProcessId` now fail fast instead of routing process instances to the multi-alias.

`PositionBasedImportMediator` now emits per-mediator `cycleDuration` and `mediatorErrors` metrics, tagged by record type and partition, so lagging or failing independent mediators are visible.

### Operational note

Each scheduler's thread pool now sizes to its mediator count instead of sharing one thread. For a multi-partition Zeebe deployment this means more mostly-idle daemon threads than before; this is the intended cost of mediator independence.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)) (to be decided after review)

## Related issues

closes #56669
