### PR TITLE
fix: archiver to validate reindex response before deleting documents

### DIFF
--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
@@ -320,6 +320,41 @@ public class SearchClientAdapter {
     }
   }
 
+  /**
+   * Creates a single-shard index whose documents cannot be written ({@code index.blocks.write}).
+   *
+   * <p>Writing to such an index does not throw at the request level: a bulk/reindex request against
+   * it returns HTTP 200 with a populated {@code failures[]} array (a per-item {@code
+   * cluster_block_exception}).
+   */
+  public void createIndexWithWriteBlock(final String indexName) throws IOException {
+    if (elsClient != null) {
+      elsClient
+          .indices()
+          .create(
+              c ->
+                  c.index(indexName)
+                      .settings(
+                          settings ->
+                              settings
+                                  .numberOfShards("1")
+                                  .numberOfReplicas("0")
+                                  .blocks(b -> b.write(true))));
+    } else if (osClient != null) {
+      osClient
+          .indices()
+          .create(
+              c ->
+                  c.index(indexName)
+                      .settings(
+                          settings ->
+                              settings
+                                  .numberOfShards(1)
+                                  .numberOfReplicas(0)
+                                  .blocks(b -> b.write(true))));
+    }
+  }
+
   public void deleteIndex(final String indexName) throws IOException {
     if (elsClient != null) {
       elsClient.indices().delete(d -> d.index(indexName));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -352,7 +352,12 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             (response, error) ->
                 metrics.measureArchiverReindex(response != null ? response.total() : null, timer),
             executor)
-        .thenApplyAsync(ignored -> null, executor);
+        .thenApplyAsync(
+            response -> {
+              validateReindexResponse(sourceIndexName, response);
+              return null;
+            },
+            executor);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -362,7 +362,12 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             (response, error) ->
                 metrics.measureArchiverReindex(response != null ? response.total() : null, timer),
             executor)
-        .thenApplyAsync(ignored -> null, executor);
+        .thenApplyAsync(
+            response -> {
+              validateReindexResponse(sourceIndexName, response);
+              return null;
+            },
+            executor);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -55,6 +55,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.TestTemplate;
 
 public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInstanceArchiverJob>
@@ -431,6 +432,60 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
               verifyMoved(dependent.template(), client, entity, "2020-01-01");
             }
           }
+        });
+  }
+
+  @TestTemplate
+  void shouldNotDeleteDocumentsWhenReindexDoesNotFullySucceed(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withArchiverJob(
+        config,
+        (job, resourceProvider) -> {
+          // given - a finished process instance together with its dependent records
+          final var listViewTemplate =
+              resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+          final ProcessInstanceForListViewEntity processInstance =
+              processInstanceForListViewEntity("2026-01-01T00:00:00+00:00");
+          final var dependents =
+              getProcessInstanceDependentEntities(resourceProvider, processInstance);
+
+          store(listViewTemplate, client, processInstance);
+          for (final var dependent : dependents) {
+            for (final var entity : dependent.entities()) {
+              store(dependent.template(), client, entity);
+            }
+          }
+          client.refresh();
+
+          // and - every dated destination index is pre-created with a write block, so the reindex
+          // step cannot copy any document. Elasticsearch will report the rejected writes in
+          // failures[] array in an HTTP 200 reindex response (no exception), which the archiver
+          // must detect before deleting the source documents.
+          final var datedSuffix = "2026-01-01";
+          client.createIndexWithWriteBlock(listViewTemplate.getFullQualifiedName() + datedSuffix);
+          for (final var dependent : dependents) {
+            client.createIndexWithWriteBlock(
+                dependent.template().getFullQualifiedName() + datedSuffix);
+          }
+
+          // when
+          final var result = job.execute().toCompletableFuture();
+          Awaitility.await("until the archive job has finished")
+              .atMost(ARCHIVE_TIMEOUT)
+              .until(result::isDone);
+          client.refresh();
+
+          // then - nothing was copied to the write-blocked dated indices, so no source document may
+          // have been deleted: the reindex failure must never lead to silent data loss
+          verifyNotMoved(listViewTemplate, client, processInstance);
+          for (final var dependent : dependents) {
+            for (final var entity : dependent.entities()) {
+              verifyNotMoved(dependent.template(), client, entity);
+            }
+          }
+
+          // and - the failure must be surfaced to the caller instead of being silently swallowed
+          assertThat(result).isCompletedExceptionally();
         });
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Elasticsearch sync reindex may return HTTP 200, even when it does not succeed to reindex all the requested documents. In this pull request we validate the reindex response before proceeding with document deletion from main index, to avoid historical data loss
Note: this is not affecting the archiver-by-id mode, that is enabled by default in all the latest 8.8 and 8.9 patch versions

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56720
