### PR TITLE
fix: wait for completed instances before querying active ones in ProcessInstanceSearchIT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -14,6 +14,7 @@ import static io.camunda.it.util.TestHelper.assertSorted;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.startProcessInstanceWithBusinessId;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToBeCompleted;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitUntilJobWorkerHasFailedJob;
@@ -101,6 +102,7 @@ public class ProcessInstanceSearchIT {
 
     waitForProcessInstancesToStart(camundaClient, 10);
     waitUntilProcessInstanceHasIncidents(camundaClient, 2);
+    waitForProcessInstancesToBeCompleted(camundaClient, f -> {}, 5);
   }
 
   @AfterAll


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR is targeting the following error:
```
Error:  Failures: 
Error:    ProcessInstanceSearchIT.shouldQueryByMultipleOrConditionsOnly:507 
Expected size: 5 but was: 6 in:
[io.camunda.client.impl.search.response.ProcessInstanceImpl@707ed0ad,
    io.camunda.client.impl.search.response.ProcessInstanceImpl@3a6c9c1a,
    io.camunda.client.impl.search.response.ProcessInstanceImpl@62856fdf,
    io.camunda.client.impl.search.response.ProcessInstanceImpl@36341c44,
    io.camunda.client.impl.search.response.ProcessInstanceImpl@30c94997,
    io.camunda.client.impl.search.response.ProcessInstanceImpl@6e1b9fd8]
```

The test `shouldQueryByMultipleOrConditionsOnly` is flaky because the beforeAll setup only waited for 10 instances to start, not for the manual/parent/child instances to complete. Adding a wait for 5 completed instances ensures the ACTIVE count has settled before any test runs.

The error can be observed in the following nightly job run:
https://github.com/camunda/camunda/actions/runs/28769880684/job/85301677086#logs

New run:
https://github.com/camunda/camunda/actions/runs/28791073220/job/85369967829

The whole pipeline becomes green:
<img width="303" height="71" alt="image" src="https://github.com/user-attachments/assets/76de0d38-0cc6-4009-9bfc-77dac6f6bc74" />


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
