### PR TITLE
fix: load-test: wait after namespace creation before continuing setting up

### DIFF
--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -149,7 +149,8 @@ check-deadline:
 .PHONY: create-namespace
 create-namespace:
 	@echo "Making sure the namespace $(namespace) exists..."
-	kubectl get namespace "$(namespace)" > /dev/null 2>&1 || kubectl create namespace "$(namespace)"
+	@# Sleep a bit to let Kubernetes finish the creation of the namespace and make it fully consistent for read and write operations.
+	kubectl get namespace "$(namespace)" > /dev/null 2>&1 || (kubectl create namespace "$(namespace)" && sleep 1)
 
 # Apply the camunda-credentials secret. Idempotent: rerunning after a TTL
 # deletion reapplies the SAME credentials, so the orchestration secret in

--- a/load-tests/setup/stable-87/Makefile
+++ b/load-tests/setup/stable-87/Makefile
@@ -131,7 +131,8 @@ check-deadline:
 .PHONY: create-namespace
 create-namespace:
 	@echo "Making sure the namespace $(namespace) exists..."
-	kubectl get namespace "$(namespace)" > /dev/null 2>&1 || kubectl create namespace "$(namespace)"
+	@# Sleep a bit to let Kubernetes finish the creation of the namespace and make it fully consistent for read and write operations.
+	kubectl get namespace "$(namespace)" > /dev/null 2>&1 || (kubectl create namespace "$(namespace)" && sleep 1)
 
 # Apply the camunda-credentials secret. Idempotent: rerunning after a TTL
 # deletion reapplies the SAME credentials, so the orchestration secret in

--- a/load-tests/setup/stable-88/Makefile
+++ b/load-tests/setup/stable-88/Makefile
@@ -140,7 +140,8 @@ check-deadline:
 .PHONY: create-namespace
 create-namespace:
 	@echo "Making sure the namespace $(namespace) exists..."
-	kubectl get namespace "$(namespace)" > /dev/null 2>&1 || kubectl create namespace "$(namespace)"
+	@# Sleep a bit to let Kubernetes finish the creation of the namespace and make it fully consistent for read and write operations.
+	kubectl get namespace "$(namespace)" > /dev/null 2>&1 || (kubectl create namespace "$(namespace)" && sleep 1)
 
 # Apply the camunda-credentials secret. Idempotent: rerunning after a TTL
 # deletion reapplies the SAME credentials, so the orchestration secret in

--- a/load-tests/setup/stable-89/Makefile
+++ b/load-tests/setup/stable-89/Makefile
@@ -146,7 +146,8 @@ check-deadline:
 .PHONY: create-namespace
 create-namespace:
 	@echo "Making sure the namespace $(namespace) exists..."
-	kubectl get namespace "$(namespace)" > /dev/null 2>&1 || kubectl create namespace "$(namespace)"
+	@# Sleep a bit to let Kubernetes finish the creation of the namespace and make it fully consistent for read and write operations.
+	kubectl get namespace "$(namespace)" > /dev/null 2>&1 || (kubectl create namespace "$(namespace)" && sleep 1)
 
 # Apply the camunda-credentials secret. Idempotent: rerunning after a TTL
 # deletion reapplies the SAME credentials, so the orchestration secret in


### PR DESCRIPTION
## Description

Creating a namespace seems to be eventually consistent: `kubectl create ns` returns, `kubectl get ns` returns successfully but doing editing commands still fails, sometimes. This happens rarely though.

This adds a short delay after the creation to (hopefully) prevent subsequent commands from failing.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
