### PR TITLE
deps: bump google-java-format to 1.34.1 and spotless to 3.2.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>4.0.0</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath></relativePath>
+    <relativePath/>
   </parent>
 
   <groupId>io.camunda</groupId>
@@ -255,7 +255,7 @@
           <configuration>
             <pom>
               <!-- https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md#sortpom -->
-              <sortPom></sortPom>
+              <sortPom/>
             </pom>
           </configuration>
         </plugin>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -44,7 +44,7 @@
     <plugin.version.flatten>1.6.0</plugin.version.flatten>
     <plugin.version.javadoc>3.10.1</plugin.version.javadoc>
     <plugin.version.license>4.5</plugin.version.license>
-    <plugin.version.spotless>2.43.0</plugin.version.spotless>
+    <plugin.version.spotless>3.2.1</plugin.version.spotless>
 
     <!--
       Define the skipChecks property here ONLY for the plugins defined in this module;

--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -35,7 +35,7 @@
         <artifactId>flatten-maven-plugin</artifactId>
         <configuration>
           <pomElements>
-            <distributionManagement></distributionManagement>
+            <distributionManagement/>
           </pomElements>
         </configuration>
       </plugin>

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -159,9 +159,9 @@
               </filters>
               <transformers>
                 <!-- Merge service files -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <!-- Keep manifest entries -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"></transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
               </transformers>
             </configuration>
           </execution>

--- a/debug-cli/src/test/java/io/camunda/debug/cli/RaftCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/RaftCommandTest.java
@@ -66,7 +66,7 @@ public class RaftCommandTest {
     assertThat(output).isNotBlank();
 
     final var expected =
-        """
+"""
 {
     "index": 88,
     "term": 70,

--- a/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
@@ -20,7 +20,7 @@ import picocli.CommandLine;
 public class SbeCommandTest {
 
   private static final String EXPECTED_CONFIGURATION =
-      """
+"""
 {
     "index": 88,
     "term": 70,

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -659,7 +659,7 @@
               <goal>assemble</goal>
             </goals>
             <phase>package</phase>
-            <configuration></configuration>
+            <configuration/>
           </execution>
         </executions>
       </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2399,7 +2399,7 @@
                 <goal>check</goal>
               </goals>
               <phase>validate</phase>
-              <configuration></configuration>
+              <configuration/>
             </execution>
           </executions>
         </plugin>
@@ -2431,7 +2431,7 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
-            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"/>
             <skip>${skipUTs}</skip>
           </configuration>
           <dependencies>
@@ -2473,7 +2473,7 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
-            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"/>
             <skip>${skipITs}</skip>
           </configuration>
           <dependencies>
@@ -2564,7 +2564,7 @@
                   <argument>-classpath</argument>
                   <!-- automatically creates the classpath using all project dependencies,
                      also adding the project build directory -->
-                  <classpath></classpath>
+                  <classpath/>
                   <argument>uk.co.real_logic.sbe.SbeTool</argument>
                 </arguments>
                 <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
@@ -2599,7 +2599,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -2701,7 +2701,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <banDuplicatePomDependencyVersions></banDuplicatePomDependencyVersions>
+                  <banDuplicatePomDependencyVersions/>
                 </rules>
               </configuration>
             </execution>
@@ -2977,7 +2977,7 @@
             <configuration>
               <groups>strace</groups>
               <!-- Reset <excludedGroups> as it take precedence over <groups> -->
-              <excludedGroups combine.self="override"></excludedGroups>
+              <excludedGroups combine.self="override"/>
             </configuration>
           </plugin>
         </plugins>
@@ -2995,7 +2995,7 @@
             <configuration>
               <groups>performance</groups>
               <!-- Reset <excludedGroups> as it take precedence over <groups> -->
-              <excludedGroups combine.self="override"></excludedGroups>
+              <excludedGroups combine.self="override"/>
             </configuration>
           </plugin>
         </plugins>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -233,7 +233,7 @@
     <plugin.version.maven-source>3.3.1</plugin.version.maven-source>
 
     <!-- when updating this version, also change it in .idea/externalDependencies.xml -->
-    <plugin.version.google-java-format>1.23.0</plugin.version.google-java-format>
+    <plugin.version.google-java-format>1.34.1</plugin.version.google-java-format>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.7.1</extension.version.os-maven-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
               <exclude>.claude/skills/**/*.md</exclude>
               <exclude>.github/agents/**/*.md</exclude>
             </excludes>
-            <flexmark></flexmark>
+            <flexmark/>
           </markdown>
         </configuration>
       </plugin>

--- a/testing/camunda-process-test-spring-4/pom.xml
+++ b/testing/camunda-process-test-spring-4/pom.xml
@@ -212,9 +212,9 @@
               </artifactSet>
               <transformers>
                 <!-- Merge service files -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <!-- Keep manifest entries -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"></transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
               </transformers>
             </configuration>
           </execution>

--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -19,6 +19,6 @@
   <artifactId>webapps-schema</artifactId>
   <name>Webapps Schema</name>
 
-  <dependencies></dependencies>
+  <dependencies/>
 
 </project>

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
@@ -82,7 +82,7 @@ class StaticConfigurationGeneratorTest {
     final var expectedDistribution =
         Map.of(1, Set.of(0, 1, 2), 2, Set.of(1, 2, 0), 3, Set.of(0, 1, 2));
     final String config =
-        """
+"""
 fixed:
    - partitionId: 1
      nodes:

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -217,7 +217,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     // throwable is always CompletionException
     return switch (throwable.getCause()) {
       case final ClusterConfigurationRequestFailedException.OperationNotAllowed
-                  operationNotAllowed ->
+              operationNotAllowed ->
           Either.left(
               new ErrorResponse(ErrorCode.OPERATION_NOT_ALLOWED, operationNotAllowed.getMessage()));
       case final ClusterConfigurationRequestFailedException.InvalidRequest invalidRequest ->

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -286,7 +286,7 @@ final class BulkIndexRequestTest {
           .describedAs("Expect that the records are serialized with resourceMetadata")
           .map(source -> MAPPER.writeValueAsString(source))
           .containsExactly(
-              """
+"""
 [{"checksum":"Y2hlY2tzdW0=","deploymentKey":12345,"duplicate":false,"resourceId":"resourceId","resourceKey":1,"resourceName":"resourceName","tenantId":"<default>","version":1,"versionTag":""}]""");
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -205,7 +205,7 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
         .json(
-            """
+"""
 {
    "processDefinitionKey":"123",
    "processDefinitionId":"bpmnProcessId",

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -413,7 +413,7 @@ public class UserTaskControllerTest extends RestControllerTest {
   void shouldYieldBadRequestWhenUpdateTaskWithoutActionAndChanges(final String baseUrl) {
     // given
     final var expectedBody =
-        """
+"""
         {
           "type": "about:blank",
           "status": 400,
@@ -537,7 +537,7 @@ for a supported attribute in the \\"changeset\\".",
             }""";
 
     final var expectedBody =
-        """
+"""
             {
               "type": "about:blank",
               "status": 400,

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
@@ -34,7 +34,7 @@ import org.agrona.IoUtil;
 public final class SfvChecksumImpl implements MutableChecksumsSFV {
 
   private static final String SFV_HEADER =
-      """
+"""
 ; This is an SFC checksum file for all files in the given directory.
 ; You might use cksfv or another tool to validate these files manually.
 ; This is an automatically created file - please do NOT modify.


### PR DESCRIPTION
## Description

`google-java-format` 1.23.0 (with `spotless` 2.43.0) cannot run on modern JDKs:

- Under JDK 25+ it throws `NoSuchMethodError: Log$DeferredDiagnosticHandler.getDiagnostics()` against javac internals.
- Under JDK 21 it fails to parse record patterns (`illegal start of expression`).

Since the rest of the build runs on a modern JDK, this forced a JDK switch just to run spotless. This bumps `google-java-format` to `1.34.1` and `spotless` to `3.2.1` — the versions already in use on `stable/8.9` — so the whole build, including spotless, runs under a single modern JDK (verified locally on JDK 26).

Ratcheting is enabled, so no existing files are reformatted: a full `spotless:apply` on the module with the highest record-pattern density (`zeebe-logstreams`) changed 0 of 66 files.