### PR TITLE
fix: load-test: configure OpenSearch to log as JSON

### DIFF
--- a/load-tests/setup/main/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-opensearch.yaml
@@ -82,6 +82,16 @@ config:
     # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
     logger.org.opensearch.deprecation: "OFF"
 
+  # Log as JSON
+  log4j2.properties: |
+    appender.console.type = Console
+    appender.console.name = console
+    appender.console.layout.type = OpenSearchJsonLayout
+    appender.console.layout.type_name = json_logger
+
+    rootLogger.level = info
+    rootLogger.appenderRef.console.ref = console
+
 extraEnvs:
   - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
     value: "yourStrongPassword123!"

--- a/load-tests/setup/stable-88/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-opensearch.yaml
@@ -56,6 +56,16 @@ config:
     # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
     logger.org.opensearch.deprecation: "OFF"
 
+  # Log as JSON
+  log4j2.properties: |
+    appender.console.type = Console
+    appender.console.name = console
+    appender.console.layout.type = OpenSearchJsonLayout
+    appender.console.layout.type_name = json_logger
+
+    rootLogger.level = info
+    rootLogger.appenderRef.console.ref = console
+
 extraEnvs:
   - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
     value: "yourStrongPassword123!"

--- a/load-tests/setup/stable-89/values/camunda-platform-values-opensearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-opensearch.yaml
@@ -82,6 +82,16 @@ config:
     # Disable deprecation logging to avoid filling up the logs with warnings about deprecated features that we might be using in our tests
     logger.org.opensearch.deprecation: "OFF"
 
+  # Log as JSON
+  log4j2.properties: |
+    appender.console.type = Console
+    appender.console.name = console
+    appender.console.layout.type = OpenSearchJsonLayout
+    appender.console.layout.type_name = json_logger
+
+    rootLogger.level = info
+    rootLogger.appenderRef.console.ref = console
+
 extraEnvs:
   - name: OPENSEARCH_INITIAL_ADMIN_PASSWORD
     value: "yourStrongPassword123!"


### PR DESCRIPTION
## Description

Cf. https://app.incident.io/camunda/incidents/6430
Coming from https://forum.opensearch.org/t/opensearch-json-logging/15797/2 ; tested and confirmed locally:
<img width="975" height="798" alt="image" src="https://github.com/user-attachments/assets/e89b2f49-371c-464c-89dd-6dc1ed58acf7" />


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* [INC-6430](https://app.incident.io/camunda/incidents/6430)
