### PR TITLE
fix: keep inherited OIDC providers when binding empty physical-tenant overlay

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -56,11 +56,9 @@ import org.springframework.core.env.Environment;
  *   <li>the single nested default slot ({@code authentication.oidc.*}) merges field-by-field.
  * </ul>
  *
- * <p>The one place {@code Binder} does not do the right thing on its own is the {@code providers}
- * <em>map</em>: binding the overlay key-merges the map (root-only and PT-only providers both
- * survive) but <em>replaces</em> the value object of any provider id present on both sides,
- * dropping the root fields the overlay did not restate. {@link #mergeSharedProviders} repairs that
- * by re-binding the overlay onto each pristine root provider object.
+ * <p>The {@code providers} <em>map</em> is reconciled explicitly by {@link #mergeRootProviders}
+ * rather than left to the overlay bind: every cluster (root) provider is kept, with the overlay's
+ * fields for that id applied on top, alongside any provider defined only in the overlay.
  *
  * <p>{@code method} is deliberately not taken from the overlay: it is cluster-wide and re-asserted
  * from the root after binding. Overriding it per tenant is rejected at startup by the configuration
@@ -186,13 +184,13 @@ public final class PhysicalTenantAuthConfigurations {
     // Snapshot the pristine root provider objects before the overlay bind can replace them.
     final Map<String, OidcConfiguration> rootProviders = snapshotProviders(config);
 
-    // Bind the overlay into the SAME instance: scalars override, lists replace, the default slot
-    // field-merges, and the providers map key-merges (but replaces shared values — repaired next).
+    // Bind the overlay into the SAME instance: scalars override, lists replace, and the default
+    // slot field-merges. The providers map is reconciled separately by mergeRootProviders.
     binder.bind(ptPrefix, Bindable.ofInstance(config));
 
     // method is cluster-wide, not per-tenant.
     config.setMethod(rootMethod != null ? rootMethod : AuthenticationMethod.BASIC);
-    mergeSharedProviders(binder, ptPrefix, rootProviders, config);
+    mergeRootProviders(binder, ptPrefix, rootProviders, config);
     narrowToAssigned(binder, ptPrefix, config);
     return config;
   }
@@ -254,27 +252,29 @@ public final class PhysicalTenantAuthConfigurations {
   }
 
   /**
-   * Repairs provider ids present on both root and overlay. The overlay bind replaced each such
-   * value with a fresh object carrying only the overlay's keys; here we re-bind the overlay onto
-   * the <em>pristine</em> root object so the fields the overlay omitted survive (override +
-   * list-replace + inherit, all by {@link Binder}). Root-only and PT-only providers need no repair.
+   * Sets the tenant's OIDC providers to the union of the cluster (root) providers and the
+   * per-tenant overlay: every root provider is present with the overlay's fields for that id
+   * applied on top, and providers defined only in the overlay are kept. {@code rootProviders} is
+   * the snapshot of the root providers taken before the overlay was bound onto {@code config}.
    */
-  private static void mergeSharedProviders(
+  private static void mergeRootProviders(
       final Binder binder,
       final String ptPrefix,
       final Map<String, OidcConfiguration> rootProviders,
       final AuthenticationConfiguration config) {
-    final Map<String, OidcConfiguration> merged = namedProviders(config);
-    if (merged == null) {
-      return;
+    final Map<String, OidcConfiguration> postOverlayProviders = namedProviders(config);
+    final Map<String, OidcConfiguration> union = new LinkedHashMap<>();
+    // Seed with the map as the overlay bind left it (PT-only providers, plus any partially-bound
+    // shared ids), then overwrite every root id with its pristine root object + overlay delta.
+    if (postOverlayProviders != null) {
+      union.putAll(postOverlayProviders);
     }
     rootProviders.forEach(
         (id, rootProvider) -> {
-          if (merged.containsKey(id)) {
-            binder.bind(ptPrefix + ".providers.oidc." + id, Bindable.ofInstance(rootProvider));
-            merged.put(id, rootProvider);
-          }
+          binder.bind(ptPrefix + ".providers.oidc." + id, Bindable.ofInstance(rootProvider));
+          union.put(id, rootProvider);
         });
+    config.getProviders().setOidc(union);
   }
 
   private static Map<String, OidcConfiguration> snapshotProviders(

--- a/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
+++ b/authentication/src/main/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurations.java
@@ -274,7 +274,11 @@ public final class PhysicalTenantAuthConfigurations {
           binder.bind(ptPrefix + ".providers.oidc." + id, Bindable.ofInstance(rootProvider));
           union.put(id, rootProvider);
         });
-    config.getProviders().setOidc(union);
+    // getProviders() is null only when neither root nor overlay declared any providers, in which
+    // case the union is empty and there is nothing to write.
+    if (config.getProviders() != null) {
+      config.getProviders().setOidc(union);
+    }
   }
 
   private static Map<String, OidcConfiguration> snapshotProviders(

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -388,6 +388,52 @@ class PhysicalTenantAuthConfigurationsTest {
     assertThat(tenanta.getClientId()).isEqualTo("camunda-pt-tenanta-client"); // overlay wins
   }
 
+  @Test
+  void shouldKeepRootNamedProvidersForDefaultTenantWithEmptyProvidersOverlay() throws Exception {
+    // Reproduces the multi-tenant demo's `default` overlay: `providers: {}` (present but empty).
+    // The default tenant declares no `assigned`, so it must keep the FULL root union — both named
+    // providers inherited from the cluster config, alongside the default slot. A present-but-empty
+    // providers overlay must be a no-op, not a reset of the inherited providers map.
+    final String yaml =
+        """
+        camunda:
+          security:
+            authentication:
+              method: oidc
+              oidc:
+                client-id: camunda-pt-default-client
+                issuer-uri: http://localhost:8081/realms/default
+                audiences: [pt-default-aud]
+              providers:
+                oidc:
+                  tenanta:
+                    client-id: camunda-pt-default-via-tenanta-client
+                    issuer-uri: http://localhost:8082/realms/tenanta
+                    audiences: [pt-default-via-tenanta-aud]
+                  tenantb:
+                    client-id: camunda-pt-tenantb-client
+                    issuer-uri: http://localhost:8083/realms/tenantb
+                    audiences: [pt-tenantb-aud]
+          physical-tenants:
+            default:
+              security:
+                authentication:
+                  providers: {}
+        """;
+
+    final AuthenticationConfiguration cfg =
+        PhysicalTenantAuthConfigurations.forPhysicalTenant("default", yamlEnv(yaml));
+
+    // default slot survives
+    assertThat(cfg.getOidc().getIssuerUri()).isEqualTo("http://localhost:8081/realms/default");
+    // both inherited named providers survive the empty `providers: {}` overlay
+    assertThat(cfg.getProviders().getOidc()).containsKeys("tenanta", "tenantb");
+    assertThat(cfg.getProviders().getOidc().get("tenanta").getIssuerUri())
+        .isEqualTo("http://localhost:8082/realms/tenanta");
+    assertThat(cfg.getProviders().getOidc().get("tenantb").getIssuerUri())
+        .isEqualTo("http://localhost:8083/realms/tenantb");
+  }
+
   // -------------------------------------------------------------------------
   // 7. providers.assigned narrows a non-default tenant to its selected providers (#54730)
   // -------------------------------------------------------------------------

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantAuthConfigurationsTest.java
@@ -427,6 +427,7 @@ class PhysicalTenantAuthConfigurationsTest {
     // default slot survives
     assertThat(cfg.getOidc().getIssuerUri()).isEqualTo("http://localhost:8081/realms/default");
     // both inherited named providers survive the empty `providers: {}` overlay
+    assertThat(cfg.getProviders()).isNotNull();
     assertThat(cfg.getProviders().getOidc()).containsKeys("tenanta", "tenantb");
     assertThat(cfg.getProviders().getOidc().get("tenanta").getIssuerUri())
         .isEqualTo("http://localhost:8082/realms/tenanta");

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAuthenticationConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAuthenticationConfigurations.java
@@ -22,14 +22,13 @@ import org.springframework.core.env.Environment;
  * camunda.physical-tenants.<id>.security.authentication.*} on top of the root {@code
  * camunda.security.authentication.*} config.
  *
- * <p>Uses a snapshot-then-rebind strategy to avoid Spring's {@link Binder} replacing entire map
- * entries on partial field overrides. When a tenant overrides only some fields of a named OIDC
- * provider (e.g. {@code client-id}, {@code client-secret}, {@code audiences}), {@link Binder} would
- * replace the whole map entry with a fresh {@link OidcConfiguration} built only from the
- * PT-specific keys, silently losing root fields like {@code issuer-uri}, {@code username-claim},
- * and {@code redirect-uri}. This class avoids that by snapshotting the root POJOs first, running
- * the PT overlay, then re-binding the PT overlay keys onto the pristine root POJO for any shared
- * provider id so that Binder applies the PT delta on top of a fully-populated root object.
+ * <p>The root config is bound first, its providers are snapshotted, then the PT overlay is bound on
+ * top and the {@code providers} map is reconciled by {@link #mergeRootProviders}: every root
+ * provider is kept with the overlay's fields for that id applied on top, alongside any provider
+ * defined only in the overlay. This is needed because binding the overlay onto the root instance
+ * would otherwise replace a shared provider's value object with one holding only the PT-specific
+ * keys (losing root fields like {@code issuer-uri}), and an empty overlay {@code providers} map
+ * would reset the whole map (dropping the inherited providers).
  */
 @NullMarked
 public final class PhysicalTenantAuthenticationConfigurations {
@@ -56,33 +55,35 @@ public final class PhysicalTenantAuthenticationConfigurations {
     final String ptPrefix = PT_PREFIX_TEMPLATE.formatted(tenantId);
     binder.bind(ptPrefix, Bindable.ofInstance(auth));
 
-    mergeSharedProviders(auth, rootOidc, binder, ptPrefix);
+    mergeRootProviders(auth, rootOidc, binder, ptPrefix);
 
     return auth;
   }
 
   /**
-   * Re-binds the PT overlay onto the pristine root POJOs for any provider id that existed in both
-   * root and PT configs. Without this step a tenant that overrides only some fields of a shared
-   * provider would lose all other root-level fields because Spring's {@link Binder} replaces the
-   * entire map entry on the first matching key.
+   * Sets the tenant's OIDC providers to the union of the root providers and the PT overlay: every
+   * root provider is present with the overlay's fields for that id applied on top, and providers
+   * defined only in the overlay are kept. {@code rootOidc} is the snapshot of the root providers
+   * taken before the overlay was bound onto {@code auth}.
    */
-  private static void mergeSharedProviders(
+  private static void mergeRootProviders(
       final AuthenticationConfiguration auth,
       final Map<String, OidcConfiguration> rootOidc,
       final Binder binder,
       final String ptPrefix) {
-    final Map<String, OidcConfiguration> resolvedOidc = auth.getProviders().getOidc();
+    final Map<String, OidcConfiguration> postOverlayProviders = auth.getProviders().getOidc();
+    final Map<String, OidcConfiguration> union = new LinkedHashMap<>();
+    // Seed with the map as the overlay bind left it (PT-only providers, plus any partially-bound
+    // shared ids), then overwrite every root id with its pristine root object + overlay delta.
+    if (postOverlayProviders != null) {
+      union.putAll(postOverlayProviders);
+    }
     rootOidc.forEach(
         (providerId, rootProvider) -> {
-          if (resolvedOidc.containsKey(providerId)) {
-            // Apply the PT delta onto the pristine root POJO, then swap it back in for the
-            // Binder-created entry that holds only the PT-specified fields. Both steps are
-            // required: the bind layers the override, the put restores the merged result.
-            binder.bind(
-                ptPrefix + ".providers.oidc." + providerId, Bindable.ofInstance(rootProvider));
-            resolvedOidc.put(providerId, rootProvider);
-          }
+          binder.bind(
+              ptPrefix + ".providers.oidc." + providerId, Bindable.ofInstance(rootProvider));
+          union.put(providerId, rootProvider);
         });
+    auth.getProviders().setOidc(union);
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAuthenticationConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantAuthenticationConfigurations.java
@@ -10,9 +10,11 @@ package io.camunda.configuration.physicaltenants;
 import io.camunda.configuration.Camunda;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
 import io.camunda.security.api.model.config.oidc.OidcConfiguration;
+import io.camunda.security.api.model.config.oidc.OidcProvidersConfiguration;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.core.env.Environment;
@@ -49,8 +51,9 @@ public final class PhysicalTenantAuthenticationConfigurations {
             .orElseGet(AuthenticationConfiguration::new);
 
     // snapshot pristine root provider POJOs before the PT overlay mutates them
+    final Map<String, OidcConfiguration> rootProviders = namedProviders(auth);
     final Map<String, OidcConfiguration> rootOidc =
-        new LinkedHashMap<>(auth.getProviders().getOidc());
+        rootProviders == null ? new LinkedHashMap<>() : new LinkedHashMap<>(rootProviders);
 
     final String ptPrefix = PT_PREFIX_TEMPLATE.formatted(tenantId);
     binder.bind(ptPrefix, Bindable.ofInstance(auth));
@@ -71,7 +74,7 @@ public final class PhysicalTenantAuthenticationConfigurations {
       final Map<String, OidcConfiguration> rootOidc,
       final Binder binder,
       final String ptPrefix) {
-    final Map<String, OidcConfiguration> postOverlayProviders = auth.getProviders().getOidc();
+    final Map<String, OidcConfiguration> postOverlayProviders = namedProviders(auth);
     final Map<String, OidcConfiguration> union = new LinkedHashMap<>();
     // Seed with the map as the overlay bind left it (PT-only providers, plus any partially-bound
     // shared ids), then overwrite every root id with its pristine root object + overlay delta.
@@ -84,6 +87,16 @@ public final class PhysicalTenantAuthenticationConfigurations {
               ptPrefix + ".providers.oidc." + providerId, Bindable.ofInstance(rootProvider));
           union.put(providerId, rootProvider);
         });
-    auth.getProviders().setOidc(union);
+    // getProviders() is null only when neither root nor overlay declared any providers, in which
+    // case the union is empty and there is nothing to write.
+    if (auth.getProviders() != null) {
+      auth.getProviders().setOidc(union);
+    }
+  }
+
+  private static @Nullable Map<String, OidcConfiguration> namedProviders(
+      final AuthenticationConfiguration auth) {
+    final OidcProvidersConfiguration providers = auth.getProviders();
+    return providers == null ? null : providers.getOidc();
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
@@ -78,7 +78,7 @@ class PhysicalTenantOidcProviderOverlayTest {
     final AuthenticationConfiguration auth =
         PhysicalTenantAuthenticationConfigurations.forPhysicalTenant("tenanta", environment);
     assertThat(auth.getOidc().getClientId()).isEqualTo("default-client");
-    assertThat(auth.getProviders().getOidc()).isEmpty();
+    assertThat(auth.getProviders() == null ? null : auth.getProviders().getOidc()).isNullOrEmpty();
   }
 
   @Test

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
@@ -108,6 +108,7 @@ class PhysicalTenantOidcProviderOverlayTest {
         PhysicalTenantAuthenticationConfigurations.forPhysicalTenant("default", environment);
 
     // then both inherited providers survive the empty overlay
+    assertThat(auth.getProviders()).isNotNull();
     assertThat(auth.getProviders().getOidc()).containsKeys("tenanta", "tenantb");
     assertThat(auth.getProviders().getOidc().get("tenanta").getIssuerUri())
         .isEqualTo("http://localhost:8082/realms/tenanta");

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
@@ -61,6 +61,40 @@ class PhysicalTenantOidcProviderOverlayTest {
   }
 
   @Test
+  void shouldKeepRootProvidersWhenTenantOverlayHasEmptyProvidersMap() {
+    // given root declares two named providers, and the tenant's only overlay is an empty
+    // `providers` map. Spring Boot 4.1 surfaces an empty YAML map (`providers: {}`) as an empty
+    // property value; binding it onto the root instance must not reset the inherited providers.
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.security.authentication.providers.oidc.tenanta.issuer-uri",
+                    "http://localhost:8082/realms/tenanta",
+                    "camunda.security.authentication.providers.oidc.tenanta.client-id",
+                    "tenanta-client",
+                    "camunda.security.authentication.providers.oidc.tenantb.issuer-uri",
+                    "http://localhost:8083/realms/tenantb",
+                    "camunda.security.authentication.providers.oidc.tenantb.client-id",
+                    "tenantb-client",
+                    "camunda.physical-tenants.default.security.authentication.providers",
+                    "")));
+
+    // when
+    final AuthenticationConfiguration auth =
+        PhysicalTenantAuthenticationConfigurations.forPhysicalTenant("default", environment);
+
+    // then both inherited providers survive the empty overlay
+    assertThat(auth.getProviders().getOidc()).containsKeys("tenanta", "tenantb");
+    assertThat(auth.getProviders().getOidc().get("tenanta").getIssuerUri())
+        .isEqualTo("http://localhost:8082/realms/tenanta");
+    assertThat(auth.getProviders().getOidc().get("tenantb").getIssuerUri())
+        .isEqualTo("http://localhost:8083/realms/tenantb");
+  }
+
+  @Test
   void shouldOverrideOnlyTheFieldsTenantSets() {
     // given root declares a full tenanta provider; the PT overlay overrides only
     // client-id/secret/audiences — omitting issuer-uri, username-claim, client-id-claim,

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantOidcProviderOverlayTest.java
@@ -61,6 +61,27 @@ class PhysicalTenantOidcProviderOverlayTest {
   }
 
   @Test
+  void shouldResolveWithoutErrorWhenNoNamedProvidersAreConfigured() {
+    // given a config that uses only the default slot, so no providers map exists
+    environment
+        .getPropertySources()
+        .addFirst(
+            new MapPropertySource(
+                "test",
+                Map.of(
+                    "camunda.security.authentication.oidc.issuer-uri",
+                    "http://localhost:8081/realms/default",
+                    "camunda.security.authentication.oidc.client-id",
+                    "default-client")));
+
+    // when / then resolving a tenant does not throw and yields no named providers
+    final AuthenticationConfiguration auth =
+        PhysicalTenantAuthenticationConfigurations.forPhysicalTenant("tenanta", environment);
+    assertThat(auth.getOidc().getClientId()).isEqualTo("default-client");
+    assertThat(auth.getProviders().getOidc()).isEmpty();
+  }
+
+  @Test
   void shouldKeepRootProvidersWhenTenantOverlayHasEmptyProvidersMap() {
     // given root declares two named providers, and the tenant's only overlay is an empty
     // `providers` map. Spring Boot 4.1 surfaces an empty YAML map (`providers: {}`) as an empty


### PR DESCRIPTION
## Problem

In a physical-tenant deployment, a PT overlay with an empty providers map (`camunda.physical-tenants.<id>.security.authentication.providers: {}`) removes the OIDC providers that the tenant inherits from the cluster config. The [demo's default tenant](https://github.com/camunda/camunda/blob/pt-webapp-routes-demo/dist/src/main/resources/application-pt-smoke-test.yaml#L83-L88) has such a placeholder. On Spring Boot 4.1.0 it then keeps only its default slot: the webapp shows no provider selection, and the per-tenant `/sso-callback` returns HTTP 500 with `NullPointerException: ...OidcConfiguration.getResource() because "oidcConfig" is null`.

Plain multi-provider OIDC (without physical tenants) is not affected.

## Root cause

Spring Boot 4.1.0 changed `YamlPropertySourceLoader`: an empty YAML map (`providers: {}`) now becomes the property `...providers = ""`, while 4.0.7 dropped it. The per-tenant merge binds the overlay into the root `AuthenticationConfiguration` instance, and that empty value resets the whole providers map. The `default` tenant has no `providers.assigned` to restore them, so the loss is permanent. This is independent of the CSL version.

## Fix

Both merge implementations now rebuild the union of root and overlay providers after the bind, so inherited providers survive an empty overlay on both 4.0 and 4.1:

- `io.camunda.authentication.pt.PhysicalTenantAuthConfigurations` (per-tenant security chains, the source of the demo symptoms)
- `io.camunda.configuration.physicaltenants.PhysicalTenantAuthenticationConfigurations` (used by `PhysicalTenantResolver`)

## Tests

- `PhysicalTenantAuthConfigurationsTest#shouldKeepRootNamedProvidersForDefaultTenantWithEmptyProvidersOverlay` loads `providers: {}` from YAML. It fails on 4.1.0 before the fix and passes on 4.0.7 and 4.1.0 after.
- `PhysicalTenantOidcProviderOverlayTest#shouldKeepRootProvidersWhenTenantOverlayHasEmptyProvidersMap` injects the empty providers property. It fails before and passes after.

## Note

The empty `providers: {}` is only a placeholder in the demo config and could be removed. The fix makes an empty overlay harmless in any case. See #56783 for the edge-case framing.

The two implementations are kept separate on purpose. They do different things: the `configuration` one keeps the full provider set for the property beans, the `authentication` one also narrows to `providers.assigned` for the security chains. They also live in sibling modules that do not depend on each other, and there is no shared Spring module to hold the small merge they have in common. Removing the duplication would need a new module or a dependency change, which is not worth it for now. So there is no follow-up yet, and the two copies are kept in sync.

Closes #56783

🤖 Generated with [Claude Code](https://claude.com/claude-code)
