### PR TITLE
ci: remove deprecated nightly schedule from optimize C8 release

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -3,8 +3,6 @@
 name: Optimize Release Camunda Optimize C8
 
 on:
-  schedule:
-    - cron: "0 0 * * 1-5"
   workflow_dispatch:
     inputs:
       RELEASE_VERSION:


### PR DESCRIPTION
## Description

- Removed `schedule` (cron) trigger from `optimize-release-optimize-c8-only.yml` — nightly ran with default `RELEASE_VERSION=0.0.0`, failing daily at `release:prepare` (can't resolve `zeebe-build-tools:0.0.0`).
- No coverage lost: `workflow_dispatch` kept for on-demand releases; regular optimize CI already builds `runAssembly` + checkstyle on every push/PR.

## Related issues

closes #56782
