### PR TITLE
fix: check out .github before npm ci retry in preview smoke test

### DIFF
--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -160,6 +160,13 @@ jobs:
           owner: camunda
           repositories: c8-cross-component-e2e-tests
 
+      # Sparse-checkout .github so local composite actions (npm-ci-with-retry,
+      # observe-build-status) resolve.
+      - name: Check out .github for local actions
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          sparse-checkout: .github
+
       - name: Checkout Smoke Tests
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -211,9 +218,6 @@ jobs:
             e2e-tests/html-report/
             e2e-tests/test-results/
           retention-days: 7
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          sparse-checkout: .github
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Problem

The `Preview Environment Smoke Test` workflow started failing (e.g. [run 28775516193](https://github.com/camunda/camunda/actions/runs/28775516193/job/85335726361)):

```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.../.github/actions/npm-ci-with-retry'.
Did you forget to run actions/checkout before running your local action?
```

The `test` job checks out only the **external** `camunda/c8-cross-component-e2e-tests` repo (into `e2e-tests/`) and did a **late sparse `.github` checkout** — placed just before `observe-build-status` — as the only checkout of this repo. #56417 converted the job's `run: npm ci` step to the local `./.github/actions/npm-ci-with-retry` composite action, but at that point the camunda repo isn't on disk, so the local action can't be found and the step fails.

## Fix

Move the existing sparse `.github` checkout **earlier** — before the `Install Dependencies` step — and drop the now-redundant late copy:

- The new checkout is placed **before** the `Checkout Smoke Tests` step. It's a root checkout whose `clean` would wipe the `e2e-tests/` working tree if it ran afterwards, so it must come first.
- `.github` then stays on disk for the rest of the job, so both local composite actions — `npm-ci-with-retry` (install) and `observe-build-status` (final step) — resolve.

This keeps the composite-action usage consistent with the rest of #56417 rather than reintroducing an inline retry block.

## Scan

Reviewed all 17 `npm-ci-with-retry` call sites. Every other workflow job performs a standard root `actions/checkout` before its install (container and e2e jobs included), and the composite-action call sites inherit their caller's checkout. **This is the only affected job.** The backport branches don't contain this workflow (dropped as main-only).

## Validation

`actionlint` clean, `conftest --policy .github` 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)