### PR TITLE
test: add and wire up unit tests for load-test comparison scripts

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -242,6 +242,15 @@ outputs:
         steps.ci-github-actions.outputs.ci-relevant == 'true' ||
         steps.filter-load-test-setup.outputs.load-test-setup-change == 'true'
       }}
+  scripts-changes:
+    description: Output whether any file under .github/scripts/ changed, so its Python unit tests should be run
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        steps.ci-github-actions.outputs.ci-relevant == 'true' ||
+        steps.filter-scripts.outputs.scripts-change == 'true'
+      }}
 
 runs:
   using: composite
@@ -473,6 +482,15 @@ runs:
         load-test-setup-change:
           - 'load-tests/setup/**'
           - '.tool-versions'
+
+  - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+    id: filter-scripts
+    with:
+      base: ${{ github.event.merge_group.base_ref || '' }}
+      ref: ${{ github.event.merge_group.head_ref || github.ref }}
+      filters: |
+        scripts-change:
+          - '.github/scripts/**'
 
   # only works `on: push` and `on: pull_request` GitHub trigger events
   - id: filter-special-branch

--- a/.github/scripts/test_render_comparison.py
+++ b/.github/scripts/test_render_comparison.py
@@ -1,0 +1,61 @@
+"""Unit tests for render-comparison.py (daily_window_start).
+
+Run with:
+    pytest .github/scripts/test_render_comparison.py
+"""
+
+import importlib.util
+import os
+import sys
+from datetime import datetime, timedelta
+
+# Load the hyphen-named module via importlib and register it so mock.patch works.
+_SCRIPT = os.path.join(os.path.dirname(__file__), "render-comparison.py")
+_spec = importlib.util.spec_from_file_location("render_comparison", _SCRIPT)
+rc = importlib.util.module_from_spec(_spec)
+sys.modules["render_comparison"] = rc
+_spec.loader.exec_module(rc)
+
+
+class TestDailyWindowStart:
+    def test_normal_case_subtracts_duration(self):
+        # given: anchor is the end of the 1800s window
+        # when
+        result = rc.daily_window_start("2026-07-01T03:30:00Z", 1800)
+        # then: window start = anchor - 1800s
+        assert result == "2026-07-01T03:00:00Z"
+
+    def test_empty_string_returns_none(self):
+        # given / when / then
+        assert rc.daily_window_start("", 1800) is None
+
+    def test_invalid_timestamp_returns_none(self):
+        # given / when / then
+        assert rc.daily_window_start("not-a-timestamp", 1800) is None
+
+    def test_crosses_midnight_backwards(self):
+        # given: anchor is 15 min past midnight; window extends into the previous day
+        # when
+        result = rc.daily_window_start("2026-07-01T00:15:00Z", 1800)
+        # then
+        assert result == "2026-06-30T23:45:00Z"
+
+    def test_zero_duration_returns_same_time(self):
+        # given / when
+        result = rc.daily_window_start("2026-07-01T03:30:00Z", 0)
+        # then
+        assert result == "2026-07-01T03:30:00Z"
+
+    def test_matches_full_pr_anchor_math(self):
+        # given: soak.started_at = 02:45:00, with WARMUP=900s and WINDOW=1800s.
+        #        resolve-daily.py sets anchor = soak_start + warmup + window = 03:30:00.
+        soak_start = "2026-07-01T02:45:00Z"
+        warmup_s = 900
+        window_s = 1800
+        start_dt = datetime.fromisoformat(soak_start.replace("Z", "+00:00"))
+        anchor = (start_dt + timedelta(seconds=warmup_s + window_s)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # when: recover the window start from the anchor
+        window_start = rc.daily_window_start(anchor, window_s)
+        # then: window_start = soak_start + warmup (the first steady-state second)
+        expected = (start_dt + timedelta(seconds=warmup_s)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        assert window_start == expected

--- a/.github/scripts/test_resolve_daily.py
+++ b/.github/scripts/test_resolve_daily.py
@@ -1,0 +1,284 @@
+"""Unit tests for resolve-daily.py
+
+Run with:
+    pytest .github/scripts/test_resolve_daily.py
+"""
+
+import importlib.util
+import os
+import sys
+from datetime import date, datetime, timezone
+from unittest import mock
+
+import pytest
+
+# Load the hyphen-named module via importlib and register it so mock.patch works.
+_SCRIPT = os.path.join(os.path.dirname(__file__), "resolve-daily.py")
+_spec = importlib.util.spec_from_file_location("resolve_daily", _SCRIPT)
+r = importlib.util.module_from_spec(_spec)
+sys.modules["resolve_daily"] = r
+_spec.loader.exec_module(r)
+
+
+def _utc(year: int, month: int, day: int, hour: int = 12, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=timezone.utc)
+
+
+class TestIsWeekday:
+    @pytest.mark.parametrize("day", [
+        date(2026, 6, 29), date(2026, 6, 30), date(2026, 7, 1),
+        date(2026, 7, 2), date(2026, 7, 3),
+    ])
+    def test_monday_through_friday_are_weekdays(self, day):
+        assert r.is_weekday(day)
+
+    def test_saturday_and_sunday_are_not_weekdays(self):
+        assert not r.is_weekday(date(2026, 7, 4))  # Saturday
+        assert not r.is_weekday(date(2026, 7, 5))  # Sunday
+
+
+class TestPreviousBusinessDay:
+    def test_monday_gives_friday(self):
+        # Must skip Saturday and Sunday
+        assert r.previous_business_day(date(2026, 6, 29)) == date(2026, 6, 26)
+
+    def test_tuesday_gives_monday(self):
+        assert r.previous_business_day(date(2026, 6, 30)) == date(2026, 6, 29)
+
+    def test_friday_gives_thursday(self):
+        assert r.previous_business_day(date(2026, 7, 3)) == date(2026, 7, 2)
+
+    def test_saturday_gives_friday(self):
+        assert r.previous_business_day(date(2026, 7, 4)) == date(2026, 7, 3)
+
+    def test_sunday_gives_friday(self):
+        assert r.previous_business_day(date(2026, 7, 5)) == date(2026, 7, 3)
+
+
+class TestCandidateDates:
+
+    # --- start date selection ---
+
+    def test_weekday_at_or_after_cutoff_starts_today(self):
+        # given: Wednesday 2026-07-01 exactly at the availability cutoff
+        now = _utc(2026, 7, 1, hour=r.TODAY_AVAILABLE_UTC_HOUR)
+        # when / then
+        assert r.candidate_dates(now)[0] == date(2026, 7, 1)
+
+    def test_weekday_before_cutoff_falls_back_to_previous_business_day(self):
+        # given: Wednesday 2026-07-01 at 05:59 UTC — daily not finished yet
+        now = _utc(2026, 7, 1, hour=r.TODAY_AVAILABLE_UTC_HOUR - 1)
+        # when / then
+        assert r.candidate_dates(now)[0] == date(2026, 6, 30)  # Tuesday
+
+    def test_saturday_falls_back_to_friday(self):
+        # given: Saturday — no daily runs on weekends
+        now = _utc(2026, 7, 4, hour=12)
+        # when / then
+        assert r.candidate_dates(now)[0] == date(2026, 7, 3)  # Friday
+
+    def test_sunday_falls_back_to_friday(self):
+        # given: Sunday — no daily runs on weekends
+        now = _utc(2026, 7, 5, hour=12)
+        # when / then
+        assert r.candidate_dates(now)[0] == date(2026, 7, 3)  # Friday
+
+    def test_monday_before_cutoff_falls_back_to_friday(self):
+        # given: Monday 05:00 UTC — yesterday was Sunday, so previous business day is Friday
+        now = _utc(2026, 6, 29, hour=5)
+        # when / then
+        assert r.candidate_dates(now)[0] == date(2026, 6, 26)  # Friday
+
+    # --- list shape ---
+
+    def test_returns_exactly_seven_dates(self):
+        # given
+        now = _utc(2026, 7, 1, hour=12)
+        # when
+        dates = r.candidate_dates(now)
+        # then
+        assert len(dates) == r.LOOKBACK_BUSINESS_DAYS
+
+    def test_all_dates_are_weekdays(self):
+        # given
+        now = _utc(2026, 7, 1, hour=12)
+        # when
+        dates = r.candidate_dates(now)
+        # then
+        assert all(r.is_weekday(d) for d in dates)
+
+    def test_dates_are_newest_first(self):
+        # given
+        now = _utc(2026, 7, 1, hour=12)
+        # when
+        dates = r.candidate_dates(now)
+        # then
+        assert all(dates[i] > dates[i + 1] for i in range(len(dates) - 1))
+
+
+class TestSoakStartedAt:
+    def test_returns_timestamp_on_success(self):
+        # given: gh returns a clean timestamp with trailing newline
+        with mock.patch.object(r, "gh", return_value="2026-07-01T02:45:00Z\n"):
+            # when
+            result = r.soak_started_at("123")
+        # then
+        assert result == "2026-07-01T02:45:00Z"
+
+    def test_returns_none_when_gh_fails(self):
+        # given: gh CLI exits non-zero
+        with mock.patch.object(r, "gh", return_value=None):
+            # when
+            result = r.soak_started_at("123")
+        # then
+        assert result is None
+
+    def test_returns_none_when_empty_output(self):
+        # given: gh succeeds but returns empty output (job not yet started)
+        with mock.patch.object(r, "gh", return_value=""):
+            # when
+            result = r.soak_started_at("123")
+        # then
+        assert result is None
+
+    def test_skips_null_lines_and_returns_first_real_value(self):
+        # given: jq emits "null" for non-matching jobs before the soak job
+        with mock.patch.object(r, "gh", return_value="null\n2026-07-01T02:45:00Z\n"):
+            # when
+            result = r.soak_started_at("123")
+        # then: null line skipped, real value returned
+        assert result == "2026-07-01T02:45:00Z"
+
+    def test_returns_none_when_all_lines_are_null(self):
+        # given: soak job is absent from the run (e.g. setup failed before it started)
+        with mock.patch.object(r, "gh", return_value="null\nnull\n"):
+            # when
+            result = r.soak_started_at("123")
+        # then
+        assert result is None
+
+
+class TestBenchmarkFromArtifacts:
+    def test_strips_artifact_prefix_correctly(self):
+        # given
+        artifact = "daily-load-test-metrics-medic-daily-2026-07-01-abc1234-test"
+        with mock.patch.object(r, "gh", return_value=artifact + "\n"):
+            # when
+            result = r.benchmark_from_artifacts("123")
+        # then: "daily-load-test-metrics-" prefix is stripped
+        assert result == "medic-daily-2026-07-01-abc1234-test"
+
+    def test_returns_none_when_gh_fails(self):
+        # given: gh CLI exits non-zero
+        with mock.patch.object(r, "gh", return_value=None):
+            # when
+            result = r.benchmark_from_artifacts("123")
+        # then
+        assert result is None
+
+    def test_returns_none_when_output_is_empty(self):
+        # given: no matching artifact found (expired or never uploaded)
+        with mock.patch.object(r, "gh", return_value=""):
+            # when
+            result = r.benchmark_from_artifacts("123")
+        # then
+        assert result is None
+
+    def test_returns_first_artifact_when_multiple_lines(self):
+        # given: two matching artifacts (gRPC + REST runs)
+        output = (
+            "daily-load-test-metrics-medic-daily-2026-07-01-abc1234-test\n"
+            "daily-load-test-metrics-medic-daily-2026-07-01-abc1234-test-rest\n"
+        )
+        with mock.patch.object(r, "gh", return_value=output):
+            # when
+            result = r.benchmark_from_artifacts("123")
+        # then: first artifact (gRPC namespace) is returned
+        assert result == "medic-daily-2026-07-01-abc1234-test"
+
+
+class TestResolve:
+
+    _SOAK_START = "2026-07-01T02:45:00Z"
+    _BENCHMARK = "medic-daily-2026-07-01-abc1234-test"
+    _NOW = _utc(2026, 7, 1, hour=12)
+
+    def test_anchor_is_soak_start_plus_warmup_plus_window(self):
+        """anchor = soak.started_at + WARMUP_SECONDS(900) + METRICS_WINDOW_SECONDS(1800) = +45min"""
+        # given: a completed daily run with a known soak start time
+        with mock.patch.object(r, "find_run_id", return_value="42"), \
+             mock.patch.object(r, "soak_started_at", return_value=self._SOAK_START), \
+             mock.patch.object(r, "benchmark_from_artifacts", return_value=self._BENCHMARK):
+            # when
+            result = r.resolve(self._NOW)
+        # then: anchor = 02:45:00 + 900s (warmup) + 1800s (window) = 03:30:00
+        assert result is not None
+        namespace, anchor = result
+        assert anchor == "2026-07-01T03:30:00Z"
+        assert namespace == f"c8-{self._BENCHMARK}"
+
+    def test_returns_none_when_no_run_found_for_any_candidate(self):
+        # given: no completed run exists for any candidate date
+        with mock.patch.object(r, "find_run_id", return_value=None):
+            # when / then
+            assert r.resolve(self._NOW) is None
+
+    def test_skips_candidate_missing_soak_time(self):
+        # given: run found but soak job has no started_at (e.g. job was cancelled)
+        with mock.patch.object(r, "find_run_id", return_value="42"), \
+             mock.patch.object(r, "soak_started_at", return_value=None), \
+             mock.patch.object(r, "benchmark_from_artifacts", return_value=self._BENCHMARK):
+            # when / then
+            assert r.resolve(self._NOW) is None
+
+    def test_skips_candidate_missing_artifact(self):
+        # given: run found but metrics artifact has expired or was never uploaded
+        with mock.patch.object(r, "find_run_id", return_value="42"), \
+             mock.patch.object(r, "soak_started_at", return_value=self._SOAK_START), \
+             mock.patch.object(r, "benchmark_from_artifacts", return_value=None):
+            # when / then
+            assert r.resolve(self._NOW) is None
+
+    def test_skips_candidate_with_unparseable_timestamp(self):
+        # given: soak.started_at is present but not a valid ISO-8601 timestamp
+        with mock.patch.object(r, "find_run_id", return_value="42"), \
+             mock.patch.object(r, "soak_started_at", return_value="not-a-timestamp"), \
+             mock.patch.object(r, "benchmark_from_artifacts", return_value=self._BENCHMARK):
+            # when / then
+            assert r.resolve(self._NOW) is None
+
+    def test_falls_back_to_next_candidate_on_no_run(self):
+        """First candidate has no run ID; resolver must try the next one."""
+        # given: only the second candidate date has a completed run
+        calls = []
+
+        def find_side_effect(d):
+            calls.append(d)
+            return None if len(calls) == 1 else "42"
+
+        with mock.patch.object(r, "find_run_id", side_effect=find_side_effect), \
+             mock.patch.object(r, "soak_started_at", return_value=self._SOAK_START), \
+             mock.patch.object(r, "benchmark_from_artifacts", return_value=self._BENCHMARK):
+            # when
+            result = r.resolve(self._NOW)
+        # then: succeeded after falling back to the second candidate
+        assert result is not None
+        assert len(calls) == 2
+
+    def test_falls_back_to_next_candidate_on_missing_artifact(self):
+        """First candidate has a run but no artifact; resolver must try the next one."""
+        # given: first candidate's run has no metrics artifact, second does
+        calls = []
+
+        def artifact_side_effect(run_id):
+            calls.append(run_id)
+            return None if len(calls) == 1 else self._BENCHMARK
+
+        with mock.patch.object(r, "find_run_id", return_value="42"), \
+             mock.patch.object(r, "soak_started_at", return_value=self._SOAK_START), \
+             mock.patch.object(r, "benchmark_from_artifacts", side_effect=artifact_side_effect):
+            # when
+            result = r.resolve(self._NOW)
+        # then: succeeded after falling back to the second candidate
+        assert result is not None
+        assert len(calls) == 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
       c8-e2e-test-suite-changes: ${{ steps.filter.outputs.c8-e2e-test-suite-changes }}
       deps-changed: ${{ steps.filter.outputs.deps-changed }}
       load-test-setup-changes: ${{ steps.filter.outputs.load-test-setup-changes }}
+      scripts-changes: ${{ steps.filter.outputs.scripts-changes }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -2364,6 +2365,31 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  scripts-tests:
+    if: needs.detect-changes.outputs.scripts-changes == 'true'
+    name: "Scripts / Python Unit Tests"
+    needs: [ detect-changes ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@be5b0496892a83e6b3c5cedb818b771e8ed68121 # main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        timeout-minutes: 1
+      - name: Install pytest
+        run: pip install --quiet pytest
+      - name: Run unit tests
+        run: pytest .github/scripts
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   check-results:
     # Used by the merge queue to check all tests, including the unit test matrix.
     # New test jobs must be added to the `needs` lists!
@@ -2409,6 +2435,7 @@ jobs:
       - protobuf-checks
       - rdbms-integration-tests
       - renovatelint
+      - scripts-tests
       - setup-tests
       - shell-script-tests
       - tasklist-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2379,7 +2379,7 @@ jobs:
       - name: Install pytest
         run: pip install --quiet pytest
       - name: Run unit tests
-        run: pytest .github/scripts
+        run: pytest --verbose --color=yes --tb=short .github/scripts
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

`resolve-daily.py`/`render-comparison.py` had unit tests that never ran in CI, and used `unittest` over `pytest`. Split out of #54635 (merged) to review this test/CI infra separately from the feature.

- Added unit tests for both scripts, migrated to `pytest` ([review comment](https://github.com/camunda/camunda/pull/54635#discussion_r3520529119))
- Wired into `ci.yml`: a path-filtered `scripts-tests` job runs `pytest .github/scripts` on any change under `.github/scripts/`, gated into `check-results` ([review comment](https://github.com/camunda/camunda/pull/54635#issuecomment-4877558490))

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

N/A