### PR TITLE
fix: make flaky-gate sticky state durable via the PR comment (survives runs + re-runs)

### DIFF
--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -40,8 +40,8 @@ This "re-runs count" guarantee depends on where state is stored. State lives
 in the gate's **PR comment** (a hidden base64 marker), not a workflow
 artifact. GitHub's "Re-run jobs" button and force-pushes both **delete
 run-scoped artifacts**, so an artifact-based counter silently reset on every
-re-run and could only advance via new distinct runs (throwaway commits) —
-this was GAP-11. The comment is durable across re-runs, attempts, and
+re-run and could only advance via new distinct runs (throwaway commits).
+The comment is durable across re-runs, attempts, and
 force-pushes, so a fixed test genuinely clears by re-running CI.
 
 ## How it works
@@ -113,7 +113,7 @@ Statuses: `active`, `cleared_via_fix`, `cleared_via_bypass`,
 ## Why the PR comment holds state
 
 State was previously a per-PR workflow artifact (`flaky-gate-state-pr-<N>`,
-selected newest-by-`created_at`). That was **GAP-11**: GitHub's "Re-run jobs"
+selected newest-by-`created_at`). The root cause: GitHub's "Re-run jobs"
 button starts a new run attempt and **deletes the run's own prior-attempt
 artifacts**, and `upload-artifact overwrite` is run-scoped. So a re-run could
 not see the counter its earlier attempt banked — it fell back to an older

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -36,6 +36,14 @@ commits, so authors aren't forced to push throwaway commits to bank
 evidence — but the gate is only reachable after a real modification, so
 re-run-spam-without-fix can't game it.
 
+This "re-runs count" guarantee depends on where state is stored. State lives
+in the gate's **PR comment** (a hidden base64 marker), not a workflow
+artifact. GitHub's "Re-run jobs" button and force-pushes both **delete
+run-scoped artifacts**, so an artifact-based counter silently reset on every
+re-run and could only advance via new distinct runs (throwaway commits) —
+this was GAP-11. The comment is durable across re-runs, attempts, and
+force-pushes, so a fixed test genuinely clears by re-running CI.
+
 ## How it works
 
 ```
@@ -50,8 +58,8 @@ re-run-spam-without-fix can't game it.
 │     ├─ Read bypass label                                             │
 │     ├─ Query BigQuery for baseline (only if new flakes this run)     │
 │     └─ detect-new-flaky-tests action (composite)                     │
-│        ├─ Discover + download prior state artifact (or fresh)        │
 │        ├─ Run detect_new_flaky_tests.py                              │
+│        │  ├─ Read prior state from the PR comment (or fresh)         │
 │        │  ├─ No prior state + no flakes + no bypass? → no-op         │
 │        │  ├─ Bypass label?  → mark all active → cleared_via_bypass   │
 │        │  ├─ Else:                                                   │
@@ -61,16 +69,17 @@ re-run-spam-without-fix can't game it.
 │        │  │    4. Merge surviving new flakes / reset re-flaked       │
 │        │  │    5. Increment counters where job ran AND test clean    │
 │        │  │    6. Promote counter>=3 entries to cleared_via_fix      │
-│        │  └─ Render comment, write state.json                        │
-│        ├─ Upload state artifact (flaky-gate-state-pr-<N>, 30d)       │
+│        │  └─ Render comment (state embedded) + upsert PR comment     │
 │        └─ Exit non-zero if any entries remain active (blocking)      │
 └──────────────────────────────────────────────────────────────────────┘
 ```
 
 ## State schema
 
-Per-PR JSON written to / read from the workflow artifact
-`flaky-gate-state-pr-<PR_NUMBER>` (retention 30 days).
+Per-PR JSON embedded (base64) in the hidden `<!-- flaky-gate-state: … -->`
+marker of the gate's PR comment — the durable store (see "Why the PR comment
+holds state" below). The detector reads it back on the next run via the GitHub
+comments API.
 
 ```json
 {
@@ -100,6 +109,36 @@ Per-PR JSON written to / read from the workflow artifact
 
 Statuses: `active`, `cleared_via_fix`, `cleared_via_bypass`,
 `dropped_force_push`.
+
+## Why the PR comment holds state
+
+State was previously a per-PR workflow artifact (`flaky-gate-state-pr-<N>`,
+selected newest-by-`created_at`). That was **GAP-11**: GitHub's "Re-run jobs"
+button starts a new run attempt and **deletes the run's own prior-attempt
+artifacts**, and `upload-artifact overwrite` is run-scoped. So a re-run could
+not see the counter its earlier attempt banked — it fell back to an older
+distinct run's artifact and re-landed on the same value. Documented "re-runs
+count" clearance was therefore impossible; only new distinct runs (throwaway
+commits) advanced the counter. No artifact-selection strategy fixes this,
+because the advanced state only ever lived in the deleted artifact.
+
+The PR comment is **not** run-scoped: it survives re-runs, attempts, and
+force-pushes. Storing state in it makes the counter durable and monotonic
+across every kind of subsequent run, so a genuinely fixed test clears by
+re-running CI — no empty commits. It also removed the artifact entirely
+(no retention window, no `actions:` permission).
+
+Trade-offs (accepted for a pilot advisory gate):
+
+- **Visibility / tamper** — the base64 state is present in the comment source;
+  a maintainer could edit it. The gate is advisory and already has a
+  `ci:flaky-test-bypass` label escape hatch, so this is not a new trust
+  boundary.
+- **Concurrency** — two runs finishing at once do last-writer-wins on the
+  comment (same race the artifact had). `MIN_CLEAN_RUNS = 3` absorbs a rare
+  lost increment.
+- **Size** — base64 state is well under GitHub's 65 536-char comment cap for
+  realistic per-PR test counts.
 
 ## BigQuery baseline query
 
@@ -258,12 +297,13 @@ detection. For each entry:
 
 ## Comment rendering
 
-Single PR comment, identified by `<!-- new-flaky-tests-alert -->`. Carries
-a hidden pointer to the state artifact:
+Single PR comment, identified by `<!-- new-flaky-tests-alert -->`. The second
+line carries the full sticky state as a base64-encoded hidden marker (invisible
+in the rendered comment); the detector reads it back on the next run:
 
 ```
 <!-- new-flaky-tests-alert -->
-<!-- flaky-gate-state-artifact: flaky-gate-state-pr-54375 -->
+<!-- flaky-gate-state: eyJzY2hlbWFfdmVyc2lvbiI6MSwicHJfbnVtYmVy… -->
 ```
 
 ### Active alert
@@ -308,16 +348,17 @@ See `.github/workflows/ci.yml` `detect-new-flaky-tests` job. Key steps:
 
 1. **`actions/checkout`** with `fetch-depth: 0` (full history required for
    `git log -L`).
-2. **Discover and download** the latest non-expired
-   `flaky-gate-state-pr-<N>` artifact via `gh api`.
-3. **Build `ran-jobs-json`** from `needs.<job>.result` values (any value
+2. **Build `ran-jobs-json`** from `needs.<job>.result` values (any value
    other than `skipped`).
-4. **Read bypass label** from `pull_request.labels`.
-5. **Query BigQuery** only when this run produced new flakes.
-6. **Invoke the composite action** with all of the above plus
+3. **Read bypass label** from `pull_request.labels`.
+4. **Query BigQuery** only when this run produced new flakes.
+5. **Invoke the composite action** with all of the above plus
    `head-sha`, `base-ref`, `blocking: 'true'`.
-7. **Upload** the new `state.json` as
-   `flaky-gate-state-pr-<N>` (retention 30 days, overwrite previous).
+
+The action needs only `pull-requests: write` + `contents: read`. Prior state
+is read from the gate's PR comment at the start of the detector and the updated
+state is written back into that comment at the end — there is no artifact
+download/upload step and no `actions:` permission.
 
 ## When the gate runs
 
@@ -365,13 +406,13 @@ If the gate flags a flaky test that is **not caused by your changes**:
 
 ## Secrets
 
-|      Secret       |                        Source                        |        Purpose         |
-|-------------------|------------------------------------------------------|------------------------|
-| `VAULT_ADDR`      | Repository secret                                    | Vault server URL       |
-| `VAULT_ROLE_ID`   | Repository secret                                    | Vault AppRole auth     |
-| `VAULT_SECRET_ID` | Repository secret                                    | Vault AppRole auth     |
-| GCP SA key        | Vault (`secret/data/products/zeebe/ci/ci-analytics`) | BigQuery access        |
-| `GITHUB_TOKEN`    | Auto                                                 | Comment + artifact API |
+|      Secret       |                        Source                        |             Purpose              |
+|-------------------|------------------------------------------------------|----------------------------------|
+| `VAULT_ADDR`      | Repository secret                                    | Vault server URL                 |
+| `VAULT_ROLE_ID`   | Repository secret                                    | Vault AppRole auth               |
+| `VAULT_SECRET_ID` | Repository secret                                    | Vault AppRole auth               |
+| GCP SA key        | Vault (`secret/data/products/zeebe/ci/ci-analytics`) | BigQuery access                  |
+| `GITHUB_TOKEN`    | Auto                                                 | Comment read/write (state store) |
 
 ## Running locally
 
@@ -394,7 +435,9 @@ bq query --project_id=ci-30-162810 --use_legacy_sql=false --format=json \
      AND ts.test_status IN ("flaky","failure","error")
      AND bs.ci_url IS NOT NULL' > /tmp/known-flaky-tests.json
 
-# 2. Optional: provide a prior state file.
+# 2. Optional: provide a prior state file. In CI, prior state is read from the
+#    PR comment marker; STATE_FILE_IN is only the local/offline fallback used
+#    when the comment cannot be fetched (e.g. a fake token, as below).
 echo '{"schema_version":1,"pr_number":12345,"last_known_head_sha":"prev","last_updated_at":"t","tests":[]}' > /tmp/state-in.json
 
 # 3. Simulate PR flaky data and run the detector.

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -251,7 +251,7 @@ True positives are unaffected by design:
 For each active entry, the detector runs:
 
 ```bash
-git log --format=%H -L:<method_name>:<file_path> <merge-base(base, HEAD)>..HEAD
+git log --format=%H -L:<method_name>[(]:<file_path> <merge-base(base, HEAD)>..HEAD
 ```
 
 Git's `-L :funcname:file` matcher uses language-aware function-boundary
@@ -259,13 +259,32 @@ detection (Java's default funcname regex). The first SHA output is the
 most-recent commit that modified the method body within the range. None
 means no modification, so the counter stays at 0.
 
+The `[(]` suffix anchors the regex to the method **declaration** by requiring
+the name to be immediately followed by `(` (google-java-format leaves no space
+before the parameter list). Without it, a short name matches inside a longer
+method header sharing its prefix — a query for `getVersion` would also match
+`getVersionLowerCase(`, and `-L` locks onto whichever declaration appears
+first, tracking the wrong method. The `[(]` character class is used rather than
+an escaped `\(`, which git's `-L` parser rejects with "parentheses not
+balanced".
+
+This detection depends on git's Java funcname driver being active. The repo
+has no `*.java diff=java` gitattributes, so the composite action enables the
+built-in driver for the gate's checkout only (appends `*.java diff=java` to
+`.git/info/attributes`, which is local and not committed) and then verifies it
+took effect via `git check-attr diff`, failing loud otherwise. See
+`action.yml`.
+
 Known limitations:
 
-- **Java overloads** share a method name; they are treated as a single unit.
-  Modifying any overload of the same name counts as "fix attempted." Worth
-  noting in PR review but rarely problematic in practice.
-- **Renamed / moved tests** that change file or class are not followed.
-  Use `ci:flaky-test-bypass` for those.
+- **Java overloads** share a method name; since all overloads share `name(`,
+  they are treated as a single unit. Modifying any overload of the same name
+  counts as "fix attempted." Worth noting in PR review but rarely problematic
+  in practice.
+- **Renamed / moved tests** that change file or class are not followed by
+  `-L`. Such a change also re-keys the entry (the key is
+  `package.class.method`), so the test simply re-alerts fresh; use
+  `ci:flaky-test-bypass` if that is unwanted.
 
 ## Per-test counter semantics
 

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -57,7 +57,7 @@ runs:
     # Prior sticky state is recovered from the gate's own PR comment (a hidden
     # base64 marker), not a workflow artifact. The comment is durable across the
     # "Re-run jobs" button and force-pushes, both of which delete run-scoped
-    # artifacts and previously froze the clean-run counter (GAP-11). The detector
+    # artifacts and previously froze the clean-run counter. The detector
     # reads the comment directly via the GitHub API — no download step needed.
 
     # Method-fix detection uses `git log -L:<method>:<file>`, which needs git's
@@ -100,4 +100,4 @@ runs:
       run: python3 ${{ github.action_path }}/detect_new_flaky_tests.py
     # Updated state is persisted by the detector into the PR comment's hidden
     # marker (durable across re-runs / force-push). No artifact upload step —
-    # the run-scoped artifact was the root cause of GAP-11.
+    # the run-scoped artifact was the root cause of the stuck counter.

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -3,10 +3,11 @@ name: Detect New Flaky Tests
 
 description: >
   Compares flaky tests from the current PR run against known flaky tests from BigQuery
-  and a sticky per-PR state artifact. Once a test is flagged it stays flagged until
-  the method body is modified and 3 subsequent gate runs observe it clean, or until
-  the ci:flaky-test-bypass label is applied. Posts/updates a single PR comment that
-  renders the current state and writes the updated state JSON for upload.
+  and sticky per-PR state stored in the gate's PR comment. Once a test is flagged it
+  stays flagged until the method body is modified and 3 subsequent gate runs observe it
+  clean, or until the ci:flaky-test-bypass label is applied. Posts/updates a single PR
+  comment that renders the current state and embeds it as a hidden base64 marker for the
+  next run to read (durable across re-runs / force-push, unlike a run-scoped artifact).
 
 inputs:
   pr-flaky-tests-data:
@@ -53,42 +54,11 @@ outputs:
 runs:
   using: composite
   steps:
-    # Discover the most recent non-expired state artifact for this PR across any
-    # prior CI run on this repo. The artifact name is per-PR-number, so this works
-    # across force-pushes and re-runs. Missing/failed download => fresh-state path.
-    - name: Download prior sticky-state artifact
-      id: download-state
-      shell: bash
-      env:
-        GH_TOKEN: ${{ github.token }}
-        REPO: ${{ github.repository }}
-        ARTIFACT_NAME: flaky-gate-state-pr-${{ inputs.pr-number }}
-      run: |
-        set -euo pipefail
-        state_dir="${RUNNER_TEMP}/flaky-gate-state-in"
-        mkdir -p "$state_dir"
-        state_file="${state_dir}/state.json"
-        echo "state_file=${state_file}" >> "$GITHUB_OUTPUT"
-
-        if ! artifact_id=$(gh api -X GET "/repos/${REPO}/actions/artifacts" \
-            -f "name=${ARTIFACT_NAME}" -F per_page=100 \
-            --jq '.artifacts | map(select(.expired == false)) | sort_by(.created_at) | reverse | .[0].id // ""'); then
-          echo "Artifact list API call failed; continuing with no prior state."
-          exit 0
-        fi
-
-        if [[ -z "$artifact_id" ]]; then
-          echo "No prior sticky-state artifact found; first-run for this PR."
-          exit 0
-        fi
-        echo "Found prior artifact id: $artifact_id"
-
-        if ! gh api "/repos/${REPO}/actions/artifacts/${artifact_id}/zip" \
-                > "${RUNNER_TEMP}/prior-state.zip"; then
-          echo "Artifact download failed; continuing with no prior state."
-          exit 0
-        fi
-        unzip -q -o "${RUNNER_TEMP}/prior-state.zip" -d "$state_dir" || true
+    # Prior sticky state is recovered from the gate's own PR comment (a hidden
+    # base64 marker), not a workflow artifact. The comment is durable across the
+    # "Re-run jobs" button and force-pushes, both of which delete run-scoped
+    # artifacts and previously froze the clean-run counter (GAP-11). The detector
+    # reads the comment directly via the GitHub API — no download step needed.
 
     # Method-fix detection uses `git log -L:<method>:<file>`, which needs git's
     # language-aware funcname driver to locate Java methods. The repo has no
@@ -117,7 +87,8 @@ runs:
         KNOWN_FLAKY_TESTS_FILE: ${{ inputs.known-flaky-tests-file }}
         PR_NUMBER: ${{ inputs.pr-number }}
         BLOCKING: ${{ inputs.blocking }}
-        STATE_FILE_IN: ${{ steps.download-state.outputs.state_file }}
+        # Prior state now comes from the PR comment; STATE_FILE_OUT is retained
+        # only as a debug artifact of the run (not uploaded, not read back).
         STATE_FILE_OUT: ${{ runner.temp }}/flaky-gate-state-out/state.json
         RAN_JOBS_JSON: ${{ inputs.ran-jobs-json }}
         BYPASS_LABEL_PRESENT: ${{ inputs.bypass-label-present }}
@@ -127,38 +98,6 @@ runs:
         REPO_ROOT: ${{ inputs.repo-root != '' && inputs.repo-root || github.workspace }}
         GITHUB_TOKEN: ${{ github.token }}
       run: python3 ${{ github.action_path }}/detect_new_flaky_tests.py
-
-    # Detect whether the detector actually wrote a state file. hashFiles() cannot
-    # be used to guard the upload: it only hashes paths under GITHUB_WORKSPACE, but
-    # the state file lives in RUNNER_TEMP (outside the workspace), so hashFiles always
-    # returned '' and the upload was silently skipped on every run — sticky state never
-    # persisted across runs (the clean-run counter was frozen and cross-run stickiness
-    # was dead). A plain existence check reads the absolute path fine.
-    - name: Check sticky-state file written
-      id: state-written
-      if: always()
-      shell: bash
-      env:
-        STATE_FILE_OUT: ${{ runner.temp }}/flaky-gate-state-out/state.json
-      run: |
-        state_dir="$(dirname "$STATE_FILE_OUT")"
-        echo "sticky-state dir contents:"
-        ls -la "$state_dir" 2>/dev/null || echo "  (directory absent)"
-        if [[ -f "$STATE_FILE_OUT" ]]; then
-          echo "written=true" >> "$GITHUB_OUTPUT"
-          echo "state file present -> will upload for the next run"
-        else
-          echo "written=false" >> "$GITHUB_OUTPUT"
-          echo "state file absent -> skipping upload (no flakes and no prior state)"
-        fi
-
-    # Persist updated state for the next run. Skipped when the detector wrote
-    # nothing (no flakes + no prior state => no-op, no file to upload).
-    - name: Upload sticky-state artifact
-      if: always() && steps.state-written.outputs.written == 'true'
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: flaky-gate-state-pr-${{ inputs.pr-number }}
-        path: ${{ runner.temp }}/flaky-gate-state-out/state.json
-        retention-days: 30
-        overwrite: true
+    # Updated state is persisted by the detector into the PR comment's hidden
+    # marker (durable across re-runs / force-push). No artifact upload step —
+    # the run-scoped artifact was the root cause of GAP-11.

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -109,10 +109,34 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: python3 ${{ github.action_path }}/detect_new_flaky_tests.py
 
+    # Detect whether the detector actually wrote a state file. hashFiles() cannot
+    # be used to guard the upload: it only hashes paths under GITHUB_WORKSPACE, but
+    # the state file lives in RUNNER_TEMP (outside the workspace), so hashFiles always
+    # returned '' and the upload was silently skipped on every run — sticky state never
+    # persisted across runs (the clean-run counter was frozen and cross-run stickiness
+    # was dead). A plain existence check reads the absolute path fine.
+    - name: Check sticky-state file written
+      id: state-written
+      if: always()
+      shell: bash
+      env:
+        STATE_FILE_OUT: ${{ runner.temp }}/flaky-gate-state-out/state.json
+      run: |
+        state_dir="$(dirname "$STATE_FILE_OUT")"
+        echo "sticky-state dir contents:"
+        ls -la "$state_dir" 2>/dev/null || echo "  (directory absent)"
+        if [[ -f "$STATE_FILE_OUT" ]]; then
+          echo "written=true" >> "$GITHUB_OUTPUT"
+          echo "state file present -> will upload for the next run"
+        else
+          echo "written=false" >> "$GITHUB_OUTPUT"
+          echo "state file absent -> skipping upload (no flakes and no prior state)"
+        fi
+
     # Persist updated state for the next run. Skipped when the detector wrote
     # nothing (no flakes + no prior state => no-op, no file to upload).
     - name: Upload sticky-state artifact
-      if: always() && hashFiles(format('{0}/flaky-gate-state-out/state.json', runner.temp)) != ''
+      if: always() && steps.state-written.outputs.written == 'true'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: flaky-gate-state-pr-${{ inputs.pr-number }}

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -90,6 +90,25 @@ runs:
         fi
         unzip -q -o "${RUNNER_TEMP}/prior-state.zip" -d "$state_dir" || true
 
+    # Method-fix detection uses `git log -L:<method>:<file>`, which needs git's
+    # language-aware funcname driver to locate Java methods. The repo has no
+    # `*.java diff=java` gitattributes, so without this the -L call fails with
+    # "no match" for every method, method_last_modified is never resolved, and the
+    # clean-run clearance counter can never advance (cleared_via_fix unreachable).
+    # Enable the built-in Java driver for this checkout only (.git/info/attributes
+    # is local and not committed), scoping the change to the gate.
+    - name: Enable Java funcname driver for method-fix detection
+      if: always()
+      shell: bash
+      env:
+        REPO_ROOT: ${{ inputs.repo-root != '' && inputs.repo-root || github.workspace }}
+      run: |
+        git_info="${REPO_ROOT}/.git/info"
+        if [[ -d "$git_info" ]] && ! grep -qxF '*.java diff=java' "${git_info}/attributes" 2>/dev/null; then
+          printf '*.java diff=java\n' >> "${git_info}/attributes"
+          echo "enabled Java funcname driver in ${git_info}/attributes"
+        fi
+
     - name: Detect new flaky tests
       id: detect
       shell: bash

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -66,7 +66,15 @@ runs:
     # "no match" for every method, method_last_modified is never resolved, and the
     # clean-run clearance counter can never advance (cleared_via_fix unreachable).
     # Enable the built-in Java driver for this checkout only (.git/info/attributes
-    # is local and not committed), scoping the change to the gate.
+    # is local and not committed), scoping the change to the gate rather than
+    # committing a repo-wide `.gitattributes` change.
+    #
+    # The whole clearance mechanism silently depends on this driver being active,
+    # so verify it took effect and fail loud otherwise. Without the check, a
+    # future change to the gate's checkout (a linked worktree or `path:` makes
+    # `.git` a file, not a dir) would skip the driver silently — and under
+    # blocking a genuinely-fixed test could then never clear, with no error to
+    # explain why.
     - name: Enable Java funcname driver for method-fix detection
       if: always()
       shell: bash
@@ -74,9 +82,17 @@ runs:
         REPO_ROOT: ${{ inputs.repo-root != '' && inputs.repo-root || github.workspace }}
       run: |
         git_info="${REPO_ROOT}/.git/info"
-        if [[ -d "$git_info" ]] && ! grep -qxF '*.java diff=java' "${git_info}/attributes" 2>/dev/null; then
+        mkdir -p "$git_info"
+        if ! grep -qxF '*.java diff=java' "${git_info}/attributes" 2>/dev/null; then
           printf '*.java diff=java\n' >> "${git_info}/attributes"
           echo "enabled Java funcname driver in ${git_info}/attributes"
+        fi
+        # Verify git actually honors the driver (probe path need not exist).
+        if git -C "$REPO_ROOT" check-attr diff -- Probe.java | grep -q 'diff: java'; then
+          echo "Java funcname driver active"
+        else
+          echo "::error::Java funcname driver NOT active for *.java in ${REPO_ROOT} — flaky-gate method-fix detection would silently fail (a fixed test could never clear). Check the checkout topology / repo-root input."
+          exit 1
         fi
 
     - name: Detect new flaky tests

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -7,7 +7,7 @@ description: >
   stays flagged until the method body is modified and 3 subsequent gate runs observe it
   clean, or until the ci:flaky-test-bypass label is applied. Posts/updates a single PR
   comment that renders the current state and embeds it as a hidden base64 marker for the
-  next run to read (durable across re-runs / force-push, unlike a run-scoped artifact).
+  next run to read (durable across re-runs / force-push).
 
 inputs:
   pr-flaky-tests-data:
@@ -54,11 +54,8 @@ outputs:
 runs:
   using: composite
   steps:
-    # Prior sticky state is recovered from the gate's own PR comment (a hidden
-    # base64 marker), not a workflow artifact. The comment is durable across the
-    # "Re-run jobs" button and force-pushes, both of which delete run-scoped
-    # artifacts and previously froze the clean-run counter. The detector
-    # reads the comment directly via the GitHub API — no download step needed.
+    # Sticky state lives in the gate's PR comment (a hidden base64 marker),
+    # read and written by the detector via the GitHub API.
 
     # Method-fix detection uses `git log -L:<method>:<file>`, which needs git's
     # language-aware funcname driver to locate Java methods. The repo has no
@@ -103,8 +100,7 @@ runs:
         KNOWN_FLAKY_TESTS_FILE: ${{ inputs.known-flaky-tests-file }}
         PR_NUMBER: ${{ inputs.pr-number }}
         BLOCKING: ${{ inputs.blocking }}
-        # Prior state now comes from the PR comment; STATE_FILE_OUT is retained
-        # only as a debug artifact of the run (not uploaded, not read back).
+        # STATE_FILE_OUT is a debug dump of the run's state — not uploaded, not read back.
         STATE_FILE_OUT: ${{ runner.temp }}/flaky-gate-state-out/state.json
         RAN_JOBS_JSON: ${{ inputs.ran-jobs-json }}
         BYPASS_LABEL_PRESENT: ${{ inputs.bypass-label-present }}
@@ -115,5 +111,4 @@ runs:
         GITHUB_TOKEN: ${{ github.token }}
       run: python3 ${{ github.action_path }}/detect_new_flaky_tests.py
     # Updated state is persisted by the detector into the PR comment's hidden
-    # marker (durable across re-runs / force-push). No artifact upload step —
-    # the run-scoped artifact was the root cause of the stuck counter.
+    # marker (durable across re-runs / force-push).

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -8,8 +8,11 @@ flagged until either:
       runs observe the test passing (zero Maven retries) in the originally
       affected job.
 
-State is persisted between gate runs via a per-PR workflow artifact (JSON).
-The PR comment is a human-readable render of that state.
+State is persisted between gate runs inside the gate's PR comment: a hidden
+base64 `<!-- flaky-gate-state: … -->` marker holds the full JSON, and the
+visible comment body is a human-readable render of it. The comment is durable
+across the "Re-run jobs" button and force-pushes, unlike a run-scoped artifact
+(see GAP-11 / README "Why the PR comment holds state").
 
 Inputs (environment variables):
   PR_FLAKY_TESTS_DATA    – JSON array of {job, flaky_tests}
@@ -18,8 +21,9 @@ Inputs (environment variables):
   GITHUB_TOKEN           – GitHub API token
   GITHUB_REPOSITORY      – owner/repo
   GITHUB_OUTPUT          – Path to the GHA step output file
-  STATE_FILE_IN          – Path to existing state.json (may not exist on first run)
-  STATE_FILE_OUT         – Path to write updated state.json
+  STATE_FILE_IN          – Fallback prior-state path for local/offline runs when
+                           the PR comment cannot be fetched (CI reads the comment)
+  STATE_FILE_OUT         – Optional debug dump of the updated state (not uploaded)
   RAN_JOBS_JSON          – JSON array of parent job names whose result is not 'skipped'
   BYPASS_LABEL_PRESENT   – 'true' / 'false'
   HEAD_SHA               – Current PR head SHA
@@ -28,6 +32,7 @@ Inputs (environment variables):
   REPO_ROOT              – Absolute path to the checked-out repo (for git/find)
 """
 
+import base64
 import datetime as _dt
 import json
 import os
@@ -39,7 +44,10 @@ import urllib.request
 
 PREFIX = "[new-flaky]"
 COMMENT_MARKER = "<!-- new-flaky-tests-alert -->"
-STATE_ARTIFACT_MARKER_PREFIX = "<!-- flaky-gate-state-artifact: "
+# The full sticky-state JSON is base64-encoded into this hidden marker in the
+# gate's PR comment. The comment — unlike a run-scoped artifact — survives the
+# "Re-run jobs" button and force-pushes, so it is the durable state store.
+STATE_MARKER_PREFIX = "<!-- flaky-gate-state: "
 SCHEMA_VERSION = 1
 MIN_CLEAN_RUNS = 3
 
@@ -133,6 +141,43 @@ def save_state(path: str, state: dict) -> None:
 
 def _now_iso() -> str:
     return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def encode_state_marker(state: dict) -> str:
+    """Serialize state into the hidden comment marker line.
+
+    The full state JSON is base64-encoded inside an HTML comment: invisible in
+    the rendered comment, but round-trips exactly on the next run. This makes
+    the comment the durable state store — it survives the "Re-run jobs" button
+    and force-pushes, both of which delete run-scoped artifacts (see GAP-11).
+    """
+    payload = base64.b64encode(
+        json.dumps(state, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ).decode("ascii")
+    return f"{STATE_MARKER_PREFIX}{payload} -->"
+
+
+def extract_state_from_comment(body: str | None) -> dict | None:
+    """Recover prior state from the hidden marker in an existing PR comment.
+
+    Returns None when there is no comment, no marker, or the payload is
+    unreadable / schema-mismatched — the caller then starts fresh.
+    """
+    if not body:
+        return None
+    m = re.search(re.escape(STATE_MARKER_PREFIX) + r"([A-Za-z0-9+/=]+) -->", body)
+    if not m:
+        return None
+    try:
+        raw = base64.b64decode(m.group(1)).decode("utf-8")
+        state = json.loads(raw)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"{PREFIX} WARN: could not decode comment state ({exc}) — starting fresh.")
+        return None
+    if not isinstance(state, dict) or state.get("schema_version") != SCHEMA_VERSION:
+        print(f"{PREFIX} WARN: comment state schema mismatch — starting fresh.")
+        return None
+    return state
 
 
 # ---------------------------------------------------------------------------
@@ -446,14 +491,14 @@ def _render_cleared_test(entry: dict) -> list[str]:
     ]
 
 
-def render_comment(state: dict, artifact_name: str) -> str:
+def render_comment(state: dict) -> str:
     active = [e for e in state["tests"] if e.get("status") == "active"]
     cleared = [e for e in state["tests"] if e.get("status") in
                ("cleared_via_fix", "cleared_via_bypass", "dropped_force_push")]
 
     lines = [
         COMMENT_MARKER,
-        f"{STATE_ARTIFACT_MARKER_PREFIX}{artifact_name} -->",
+        encode_state_marker(state),
     ]
 
     if active:
@@ -537,25 +582,32 @@ def _github_api(url: str, token: str, method: str = "GET",
         raise GitHubAPIError(f"{exc.status} {exc.reason} — {body}") from exc
 
 
-def _find_existing_comment(owner: str, repo: str, pr: int, token: str) -> int | None:
+def _find_existing_comment(owner: str, repo: str, pr: int,
+                           token: str) -> tuple[int | None, str | None]:
+    """Return (comment_id, body) of the gate's comment, or (None, None)."""
     page = 1
     while True:
         url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr}/comments?per_page=100&page={page}"
         raw = _github_api(url, token)
         comments = json.loads(raw)
         if not comments:
-            return None
+            return None, None
         for c in comments:
-            if COMMENT_MARKER in (c.get("body") or ""):
-                return c["id"]
+            body = c.get("body") or ""
+            if COMMENT_MARKER in body:
+                return c["id"], body
         page += 1
 
 
-def post_or_update_comment(owner: str, repo: str, pr: int, body: str, token: str) -> None:
-    existing = _find_existing_comment(owner, repo, pr, token)
+def post_or_update_comment(owner: str, repo: str, pr: int, body: str,
+                           token: str, existing_id: int | None = None) -> None:
+    # existing_id is passed in when the caller already located the comment
+    # (to read prior state), so we avoid a second full comment scan.
+    if existing_id is None:
+        existing_id, _ = _find_existing_comment(owner, repo, pr, token)
     payload = json.dumps({"body": body}).encode()
-    if existing:
-        url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments/{existing}"
+    if existing_id:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/comments/{existing_id}"
         _github_api(url, token, method="PATCH", data=payload)
     else:
         url = f"https://api.github.com/repos/{owner}/{repo}/issues/{pr}/comments"
@@ -752,9 +804,29 @@ def main() -> None:
     base_sha_input = os.environ.get("BASE_SHA", "")
     blocking = os.environ.get("BLOCKING", "true").lower() == "true"
     repo_root = os.environ.get("REPO_ROOT", os.getcwd())
-    artifact_name = f"flaky-gate-state-pr-{pr_number}"
+    owner, name = repository.split("/", 1) if "/" in repository else (None, None)
 
-    state = load_state(state_in, pr_number, head_sha)
+    # Load prior state. The gate's PR comment carries the full state in a hidden
+    # base64 marker and is the durable source of truth: it survives the "Re-run
+    # jobs" button and force-pushes, which delete the run-scoped artifact the
+    # gate used to rely on (GAP-11). STATE_FILE_IN remains a fallback for local
+    # / offline runs where the comment cannot be fetched.
+    existing_comment_id: int | None = None
+    prior_state: dict | None = None
+    if owner and token:
+        try:
+            existing_comment_id, existing_body = _find_existing_comment(
+                owner, name, pr_number, token)
+            prior_state = extract_state_from_comment(existing_body)
+        except GitHubAPIError as exc:
+            print(f"{PREFIX} WARN: could not fetch existing comment ({exc}) "
+                  "— falling back to state file / fresh.")
+
+    if prior_state is not None:
+        print(f"{PREFIX} Loaded prior state from PR comment marker.")
+        state = prior_state
+    else:
+        state = load_state(state_in, pr_number, head_sha)
     state["pr_number"] = pr_number
 
     # Snapshot prior method_last_modified for Q4c counter-reset detection.
@@ -812,11 +884,13 @@ def main() -> None:
         for entry in state["tests"]:
             entry.pop("_prev_last_mod", None)
         state["last_known_head_sha"] = head_sha
-        save_state(state_out, state)
-        comment = render_comment(state, artifact_name)
+        if state_out:
+            save_state(state_out, state)
+        comment = render_comment(state)
         # Bypass is an escape hatch: entries are already cleared, so a failed
         # comment post must never fail the job (would defeat the unblock).
-        _post_comment_with_handling(repository, pr_number, comment, token, blocking=False)
+        _post_comment_with_handling(repository, pr_number, comment, token,
+                                    blocking=False, existing_id=existing_comment_id)
         set_output("has-new-flaky-tests", "false")
         return
 
@@ -838,13 +912,15 @@ def main() -> None:
         entry.pop("_prev_last_mod", None)
 
     state["last_known_head_sha"] = head_sha
-    save_state(state_out, state)
+    if state_out:
+        save_state(state_out, state)
 
     active_count = sum(1 for e in state["tests"] if e.get("status") == "active")
     print(f"{PREFIX} active={active_count} total_tracked={len(state['tests'])}")
 
-    comment = render_comment(state, artifact_name)
-    _post_comment_with_handling(repository, pr_number, comment, token, blocking)
+    comment = render_comment(state)
+    _post_comment_with_handling(repository, pr_number, comment, token, blocking,
+                                existing_id=existing_comment_id)
 
     set_output("has-new-flaky-tests", "true" if active_count > 0 else "false")
     if active_count > 0 and blocking:
@@ -853,13 +929,14 @@ def main() -> None:
 
 
 def _post_comment_with_handling(repo: str, pr: int, body: str,
-                                 token: str, blocking: bool) -> None:
+                                 token: str, blocking: bool,
+                                 existing_id: int | None = None) -> None:
     if not repo or "/" not in repo:
         print(f"{PREFIX} WARN: GITHUB_REPOSITORY not set — skipping comment.")
         return
     owner, name = repo.split("/", 1)
     try:
-        post_or_update_comment(owner, name, pr, body, token)
+        post_or_update_comment(owner, name, pr, body, token, existing_id=existing_id)
     except GitHubAPIError as exc:
         msg = f"comment post/update failed: {exc}"
         if blocking:

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -253,7 +253,16 @@ def method_last_modified_in_range(file_path: str, method_name: str,
     """
     if not file_path or not method_name or not base_sha or not head_sha:
         return None
-    safe = re.escape(method_name)
+    # Anchor the funcname regex to the method *declaration* by requiring the
+    # name to be immediately followed by '(' (google-java-format leaves no
+    # space before the parameter list). Without this, a short name matches
+    # inside a longer method header sharing its prefix — e.g. a query for
+    # `getVersion` also matches `getVersionLowerCase(`, and git -L locks onto
+    # whichever declaration appears first, tracking the wrong method and
+    # returning the wrong "last modified" SHA. Use the '[(]' character class,
+    # not an escaped '\(' — git's -L parser rejects the latter with
+    # "parentheses not balanced".
+    safe = re.escape(method_name) + "[(]"
     rc, out, err = _run_git(
         ["log", "--format=%H", f"-L:{safe}:{file_path}",
          f"{base_sha}..{head_sha}"],

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -12,7 +12,7 @@ State is persisted between gate runs inside the gate's PR comment: a hidden
 base64 `<!-- flaky-gate-state: … -->` marker holds the full JSON, and the
 visible comment body is a human-readable render of it. The comment is durable
 across the "Re-run jobs" button and force-pushes, unlike a run-scoped artifact
-(see GAP-11 / README "Why the PR comment holds state").
+(see README "Why the PR comment holds state").
 
 Inputs (environment variables):
   PR_FLAKY_TESTS_DATA    – JSON array of {job, flaky_tests}
@@ -149,7 +149,7 @@ def encode_state_marker(state: dict) -> str:
     The full state JSON is base64-encoded inside an HTML comment: invisible in
     the rendered comment, but round-trips exactly on the next run. This makes
     the comment the durable state store — it survives the "Re-run jobs" button
-    and force-pushes, both of which delete run-scoped artifacts (see GAP-11).
+    and force-pushes, both of which delete run-scoped artifacts.
     """
     payload = base64.b64encode(
         json.dumps(state, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -809,7 +809,7 @@ def main() -> None:
     # Load prior state. The gate's PR comment carries the full state in a hidden
     # base64 marker and is the durable source of truth: it survives the "Re-run
     # jobs" button and force-pushes, which delete the run-scoped artifact the
-    # gate used to rely on (GAP-11). STATE_FILE_IN remains a fallback for local
+    # gate used to rely on. STATE_FILE_IN remains a fallback for local
     # / offline runs where the comment cannot be fetched.
     existing_comment_id: int | None = None
     prior_state: dict | None = None

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -45,8 +45,7 @@ import urllib.request
 PREFIX = "[new-flaky]"
 COMMENT_MARKER = "<!-- new-flaky-tests-alert -->"
 # The full sticky-state JSON is base64-encoded into this hidden marker in the
-# gate's PR comment. The comment — unlike a run-scoped artifact — survives the
-# "Re-run jobs" button and force-pushes, so it is the durable state store.
+# gate's PR comment (see the module docstring for why the comment holds state).
 STATE_MARKER_PREFIX = "<!-- flaky-gate-state: "
 SCHEMA_VERSION = 1
 MIN_CLEAN_RUNS = 3
@@ -147,9 +146,7 @@ def encode_state_marker(state: dict) -> str:
     """Serialize state into the hidden comment marker line.
 
     The full state JSON is base64-encoded inside an HTML comment: invisible in
-    the rendered comment, but round-trips exactly on the next run. This makes
-    the comment the durable state store — it survives the "Re-run jobs" button
-    and force-pushes, both of which delete run-scoped artifacts.
+    the rendered comment, but round-trips exactly on the next run.
     """
     payload = base64.b64encode(
         json.dumps(state, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -815,11 +812,9 @@ def main() -> None:
     repo_root = os.environ.get("REPO_ROOT", os.getcwd())
     owner, name = repository.split("/", 1) if "/" in repository else (None, None)
 
-    # Load prior state. The gate's PR comment carries the full state in a hidden
-    # base64 marker and is the durable source of truth: it survives the "Re-run
-    # jobs" button and force-pushes, which delete the run-scoped artifact the
-    # gate used to rely on. STATE_FILE_IN remains a fallback for local
-    # / offline runs where the comment cannot be fetched.
+    # Load prior state from the gate's PR comment (the durable base64 marker).
+    # STATE_FILE_IN is a fallback for local / offline runs where the comment
+    # cannot be fetched.
     existing_comment_id: int | None = None
     prior_state: dict | None = None
     if owner and token:
@@ -879,7 +874,7 @@ def main() -> None:
     # -- Nothing-to-do short-circuit --------------------------------------
     # No prior tracked entries, no new flakes this run, and no bypass: there is
     # nothing to reconcile and nothing to show. Return without posting a comment
-    # or writing state (so no artifact is uploaded) — keeps clean PRs untouched.
+    # or writing state — keeps clean PRs untouched.
     if not bypass and not new_flaky_tests and not state["tests"]:
         print(f"{PREFIX} No prior state and no flaky tests this run — nothing to do.")
         set_output("has-new-flaky-tests", "false")

--- a/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
@@ -357,11 +357,11 @@ class TestRenderComment(unittest.TestCase):
             method_last_modified_sha="abcdef0",
             clean_runs_since_modified=1,
         ))
-        body = d.render_comment(state, "art-name")
+        body = d.render_comment(state)
         self.assertIn("⚠️ New Flaky Tests Detected", body)
         self.assertIn("Clean re-runs since fix: 1 / 3", body)
         self.assertIn("Method last modified at: `abcdef0`", body)
-        self.assertIn("art-name", body)
+        self.assertIn(d.STATE_MARKER_PREFIX, body)
 
     def test_all_clear_template(self):
         state = _make_state(_make_entry(
@@ -369,7 +369,7 @@ class TestRenderComment(unittest.TestCase):
             method_last_modified_sha="fix1",
             cleared_at="t",
         ))
-        body = d.render_comment(state, "art-name")
+        body = d.render_comment(state)
         self.assertIn("✅ Cleared", body)
         self.assertNotIn("⚠️", body)
         self.assertIn("<details>", body)
@@ -380,10 +380,42 @@ class TestRenderComment(unittest.TestCase):
             _make_entry(key="t2", status="cleared_via_bypass",
                          cleared_at="t"),
         )
-        body = d.render_comment(state, "art-name")
+        body = d.render_comment(state)
         self.assertIn("⚠️", body)
         self.assertIn("1 cleared test(s) (history)", body)
         self.assertIn("cleared via `ci:flaky-test-bypass`", body)
+
+
+class TestStateMarkerRoundtrip(unittest.TestCase):
+    def test_state_survives_render_then_extract(self):
+        # The rendered comment is the durable store: state embedded by
+        # render_comment must decode back identically on the next run.
+        state = _make_state(_make_entry(
+            method_last_modified_sha="fix1",
+            clean_runs_since_modified=2,
+        ))
+        body = d.render_comment(state)
+        recovered = d.extract_state_from_comment(body)
+        self.assertIsNotNone(recovered)
+        self.assertEqual(recovered["tests"][0]["clean_runs_since_modified"], 2)
+        self.assertEqual(recovered["tests"][0]["method_last_modified_sha"], "fix1")
+        self.assertEqual(recovered["pr_number"], state["pr_number"])
+
+    def test_extract_returns_none_without_marker(self):
+        self.assertIsNone(d.extract_state_from_comment(None))
+        self.assertIsNone(d.extract_state_from_comment(""))
+        self.assertIsNone(d.extract_state_from_comment("no marker here"))
+
+    def test_extract_returns_none_on_corrupt_payload(self):
+        corrupt = f"{d.COMMENT_MARKER}\n{d.STATE_MARKER_PREFIX}not!valid!base64 -->"
+        self.assertIsNone(d.extract_state_from_comment(corrupt))
+
+    def test_extract_returns_none_on_schema_mismatch(self):
+        import base64 as _b64
+        payload = _b64.b64encode(
+            json.dumps({"schema_version": 999}).encode()).decode()
+        body = f"{d.COMMENT_MARKER}\n{d.STATE_MARKER_PREFIX}{payload} -->"
+        self.assertIsNone(d.extract_state_from_comment(body))
 
 
 class TestMergeBase(unittest.TestCase):

--- a/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
@@ -94,6 +94,49 @@ class TestBaseline(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Method-fix detection: git log -L funcname anchoring
+# ---------------------------------------------------------------------------
+
+class TestMethodLastModified(unittest.TestCase):
+    def _captured_L_arg(self, method_name):
+        """Return the -L:... arg passed to git for a given method name."""
+        captured = {}
+
+        def fake_run_git(args, repo_root):
+            for a in args:
+                if a.startswith("-L:"):
+                    captured["L"] = a
+            return 0, "", ""
+
+        with mock.patch.object(d, "_run_git", side_effect=fake_run_git):
+            d.method_last_modified_in_range(
+                "path/To/C.java", method_name, "base", "head", "/repo")
+        return captured.get("L")
+
+    def test_L_arg_anchors_method_name_to_open_paren(self):
+        # The funcname regex must require '(' after the name so a query does
+        # not match a longer method sharing its prefix.
+        self.assertEqual(
+            self._captured_L_arg("getVersion"),
+            "-L:getVersion[(]:path/To/C.java",
+        )
+
+    def test_L_arg_escapes_regex_metacharacters(self):
+        # Defensive: any regex-special chars in the name are escaped before
+        # the '[(]' anchor is appended.
+        self.assertEqual(
+            self._captured_L_arg("get.value"),
+            "-L:get\\.value[(]:path/To/C.java",
+        )
+
+    def test_returns_none_on_missing_inputs(self):
+        self.assertIsNone(
+            d.method_last_modified_in_range("", "m", "b", "h", "/repo"))
+        self.assertIsNone(
+            d.method_last_modified_in_range("f", "", "b", "h", "/repo"))
+
+
+# ---------------------------------------------------------------------------
 # State persistence
 # ---------------------------------------------------------------------------
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1644,9 +1644,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      pull-requests: write
+      pull-requests: write  # read prior state from + write updated state to the gate's PR comment
       contents: read
-      actions: read  # read the prior per-PR sticky-state run artifact via the Artifacts API
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         timeout-minutes: 5


### PR DESCRIPTION
## Problem

The flaky-gate's per-PR sticky state never worked end-to-end, for two reasons:

1. **State didn't survive across runs or re-runs.** State was kept in a run-scoped workflow artifact (`flaky-gate-state-pr-<N>`). GitHub's **"Re-run jobs"** button starts a new run attempt and **deletes the run's own prior-attempt artifacts**, so a re-run could never see the clean-run counter its earlier attempt banked — it fell back to an older run's artifact and re-landed on the same value. The documented "fix the test, let CI run 3× to clear" flow was therefore impossible; only brand-new commits (throwaway pushes) advanced the counter. No artifact-selection strategy fixes this, because the advanced state only ever lived in the deleted artifact.

2. **Method-fix detection was dead.** Clearance requires detecting that the flagged test's method body changed, via `git log -L:<method>:<file>`. That needs git's Java funcname driver, but the repo has no `*.java diff=java` gitattributes — so `-L` matched nothing, `method_last_modified` never resolved, and the counter could never advance even once.

## Fix

- **Store sticky state in the gate's PR comment** (a hidden base64 marker, `<!-- flaky-gate-state: … -->`) instead of a workflow artifact. The comment is **not** run-scoped: it survives re-runs, attempts, and force-pushes, so the counter is durable and monotonic and a genuinely fixed test clears by re-running CI — **no throwaway commits**. The workflow artifact is removed entirely, along with its `retention-days` config and the job's `actions: read` permission.
- **Enable the Java funcname driver** for the gate's checkout only — appends `*.java diff=java` to `.git/info/attributes` (local to the checkout, not committed) so `git log -L` can locate Java methods and method-fix detection works.
- Detector logic is otherwise unchanged (re-flake still resets the counter to `0`, so a test that starts flaking again mid-clearance restarts the walk). 53 unit tests pass, including new state-marker roundtrip / corrupt-payload / schema-mismatch cases. Full rationale in the action's README ("Why the PR comment holds state").

**Trade-offs** (acceptable for a pilot, comment-only advisory gate): the base64 state is visible and editable in the comment source (advisory gate, and the `ci:flaky-test-bypass` label escape hatch already exists); concurrent runs are last-writer-wins on the comment (absorbed by `MIN_CLEAN_RUNS = 3`); state size is well under GitHub's comment cap.

## Testing — validated live on canary PR #56731

Ran the full **flag → fix → re-run** cycle on the canary ([#56731](https://github.com/camunda/camunda/pull/56731), DO NOT MERGE):

| Step | CI run | Result in the PR comment |
|---|---|---|
| Test flakes → gate flags it | [run 28793539568](https://github.com/camunda/camunda/actions/runs/28793539568) | comment posts at **0/3**, active |
| Fix the method (clean run) | [run 28795289951 · attempt 1](https://github.com/camunda/camunda/actions/runs/28795289951/attempts/1) | **1/3**, "Method last modified" resolved |
| **Re-run all jobs** (no new commit) | [run 28795289951 · attempt 2](https://github.com/camunda/camunda/actions/runs/28795289951/attempts/2) | **2/3** — counter advanced on the re-run button |

The re-run advancing **1/3 → 2/3** is the key proof: with the old run-scoped artifact the counter was permanently stuck at 1/3 on the re-run button. Live comment on the canary: [#56731 (comment)](https://github.com/camunda/camunda/pull/56731#issuecomment-4891337858). (3/3 → cleared is cosmetic; 2/3 already demonstrates re-runs advance.)
