### PR TITLE
feat: support limiting batch processing by elapsed time

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
@@ -15,6 +15,7 @@ public final class ProcessingCfg implements ConfigurationEntry {
   private static final int DEFAULT_PROCESSING_BATCH_LIMIT = 100;
   private static final int DEFAULT_MAX_RECOVERABLE_RETRIES = 1000;
   private Integer maxCommandsInBatch = DEFAULT_PROCESSING_BATCH_LIMIT;
+  private Duration maxBatchProcessingTime;
   private int maxRecoverableRetries = DEFAULT_MAX_RECOVERABLE_RETRIES;
   private boolean enableAsyncScheduledTasks = true;
   private Duration scheduledTaskCheckInterval = Duration.ofSeconds(1);
@@ -25,6 +26,10 @@ public final class ProcessingCfg implements ConfigurationEntry {
     if (maxCommandsInBatch < 1) {
       throw new IllegalArgumentException(
           "maxCommandsInBatch must be >= 1 but was %s".formatted(maxCommandsInBatch));
+    }
+    if (maxBatchProcessingTime != null && !maxBatchProcessingTime.isPositive()) {
+      throw new IllegalArgumentException(
+          "maxBatchProcessingTime must be positive but was %s".formatted(maxBatchProcessingTime));
     }
     if (maxRecoverableRetries < 1) {
       throw new IllegalArgumentException(
@@ -43,6 +48,20 @@ public final class ProcessingCfg implements ConfigurationEntry {
 
   public void setMaxCommandsInBatch(final int maxCommandsInBatch) {
     this.maxCommandsInBatch = maxCommandsInBatch;
+  }
+
+  /**
+   * Maximum time a processing batch is allowed to grow, or {@code null} if batching is only limited
+   * by {@link #getMaxCommandsInBatch()}. This is a soft limit: once exceeded, no further follow-up
+   * commands are processed in the same batch, but the commands already part of the batch are still
+   * processed.
+   */
+  public Duration getMaxBatchProcessingTime() {
+    return maxBatchProcessingTime;
+  }
+
+  public void setMaxBatchProcessingTime(final Duration maxBatchProcessingTime) {
+    this.maxBatchProcessingTime = maxBatchProcessingTime;
   }
 
   public int getMaxRecoverableRetries() {
@@ -74,6 +93,8 @@ public final class ProcessingCfg implements ConfigurationEntry {
     return "ProcessingCfg{"
         + "maxCommandsInBatch="
         + maxCommandsInBatch
+        + ", maxBatchProcessingTime="
+        + maxBatchProcessingTime
         + ", maxRecoverableRetries="
         + maxRecoverableRetries
         + ", enableAsyncScheduledTasks="

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
@@ -13,9 +13,10 @@ import java.util.Set;
 public final class ProcessingCfg implements ConfigurationEntry {
 
   private static final int DEFAULT_PROCESSING_BATCH_LIMIT = 100;
+  private static final Duration DEFAULT_MAX_BATCH_PROCESSING_TIME = Duration.ofMillis(75);
   private static final int DEFAULT_MAX_RECOVERABLE_RETRIES = 1000;
   private Integer maxCommandsInBatch = DEFAULT_PROCESSING_BATCH_LIMIT;
-  private Duration maxBatchProcessingTime;
+  private Duration maxBatchProcessingTime = DEFAULT_MAX_BATCH_PROCESSING_TIME;
   private int maxRecoverableRetries = DEFAULT_MAX_RECOVERABLE_RETRIES;
   private boolean enableAsyncScheduledTasks = true;
   private Duration scheduledTaskCheckInterval = Duration.ofSeconds(1);
@@ -51,10 +52,11 @@ public final class ProcessingCfg implements ConfigurationEntry {
   }
 
   /**
-   * Maximum time a processing batch is allowed to grow, or {@code null} if batching is only limited
-   * by {@link #getMaxCommandsInBatch()}. This is a soft limit: once exceeded, no further follow-up
-   * commands are processed in the same batch, but the commands already part of the batch are still
-   * processed.
+   * Maximum time a processing batch is allowed to grow, 75ms by default. This is a soft limit: once
+   * exhausted, no further follow-up commands are processed in the same batch, but the commands
+   * already part of the batch are still processed. The batch is only truncated if a client is
+   * waiting on a response from it or further records are waiting on the log, otherwise batching
+   * continues past the limit.
    */
   public Duration getMaxBatchProcessingTime() {
     return maxBatchProcessingTime;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -171,6 +171,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .recordProcessors(recordProcessors)
         .commandResponseWriter(context.getCommandApiService().newCommandResponseWriter())
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
+        .maxBatchProcessingTime(context.getBrokerCfg().getProcessing().getMaxBatchProcessingTime())
         .maxRecoverableRetries(context.getBrokerCfg().getProcessing().getMaxRecoverableRetries())
         .setEnableAsyncScheduledTasks(
             context.getBrokerCfg().getProcessing().isEnableAsyncScheduledTasks())

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
@@ -70,7 +70,7 @@ final class ProcessingCfgTest {
   }
 
   @Test
-  void shouldNotLimitBatchProcessingTimeByDefault() {
+  void shouldUseDefaultMaxBatchProcessingTime() {
     // given
     final var cfg = new ProcessingCfg();
 
@@ -78,7 +78,7 @@ final class ProcessingCfgTest {
     final var limit = cfg.getMaxBatchProcessingTime();
 
     // then
-    assertThat(limit).isNull();
+    assertThat(limit).isEqualTo(Duration.ofMillis(75));
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.configuration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -66,6 +67,70 @@ final class ProcessingCfgTest {
 
     // then
     assertThat(limit).isEqualTo(75);
+  }
+
+  @Test
+  void shouldNotLimitBatchProcessingTimeByDefault() {
+    // given
+    final var cfg = new ProcessingCfg();
+
+    // when
+    final var limit = cfg.getMaxBatchProcessingTime();
+
+    // then
+    assertThat(limit).isNull();
+  }
+
+  @Test
+  void shouldSetMaxBatchProcessingTime() {
+    // given
+    final var cfg = new ProcessingCfg();
+    cfg.setMaxBatchProcessingTime(Duration.ofMillis(250));
+
+    // when
+    final var limit = cfg.getMaxBatchProcessingTime();
+
+    // then
+    assertThat(limit).isEqualTo(Duration.ofMillis(250));
+  }
+
+  @Test
+  void shouldSetMaxBatchProcessingTimeFromConfig() {
+    // given
+    final var cfg =
+        TestConfigReader.readConfig("processing-cfg", Collections.emptyMap()).getProcessing();
+
+    // when
+    final var limit = cfg.getMaxBatchProcessingTime();
+
+    // then
+    assertThat(limit).isEqualTo(Duration.ofMillis(500));
+  }
+
+  @Test
+  void shouldSetMaxBatchProcessingTimeFromEnvironment() {
+    // given
+    final var environment =
+        Collections.singletonMap("zeebe.broker.processing.maxBatchProcessingTime", "100ms");
+    final var cfg = TestConfigReader.readConfig("processing-cfg", environment).getProcessing();
+
+    // when
+    final var limit = cfg.getMaxBatchProcessingTime();
+
+    // then
+    assertThat(limit).isEqualTo(Duration.ofMillis(100));
+  }
+
+  @Test
+  void shouldRejectInvalidMaxBatchProcessingTime() {
+    // given
+    final var environment =
+        Collections.singletonMap("zeebe.broker.processing.maxBatchProcessingTime", "-1s");
+
+    // then
+    assertThatThrownBy(() -> TestConfigReader.readConfig("processing-cfg", environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxBatchProcessingTime must be positive");
   }
 
   @Test

--- a/zeebe/broker/src/test/resources/system/processing-cfg.yaml
+++ b/zeebe/broker/src/test/resources/system/processing-cfg.yaml
@@ -2,6 +2,7 @@ zeebe:
   broker:
     processing:
       maxCommandsInBatch: 125
+      maxBatchProcessingTime: 500ms
       maxRecoverableRetries: 200
       enableAsyncScheduledTasks: false
       skipPositions: 1, 2, 3

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -401,6 +401,7 @@ public final class ProcessingStateMachine {
               .orElseThrow(() -> NoSuchProcessorException.forRecord(command));
 
       currentProcessingResult = currentProcessor.process(command, processingResultBuilder);
+      currentProcessingResult.getProcessingResponse().ifPresent(pendingResponses::add);
 
       final BatchProcessingStepResult batchProcessingStepResult =
           collectBatchProcessingStepResult(
@@ -409,11 +410,10 @@ public final class ProcessingStateMachine {
               // +1 since we already need include the current command in the calculation
               pendingCommands.size() + processedCommandsCount + 1,
               currentProcessingBatchLimit,
-              isBatchProcessingTimeExhausted(batchStartTimeNanos));
+              shouldTruncateBatch(batchStartTimeNanos));
 
       pendingCommands.addAll(batchProcessingStepResult.toProcess());
       pendingWrites.addAll(batchProcessingStepResult.toWrite());
-      currentProcessingResult.getProcessingResponse().ifPresent(pendingResponses::add);
 
       lastProcessingResultSize = currentProcessingResult.getRecordBatch().entries().size();
       processedCommandsCount++;
@@ -433,9 +433,9 @@ public final class ProcessingStateMachine {
    *     command
    * @param currentBatchSize the current batch size (only commands counted), includes already
    *     processed and pending commands
-   * @param batchProcessingTimeExhausted true if the batch already took longer than the configured
-   *     maximum batch processing time, in which case follow-up commands are written unmarked and
-   *     processed later in their own batch instead of growing this one
+   * @param truncateBatch true if the batch should not grow any further, in which case follow-up
+   *     commands are written unmarked and processed later in their own batch instead of growing
+   *     this one
    * @return the result of the current batch processing step, which contains the next to processed
    *     commands and the records which should be written to the log
    */
@@ -444,7 +444,7 @@ public final class ProcessingStateMachine {
       final int lastProcessingResultSize,
       final int currentBatchSize,
       final int currentProcessingBatchLimit,
-      final boolean batchProcessingTimeExhausted) {
+      final boolean truncateBatch) {
 
     final var commandsToProcess = new ArrayList<TypedRecord<?>>();
     final var toWriteEntries = new ArrayList<LogAppendEntry>();
@@ -458,7 +458,7 @@ public final class ProcessingStateMachine {
               if (entry.recordMetadata().getRecordType() == RecordType.COMMAND
                   && potentialBatchSize < currentProcessingBatchLimit
                   && !processingResult.shouldProcessInASeparateBatch()) {
-                if (batchProcessingTimeExhausted) {
+                if (truncateBatch) {
                   processingMetrics.commandDeferredAfterTimeExhausted();
                 } else {
                   commandsToProcess.add(
@@ -474,6 +474,18 @@ public final class ProcessingStateMachine {
             });
 
     return new BatchProcessingStepResult(commandsToProcess, toWriteEntries);
+  }
+
+  /**
+   * Once the maximum batch processing time is exhausted, the batch is truncated only if someone
+   * actually benefits from it: either a client waiting on a response from this batch, or further
+   * records waiting on the log, which may be commands that require a response themselves. Otherwise
+   * we might as well continue batching, since deferring follow-up commands costs an additional
+   * write-commit-read cycle.
+   */
+  private boolean shouldTruncateBatch(final long batchStartTimeNanos) {
+    return isBatchProcessingTimeExhausted(batchStartTimeNanos)
+        && (!pendingResponses.isEmpty() || logStreamReader.hasNext());
   }
 
   private boolean isBatchProcessingTimeExhausted(final long batchStartTimeNanos) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -160,6 +160,8 @@ public final class ProcessingStateMachine {
   private final LogStreamWriter logStreamWriter;
   private boolean inProcessing;
   private final int maxCommandsInBatch;
+  // -1 if batch processing time is unlimited
+  private final long maxBatchProcessingTimeNanos;
   private int processedCommandsCount;
   private final ProcessingMetrics processingMetrics;
   private final ScheduledCommandCache scheduledCommandCache;
@@ -183,6 +185,9 @@ public final class ProcessingStateMachine {
     abortCondition = context.getAbortCondition();
     lastProcessedPositionState = context.getLastProcessedPositionState();
     maxCommandsInBatch = context.getMaxCommandsInBatch();
+    final var maxBatchProcessingTime = context.getMaxBatchProcessingTime();
+    maxBatchProcessingTimeNanos =
+        maxBatchProcessingTime != null ? maxBatchProcessingTime.toNanos() : -1;
 
     writeRetryStrategy = new AbortableRetryStrategy(actor);
     sideEffectsRetryStrategy = new AbortableRetryStrategy(actor);
@@ -360,6 +365,12 @@ public final class ProcessingStateMachine {
     final var processingResultBuilder = newProcessingResultBuilder(initialCommand);
     var lastProcessingResultSize = 0;
 
+    // Measured with System.nanoTime instead of the stream clock: the stream clock is sourced from
+    // the actor clock which does not advance within a single actor job (i.e. during this batch),
+    // and it can be pinned or offset through the clock management API which must not affect how
+    // long we allow a batch to grow.
+    final var batchStartTimeNanos = System.nanoTime();
+
     // It might be that we reached the batch size limit during processing a command.
     // We rolled back the transaction and processing result and retried the processing.
     // We know that we can process until the last processed commands count, which is why we set it
@@ -397,7 +408,8 @@ public final class ProcessingStateMachine {
               lastProcessingResultSize,
               // +1 since we already need include the current command in the calculation
               pendingCommands.size() + processedCommandsCount + 1,
-              currentProcessingBatchLimit);
+              currentProcessingBatchLimit,
+              isBatchProcessingTimeExhausted(batchStartTimeNanos));
 
       pendingCommands.addAll(batchProcessingStepResult.toProcess());
       pendingWrites.addAll(batchProcessingStepResult.toWrite());
@@ -421,6 +433,9 @@ public final class ProcessingStateMachine {
    *     command
    * @param currentBatchSize the current batch size (only commands counted), includes already
    *     processed and pending commands
+   * @param batchProcessingTimeExhausted true if the batch already took longer than the configured
+   *     maximum batch processing time, in which case follow-up commands are written unmarked and
+   *     processed later in their own batch instead of growing this one
    * @return the result of the current batch processing step, which contains the next to processed
    *     commands and the records which should be written to the log
    */
@@ -428,7 +443,8 @@ public final class ProcessingStateMachine {
       final ProcessingResult processingResult,
       final int lastProcessingResultSize,
       final int currentBatchSize,
-      final int currentProcessingBatchLimit) {
+      final int currentProcessingBatchLimit,
+      final boolean batchProcessingTimeExhausted) {
 
     final var commandsToProcess = new ArrayList<TypedRecord<?>>();
     final var toWriteEntries = new ArrayList<LogAppendEntry>();
@@ -442,18 +458,27 @@ public final class ProcessingStateMachine {
               if (entry.recordMetadata().getRecordType() == RecordType.COMMAND
                   && potentialBatchSize < currentProcessingBatchLimit
                   && !processingResult.shouldProcessInASeparateBatch()) {
-                commandsToProcess.add(
-                    new UnwrittenRecord(
-                        entry.key(),
-                        context.getPartitionId(),
-                        entry.recordValue(),
-                        entry.recordMetadata()));
-                toWriteEntry = LogAppendEntry.ofProcessed(entry);
+                if (batchProcessingTimeExhausted) {
+                  processingMetrics.commandDeferredAfterTimeExhausted();
+                } else {
+                  commandsToProcess.add(
+                      new UnwrittenRecord(
+                          entry.key(),
+                          context.getPartitionId(),
+                          entry.recordValue(),
+                          entry.recordMetadata()));
+                  toWriteEntry = LogAppendEntry.ofProcessed(entry);
+                }
               }
               toWriteEntries.add(toWriteEntry);
             });
 
     return new BatchProcessingStepResult(commandsToProcess, toWriteEntries);
+  }
+
+  private boolean isBatchProcessingTimeExhausted(final long batchStartTimeNanos) {
+    return maxBatchProcessingTimeNanos >= 0
+        && System.nanoTime() - batchStartTimeNanos >= maxBatchProcessingTimeNanos;
   }
 
   private void onError(final Throwable error, final NextProcessingStep nextStep) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -148,10 +148,20 @@ public final class StreamProcessorBuilder {
           "maxRecoverableRetries must be >= 1 but was %s"
               .formatted(streamProcessorContext.getMaxRecoverableRetries()));
     }
+    final var maxBatchProcessingTime = streamProcessorContext.getMaxBatchProcessingTime();
+    if (maxBatchProcessingTime != null && !maxBatchProcessingTime.isPositive()) {
+      throw new IllegalArgumentException(
+          "maxBatchProcessingTime must be positive but was %s".formatted(maxBatchProcessingTime));
+    }
   }
 
   public StreamProcessorBuilder maxCommandsInBatch(final int maxCommandsInBatch) {
     streamProcessorContext.maxCommandsInBatch(maxCommandsInBatch);
+    return this;
+  }
+
+  public StreamProcessorBuilder maxBatchProcessingTime(final Duration maxBatchProcessingTime) {
+    streamProcessorContext.maxBatchProcessingTime(maxBatchProcessingTime);
     return this;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -56,6 +56,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private volatile StreamProcessor.Phase phase = Phase.INITIAL;
   private KeyGeneratorControls keyGeneratorControls;
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
+  private Duration maxBatchProcessingTime;
   private int maxRecoverableRetries = DEFAULT_MAX_RECOVERABLE_RETRIES;
   private boolean enableAsyncScheduledTasks = true;
   private EventFilter processingFilter = e -> true;
@@ -242,6 +243,19 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public int getMaxCommandsInBatch() {
     return maxCommandsInBatch;
+  }
+
+  public StreamProcessorContext maxBatchProcessingTime(final Duration maxBatchProcessingTime) {
+    this.maxBatchProcessingTime = maxBatchProcessingTime;
+    return this;
+  }
+
+  /**
+   * Maximum time a processing batch is allowed to grow, or {@code null} if batching is only limited
+   * by {@link #getMaxCommandsInBatch()}.
+   */
+  public Duration getMaxBatchProcessingTime() {
+    return maxBatchProcessingTime;
   }
 
   public StreamProcessorContext maxRecoverableRetries(final int maxRecoverableRetries) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
@@ -41,6 +41,7 @@ public class ProcessingMetrics {
   private final Timer batchProcessingPostCommitTasks;
   private final DistributionSummary batchProcessingCommands;
   private final Counter batchProcessingRetries;
+  private final Counter batchProcessingDeferredCommands;
   private final EnumMeter<ErrorHandlingPhase> errorHandlingPhase;
   private final Timer processingLatency;
 
@@ -53,6 +54,7 @@ public class ProcessingMetrics {
         registerTimer(StreamMetricsDoc.BATCH_PROCESSING_POST_COMMIT_TASKS);
     batchProcessingCommands = registerBatchProcessingCommands();
     batchProcessingRetries = registerBatchProcessingRetries();
+    batchProcessingDeferredCommands = registerBatchProcessingDeferredCommands();
     errorHandlingPhase =
         EnumMeter.register(
             ErrorHandlingPhase.class,
@@ -75,6 +77,10 @@ public class ProcessingMetrics {
 
   public void countRetry() {
     batchProcessingRetries.increment();
+  }
+
+  public void commandDeferredAfterTimeExhausted() {
+    batchProcessingDeferredCommands.increment();
   }
 
   public CloseableSilently startBatchProcessingPostCommitTasksTimer() {
@@ -143,6 +149,13 @@ public class ProcessingMetrics {
             .description(retriesDoc.getDescription())
             .register(registry);
     return batchProcessingRetries;
+  }
+
+  private Counter registerBatchProcessingDeferredCommands() {
+    final var deferredDoc = StreamMetricsDoc.BATCH_PROCESSING_DEFERRED_COMMANDS;
+    return Counter.builder(deferredDoc.getName())
+        .description(deferredDoc.getDescription())
+        .register(registry);
   }
 
   private Timer registerTimer(final StreamMetricsDoc meterDoc) {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
@@ -127,6 +127,28 @@ public enum StreamMetricsDoc implements ExtendedMeterDocumentation {
   },
 
   /**
+   * Number of follow-up commands deferred to their own batch because the maximum batch processing
+   * time was exhausted
+   */
+  BATCH_PROCESSING_DEFERRED_COMMANDS {
+    @Override
+    public String getDescription() {
+      return "Number of follow-up commands deferred to their own batch because the maximum batch"
+          + " processing time was exhausted";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.batch.processing.deferred.commands";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+  },
+
+  /**
    * The current phase of error handling the processor is in; see {@link
    * io.camunda.zeebe.stream.impl.ProcessingStateMachine.ErrorHandlingPhase} for possible values.
    */

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorMaxBatchProcessingTimeTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorMaxBatchProcessingTimeTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.stream.api.ProcessingResult;
+import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.util.RecordToWrite;
+import io.camunda.zeebe.stream.util.Records;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.verification.VerificationWithTimeout;
+
+@ExtendWith(StreamPlatformExtension.class)
+final class StreamProcessorMaxBatchProcessingTimeTest {
+
+  private static final long TIMEOUT_MILLIS = 2_000L;
+  private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
+
+  @SuppressWarnings("unused") // injected by the extension
+  private StreamPlatform streamPlatform;
+
+  @Test
+  void shouldProcessFollowUpCommandInOwnBatchWhenMaxBatchProcessingTimeIsExhausted() {
+    // given -- processing a command takes longer than the maximum batch processing time
+    final var processor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(processor.process(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              simulateProcessingFor(Duration.ofMillis(25));
+              return followUpCommandResult(invocation.getArgument(1));
+            })
+        .thenAnswer(invocation -> followUpEventResult(invocation.getArgument(1)));
+    streamPlatform.buildStreamProcessor(
+        streamPlatform.getLogStream(),
+        true,
+        cfg -> cfg.maxBatchProcessingTime(Duration.ofMillis(1)));
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then -- the follow-up command is not batched but processed on its own
+    verify(processor, TIMEOUT.times(2)).process(any(), any());
+    final var listener = streamPlatform.getMockStreamProcessorListener();
+    verify(listener, TIMEOUT.times(2)).onProcessed(any());
+  }
+
+  @Test
+  void shouldProcessFollowUpCommandInSameBatchWhenMaxBatchProcessingTimeIsNotExhausted() {
+    // given -- processing is much faster than the maximum batch processing time
+    final var processor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(processor.process(any(), any()))
+        .thenAnswer(invocation -> followUpCommandResult(invocation.getArgument(1)))
+        .thenAnswer(invocation -> followUpEventResult(invocation.getArgument(1)));
+    streamPlatform.buildStreamProcessor(
+        streamPlatform.getLogStream(),
+        true,
+        cfg -> cfg.maxBatchProcessingTime(Duration.ofMinutes(10)));
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then -- the follow-up command is processed in the same batch, so both the command and the
+    // follow-up event are skipped when they are read from the log
+    verify(processor, TIMEOUT.times(2)).process(any(), any());
+    final var listener = streamPlatform.getMockStreamProcessorListener();
+    verify(listener, TIMEOUT.times(2)).onSkipped(any());
+    verify(listener, times(1)).onProcessed(any());
+  }
+
+  private static ProcessingResult followUpCommandResult(final ProcessingResultBuilder builder) {
+    return builder
+        .appendRecord(
+            4,
+            Records.processInstance(1),
+            new RecordMetadata()
+                .recordType(RecordType.COMMAND)
+                .intent(ELEMENT_ACTIVATING)
+                .rejectionType(RejectionType.NULL_VAL)
+                .rejectionReason(""))
+        .build();
+  }
+
+  private static ProcessingResult followUpEventResult(final ProcessingResultBuilder builder) {
+    return builder
+        .appendRecord(
+            5,
+            Records.processInstance(1),
+            new RecordMetadata()
+                .recordType(RecordType.EVENT)
+                .intent(ELEMENT_ACTIVATING)
+                .rejectionType(RejectionType.NULL_VAL)
+                .rejectionReason(""))
+        .build();
+  }
+
+  /** Simulates a slow processor by busy-waiting for the given duration. */
+  private static void simulateProcessingFor(final Duration duration) {
+    final var end = System.nanoTime() + duration.toNanos();
+    while (System.nanoTime() - end < 0) {
+      Thread.onSpinWait();
+    }
+  }
+}

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorMaxBatchProcessingTimeTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorMaxBatchProcessingTimeTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.stream.api.ProcessingResult;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.util.RecordToWrite;
@@ -27,6 +28,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.verification.VerificationWithTimeout;
 
+/**
+ * Tests the maximum batch processing time: a batch stops growing once processing it took longer
+ * than the configured limit, but only if a client is waiting on a response from the batch or
+ * further records are waiting on the log.
+ */
 @ExtendWith(StreamPlatformExtension.class)
 final class StreamProcessorMaxBatchProcessingTimeTest {
 
@@ -38,7 +44,117 @@ final class StreamProcessorMaxBatchProcessingTimeTest {
 
   @Test
   void shouldProcessFollowUpCommandInOwnBatchWhenMaxBatchProcessingTimeIsExhausted() {
-    // given -- processing a command takes longer than the maximum batch processing time
+    // given -- processing takes longer than the maximum batch processing time, a client is waiting
+    // on a response and another command is waiting on the log
+    final var processor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(processor.process(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              simulateProcessingFor(Duration.ofMillis(25));
+              return followUpCommandAndResponseResult(invocation.getArgument(1));
+            })
+        .thenAnswer(invocation -> followUpEventResult(invocation.getArgument(1)));
+    streamPlatform.buildStreamProcessor(
+        streamPlatform.getLogStream(),
+        true,
+        cfg -> cfg.maxBatchProcessingTime(Duration.ofMillis(1)));
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then -- the follow-up command is not batched but processed on its own, resulting in three
+    // batches: the initial command, the waiting command and the deferred follow-up command
+    verify(processor, TIMEOUT.times(3)).process(any(), any());
+    final var listener = streamPlatform.getMockStreamProcessorListener();
+    verify(listener, TIMEOUT.times(3)).onProcessed(any());
+  }
+
+  @Test
+  void shouldProcessFollowUpCommandInSameBatchWhenMaxBatchProcessingTimeIsNotExhausted() {
+    // given -- processing is much faster than the maximum batch processing time
+    final var processor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(processor.process(any(), any()))
+        .thenAnswer(invocation -> followUpCommandAndResponseResult(invocation.getArgument(1)))
+        .thenAnswer(invocation -> followUpEventResult(invocation.getArgument(1)));
+    streamPlatform.buildStreamProcessor(
+        streamPlatform.getLogStream(),
+        true,
+        cfg -> cfg.maxBatchProcessingTime(Duration.ofMinutes(10)));
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then -- the follow-up command is processed in the same batch, so it is skipped when read
+    // from the log, along with the follow-up events of both batches
+    final var listener = streamPlatform.getMockStreamProcessorListener();
+    verify(listener, TIMEOUT.times(3)).onSkipped(any());
+    verify(processor, times(3)).process(any(), any());
+    verify(listener, times(2)).onProcessed(any());
+  }
+
+  @Test
+  void shouldProcessFollowUpCommandInOwnBatchWhenOnlyRecordsAreWaiting() {
+    // given -- processing takes longer than the maximum batch processing time and another command
+    // is waiting on the log, but no client is waiting on a response from this batch
+    final var processor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(processor.process(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              simulateProcessingFor(Duration.ofMillis(25));
+              return followUpCommandResult(invocation.getArgument(1));
+            })
+        .thenAnswer(invocation -> followUpEventResult(invocation.getArgument(1)));
+    streamPlatform.buildStreamProcessor(
+        streamPlatform.getLogStream(),
+        true,
+        cfg -> cfg.maxBatchProcessingTime(Duration.ofMillis(1)));
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then -- the follow-up command is deferred so that the waiting command is processed first
+    verify(processor, TIMEOUT.times(3)).process(any(), any());
+    final var listener = streamPlatform.getMockStreamProcessorListener();
+    verify(listener, TIMEOUT.times(3)).onProcessed(any());
+  }
+
+  @Test
+  void shouldProcessFollowUpCommandInOwnBatchWhenOnlyClientIsWaitingForResponse() {
+    // given -- processing takes longer than the maximum batch processing time and a client is
+    // waiting on a response, but nothing else is waiting on the log
+    final var processor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(processor.process(any(), any()))
+        .thenAnswer(
+            invocation -> {
+              simulateProcessingFor(Duration.ofMillis(25));
+              return followUpCommandAndResponseResult(invocation.getArgument(1));
+            })
+        .thenAnswer(invocation -> followUpEventResult(invocation.getArgument(1)));
+    streamPlatform.buildStreamProcessor(
+        streamPlatform.getLogStream(),
+        true,
+        cfg -> cfg.maxBatchProcessingTime(Duration.ofMillis(1)));
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then -- the follow-up command is deferred so that the response is sent out earlier
+    verify(processor, TIMEOUT.times(2)).process(any(), any());
+    final var listener = streamPlatform.getMockStreamProcessorListener();
+    verify(listener, TIMEOUT.times(2)).onProcessed(any());
+  }
+
+  @Test
+  void shouldContinueBatchWhenNoOneIsWaiting() {
+    // given -- processing takes longer than the maximum batch processing time, but no client is
+    // waiting on a response and nothing else is waiting on the log
     final var processor = streamPlatform.getDefaultMockedRecordProcessor();
     when(processor.process(any(), any()))
         .thenAnswer(
@@ -56,47 +172,44 @@ final class StreamProcessorMaxBatchProcessingTimeTest {
     streamPlatform.writeBatch(
         RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
 
-    // then -- the follow-up command is not batched but processed on its own
-    verify(processor, TIMEOUT.times(2)).process(any(), any());
-    final var listener = streamPlatform.getMockStreamProcessorListener();
-    verify(listener, TIMEOUT.times(2)).onProcessed(any());
-  }
-
-  @Test
-  void shouldProcessFollowUpCommandInSameBatchWhenMaxBatchProcessingTimeIsNotExhausted() {
-    // given -- processing is much faster than the maximum batch processing time
-    final var processor = streamPlatform.getDefaultMockedRecordProcessor();
-    when(processor.process(any(), any()))
-        .thenAnswer(invocation -> followUpCommandResult(invocation.getArgument(1)))
-        .thenAnswer(invocation -> followUpEventResult(invocation.getArgument(1)));
-    streamPlatform.buildStreamProcessor(
-        streamPlatform.getLogStream(),
-        true,
-        cfg -> cfg.maxBatchProcessingTime(Duration.ofMinutes(10)));
-
-    // when
-    streamPlatform.writeBatch(
-        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
-
-    // then -- the follow-up command is processed in the same batch, so both the command and the
-    // follow-up event are skipped when they are read from the log
-    verify(processor, TIMEOUT.times(2)).process(any(), any());
+    // then -- the follow-up command is still processed in the same batch, so it is skipped when
+    // read from the log, along with the follow-up event
     final var listener = streamPlatform.getMockStreamProcessorListener();
     verify(listener, TIMEOUT.times(2)).onSkipped(any());
+    verify(processor, times(2)).process(any(), any());
     verify(listener, times(1)).onProcessed(any());
   }
 
-  private static ProcessingResult followUpCommandResult(final ProcessingResultBuilder builder) {
-    return builder
-        .appendRecord(
-            4,
+  private static ProcessingResult followUpCommandAndResponseResult(
+      final ProcessingResultBuilder builder) {
+    return appendFollowUpCommand(builder)
+        .withResponse(
+            RecordType.EVENT,
+            3,
+            ELEMENT_ACTIVATING,
             Records.processInstance(1),
-            new RecordMetadata()
-                .recordType(RecordType.COMMAND)
-                .intent(ELEMENT_ACTIVATING)
-                .rejectionType(RejectionType.NULL_VAL)
-                .rejectionReason(""))
+            ValueType.PROCESS_INSTANCE,
+            RejectionType.NULL_VAL,
+            "",
+            1,
+            12)
         .build();
+  }
+
+  private static ProcessingResult followUpCommandResult(final ProcessingResultBuilder builder) {
+    return appendFollowUpCommand(builder).build();
+  }
+
+  private static ProcessingResultBuilder appendFollowUpCommand(
+      final ProcessingResultBuilder builder) {
+    return builder.appendRecord(
+        4,
+        Records.processInstance(1),
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND)
+            .intent(ELEMENT_ACTIVATING)
+            .rejectionType(RejectionType.NULL_VAL)
+            .rejectionReason(""));
   }
 
   private static ProcessingResult followUpEventResult(final ProcessingResultBuilder builder) {


### PR DESCRIPTION
Adds `zeebe.broker.processing.maxBatchProcessingTime` (default 75ms) which stops growing a processing batch once processing it has taken longer than the configured duration. It complements `maxCommandsInBatch`: the batch stops growing when either limit is reached.

`maxCommandsInBatch` (default 100) is a poor proxy for the latency cost of a batch: a hundred cheap commands finish in a few milliseconds, while a few expensive ones can occupy the stream processor for much longer. Since the batch commits atomically, a long-running batch delays its own responses as well as every command queued behind it on the log — including user commands whose request-response latency the AIMD backpressure limiter is trying to keep around its 200ms default target.

The deadline is checked in `ProcessingStateMachine.collectBatchProcessingStepResult`, which is the only correct interception point: it decides whether a follow-up command is queued in-batch and written with the processed marker (`LogAppendEntry.ofProcessed`), or written unmarked to be processed later in its own batch. Once a command is written marked, we are committed to processing it in the current batch, so the check must happen before admission rather than in the processing loop. This makes the limit a soft one: commands already admitted are still processed, and a single slow command can overrun the limit.

Even when the time limit is exhausted, the batch is only truncated if someone actually benefits: either a client is waiting on a response from this batch (`pendingResponses` is not empty), or further records are waiting on the log (`logStreamReader.hasNext()`), which may be commands that require a response themselves. Otherwise batching continues past the limit, since deferring follow-up commands costs an additional write-commit-read cycle without improving any latency. Because deferred follow-up commands are appended to the log after commands that are already waiting there, truncating a batch lets waiting user commands be processed before the deferred continuation — which is exactly the intended latency benefit.

Elapsed time is measured with `System.nanoTime` instead of the stream clock, for two reasons: the stream clock is sourced from the actor clock, which only advances between actor jobs and would therefore appear frozen for the entire duration of a batch, and it can be pinned or offset through the clock management API, which must not affect how long a batch is allowed to grow. A new counter `zeebe.stream.processor.batch.processing.deferred.commands` records how many follow-up commands were deferred because the limit was exhausted, to make the mechanism observable in benchmarks.

The 75ms default lives in `ProcessingCfg` and applies to brokers; embedded uses of the stream platform (e.g. engine tests) keep unlimited batch processing time unless they configure it, so their batch boundaries stay deterministic. 75ms is well below the 200ms AIMD request timeout, leaving room in the latency budget of queued requests even when a batch overruns; whether it is the right trade-off against throughput still needs to be validated with a load test.
