### PR TITLE
deps: update httpcore5 to v5.4.3 and httpclient5 to 5.6.2 (stable/optimize-8.7)

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -48,8 +48,8 @@
     <jetty.version>12.0.33</jetty.version>
     <jackson.version>2.18.1</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
-    <apache.http5-client.version>5.5</apache.http5-client.version>
-    <apache.http5-core.version>5.3.6</apache.http5-core.version>
+    <apache.http5-client.version>5.6.2</apache.http5-client.version>
+    <apache.http5-core.version>5.4.3</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
     <spring.boot.version>3.5.15</spring.boot.version>
     <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
@@ -127,6 +127,22 @@
         <version>${opentelemetry.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!-- Override Spring Boot's httpcomponents-client5/core5 versions to address CVE-2026-54399 -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${apache.http5-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${apache.http5-core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${apache.http5-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,8 +61,8 @@
     <version.hamcrest>3.0</version.hamcrest>
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
-    <version.httpclient5>5.5</version.httpclient5>
-    <version.httpcore5>5.3.4</version.httpcore5>
+    <version.httpclient5>5.6.2</version.httpclient5>
+    <version.httpcore5>5.4.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.5.5</version.identity>
     <version.surefire>3.5.0</version.surefire>


### PR DESCRIPTION
## Description

fixes CVE-2026-54399
Pair properly httpcore5 with httpclient5

Also need to override Spring Boot's httpcomponents-client5/core5 versions

## Related issues

relates https://github.com/camunda/camunda/issues/56775
