### PR TITLE
ci: temporarily disable flaky test

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/task-assignment.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/test/integration/tasklist/task-assignment.test.ts
@@ -139,7 +139,8 @@ test.describe('Task assignment', () => {
 		await expect(taskDetailPage.assignButton).toBeVisible();
 	});
 
-	test('should handle tasks with task listeners', async ({network, taskDetailPage}) => {
+	// Temporarily skipped due to incident INC-6420: https://app.incident.io/camunda/incidents/6420
+	test.skip('should handle tasks with task listeners', async ({network, taskDetailPage}) => {
 		network.use(
 			mockQueryUserTasksEndpoint({
 				successResponse: HttpResponse.json(createQueryUserTasksResponse()),


### PR DESCRIPTION
Related to INC-6420

## Description

See [#inc-6420-unsuccessful-job-ci-webapp-clientintegration-on-main](https://camunda.slack.com/archives/C0BFFL9TGN8)
Disable for now, I will look into a fix tomorrow and re enable.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
