### PR TITLE
test: skip global-task-listener eventTypes filter (product bug #56636); ci trace upload; fix-agent playbook

### DIFF
--- a/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-api-tests.yml
@@ -249,6 +249,18 @@ jobs:
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
           retention-days: 60
 
+      # test-results/ holds the per-test Playwright trace.zip (retain-on-failure).
+      # The trace captures the request/response body, which json-report omits;
+      # nightly triage needs it to tell a request-shape/test bug from a product bug.
+      - name: Upload Playwright traces to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-nightly-api-${{ steps.sanitize.outputs.safe_branch }}-${{ inputs.camunda_mode }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/test-results/**
+          if-no-files-found: ignore
+          retention-days: 5
+
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -416,6 +416,18 @@ jobs:
           path: qa/c8-orchestration-cluster-e2e-test-suite/json-report/**
           retention-days: 60
 
+      # test-results/ holds the per-test Playwright trace.zip (retain-on-failure).
+      # The trace captures the request/response body, which json-report omits;
+      # nightly triage needs it to tell a request-shape/test bug from a product bug.
+      - name: Upload Playwright traces to GitHub Actions Artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-results-nightly-api-rdbms-${{ steps.sanitize.outputs.safe_branch }}-${{ matrix.database.database-name }}-${{ inputs.camunda_mode }}
+          path: qa/c8-orchestration-cluster-e2e-test-suite/test-results/**
+          if-no-files-found: ignore
+          retention-days: 5
+
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/AGENTS.md
@@ -323,7 +323,16 @@ Only re-examine for a test-side cause if Gate A or Gate C is genuinely in doubt.
 
 **Gate C — Confirm the test is still correct.** The assertion must still match intended behavior,
 the selector must target a real element, and the test must not be stale. If the test itself is wrong
-→ that is a test fix (Step 4), not a product bug.
+→ that is a test fix (Step 4), not a product bug. **For any API test that failed with a non-happy
+response (unexpected status, error body, or wrong payload), "still correct" also requires the request
+the test SENT to conform to the API agreement** — diff the request (endpoint, method, body shape,
+field types, enum casing, params) against `zeebe/gateway-protocol/src/main/proto/v2/*.yaml`. If the
+request conforms and the response is still wrong, it is a genuine product bug (escalate; do not change
+the test); if the request is malformed or the test is badly planned, fix the test. **If the test uses
+the conventional shape that sibling filters use but the contract itself is the outlier and no request
+shape works, the contract/spec is the bug — escalate; do NOT rewrite the test to match a broken
+agreement (#56636 is exactly this case).** A backend-agnostic failure is, by itself, evidence of
+neither a product bug nor a test bug.
 
 ### Owning-component routing
 
@@ -530,6 +539,36 @@ a specific assertion or action. Typical patterns:
 - **API response shape change** — only a test-side fix is in scope if the
   test was asserting on a field that legitimately moved/renamed. If the
   endpoint regressed, this is a product bug — see Step 4.
+- **Any unexpected / non-happy API response** (an unexpected status — 4xx *or*
+  5xx — an error body, or a wrong/empty payload) — before deciding, check the
+  request the test SENT against both the API agreement AND the established
+  convention. Diff the request (endpoint, method, body shape, field types, enum
+  values/casing, params) against the OpenAPI/proto contract in
+  `zeebe/gateway-protocol/src/main/proto/v2/*.yaml`, compare with how sibling
+  filters are queried (they share conventions — e.g. every enum filter is a single
+  `field: {$in: [...]}` property), and re-read what the test verifies. Then decide:
+  - **Request conforms and matches the test's intent, but the response is still
+    wrong** → the product is misbehaving → **product bug** (Step 4); do NOT change
+    the test to pass.
+  - **Request is malformed / the test is badly planned** (wrong body shape, field
+    type, enum casing, or endpoint) → **fix the test**, even when it looks
+    well-formed.
+  - **The contract/spec ITSELF is the bug** — the test uses the conventional shape
+    that every sibling filter uses, yet the contract is the outlier and NO request
+    shape works → escalate as a **product/spec bug** (Step 4). Do NOT rewrite the
+    test to match a broken agreement — that masks the bug. "Contradicts the
+    contract" is a test fix ONLY when the contract agrees with the convention; if
+    the contract is the outlier, the contract is wrong.
+
+  A backend-agnostic failure (same on ES and RDBMS) is by itself evidence of
+  neither a product nor a test bug — a malformed request AND a broken contract both
+  fail on every backend; decide by conformance to the *convention*, not the literal
+  contract alone. Worked example (#56636): `eventTypes` is declared as an *array*
+  while every other enum filter is a single `{$in: [...]}` property, so both
+  `eventTypes: {$in: [...]}` (convention → "cannot be parsed") and
+  `eventTypes: [{$in: [...]}]` (matches the array spec → "Type definition error")
+  fail → the *spec* is the outlier → **product/spec bug: skip & escalate**, NOT a
+  test fix.
 
 **Step 4 — Decide: fix or stop.**
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-search-sort-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/global-task-listener/global-task-listener-search-sort-api-tests.spec.ts
@@ -253,7 +253,12 @@ test.describe.serial('Global Task Listener API Tests - Search and Sort', () => {
     }).toPass(defaultAssertionOptions);
   });
 
-  test('Search Global Task Listeners - filter by eventTypes', async ({
+  // Skipped due to bug #56636: https://github.com/camunda/camunda/issues/56636
+  // The `eventTypes` search filter is mis-declared as an array of filter
+  // properties; it should be a single GlobalTaskListenerEventTypeFilterProperty
+  // like every other enum filter (e.g. `state`), so `eventTypes: {$in: [...]}` —
+  // the correct convention used here — is not yet accepted by the API.
+  test.skip('Search Global Task Listeners - filter by eventTypes', async ({
     request,
   }) => {
     await expect(async () => {


### PR DESCRIPTION
The `eventTypes` search filter (`POST /global-task-listeners/search`) returns 400.
Investigation shows it is a **product/spec bug**, not a test defect.

## Root cause — `eventTypes` filter is mis-declared as an array

Every enum filter in the v2 API is a **single** filter property, queried as
`field: {$in: [...]}` (e.g. `state: {$in: [...]}`, `processInstanceKey: {$in: [...]}`).
But `eventTypes` is uniquely declared as an **array** of filter properties
(`type: array, items: GlobalTaskListenerEventTypeFilterProperty`). That single
deviation breaks it both ways:

- `eventTypes: {$in: [...]}` (the correct convention) → `400 "Request property
  [filter.eventTypes] cannot be parsed"` (spec wrongly demands an array);
- `eventTypes: [{$in: [...]}]` (matching the array spec) → `400 "Type definition
  error: …GlobalTaskListenerEventTypeFilterProperty"` (the array-of-`oneOf` model
  can't be deserialized).

Neither works, on any backend (ES + RDBMS). This is #56636.

## 1. `test:` — skip the eventTypes filter test pending #56636

The test keeps the **correct** single-object shape (`eventTypes: {$in: ['creating']}`,
matching `processInstanceKey`/`state`) and is skipped with a bug-linked annotation.
No test hack — the test is correct; the product must fix the declaration, after
which the test un-skips and passes.

## 2. `ci:` — upload Playwright traces from the API nightlies

The nightly uploaded only `json-report` (status assertion, no response body). The
body (`"cannot be parsed"` / `"Type definition error"`) is exactly what identified
this as a contract/spec bug, and triage never saw it. Both reusable API workflows
(ES + RDBMS) now upload `test-results/` (per-test `trace.zip`); `if-no-files-found:
ignore`, 5-day retention.

## 3. `docs:` — teach the Nightly Fix Agent to vet the request against the agreement

For any non-happy API response, diff the request the test SENT against the
OpenAPI/proto contract first; a backend-agnostic failure is not, by itself, a
product bug — decide by whether the request conforms to the contract.

## Product fix (separate, in the product)

Change `eventTypes` in `global-listeners.yaml` from `type: array, items: [$ref]`
to `allOf: [$ref: GlobalTaskListenerEventTypeFilterProperty]` (a single filter
property, like `state`). Then `eventTypes: {$in: [...]}` works and this test
un-skips.

Relates to #56636
