### PR TITLE
test: flaky-gate sticky-state canary [DO NOT MERGE]

### DIFF
--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -36,6 +36,14 @@ commits, so authors aren't forced to push throwaway commits to bank
 evidence — but the gate is only reachable after a real modification, so
 re-run-spam-without-fix can't game it.
 
+This "re-runs count" guarantee depends on where state is stored. State lives
+in the gate's **PR comment** (a hidden base64 marker), not a workflow
+artifact. GitHub's "Re-run jobs" button and force-pushes both **delete
+run-scoped artifacts**, so an artifact-based counter silently reset on every
+re-run and could only advance via new distinct runs (throwaway commits) —
+this was GAP-11. The comment is durable across re-runs, attempts, and
+force-pushes, so a fixed test genuinely clears by re-running CI.
+
 ## How it works
 
 ```
@@ -50,8 +58,8 @@ re-run-spam-without-fix can't game it.
 │     ├─ Read bypass label                                             │
 │     ├─ Query BigQuery for baseline (only if new flakes this run)     │
 │     └─ detect-new-flaky-tests action (composite)                     │
-│        ├─ Discover + download prior state artifact (or fresh)        │
 │        ├─ Run detect_new_flaky_tests.py                              │
+│        │  ├─ Read prior state from the PR comment (or fresh)         │
 │        │  ├─ No prior state + no flakes + no bypass? → no-op         │
 │        │  ├─ Bypass label?  → mark all active → cleared_via_bypass   │
 │        │  ├─ Else:                                                   │
@@ -61,16 +69,17 @@ re-run-spam-without-fix can't game it.
 │        │  │    4. Merge surviving new flakes / reset re-flaked       │
 │        │  │    5. Increment counters where job ran AND test clean    │
 │        │  │    6. Promote counter>=3 entries to cleared_via_fix      │
-│        │  └─ Render comment, write state.json                        │
-│        ├─ Upload state artifact (flaky-gate-state-pr-<N>, 30d)       │
+│        │  └─ Render comment (state embedded) + upsert PR comment     │
 │        └─ Exit non-zero if any entries remain active (blocking)      │
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
 ## State schema
 
-Per-PR JSON written to / read from the workflow artifact
-`flaky-gate-state-pr-<PR_NUMBER>` (retention 30 days).
+Per-PR JSON embedded (base64) in the hidden `<!-- flaky-gate-state: … -->`
+marker of the gate's PR comment — the durable store (see "Why the PR comment
+holds state" below). The detector reads it back on the next run via the GitHub
+comments API.
 
 ```json
 {
@@ -100,6 +109,36 @@ Per-PR JSON written to / read from the workflow artifact
 
 Statuses: `active`, `cleared_via_fix`, `cleared_via_bypass`,
 `dropped_force_push`.
+
+## Why the PR comment holds state
+
+State was previously a per-PR workflow artifact (`flaky-gate-state-pr-<N>`,
+selected newest-by-`created_at`). That was **GAP-11**: GitHub's "Re-run jobs"
+button starts a new run attempt and **deletes the run's own prior-attempt
+artifacts**, and `upload-artifact overwrite` is run-scoped. So a re-run could
+not see the counter its earlier attempt banked — it fell back to an older
+distinct run's artifact and re-landed on the same value. Documented "re-runs
+count" clearance was therefore impossible; only new distinct runs (throwaway
+commits) advanced the counter. No artifact-selection strategy fixes this,
+because the advanced state only ever lived in the deleted artifact.
+
+The PR comment is **not** run-scoped: it survives re-runs, attempts, and
+force-pushes. Storing state in it makes the counter durable and monotonic
+across every kind of subsequent run, so a genuinely fixed test clears by
+re-running CI — no empty commits. It also removed the artifact entirely
+(no retention window, no `actions:` permission).
+
+Trade-offs (accepted for a pilot advisory gate):
+
+- **Visibility / tamper** — the base64 state is present in the comment source;
+  a maintainer could edit it. The gate is advisory and already has a
+  `ci:flaky-test-bypass` label escape hatch, so this is not a new trust
+  boundary.
+- **Concurrency** — two runs finishing at once do last-writer-wins on the
+  comment (same race the artifact had). `MIN_CLEAN_RUNS = 3` absorbs a rare
+  lost increment.
+- **Size** — base64 state is well under GitHub's 65 536-char comment cap for
+  realistic per-PR test counts.
 
 ## BigQuery baseline query
 
@@ -258,12 +297,13 @@ detection. For each entry:
 
 ## Comment rendering
 
-Single PR comment, identified by `<!-- new-flaky-tests-alert -->`. Carries
-a hidden pointer to the state artifact:
+Single PR comment, identified by `<!-- new-flaky-tests-alert -->`. The second
+line carries the full sticky state as a base64-encoded hidden marker (invisible
+in the rendered comment); the detector reads it back on the next run:
 
 ```
 <!-- new-flaky-tests-alert -->
-<!-- flaky-gate-state-artifact: flaky-gate-state-pr-54375 -->
+<!-- flaky-gate-state: eyJzY2hlbWFfdmVyc2lvbiI6MSwicHJfbnVtYmVy… -->
 ```
 
 ### Active alert
@@ -308,16 +348,17 @@ See `.github/workflows/ci.yml` `detect-new-flaky-tests` job. Key steps:
 
 1. **`actions/checkout`** with `fetch-depth: 0` (full history required for
    `git log -L`).
-2. **Discover and download** the latest non-expired
-   `flaky-gate-state-pr-<N>` artifact via `gh api`.
-3. **Build `ran-jobs-json`** from `needs.<job>.result` values (any value
+2. **Build `ran-jobs-json`** from `needs.<job>.result` values (any value
    other than `skipped`).
-4. **Read bypass label** from `pull_request.labels`.
-5. **Query BigQuery** only when this run produced new flakes.
-6. **Invoke the composite action** with all of the above plus
+3. **Read bypass label** from `pull_request.labels`.
+4. **Query BigQuery** only when this run produced new flakes.
+5. **Invoke the composite action** with all of the above plus
    `head-sha`, `base-ref`, `blocking: 'true'`.
-7. **Upload** the new `state.json` as
-   `flaky-gate-state-pr-<N>` (retention 30 days, overwrite previous).
+
+The action needs only `pull-requests: write` + `contents: read`. Prior state
+is read from the gate's PR comment at the start of the detector and the updated
+state is written back into that comment at the end — there is no artifact
+download/upload step and no `actions:` permission.
 
 ## When the gate runs
 
@@ -365,13 +406,13 @@ If the gate flags a flaky test that is **not caused by your changes**:
 
 ## Secrets
 
-|      Secret       |                        Source                        |        Purpose         |
-|-------------------|------------------------------------------------------|------------------------|
-| `VAULT_ADDR`      | Repository secret                                    | Vault server URL       |
-| `VAULT_ROLE_ID`   | Repository secret                                    | Vault AppRole auth     |
-| `VAULT_SECRET_ID` | Repository secret                                    | Vault AppRole auth     |
-| GCP SA key        | Vault (`secret/data/products/zeebe/ci/ci-analytics`) | BigQuery access        |
-| `GITHUB_TOKEN`    | Auto                                                 | Comment + artifact API |
+|      Secret       |                        Source                        |             Purpose              |
+|-------------------|------------------------------------------------------|----------------------------------|
+| `VAULT_ADDR`      | Repository secret                                    | Vault server URL                 |
+| `VAULT_ROLE_ID`   | Repository secret                                    | Vault AppRole auth               |
+| `VAULT_SECRET_ID` | Repository secret                                    | Vault AppRole auth               |
+| GCP SA key        | Vault (`secret/data/products/zeebe/ci/ci-analytics`) | BigQuery access                  |
+| `GITHUB_TOKEN`    | Auto                                                 | Comment read/write (state store) |
 
 ## Running locally
 
@@ -394,7 +435,9 @@ bq query --project_id=ci-30-162810 --use_legacy_sql=false --format=json \
      AND ts.test_status IN ("flaky","failure","error")
      AND bs.ci_url IS NOT NULL' > /tmp/known-flaky-tests.json
 
-# 2. Optional: provide a prior state file.
+# 2. Optional: provide a prior state file. In CI, prior state is read from the
+#    PR comment marker; STATE_FILE_IN is only the local/offline fallback used
+#    when the comment cannot be fetched (e.g. a fake token, as below).
 echo '{"schema_version":1,"pr_number":12345,"last_known_head_sha":"prev","last_updated_at":"t","tests":[]}' > /tmp/state-in.json
 
 # 3. Simulate PR flaky data and run the detector.

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -3,10 +3,11 @@ name: Detect New Flaky Tests
 
 description: >
   Compares flaky tests from the current PR run against known flaky tests from BigQuery
-  and a sticky per-PR state artifact. Once a test is flagged it stays flagged until
-  the method body is modified and 3 subsequent gate runs observe it clean, or until
-  the ci:flaky-test-bypass label is applied. Posts/updates a single PR comment that
-  renders the current state and writes the updated state JSON for upload.
+  and sticky per-PR state stored in the gate's PR comment. Once a test is flagged it
+  stays flagged until the method body is modified and 3 subsequent gate runs observe it
+  clean, or until the ci:flaky-test-bypass label is applied. Posts/updates a single PR
+  comment that renders the current state and embeds it as a hidden base64 marker for the
+  next run to read (durable across re-runs / force-push, unlike a run-scoped artifact).
 
 inputs:
   pr-flaky-tests-data:
@@ -53,42 +54,11 @@ outputs:
 runs:
   using: composite
   steps:
-    # Discover the most recent non-expired state artifact for this PR across any
-    # prior CI run on this repo. The artifact name is per-PR-number, so this works
-    # across force-pushes and re-runs. Missing/failed download => fresh-state path.
-    - name: Download prior sticky-state artifact
-      id: download-state
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-        REPO: ${{ github.repository }}
-        ARTIFACT_NAME: flaky-gate-state-pr-${{ inputs.pr-number }}
-      run: |
-        set -euo pipefail
-        state_dir="${RUNNER_TEMP}/flaky-gate-state-in"
-        mkdir -p "$state_dir"
-        state_file="${state_dir}/state.json"
-        echo "state_file=${state_file}" >> "$GITHUB_OUTPUT"
-
-        if ! artifact_id=$(gh api -X GET "/repos/${REPO}/actions/artifacts" \
-            -f "name=${ARTIFACT_NAME}" -F per_page=100 \
-            --jq '.artifacts | map(select(.expired == false)) | sort_by(.created_at) | reverse | .[0].id // ""'); then
-          echo "Artifact list API call failed; continuing with no prior state."
-          exit 0
-        fi
-
-        if [[ -z "$artifact_id" ]]; then
-          echo "No prior sticky-state artifact found; first-run for this PR."
-          exit 0
-        fi
-        echo "Found prior artifact id: $artifact_id"
-
-        if ! gh api "/repos/${REPO}/actions/artifacts/${artifact_id}/zip" \
-                > "${RUNNER_TEMP}/prior-state.zip"; then
-          echo "Artifact download failed; continuing with no prior state."
-          exit 0
-        fi
-        unzip -q -o "${RUNNER_TEMP}/prior-state.zip" -d "$state_dir" || true
+    # Prior sticky state is recovered from the gate's own PR comment (a hidden
+    # base64 marker), not a workflow artifact. The comment is durable across the
+    # "Re-run jobs" button and force-pushes, both of which delete run-scoped
+    # artifacts and previously froze the clean-run counter (GAP-11). The detector
+    # reads the comment directly via the GitHub API — no download step needed.
 
     # Method-fix detection uses `git log -L:<method>:<file>`, which needs git's
     # language-aware funcname driver to locate Java methods. The repo has no
@@ -117,7 +87,8 @@ runs:
         KNOWN_FLAKY_TESTS_FILE: ${{ inputs.known-flaky-tests-file }}
         PR_NUMBER: ${{ inputs.pr-number }}
         BLOCKING: ${{ inputs.blocking }}
-        STATE_FILE_IN: ${{ steps.download-state.outputs.state_file }}
+        # Prior state now comes from the PR comment; STATE_FILE_OUT is retained
+        # only as a debug artifact of the run (not uploaded, not read back).
         STATE_FILE_OUT: ${{ runner.temp }}/flaky-gate-state-out/state.json
         RAN_JOBS_JSON: ${{ inputs.ran-jobs-json }}
         BYPASS_LABEL_PRESENT: ${{ inputs.bypass-label-present }}
@@ -127,38 +98,6 @@ runs:
         REPO_ROOT: ${{ inputs.repo-root != '' && inputs.repo-root || github.workspace }}
         GITHUB_TOKEN: ${{ github.token }}
       run: python3 ${{ github.action_path }}/detect_new_flaky_tests.py
-
-    # Detect whether the detector actually wrote a state file. hashFiles() cannot
-    # be used to guard the upload: it only hashes paths under GITHUB_WORKSPACE, but
-    # the state file lives in RUNNER_TEMP (outside the workspace), so hashFiles always
-    # returned '' and the upload was silently skipped on every run — sticky state never
-    # persisted across runs (the clean-run counter was frozen and cross-run stickiness
-    # was dead). A plain existence check reads the absolute path fine.
-    - name: Check sticky-state file written
-      id: state-written
-      if: always()
-      shell: bash
-      env:
-        STATE_FILE_OUT: ${{ runner.temp }}/flaky-gate-state-out/state.json
-      run: |
-        state_dir="$(dirname "$STATE_FILE_OUT")"
-        echo "sticky-state dir contents:"
-        ls -la "$state_dir" 2>/dev/null || echo "  (directory absent)"
-        if [[ -f "$STATE_FILE_OUT" ]]; then
-          echo "written=true" >> "$GITHUB_OUTPUT"
-          echo "state file present -> will upload for the next run"
-        else
-          echo "written=false" >> "$GITHUB_OUTPUT"
-          echo "state file absent -> skipping upload (no flakes and no prior state)"
-        fi
-
-    # Persist updated state for the next run. Skipped when the detector wrote
-    # nothing (no flakes + no prior state => no-op, no file to upload).
-    - name: Upload sticky-state artifact
-      if: always() && steps.state-written.outputs.written == 'true'
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: flaky-gate-state-pr-${{ inputs.pr-number }}
-        path: ${{ runner.temp }}/flaky-gate-state-out/state.json
-        retention-days: 30
-        overwrite: true
+    # Updated state is persisted by the detector into the PR comment's hidden
+    # marker (durable across re-runs / force-push). No artifact upload step —
+    # the run-scoped artifact was the root cause of GAP-11.

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -109,10 +109,34 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: python3 ${{ github.action_path }}/detect_new_flaky_tests.py
 
+    # Detect whether the detector actually wrote a state file. hashFiles() cannot
+    # be used to guard the upload: it only hashes paths under GITHUB_WORKSPACE, but
+    # the state file lives in RUNNER_TEMP (outside the workspace), so hashFiles always
+    # returned '' and the upload was silently skipped on every run — sticky state never
+    # persisted across runs (the clean-run counter was frozen and cross-run stickiness
+    # was dead). A plain existence check reads the absolute path fine.
+    - name: Check sticky-state file written
+      id: state-written
+      if: always()
+      shell: bash
+      env:
+        STATE_FILE_OUT: ${{ runner.temp }}/flaky-gate-state-out/state.json
+      run: |
+        state_dir="$(dirname "$STATE_FILE_OUT")"
+        echo "sticky-state dir contents:"
+        ls -la "$state_dir" 2>/dev/null || echo "  (directory absent)"
+        if [[ -f "$STATE_FILE_OUT" ]]; then
+          echo "written=true" >> "$GITHUB_OUTPUT"
+          echo "state file present -> will upload for the next run"
+        else
+          echo "written=false" >> "$GITHUB_OUTPUT"
+          echo "state file absent -> skipping upload (no flakes and no prior state)"
+        fi
+
     # Persist updated state for the next run. Skipped when the detector wrote
     # nothing (no flakes + no prior state => no-op, no file to upload).
     - name: Upload sticky-state artifact
-      if: always() && hashFiles(format('{0}/flaky-gate-state-out/state.json', runner.temp)) != ''
+      if: always() && steps.state-written.outputs.written == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: flaky-gate-state-pr-${{ inputs.pr-number }}

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -90,6 +90,25 @@ runs:
         fi
         unzip -q -o "${RUNNER_TEMP}/prior-state.zip" -d "$state_dir" || true
 
+    # Method-fix detection uses `git log -L:<method>:<file>`, which needs git's
+    # language-aware funcname driver to locate Java methods. The repo has no
+    # `*.java diff=java` gitattributes, so without this the -L call fails with
+    # "no match" for every method, method_last_modified is never resolved, and the
+    # clean-run clearance counter can never advance (cleared_via_fix unreachable).
+    # Enable the built-in Java driver for this checkout only (.git/info/attributes
+    # is local and not committed), scoping the change to the gate.
+    - name: Enable Java funcname driver for method-fix detection
+      if: always()
+      shell: bash
+      env:
+        REPO_ROOT: ${{ inputs.repo-root != '' && inputs.repo-root || github.workspace }}
+      run: |
+        git_info="${REPO_ROOT}/.git/info"
+        if [[ -d "$git_info" ]] && ! grep -qxF '*.java diff=java' "${git_info}/attributes" 2>/dev/null; then
+          printf '*.java diff=java\n' >> "${git_info}/attributes"
+          echo "enabled Java funcname driver in ${git_info}/attributes"
+        fi
+
     - name: Detect new flaky tests
       id: detect
       shell: bash

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -8,8 +8,11 @@ flagged until either:
       runs observe the test passing (zero Maven retries) in the originally
       affected job.
 
-State is persisted between gate runs via a per-PR workflow artifact (JSON).
-The PR comment is a human-readable render of that state.
+State is persisted between gate runs inside the gate's PR comment: a hidden
+base64 `<!-- flaky-gate-state: … -->` marker holds the full JSON, and the
+visible comment body is a human-readable render of it. The comment is durable
+across the "Re-run jobs" button and force-pushes, unlike a run-scoped artifact
+(see GAP-11 / README "Why the PR comment holds state").
 
 Inputs (environment variables):
   PR_FLAKY_TESTS_DATA    – JSON array of {job, flaky_tests}
@@ -18,8 +21,9 @@ Inputs (environment variables):
   GITHUB_TOKEN           – GitHub API token
   GITHUB_REPOSITORY      – owner/repo
   GITHUB_OUTPUT          – Path to the GHA step output file
-  STATE_FILE_IN          – Path to existing state.json (may not exist on first run)
-  STATE_FILE_OUT         – Path to write updated state.json
+  STATE_FILE_IN          – Fallback prior-state path for local/offline runs when
+                           the PR comment cannot be fetched (CI reads the comment)
+  STATE_FILE_OUT         – Optional debug dump of the updated state (not uploaded)
   RAN_JOBS_JSON          – JSON array of parent job names whose result is not 'skipped'
   BYPASS_LABEL_PRESENT   – 'true' / 'false'
   HEAD_SHA               – Current PR head SHA
@@ -28,6 +32,7 @@ Inputs (environment variables):
   REPO_ROOT              – Absolute path to the checked-out repo (for git/find)
 """
 
+import base64
 import datetime as _dt
 import json
 import os
@@ -39,7 +44,10 @@ import urllib.request
 
 PREFIX = "[new-flaky]"
 COMMENT_MARKER = "<!-- new-flaky-tests-alert -->"
-STATE_ARTIFACT_MARKER_PREFIX = "<!-- flaky-gate-state-artifact: "
+# The full sticky-state JSON is base64-encoded into this hidden marker in the
+# gate's PR comment. The comment — unlike a run-scoped artifact — survives the
+# "Re-run jobs" button and force-pushes, so it is the durable state store.
+STATE_MARKER_PREFIX = "<!-- flaky-gate-state: "
 SCHEMA_VERSION = 1
 MIN_CLEAN_RUNS = 3
 
@@ -133,6 +141,43 @@ def save_state(path: str, state: dict) -> None:
 
 def _now_iso() -> str:
     return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def encode_state_marker(state: dict) -> str:
+    """Serialize state into the hidden comment marker line.
+
+    The full state JSON is base64-encoded inside an HTML comment: invisible in
+    the rendered comment, but round-trips exactly on the next run. This makes
+    the comment the durable state store — it survives the "Re-run jobs" button
+    and force-pushes, both of which delete run-scoped artifacts (see GAP-11).
+    """
+    payload = base64.b64encode(
+        json.dumps(state, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).decode("ascii")
+    return f"{STATE_MARKER_PREFIX}{payload} -->"
+
+
+def extract_state_from_comment(body: str | None) -> dict | None:
+    """Recover prior state from the hidden marker in an existing PR comment.
+
+    Returns None when there is no comment, no marker, or the payload is
+    unreadable / schema-mismatched — the caller then starts fresh.
+    """
+    if not body:
+        return None
+    m = re.search(re.escape(STATE_MARKER_PREFIX) + r"([A-Za-z0-9+/=]+) -->", body)
+    if not m:
+        return None
+    try:
+        raw = base64.b64decode(m.group(1)).decode("utf-8")
+        state = json.loads(raw)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"{PREFIX} WARN: could not decode comment state ({exc}) — starting fresh.")
+        return None
+    if not isinstance(state, dict) or state.get("schema_version") != SCHEMA_VERSION:
+        print(f"{PREFIX} WARN: comment state schema mismatch — starting fresh.")
+        return None
+    return state
 
 
 # ---------------------------------------------------------------------------
@@ -446,14 +491,14 @@ def _render_cleared_test(entry: dict) -> list[str]:
     ]
 
 
-def render_comment(state: dict, artifact_name: str) -> str:
+def render_comment(state: dict) -> str:
     active = [e for e in state["tests"] if e.get("status") == "active"]
     cleared = [e for e in state["tests"] if e.get("status") in
                ("cleared_via_fix", "cleared_via_bypass", "dropped_force_push")]
 
     lines = [
         COMMENT_MARKER,
-        f"{STATE_ARTIFACT_MARKER_PREFIX}{artifact_name} -->",
+        encode_state_marker(state),
     ]
 
     if active:
@@ -537,25 +582,32 @@ def _github_api(url: str, token: str, method: str = "GET",
         raise GitHubAPIError(f"{exc.status} {exc.reason} — {body}") from exc
 
 
-def _find_existing_comment(owner: str, repo: str, pr: int, token: str) -> int | None:
+def _find_existing_comment(owner: str, repo: str, pr: int,
+                           token: str) -> tuple[int | None, str | None]:
+    """Return (comment_id, body) of the gate's comment, or (None, None)."""
     page = 1
     while True:
         url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr}/comments?per_page=100&page={page}"
         raw = _github_api(url, token)
         comments = json.loads(raw)
         if not comments:
-            return None
+            return None, None
         for c in comments:
-            if COMMENT_MARKER in (c.get("body") or ""):
-                return c["id"]
+            body = c.get("body") or ""
+            if COMMENT_MARKER in body:
+                return c["id"], body
         page += 1
 
 
-def post_or_update_comment(owner: str, repo: str, pr: int, body: str, token: str) -> None:
-    existing = _find_existing_comment(owner, repo, pr, token)
+def post_or_update_comment(owner: str, repo: str, pr: int, body: str,
+                           token: str, existing_id: int | None = None) -> None:
+    # existing_id is passed in when the caller already located the comment
+    # (to read prior state), so we avoid a second full comment scan.
+    if existing_id is None:
+        existing_id, _ = _find_existing_comment(owner, repo, pr, token)
     payload = json.dumps({"body": body}).encode()
-    if existing:
-        url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments/{existing}"
+    if existing_id:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments/{existing_id}"
         _github_api(url, token, method="PATCH", data=payload)
     else:
         url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr}/comments"
@@ -752,9 +804,29 @@ def main() -> None:
     base_sha_input = os.environ.get("BASE_SHA", "")
     blocking = os.environ.get("BLOCKING", "true").lower() == "true"
     repo_root = os.environ.get("REPO_ROOT", os.getcwd())
-    artifact_name = f"flaky-gate-state-pr-{pr_number}"
+    owner, name = repository.split("/", 1) if "/" in repository else (None, None)
 
-    state = load_state(state_in, pr_number, head_sha)
+    # Load prior state. The gate's PR comment carries the full state in a hidden
+    # base64 marker and is the durable source of truth: it survives the "Re-run
+    # jobs" button and force-pushes, which delete the run-scoped artifact the
+    # gate used to rely on (GAP-11). STATE_FILE_IN remains a fallback for local
+    # / offline runs where the comment cannot be fetched.
+    existing_comment_id: int | None = None
+    prior_state: dict | None = None
+    if owner and token:
+        try:
+            existing_comment_id, existing_body = _find_existing_comment(
+                owner, name, pr_number, token)
+            prior_state = extract_state_from_comment(existing_body)
+        except GitHubAPIError as exc:
+            print(f"{PREFIX} WARN: could not fetch existing comment ({exc}) "
+                  "— falling back to state file / fresh.")
+
+    if prior_state is not None:
+        print(f"{PREFIX} Loaded prior state from PR comment marker.")
+        state = prior_state
+    else:
+        state = load_state(state_in, pr_number, head_sha)
     state["pr_number"] = pr_number
 
     # Snapshot prior method_last_modified for Q4c counter-reset detection.
@@ -812,11 +884,13 @@ def main() -> None:
         for entry in state["tests"]:
             entry.pop("_prev_last_mod", None)
         state["last_known_head_sha"] = head_sha
-        save_state(state_out, state)
-        comment = render_comment(state, artifact_name)
+        if state_out:
+            save_state(state_out, state)
+        comment = render_comment(state)
         # Bypass is an escape hatch: entries are already cleared, so a failed
         # comment post must never fail the job (would defeat the unblock).
-        _post_comment_with_handling(repository, pr_number, comment, token, blocking=False)
+        _post_comment_with_handling(repository, pr_number, comment, token,
+                                    blocking=False, existing_id=existing_comment_id)
         set_output("has-new-flaky-tests", "false")
         return
 
@@ -838,13 +912,15 @@ def main() -> None:
         entry.pop("_prev_last_mod", None)
 
     state["last_known_head_sha"] = head_sha
-    save_state(state_out, state)
+    if state_out:
+        save_state(state_out, state)
 
     active_count = sum(1 for e in state["tests"] if e.get("status") == "active")
     print(f"{PREFIX} active={active_count} total_tracked={len(state['tests'])}")
 
-    comment = render_comment(state, artifact_name)
-    _post_comment_with_handling(repository, pr_number, comment, token, blocking)
+    comment = render_comment(state)
+    _post_comment_with_handling(repository, pr_number, comment, token, blocking,
+                                existing_id=existing_comment_id)
 
     set_output("has-new-flaky-tests", "true" if active_count > 0 else "false")
     if active_count > 0 and blocking:
@@ -853,13 +929,14 @@ def main() -> None:
 
 
 def _post_comment_with_handling(repo: str, pr: int, body: str,
-                                 token: str, blocking: bool) -> None:
+                                 token: str, blocking: bool,
+                                 existing_id: int | None = None) -> None:
     if not repo or "/" not in repo:
         print(f"{PREFIX} WARN: GITHUB_REPOSITORY not set — skipping comment.")
         return
     owner, name = repo.split("/", 1)
     try:
-        post_or_update_comment(owner, name, pr, body, token)
+        post_or_update_comment(owner, name, pr, body, token, existing_id=existing_id)
     except GitHubAPIError as exc:
         msg = f"comment post/update failed: {exc}"
         if blocking:

--- a/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
@@ -357,11 +357,11 @@ class TestRenderComment(unittest.TestCase):
             method_last_modified_sha="abcdef0",
             clean_runs_since_modified=1,
         ))
-        body = d.render_comment(state, "art-name")
+        body = d.render_comment(state)
         self.assertIn("⚠️ New Flaky Tests Detected", body)
         self.assertIn("Clean re-runs since fix: 1 / 3", body)
         self.assertIn("Method last modified at: `abcdef0`", body)
-        self.assertIn("art-name", body)
+        self.assertIn(d.STATE_MARKER_PREFIX, body)
 
     def test_all_clear_template(self):
         state = _make_state(_make_entry(
@@ -369,7 +369,7 @@ class TestRenderComment(unittest.TestCase):
             method_last_modified_sha="fix1",
             cleared_at="t",
         ))
-        body = d.render_comment(state, "art-name")
+        body = d.render_comment(state)
         self.assertIn("✅ Cleared", body)
         self.assertNotIn("⚠️", body)
         self.assertIn("<details>", body)
@@ -380,10 +380,42 @@ class TestRenderComment(unittest.TestCase):
             _make_entry(key="t2", status="cleared_via_bypass",
                          cleared_at="t"),
         )
-        body = d.render_comment(state, "art-name")
+        body = d.render_comment(state)
         self.assertIn("⚠️", body)
         self.assertIn("1 cleared test(s) (history)", body)
         self.assertIn("cleared via `ci:flaky-test-bypass`", body)
+
+
+class TestStateMarkerRoundtrip(unittest.TestCase):
+    def test_state_survives_render_then_extract(self):
+        # The rendered comment is the durable store: state embedded by
+        # render_comment must decode back identically on the next run.
+        state = _make_state(_make_entry(
+            method_last_modified_sha="fix1",
+            clean_runs_since_modified=2,
+        ))
+        body = d.render_comment(state)
+        recovered = d.extract_state_from_comment(body)
+        self.assertIsNotNone(recovered)
+        self.assertEqual(recovered["tests"][0]["clean_runs_since_modified"], 2)
+        self.assertEqual(recovered["tests"][0]["method_last_modified_sha"], "fix1")
+        self.assertEqual(recovered["pr_number"], state["pr_number"])
+
+    def test_extract_returns_none_without_marker(self):
+        self.assertIsNone(d.extract_state_from_comment(None))
+        self.assertIsNone(d.extract_state_from_comment(""))
+        self.assertIsNone(d.extract_state_from_comment("no marker here"))
+
+    def test_extract_returns_none_on_corrupt_payload(self):
+        corrupt = f"{d.COMMENT_MARKER}\n{d.STATE_MARKER_PREFIX}not!valid!base64 -->"
+        self.assertIsNone(d.extract_state_from_comment(corrupt))
+
+    def test_extract_returns_none_on_schema_mismatch(self):
+        import base64 as _b64
+        payload = _b64.b64encode(
+            json.dumps({"schema_version": 999}).encode()).decode()
+        body = f"{d.COMMENT_MARKER}\n{d.STATE_MARKER_PREFIX}{payload} -->"
+        self.assertIsNone(d.extract_state_from_comment(body))
 
 
 class TestMergeBase(unittest.TestCase):

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1701,9 +1701,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      pull-requests: write
+      pull-requests: write  # read prior state from + write updated state to the gate's PR comment
       contents: read
-      actions: read  # read the prior per-PR sticky-state run artifact via the Artifacts API
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         timeout-minutes: 5

--- a/.github/workflows/test-flaky-gate-state.yml
+++ b/.github/workflows/test-flaky-gate-state.yml
@@ -1,0 +1,74 @@
+# TEMPORARY act harness — reproduces the flaky-gate sticky-state upload-skip bug.
+# NOT for merge. Delete after local act validation.
+#
+# Bug under test: .github/actions/detect-new-flaky-tests/action.yml "Upload sticky-state
+# artifact" step is guarded by
+#   if: always() && hashFiles(format('{0}/flaky-gate-state-out/state.json', runner.temp)) != ''
+# hashFiles() only hashes files under GITHUB_WORKSPACE. state.json lives in RUNNER_TEMP
+# (outside the workspace), so hashFiles returns '' regardless of whether the file exists,
+# and the upload step is ALWAYS skipped -> sticky state never persists across runs.
+#
+# This harness writes state.json into RUNNER_TEMP (exactly as the Python save_state does),
+# then evaluates BOTH guards in one run:
+#   - CURRENT (hashFiles)  -> expected SKIPPED (no MARKER printed)
+#   - PROPOSED ([ -f ] via step output) -> expected RUNS (MARKER printed)
+name: test-flaky-gate-state
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  state-guard-repro:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write state.json into RUNNER_TEMP (mimics detect_new_flaky_tests.py save_state)
+        shell: bash
+        run: |
+          mkdir -p "${RUNNER_TEMP}/flaky-gate-state-out"
+          echo '{"pr_number": 56467, "tests": [], "last_known_head_sha": "deadbeef"}' \
+            > "${RUNNER_TEMP}/flaky-gate-state-out/state.json"
+          echo "GITHUB_WORKSPACE = ${GITHUB_WORKSPACE}"
+          echo "RUNNER_TEMP      = ${RUNNER_TEMP}"
+          echo "state file on disk:"
+          ls -la "${RUNNER_TEMP}/flaky-gate-state-out/"
+
+      - name: Diagnostic — raw hashFiles value for the RUNNER_TEMP path
+        if: always()
+        shell: bash
+        run: |
+          echo "MARKER hashFiles-value='${{ hashFiles(format('{0}/flaky-gate-state-out/state.json', runner.temp)) }}'"
+          echo "(empty string => guard is broken: hashFiles cannot see outside GITHUB_WORKSPACE)"
+
+      # ---- CURRENT PRODUCTION GUARD (copied verbatim from action.yml) ----
+      - name: Upload state (CURRENT hashFiles guard)
+        if: always() && hashFiles(format('{0}/flaky-gate-state-out/state.json', runner.temp)) != ''
+        shell: bash
+        run: echo "MARKER UPLOAD-RAN-WITH-HASHFILES-GUARD"
+
+      # ---- PROPOSED FIX GUARD (existence check via step output) ----
+      - name: Check state written (proposed fix)
+        id: state-check
+        if: always()
+        shell: bash
+        run: |
+          if [ -f "${RUNNER_TEMP}/flaky-gate-state-out/state.json" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "state-check: file exists -> exists=true"
+          else
+            echo "state-check: file MISSING"
+          fi
+
+      - name: Upload state (FIXED existence-check guard)
+        if: always() && steps.state-check.outputs.exists == 'true'
+        shell: bash
+        run: echo "MARKER UPLOAD-RAN-WITH-EXISTENCE-GUARD"
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          echo "Expected under real GitHub:"
+          echo "  hashFiles-value empty, HASHFILES-guard step SKIPPED, EXISTENCE-guard step RAN."

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/FlakyGateCanaryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/FlakyGateCanaryTest.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.util;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -36,10 +39,16 @@ import org.junit.jupiter.api.Test;
 final class FlakyGateCanaryTest {
 
   @Test
-  void shouldBeStable() {
-    // PHASE 2 (clear): method body modified to a deterministic pass. The gate sees the flagged
-    // method changed ("fix detected") and, with three subsequent clean runs, advances the
-    // clearance counter 1/3 -> 2/3 -> 3/3 -> cleared_via_fix.
-    // cleared
+  void shouldBeStable() throws IOException {
+    // PHASE 1 (flag): fail on the first attempt, pass on Maven's retry -> recorded flaky.
+    // PHASE 2 (clear): replace this whole body with a no-op (e.g. `// cleared`).
+    final Path marker =
+        Path.of(System.getProperty("java.io.tmpdir"), "flaky-gate-canary-attempt.marker");
+    if (Files.exists(marker)) {
+      return; // retry attempt on the same runner: pass
+    }
+    Files.createFile(marker);
+    throw new AssertionError(
+        "flaky-gate canary: intentional first-attempt failure to exercise the flaky gate");
   }
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/FlakyGateCanaryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/FlakyGateCanaryTest.java
@@ -7,9 +7,6 @@
  */
 package io.camunda.zeebe.util;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,16 +36,10 @@ import org.junit.jupiter.api.Test;
 final class FlakyGateCanaryTest {
 
   @Test
-  void shouldBeStable() throws IOException {
-    // PHASE 1 (flag): fail on the first attempt, pass on Maven's retry -> recorded flaky.
-    // PHASE 2 (clear): replace this whole body with a no-op (e.g. `// cleared`).
-    final Path marker =
-        Path.of(System.getProperty("java.io.tmpdir"), "flaky-gate-canary-attempt.marker");
-    if (Files.exists(marker)) {
-      return; // retry attempt on the same runner: pass
-    }
-    Files.createFile(marker);
-    throw new AssertionError(
-        "flaky-gate canary: intentional first-attempt failure to exercise the flaky gate");
+  void shouldBeStable() {
+    // PHASE 2 (clear): method body modified to a deterministic pass. The gate sees the flagged
+    // method changed ("fix detected") and, with three subsequent clean runs, advances the
+    // clearance counter 1/3 -> 2/3 -> 3/3 -> cleared_via_fix.
+    // cleared
   }
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/FlakyGateCanaryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/FlakyGateCanaryTest.java
@@ -7,42 +7,48 @@
  */
 package io.camunda.zeebe.util;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.concurrent.ThreadLocalRandom;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
 /**
  * CANARY — DO NOT MERGE.
  *
  * <p>Temporary flaky test that validates the flaky-gate sticky-state persistence fix (commit "fix:
- * persist flaky-gate sticky state across CI runs"). It exists only on the throwaway branch {@code
- * test/flaky-gate-state-canary} and must be removed before that branch — if ever — is merged.
+ * persist flaky-gate sticky state across CI runs"). Exists only on the throwaway branch {@code
+ * ci/flaky-gate-state-canary-DONOTMERGE}; remove before that branch is ever merged.
  *
- * <p>It lives in the {@code zeebe-util} module so it runs in the {@code zeebe-unit-tests} job, which
- * the flaky gate collects. Because the test file itself is in the PR diff, the gate's touch-check
- * keeps the alert (test-file-in-diff override).
+ * <p>It lives in {@code zeebe-util} so it runs in the gate-collected {@code zeebe-unit-tests} job.
+ * The test file is in the PR diff, so the gate's touch-check keeps the alert (test-file-in-diff
+ * override).
  *
- * <p>Validation walkthrough:
+ * <p><b>Deterministic flake:</b> the first execution creates a marker file and fails; Maven's
+ * retry (same runner filesystem) sees the marker and passes. Net result on every CI run: failed
+ * once, passed on retry → recorded in FLAKY.xml → the gate flags it. This removes the ~50% luck of
+ * a random flake so the sticky-state / counter path is exercised reliably.
  *
- * <ul>
- *   <li><b>Phase 1 (flag):</b> {@link #shouldBeStable()} fails ~50% of the time, so Maven's retry
- *       records it in FLAKY.xml and the gate raises a sticky alert, uploading the {@code
- *       flaky-gate-state-pr-<N>} artifact. Assert: the artifact now exists and the "Upload
- *       sticky-state artifact" step runs (before the fix it was skipped).
- *   <li><b>Phase 2 (clear):</b> replace the body of {@link #shouldBeStable()} with {@code
- *       assertThat(true).isTrue();}. That stops the flake AND counts as a method fix, so the next
- *       three clean re-runs advance the counter 1/3 → 2/3 → 3/3 → {@code cleared_via_fix}. Assert:
- *       run #2's log reports "Found prior artifact id: …" (not "No prior sticky-state artifact
- *       found"), proving state now persists across runs.
- * </ul>
+ * <p><b>Phase 1 (flag):</b> as above → gate raises a sticky alert and (with the fix) uploads the
+ * {@code flaky-gate-state-pr-<N>} artifact.
+ *
+ * <p><b>Phase 2 (clear):</b> replace the body of {@link #shouldBeStable()} with a no-op (delete the
+ * fail-then-pass logic). That stops the flake AND counts as a method fix, so the next three clean
+ * re-runs advance the counter 1/3 → 2/3 → 3/3 → {@code cleared_via_fix}. Assert run #2's log shows
+ * "Found prior artifact id: …" (not "No prior sticky-state artifact found").
  */
 final class FlakyGateCanaryTest {
 
   @Test
-  void shouldBeStable() {
-    // PHASE 1 (flag): ~50% failure so the test is recorded as flaky.
-    // PHASE 2 (clear): replace the assertion below with `assertThat(true).isTrue();`.
-    assertThat(ThreadLocalRandom.current().nextInt(2)).isZero();
+  void shouldBeStable() throws IOException {
+    // PHASE 1 (flag): fail on the first attempt, pass on Maven's retry -> recorded flaky.
+    // PHASE 2 (clear): replace this whole body with a no-op (e.g. `// cleared`).
+    final Path marker =
+        Path.of(System.getProperty("java.io.tmpdir"), "flaky-gate-canary-attempt.marker");
+    if (Files.exists(marker)) {
+      return; // retry attempt on the same runner: pass
+    }
+    Files.createFile(marker);
+    throw new AssertionError(
+        "flaky-gate canary: intentional first-attempt failure to exercise the flaky gate");
   }
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/FlakyGateCanaryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/FlakyGateCanaryTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.junit.jupiter.api.Test;
+
+/**
+ * CANARY — DO NOT MERGE.
+ *
+ * <p>Temporary flaky test that validates the flaky-gate sticky-state persistence fix (commit "fix:
+ * persist flaky-gate sticky state across CI runs"). It exists only on the throwaway branch {@code
+ * test/flaky-gate-state-canary} and must be removed before that branch — if ever — is merged.
+ *
+ * <p>It lives in the {@code zeebe-util} module so it runs in the {@code zeebe-unit-tests} job, which
+ * the flaky gate collects. Because the test file itself is in the PR diff, the gate's touch-check
+ * keeps the alert (test-file-in-diff override).
+ *
+ * <p>Validation walkthrough:
+ *
+ * <ul>
+ *   <li><b>Phase 1 (flag):</b> {@link #shouldBeStable()} fails ~50% of the time, so Maven's retry
+ *       records it in FLAKY.xml and the gate raises a sticky alert, uploading the {@code
+ *       flaky-gate-state-pr-<N>} artifact. Assert: the artifact now exists and the "Upload
+ *       sticky-state artifact" step runs (before the fix it was skipped).
+ *   <li><b>Phase 2 (clear):</b> replace the body of {@link #shouldBeStable()} with {@code
+ *       assertThat(true).isTrue();}. That stops the flake AND counts as a method fix, so the next
+ *       three clean re-runs advance the counter 1/3 → 2/3 → 3/3 → {@code cleared_via_fix}. Assert:
+ *       run #2's log reports "Found prior artifact id: …" (not "No prior sticky-state artifact
+ *       found"), proving state now persists across runs.
+ * </ul>
+ */
+final class FlakyGateCanaryTest {
+
+  @Test
+  void shouldBeStable() {
+    // PHASE 1 (flag): ~50% failure so the test is recorded as flaky.
+    // PHASE 2 (clear): replace the assertion below with `assertThat(true).isTrue();`.
+    assertThat(ThreadLocalRandom.current().nextInt(2)).isZero();
+  }
+}


### PR DESCRIPTION
**DO NOT MERGE — throwaway validation branch.**

Validates `fix/flaky-gate-state-persistence` (the flaky-gate sticky-state
upload guard fix) end-to-end in live CI, before that fix merges to `main`.

This branch is based off the fix branch, so the gate on this PR runs the
**fixed** `detect-new-flaky-tests` action.

## Contents (both to be deleted, never merged)
- `FlakyGateCanaryTest` — a ~50% flaky unit test in `zeebe-util` (runs in the
  gate-collected `zeebe-unit-tests` job).
- `test-flaky-gate-state.yml` — harness evaluating the old `hashFiles` guard vs
  the new existence-check guard side by side.

## Validation steps
1. **Run 1** (canary flakes): in the `detect new flaky tests` job, the new
   "Check sticky-state file written" step should print the state dir and
   `written=true`, and the "Upload sticky-state artifact" step should RUN.
   Confirm the artifact exists:
   `gh api "/repos/camunda/camunda/actions/artifacts?name=flaky-gate-state-pr-<PR>" --jq .total_count` ≥ 1.
   (Before the fix this was always 0.)
2. Edit `FlakyGateCanaryTest.shouldBeStable()` → `assertThat(true).isTrue();`,
   push → **Run 2**: log shows "Found prior artifact id: …" (not "No prior
   sticky-state artifact found") and the sticky comment shows `1 / 3`.
3. "Re-run all jobs" ×2 → `2 / 3` → `3 / 3` → ✅ Cleared.

Close this PR once validated.