### PR TITLE
deps: update httpcore5 to v5.4.3 and httpclient5 to 5.6.2 (main)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,8 +71,8 @@
     <version.hamcrest>3.0</version.hamcrest>
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
-    <version.httpclient5>5.6.1</version.httpclient5>
-    <version.httpcore5>5.4.2</version.httpcore5>
+    <version.httpclient5>5.6.2</version.httpclient5>
+    <version.httpcore5>5.4.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.10.0-alpha2</version.identity>
     <version.instancio>5.6.0</version.instancio>


### PR DESCRIPTION
## Description

fixes CVE-2026-54399

`stable/8.9` already updated httpcore5 https://github.com/camunda/camunda/pull/56368, backport to update also `httpclient5` to `5.6.2`

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes https://github.com/camunda/camunda/issues/56775
