### PR TITLE
feat: tool result details modal in agent conversation history

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/styled.ts
@@ -35,7 +35,7 @@ const EmptyHint = styled.span`
   line-height: var(--cds-body-compact-01-line-height);
   letter-spacing: var(--cds-body-compact-01-letter-spacing);
   font-weight: var(--cds-body-compact-01-font-weight);
-  color: var(--cds-text-primary);
+  color: var(--cds-text-secondary);
 `;
 
 export {ToolList, ToolName, ToolDescription, EmptyHint};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/index.test.tsx
@@ -28,22 +28,6 @@ describe('<ToolResultModal />', () => {
     expect(modal.getByText('Searches the web.')).toBeInTheDocument();
   });
 
-  it('should render a fallback when the tool has no description', () => {
-    render(
-      <ToolResultModal
-        toolName="search"
-        description={null}
-        input={null}
-        content={[]}
-        onClose={vi.fn()}
-      />,
-    );
-
-    expect(
-      screen.getByText('No description available for this tool.'),
-    ).toBeInTheDocument();
-  });
-
   it('should render the input and output in rich-text editors', async () => {
     render(
       <ToolResultModal

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/index.test.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen, within} from 'modules/testing-library';
+import {ToolResultModal} from './index';
+
+describe('<ToolResultModal />', () => {
+  it('should render the tool name as the modal heading and tool description', () => {
+    render(
+      <ToolResultModal
+        toolName="search"
+        description="Searches the web."
+        input={null}
+        content={[]}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const modal = within(screen.getByRole('dialog'));
+    expect(
+      modal.getByRole('heading', {name: 'Tool call: search'}),
+    ).toBeInTheDocument();
+    expect(modal.getByText('Searches the web.')).toBeInTheDocument();
+  });
+
+  it('should render a fallback when the tool has no description', () => {
+    render(
+      <ToolResultModal
+        toolName="search"
+        description={null}
+        input={null}
+        content={[]}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText('No description available for this tool.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render the input and output in rich-text editors', async () => {
+    render(
+      <ToolResultModal
+        toolName="search"
+        description="Searches the web."
+        input={{query: 'camunda'}}
+        content={[{contentType: 'TEXT', text: 'Tool output here'}]}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const inputEditor = await within(
+      screen.getByTestId('tool-call-input'),
+    ).findByTestId('monaco-editor');
+    const outputEditor = within(
+      screen.getByTestId('tool-call-output'),
+    ).getByTestId('monaco-editor');
+    expect(inputEditor).toHaveValue(
+      JSON.stringify({query: 'camunda'}, null, 2),
+    );
+    expect(outputEditor).toHaveValue('Tool output here');
+  });
+
+  it('should render object results as output', async () => {
+    render(
+      <ToolResultModal
+        toolName="search"
+        description="Searches the web."
+        input={{query: 'camunda'}}
+        content={[
+          {contentType: 'OBJECT', object: {message: 'Tool output here'}},
+        ]}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const outputEditor = await within(
+      screen.getByTestId('tool-call-output'),
+    ).findByTestId('monaco-editor');
+    expect(outputEditor).toHaveValue(
+      JSON.stringify({message: 'Tool output here'}, null, 2),
+    );
+  });
+
+  it('should not show an input editor when no input was provided', async () => {
+    render(
+      <ToolResultModal
+        toolName="search"
+        description="Searches the web."
+        input={null}
+        content={[]}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const inputColumn = within(screen.getByTestId('tool-call-input'));
+    expect(
+      screen.getByText('Tool called without input arguments.'),
+    ).toBeInTheDocument();
+    expect(inputColumn.queryByTestId('monaco-editor')).not.toBeInTheDocument();
+    expect(
+      inputColumn.queryByRole('button', {name: 'Copy to clipboard'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should not show an output editor when no renderable content was provided', async () => {
+    render(
+      <ToolResultModal
+        toolName="search"
+        description="Searches the web."
+        input={{query: 'camunda'}}
+        content={[
+          {
+            contentType: 'DOCUMENT',
+            documentReference: {
+              'camunda.document.type': 'camunda',
+              contentHash: 'abc123',
+              documentId: 'doc-1',
+              storeId: 'default',
+              metadata: {
+                contentType: 'text/plain',
+                fileName: 'report.txt',
+                size: 1234,
+                expiresAt: null,
+                processDefinitionId: null,
+                processInstanceKey: null,
+                customProperties: {},
+              },
+            },
+          },
+        ]}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const outputColumn = within(screen.getByTestId('tool-call-output'));
+    expect(
+      screen.getByText('The tool call did not return content.'),
+    ).toBeInTheDocument();
+    expect(outputColumn.queryByTestId('monaco-editor')).not.toBeInTheDocument();
+    expect(
+      outputColumn.queryByRole('button', {name: 'Copy to clipboard'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should call onClose when the close button is clicked', async () => {
+    const onClose = vi.fn();
+    const {user} = render(
+      <ToolResultModal
+        toolName="search"
+        description="Searches the web."
+        input={{query: 'camunda'}}
+        content={[{contentType: 'TEXT', text: 'Tool output here'}]}
+        onClose={onClose}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Close'}));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/index.tsx
@@ -14,7 +14,14 @@ import {
   getToolCallResult,
   type ContentItem,
 } from '../getRenderableResult';
-import {Description, Columns, Column, ColumnLabel, EmptyHint} from './styled';
+import {
+  Description,
+  Columns,
+  Column,
+  ColumnLabel,
+  EditorContainer,
+  EmptyHint,
+} from './styled';
 
 const RichTextEditor = lazy(async () => {
   const [{loadMonaco}, {RichTextEditor}] = await Promise.all([
@@ -63,14 +70,16 @@ const ToolResultModal: React.FC<ToolResultModalProps> = ({
             <CopyButton value={inputValue} hasIconOnly tooltipAlignment="end" />
           )}
           {inputValue !== null ? (
-            <Suspense>
-              <RichTextEditor
-                value={inputValue}
-                readOnly
-                language="json"
-                height="40vh"
-              />
-            </Suspense>
+            <EditorContainer>
+              <Suspense>
+                <RichTextEditor
+                  value={inputValue}
+                  readOnly
+                  language="json"
+                  height="100%"
+                />
+              </Suspense>
+            </EditorContainer>
           ) : (
             <EmptyHint>Tool called without input arguments.</EmptyHint>
           )}
@@ -85,14 +94,16 @@ const ToolResultModal: React.FC<ToolResultModalProps> = ({
             />
           )}
           {result !== null ? (
-            <Suspense>
-              <RichTextEditor
-                value={result.value}
-                readOnly
-                language={result.language}
-                height="40vh"
-              />
-            </Suspense>
+            <EditorContainer>
+              <Suspense>
+                <RichTextEditor
+                  value={result.value}
+                  readOnly
+                  language={result.language}
+                  height="100%"
+                />
+              </Suspense>
+            </EditorContainer>
           ) : (
             <EmptyHint>{EMPTY_RESULT_MESSAGE}</EmptyHint>
           )}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/index.tsx
@@ -60,9 +60,7 @@ const ToolResultModal: React.FC<ToolResultModalProps> = ({
       size="lg"
       passiveModal
     >
-      <Description>
-        {description ?? 'No description available for this tool.'}
-      </Description>
+      {description && <Description>{description}</Description>}
       <Columns>
         <Column aria-label="Input" data-testid="tool-call-input">
           <ColumnLabel>Input</ColumnLabel>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/index.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {lazy, Suspense} from 'react';
+import {Modal} from '@carbon/react';
+import {CopyButton} from 'modules/components/CopyButton';
+import {
+  EMPTY_RESULT_MESSAGE,
+  getToolCallResult,
+  type ContentItem,
+} from '../getRenderableResult';
+import {Description, Columns, Column, ColumnLabel, EmptyHint} from './styled';
+
+const RichTextEditor = lazy(async () => {
+  const [{loadMonaco}, {RichTextEditor}] = await Promise.all([
+    import('modules/loadMonaco'),
+    import('modules/components/RichTextEditor'),
+  ]);
+
+  loadMonaco();
+
+  return {default: RichTextEditor};
+});
+
+type ToolResultModalProps = {
+  toolName: string;
+  description: string | null;
+  input: Record<string, unknown> | null;
+  content: ContentItem[];
+  onClose: () => void;
+};
+
+const ToolResultModal: React.FC<ToolResultModalProps> = ({
+  toolName,
+  description,
+  input,
+  content,
+  onClose,
+}) => {
+  const inputValue = input !== null ? JSON.stringify(input, null, 2) : null;
+  const result = getToolCallResult(content);
+
+  return (
+    <Modal
+      open
+      modalHeading={`Tool call: ${toolName}`}
+      onRequestClose={onClose}
+      size="lg"
+      passiveModal
+    >
+      <Description>
+        {description ?? 'No description available for this tool.'}
+      </Description>
+      <Columns>
+        <Column aria-label="Input" data-testid="tool-call-input">
+          <ColumnLabel>Input</ColumnLabel>
+          {inputValue !== null && (
+            <CopyButton value={inputValue} hasIconOnly tooltipAlignment="end" />
+          )}
+          {inputValue !== null ? (
+            <Suspense>
+              <RichTextEditor
+                value={inputValue}
+                readOnly
+                language="json"
+                height="40vh"
+              />
+            </Suspense>
+          ) : (
+            <EmptyHint>Tool called without input arguments.</EmptyHint>
+          )}
+        </Column>
+        <Column aria-label="Output" data-testid="tool-call-output">
+          <ColumnLabel>Output</ColumnLabel>
+          {result !== null && (
+            <CopyButton
+              value={result.value}
+              hasIconOnly
+              tooltipAlignment="end"
+            />
+          )}
+          {result !== null ? (
+            <Suspense>
+              <RichTextEditor
+                value={result.value}
+                readOnly
+                language={result.language}
+                height="40vh"
+              />
+            </Suspense>
+          ) : (
+            <EmptyHint>{EMPTY_RESULT_MESSAGE}</EmptyHint>
+          )}
+        </Column>
+      </Columns>
+    </Modal>
+  );
+};
+
+export {ToolResultModal};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/styled.ts
@@ -8,6 +8,10 @@
 
 import styled from 'styled-components';
 
+// The styles use container queries, which do not support CSS variables in their selectors.
+const EDITOR_BASIS = '400px';
+const COLUMN_GAP = '1rem'; // --cds-spacing-05
+
 const Description = styled.p`
   // Modal's set a default top margin for paragraph content.
   margin-block-start: 0 !important;
@@ -17,11 +21,12 @@ const Description = styled.p`
 const Columns = styled.div`
   display: flex;
   flex-wrap: wrap;
-  gap: var(--cds-spacing-05);
+  gap: ${COLUMN_GAP};
+  container-type: inline-size;
 `;
 
 const Column = styled.section`
-  flex: 1 1 400px;
+  flex: 1 1 ${EDITOR_BASIS};
   display: grid;
   grid-template-rows: auto 1fr;
   grid-template-columns: 1fr auto;
@@ -31,6 +36,14 @@ const Column = styled.section`
   & > :last-child {
     align-self: start;
     grid-column: 1 / -1;
+  }
+`;
+
+const EditorContainer = styled.div`
+  block-size: 40vh;
+
+  @container (max-inline-size: calc(2 * ${EDITOR_BASIS} + ${COLUMN_GAP})) {
+    block-size: 25vh;
   }
 `;
 
@@ -50,4 +63,4 @@ const EmptyHint = styled.span`
   color: var(--cds-text-secondary);
 `;
 
-export {Description, Columns, Column, ColumnLabel, EmptyHint};
+export {Description, Columns, Column, ColumnLabel, EditorContainer, EmptyHint};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/styled.ts
@@ -13,7 +13,7 @@ const EDITOR_BASIS = '400px';
 const COLUMN_GAP = '1rem'; // --cds-spacing-05
 
 const Description = styled.p`
-  // Modal's set a default top margin for paragraph content.
+  // Modals set a default top margin for paragraph content.
   margin-block-start: 0 !important;
   color: var(--cds-text-secondary);
 `;

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/ToolResultModal/styled.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const Description = styled.p`
+  // Modal's set a default top margin for paragraph content.
+  margin-block-start: 0 !important;
+  color: var(--cds-text-secondary);
+`;
+
+const Columns = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cds-spacing-05);
+`;
+
+const Column = styled.section`
+  flex: 1 1 400px;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+
+  & > :last-child {
+    align-self: start;
+    grid-column: 1 / -1;
+  }
+`;
+
+const ColumnLabel = styled.h3`
+  font-size: var(--cds-heading-compact-01-font-size);
+  font-weight: var(--cds-heading-compact-01-font-weight);
+  line-height: var(--cds-heading-compact-01-line-height);
+  letter-spacing: var(--cds-heading-compact-01-letter-spacing);
+  color: var(--cds-text-primary);
+`;
+
+const EmptyHint = styled.span`
+  font-size: var(--cds-body-compact-01-font-size);
+  line-height: var(--cds-body-compact-01-line-height);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing);
+  font-weight: var(--cds-body-compact-01-font-weight);
+  color: var(--cds-text-secondary);
+`;
+
+export {Description, Columns, Column, ColumnLabel, EmptyHint};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/getRenderableResult.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/getRenderableResult.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {AgentInstanceHistoryItem} from '@camunda/camunda-api-zod-schemas/8.10';
+
+type ContentItem = AgentInstanceHistoryItem['content'][number];
+
+type ToolCallResult = {
+  value: string;
+  language: 'markdown' | 'json';
+};
+
+const EMPTY_RESULT_MESSAGE = 'The tool call did not return content.';
+
+/**
+ * Extracts a tool call result for rendering in a rich text editor.
+ * For now, we expect only one text/object content-item for tool results.
+ */
+const getToolCallResult = (content: ContentItem[]): ToolCallResult | null => {
+  const entry = content.find(
+    (item) => item.contentType === 'TEXT' || item.contentType === 'OBJECT',
+  );
+  switch (entry?.contentType) {
+    case 'TEXT':
+      return {value: entry.text, language: 'markdown'};
+    case 'OBJECT':
+      return {value: JSON.stringify(entry.object, null, 2), language: 'json'};
+    default:
+      return null;
+  }
+};
+
+/** Extracts a tool call result for rendering in a single-line preview. */
+const getResultPreview = (content: ContentItem[]): string => {
+  const entry = content.find(
+    (item) => item.contentType === 'TEXT' || item.contentType === 'OBJECT',
+  );
+  switch (entry?.contentType) {
+    case 'TEXT':
+      return entry.text;
+    case 'OBJECT':
+      return JSON.stringify(entry.object);
+    default:
+      return EMPTY_RESULT_MESSAGE;
+  }
+};
+
+export {getToolCallResult, getResultPreview, EMPTY_RESULT_MESSAGE};
+export type {ContentItem, ToolCallResult};

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.test.tsx
@@ -96,4 +96,34 @@ describe('<ToolResultMessage />', () => {
       screen.getByText('The tool call did not return content.'),
     ).toBeInTheDocument();
   });
+
+  it('should open the tool result modal when the expand button is clicked', async () => {
+    const {user} = render(
+      <ToolResultMessage
+        availableTools={[
+          {name: 'search', description: 'Searches the web.', elementId: null},
+        ]}
+        toolCalls={[
+          {
+            toolCallId: '1',
+            toolName: 'search',
+            elementId: null,
+            arguments: {},
+          },
+        ]}
+        content={[]}
+      />,
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    const expandButton = screen.getByRole('button', {name: 'Expand'});
+    await user.click(expandButton);
+
+    const modal = within(screen.getByRole('dialog'));
+    expect(
+      modal.getByRole('heading', {name: 'Tool call: search'}),
+    ).toBeInTheDocument();
+    expect(modal.getByText('Searches the web.')).toBeInTheDocument();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationMessage/ToolResultMessage/index.tsx
@@ -6,8 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {useMemo, useState} from 'react';
 import type {
-  AgentInstanceHistoryItem,
   AgentInstanceToolCall,
   AgentTool,
 } from '@camunda/camunda-api-zod-schemas/8.10';
@@ -20,22 +20,8 @@ import {
   ToolLabel,
 } from './styled';
 import {Button} from '@carbon/react';
-
-type ContentItem = AgentInstanceHistoryItem['content'][number];
-
-const getResultPreview = (result: ContentItem[]): string => {
-  const entry = result.find(
-    (item) => item.contentType === 'TEXT' || item.contentType === 'OBJECT',
-  );
-  switch (entry?.contentType) {
-    case 'TEXT':
-      return entry.text;
-    case 'OBJECT':
-      return JSON.stringify(entry.object);
-    default:
-      return 'The tool call did not return content.';
-  }
-};
+import {getResultPreview, type ContentItem} from './getRenderableResult';
+import {ToolResultModal} from './ToolResultModal';
 
 type ToolResultMessageProps = {
   availableTools: AgentTool[];
@@ -44,16 +30,26 @@ type ToolResultMessageProps = {
 };
 
 const ToolResultMessage: React.FC<ToolResultMessageProps> = ({
+  availableTools,
   toolCalls,
   content,
 }) => {
   // According to the API, the tool call is a single entry in the tool calls list on a TOOL_RESULT message.
   const toolCall = toolCalls[0];
+
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const resultPreview = useMemo(() => getResultPreview(content), [content]);
+  const description = useMemo(() => {
+    const tool = availableTools.find(
+      (tool) => tool.name === toolCall?.toolName,
+    );
+    return tool?.description ?? null;
+  }, [availableTools, toolCall]);
+
   if (!toolCall) {
     return null;
   }
-
-  const resultPreview = getResultPreview(content);
 
   return (
     <Container
@@ -68,15 +64,24 @@ const ToolResultMessage: React.FC<ToolResultMessageProps> = ({
       <ResultPreview>{resultPreview}</ResultPreview>
       <ToolActions>
         <Button
-          disabled // disabled until implemented.
           kind="ghost"
           size="sm"
           renderIcon={Maximize}
           iconDescription="Expand"
           tooltipAlignment="end"
           hasIconOnly
+          onClick={() => setIsExpanded(true)}
         />
       </ToolActions>
+      {isExpanded && (
+        <ToolResultModal
+          toolName={toolCall.toolName}
+          description={description}
+          input={toolCall.arguments}
+          content={content}
+          onClose={() => setIsExpanded(false)}
+        />
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
## Description

This PR adds a new tool result modal to the `ToolResultMessage` component. It renders the description, input arguments, and output of a tool call.

**Note:** Only the first renderable result `content` entry is shown. This has had been [discussed in the agent visibility sync](https://camunda.slack.com/archives/C0AH08C7UA2/p1783071049452209?thread_ts=1783070899.122519&cid=C0AH08C7UA2). 

Furthermore, I fixed the color styling for the empty hint in the available tools sections...

## Related issues

closes #56089
