### PR TITLE
ci: prevent repeated Slack alerts when conversations.history scope is missing

### DIFF
--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -162,6 +162,7 @@ jobs:
             # ----------------------------------------------------------------
             ACTIVE_MARKER="${STREAK_MARKER_ACTIVE} on ${BASE_REF}"
             EXISTING_TS=""
+            HISTORY_FAILED=false
 
             SLACK_HISTORY=$(curl -sS -X GET \
               -H "Authorization: Bearer ${SLACK_TOKEN}" \
@@ -180,18 +181,19 @@ jobs:
                 echo "  No existing active streak message for ${BASE_REF}"
               fi
             else
+              HISTORY_FAILED=true
               echo "  conversations.history failed: $(jq -r '.error // "unknown"' <<<"$SLACK_HISTORY") — will post fresh if needed"
             fi
 
-            # Guard: when conversations.history is unavailable and the streak
-            # has already exceeded the threshold, the crossing-point alert was
-            # sent in a prior run. Skip this tick to prevent a new chat.postMessage
-            # on every scheduled poll (the root cause of repeated Slack alerts).
-            # Only the exact threshold-crossing run (streak == threshold) is
-            # allowed through so the initial notification still fires.
+            # Guard: only when the conversations.history API call itself failed
+            # (not when it succeeded but found no message — e.g. after deletion or
+            # a marker change, where re-posting a fresh alert is the correct action).
+            # When the API is unavailable and the streak has already exceeded the
+            # threshold, the crossing-point alert was sent in a prior run; skip this
+            # tick to prevent repeated chat.postMessage calls.
             # Fix: grant channels:history scope to the Slack bot to remove this
             # guard and enable proper silent find-and-update behaviour.
-            if [[ -z "${EXISTING_TS}" && "${IS_STREAK}" == "true" && ${STREAK} -gt ${STREAK_THRESHOLD} ]]; then
+            if [[ "${HISTORY_FAILED}" == "true" && "${IS_STREAK}" == "true" && ${STREAK} -gt ${STREAK_THRESHOLD} ]]; then
               echo "  ⚠️  conversations.history unavailable, streak=${STREAK} > ${STREAK_THRESHOLD} — skipping to avoid repeated alerts"
               SUMMARY_LINES+=("- \`${BASE_REF}\`: ⚠️ skipped repeat alert (conversations.history unavailable, streak=${STREAK}/${STREAK_THRESHOLD}) — grant channels:history scope to the Slack bot to re-enable silent updates")
               continue

--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -183,6 +183,20 @@ jobs:
               echo "  conversations.history failed: $(jq -r '.error // "unknown"' <<<"$SLACK_HISTORY") — will post fresh if needed"
             fi
 
+            # Guard: when conversations.history is unavailable and the streak
+            # has already exceeded the threshold, the crossing-point alert was
+            # sent in a prior run. Skip this tick to prevent a new chat.postMessage
+            # on every scheduled poll (the root cause of repeated Slack alerts).
+            # Only the exact threshold-crossing run (streak == threshold) is
+            # allowed through so the initial notification still fires.
+            # Fix: grant channels:history scope to the Slack bot to remove this
+            # guard and enable proper silent find-and-update behaviour.
+            if [[ -z "${EXISTING_TS}" && "${IS_STREAK}" == "true" && ${STREAK} -gt ${STREAK_THRESHOLD} ]]; then
+              echo "  ⚠️  conversations.history unavailable, streak=${STREAK} > ${STREAK_THRESHOLD} — skipping to avoid repeated alerts"
+              SUMMARY_LINES+=("- \`${BASE_REF}\`: ⚠️ skipped repeat alert (conversations.history unavailable, streak=${STREAK}/${STREAK_THRESHOLD}) — grant channels:history scope to the Slack bot to re-enable silent updates")
+              continue
+            fi
+
             # ----------------------------------------------------------------
             # Build medic pings from failure-context artifacts on the latest run.
             # ----------------------------------------------------------------


### PR DESCRIPTION
## Root cause

The Slack bot token lacks the \`channels:history\` scope, so every call to \`conversations.history\` fails with \`missing_scope\`. This leaves \`EXISTING_TS\` empty, which causes the existing fallback code ("will post fresh if needed") to call \`chat.postMessage\` on **every 15-minute poll tick** while a streak is active — instead of the intended silent \`chat.update\`.

During the July 3rd SaaS E2E outage, the stable/8.8 and main streaks were active across ~9 scheduled ticks, producing ~60 new Slack messages to #alwaysgreen-reliability instead of 2 (one per branch crossing the threshold).

Confirmed from the 15:52 July 3rd streak detector log:
```
conversations.history failed: missing_scope — will post fresh if needed
=== Checking stable/8.8 ===
  Streak: 3/3 | Latest: failure | is_streak=true | latest_success=false
  conversations.history failed: missing_scope — will post fresh if needed
  :rotating_light: Posted NEW streak alert to #alwaysgreen-reliability (medic notified)
```

## Fix

Add a guard after the \`conversations.history\` fallback: when history is unavailable **and** the streak count already exceeds the threshold, skip the current tick. The exact threshold-crossing run (streak == threshold) is still allowed through so the initial notification fires as expected.

**Root fix (required for proper silent-update behaviour):** grant \`channels:history\` scope to the Slack bot token stored at `secret/data/products/camunda/ci/github-actions SLACK_CORE_DOMAIN_BOT_TOKEN`. Until that is done, this guard prevents the spam.

## Effect

- Before: 1 new `chat.postMessage` per poll tick per active streak branch → ~60 messages
- After: 1 `chat.postMessage` at threshold crossing, then silence until scope is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)