### PR TITLE
deps: bump google-java-format to 1.34.1 and spotless to 3.2.1

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -44,7 +44,7 @@
     <plugin.version.flatten>1.7.3</plugin.version.flatten>
     <plugin.version.javadoc>3.12.0</plugin.version.javadoc>
     <plugin.version.license>5.0.0</plugin.version.license>
-    <plugin.version.spotless>2.44.5</plugin.version.spotless>
+    <plugin.version.spotless>3.2.1</plugin.version.spotless>
 
     <!--
       Define the skipChecks property here ONLY for the plugins defined in this module;

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>4.1.1</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath></relativePath>
+    <relativePath/>
   </parent>
 
   <groupId>io.camunda</groupId>
@@ -272,7 +272,7 @@
           <configuration>
             <pom>
               <!-- https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md#sortpom -->
-              <sortPom></sortPom>
+              <sortPom/>
             </pom>
           </configuration>
         </plugin>

--- a/clients/camunda-spring-boot-3-starter/pom.xml
+++ b/clients/camunda-spring-boot-3-starter/pom.xml
@@ -36,7 +36,7 @@
         <artifactId>flatten-maven-plugin</artifactId>
         <configuration>
           <pomElements>
-            <distributionManagement></distributionManagement>
+            <distributionManagement/>
           </pomElements>
         </configuration>
       </plugin>

--- a/clients/camunda-spring-boot-4-starter/pom.xml
+++ b/clients/camunda-spring-boot-4-starter/pom.xml
@@ -177,9 +177,9 @@
               </filters>
               <transformers>
                 <!-- Merge service files -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <!-- Keep manifest entries -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"></transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
               </transformers>
             </configuration>
           </execution>

--- a/clients/spring-boot-starter-camunda-sdk-deprecated/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk-deprecated/pom.xml
@@ -26,7 +26,7 @@
         <artifactId>flatten-maven-plugin</artifactId>
         <configuration>
           <pomElements>
-            <distributionManagement></distributionManagement>
+            <distributionManagement/>
           </pomElements>
         </configuration>
       </plugin>

--- a/debug-cli/src/test/java/io/camunda/debug/cli/RaftCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/RaftCommandTest.java
@@ -67,7 +67,7 @@ public class RaftCommandTest {
     assertThat(output).isNotBlank();
 
     final var expected =
-        """
+"""
 {
     "index": 88,
     "term": 70,

--- a/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/SbeCommandTest.java
@@ -20,7 +20,7 @@ import picocli.CommandLine;
 public class SbeCommandTest {
 
   private static final String EXPECTED_CONFIGURATION =
-      """
+"""
 {
     "index": 88,
     "term": 70,

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -902,7 +902,7 @@
               <goal>assemble</goal>
             </goals>
             <phase>package</phase>
-            <configuration></configuration>
+            <configuration/>
           </execution>
         </executions>
       </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2469,7 +2469,7 @@
                 <goal>check</goal>
               </goals>
               <phase>validate</phase>
-              <configuration></configuration>
+              <configuration/>
             </execution>
           </executions>
         </plugin>
@@ -2501,7 +2501,7 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
-            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"/>
             <skip>${skipUTs}</skip>
           </configuration>
           <dependencies>
@@ -2543,7 +2543,7 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
-            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"/>
             <skip>${skipITs}</skip>
           </configuration>
           <dependencies>
@@ -2634,7 +2634,7 @@
                   <argument>-classpath</argument>
                   <!-- automatically creates the classpath using all project dependencies,
                      also adding the project build directory -->
-                  <classpath></classpath>
+                  <classpath/>
                   <argument>uk.co.real_logic.sbe.SbeTool</argument>
                 </arguments>
                 <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
@@ -2669,7 +2669,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore></ignore>
+                    <ignore/>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -2771,7 +2771,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <banDuplicatePomDependencyVersions></banDuplicatePomDependencyVersions>
+                  <banDuplicatePomDependencyVersions/>
                 </rules>
               </configuration>
             </execution>
@@ -3055,7 +3055,7 @@
             <configuration>
               <groups>strace</groups>
               <!-- Reset <excludedGroups> as it take precedence over <groups> -->
-              <excludedGroups combine.self="override"></excludedGroups>
+              <excludedGroups combine.self="override"/>
             </configuration>
           </plugin>
         </plugins>
@@ -3073,7 +3073,7 @@
             <configuration>
               <groups>performance</groups>
               <!-- Reset <excludedGroups> as it take precedence over <groups> -->
-              <excludedGroups combine.self="override"></excludedGroups>
+              <excludedGroups combine.self="override"/>
               <excludes>
                 <exclude>**/LargeStateControllerPerformanceTest.java</exclude>
               </excludes>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -237,7 +237,7 @@
     <plugin.version.maven-source>3.3.1</plugin.version.maven-source>
 
     <!-- when updating this version, also change it in .idea/externalDependencies.xml -->
-    <plugin.version.google-java-format>1.25.2</plugin.version.google-java-format>
+    <plugin.version.google-java-format>1.34.1</plugin.version.google-java-format>
 
     <!-- maven extensions -->
     <extension.version.os-maven-plugin>1.7.1</extension.version.os-maven-plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
               <exclude>.claude/skills/**/*.md</exclude>
               <exclude>.github/agents/**/*.md</exclude>
             </excludes>
-            <flexmark></flexmark>
+            <flexmark/>
           </markdown>
         </configuration>
       </plugin>

--- a/schema-manager/pom.xml
+++ b/schema-manager/pom.xml
@@ -21,7 +21,7 @@
 
   <properties>
     <skipITs>false</skipITs>
-    <excludeITNames></excludeITNames>
+    <excludeITNames/>
   </properties>
 
   <dependencies>

--- a/testing/camunda-process-test-spring-4/pom.xml
+++ b/testing/camunda-process-test-spring-4/pom.xml
@@ -42,7 +42,7 @@
         <artifactId>flatten-maven-plugin</artifactId>
         <configuration>
           <pomElements>
-            <distributionManagement></distributionManagement>
+            <distributionManagement/>
           </pomElements>
         </configuration>
       </plugin>

--- a/testing/camunda-process-test-spring-boot-3/pom.xml
+++ b/testing/camunda-process-test-spring-boot-3/pom.xml
@@ -43,7 +43,7 @@
         <artifactId>flatten-maven-plugin</artifactId>
         <configuration>
           <pomElements>
-            <distributionManagement></distributionManagement>
+            <distributionManagement/>
           </pomElements>
         </configuration>
       </plugin>

--- a/testing/camunda-process-test-spring-boot-4/pom.xml
+++ b/testing/camunda-process-test-spring-boot-4/pom.xml
@@ -238,9 +238,9 @@
               </artifactSet>
               <transformers>
                 <!-- Merge service files -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"></transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 <!-- Keep manifest entries -->
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"></transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
               </transformers>
             </configuration>
           </execution>

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
@@ -82,7 +82,7 @@ class StaticConfigurationGeneratorTest {
     final var expectedDistribution =
         Map.of(1, Set.of(0, 1, 2), 2, Set.of(1, 2, 0), 3, Set.of(0, 1, 2));
     final String config =
-        """
+"""
 fixed:
    - partitionId: 1
      nodes:

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EmbeddedFormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EmbeddedFormHandlerTest.java
@@ -280,7 +280,8 @@ public class EmbeddedFormHandlerTest {
   }
 
   private String formJson() {
-    return """
+    return
+"""
 {
   "components": [
     {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
@@ -205,7 +205,8 @@ public class FormHandlerTest {
   }
 
   private String formJsonResource() {
-    return """
+    return
+"""
 {
   "components": [
     {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
@@ -35,7 +35,7 @@ import org.agrona.IoUtil;
 public final class SfvChecksumImpl implements MutableChecksumsSFV {
 
   private static final String SFV_HEADER =
-      """
+"""
 ; This is an SFC checksum file for all files in the given directory.
 ; You might use cksfv or another tool to validate these files manually.
 ; This is an automatically created file - please do NOT modify.

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotMetadataTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotMetadataTest.java
@@ -18,7 +18,7 @@ public class FileBasedSnapshotMetadataTest {
   @Test
   public void shouldDeserializeMetadataFromPreviousVersion() throws IOException {
     final var previousMetadata =
-        """
+"""
 {"version":1,"processedPosition":71662471,"exportedPosition":74709149,"lastFollowupEventPosition":74708149}
 """;
     final var deserialized = FileBasedSnapshotMetadata.decode(previousMetadata.getBytes());

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/modelreader/ProcessModelReaderTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/modelreader/ProcessModelReaderTest.java
@@ -281,7 +281,8 @@ public class ProcessModelReaderTest {
   }
 
   private String formOneJson() {
-    return """
+    return
+"""
 {
   "components": [
     {
@@ -309,7 +310,8 @@ public class ProcessModelReaderTest {
   }
 
   private String formTwoJson() {
-    return """
+    return
+"""
 {
   "components": [
     {


### PR DESCRIPTION
## Description

`google-java-format` 1.25.2 (with `spotless` 2.44.5) cannot run on modern JDKs:

- Under JDK 25+ it throws `NoSuchMethodError: Log$DeferredDiagnosticHandler.getDiagnostics()` against javac internals.
- Under JDK 21 it fails to parse record patterns (`illegal start of expression`).

Since the rest of the build runs on a modern JDK, this forced a JDK switch just to run spotless. This bumps `google-java-format` to `1.34.1` and `spotless` to `3.2.1` — the versions already in use on `stable/8.9` — so the whole build, including spotless, runs under a single modern JDK (verified locally on JDK 26).

Ratcheting is enabled, so no existing files are reformatted: a full `spotless:apply` on the module with the highest record-pattern density (`zeebe-logstreams`) changed 0 of 65 files.