### PR TITLE
ci: retire component/zeebe in favor of component/zeebe-engine and component/zeebe-platform

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -80,9 +80,8 @@ Map path prefixes to component labels:
 | `tasklist/`              | `component/tasklist`             |
 | `identity/`              | `component/identity`             |
 | `optimize/`              | `component/optimize`             |
-| `clients/`               | `component/clients` (also Core Features) |
-| `clients/spring-zeebe/` or `clients/spring-boot-starter/` | `component/spring-boot-starter` (also Core Features) |
-| `webapp/`                | `component/c8-api` (also Core Features) |
+| `clients/`               | `component/clients`              |
+| `webapp/`                | `component/c8-api`               |
 | `gateways/gateway-mcp/`  | `component/mcp`                  |
 | `gateways/`              | `component/gateway`              |
 | `db/` or `search/`       | `component/data-layer`           |

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -80,8 +80,9 @@ Map path prefixes to component labels:
 | `tasklist/`              | `component/tasklist`             |
 | `identity/`              | `component/identity`             |
 | `optimize/`              | `component/optimize`             |
-| `clients/`               | `component/clients`              |
-| `webapp/`                | `component/c8-api`               |
+| `clients/`               | `component/clients` (also Core Features) |
+| `clients/spring-zeebe/` or `clients/spring-boot-starter/` | `component/spring-boot-starter` (also Core Features) |
+| `webapp/`                | `component/c8-api` (also Core Features) |
 | `gateways/gateway-mcp/`  | `component/mcp`                  |
 | `gateways/`              | `component/gateway`              |
 | `db/` or `search/`       | `component/data-layer`           |

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -75,7 +75,9 @@ Map path prefixes to component labels:
 
 | Path prefix              | Component label                  |
 |--------------------------|----------------------------------|
-| `zeebe/`                 | `component/zeebe`                |
+| `zeebe/` (engine)        | `component/zeebe-engine`         |
+| `zeebe/` (platform/infra)| `component/zeebe-platform`       |
+| `zeebe/` (unsure)        | `component/zeebe` (fallback)     |
 | `operate/`               | `component/operate`              |
 | `tasklist/`              | `component/tasklist`             |
 | `identity/`              | `component/identity`             |

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -75,9 +75,9 @@ Map path prefixes to component labels:
 
 | Path prefix              | Component label                  |
 |--------------------------|----------------------------------|
-| `zeebe/` (engine)        | `component/zeebe-engine`         |
-| `zeebe/` (platform/infra)| `component/zeebe-platform`       |
-| `zeebe/` (unsure)        | `component/zeebe` (fallback)     |
+| `zeebe/engine/` or `zeebe/broker/` | `component/zeebe-engine`         |
+| `zeebe/gateway/` or `zeebe/docker/` | `component/zeebe-platform`       |
+| `zeebe/` (mixed/unsure)             | `component/zeebe` (fallback)     |
 | `operate/`               | `component/operate`              |
 | `tasklist/`              | `component/tasklist`             |
 | `identity/`              | `component/identity`             |

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -75,9 +75,7 @@ Map path prefixes to component labels:
 
 | Path prefix              | Component label                  |
 |--------------------------|----------------------------------|
-| `zeebe/engine/` or `zeebe/broker/` | `component/zeebe-engine`         |
-| `zeebe/gateway/` or `zeebe/docker/` | `component/zeebe-platform`       |
-| `zeebe/` (mixed/unsure)             | `component/zeebe` (fallback)     |
+| `zeebe/` — see below     | `component/zeebe-engine` or `component/zeebe-platform` (fallback: `component/zeebe`) |
 | `operate/`               | `component/operate`              |
 | `tasklist/`              | `component/tasklist`             |
 | `identity/`              | `component/identity`             |
@@ -91,6 +89,15 @@ Map path prefixes to component labels:
 | `testing/`               | `component/camunda-process-test` |
 | `qa/`                    | `component/qa`                   |
 | `.github/` or `.claude/` | `component/build-pipeline`       |
+
+**Zeebe label split — use the conceptual layer, not the path:**
+
+- `component/zeebe-engine` — application/engine layer: BPMN/DMN execution, process state, variable
+  handling, FEEL evaluation, gRPC/REST API surface, `zeebe/gateway`, `zeebe/engine`
+- `component/zeebe-platform` — platform/infrastructure layer: broker internals, clustering, Raft,
+  replication, storage (RocksDB), job streaming, `zeebe/broker` (infra aspects)
+- Grey areas (e.g. `zeebe/broker` engine logic, job streaming in `zeebe/gateway`): prefer the
+  layer that is more affected; use `component/zeebe` as fallback when genuinely unclear
 
 When multiple modules are touched, pick the label for the most-affected one. If uncertain, ask the
 user. If no files are modified, ask the user which component applies.

--- a/.github/opened_issue_labeler.yml
+++ b/.github/opened_issue_labeler.yml
@@ -28,6 +28,10 @@ component/tasklist:
   '(Tasklist-)'
 component/zeebe:
   '(Zeebe-)'
+component/zeebe-engine:
+  '(Zeebe-Engine-)'
+component/zeebe-platform:
+  '(Zeebe-Platform-)'
 needs component label:
   '(Not sure-)'
 severity/critical:

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -24,9 +24,42 @@ jobs:
           vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           vault-url: ${{ secrets.VAULT_ADDR }}
-      - id: add-to-zdp
-        if: github.event.action != 'labeled' || github.event.label.name == 'component/zeebe'
-        name: Add to ZDP project
+      - id: add-zeebe-engine-to-core-features
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/zeebe-engine'
+        name: Add Zeebe Engine issues to Core Features project
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        with:
+          project-url: https://github.com/orgs/camunda/projects/173
+          github-token: ${{ steps.github-token.outputs.token }}
+          labeled: component/zeebe-engine
+
+      - id: add-zeebe-platform-to-zdp
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/zeebe-platform'
+        name: Add Zeebe Platform issues to ZDP project
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        with:
+          project-url: https://github.com/orgs/camunda/projects/92
+          github-token: ${{ steps.github-token.outputs.token }}
+          labeled: component/zeebe-platform
+
+      - id: add-zeebe-fallback-to-core-features
+        if: >
+          (github.event.action != 'labeled' || github.event.label.name == 'component/zeebe') &&
+          !contains(github.event.issue.labels.*.name, 'component/zeebe-engine') &&
+          !contains(github.event.issue.labels.*.name, 'component/zeebe-platform')
+        name: Add Zeebe fallback issues to Core Features project
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        with:
+          project-url: https://github.com/orgs/camunda/projects/173
+          github-token: ${{ steps.github-token.outputs.token }}
+          labeled: component/zeebe
+
+      - id: add-zeebe-fallback-to-zdp
+        if: >
+          (github.event.action != 'labeled' || github.event.label.name == 'component/zeebe') &&
+          !contains(github.event.issue.labels.*.name, 'component/zeebe-engine') &&
+          !contains(github.event.issue.labels.*.name, 'component/zeebe-platform')
+        name: Add Zeebe fallback issues to ZDP project
         uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/camunda/projects/92

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -102,6 +102,15 @@ jobs:
           github-token: ${{ steps.github-token.outputs.token }}
           labeled: component/data-layer
 
+      - id: add-c8-api-to-core-features
+        if: github.event.action != 'labeled' || github.event.label.name == 'component/c8-api'
+        name: Add C8 API issues to Core Features project
+        uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
+        with:
+          project-url: https://github.com/orgs/camunda/projects/173
+          github-token: ${{ steps.github-token.outputs.token }}
+          labeled: component/c8-api
+
       - id: add-to-api
         if: >
           github.event.action != 'labeled' ||

--- a/.github/workflows/critical-issue.yml
+++ b/.github/workflows/critical-issue.yml
@@ -13,6 +13,8 @@ jobs:
       github.event.label.name == 'severity/critical' &&
       (
         contains(github.event.issue.labels.*.name, 'component/zeebe') ||
+        contains(github.event.issue.labels.*.name, 'component/zeebe-engine') ||
+        contains(github.event.issue.labels.*.name, 'component/zeebe-platform') ||
         !contains(join(github.event.issue.labels.*.name, ', '), 'component/')
       )
     steps:


### PR DESCRIPTION
## Summary

- Adds `component/zeebe-engine` (→ Core Features board) and `component/zeebe-platform` (→ ZDP board) labels to all routing automations
- Keeps `component/zeebe` as a fallback that routes to **both** boards, but only when neither fine-grained label is present
- Extends critical-issue Slack notification to trigger on all three Zeebe component labels
- Updates `create-issue` skill docs to reflect the new label split

## Label routing

| Label | Core Features (173) | ZDP (92) |
|---|---|---|
| `component/zeebe-engine` | ✓ | |
| `component/zeebe-platform` | | ✓ |
| `component/zeebe` (no fine-grained label) | ✓ | ✓ |

## Notes

- The two new GitHub labels (`component/zeebe-engine`, `component/zeebe-platform`) need to be created manually in the repo before this takes effect
- `component/zeebe` is intentionally not removed — existing issues keep working and it serves as a fallback for unlabeled triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)