### PR TITLE
ci: suppress Renovate lookup failures for unreachable internal packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -507,7 +507,7 @@
         "docker"
       ],
       "matchPackageNames": [
-        "registry.camunda.cloud/team-zeebe",
+        "/^registry\\.camunda\\.cloud\\/team-zeebe\\//",
         "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter"
       ],
       "enabled": false

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -490,6 +490,29 @@
       "enabled": false
     },
     {
+      "description": "Disable Maven lookup for internal monorepo parent POMs (operate-qa, tasklist-qa, camunda-qa) that are never published to any external registry. depType 'parent' (non-root) is not covered by the parent-root exclusion above.",
+      "matchManagers": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "io.camunda:operate-qa",
+        "io.camunda:camunda-qa",
+        "io.camunda:tasklist-qa"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable Docker updates for private registries used in load tests that Renovate cannot authenticate to: registry.camunda.cloud (internal Harbor) and europe-west1-docker.pkg.dev/camunda-benchmark (GCP AR pull-through cache for quay.io/prometheuscommunity/elasticsearch-exporter — track upstream manually).",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "registry.camunda.cloud/team-zeebe",
+        "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Disable internal io.camunda Maven updates on stable branches; versions are controlled by the release process.",
       "matchManagers": [
         "maven"


### PR DESCRIPTION
## Summary

- Adds `enabled: false` rules for three classes of dependencies that Renovate cannot look up, clearing the persistent "Failed to look up" warnings in the dependency dashboard and unblocking PR rebases
- Internal monorepo Maven parent POMs (`io.camunda:operate-qa`, `camunda-qa`, `tasklist-qa`) — never published to any external registry; the existing `parent-root` exclusion doesn't cover `depType: parent` (non-root multi-module parents)
- Private Docker registries used by load tests: `registry.camunda.cloud/team-zeebe` (internal Harbor, no credentials) and the GCP AR pull-through cache path for `quay.io/prometheuscommunity/elasticsearch-exporter` (introduced to avoid rate limiting but not authenticatable by Renovate — track upstream version manually)
- The `camunda/team-qa-engineering` github-tags warning needs no config change; the action reference was already replaced by `camunda/infra-global-github-actions` and the stale dashboard entry clears on the next scan

## Test plan

- [ ] Verify Renovate dependency dashboard no longer shows "Failed to look up" warnings for the listed packages after the next Renovate run
- [ ] Confirm existing Renovate PRs can be rebased without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)