### PR TITLE
feat: introduce PartitionGroupConfiguration and BrokerPartitionState records

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/BrokerPartitionState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/BrokerPartitionState.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import com.google.common.collect.ImmutableSortedMap;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.function.UnaryOperator;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents the partition assignment of a single broker within one partition group.
+ *
+ * <p>Unlike the legacy {@code MemberState}, this record carries <em>no</em> broker lifecycle {@code
+ * State} (JOINING/ACTIVE/LEAVING/LEFT). Broker lifecycle is tracked once, cluster-wide, in {@code
+ * GlobalConfiguration}; here we only record which partitions of this group the broker replicates.
+ * Presence of the broker in a {@code PartitionGroupConfiguration} with at least one partition means
+ * it is active in that group.
+ *
+ * <p>{@code mode} is the per-broker operating mode <em>scoped to this group</em> — {@link
+ * Mode#PROCESSING} or {@link Mode#RECOVERING} (the structural equivalent of the legacy {@code
+ * MemberState.State.RECOVERING} set via {@code toRecovering()}). Because the mode is per broker and
+ * per group (a broker may be recovering in one group but not another), it is tracked here rather
+ * than on {@code PartitionGroupConfiguration} or on the cluster-wide broker lifecycle state.
+ *
+ * <p>{@code version} is incremented every time the state is updated. It is used to resolve
+ * conflicts when members receive gossip updates out of order. Only a member updates its own state,
+ * which prevents conflicting concurrent updates. To keep this invariant self-contained, all
+ * mutations go through the update methods ({@link #setMode(Mode)}, {@link #addPartition(int,
+ * PartitionState)}, {@link #updatePartition(int, UnaryOperator)}, {@link #removePartition(int)}),
+ * each of which returns a new instance with an incremented version — callers never manage the
+ * version themselves.
+ *
+ * @param version version of this broker's partition state within the group
+ * @param lastUpdated time this state was last updated
+ * @param partitions state of every partition of this group that the broker replicates
+ * @param mode the operating mode of this broker within this group
+ */
+@NullMarked
+public record BrokerPartitionState(
+    long version, Instant lastUpdated, SortedMap<Integer, PartitionState> partitions, Mode mode) {
+
+  public BrokerPartitionState {
+    Objects.requireNonNull(mode, "mode must not be null");
+    partitions = ImmutableSortedMap.copyOf(partitions);
+  }
+
+  public BrokerPartitionState(
+      final long version,
+      final Instant lastUpdated,
+      final Map<Integer, PartitionState> partitions,
+      final Mode mode) {
+    this(version, lastUpdated, ImmutableSortedMap.copyOf(partitions), mode);
+  }
+
+  /**
+   * Creates an initial state at version {@code 0} with the given partition assignment, in {@link
+   * Mode#PROCESSING}.
+   */
+  public static BrokerPartitionState initialize(
+      final Map<Integer, PartitionState> initialPartitions) {
+    return new BrokerPartitionState(0, Instant.MIN, initialPartitions, Mode.PROCESSING);
+  }
+
+  /**
+   * Returns a new state with the given mode and an incremented version, or {@code this} if the mode
+   * is unchanged.
+   */
+  public BrokerPartitionState setMode(final Mode mode) {
+    if (this.mode == mode) {
+      return this;
+    }
+    return update(mode, partitions);
+  }
+
+  /**
+   * Returns a new state with the given partition added and an incremented version.
+   *
+   * @throws IllegalStateException if the partition already exists
+   */
+  public BrokerPartitionState addPartition(
+      final int partitionId, final PartitionState partitionState) {
+    if (partitions.containsKey(partitionId)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to add a new partition, but partition %d already exists with state %s",
+              partitionId, partitions.get(partitionId)));
+    }
+    return internalUpdatePartition(partitionId, partitionState);
+  }
+
+  /**
+   * Returns a new state with the given partition transformed by {@code partitionStateUpdater} and
+   * an incremented version.
+   *
+   * @throws IllegalStateException if the partition does not exist
+   */
+  public BrokerPartitionState updatePartition(
+      final int partitionId, final UnaryOperator<PartitionState> partitionStateUpdater) {
+    if (!partitions.containsKey(partitionId)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to update partition %d, but partition does not exist", partitionId));
+    }
+    final var updatedPartitionState = partitionStateUpdater.apply(partitions.get(partitionId));
+    return internalUpdatePartition(partitionId, updatedPartitionState);
+  }
+
+  /** Returns a new state with the given partition removed and an incremented version. */
+  public BrokerPartitionState removePartition(final int partitionId) {
+    final var updatedPartitions = new HashMap<>(partitions);
+    updatedPartitions.remove(partitionId);
+    return update(mode, updatedPartitions);
+  }
+
+  /**
+   * Returns a new {@link BrokerPartitionState} after merging this and {@code other}. Does not
+   * mutate either operand.
+   *
+   * <p>The state is always updated by a member for itself, so the highest version is guaranteed to
+   * be the latest state and wins. Two states at the same version must be identical; otherwise the
+   * inputs are in conflict and cannot be reconciled.
+   *
+   * @param other the state to merge with, may be {@code null}
+   * @return the merged state
+   */
+  BrokerPartitionState merge(final @Nullable BrokerPartitionState other) {
+    if (other == null) {
+      return this;
+    }
+
+    if (version == other.version && !equals(other)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to find same BrokerPartitionState at same version, but found %s and %s",
+              this, other));
+    }
+
+    return version >= other.version ? this : other;
+  }
+
+  public boolean hasPartition(final int partitionId) {
+    return partitions.containsKey(partitionId);
+  }
+
+  public @Nullable PartitionState getPartition(final int partitionId) {
+    return partitions.get(partitionId);
+  }
+
+  private BrokerPartitionState internalUpdatePartition(
+      final int partitionId, final PartitionState partitionState) {
+    final var updatedPartitions = new HashMap<>(partitions);
+    updatedPartitions.put(partitionId, partitionState);
+    return update(mode, updatedPartitions);
+  }
+
+  private BrokerPartitionState update(
+      final Mode mode, final Map<Integer, PartitionState> partitions) {
+    return new BrokerPartitionState(version + 1, Instant.now(), partitions, mode);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/BrokerPartitionState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/BrokerPartitionState.java
@@ -51,6 +51,7 @@ public record BrokerPartitionState(
 
   public BrokerPartitionState {
     Objects.requireNonNull(mode, "mode must not be null");
+    Objects.requireNonNull(lastUpdated, "lastUpdated must not be null");
     partitions = ImmutableSortedMap.copyOf(partitions);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -40,7 +40,7 @@ import org.jspecify.annotations.Nullable;
  * <p>This class is immutable; every mutating method returns a new instance.
  *
  * @param version version of this group configuration, bumped at plan boundaries
- * @param incarnationNumber incarnation number of this group configuration
+ * @param incarnationNumber incarnation number of this group, incremented after the data is purged.
  * @param members per-broker partition state within this group
  * @param routingState routing state scoped to this group, if any
  * @param pendingChanges the ongoing change plan for this group, if any

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfiguration.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import com.google.common.collect.ImmutableSortedMap;
+import io.atomix.cluster.MemberId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents the configuration of a single named Raft partition group (e.g. one physical tenant).
+ *
+ * <p>Holds <em>only</em> per-group partition assignment and Raft replica state. Broker lifecycle
+ * (JOINING → ACTIVE → LEAVING → LEFT) lives once, cluster-wide, in {@code GlobalConfiguration};
+ * this record has no lifecycle {@code State} field. A broker is "active" in this group iff it is
+ * present in {@code members} with a non-empty partition map. The per-broker operating mode
+ * (PROCESSING/RECOVERING) is tracked on each {@link BrokerPartitionState}, since the mode is scoped
+ * to a broker within a single group.
+ *
+ * <p>{@code version} is incremented only at plan boundaries (see {@link
+ * #startConfigurationChange(List)} and {@link #advance()}). Merge uses a two-level scheme: if two
+ * copies have different versions, the higher version wins wholesale; if equal, members are merged
+ * field-by-field using their per-member versions.
+ *
+ * <p>This class is immutable; every mutating method returns a new instance.
+ *
+ * @param version version of this group configuration, bumped at plan boundaries
+ * @param incarnationNumber incarnation number of this group configuration
+ * @param members per-broker partition state within this group
+ * @param routingState routing state scoped to this group, if any
+ * @param pendingChanges the ongoing change plan for this group, if any
+ * @param lastChange the last completed change plan for this group, if any
+ */
+@NullMarked
+public record PartitionGroupConfiguration(
+    long version,
+    long incarnationNumber,
+    SortedMap<MemberId, BrokerPartitionState> members,
+    Optional<RoutingState> routingState,
+    Optional<ClusterChangePlan> pendingChanges,
+    Optional<CompletedChange> lastChange) {
+
+  public static final long INITIAL_INCARNATION_NUMBER = 0;
+
+  public PartitionGroupConfiguration {
+    Objects.requireNonNull(members, "members must not be null");
+    Objects.requireNonNull(routingState, "routingState must not be null");
+    Objects.requireNonNull(pendingChanges, "pendingChanges must not be null");
+    Objects.requireNonNull(lastChange, "lastChange must not be null");
+    if (incarnationNumber < 0) {
+      throw new IllegalArgumentException("Incarnation number must be >= 0");
+    }
+    members = ImmutableSortedMap.copyOf(members);
+  }
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  public PartitionGroupConfiguration(
+      final long version,
+      final long incarnationNumber,
+      final Map<MemberId, BrokerPartitionState> members,
+      final Optional<RoutingState> routingState,
+      final Optional<ClusterChangePlan> pendingChanges,
+      final Optional<CompletedChange> lastChange) {
+    this(
+        version,
+        incarnationNumber,
+        ImmutableSortedMap.copyOf(members),
+        routingState,
+        pendingChanges,
+        lastChange);
+  }
+
+  /** Creates an empty group configuration at the given version with no members and no changes. */
+  public static PartitionGroupConfiguration empty(final long version) {
+    return new PartitionGroupConfiguration(
+        version,
+        INITIAL_INCARNATION_NUMBER,
+        Map.of(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  /**
+   * Starts a new configuration change for this group by setting {@code pendingChanges} to a new
+   * {@link ClusterChangePlan} and bumping the group version.
+   *
+   * @param operations the operations to execute, must be non-empty
+   * @return the updated group configuration
+   * @throws IllegalArgumentException if a change is already in progress, or {@code operations} is
+   *     empty
+   */
+  public PartitionGroupConfiguration startConfigurationChange(
+      final List<ClusterConfigurationChangeOperation> operations) {
+    if (hasPendingChanges()) {
+      throw new IllegalArgumentException(
+          "Expected to start new configuration change, but there is a configuration change in progress "
+              + pendingChanges);
+    }
+    if (operations.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected to start new configuration change, but there is no operation");
+    }
+    final long newVersion = version + 1;
+    return new PartitionGroupConfiguration(
+        newVersion,
+        incarnationNumber,
+        members,
+        routingState,
+        Optional.of(ClusterChangePlan.init(newVersion, operations)),
+        lastChange);
+  }
+
+  /**
+   * Advances the ongoing change plan by removing its first pending operation, following the same
+   * semantics as {@code ClusterConfiguration#advance()}.
+   *
+   * <p>While operations remain, the plan is simply stepped forward and the group version is
+   * unchanged. When the last operation is removed, the change is completed: {@code pendingChanges}
+   * is cleared, {@code lastChange} is set to the completed change, members whose {@code partitions}
+   * map is empty are removed (the structural equivalent of {@code State.LEFT} in the legacy model —
+   * a broker no longer replicating any partition of this group is no longer part of it), and the
+   * group version is bumped so peers overwrite their local copy on merge.
+   *
+   * @return the updated group configuration
+   * @throws IllegalStateException if there is no pending change to advance
+   */
+  public PartitionGroupConfiguration advance() {
+    if (!hasPendingChanges()) {
+      throw new IllegalStateException(
+          "Expected to advance the configuration change, but there is no pending change");
+    }
+
+    final var result =
+        new PartitionGroupConfiguration(
+            version,
+            incarnationNumber,
+            members,
+            routingState,
+            Optional.of(pendingChanges.orElseThrow().advance()),
+            lastChange);
+
+    if (result.hasPendingChanges()) {
+      return result;
+    }
+
+    // The last operation has been applied. Complete the change: clean up members that no longer
+    // replicate any partition of this group and bump the version so other members merge by
+    // overwriting their local copy.
+    final var remainingMembers =
+        result.members().entrySet().stream()
+            .filter(entry -> !entry.getValue().partitions().isEmpty())
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    final var completedChange = pendingChanges.orElseThrow().completed();
+    return new PartitionGroupConfiguration(
+        result.version() + 1,
+        incarnationNumber,
+        remainingMembers,
+        routingState,
+        Optional.empty(),
+        Optional.of(completedChange));
+  }
+
+  /**
+   * Returns a new {@link PartitionGroupConfiguration} after merging this and {@code other}. Does
+   * not mutate either operand.
+   *
+   * <p>If the versions differ, the higher version wins wholesale. If equal, the result merges:
+   * {@code members} field-by-field by per-member version (which also carries each broker's
+   * operating mode); {@code pendingChanges} by plan-internal version; {@code routingState} by the
+   * higher version; and {@code incarnationNumber} via {@link Math#max}.
+   *
+   * @param other the configuration to merge with
+   * @return the merged configuration
+   */
+  public PartitionGroupConfiguration merge(final PartitionGroupConfiguration other) {
+    if (version > other.version) {
+      return this;
+    } else if (other.version > version) {
+      return other;
+    }
+
+    final var mergedMembers =
+        Stream.concat(members.entrySet().stream(), other.members().entrySet().stream())
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue, BrokerPartitionState::merge));
+
+    final Optional<RoutingState> mergedRoutingState =
+        Stream.of(routingState, other.routingState)
+            .flatMap(Optional::stream)
+            .reduce(RoutingState::merge);
+
+    final Optional<ClusterChangePlan> mergedChanges =
+        Stream.of(pendingChanges, other.pendingChanges)
+            .flatMap(Optional::stream)
+            .reduce(ClusterChangePlan::merge);
+
+    return new PartitionGroupConfiguration(
+        version,
+        Math.max(incarnationNumber, other.incarnationNumber),
+        mergedMembers,
+        mergedRoutingState,
+        mergedChanges,
+        lastChange);
+  }
+
+  /**
+   * Adds a new broker to this group. Does not change the group version — the broker carries its own
+   * per-member version; the group version only moves at plan boundaries.
+   *
+   * @throws IllegalStateException if the broker is already part of the group
+   */
+  public PartitionGroupConfiguration addMember(
+      final MemberId memberId, final BrokerPartitionState state) {
+    if (members.containsKey(memberId)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to add a new member, but member %s already exists with state %s",
+              memberId.id(), members.get(memberId)));
+    }
+    final var updatedMembers = new HashMap<>(members);
+    updatedMembers.put(memberId, state);
+    return withMembers(updatedMembers);
+  }
+
+  /**
+   * Transforms an existing broker's state via {@code memberStateUpdater} (e.g. {@code bps ->
+   * bps.setMode(RECOVERING)}). The updater is responsible only for the transformation; the
+   * per-member version is bumped by {@link BrokerPartitionState}'s own update methods. Does not
+   * change the group version. Returns {@code this} if the state is unchanged.
+   *
+   * @throws IllegalStateException if the broker is not part of the group
+   */
+  public PartitionGroupConfiguration updateMember(
+      final MemberId memberId, final UnaryOperator<BrokerPartitionState> memberStateUpdater) {
+    final BrokerPartitionState current = members.get(memberId);
+    if (current == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to update member %s, but it is not part of the group", memberId.id()));
+    }
+    final var updated = memberStateUpdater.apply(current);
+    if (updated.equals(current)) {
+      return this;
+    }
+    final var updatedMembers = new HashMap<>(members);
+    updatedMembers.put(memberId, updated);
+    return withMembers(updatedMembers);
+  }
+
+  /**
+   * Sets the routing state for this group. Does not change the group version — {@link RoutingState}
+   * carries its own version.
+   */
+  public PartitionGroupConfiguration setRoutingState(final RoutingState updatedRoutingState) {
+    return new PartitionGroupConfiguration(
+        version,
+        incarnationNumber,
+        members,
+        Optional.of(updatedRoutingState),
+        pendingChanges,
+        lastChange);
+  }
+
+  public boolean hasPendingChanges() {
+    return pendingChanges.isPresent() && pendingChanges.orElseThrow().hasPendingChanges();
+  }
+
+  public boolean hasMember(final MemberId memberId) {
+    return members.containsKey(memberId);
+  }
+
+  public @Nullable BrokerPartitionState getMember(final MemberId memberId) {
+    return members.get(memberId);
+  }
+
+  private PartitionGroupConfiguration withMembers(
+      final Map<MemberId, BrokerPartitionState> updatedMembers) {
+    return new PartitionGroupConfiguration(
+        version, incarnationNumber, updatedMembers, routingState, pendingChanges, lastChange);
+  }
+}

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -33,11 +33,10 @@ message GlobalConfiguration {
 message PartitionGroupConfiguration {
   int64 version = 1;
   int64 incarnationNumber = 2;
-  bool recovery = 3;
-  map<string, BrokerPartitionState> members = 4;
-  RoutingState routingState = 5;
-  ClusterChangePlan pendingChanges = 6;
-  CompletedChange lastChange = 7;
+  map<string, BrokerPartitionState> members = 3;
+  RoutingState routingState = 4;
+  ClusterChangePlan pendingChanges = 5;
+  CompletedChange lastChange = 6;
 }
 
 // Broker lifecycle state. Holds State and timestamps; no partition assignment.
@@ -48,10 +47,14 @@ message BrokerState {
 }
 
 // A broker's partition assignment within a single group. No lifecycle State.
+// mode is the per-broker, per-group operating mode (PROCESSING or RECOVERING,
+// the structural equivalent of the legacy State.RECOVERING), scoped to this
+// group only.
 message BrokerPartitionState {
   int64 version = 1;
   google.protobuf.Timestamp lastUpdated = 2;
   map<int32, PartitionState> partitions = 3;
+  Mode mode = 4;
 }
 
 // Pre-computed sequence of phases for cluster-spanning operations.

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/BrokerPartitionStateTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/BrokerPartitionStateTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class BrokerPartitionStateTest {
+
+  private static PartitionState partition(final int priority) {
+    return PartitionState.active(priority, DynamicPartitionConfig.init());
+  }
+
+  @Nested
+  class Merge {
+
+    @Test
+    void shouldReturnThisWhenOtherIsNull() {
+      // given
+      final var state = BrokerPartitionState.initialize(Map.of(1, partition(1)));
+
+      // when
+      final var merged = state.merge(null);
+
+      // then
+      assertThat(merged).isSameAs(state);
+    }
+
+    @Test
+    void shouldPickHigherVersion() {
+      // given
+      final var lower =
+          new BrokerPartitionState(1, Instant.EPOCH, Map.of(1, partition(1)), Mode.PROCESSING);
+      final var higher =
+          new BrokerPartitionState(2, Instant.EPOCH, Map.of(1, partition(5)), Mode.PROCESSING);
+
+      // when / then — higher version wins regardless of merge direction
+      assertThat(lower.merge(higher)).isEqualTo(higher);
+      assertThat(higher.merge(lower)).isEqualTo(higher);
+    }
+
+    @Test
+    void shouldReturnEqualStateWhenSameVersionAndIdenticalContent() {
+      // given
+      final var a =
+          new BrokerPartitionState(3, Instant.EPOCH, Map.of(1, partition(1)), Mode.PROCESSING);
+      final var b =
+          new BrokerPartitionState(3, Instant.EPOCH, Map.of(1, partition(1)), Mode.PROCESSING);
+
+      // when
+      final var merged = a.merge(b);
+
+      // then
+      assertThat(merged).isEqualTo(a);
+    }
+
+    @Test
+    void shouldThrowWhenSameVersionButDifferentContent() {
+      // given
+      final var a =
+          new BrokerPartitionState(3, Instant.EPOCH, Map.of(1, partition(1)), Mode.PROCESSING);
+      final var b =
+          new BrokerPartitionState(3, Instant.EPOCH, Map.of(1, partition(9)), Mode.PROCESSING);
+
+      // when / then
+      assertThatThrownBy(() -> a.merge(b)).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowWhenSameVersionButDifferentMode() {
+      // given — the mode is part of the state, so it participates in the conflict check
+      final var processing =
+          new BrokerPartitionState(3, Instant.EPOCH, Map.of(1, partition(1)), Mode.PROCESSING);
+      final var recovering =
+          new BrokerPartitionState(3, Instant.EPOCH, Map.of(1, partition(1)), Mode.RECOVERING);
+
+      // when / then
+      assertThatThrownBy(() -> processing.merge(recovering))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldCarryModeFromHigherVersionOnEnterRecovery() {
+      // given — the broker entered recovery in its newer state
+      final var before =
+          new BrokerPartitionState(1, Instant.EPOCH, Map.of(1, partition(1)), Mode.PROCESSING);
+      final var recovering =
+          new BrokerPartitionState(2, Instant.EPOCH, Map.of(1, partition(1)), Mode.RECOVERING);
+
+      // when
+      final var merged = before.merge(recovering);
+
+      // then
+      assertThat(merged.mode()).isEqualTo(Mode.RECOVERING);
+    }
+
+    @Test
+    void shouldCarryModeFromHigherVersionOnExitRecovery() {
+      // given — the broker exited recovery in its newer state; merge must not latch recovery on
+      final var recovering =
+          new BrokerPartitionState(1, Instant.EPOCH, Map.of(1, partition(1)), Mode.RECOVERING);
+      final var recovered =
+          new BrokerPartitionState(2, Instant.EPOCH, Map.of(1, partition(1)), Mode.PROCESSING);
+
+      // when
+      final var merged = recovering.merge(recovered);
+
+      // then
+      assertThat(merged.mode()).isEqualTo(Mode.PROCESSING);
+    }
+  }
+
+  @Nested
+  class Updates {
+
+    @Test
+    void shouldSetModeAndIncrementVersion() {
+      // given
+      final var initial = BrokerPartitionState.initialize(Map.of(1, partition(1)));
+
+      // when
+      final var updated = initial.setMode(Mode.RECOVERING);
+
+      // then
+      assertThat(updated.mode()).isEqualTo(Mode.RECOVERING);
+      assertThat(updated.version()).isEqualTo(initial.version() + 1);
+      assertThat(updated.lastUpdated()).isAfter(initial.lastUpdated());
+    }
+
+    @Test
+    void shouldReturnSameInstanceWhenModeUnchanged() {
+      // given
+      final var initial = BrokerPartitionState.initialize(Map.of(1, partition(1)));
+
+      // when / then
+      assertThat(initial.setMode(Mode.PROCESSING)).isSameAs(initial);
+    }
+
+    @Test
+    void shouldAddPartitionAndIncrementVersion() {
+      // given
+      final var initial = BrokerPartitionState.initialize(Map.of(1, partition(1)));
+
+      // when
+      final var updated = initial.addPartition(2, partition(3));
+
+      // then
+      assertThat(updated.hasPartition(2)).isTrue();
+      assertThat(updated.version()).isEqualTo(initial.version() + 1);
+    }
+
+    @Test
+    void shouldThrowWhenAddingExistingPartition() {
+      // given
+      final var initial = BrokerPartitionState.initialize(Map.of(1, partition(1)));
+
+      // when / then
+      assertThatThrownBy(() -> initial.addPartition(1, partition(2)))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldUpdatePartitionAndIncrementVersion() {
+      // given
+      final var initial = BrokerPartitionState.initialize(Map.of(1, partition(1)));
+
+      // when
+      final var updated = initial.updatePartition(1, PartitionState::toLeaving);
+
+      // then
+      assertThat(updated.getPartition(1).state()).isEqualTo(PartitionState.State.LEAVING);
+      assertThat(updated.version()).isEqualTo(initial.version() + 1);
+    }
+
+    @Test
+    void shouldThrowWhenUpdatingUnknownPartition() {
+      // given
+      final var initial = BrokerPartitionState.initialize(Map.of(1, partition(1)));
+
+      // when / then
+      assertThatThrownBy(() -> initial.updatePartition(99, UnaryOperator.identity()))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldRemovePartitionAndIncrementVersion() {
+      // given
+      final var initial = BrokerPartitionState.initialize(Map.of(1, partition(1), 2, partition(2)));
+
+      // when
+      final var updated = initial.removePartition(1);
+
+      // then
+      assertThat(updated.hasPartition(1)).isFalse();
+      assertThat(updated.partitions()).containsOnlyKeys(2);
+      assertThat(updated.version()).isEqualTo(initial.version() + 1);
+    }
+  }
+
+  @Nested
+  class Validation {
+
+    @Test
+    void shouldThrowWhenModeIsNull() {
+      // when / then
+      assertThatThrownBy(() -> new BrokerPartitionState(0, Instant.EPOCH, Map.of(), null))
+          .isInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Nested
+  class Accessors {
+
+    @Test
+    void shouldReturnPartitionForKnownId() {
+      // given
+      final var state = BrokerPartitionState.initialize(Map.of(1, partition(4)));
+
+      // when / then
+      assertThat(state.getPartition(1)).isEqualTo(partition(4));
+      assertThat(state.hasPartition(1)).isTrue();
+    }
+
+    @Test
+    void shouldReturnNullForUnknownPartition() {
+      // given
+      final var state = BrokerPartitionState.initialize(Map.of(1, partition(1)));
+
+      // when / then
+      assertThat(state.getPartition(2)).isNull();
+      assertThat(state.hasPartition(2)).isFalse();
+    }
+  }
+
+  @Nested
+  class ImmutableCollections {
+
+    @Test
+    void shouldDefensivelyCopyPartitionsInCanonicalConstructor() {
+      // given — a mutable sorted map passed to the canonical constructor
+      final var mutable = new java.util.TreeMap<Integer, PartitionState>();
+      mutable.put(1, partition(1));
+      final var state = new BrokerPartitionState(0, Instant.EPOCH, mutable, Mode.PROCESSING);
+
+      // when — the source map is mutated after construction
+      mutable.put(2, partition(2));
+
+      // then — the record's view is unaffected
+      assertThat(state.partitions()).containsOnlyKeys(1);
+    }
+
+    @Test
+    void shouldDefensivelyCopyPartitionsInMapConstructor() {
+      // given — a mutable (unsorted) map passed to the Map constructor
+      final var mutable = new HashMap<Integer, PartitionState>();
+      mutable.put(1, partition(1));
+      final var state = new BrokerPartitionState(0, Instant.EPOCH, mutable, Mode.PROCESSING);
+
+      // when
+      mutable.put(2, partition(2));
+
+      // then
+      assertThat(state.partitions()).containsOnlyKeys(1);
+    }
+
+    @Test
+    void shouldReturnImmutablePartitionsMap() {
+      // given
+      final var state = BrokerPartitionState.initialize(Map.of(1, partition(1)));
+
+      // when / then
+      assertThatThrownBy(() -> state.partitions().put(2, partition(2)))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/PartitionGroupConfigurationTest.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class PartitionGroupConfigurationTest {
+
+  private static final MemberId MEMBER_0 = MemberId.from("0");
+  private static final MemberId MEMBER_1 = MemberId.from("1");
+
+  private static PartitionState partition(final int priority) {
+    return PartitionState.active(priority, DynamicPartitionConfig.init());
+  }
+
+  private static BrokerPartitionState broker(final long version, final Integer... partitionIds) {
+    final Map<Integer, PartitionState> partitions = new HashMap<>();
+    for (final Integer id : partitionIds) {
+      partitions.put(id, partition(1));
+    }
+    return new BrokerPartitionState(version, Instant.EPOCH, partitions, Mode.PROCESSING);
+  }
+
+  private static PartitionGroupConfiguration group(
+      final long version, final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        version,
+        PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER,
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  @Nested
+  class Merge {
+
+    @Test
+    void shouldTakeHigherConfigVersionWholesale() {
+      // given — same member id, but the higher-version group has a different broker state
+      final var lower = group(1, Map.of(MEMBER_0, broker(5, 1)));
+      final var higher = group(2, Map.of(MEMBER_0, broker(1, 2)));
+
+      // when / then — the whole higher-version config wins, regardless of member versions
+      assertThat(lower.merge(higher)).isEqualTo(higher);
+      assertThat(higher.merge(lower)).isEqualTo(higher);
+    }
+
+    @Test
+    void shouldMergeMembersByMemberVersionWhenConfigVersionsEqual() {
+      // given — same config version; MEMBER_0 is newer on the left, MEMBER_1 only on the right
+      final var left = group(3, Map.of(MEMBER_0, broker(9, 1)));
+      final var right = group(3, Map.of(MEMBER_0, broker(2, 1), MEMBER_1, broker(1, 2)));
+
+      // when
+      final var merged = left.merge(right);
+
+      // then — higher per-member version wins, union of members is kept
+      assertThat(merged.members().get(MEMBER_0)).isEqualTo(broker(9, 1));
+      assertThat(merged.members().get(MEMBER_1)).isEqualTo(broker(1, 2));
+    }
+
+    @Test
+    void shouldMergeRoutingStateByVersion() {
+      // given
+      final var lowerRouting = RoutingState.initializeWithPartitionCount(1).withVersion(1);
+      final var higherRouting = RoutingState.initializeWithPartitionCount(1).withVersion(2);
+      final var left =
+          new PartitionGroupConfiguration(
+              1, 0, Map.of(), Optional.of(lowerRouting), Optional.empty(), Optional.empty());
+      final var right =
+          new PartitionGroupConfiguration(
+              1, 0, Map.of(), Optional.of(higherRouting), Optional.empty(), Optional.empty());
+
+      // when
+      final var merged = left.merge(right);
+
+      // then
+      assertThat(merged.routingState()).contains(higherRouting);
+    }
+
+    @Test
+    void shouldMergePendingChangesByPlanVersion() {
+      // given — same config version, two versions of the same plan
+      final var plan = ClusterChangePlan.init(1, List.of(new DeleteHistoryOperation(MEMBER_0)));
+      final var advancedPlan = plan.advance();
+      final var left =
+          new PartitionGroupConfiguration(
+              1, 0, Map.of(), Optional.empty(), Optional.of(plan), Optional.empty());
+      final var right =
+          new PartitionGroupConfiguration(
+              1, 0, Map.of(), Optional.empty(), Optional.of(advancedPlan), Optional.empty());
+
+      // when
+      final var merged = left.merge(right);
+
+      // then — the higher plan version wins
+      assertThat(merged.pendingChanges()).contains(advancedPlan);
+    }
+
+    @Test
+    void shouldTakeMaxIncarnationNumber() {
+      // given
+      final var left =
+          new PartitionGroupConfiguration(
+              1, 7, Map.of(), Optional.empty(), Optional.empty(), Optional.empty());
+      final var right =
+          new PartitionGroupConfiguration(
+              1, 3, Map.of(), Optional.empty(), Optional.empty(), Optional.empty());
+
+      // when / then
+      assertThat(left.merge(right).incarnationNumber()).isEqualTo(7);
+      assertThat(right.merge(left).incarnationNumber()).isEqualTo(7);
+    }
+
+    @Test
+    void shouldCarryPerBrokerModeThroughMemberMerge() {
+      // given — same config version; MEMBER_0 entered recovery in its newer state
+      final var left = group(3, Map.of(MEMBER_0, broker(1, 1)));
+      final var recoveringBroker =
+          new BrokerPartitionState(2, Instant.EPOCH, Map.of(1, partition(1)), Mode.RECOVERING);
+      final var right = group(3, Map.of(MEMBER_0, recoveringBroker));
+
+      // when
+      final var merged = left.merge(right);
+
+      // then — the mode rides the winning (higher-version) broker state
+      assertThat(merged.members().get(MEMBER_0).mode()).isEqualTo(Mode.RECOVERING);
+    }
+  }
+
+  @Nested
+  class StartConfigurationChange {
+
+    @Test
+    void shouldSetPendingChangesAndIncrementVersion() {
+      // given
+      final var config = group(4, Map.of(MEMBER_0, broker(1, 1)));
+
+      // when
+      final var updated =
+          config.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0)));
+
+      // then
+      assertThat(updated.version()).isEqualTo(5);
+      assertThat(updated.hasPendingChanges()).isTrue();
+      assertThat(updated.pendingChanges()).isPresent();
+      assertThat(updated.pendingChanges().get().pendingOperations())
+          .containsExactly(new DeleteHistoryOperation(MEMBER_0));
+    }
+
+    @Test
+    void shouldUseNewVersionAsPlanId() {
+      // given
+      final var config = group(4, Map.of());
+
+      // when
+      final var updated =
+          config.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0)));
+
+      // then
+      assertThat(updated.pendingChanges().get().id()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldThrowWhenChangeAlreadyInProgress() {
+      // given
+      final var config =
+          group(4, Map.of())
+              .startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0)));
+
+      // when / then
+      assertThatThrownBy(
+              () -> config.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0))))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowWhenNoOperations() {
+      // given
+      final var config = group(4, Map.of());
+
+      // when / then
+      assertThatThrownBy(() -> config.startConfigurationChange(List.of()))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class Advance {
+
+    private static final DeleteHistoryOperation OP_1 = new DeleteHistoryOperation(MEMBER_0);
+    private static final DeleteHistoryOperation OP_2 = new DeleteHistoryOperation(MEMBER_1);
+
+    @Test
+    void shouldThrowWhenNoPendingChange() {
+      // given
+      final var config = group(4, Map.of(MEMBER_0, broker(1, 1)));
+
+      // when / then
+      assertThatThrownBy(config::advance).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldRemoveFirstPendingOperationWhenMoreRemain() {
+      // given — a plan with two operations
+      final var config =
+          group(4, Map.of(MEMBER_0, broker(1, 1))).startConfigurationChange(List.of(OP_1, OP_2));
+      final var versionAfterStart = config.version();
+
+      // when
+      final var advanced = config.advance();
+
+      // then — the first operation is removed, the change is still pending, version is unchanged
+      assertThat(advanced.hasPendingChanges()).isTrue();
+      assertThat(advanced.pendingChanges().get().pendingOperations()).containsExactly(OP_2);
+      assertThat(advanced.version()).isEqualTo(versionAfterStart);
+    }
+
+    @Test
+    void shouldCompleteChangeWhenLastOperationIsRemoved() {
+      // given — a plan with a single operation
+      final var config =
+          group(4, Map.of(MEMBER_0, broker(1, 1))).startConfigurationChange(List.of(OP_1));
+      final var planId = config.pendingChanges().get().id();
+      final var versionAfterStart = config.version();
+
+      // when
+      final var advanced = config.advance();
+
+      // then — pending changes are cleared, the completed change is recorded, version is bumped
+      assertThat(advanced.hasPendingChanges()).isFalse();
+      assertThat(advanced.pendingChanges()).isEmpty();
+      assertThat(advanced.lastChange()).isPresent();
+      assertThat(advanced.lastChange().get().id()).isEqualTo(planId);
+      assertThat(advanced.version()).isEqualTo(versionAfterStart + 1);
+    }
+
+    @Test
+    void shouldRemoveMembersWithEmptyPartitionsOnCompletion() {
+      // given — MEMBER_0 still hosts partition 1, MEMBER_1 hosts none; a single-op plan
+      final var config =
+          group(4, Map.of(MEMBER_0, broker(1, 1), MEMBER_1, broker(1)))
+              .startConfigurationChange(List.of(OP_1));
+
+      // when
+      final var advanced = config.advance();
+
+      // then — on completion the member with no partitions is removed, the other is kept
+      assertThat(advanced.members()).containsOnlyKeys(MEMBER_0);
+      assertThat(advanced.hasMember(MEMBER_1)).isFalse();
+    }
+
+    @Test
+    void shouldNotRemoveEmptyMembersWhileOperationsRemain() {
+      // given — MEMBER_1 hosts no partitions, but the plan still has a pending operation
+      final var config =
+          group(4, Map.of(MEMBER_0, broker(1, 1), MEMBER_1, broker(1)))
+              .startConfigurationChange(List.of(OP_1, OP_2));
+
+      // when
+      final var advanced = config.advance();
+
+      // then — members are untouched during an intermediate advance
+      assertThat(advanced.members()).containsOnlyKeys(MEMBER_0, MEMBER_1);
+    }
+  }
+
+  @Nested
+  class MemberUpdates {
+
+    @Test
+    void shouldAddMemberWithoutChangingGroupVersion() {
+      // given
+      final var config = group(4, Map.of());
+
+      // when
+      final var updated = config.addMember(MEMBER_0, broker(0, 1));
+
+      // then — member is present, group version is unchanged
+      assertThat(updated.hasMember(MEMBER_0)).isTrue();
+      assertThat(updated.version()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldThrowWhenAddingExistingMember() {
+      // given
+      final var config = group(4, Map.of(MEMBER_0, broker(0, 1)));
+
+      // when / then
+      assertThatThrownBy(() -> config.addMember(MEMBER_0, broker(0, 2)))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldUpdateMemberBumpingOnlyTheMemberVersion() {
+      // given
+      final var config =
+          group(4, Map.of(MEMBER_0, BrokerPartitionState.initialize(Map.of(1, partition(1)))));
+
+      // when
+      final var updated = config.updateMember(MEMBER_0, b -> b.setMode(Mode.RECOVERING));
+
+      // then — the member's own version is bumped, the group version is not
+      assertThat(updated.getMember(MEMBER_0).mode()).isEqualTo(Mode.RECOVERING);
+      assertThat(updated.getMember(MEMBER_0).version()).isEqualTo(1);
+      assertThat(updated.version()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldThrowWhenUpdatingUnknownMember() {
+      // given
+      final var config = group(4, Map.of());
+
+      // when / then
+      assertThatThrownBy(() -> config.updateMember(MEMBER_0, b -> b.setMode(Mode.RECOVERING)))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldReturnSameConfigWhenMemberUpdateIsNoOp() {
+      // given
+      final var config = group(4, Map.of(MEMBER_0, broker(0, 1)));
+
+      // when / then — setMode to the current mode is a no-op, so the config is returned unchanged
+      assertThat(config.updateMember(MEMBER_0, b -> b.setMode(Mode.PROCESSING))).isSameAs(config);
+    }
+
+    @Test
+    void shouldSetRoutingStateWithoutChangingGroupVersion() {
+      // given
+      final var config = group(4, Map.of());
+      final var routing = RoutingState.initializeWithPartitionCount(1);
+
+      // when
+      final var updated = config.setRoutingState(routing);
+
+      // then
+      assertThat(updated.routingState()).contains(routing);
+      assertThat(updated.version()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldReturnNullForUnknownMember() {
+      // given
+      final var config = group(4, Map.of());
+
+      // when / then
+      assertThat(config.getMember(MEMBER_0)).isNull();
+    }
+  }
+
+  @Nested
+  class Factory {
+
+    @Test
+    void shouldCreateEmptyConfigAtGivenVersion() {
+      // when
+      final var config = PartitionGroupConfiguration.empty(7);
+
+      // then
+      assertThat(config.version()).isEqualTo(7);
+      assertThat(config.incarnationNumber())
+          .isEqualTo(PartitionGroupConfiguration.INITIAL_INCARNATION_NUMBER);
+      assertThat(config.members()).isEmpty();
+      assertThat(config.routingState()).isEmpty();
+      assertThat(config.pendingChanges()).isEmpty();
+      assertThat(config.lastChange()).isEmpty();
+    }
+  }
+
+  @Nested
+  class Validation {
+
+    @Test
+    void shouldThrowWhenIncarnationNumberIsNegative() {
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new PartitionGroupConfiguration(
+                      1, -1, Map.of(), Optional.empty(), Optional.empty(), Optional.empty()))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowWhenMembersIsNull() {
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new PartitionGroupConfiguration(
+                      1, 0, null, Optional.empty(), Optional.empty(), Optional.empty()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowWhenRoutingStateIsNull() {
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new PartitionGroupConfiguration(
+                      1, 0, Map.of(), null, Optional.empty(), Optional.empty()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowWhenPendingChangesIsNull() {
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new PartitionGroupConfiguration(
+                      1, 0, Map.of(), Optional.empty(), null, Optional.empty()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowWhenLastChangeIsNull() {
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new PartitionGroupConfiguration(
+                      1, 0, Map.of(), Optional.empty(), Optional.empty(), null))
+          .isInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Nested
+  class ImmutableCollections {
+
+    @Test
+    void shouldDefensivelyCopyMembersInMapConstructor() {
+      // given — a mutable map passed to the constructor
+      final var mutable = new HashMap<MemberId, BrokerPartitionState>();
+      mutable.put(MEMBER_0, broker(1, 1));
+      final var config = group(1, mutable);
+
+      // when — the source map is mutated after construction
+      mutable.put(MEMBER_1, broker(1, 2));
+
+      // then — the record's view is unaffected
+      assertThat(config.members()).containsOnlyKeys(MEMBER_0);
+    }
+
+    @Test
+    void shouldReturnImmutableMembersMap() {
+      // given
+      final var config = group(1, Map.of(MEMBER_0, broker(1, 1)));
+
+      // when / then
+      assertThatThrownBy(() -> config.members().put(MEMBER_1, broker(1, 2)))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Introduces the two per-group data-model records for multi-partition-group cluster configuration (physical tenants), as specified in #56213 (Phase 1 — Data layer of #56018).

- **`BrokerPartitionState`** — a single broker's partition assignment within one group: `version`, `lastUpdated`, `SortedMap<Integer, PartitionState> partitions`, and `Mode mode` (`PROCESSING`/`RECOVERING`). No lifecycle `State` field (broker lifecycle lives cluster-wide in the upcoming `GlobalConfiguration`). `merge()` picks the highest per-member version; equal versions must be identical or the states are in conflict.
- **`PartitionGroupConfiguration`** — per-group state: `version`, `incarnationNumber`, `Map<MemberId, BrokerPartitionState> members`, `Optional<RoutingState> routingState`, `Optional<ClusterChangePlan> pendingChanges`, `Optional<CompletedChange> lastChange`.
  - `merge()` uses the two-level scheme from ADR 0001: differing config versions win wholesale; equal versions merge members field-by-field by member version, `pendingChanges` by plan version, `routingState` by version, `incarnationNumber` via `max`.
  - `startConfigurationChange()` sets `pendingChanges` to a new plan and bumps the config version.
  - `advance()` follows the same semantics as `ClusterConfiguration#advance()`: removes the first pending operation; when the last operation is removed, completes the change — clears `pendingChanges`, records `lastChange`, removes members whose partition map is empty (structural equivalent of `State.LEFT`), and bumps the version.

Both records are `@NullMarked` and defensively copy their collections. **No proto wiring; no existing class is modified.**

BREAKING CHANGE:  The proto message for PartitionGroupState is updated to remove the filed for recovery. The recovery field was moved from legacy ClusterConfiguration from the root to MemberState. The spec was not updated after this change which resulted in adding the wrong proto format in the previous PRs. The breaking change is acceptable because this is still unreleased.

### Self-contained version management (update methods)

Version invariants are enforced inside the objects — callers never set versions, so merge stays correct without relying on callers to update atomically:

- `BrokerPartitionState#setMode`, `#addPartition`, `#updatePartition`, `#removePartition` each return a new instance with an incremented version (and refreshed `lastUpdated`). Updating a contained `PartitionState` goes through `updatePartition`, which bumps the broker version.
- `PartitionGroupConfiguration#addMember`, `#updateMember`, `#setRoutingState` update members **without** bumping the group version — per ADR D3 the group version only moves at plan boundaries; per-member versions are owned by `BrokerPartitionState`.

Note: Java forbids a private canonical constructor on a `public record`, so construction can't be hidden while keeping these as records (consistent with `MemberState`/`ClusterConfiguration`). The public canonical constructor is also required for future proto deserialization; the update methods are the sanctioned mutation path.

### `mode` / recovery placement

The per-broker operating mode (`PROCESSING`/`RECOVERING`, structural equivalent of legacy `MemberState.State.RECOVERING`) is **per-broker and per-group** — a broker can be recovering in one group but not another. It therefore lives on `BrokerPartitionState` (reusing the existing `Mode` enum), not as a group-level flag and not on the cluster-wide broker lifecycle. As a field of `BrokerPartitionState`, it rides the broker's version-based merge — correct on recovery **exit**, unlike a group-level OR merge which would latch it on. `topology.proto` moves the field from the `PartitionGroupConfiguration` message to `BrokerPartitionState` (`Mode mode`).

### Other decisions
- `pendingChanges` / `lastChange` / `routingState` are `Optional` — consistent with `ClusterConfiguration`, required for the `flatMap(Optional::stream).reduce(...)` merge and under `@NullMarked`.
- `members` is a `SortedMap` for deterministic iteration/serialization.

## Testing

`BrokerPartitionStateTest` and `PartitionGroupConfigurationTest` — 41 tests covering merge (all axes, incl. per-broker mode enter/exit), `startConfigurationChange`, `advance` (step / complete / member cleanup / no-pending-change), the update methods (mode/partition/member updates, version bumps, no-ops, error cases), and defensive-copy/immutability. All green.

## Acceptance criteria

- [x] `merge()`: higher config version wins wholesale; equal versions → members by member version; routingState by version; incarnationNumber = max
- [x] `startConfigurationChange()`: pendingChanges set; version incremented
- [x] `advance()`: removes the first pending operation; completes and removes empty-partition members when the last operation is applied
- [x] All collections are defensively copied
- [x] No existing class is modified

closes #56213


🤖 Generated with [Claude Code](https://claude.com/claude-code)
