### PR TITLE
feat: gateway physical-tenant on the gRPC stream API

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/StreamJobsHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/StreamJobsHandler.java
@@ -9,7 +9,9 @@ package io.camunda.zeebe.gateway.impl.stream;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.gateway.ResponseMapper;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJobImpl;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
@@ -26,6 +28,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
@@ -59,13 +62,18 @@ public class StreamJobsHandler extends Actor {
       return;
     }
 
-    handleInternal(jobType, jobActivationProperties, responseObserver);
+    final var group =
+        Objects.requireNonNullElse(
+            InterceptorUtil.getPhysicalTenantIdKey().get(),
+            PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    handleInternal(jobType, jobActivationProperties, responseObserver, group);
   }
 
   private void handleInternal(
       final String jobType,
       final JobActivationProperties jobActivationProperties,
-      final ServerCallStreamObserver<ActivatedJob> responseObserver) {
+      final ServerCallStreamObserver<ActivatedJob> responseObserver,
+      final String group) {
     final var streamType = wrapString(jobType);
     final var consumer = new JobStreamConsumer(responseObserver, actor);
     final var cleaner = new AsyncJobStreamRemover(jobStreamer, actor);
@@ -78,7 +86,7 @@ public class StreamJobsHandler extends Actor {
     actor.run(
         () ->
             actor.runOnCompletion(
-                jobStreamer.add(streamType, jobActivationProperties, consumer),
+                jobStreamer.add(streamType, jobActivationProperties, consumer, group),
                 (streamId, error) -> onStreamAdded(responseObserver, cleaner, streamId, error)));
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/StreamJobsHandler.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/StreamJobsHandler.java
@@ -62,18 +62,18 @@ public class StreamJobsHandler extends Actor {
       return;
     }
 
-    final var group =
+    final var physicalTenantId =
         Objects.requireNonNullElse(
             InterceptorUtil.getPhysicalTenantIdKey().get(),
             PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    handleInternal(jobType, jobActivationProperties, responseObserver, group);
+    handleInternal(jobType, jobActivationProperties, responseObserver, physicalTenantId);
   }
 
   private void handleInternal(
       final String jobType,
       final JobActivationProperties jobActivationProperties,
       final ServerCallStreamObserver<ActivatedJob> responseObserver,
-      final String group) {
+      final String physicalTenantId) {
     final var streamType = wrapString(jobType);
     final var consumer = new JobStreamConsumer(responseObserver, actor);
     final var cleaner = new AsyncJobStreamRemover(jobStreamer, actor);
@@ -86,7 +86,7 @@ public class StreamJobsHandler extends Actor {
     actor.run(
         () ->
             actor.runOnCompletion(
-                jobStreamer.add(streamType, jobActivationProperties, consumer, group),
+                jobStreamer.add(streamType, jobActivationProperties, consumer, physicalTenantId),
                 (streamId, error) -> onStreamAdded(responseObserver, cleaner, streamId, error)));
   }
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
@@ -10,9 +10,12 @@ package io.camunda.zeebe.gateway.api.job;
 import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
+import io.camunda.zeebe.gateway.protocol.GrpcHeaders;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJobImpl;
 import io.camunda.zeebe.protocol.record.value.JobKind;
@@ -20,8 +23,10 @@ import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.grpc.Metadata;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.MetadataUtils;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -34,6 +39,14 @@ import org.junit.Test;
 public class StreamActivatedJobsTest extends GatewayTest {
   public static final long DEADLINE = 123123123L;
   private static final String WORKER = "testWorker";
+  private static final String KNOWN_TENANT = "tenant-a";
+
+  public StreamActivatedJobsTest() {
+    super(
+        new GatewayCfg(),
+        EngineSecurityConfigurations.defaultConfig(),
+        () -> Set.of(DEFAULT_PHYSICAL_TENANT_ID, KNOWN_TENANT));
+  }
 
   @Test
   public void shouldMapRequestAndResponse() {
@@ -148,6 +161,30 @@ public class StreamActivatedJobsTest extends GatewayTest {
 
     // then
     assertThat(jobStreamer.getStreamGroup(jobType)).isEqualTo(DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  public void shouldRegisterStreamWithGroupFromPhysicalTenantHeader() {
+    // given
+    final String jobType = "testJobPhysicalTenantHeader";
+    final var headers = new Metadata();
+    headers.put(GrpcHeaders.PHYSICAL_TENANT, KNOWN_TENANT);
+    final var tenantAsyncClient =
+        asyncClient.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers));
+
+    // when
+    tenantAsyncClient.streamActivatedJobs(
+        StreamActivatedJobsRequest.newBuilder()
+            .setType(jobType)
+            .setWorker(WORKER)
+            .setTimeout(Duration.ofMinutes(1).toMillis())
+            .addAllFetchVariable(List.of("foo"))
+            .build(),
+        new TestStreamObserver());
+    jobStreamer.waitStreamToBeAvailable(BufferUtil.wrapString(jobType));
+
+    // then
+    assertThat(jobStreamer.getStreamGroup(jobType)).isEqualTo(KNOWN_TENANT);
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.api.job;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
@@ -133,6 +134,20 @@ public class StreamActivatedJobsTest extends GatewayTest {
     // then
     Awaitility.await("until the stream is removed")
         .until(() -> !jobStreamer.containsStreamFor(jobType));
+  }
+
+  @Test
+  public void shouldRegisterStreamWithDefaultGroupWhenNoPhysicalTenantHeaderPresent() {
+    // given - no Camunda-Physical-Tenant header set (interceptor not in test chain)
+    final String jobType = "testJobGroup";
+    final Duration timeout = Duration.ofMinutes(1);
+    final List<String> fetchVariables = List.of("foo");
+
+    // when
+    getStreamActivatedJobsRequest(jobType, WORKER, timeout, fetchVariables);
+
+    // then
+    assertThat(jobStreamer.getStreamGroup(jobType)).isEqualTo(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/StreamActivatedJobsTest.java
@@ -150,7 +150,7 @@ public class StreamActivatedJobsTest extends GatewayTest {
   }
 
   @Test
-  public void shouldRegisterStreamWithDefaultGroupWhenNoPhysicalTenantHeaderPresent() {
+  public void shouldRegisterStreamWithDefaultPhysicalTenantIdWhenNoPhysicalTenantHeaderPresent() {
     // given - no Camunda-Physical-Tenant header set (interceptor not in test chain)
     final String jobType = "testJobGroup";
     final Duration timeout = Duration.ofMinutes(1);
@@ -160,11 +160,12 @@ public class StreamActivatedJobsTest extends GatewayTest {
     getStreamActivatedJobsRequest(jobType, WORKER, timeout, fetchVariables);
 
     // then
-    assertThat(jobStreamer.getStreamGroup(jobType)).isEqualTo(DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(jobStreamer.getStreamPhysicalTenantId(jobType))
+        .isEqualTo(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   @Test
-  public void shouldRegisterStreamWithGroupFromPhysicalTenantHeader() {
+  public void shouldRegisterStreamWithPhysicalTenantIdFromPhysicalTenantHeader() {
     // given
     final String jobType = "testJobPhysicalTenantHeader";
     final var headers = new Metadata();
@@ -184,7 +185,7 @@ public class StreamActivatedJobsTest extends GatewayTest {
     jobStreamer.waitStreamToBeAvailable(BufferUtil.wrapString(jobType));
 
     // then
-    assertThat(jobStreamer.getStreamGroup(jobType)).isEqualTo(KNOWN_TENANT);
+    assertThat(jobStreamer.getStreamPhysicalTenantId(jobType)).isEqualTo(KNOWN_TENANT);
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -212,7 +212,8 @@ public final class StubbedGateway {
     public ActorFuture<ClientStreamId> add(
         final DirectBuffer streamType,
         final JobActivationProperties metadata,
-        final ClientStreamConsumer clientStreamConsumer) {
+        final ClientStreamConsumer clientStreamConsumer,
+        final String group) {
       final var failure = failOnAdd.get();
       if (failure != null) {
         return CompletableActorFuture.completedExceptionally(failure);
@@ -220,7 +221,7 @@ public final class StubbedGateway {
 
       final StubbedClientStreamId streamId = new StubbedClientStreamId(UUID.randomUUID());
       final StreamTypeConsumer consumer =
-          new StreamTypeConsumer(streamType, metadata, clientStreamConsumer);
+          new StreamTypeConsumer(streamType, metadata, clientStreamConsumer, group);
       registeredStreams.put(streamType, consumer);
       streamIdToConsumer.put(streamId, consumer);
 
@@ -268,6 +269,11 @@ public final class StubbedGateway {
       return consumer != null ? consumer.metadata() : null;
     }
 
+    public String getStreamGroup(final String streamType) {
+      final var consumer = registeredStreams.get(BufferUtil.wrapString(streamType));
+      return consumer != null ? consumer.group() : null;
+    }
+
     public void setFailOnAdd(final Throwable failure) {
       failOnAdd.set(failure);
     }
@@ -276,7 +282,8 @@ public final class StubbedGateway {
   private record StreamTypeConsumer(
       DirectBuffer streamType,
       JobActivationProperties metadata,
-      ClientStreamConsumer clientStreamConsumer) {}
+      ClientStreamConsumer clientStreamConsumer,
+      String group) {}
 
   private record StubbedClientStreamId(UUID serverStreamId) implements ClientStreamId {}
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -213,7 +213,7 @@ public final class StubbedGateway {
         final DirectBuffer streamType,
         final JobActivationProperties metadata,
         final ClientStreamConsumer clientStreamConsumer,
-        final String group) {
+        final String physicalTenantId) {
       final var failure = failOnAdd.get();
       if (failure != null) {
         return CompletableActorFuture.completedExceptionally(failure);
@@ -221,7 +221,7 @@ public final class StubbedGateway {
 
       final StubbedClientStreamId streamId = new StubbedClientStreamId(UUID.randomUUID());
       final StreamTypeConsumer consumer =
-          new StreamTypeConsumer(streamType, metadata, clientStreamConsumer, group);
+          new StreamTypeConsumer(streamType, metadata, clientStreamConsumer, physicalTenantId);
       registeredStreams.put(streamType, consumer);
       streamIdToConsumer.put(streamId, consumer);
 
@@ -269,9 +269,9 @@ public final class StubbedGateway {
       return consumer != null ? consumer.metadata() : null;
     }
 
-    public String getStreamGroup(final String streamType) {
+    public String getStreamPhysicalTenantId(final String streamType) {
       final var consumer = registeredStreams.get(BufferUtil.wrapString(streamType));
-      return consumer != null ? consumer.group() : null;
+      return consumer != null ? consumer.physicalTenantId() : null;
     }
 
     public void setFailOnAdd(final Throwable failure) {
@@ -283,7 +283,7 @@ public final class StubbedGateway {
       DirectBuffer streamType,
       JobActivationProperties metadata,
       ClientStreamConsumer clientStreamConsumer,
-      String group) {}
+      String physicalTenantId) {}
 
   private record StubbedClientStreamId(UUID serverStreamId) implements ClientStreamId {}
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/stream/AsyncJobStreamRemoverTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/stream/AsyncJobStreamRemoverTest.java
@@ -78,7 +78,7 @@ final class AsyncJobStreamRemoverTest {
         final DirectBuffer streamType,
         final JobActivationProperties metadata,
         final ClientStreamConsumer clientStreamConsumer,
-        final String group) {
+        final String physicalTenantId) {
       final var id = new StreamId(streamType);
       consumers.put(id, clientStreamConsumer);
       return CompletableActorFuture.completed(id);

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/stream/AsyncJobStreamRemoverTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/stream/AsyncJobStreamRemoverTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.impl.stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.gateway.impl.stream.StreamJobsHandler.AsyncJobStreamRemover;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -34,7 +35,14 @@ final class AsyncJobStreamRemoverTest {
     remover.run();
 
     // when
-    final var id = jobStreamer.add(BufferUtil.wrapString("foo"), null, consumer).join();
+    final var id =
+        jobStreamer
+            .add(
+                BufferUtil.wrapString("foo"),
+                null,
+                consumer,
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+            .join();
     remover.streamId(id);
 
     // then
@@ -45,7 +53,14 @@ final class AsyncJobStreamRemoverTest {
   void shouldRemoveStreamOnRun() {
     // given - a stream observer which is added before being cancelled
     final var remover = new AsyncJobStreamRemover(jobStreamer, Runnable::run);
-    final var id = jobStreamer.add(BufferUtil.wrapString("foo"), null, consumer).join();
+    final var id =
+        jobStreamer
+            .add(
+                BufferUtil.wrapString("foo"),
+                null,
+                consumer,
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+            .join();
     remover.streamId(id);
 
     // when
@@ -62,7 +77,8 @@ final class AsyncJobStreamRemoverTest {
     public ActorFuture<ClientStreamId> add(
         final DirectBuffer streamType,
         final JobActivationProperties metadata,
-        final ClientStreamConsumer clientStreamConsumer) {
+        final ClientStreamConsumer clientStreamConsumer,
+        final String group) {
       final var id = new StreamId(streamType);
       consumers.put(id, clientStreamConsumer);
       return CompletableActorFuture.completed(id);

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStream.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStream.java
@@ -20,5 +20,5 @@ public interface ClientStream<M> {
 
   Set<MemberId> liveConnections();
 
-  String group();
+  String physicalTenantId();
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStream.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStream.java
@@ -19,4 +19,6 @@ public interface ClientStream<M> {
   M metadata();
 
   Set<MemberId> liveConnections();
+
+  String group();
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
-import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -32,27 +31,14 @@ public interface ClientStreamer<M extends BufferWriter> extends CloseableSilentl
    * @param streamType type of the stream
    * @param metadata metadata associated with the stream
    * @param clientStreamConsumer consumer which process data received from the server
-   * @param group the physical tenant / partition group this stream belongs to
+   * @param physicalTenantId the physical tenant / partition physicalTenantId this stream belongs to
    * @return a unique id of the stream
    */
   ActorFuture<ClientStreamId> add(
       final DirectBuffer streamType,
       final M metadata,
       final ClientStreamConsumer clientStreamConsumer,
-      final String group);
-
-  /**
-   * Registers a client stream using the default physical tenant group. Delegates to {@link
-   * #add(DirectBuffer, BufferWriter, ClientStreamConsumer, String)} with {@link
-   * PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID}.
-   */
-  default ActorFuture<ClientStreamId> add(
-      final DirectBuffer streamType,
-      final M metadata,
-      final ClientStreamConsumer clientStreamConsumer) {
-    return add(
-        streamType, metadata, clientStreamConsumer, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-  }
+      final String physicalTenantId);
 
   /**
    * Removes a stream that is added via {@link ClientStreamer#add(DirectBuffer, BufferWriter,

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -31,16 +32,31 @@ public interface ClientStreamer<M extends BufferWriter> extends CloseableSilentl
    * @param streamType type of the stream
    * @param metadata metadata associated with the stream
    * @param clientStreamConsumer consumer which process data received from the server
+   * @param group the physical tenant / partition group this stream belongs to
    * @return a unique id of the stream
    */
   ActorFuture<ClientStreamId> add(
       final DirectBuffer streamType,
       final M metadata,
-      final ClientStreamConsumer clientStreamConsumer);
+      final ClientStreamConsumer clientStreamConsumer,
+      final String group);
+
+  /**
+   * Registers a client stream using the default physical tenant group. Delegates to {@link
+   * #add(DirectBuffer, BufferWriter, ClientStreamConsumer, String)} with {@link
+   * PhysicalTenantIds#DEFAULT_PHYSICAL_TENANT_ID}.
+   */
+  default ActorFuture<ClientStreamId> add(
+      final DirectBuffer streamType,
+      final M metadata,
+      final ClientStreamConsumer clientStreamConsumer) {
+    return add(
+        streamType, metadata, clientStreamConsumer, PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+  }
 
   /**
    * Removes a stream that is added via {@link ClientStreamer#add(DirectBuffer, BufferWriter,
-   * ClientStreamConsumer)}. After the returned future is completed, the {@link
+   * ClientStreamConsumer, String)}. After the returned future is completed, the {@link
    * ClientStreamConsumer} will not receive any more data.
    *
    * @param streamId unique id of the stream

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
@@ -21,7 +21,7 @@ final class AggregatedClientStream<M extends BufferWriter> {
 
   private final UUID streamId;
   private final LogicalId<M> logicalId;
-  private final String group;
+  private final String physicalTenantId;
   private final Set<MemberId> liveConnections = new HashSet<>();
   private final ClientStreamMetrics metrics;
   private final Int2ObjectHashMap<ClientStreamImpl<M>> clientStreams = new Int2ObjectHashMap<>();
@@ -29,18 +29,19 @@ final class AggregatedClientStream<M extends BufferWriter> {
   private boolean isOpened;
   private int nextLocalId;
 
-  AggregatedClientStream(final UUID streamId, final LogicalId<M> logicalId, final String group) {
-    this(streamId, logicalId, group, ClientStreamMetrics.noop());
+  AggregatedClientStream(
+      final UUID streamId, final LogicalId<M> logicalId, final String physicalTenantId) {
+    this(streamId, logicalId, physicalTenantId, ClientStreamMetrics.noop());
   }
 
   AggregatedClientStream(
       final UUID streamId,
       final LogicalId<M> logicalId,
-      final String group,
+      final String physicalTenantId,
       final ClientStreamMetrics metrics) {
     this.streamId = streamId;
     this.logicalId = logicalId;
-    this.group = group;
+    this.physicalTenantId = physicalTenantId;
     this.metrics = metrics;
   }
 
@@ -53,8 +54,8 @@ final class AggregatedClientStream<M extends BufferWriter> {
     return streamId;
   }
 
-  String group() {
-    return group;
+  String physicalTenantId() {
+    return physicalTenantId;
   }
 
   Collection<ClientStreamImpl<M>> list() {
@@ -139,8 +140,8 @@ final class AggregatedClientStream<M extends BufferWriter> {
         + streamId
         + ", logicalId="
         + logicalId
-        + ", group="
-        + group
+        + ", physicalTenantId="
+        + physicalTenantId
         + ", liveConnections="
         + liveConnections
         + ", clientStreams="

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStream.java
@@ -21,6 +21,7 @@ final class AggregatedClientStream<M extends BufferWriter> {
 
   private final UUID streamId;
   private final LogicalId<M> logicalId;
+  private final String group;
   private final Set<MemberId> liveConnections = new HashSet<>();
   private final ClientStreamMetrics metrics;
   private final Int2ObjectHashMap<ClientStreamImpl<M>> clientStreams = new Int2ObjectHashMap<>();
@@ -28,14 +29,18 @@ final class AggregatedClientStream<M extends BufferWriter> {
   private boolean isOpened;
   private int nextLocalId;
 
-  AggregatedClientStream(final UUID streamId, final LogicalId<M> logicalId) {
-    this(streamId, logicalId, ClientStreamMetrics.noop());
+  AggregatedClientStream(final UUID streamId, final LogicalId<M> logicalId, final String group) {
+    this(streamId, logicalId, group, ClientStreamMetrics.noop());
   }
 
   AggregatedClientStream(
-      final UUID streamId, final LogicalId<M> logicalId, final ClientStreamMetrics metrics) {
+      final UUID streamId,
+      final LogicalId<M> logicalId,
+      final String group,
+      final ClientStreamMetrics metrics) {
     this.streamId = streamId;
     this.logicalId = logicalId;
+    this.group = group;
     this.metrics = metrics;
   }
 
@@ -46,6 +51,10 @@ final class AggregatedClientStream<M extends BufferWriter> {
 
   UUID streamId() {
     return streamId;
+  }
+
+  String group() {
+    return group;
   }
 
   Collection<ClientStreamImpl<M>> list() {
@@ -130,6 +139,8 @@ final class AggregatedClientStream<M extends BufferWriter> {
         + streamId
         + ", logicalId="
         + logicalId
+        + ", group="
+        + group
         + ", liveConnections="
         + liveConnections
         + ", clientStreams="

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamImpl.java
@@ -27,4 +27,9 @@ record ClientStreamImpl<M extends BufferWriter>(
   public Set<MemberId> liveConnections() {
     return serverStream().liveConnections();
   }
+
+  @Override
+  public String group() {
+    return serverStream().group();
+  }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamImpl.java
@@ -29,7 +29,7 @@ record ClientStreamImpl<M extends BufferWriter>(
   }
 
   @Override
-  public String group() {
-    return serverStream().group();
+  public String physicalTenantId() {
+    return serverStream().physicalTenantId();
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -62,9 +62,10 @@ final class ClientStreamManager<M extends BufferWriter> {
       final DirectBuffer streamType,
       final M metadata,
       final ClientStreamConsumer clientStreamConsumer,
-      final String group) {
+      final String physicalTenantId) {
     // add first in memory to handle case of new broker while we're adding
-    final var clientStream = registry.addClient(streamType, metadata, clientStreamConsumer, group);
+    final var clientStream =
+        registry.addClient(streamType, metadata, clientStreamConsumer, physicalTenantId);
     LOG.debug("Added new client stream [{}]", clientStream.streamId());
     clientStream.serverStream().open(requestManager, servers);
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -61,9 +61,10 @@ final class ClientStreamManager<M extends BufferWriter> {
   ClientStreamId add(
       final DirectBuffer streamType,
       final M metadata,
-      final ClientStreamConsumer clientStreamConsumer) {
+      final ClientStreamConsumer clientStreamConsumer,
+      final String group) {
     // add first in memory to handle case of new broker while we're adding
-    final var clientStream = registry.addClient(streamType, metadata, clientStreamConsumer);
+    final var clientStream = registry.addClient(streamType, metadata, clientStreamConsumer, group);
     LOG.debug("Added new client stream [{}]", clientStream.streamId());
     clientStream.serverStream().open(requestManager, servers);
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -48,7 +48,7 @@ final class ClientStreamRegistry<M extends BufferWriter> {
       final DirectBuffer streamType,
       final M metadata,
       final ClientStreamConsumer clientStreamConsumer,
-      final String group) {
+      final String physicalTenantId) {
     final var streamTypeBuffer = new UnsafeBuffer(streamType);
     final LogicalId<M> logicalId = new LogicalId<>(streamTypeBuffer, metadata);
     // Find serverStreamId given streamType and metadata. Once a server stream is removed, a new
@@ -56,7 +56,8 @@ final class ClientStreamRegistry<M extends BufferWriter> {
     final var serverStreamId = serverStreamIds.computeIfAbsent(logicalId, k -> UUID.randomUUID());
     final var serverStream =
         serverStreams.computeIfAbsent(
-            serverStreamId, k -> new AggregatedClientStream<>(serverStreamId, logicalId, group));
+            serverStreamId,
+            k -> new AggregatedClientStream<>(serverStreamId, logicalId, physicalTenantId));
     final var streamId = new ClientStreamIdImpl(serverStreamId, serverStream.nextLocalId());
     final var clientStream =
         new ClientStreamImpl<>(

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -47,7 +47,8 @@ final class ClientStreamRegistry<M extends BufferWriter> {
   ClientStreamImpl<M> addClient(
       final DirectBuffer streamType,
       final M metadata,
-      final ClientStreamConsumer clientStreamConsumer) {
+      final ClientStreamConsumer clientStreamConsumer,
+      final String group) {
     final var streamTypeBuffer = new UnsafeBuffer(streamType);
     final LogicalId<M> logicalId = new LogicalId<>(streamTypeBuffer, metadata);
     // Find serverStreamId given streamType and metadata. Once a server stream is removed, a new
@@ -55,7 +56,7 @@ final class ClientStreamRegistry<M extends BufferWriter> {
     final var serverStreamId = serverStreamIds.computeIfAbsent(logicalId, k -> UUID.randomUUID());
     final var serverStream =
         serverStreams.computeIfAbsent(
-            serverStreamId, k -> new AggregatedClientStream<>(serverStreamId, logicalId));
+            serverStreamId, k -> new AggregatedClientStream<>(serverStreamId, logicalId, group));
     final var streamId = new ClientStreamIdImpl(serverStreamId, serverStream.nextLocalId());
     final var clientStream =
         new ClientStreamImpl<>(

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -88,9 +88,10 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
       final DirectBuffer streamType,
       final M metadata,
       final ClientStreamConsumer clientStreamConsumer,
-      final String group) {
+      final String physicalTenantId) {
     return actor.call(
-        () -> clientStreamManager.add(streamType, metadata, clientStreamConsumer, group));
+        () ->
+            clientStreamManager.add(streamType, metadata, clientStreamConsumer, physicalTenantId));
   }
 
   @Override

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -87,8 +87,10 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   public ActorFuture<ClientStreamId> add(
       final DirectBuffer streamType,
       final M metadata,
-      final ClientStreamConsumer clientStreamConsumer) {
-    return actor.call(() -> clientStreamManager.add(streamType, metadata, clientStreamConsumer));
+      final ClientStreamConsumer clientStreamConsumer,
+      final String group) {
+    return actor.call(
+        () -> clientStreamManager.add(streamType, metadata, clientStreamConsumer, group));
   }
 
   @Override

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -25,7 +26,10 @@ class AggregatedClientStreamTest {
   private final TestClientStreamMetrics metrics = new TestClientStreamMetrics();
   private final AggregatedClientStream<TestSerializableData> stream =
       new AggregatedClientStream<>(
-          UUID.randomUUID(), new LogicalId<>(streamType, metadata), metrics);
+          UUID.randomUUID(),
+          new LogicalId<>(streamType, metadata),
+          PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+          metrics);
 
   @Test
   void shouldReportStreamCountOnAdd() {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -84,7 +84,8 @@ class ClientStreamManagerTest {
   @Test
   void shouldAddStream() {
     // when
-    final var streamId = clientStreamManager.add(streamType, metadata, NOOP_CONSUMER);
+    final var streamId =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(registry.getClient(streamId)).isNotEmpty();
@@ -95,7 +96,8 @@ class ClientStreamManagerTest {
     // given
     final var serverId = MemberId.anonymous();
     clientStreamManager.onServerJoined(serverId);
-    final var streamId = clientStreamManager.add(streamType, metadata, NOOP_CONSUMER);
+    final var streamId =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     clientStreamManager.onServerRemoved(serverId);
 
     // when
@@ -111,9 +113,17 @@ class ClientStreamManagerTest {
   void shouldAggregateStreamsWithSameStreamTypeAndMetadata() {
     // when
     final var uuid1 =
-        clientStreamManager.add(BufferUtil.wrapString("foo"), new TestMetadata(1), NOOP_CONSUMER);
+        clientStreamManager.add(
+            BufferUtil.wrapString("foo"),
+            new TestMetadata(1),
+            NOOP_CONSUMER,
+            DEFAULT_PHYSICAL_TENANT_ID);
     final var uuid2 =
-        clientStreamManager.add(BufferUtil.wrapString("foo"), new TestMetadata(1), NOOP_CONSUMER);
+        clientStreamManager.add(
+            BufferUtil.wrapString("foo"),
+            new TestMetadata(1),
+            NOOP_CONSUMER,
+            DEFAULT_PHYSICAL_TENANT_ID);
     final var stream1 = registry.getClient(uuid1).orElseThrow();
     final var stream2 = registry.getClient(uuid2).orElseThrow();
 
@@ -124,8 +134,12 @@ class ClientStreamManagerTest {
   @Test
   void shouldNoAggregateStreamsWithDifferentMetadata() {
     // when
-    final var uuid1 = clientStreamManager.add(streamType, new TestMetadata(1), NOOP_CONSUMER);
-    final var uuid2 = clientStreamManager.add(streamType, new TestMetadata(2), NOOP_CONSUMER);
+    final var uuid1 =
+        clientStreamManager.add(
+            streamType, new TestMetadata(1), NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var uuid2 =
+        clientStreamManager.add(
+            streamType, new TestMetadata(2), NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var stream1 = registry.getClient(uuid1).orElseThrow();
     final var stream2 = registry.getClient(uuid2).orElseThrow();
 
@@ -137,9 +151,11 @@ class ClientStreamManagerTest {
   void shouldNoAggregateStreamsWithDifferentStreamType() {
     // when
     final var uuid1 =
-        clientStreamManager.add(BufferUtil.wrapString("foo"), metadata, NOOP_CONSUMER);
+        clientStreamManager.add(
+            BufferUtil.wrapString("foo"), metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var uuid2 =
-        clientStreamManager.add(BufferUtil.wrapString("bar"), metadata, NOOP_CONSUMER);
+        clientStreamManager.add(
+            BufferUtil.wrapString("bar"), metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var stream1 = registry.getClient(uuid1).orElseThrow();
     final var stream2 = registry.getClient(uuid2).orElseThrow();
 
@@ -156,7 +172,8 @@ class ClientStreamManagerTest {
     clientStreamManager.onServerJoined(server2);
 
     // when
-    final var uuid = clientStreamManager.add(streamType, metadata, NOOP_CONSUMER);
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     final UUID serverStreamId = getServerStreamId(uuid);
@@ -169,7 +186,8 @@ class ClientStreamManagerTest {
   @Test
   void shouldOpenStreamToNewlyAddedServer() {
     // given
-    final var uuid = clientStreamManager.add(streamType, metadata, NOOP_CONSUMER);
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var serverStream = registry.get(getServerStreamId(uuid)).orElseThrow();
 
     // when
@@ -184,9 +202,11 @@ class ClientStreamManagerTest {
   void shouldOpenStreamToNewlyAddedServerForAllOpenStreams() {
     // given
     final var stream1 =
-        clientStreamManager.add(BufferUtil.wrapString("foo"), metadata, NOOP_CONSUMER);
+        clientStreamManager.add(
+            BufferUtil.wrapString("foo"), metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var stream2 =
-        clientStreamManager.add(BufferUtil.wrapString("bar"), metadata, NOOP_CONSUMER);
+        clientStreamManager.add(
+            BufferUtil.wrapString("bar"), metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var serverStream1 = registry.get(getServerStreamId(stream1)).orElseThrow();
     final var serverStream2 = registry.get(getServerStreamId(stream2)).orElseThrow();
     // when
@@ -201,7 +221,8 @@ class ClientStreamManagerTest {
   @Test
   void shouldRemoveStream() {
     // given
-    final var uuid = clientStreamManager.add(streamType, metadata, NOOP_CONSUMER);
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var serverStreamId = getServerStreamId(uuid);
 
     // when
@@ -215,8 +236,10 @@ class ClientStreamManagerTest {
   @Test
   void shouldNotRemoveIfOtherClientStreamExist() {
     // given
-    final var uuid1 = clientStreamManager.add(streamType, metadata, NOOP_CONSUMER);
-    final var uuid2 = clientStreamManager.add(streamType, metadata, NOOP_CONSUMER);
+    final var uuid1 =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var uuid2 =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var serverStreamId = getServerStreamId(uuid1);
 
     // when
@@ -239,7 +262,8 @@ class ClientStreamManagerTest {
             directBuffer -> {
               payloadReceived.wrap(directBuffer);
               return CompletableActorFuture.completed(null);
-            });
+            },
+            DEFAULT_PHYSICAL_TENANT_ID);
     final var streamId = getServerStreamId(clientStreamId);
 
     // when
@@ -281,7 +305,8 @@ class ClientStreamManagerTest {
             metadata,
             p -> {
               throw new RuntimeException("Expected");
-            });
+            },
+            DEFAULT_PHYSICAL_TENANT_ID);
     final var streamId = getServerStreamId(clientStreamId);
 
     // when
@@ -302,7 +327,8 @@ class ClientStreamManagerTest {
     // given
     final MemberId server = MemberId.from("1");
     clientStreamManager.onServerJoined(server);
-    final var uuid = clientStreamManager.add(streamType, metadata, NOOP_CONSUMER);
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
     assertThat(stream.isConnected(server)).isTrue();
 

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusherTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusherTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.transport.stream.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
@@ -40,7 +41,10 @@ final class ClientStreamPusherTest {
 
   private final AggregatedClientStream<TestSerializableData> stream =
       new AggregatedClientStream<>(
-          UUID.randomUUID(), new LogicalId<>(streamType, metadata), metrics);
+          UUID.randomUUID(),
+          new LogicalId<>(streamType, metadata),
+          PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+          metrics);
   private final ClientStreamPusher streamPusher = new ClientStreamPusher(metrics);
 
   @Test

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistryTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistryTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -29,9 +30,12 @@ final class ClientStreamRegistryTest {
     final var metadata = new TestSerializableData();
 
     // when - add 2 aggregated streams, bar (2 clients) and foo (1 client)
-    registry.addClient(BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER);
-    registry.addClient(BufferUtil.wrapString("foo"), metadata, CLIENT_STREAM_CONSUMER);
-    registry.addClient(BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER);
+    registry.addClient(
+        BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    registry.addClient(
+        BufferUtil.wrapString("foo"), metadata, CLIENT_STREAM_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    registry.addClient(
+        BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(metrics.getAggregatedStreamCount()).isEqualTo(2);
@@ -43,10 +47,19 @@ final class ClientStreamRegistryTest {
     // given - 2 aggregated streams, bar and food
     final var metadata = new TestSerializableData();
     final var fooId =
-        registry.addClient(BufferUtil.wrapString("foo"), metadata, CLIENT_STREAM_CONSUMER);
+        registry.addClient(
+            BufferUtil.wrapString("foo"),
+            metadata,
+            CLIENT_STREAM_CONSUMER,
+            DEFAULT_PHYSICAL_TENANT_ID);
     final var barId =
-        registry.addClient(BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER);
-    registry.addClient(BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER);
+        registry.addClient(
+            BufferUtil.wrapString("bar"),
+            metadata,
+            CLIENT_STREAM_CONSUMER,
+            DEFAULT_PHYSICAL_TENANT_ID);
+    registry.addClient(
+        BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when - remove only one aggregated stream (bar still has one client)
     registry.removeClient(fooId.streamId());
@@ -61,9 +74,12 @@ final class ClientStreamRegistryTest {
   void shouldReportMetricsOnClear() {
     // given
     final var metadata = new TestSerializableData();
-    registry.addClient(BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER);
-    registry.addClient(BufferUtil.wrapString("foo"), metadata, CLIENT_STREAM_CONSUMER);
-    registry.addClient(BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER);
+    registry.addClient(
+        BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    registry.addClient(
+        BufferUtil.wrapString("foo"), metadata, CLIENT_STREAM_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    registry.addClient(
+        BufferUtil.wrapString("bar"), metadata, CLIENT_STREAM_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     registry.clear();

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -25,6 +25,7 @@ import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.atomix.cluster.messaging.MessagingException.ProtocolException;
 import io.atomix.cluster.messaging.MessagingException.RemoteHandlerFailure;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.transport.stream.impl.ClientStreamRegistration.State;
 import io.camunda.zeebe.transport.stream.impl.messages.AddStreamResponse;
@@ -57,7 +58,8 @@ final class ClientStreamRequestManagerTest {
   private final AggregatedClientStream<TestMetadata> clientStream =
       new AggregatedClientStream<>(
           UUID.randomUUID(),
-          new LogicalId<>(new UnsafeBuffer(BufferUtil.wrapString("foo")), new TestMetadata()));
+          new LogicalId<>(new UnsafeBuffer(BufferUtil.wrapString("foo")), new TestMetadata()),
+          PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
   private final byte[] addStreamSuccess = BufferUtil.bufferAsArray(new AddStreamResponse());
   private final byte[] removeStreamSuccess = BufferUtil.bufferAsArray(new RemoveStreamResponse());
 

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -17,6 +17,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.Node;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
+import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -114,7 +115,8 @@ final class StreamIntegrationTest {
                   payloads.get().add(payload.data());
                   latch.countDown();
                   return CompletableActorFuture.completed(null);
-                })
+                },
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
             .join();
     awaitStreamAdded(streamType, streamId, server1, server2);
 
@@ -136,7 +138,11 @@ final class StreamIntegrationTest {
     final var streamType = BufferUtil.wrapString("foo");
     final var clientStreamId =
         clientStreamer
-            .add(streamType, metadata, p -> CompletableActorFuture.completed(null))
+            .add(
+                streamType,
+                metadata,
+                p -> CompletableActorFuture.completed(null),
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
             .join();
     awaitStreamAdded(streamType, clientStreamId, server1, server2);
     final var serverStream = server1.streamer.streamFor(streamType).orElseThrow();
@@ -217,7 +223,11 @@ final class StreamIntegrationTest {
     final var properties = new TestSerializableData();
     final var streamId =
         clientStreamer
-            .add(streamType, properties, p -> CompletableActorFuture.completed(null))
+            .add(
+                streamType,
+                properties,
+                p -> CompletableActorFuture.completed(null),
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
             .join();
     final var member = client.cluster.getMembershipService().getLocalMember();
     final var memberRemovedEvent = new ClusterMembershipEvent(Type.MEMBER_REMOVED, member);
@@ -246,7 +256,11 @@ final class StreamIntegrationTest {
       // when
       final var streamId =
           clientStreamer
-              .add(streamType, properties, p -> CompletableActorFuture.completed(null))
+              .add(
+                  streamType,
+                  properties,
+                  p -> CompletableActorFuture.completed(null),
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
               .join();
 
       // then
@@ -260,7 +274,11 @@ final class StreamIntegrationTest {
       final var properties = new TestSerializableData();
       final var streamId =
           clientStreamer
-              .add(streamType, properties, p -> CompletableActorFuture.completed(null))
+              .add(
+                  streamType,
+                  properties,
+                  p -> CompletableActorFuture.completed(null),
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
               .join();
 
       // must wait until the stream is connected everywhere before removal, as otherwise there is a
@@ -284,7 +302,11 @@ final class StreamIntegrationTest {
       final var properties = new TestSerializableData();
       final var streamId =
           clientStreamer
-              .add(streamType, properties, p -> CompletableActorFuture.completed(null))
+              .add(
+                  streamType,
+                  properties,
+                  p -> CompletableActorFuture.completed(null),
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
               .join();
       awaitStreamAdded(streamType, streamId, server1, server2);
 
@@ -308,7 +330,11 @@ final class StreamIntegrationTest {
       client.streamService.onServerRemoved(server1.memberId());
       final var streamId =
           clientStreamer
-              .add(streamType, properties, p -> CompletableActorFuture.completed(null))
+              .add(
+                  streamType,
+                  properties,
+                  p -> CompletableActorFuture.completed(null),
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
               .join();
       awaitStreamOnServer(streamType, server2, stream -> assertThat(stream).isPresent());
       awaitStreamOnClient(
@@ -338,7 +364,14 @@ final class StreamIntegrationTest {
       final ClientStreamConsumer consumer = p -> CompletableActorFuture.completed(null);
       streamTypes.forEach(
           streamType -> {
-            final var id = clientStreamer.add(streamType, properties, consumer).join();
+            final var id =
+                clientStreamer
+                    .add(
+                        streamType,
+                        properties,
+                        consumer,
+                        PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                    .join();
             awaitStreamAdded(streamType, id, server1, server2);
           });
 
@@ -361,7 +394,11 @@ final class StreamIntegrationTest {
       final var properties = new TestSerializableData();
       final var streamId =
           clientStreamer
-              .add(streamType, properties, p -> CompletableActorFuture.completed(null))
+              .add(
+                  streamType,
+                  properties,
+                  p -> CompletableActorFuture.completed(null),
+                  PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
               .join();
       awaitStreamAdded(streamType, streamId, server1, server2);
       server1.close();


### PR DESCRIPTION
## Description

  Implements #56222 — part of epic #56219 (physical-tenant-aware job streaming).

  - `StreamJobsHandler` reads the `Camunda-Physical-Tenant` gRPC context key (set by `AuthenticationInterceptor`) synchronously on the gRPC handler thread — before delegating to the actor — and forwards it as the `group` parameter to `ClientStreamer.add()`.
  - `ClientStreamer`, `ClientStreamRegistry`, `ClientStreamManager`, `ClientStreamServiceImpl`, and `AggregatedClientStream` are extended with a `group` field that flows from the gateway call down to the transport layer.
  - `ClientStream` gains a `group()` accessor so callers can read back the registered group.
  - The 3-arg `ClientStreamer.add()` is preserved as a default method (delegates to 4-arg with `DEFAULT_PHYSICAL_TENANT_ID`) for backward compatibility with existing callers.

  **Not changed:** `LogicalId` — it is shared between client-side and server-side stream registries. Adding `group` there would break `RemoteStreamRegistry` and all server-side tests. Routing decisions based on group are out of scope for this ticket.

  **Known limitation:** two streams with the same job type and metadata but different groups share one `AggregatedClientStream` (first-one-wins for group). Acceptable here since no per-group routing is wired yet.

## Related issues

closes #56222
