### PR TITLE
deps: bump jackson to 2.21.5 (CVE-2026-54515)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,7 +76,7 @@
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.10.0-alpha2</version.identity>
     <version.instancio>5.6.0</version.instancio>
-    <version.jackson>2.21.4</version.jackson>
+    <version.jackson>2.21.5</version.jackson>
     <version.jackson3>3.1.4</version.jackson3>
     <version.json-base>3.0.0</version.json-base>
     <version.json-flattener>0.18.1</version.json-flattener>


### PR DESCRIPTION
## Summary

Bumps jackson-databind from **2.21.4 → 2.21.5** to remediate **CVE-2026-54515**.

The bump is applied via the `version.jackson` property in `parent/pom.xml`, which drives the `jackson-bom` import — so it covers every Camunda 8 image built from this branch (Zeebe, Operate, Tasklist, Optimize, and the combined Camunda distribution).

`version.jackson3` is already at `3.1.4` (an upstream fix version) and needs no change.

## CVE-2026-54515

In `BeanDeserializerBase.createContextual()`, a per-property `@JsonIgnoreProperties` exclusion is undone by the subsequent case-insensitivity block (`@JsonFormat(ACCEPT_CASE_INSENSITIVE_PROPERTIES)`), which rebuilds from the original unfiltered `BeanPropertyMap` and overwrites the filtered one — making an ignored property writable again.

Affected: jackson-databind `2.8.0` up to (excluding) `2.18.9` / `2.21.5` / `3.1.4`. This branch is on the 2.21 line → **2.21.5**.

## Exploitability

The security assessment for the Camunda 8 monorepo concluded this is **not exploitable from external traffic**: the only `ACCEPT_CASE_INSENSITIVE_PROPERTIES` mapper found is exporter-configuration parsing at broker startup, not a request-time deserialization path. This bump is dependency hygiene to clear the vulnerability gate / SCA scanners.

## Notes

- No tracking GitHub issue exists for this CVE.
- Trivial version-property change only — no formatting or lockfile impact (matches prior practice in #56104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
