### PR TITLE
fix: load-test: configure Zeebe records replica when using RDBMS + Optimize (+ ES)

### DIFF
--- a/load-tests/setup/main/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -22,6 +22,35 @@ global:
       # update this host value accordingly.
       host: elastic
 
+orchestration:
+  # Secondary storage configuration is not configured here, but in the
+  # Elasticsearch/OpenSearch/RDBMS-specific values file.
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
+
+    ## The values below are duplicated from
+    ## camunda-platform-values-defaults.yaml. Keep them in sync.
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
 ########################################################################################
 ################################################### Elasticsearch cluster configuration
 ########################################################################################

--- a/load-tests/setup/stable-87/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -22,6 +22,35 @@ global:
       # update this host value accordingly.
       host: elastic
 
+orchestration:
+  # Secondary storage configuration is not configured here, but in the
+  # Elasticsearch values file.
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
+
+    ## The values below are duplicated from
+    ## camunda-platform-values-defaults.yaml. Keep them in sync.
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
 ########################################################################################
 ################################################### Elasticsearch cluster configuration
 ########################################################################################

--- a/load-tests/setup/stable-88/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -22,6 +22,35 @@ global:
       # update this host value accordingly.
       host: elastic
 
+orchestration:
+  # Secondary storage configuration is not configured here, but in the
+  # Elasticsearch/OpenSearch values file.
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
+
+    ## The values below are duplicated from
+    ## camunda-platform-values-defaults.yaml. Keep them in sync.
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
 ########################################################################################
 ################################################### Elasticsearch cluster configuration
 ########################################################################################

--- a/load-tests/setup/stable-89/values/camunda-platform-values-optimize-elasticsearch.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-optimize-elasticsearch.yaml
@@ -22,6 +22,35 @@ global:
       # update this host value accordingly.
       host: elastic
 
+orchestration:
+  # Secondary storage configuration is not configured here, but in the
+  # Elasticsearch/OpenSearch/RDBMS-specific values file.
+  env:
+    - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+      value: "1"
+
+    ## The values below are duplicated from
+    ## camunda-platform-values-defaults.yaml. Keep them in sync.
+    # Enable JSON logging for google cloud stackdriver
+    - name: ZEEBE_LOG_APPENDER
+      value: Stackdriver
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+      value: zeebe
+    - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: ATOMIX_LOG_LEVEL
+      value: INFO
+    - name: ZEEBE_LOG_LEVEL
+      value: DEBUG
+    # To be able to load a separate/additional configuration
+    # See https://github.com/camunda/camunda-platform-helm/issues/2197
+    - name: SPRING_CONFIG_ADDITIONALLOCATION
+      # application-override.yml is listed second so it has higher priority and can override application.yml.
+      # Marked optional so Spring does not fail if this file is not mounted in a given deployment configuration.
+      value: "/usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml"
+
 ########################################################################################
 ################################################### Elasticsearch cluster configuration
 ########################################################################################

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
@@ -88,6 +88,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/orchestration/statefulset.yaml
@@ -87,6 +87,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_NUMBEROFREPLICAS
+              value: "1"
             - name: ZEEBE_LOG_APPENDER
               value: Stackdriver
             - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME


### PR DESCRIPTION
## Description

When configuring Camunda with RDBMS + Optimize, we _also_ need to deploy Elasticsearch just to store the `zeebe-records` indices which are read by the Optimize importer.

In this case, we also want to configure these indices to have replicas.

Same fix as https://github.com/camunda/camunda/issues/55404 but for the RDBMS + Optimize (+ Elasticsearch) scenario.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

* https://github.com/camunda/camunda/issues/55404