### PR TITLE
deps: bump jackson to 2.18.9 (CVE-2026-54515)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -66,7 +66,7 @@
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.7.21</version.identity>
     <version.surefire>3.5.6</version.surefire>
-    <version.jackson>2.18.8</version.jackson>
+    <version.jackson>2.18.9</version.jackson>
     <version.junit>5.11.4</version.junit>
     <version.junit4>4.13.2</version.junit4>
     <version.log4j>2.25.4</version.log4j>


### PR DESCRIPTION
## Summary

Bumps jackson-databind from **2.18.8 → 2.18.9** to remediate **CVE-2026-54515**.

The bump is applied via the `version.jackson` property in `parent/pom.xml`, which drives the `jackson-bom` import — so it covers the Camunda 8 images built from this branch (Zeebe, Operate, Tasklist, and the combined Camunda distribution).

Supersedes the earlier closed attempt #56104 (same branch, same target version).

## CVE-2026-54515

In `BeanDeserializerBase.createContextual()`, a per-property `@JsonIgnoreProperties` exclusion is undone by the subsequent case-insensitivity block (`@JsonFormat(ACCEPT_CASE_INSENSITIVE_PROPERTIES)`), which rebuilds from the original unfiltered `BeanPropertyMap` and overwrites the filtered one — making an ignored property writable again.

Affected: jackson-databind `2.8.0` up to (excluding) `2.18.9` / `2.21.5` / `3.1.4`. This branch is on the 2.18 line → **2.18.9** (patch bump).

## Exploitability

The security assessment for the Camunda 8 monorepo concluded this is **not exploitable from external traffic**: the only `ACCEPT_CASE_INSENSITIVE_PROPERTIES` mapper found is exporter-configuration parsing at broker startup, not a request-time deserialization path. This bump is dependency hygiene to clear the vulnerability gate / SCA scanners.

## Notes

- No tracking GitHub issue exists for this CVE.
- Trivial version-property change only — no formatting or lockfile impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
