### PR TITLE
refactor: migrate User and Tenant processors to PermissionsBehavior (CSL)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha41</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha42</version.camunda-security-library>
     <version.checkstyle>13.7.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -374,7 +374,7 @@ public final class EngineProcessors {
     TenantProcessors.addTenantProcessors(
         typedRecordProcessors,
         processingState,
-        authCheckBehavior,
+        permissionsBehavior,
         keyGenerator,
         writers,
         commandDistributionBehavior,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -359,9 +359,9 @@ public final class EngineProcessors {
         commandDistributionBehavior,
         authCheckBehavior,
         securityConfig,
-        config,
         authzService,
-        claimsConverter);
+        claimsConverter,
+        authorizationScopeStateAdapter);
 
     ScalingProcessors.addScalingProcessors(
         commandDistributionBehavior,
@@ -470,12 +470,9 @@ public final class EngineProcessors {
       final CommandDistributionBehavior commandDistributionBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
       final EngineSecurityConfig securityConfig,
-      final EngineConfiguration config,
       final AuthorizationService authzService,
-      final LazyTokenClaimsConverter claimsConverter) {
-    final var authorizationScopeStateAdapter =
-        new AuthorizationScopeStateAdapter(processingState.getAuthorizationState(), config);
-
+      final LazyTokenClaimsConverter claimsConverter,
+      final AuthorizationScopeStateAdapter authorizationScopeStateAdapter) {
     AuthorizationProcessors.addAuthorizationProcessors(
         keyGenerator,
         typedRecordProcessors,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -57,6 +57,7 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizationProcessors;
 import io.camunda.zeebe.engine.processing.identity.GroupProcessors;
 import io.camunda.zeebe.engine.processing.identity.IdentitySetupProcessors;
 import io.camunda.zeebe.engine.processing.identity.MappingRuleProcessors;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.identity.RoleProcessors;
 import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
 import io.camunda.zeebe.engine.processing.identity.adapter.MembershipStateAdapter;
@@ -312,13 +313,35 @@ public final class EngineProcessors {
         partitionsCount,
         config);
 
+    final var membershipStateAdapter =
+        new MembershipStateAdapter(
+            processingState.getMappingRuleState(), processingState.getMembershipState(), config);
+    final var authorizationScopeStateAdapter =
+        new AuthorizationScopeStateAdapter(processingState.getAuthorizationState(), config);
+    final var authorizationChecker = new AuthorizationChecker(authorizationScopeStateAdapter);
+    final var claimsConverter =
+        new LazyTokenClaimsConverter(
+            Authorization.AUTHORIZED_USERNAME,
+            Authorization.AUTHORIZED_CLIENT_ID,
+            false,
+            membershipStateAdapter);
+    final var propertyEvaluatorRegistry = new PropertyAuthorizationEvaluatorRegistry(List.of());
+    final var authzService =
+        new AuthorizationService(
+            authorizationChecker,
+            propertyEvaluatorRegistry,
+            securityConfig.isAuthorizationsEnabled(),
+            securityConfig.isMultiTenancyChecksEnabled());
+    final var permissionsBehavior =
+        new PermissionsBehavior(processingState, authzService, claimsConverter, securityConfig);
+
     UserProcessors.addUserProcessors(
         keyGenerator,
         typedRecordProcessors,
         processingState,
         writers,
         commandDistributionBehavior,
-        authCheckBehavior);
+        permissionsBehavior);
 
     ClockProcessors.addClockProcessors(
         typedRecordProcessors,
@@ -336,7 +359,9 @@ public final class EngineProcessors {
         commandDistributionBehavior,
         authCheckBehavior,
         securityConfig,
-        config);
+        config,
+        authzService,
+        claimsConverter);
 
     ScalingProcessors.addScalingProcessors(
         commandDistributionBehavior,
@@ -349,7 +374,7 @@ public final class EngineProcessors {
     TenantProcessors.addTenantProcessors(
         typedRecordProcessors,
         processingState,
-        authCheckBehavior,
+        permissionsBehavior,
         keyGenerator,
         writers,
         commandDistributionBehavior,
@@ -445,26 +470,11 @@ public final class EngineProcessors {
       final CommandDistributionBehavior commandDistributionBehavior,
       final AuthorizationCheckBehavior authCheckBehavior,
       final EngineSecurityConfig securityConfig,
-      final EngineConfiguration config) {
-    final var membershipStateAdapter =
-        new MembershipStateAdapter(
-            processingState.getMappingRuleState(), processingState.getMembershipState(), config);
+      final EngineConfiguration config,
+      final AuthorizationService authzService,
+      final LazyTokenClaimsConverter claimsConverter) {
     final var authorizationScopeStateAdapter =
         new AuthorizationScopeStateAdapter(processingState.getAuthorizationState(), config);
-    final var authorizationChecker = new AuthorizationChecker(authorizationScopeStateAdapter);
-    final var claimsConverter =
-        new LazyTokenClaimsConverter(
-            Authorization.AUTHORIZED_USERNAME,
-            Authorization.AUTHORIZED_CLIENT_ID,
-            false,
-            membershipStateAdapter);
-    final var propertyEvaluatorRegistry = new PropertyAuthorizationEvaluatorRegistry(List.of());
-    final var authzService =
-        new AuthorizationService(
-            authorizationChecker,
-            propertyEvaluatorRegistry,
-            securityConfig.isAuthorizationsEnabled(),
-            securityConfig.isMultiTenancyChecksEnabled());
 
     AuthorizationProcessors.addAuthorizationProcessors(
         keyGenerator,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -378,7 +378,9 @@ public final class EngineProcessors {
         keyGenerator,
         writers,
         commandDistributionBehavior,
-        securityConfig);
+        securityConfig,
+        authCheckBehavior,
+        authorizationScopeStateAdapter);
 
     IdentitySetupProcessors.addIdentitySetupProcessors(
         keyGenerator, typedRecordProcessors, writers, securityConfig, config);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -374,7 +374,7 @@ public final class EngineProcessors {
     TenantProcessors.addTenantProcessors(
         typedRecordProcessors,
         processingState,
-        permissionsBehavior,
+        authCheckBehavior,
         keyGenerator,
         writers,
         commandDistributionBehavior,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -138,65 +138,6 @@ public class PermissionsBehavior {
     return Either.right(command.getValue());
   }
 
-  public <V extends UnifiedRecordValue> Either<Rejection, V> isAuthorized(
-      final TypedRecord<V> command,
-      final io.camunda.zeebe.protocol.record.value.PermissionType permissionType,
-      final io.camunda.zeebe.protocol.record.value.AuthorizationResourceType resourceType) {
-    if (command.isInternalCommand()) {
-      LOG.trace("Skipping authorization check for internal command {}", command.getIntent());
-      return Either.right(command.getValue());
-    }
-    final var authorizations = command.getAuthorizations();
-    if (Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
-      LOG.trace(
-          "Skipping authorization check for anonymous user on command {}", command.getIntent());
-      return Either.right(command.getValue());
-    }
-    if (!securityConfig.isAuthorizationsEnabled()
-        && !securityConfig.isMultiTenancyChecksEnabled()) {
-      LOG.trace(
-          "Skipping authorization check for command {}: security disabled (authz={}, multiTenancy={})",
-          command.getIntent(),
-          securityConfig.isAuthorizationsEnabled(),
-          securityConfig.isMultiTenancyChecksEnabled());
-      return Either.right(command.getValue());
-    }
-    if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
-        && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
-      if (!securityConfig.isAuthorizationsEnabled()) {
-        return Either.right(command.getValue());
-      }
-      LOG.debug(
-          "Rejecting command {}: neither username nor clientId claim is present",
-          command.getIntent());
-      return Either.left(AuthorizationRejectionMapper.forbidden(permissionType, resourceType));
-    }
-    LOG.trace(
-        "Checking {} permission on {} resource for command {}",
-        permissionType,
-        resourceType,
-        command.getIntent());
-    final var auth = claimsConverter.convert(authorizations);
-    final var cslPermType = AuthzModelMapper.fromProtocol(permissionType);
-    final var cslResourceType = AuthzModelMapper.fromProtocol(resourceType);
-    final var result =
-        authCheckPort.check(
-            auth,
-            RequiredAuthorization.of(
-                b ->
-                    b.resourceType(cslResourceType)
-                        .permissionType(cslPermType)
-                        .resourceId(AuthorizationScope.WILDCARD_CHAR)));
-    if (result.isLeft()) {
-      LOG.debug(
-          "Authorization check rejected for command {}: {}",
-          command.getIntent(),
-          result.leftValue());
-      return Either.left(AuthorizationRejectionMapper.toRejection(result.leftValue()));
-    }
-    return Either.right(command.getValue());
-  }
-
   public Either<Rejection, PersistedAuthorization> authorizationExists(
       final AuthorizationRecord authorizationRecord, final String rejectionMessage) {
     final var key = authorizationRecord.getAuthorizationKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -138,6 +138,65 @@ public class PermissionsBehavior {
     return Either.right(command.getValue());
   }
 
+  public <V extends UnifiedRecordValue> Either<Rejection, V> isAuthorized(
+      final TypedRecord<V> command,
+      final io.camunda.zeebe.protocol.record.value.PermissionType permissionType,
+      final io.camunda.zeebe.protocol.record.value.AuthorizationResourceType resourceType) {
+    if (command.isInternalCommand()) {
+      LOG.trace("Skipping authorization check for internal command {}", command.getIntent());
+      return Either.right(command.getValue());
+    }
+    final var authorizations = command.getAuthorizations();
+    if (Boolean.TRUE.equals(authorizations.get(Authorization.AUTHORIZED_ANONYMOUS_USER))) {
+      LOG.trace(
+          "Skipping authorization check for anonymous user on command {}", command.getIntent());
+      return Either.right(command.getValue());
+    }
+    if (!securityConfig.isAuthorizationsEnabled()
+        && !securityConfig.isMultiTenancyChecksEnabled()) {
+      LOG.trace(
+          "Skipping authorization check for command {}: security disabled (authz={}, multiTenancy={})",
+          command.getIntent(),
+          securityConfig.isAuthorizationsEnabled(),
+          securityConfig.isMultiTenancyChecksEnabled());
+      return Either.right(command.getValue());
+    }
+    if (authorizations.get(Authorization.AUTHORIZED_USERNAME) == null
+        && authorizations.get(Authorization.AUTHORIZED_CLIENT_ID) == null) {
+      if (!securityConfig.isAuthorizationsEnabled()) {
+        return Either.right(command.getValue());
+      }
+      LOG.debug(
+          "Rejecting command {}: neither username nor clientId claim is present",
+          command.getIntent());
+      return Either.left(AuthorizationRejectionMapper.forbidden(permissionType, resourceType));
+    }
+    LOG.trace(
+        "Checking {} permission on {} resource for command {}",
+        permissionType,
+        resourceType,
+        command.getIntent());
+    final var auth = claimsConverter.convert(authorizations);
+    final var cslPermType = AuthzModelMapper.fromProtocol(permissionType);
+    final var cslResourceType = AuthzModelMapper.fromProtocol(resourceType);
+    final var result =
+        authCheckPort.check(
+            auth,
+            RequiredAuthorization.of(
+                b ->
+                    b.resourceType(cslResourceType)
+                        .permissionType(cslPermType)
+                        .resourceId(AuthorizationScope.WILDCARD_CHAR)));
+    if (result.isLeft()) {
+      LOG.debug(
+          "Authorization check rejected for command {}: {}",
+          command.getIntent(),
+          result.leftValue());
+      return Either.left(AuthorizationRejectionMapper.toRejection(result.leftValue()));
+    }
+    return Either.right(command.getValue());
+  }
+
   public Either<Rejection, PersistedAuthorization> authorizationExists(
       final AuthorizationRecord authorizationRecord, final String rejectionMessage) {
     final var key = authorizationRecord.getAuthorizationKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -10,10 +10,8 @@ package io.camunda.zeebe.engine.processing.tenant;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -47,19 +45,18 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   private final GroupState groupState;
   private final UserState userState;
   private final RoleState roleState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
-  private final SideEffectWriter sideEffectWriter;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final EngineSecurityConfig securityConfig;
   private final MembershipState membershipState;
 
   public TenantAddEntityProcessor(
       final ProcessingState state,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
@@ -70,12 +67,11 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     roleState = state.getRoleState();
     userState = state.getUserState();
     membershipState = state.getMembershipState();
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
-    sideEffectWriter = writers.sideEffect();
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.securityConfig = securityConfig;
   }
@@ -84,16 +80,11 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   public void processNewCommand(final TypedRecord<TenantRecord> command) {
     final var record = command.getValue();
     final var tenantId = record.getTenantId();
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.TENANT)
-            .permissionType(PermissionType.UPDATE)
-            .addResourceId(tenantId)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
-    if (isAuthorized.isLeft()) {
-      rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
+    final var authResult =
+        permissionsBehavior.isAuthorized(
+            command, PermissionType.UPDATE, AuthorizationResourceType.TENANT);
+    if (authResult.isLeft()) {
+      rejectCommandWithUnauthorizedError(command, authResult.getLeft());
       return;
     }
 
@@ -121,11 +112,6 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
 
     stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.ENTITY_ADDED, record);
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_ADDED, record, command);
-    sideEffectWriter.appendSideEffect(
-        () -> {
-          authCheckBehavior.clearAuthorizationsCache();
-          return true;
-        });
 
     distributeCommand(command);
   }
@@ -138,11 +124,6 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
           command, record.getEntityId(), record.getEntityType(), record.getTenantId());
     } else {
       stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.ENTITY_ADDED, record);
-      sideEffectWriter.appendSideEffect(
-          () -> {
-            authCheckBehavior.clearAuthorizationsCache();
-            return true;
-          });
     }
 
     commandDistributionBehavior.acknowledgeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -82,7 +82,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final var tenantId = record.getTenantId();
     final var authResult =
         permissionsBehavior.isAuthorized(
-            command, PermissionType.UPDATE, AuthorizationResourceType.TENANT);
+            command, AuthorizationResourceType.TENANT, PermissionType.UPDATE, tenantId);
     if (authResult.isLeft()) {
       rejectCommandWithUnauthorizedError(command, authResult.getLeft());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -11,7 +11,9 @@ import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -53,6 +55,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final EngineSecurityConfig securityConfig;
   private final MembershipState membershipState;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final SideEffectWriter sideEffectWriter;
 
   public TenantAddEntityProcessor(
       final ProcessingState state,
@@ -60,7 +64,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final EngineSecurityConfig securityConfig) {
+      final EngineSecurityConfig securityConfig,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     tenantState = state.getTenantState();
     mappingRuleState = state.getMappingRuleState();
     groupState = state.getGroupState();
@@ -72,8 +77,10 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
+    sideEffectWriter = writers.sideEffect();
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.securityConfig = securityConfig;
+    this.authCheckBehavior = authCheckBehavior;
   }
 
   @Override
@@ -112,6 +119,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
 
     stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.ENTITY_ADDED, record);
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_ADDED, record, command);
+    invalidateMembershipCache();
 
     distributeCommand(command);
   }
@@ -124,9 +132,25 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
           command, record.getEntityId(), record.getEntityType(), record.getTenantId());
     } else {
       stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.ENTITY_ADDED, record);
+      invalidateMembershipCache();
     }
 
     commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  /**
+   * Flushes the legacy authorization cache after a tenant-membership change. Non-migrated domains
+   * still resolve tenant membership through {@link AuthorizationCheckBehavior}'s cache, so a stale
+   * entry could otherwise authorize (or reject) against outdated membership until the TTL expires.
+   * The scope cache is not touched: it holds RBAC grants only, which a membership change does not
+   * affect.
+   */
+  private void invalidateMembershipCache() {
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          authCheckBehavior.clearAuthorizationsCache();
+          return true;
+        });
   }
 
   /** Loads the persisted tenant by the tenant id. */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -9,8 +9,7 @@ package io.camunda.zeebe.engine.processing.tenant;
 
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -31,7 +30,7 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
   private static final String TENANT_ALREADY_EXISTS_ERROR_MESSAGE =
       "Expected to create tenant with ID '%s', but a tenant with this ID already exists";
   private final TenantState tenantState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -40,12 +39,12 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
 
   public TenantCreateProcessor(
       final TenantState tenantState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     this.tenantState = tenantState;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -88,15 +87,11 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
   }
 
   private boolean isAuthorizedToCreate(final TypedRecord<TenantRecord> command) {
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.TENANT)
-            .permissionType(PermissionType.CREATE)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
-    if (isAuthorized.isLeft()) {
-      rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
+    final var authResult =
+        permissionsBehavior.isAuthorized(
+            command, PermissionType.CREATE, AuthorizationResourceType.TENANT);
+    if (authResult.isLeft()) {
+      rejectCommandWithUnauthorizedError(command, authResult.getLeft());
       return false;
     }
     return true;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -89,7 +89,7 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
   private boolean isAuthorizedToCreate(final TypedRecord<TenantRecord> command) {
     final var authResult =
         permissionsBehavior.isAuthorized(
-            command, PermissionType.CREATE, AuthorizationResourceType.TENANT);
+            command, AuthorizationResourceType.TENANT, PermissionType.CREATE);
     if (authResult.isLeft()) {
       rejectCommandWithUnauthorizedError(command, authResult.getLeft());
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -81,7 +81,7 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
 
     final var authResult =
         permissionsBehavior.isAuthorized(
-            command, PermissionType.DELETE, AuthorizationResourceType.TENANT);
+            command, AuthorizationResourceType.TENANT, PermissionType.DELETE, tenantId);
     if (authResult.isLeft()) {
       rejectCommandWithUnauthorizedError(command, authResult.getLeft());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -10,7 +10,10 @@ package io.camunda.zeebe.engine.processing.tenant;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
+import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -48,13 +51,18 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
   private final CommandDistributionBehavior commandDistributionBehavior;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final AuthorizationScopeStateAdapter authorizationScopeStateAdapter;
+  private final SideEffectWriter sideEffectWriter;
 
   public TenantDeleteProcessor(
       final ProcessingState state,
       final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
-      final CommandDistributionBehavior commandDistributionBehavior) {
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final AuthorizationScopeStateAdapter authorizationScopeStateAdapter) {
     tenantState = state.getTenantState();
     authorizationState = state.getAuthorizationState();
     userState = state.getUserState();
@@ -64,7 +72,10 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
+    sideEffectWriter = writers.sideEffect();
     this.commandDistributionBehavior = commandDistributionBehavior;
+    this.authCheckBehavior = authCheckBehavior;
+    this.authorizationScopeStateAdapter = authorizationScopeStateAdapter;
   }
 
   @Override
@@ -98,6 +109,7 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
 
     stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.DELETED, record);
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.DELETED, record, command);
+    invalidateAuthorizationCaches();
 
     distributeCommand(command);
   }
@@ -113,6 +125,7 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
               deleteAuthorizations(command.getValue());
               stateWriter.appendFollowUpEvent(
                   command.getKey(), TenantIntent.DELETED, command.getValue());
+              invalidateAuthorizationCaches();
             },
             () ->
                 rejectCommand(
@@ -141,6 +154,21 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
         .withKey(keyGenerator.nextKey())
         .inQueue(DistributionQueue.IDENTITY.getQueueId())
         .distribute(command);
+  }
+
+  /**
+   * Flushes both authorization caches after a tenant is deleted. Deleting a tenant removes its
+   * memberships (stale in {@link AuthorizationCheckBehavior}'s legacy cache, used by non-migrated
+   * domains) and its authorization grants (stale in the {@link AuthorizationScopeStateAdapter}
+   * scope cache), so both must be invalidated.
+   */
+  private void invalidateAuthorizationCaches() {
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          authCheckBehavior.clearAuthorizationsCache();
+          authorizationScopeStateAdapter.invalidateAll();
+          return true;
+        });
   }
 
   private void removeAssignedEntities(final TenantRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.tenant;
 
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
@@ -36,9 +37,11 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.slf4j.Logger;
 
 public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<TenantRecord> {
 
+  private static final Logger LOG = Loggers.ENGINE_IDENTITY_LOGGER;
   private static final String TENANT_NOT_FOUND_ERROR_MESSAGE =
       "Expected to delete tenant with id '%s', but no tenant with this id exists.";
   private final TenantState tenantState;
@@ -165,7 +168,11 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
   private void invalidateAuthorizationCaches() {
     sideEffectWriter.appendSideEffect(
         () -> {
-          authCheckBehavior.clearAuthorizationsCache();
+          try {
+            authCheckBehavior.clearAuthorizationsCache();
+          } catch (final Exception e) {
+            LOG.warn("Failed to clear legacy authorization cache after tenant delete", e);
+          }
           authorizationScopeStateAdapter.invalidateAll();
           return true;
         });

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -9,10 +9,8 @@ package io.camunda.zeebe.engine.processing.tenant;
 
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -44,17 +42,16 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
   private final AuthorizationState authorizationState;
   private final UserState userState;
   private final MembershipState membershipState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
-  private final SideEffectWriter sideEffectWriter;
   private final CommandDistributionBehavior commandDistributionBehavior;
 
   public TenantDeleteProcessor(
       final ProcessingState state,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
@@ -62,12 +59,11 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
     authorizationState = state.getAuthorizationState();
     userState = state.getUserState();
     membershipState = state.getMembershipState();
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
-    sideEffectWriter = writers.sideEffect();
     this.commandDistributionBehavior = commandDistributionBehavior;
   }
 
@@ -83,16 +79,11 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
       return;
     }
 
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.TENANT)
-            .permissionType(PermissionType.DELETE)
-            .addResourceId(persistedTenantRecord.get().getTenantId())
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
-    if (isAuthorized.isLeft()) {
-      rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
+    final var authResult =
+        permissionsBehavior.isAuthorized(
+            command, PermissionType.DELETE, AuthorizationResourceType.TENANT);
+    if (authResult.isLeft()) {
+      rejectCommandWithUnauthorizedError(command, authResult.getLeft());
       return;
     }
 
@@ -107,11 +98,6 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
 
     stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.DELETED, record);
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.DELETED, record, command);
-    sideEffectWriter.appendSideEffect(
-        () -> {
-          authCheckBehavior.clearAuthorizationsCache();
-          return true;
-        });
 
     distributeCommand(command);
   }
@@ -127,11 +113,6 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
               deleteAuthorizations(command.getValue());
               stateWriter.appendFollowUpEvent(
                   command.getKey(), TenantIntent.DELETED, command.getValue());
-              sideEffectWriter.appendSideEffect(
-                  () -> {
-                    authCheckBehavior.clearAuthorizationsCache();
-                    return true;
-                  });
             },
             () ->
                 rejectCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantProcessors.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.processing.tenant;
 
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -22,7 +22,7 @@ public class TenantProcessors {
   public static void addTenantProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
@@ -33,7 +33,7 @@ public class TenantProcessors {
             TenantIntent.CREATE,
             new TenantCreateProcessor(
                 processingState.getTenantState(),
-                authCheckBehavior,
+                permissionsBehavior,
                 keyGenerator,
                 writers,
                 commandDistributionBehavior))
@@ -42,7 +42,7 @@ public class TenantProcessors {
             TenantIntent.UPDATE,
             new TenantUpdateProcessor(
                 processingState.getTenantState(),
-                authCheckBehavior,
+                permissionsBehavior,
                 keyGenerator,
                 writers,
                 commandDistributionBehavior))
@@ -51,7 +51,7 @@ public class TenantProcessors {
             TenantIntent.ADD_ENTITY,
             new TenantAddEntityProcessor(
                 processingState,
-                authCheckBehavior,
+                permissionsBehavior,
                 keyGenerator,
                 writers,
                 commandDistributionBehavior,
@@ -61,7 +61,7 @@ public class TenantProcessors {
             TenantIntent.REMOVE_ENTITY,
             new TenantRemoveEntityProcessor(
                 processingState,
-                authCheckBehavior,
+                permissionsBehavior,
                 keyGenerator,
                 writers,
                 commandDistributionBehavior))
@@ -70,7 +70,7 @@ public class TenantProcessors {
             TenantIntent.DELETE,
             new TenantDeleteProcessor(
                 processingState,
-                authCheckBehavior,
+                permissionsBehavior,
                 keyGenerator,
                 writers,
                 commandDistributionBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantProcessors.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.engine.processing.tenant;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
+import io.camunda.zeebe.engine.processing.identity.adapter.AuthorizationScopeStateAdapter;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -26,7 +28,9 @@ public class TenantProcessors {
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final EngineSecurityConfig securityConfig) {
+      final EngineSecurityConfig securityConfig,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final AuthorizationScopeStateAdapter authorizationScopeStateAdapter) {
     typedRecordProcessors
         .onCommand(
             ValueType.TENANT,
@@ -55,7 +59,8 @@ public class TenantProcessors {
                 keyGenerator,
                 writers,
                 commandDistributionBehavior,
-                securityConfig))
+                securityConfig,
+                authCheckBehavior))
         .onCommand(
             ValueType.TENANT,
             TenantIntent.REMOVE_ENTITY,
@@ -64,7 +69,8 @@ public class TenantProcessors {
                 permissionsBehavior,
                 keyGenerator,
                 writers,
-                commandDistributionBehavior))
+                commandDistributionBehavior,
+                authCheckBehavior))
         .onCommand(
             ValueType.TENANT,
             TenantIntent.DELETE,
@@ -73,6 +79,8 @@ public class TenantProcessors {
                 permissionsBehavior,
                 keyGenerator,
                 writers,
-                commandDistributionBehavior));
+                commandDistributionBehavior,
+                authCheckBehavior,
+                authorizationScopeStateAdapter));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -69,7 +69,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
 
     final var authResult =
         permissionsBehavior.isAuthorized(
-            command, PermissionType.UPDATE, AuthorizationResourceType.TENANT);
+            command, AuthorizationResourceType.TENANT, PermissionType.UPDATE, tenantId);
     if (authResult.isLeft()) {
       rejectCommandWithUnauthorizedError(command, authResult.getLeft());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -12,7 +12,9 @@ import static io.camunda.zeebe.protocol.record.value.EntityType.MAPPING_RULE;
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -44,13 +46,16 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
   private final CommandDistributionBehavior commandDistributionBehavior;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final SideEffectWriter sideEffectWriter;
 
   public TenantRemoveEntityProcessor(
       final ProcessingState state,
       final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
-      final CommandDistributionBehavior commandDistributionBehavior) {
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     tenantState = state.getTenantState();
     mappingRuleState = state.getMappingRuleState();
     membershipState = state.getMembershipState();
@@ -59,7 +64,9 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
+    sideEffectWriter = writers.sideEffect();
     this.commandDistributionBehavior = commandDistributionBehavior;
+    this.authCheckBehavior = authCheckBehavior;
   }
 
   @Override
@@ -93,6 +100,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     final var tenantKey = persistedTenant.get().getTenantKey();
     stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.ENTITY_REMOVED, record);
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_REMOVED, record, command);
+    invalidateMembershipCache();
 
     distributeCommand(command);
   }
@@ -102,9 +110,25 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     if (validateEntityAssignment(command, command.getValue().getTenantId())) {
       stateWriter.appendFollowUpEvent(
           command.getKey(), TenantIntent.ENTITY_REMOVED, command.getValue());
+      invalidateMembershipCache();
     }
 
     commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  /**
+   * Flushes the legacy authorization cache after a tenant-membership change. Non-migrated domains
+   * still resolve tenant membership through {@link AuthorizationCheckBehavior}'s cache, so a stale
+   * entry could otherwise authorize (or reject) against outdated membership until the TTL expires.
+   * The scope cache is not touched: it holds RBAC grants only, which a membership change does not
+   * affect.
+   */
+  private void invalidateMembershipCache() {
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          authCheckBehavior.clearAuthorizationsCache();
+          return true;
+        });
   }
 
   private boolean validateEntityAssignment(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -11,10 +11,8 @@ import static io.camunda.zeebe.protocol.record.value.EntityType.MAPPING_RULE;
 
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -40,29 +38,27 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
   private final TenantState tenantState;
   private final MappingRuleState mappingRuleState;
   private final MembershipState membershipState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
-  private final SideEffectWriter sideEffectWriter;
   private final CommandDistributionBehavior commandDistributionBehavior;
 
   public TenantRemoveEntityProcessor(
       final ProcessingState state,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     tenantState = state.getTenantState();
     mappingRuleState = state.getMappingRuleState();
     membershipState = state.getMembershipState();
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
-    sideEffectWriter = writers.sideEffect();
     this.commandDistributionBehavior = commandDistributionBehavior;
   }
 
@@ -71,16 +67,11 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     final var record = command.getValue();
     final var tenantId = record.getTenantId();
 
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.TENANT)
-            .permissionType(PermissionType.UPDATE)
-            .addResourceId(tenantId)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
-    if (isAuthorized.isLeft()) {
-      rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
+    final var authResult =
+        permissionsBehavior.isAuthorized(
+            command, PermissionType.UPDATE, AuthorizationResourceType.TENANT);
+    if (authResult.isLeft()) {
+      rejectCommandWithUnauthorizedError(command, authResult.getLeft());
       return;
     }
 
@@ -102,11 +93,6 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     final var tenantKey = persistedTenant.get().getTenantKey();
     stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.ENTITY_REMOVED, record);
     responseWriter.writeEventOnCommand(tenantKey, TenantIntent.ENTITY_REMOVED, record, command);
-    sideEffectWriter.appendSideEffect(
-        () -> {
-          authCheckBehavior.clearAuthorizationsCache();
-          return true;
-        });
 
     distributeCommand(command);
   }
@@ -116,11 +102,6 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     if (validateEntityAssignment(command, command.getValue().getTenantId())) {
       stateWriter.appendFollowUpEvent(
           command.getKey(), TenantIntent.ENTITY_REMOVED, command.getValue());
-      sideEffectWriter.appendSideEffect(
-          () -> {
-            authCheckBehavior.clearAuthorizationsCache();
-            return true;
-          });
     }
 
     commandDistributionBehavior.acknowledgeCommand(command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -87,7 +87,10 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
       final TypedRecord<TenantRecord> command, final PersistedTenant persistedTenant) {
     final var authResult =
         permissionsBehavior.isAuthorized(
-            command, PermissionType.UPDATE, AuthorizationResourceType.TENANT);
+            command,
+            AuthorizationResourceType.TENANT,
+            PermissionType.UPDATE,
+            persistedTenant.getTenantId());
     if (authResult.isLeft()) {
       rejectCommandWithUnauthorizedError(command, authResult.getLeft());
       return false;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -9,8 +9,7 @@ package io.camunda.zeebe.engine.processing.tenant;
 
 import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -31,7 +30,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<TenantRecord> {
 
   private final TenantState tenantState;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
@@ -40,12 +39,12 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
 
   public TenantUpdateProcessor(
       final TenantState tenantState,
-      final AuthorizationCheckBehavior authCheckBehavior,
+      final PermissionsBehavior permissionsBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     this.tenantState = tenantState;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
@@ -86,16 +85,11 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
 
   private boolean isAuthorizedToUpdate(
       final TypedRecord<TenantRecord> command, final PersistedTenant persistedTenant) {
-    final var authorizationRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.TENANT)
-            .permissionType(PermissionType.UPDATE)
-            .addResourceId(persistedTenant.getTenantId())
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
-    if (isAuthorized.isLeft()) {
-      rejectCommandWithUnauthorizedError(command, isAuthorized.getLeft());
+    final var authResult =
+        permissionsBehavior.isAuthorized(
+            command, PermissionType.UPDATE, AuthorizationResourceType.TENANT);
+    if (authResult.isLeft()) {
+      rejectCommandWithUnauthorizedError(command, authResult.getLeft());
       return false;
     }
     return true;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.user;
 
-import io.camunda.zeebe.engine.processing.Rejection;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -49,7 +47,7 @@ public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<Use
   private final TypedCommandWriter commandWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final MembershipState membershipState;
   private final StateWriter stateWriter;
 
@@ -57,7 +55,7 @@ public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<Use
       final KeyGenerator keyGenerator,
       final ProcessingState processingState,
       final Writers writers,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final PermissionsBehavior permissionsBehavior) {
     this.keyGenerator = keyGenerator;
     userState = processingState.getUserState();
     roleState = processingState.getRoleState();
@@ -66,7 +64,7 @@ public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<Use
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     stateWriter = writers.state();
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
   }
 
   @Override
@@ -102,23 +100,19 @@ public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<Use
   }
 
   private Either<String, Void> checkUserCreateAuthorization(final TypedRecord<UserRecord> command) {
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.USER)
-            .permissionType(PermissionType.CREATE)
-            .build();
-    return authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).mapLeft(Rejection::reason);
+    final var authResult =
+        permissionsBehavior.isAuthorized(
+            command, PermissionType.CREATE, AuthorizationResourceType.USER);
+    return authResult.fold(
+        rejection -> Either.left(rejection.reason()), unused -> Either.right(null));
   }
 
   private Either<String, Void> checkRoleUpdateAuthorization(final TypedRecord<UserRecord> command) {
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.ROLE)
-            .permissionType(PermissionType.UPDATE)
-            .build();
-    return authCheckBehavior.isAuthorizedOrInternalCommand(authRequest).mapLeft(Rejection::reason);
+    final var authResult =
+        permissionsBehavior.isAuthorized(
+            command, PermissionType.UPDATE, AuthorizationResourceType.ROLE);
+    return authResult.fold(
+        rejection -> Either.left(rejection.reason()), unused -> Either.right(null));
   }
 
   private Either<String, Void> checkUserDoesNotExist(final String username) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateInitialAdminProcessor.java
@@ -102,7 +102,7 @@ public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<Use
   private Either<String, Void> checkUserCreateAuthorization(final TypedRecord<UserRecord> command) {
     final var authResult =
         permissionsBehavior.isAuthorized(
-            command, PermissionType.CREATE, AuthorizationResourceType.USER);
+            command, AuthorizationResourceType.USER, PermissionType.CREATE);
     return authResult.fold(
         rejection -> Either.left(rejection.reason()), unused -> Either.right(null));
   }
@@ -110,7 +110,7 @@ public class UserCreateInitialAdminProcessor implements TypedRecordProcessor<Use
   private Either<String, Void> checkRoleUpdateAuthorization(final TypedRecord<UserRecord> command) {
     final var authResult =
         permissionsBehavior.isAuthorized(
-            command, PermissionType.UPDATE, AuthorizationResourceType.ROLE);
+            command, AuthorizationResourceType.ROLE, PermissionType.UPDATE);
     return authResult.fold(
         rejection -> Either.left(rejection.reason()), unused -> Either.right(null));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -64,7 +64,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
   public void processNewCommand(final TypedRecord<UserRecord> command) {
     final var authResult =
         permissionsBehavior.isAuthorized(
-            command, PermissionType.CREATE, AuthorizationResourceType.USER);
+            command, AuthorizationResourceType.USER, PermissionType.CREATE);
     if (authResult.isLeft()) {
       final var rejection = authResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -8,8 +8,7 @@
 package io.camunda.zeebe.engine.processing.user;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -42,7 +41,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
   private final CommandDistributionBehavior distributionBehavior;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final TypedCommandWriter commandWriter;
 
   public UserCreateProcessor(
@@ -50,28 +49,24 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
       final ProcessingState state,
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final PermissionsBehavior permissionsBehavior) {
     userState = state.getUserState();
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.distributionBehavior = distributionBehavior;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
     commandWriter = writers.command();
   }
 
   @Override
   public void processNewCommand(final TypedRecord<UserRecord> command) {
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.USER)
-            .permissionType(PermissionType.CREATE)
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
-    if (isAuthorized.isLeft()) {
-      final var rejection = isAuthorized.getLeft();
+    final var authResult =
+        permissionsBehavior.isAuthorized(
+            command, PermissionType.CREATE, AuthorizationResourceType.USER);
+    if (authResult.isLeft()) {
+      final var rejection = authResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
       responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -97,7 +97,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     final var user = persistedUser.get();
     final var authResult =
         permissionsBehavior.isAuthorized(
-            command, PermissionType.DELETE, AuthorizationResourceType.USER);
+            command, AuthorizationResourceType.USER, PermissionType.DELETE, username);
     if (authResult.isLeft()) {
       final var rejection = authResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -8,8 +8,7 @@
 package io.camunda.zeebe.engine.processing.user;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -55,7 +54,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
   private final CommandDistributionBehavior distributionBehavior;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
   private final TenantState tenantState;
   private final MembershipState membershipState;
   private final RoleState roleState;
@@ -66,7 +65,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
       final ProcessingState state,
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final PermissionsBehavior permissionsBehavior) {
     this.keyGenerator = keyGenerator;
     userState = state.getUserState();
     tenantState = state.getTenantState();
@@ -78,7 +77,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.distributionBehavior = distributionBehavior;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
   }
 
   @Override
@@ -96,16 +95,11 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     }
 
     final var user = persistedUser.get();
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.USER)
-            .permissionType(PermissionType.DELETE)
-            .addResourceId(user.getUsername())
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
-    if (isAuthorized.isLeft()) {
-      final var rejection = isAuthorized.getLeft();
+    final var authResult =
+        permissionsBehavior.isAuthorized(
+            command, PermissionType.DELETE, AuthorizationResourceType.USER);
+    if (authResult.isLeft()) {
+      final var rejection = authResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
       responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.processing.user;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -23,27 +23,27 @@ public class UserProcessors {
       final MutableProcessingState processingState,
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final PermissionsBehavior permissionsBehavior) {
     typedRecordProcessors
         .onCommand(
             ValueType.USER,
             UserIntent.CREATE,
             new UserCreateProcessor(
-                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior))
+                keyGenerator, processingState, writers, distributionBehavior, permissionsBehavior))
         .onCommand(
             ValueType.USER,
             UserIntent.UPDATE,
             new UserUpdateProcessor(
-                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior))
+                keyGenerator, processingState, writers, distributionBehavior, permissionsBehavior))
         .onCommand(
             ValueType.USER,
             UserIntent.DELETE,
             new UserDeleteProcessor(
-                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior))
+                keyGenerator, processingState, writers, distributionBehavior, permissionsBehavior))
         .onCommand(
             ValueType.USER,
             UserIntent.CREATE_INITIAL_ADMIN,
             new UserCreateInitialAdminProcessor(
-                keyGenerator, processingState, writers, authCheckBehavior));
+                keyGenerator, processingState, writers, permissionsBehavior));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -70,7 +70,7 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
 
     final var authResult =
         permissionsBehavior.isAuthorized(
-            command, PermissionType.UPDATE, AuthorizationResourceType.USER);
+            command, AuthorizationResourceType.USER, PermissionType.UPDATE, username);
     if (authResult.isLeft()) {
       final var rejection = authResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -8,8 +8,7 @@
 package io.camunda.zeebe.engine.processing.user;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
-import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.PermissionsBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -34,21 +33,21 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
   private final CommandDistributionBehavior distributionBehavior;
-  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final PermissionsBehavior permissionsBehavior;
 
   public UserUpdateProcessor(
       final KeyGenerator keyGenerator,
       final ProcessingState state,
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final PermissionsBehavior permissionsBehavior) {
     this.keyGenerator = keyGenerator;
     userState = state.getUserState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.distributionBehavior = distributionBehavior;
-    this.authCheckBehavior = authCheckBehavior;
+    this.permissionsBehavior = permissionsBehavior;
   }
 
   @Override
@@ -69,16 +68,11 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
 
     final var persistedUser = persistedUserOptional.get();
 
-    final var authRequest =
-        AuthorizationRequest.builder()
-            .command(command)
-            .resourceType(AuthorizationResourceType.USER)
-            .permissionType(PermissionType.UPDATE)
-            .addResourceId(persistedUser.getUsername())
-            .build();
-    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authRequest);
-    if (isAuthorized.isLeft()) {
-      final var rejection = isAuthorized.getLeft();
+    final var authResult =
+        permissionsBehavior.isAuthorized(
+            command, PermissionType.UPDATE, AuthorizationResourceType.USER);
+    if (authResult.isLeft()) {
+      final var rejection = authResult.getLeft();
       rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
       responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
       return;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.tenant;
 
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
@@ -80,8 +81,8 @@ public class DeleteTenantAuthorizationTest {
         user,
         AuthorizationResourceType.TENANT,
         PermissionType.DELETE,
-        AuthorizationResourceMatcher.ID,
-        tenantId);
+        WILDCARD.getMatcher(),
+        WILDCARD.getResourceId());
     assignUserToTenant(user.getUsername(), tenantId);
 
     // when
@@ -110,9 +111,7 @@ public class DeleteTenantAuthorizationTest {
     // then
     assertThat(rejectedDeleteRecord)
         .hasRejectionType(RejectionType.FORBIDDEN)
-        .hasRejectionReason(
-            "Insufficient permissions to perform operation 'DELETE' on resource 'TENANT', required resource identifiers are one of '[*, %s]'"
-                .formatted(tenantId));
+        .hasRejectionReason("Expected to access tenant '*', but the principal is not authorized.");
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantAuthorizationTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.tenant;
 
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
-import static io.camunda.zeebe.protocol.record.value.AuthorizationScope.WILDCARD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.security.api.model.config.initialization.ConfiguredUser;
@@ -81,8 +80,8 @@ public class DeleteTenantAuthorizationTest {
         user,
         AuthorizationResourceType.TENANT,
         PermissionType.DELETE,
-        WILDCARD.getMatcher(),
-        WILDCARD.getResourceId());
+        AuthorizationResourceMatcher.ID,
+        tenantId);
     assignUserToTenant(user.getUsername(), tenantId);
 
     // when
@@ -111,7 +110,9 @@ public class DeleteTenantAuthorizationTest {
     // then
     assertThat(rejectedDeleteRecord)
         .hasRejectionType(RejectionType.FORBIDDEN)
-        .hasRejectionReason("Expected to access tenant '*', but the principal is not authorized.");
+        .hasRejectionReason(
+            "Expected to access tenant '%s', but the principal is not authorized."
+                .formatted(tenantId));
   }
 
   private UserRecordValue createUser() {


### PR DESCRIPTION
## Summary

Migrates the User and Tenant processors from `AuthorizationCheckBehavior` to the CSL-backed
`PermissionsBehavior` / `AuthorizationCheckPort`, **preserving `main`'s authorization output**.

Rebased onto `main`, which now includes Inc 4b (#56690 — migrated Group/Role/Mapping and added the
`isAuthorized(command, resourceType, permissionType[, resourceId])` overloads). This PR consolidates
onto that overload instead of adding a parallel one.

## Changes

- **deps:** bump `camunda-security-library` to `0.1.0-alpha42`, which carries the tenant-authorization
  gating fix (camunda/camunda-security-library#487, fixes #486): `TENANT` checks are gated on
  `authorizationEnabled` instead of `multiTenancyChecksEnabled`, matching how `main` gated
  tenant-entity commands.
- **fix — resource-scoped grants:** the migrated processors authorize against the real resource id
  (tenant id / username), matching `main`'s wildcard-OR-id matching, instead of a hardcoded wildcard
  scope that only matched wildcard grants. Create commands keep the wildcard (no resource id exists
  yet), as on `main`. Also removes the duplicate reversed-parameter `isAuthorized` overload added
  during the migration.
- **fix — cache invalidation:** restores the authorization-cache invalidation `main` performed on
  tenant membership changes (AddEntity/RemoveEntity → legacy cache) and tenant deletion
  (Delete → legacy + scope cache), which the migration had dropped. Non-migrated domains still
  resolve tenant membership through the legacy cache.
- **test:** `DeleteTenantAuthorizationTest` restored to the id-scoped grant, proving id-scoped
  `TENANT` grants authorize again.

## Net effect

Authorization output matches `main` after merge — the goal of the migration. #1 (gating axis) is
fixed upstream in alpha42; #2 (scope granularity) and #3 (cache invalidation) are fixed here as
separate `fix:` commits, while the migration commits stay `refactor:`.

## Test plan

- User + Tenant authorization tests pass, including multi-partition (distributed) paths
- Full repo `./mvnw install -Dquickly -T1C` green
- Manuel Smoke testing
- Known gap: no test asserts the cache-invalidation side effect (consistent with the codebase — no
  processor test does; a faithful assertion would require a brittle TTL/multi-partition test)

## Related

- Implements https://github.com/camunda/camunda-security-library/issues/453
- Relates to camunda/camunda-security-library#486 (fixed by #487, released in alpha42)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
