### PR TITLE
ci: supply TEST_PRODUCT env vars missing from frontend SBOM Snyk nightly

### DIFF
--- a/.github/workflows/frontend-sbom-snyk-nightly.yml
+++ b/.github/workflows/frontend-sbom-snyk-nightly.yml
@@ -28,6 +28,7 @@ jobs:
     permissions: {}
     env:
       TEST_TYPE: Tool
+      TEST_PRODUCT: Identity
     defaults:
       run:
         working-directory: identity/client
@@ -71,6 +72,7 @@ jobs:
     permissions: {}
     env:
       TEST_TYPE: Tool
+      TEST_PRODUCT: Operate
     defaults:
       run:
         working-directory: operate/client
@@ -115,6 +117,7 @@ jobs:
     permissions: {}
     env:
       TEST_TYPE: Tool
+      TEST_PRODUCT: Tasklist
     defaults:
       run:
         working-directory: tasklist/client
@@ -162,6 +165,7 @@ jobs:
         working-directory: optimize/client
     env:
       TEST_TYPE: Tool
+      TEST_PRODUCT: Optimize
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@2fee788847f2b0eedcdd8b324e48ae1fad52fe4f # main
       - name: Checkout repository
@@ -212,6 +216,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions: {}
+    env:
+      TEST_TYPE: Tool
+      TEST_PRODUCT: Camunda
     needs:
       - identity-fe-sbom-snyk
       - operate-fe-sbom-snyk


### PR DESCRIPTION
## Context

The `frontend-sbom-snyk-nightly` workflow was introduced in #56056 to move Snyk SBOM scanning from the merge queue to a nightly schedule, unblocking PRs affected by INC-6267. During that refactoring, the four product jobs and `report-to-slack` were not given a `TEST_PRODUCT` env var, which `.github/actions/print-metadata` requires and hard-fails on when absent. This caused every nightly run to fail immediately at the "Print metadata" step, before any actual Snyk scanning could take place.

Incidents:

- [#inc-6409-unsuccessful-job-frontend-sbom-snyk-nightly-identity-fe-sbom-snyk](https://camunda.slack.com/archives/C0BG5C6J24Q) 
- [#inc-6408-unsuccessful-job-frontend-sbom-snyk-nightly-optimize-fe-sbom-snyk](https://camunda.slack.com/archives/C0BG5C69PEC)
- [#inc-6407-unsuccessful-job-frontend-sbom-snyk-nightly-tasklist-fe-sbom-snyk](https://camunda.slack.com/archives/C0BFB2JM8UA)
- [#inc-6406-unsuccessful-job-frontend-sbom-snyk-nightly-report-to-slack-on-mai](https://camunda.slack.com/archives/C0BFEPRJ96G)

## Root cause

The original per-product workflows (`ci-operate.yml`, `ci-tasklist.yml`, `ci-optimize.yml`) inherited `TEST_PRODUCT` from a workflow-level `env:` block. The identity job in `ci.yml` set it explicitly. When all four products were consolidated into a single nightly workflow, the workflow-level `env:` only carried over `TEST_OWNER` — `TEST_PRODUCT` was omitted from every job. The conftest `warn` rule for missing `print-metadata` is opt-in (`GHA_BEST_PRACTICES_LINTER: enabled`) and would not have caught this anyway, as it checks for presence of the action, not completeness of its inputs.

## Changes

Adds `TEST_PRODUCT` to each job's `env:` block, matching the values used before the refactoring:

| Job | `TEST_PRODUCT` |
|---|---|
| `identity-fe-sbom-snyk` | `Identity` |
| `operate-fe-sbom-snyk` | `Operate` |
| `tasklist-fe-sbom-snyk` | `Tasklist` |
| `optimize-fe-sbom-snyk` | `Optimize` |
| `report-to-slack` | `Camunda` (cross-cutting; also adds missing `TEST_TYPE: Tool`) |

## Verification

Without fix (branch at main HEAD, all 5 jobs fail): https://github.com/camunda/camunda/actions/runs/28791506134

With fix — 5 consecutive runs, all green (no flakiness):
- https://github.com/camunda/camunda/actions/runs/28792007648
- https://github.com/camunda/camunda/actions/runs/28792203369
- https://github.com/camunda/camunda/actions/runs/28792343201
- https://github.com/camunda/camunda/actions/runs/28792487754
- https://github.com/camunda/camunda/actions/runs/28792719634

🤖 Generated with [Claude Code](https://claude.com/claude-code)