### PR TITLE
deps: bump jackson to 2.18.9 (CVE-2026-54515)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -66,7 +66,7 @@
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.5.5</version.identity>
     <version.surefire>3.5.0</version.surefire>
-    <version.jackson>2.17.2</version.jackson>
+    <version.jackson>2.18.9</version.jackson>
     <version.java-grpc-prometheus>0.6.0</version.java-grpc-prometheus>
     <version.junit>5.11.0</version.junit>
     <version.junit4>4.13.2</version.junit4>


### PR DESCRIPTION
## Summary

Bumps jackson-databind from **2.17.2 → 2.18.9** to remediate **CVE-2026-54515** on the standalone Optimize 8.7 branch.

The bump is applied via the `version.jackson` property in `parent/pom.xml`, which drives the `jackson-bom` import for Optimize built from this branch.

## CVE-2026-54515

In `BeanDeserializerBase.createContextual()`, a per-property `@JsonIgnoreProperties` exclusion is undone by the subsequent case-insensitivity block (`@JsonFormat(ACCEPT_CASE_INSENSITIVE_PROPERTIES)`), which rebuilds from the original unfiltered `BeanPropertyMap` and overwrites the filtered one — making an ignored property writable again.

Affected: jackson-databind `2.8.0` up to (excluding) `2.18.9` / `2.21.5` / `3.1.4`. The 2.17 line has no patched release, so the lowest fixed version for this line is **2.18.9**.

## ⚠️ Minor bump — needs verification

Unlike the other CVE-2026-54515 bumps (patch-level), this one crosses a **minor** version (2.17 → 2.18). Jackson minor releases can carry behavioral changes. Please run a full Optimize build + test pass before merging.

`version.jackson-annotations` is intentionally left at `2.17.2`: the companion `camunda/camunda` `stable/8.7` branch already ships databind `2.18.x` alongside annotations `2.17.x`, so the combination is known-acceptable.

## Exploitability

The security assessment for the Camunda 8 monorepo concluded this is **not exploitable from external traffic**. This bump is dependency hygiene to clear the vulnerability gate / SCA scanners.

## Notes

- No tracking GitHub issue exists for this CVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
