### PR TITLE
feat: show process-level waiting label in header & add details

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.test.tsx
@@ -300,6 +300,44 @@ describe('<DetailsTab />', () => {
     mockSearchElementInstanceInspection().withSuccess(searchResult([]));
   });
 
+  it('should show the process-level wait state status for the process scope', async () => {
+    mockSearchElementInstanceInspection().withSuccess(
+      searchResult([
+        {
+          rootProcessInstanceKey: PROCESS_INSTANCE_ID,
+          processInstanceKey: PROCESS_INSTANCE_ID,
+          elementInstanceKey: PROCESS_INSTANCE_ID,
+          elementId: 'process-def-1',
+          elementType: 'PROCESS',
+          tenantId: '<default>',
+          bpmnProcessId: 'process-def-1',
+          details: {
+            waitStateType: 'JOB',
+            jobKey: '555666777',
+            jobType: 'process-start-listener',
+            jobKind: 'EXECUTION_LISTENER',
+            listenerEventType: 'START',
+            retries: 3,
+          },
+        },
+      ]),
+    );
+
+    render(<DetailsTab />, {
+      wrapper: getWrapper(),
+    });
+
+    expect(await screen.findByTestId('details-tab')).toBeInTheDocument();
+    expect(await screen.findByTestId('waiting-status')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Waiting for execution listener: process-start-listener',
+      ),
+    ).toBeInTheDocument();
+    // No process property rows are shown for the process scope.
+    expect(screen.queryByText('Process ID')).not.toBeInTheDocument();
+  });
+
   it('should show multi-instance message when multiple instances exist', async () => {
     mockSearchElementInstances().withSuccess(
       searchResult([mockElementInstance, mockElementInstance], 2),

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -57,12 +57,16 @@ const DetailsTab: React.FC = () => {
   const clientConfig = getClientConfig();
   const {processInstanceId = ''} = useProcessInstancePageParams();
   const {
+    hasSelection,
     resolvedElementInstance,
     selectedElementId,
     selectedAnchorElementId,
     selectedInstancesCount,
     isFetchingElement,
   } = useProcessInstanceElementSelection();
+
+  // No element selected means the process scope (the PROCESS root row).
+  const isProcessScope = !hasSelection;
 
   const {data: processInstance} = useProcessInstance();
   const {data: xmlData} = useProcessInstanceXml({
@@ -78,23 +82,29 @@ const DetailsTab: React.FC = () => {
     resolvedElementInstance?.elementInstanceKey ?? null;
   const resolvedElementType = resolvedElementInstance?.type;
 
+  // For the process scope the wait state is anchored on the PROCESS container,
+  // whose element instance key equals the process instance key.
+  const inspectionElementInstanceKey = isProcessScope
+    ? processInstanceId
+    : (elementInstanceKey ?? undefined);
+
   const {data: inspectionData} = useElementInstanceInspection({
     processInstanceKey: processInstanceId,
-    elementInstanceKey: elementInstanceKey ?? undefined,
+    elementInstanceKey: inspectionElementInstanceKey,
     enabled:
       clientConfig.waitStatesEnabled &&
-      !!elementInstanceKey &&
+      !!inspectionElementInstanceKey &&
       processInstance?.state === 'ACTIVE' &&
-      resolvedElementInstance?.state === 'ACTIVE',
+      (isProcessScope || resolvedElementInstance?.state === 'ACTIVE'),
   });
 
-  const elementWaitStates = useMemo(() => {
+  const waitStates = useMemo(() => {
     return (
       inspectionData?.items?.filter(
-        (item) => item.elementInstanceKey === elementInstanceKey,
+        (item) => item.elementInstanceKey === inspectionElementInstanceKey,
       ) ?? []
     );
-  }, [inspectionData, elementInstanceKey]);
+  }, [inspectionData, inspectionElementInstanceKey]);
 
   const {data: calledProcessInstancesSearchResult} = useProcessInstancesSearch(
     {
@@ -485,6 +495,16 @@ const DetailsTab: React.FC = () => {
     messageSubscription,
   ]);
 
+  if (isProcessScope) {
+    // The process scope only surfaces the process-level wait state status
+    // (the Details tab is only shown when such a wait state exists).
+    return (
+      <Container data-testid="details-tab">
+        <WaitingStatus waitStates={waitStates} />
+      </Container>
+    );
+  }
+
   if (isFetchingElement) {
     return <StructuredListSkeleton rowCount={5} />;
   }
@@ -529,7 +549,7 @@ const DetailsTab: React.FC = () => {
         />
       )}
       {!showAgentInstance && clientConfig.waitStatesEnabled && (
-        <WaitingStatus waitStates={elementWaitStates} />
+        <WaitingStatus waitStates={waitStates} />
       )}
       <SectionContainer>
         <SectionHeading>Element Instance</SectionHeading>

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {render, screen} from 'modules/testing-library';
+import {render, screen, waitFor} from 'modules/testing-library';
 import {
   createMemoryRouter,
   Navigate,
@@ -18,6 +18,7 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {Paths} from 'modules/Routes';
 import {BottomPanelTabs} from './index';
 import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockFetchProcessInstanceWaitStateStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstanceWaitStateStatistics';
 import {createProcessInstance, searchResult} from 'modules/testUtils';
 import {mockSearchElementInstances} from 'modules/mocks/api/v2/elementInstances/searchElementInstances';
 import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
@@ -101,6 +102,10 @@ function getWrapper(initialPath?: string) {
 const SELECTED_PATH = `${Paths.processInstance(PROCESS_INSTANCE_ID)}?elementId=someElement`;
 
 describe('<BottomPanelTabs />', () => {
+  beforeEach(() => {
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({items: []});
+  });
+
   it('should render always visible tabs', async () => {
     mockFetchProcessInstance().withSuccess(
       createProcessInstance({
@@ -135,6 +140,25 @@ describe('<BottomPanelTabs />', () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('link', {name: /^Output Mappings$/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should show Details for the process scope when a process-level wait state exists', async () => {
+    const instance = createProcessInstance({
+      processInstanceKey: PROCESS_INSTANCE_ID,
+      hasIncident: false,
+    });
+    mockFetchProcessInstance().withSuccess(instance);
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({
+      items: [{elementId: instance.processDefinitionId, waitingCount: 1}],
+    });
+
+    render(<BottomPanelTabs isHistoryTabVisible />, {wrapper: getWrapper()});
+
+    expect(await screen.findByRole('link', {name: /^Details$/i})).toBeVisible();
+    // Still an element-only tab set otherwise.
+    expect(
+      screen.queryByRole('link', {name: /^Input Mappings$/i}),
     ).not.toBeInTheDocument();
   });
 
@@ -717,7 +741,7 @@ describe('<BottomPanelTabs />', () => {
     );
   });
 
-  it('should redirect details tab when no element is selected', async () => {
+  it('should redirect details tab when no element is selected and no process-level wait state', async () => {
     mockFetchProcessInstance().withSuccess(
       createProcessInstance({
         processInstanceKey: PROCESS_INSTANCE_ID,
@@ -732,10 +756,34 @@ describe('<BottomPanelTabs />', () => {
       wrapper: getWrapper(path),
     });
 
-    expect(await screen.findByTestId('pathname')).toHaveTextContent(
-      Paths.processInstanceVariables({
-        processInstanceId: PROCESS_INSTANCE_ID,
-      }),
+    // The redirect happens once the wait-state query resolves (no process-level
+    // wait state), so wait for the location to settle on Variables.
+    await waitFor(() =>
+      expect(screen.getByTestId('pathname')).toHaveTextContent(
+        Paths.processInstanceVariables({
+          processInstanceId: PROCESS_INSTANCE_ID,
+        }),
+      ),
     );
+  });
+
+  it('should not redirect details tab for the process scope when a process-level wait state exists', async () => {
+    const instance = createProcessInstance({
+      processInstanceKey: PROCESS_INSTANCE_ID,
+      hasIncident: false,
+    });
+    mockFetchProcessInstance().withSuccess(instance);
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({
+      items: [{elementId: instance.processDefinitionId, waitingCount: 1}],
+    });
+
+    const path = Paths.processInstanceDetails({
+      processInstanceId: PROCESS_INSTANCE_ID,
+    });
+    render(<BottomPanelTabs isHistoryTabVisible />, {
+      wrapper: getWrapper(path),
+    });
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(path);
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
@@ -16,6 +16,9 @@ import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstan
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useProcessInstanceIncidentsCount} from 'modules/queries/incidents/useProcessInstanceIncidentsCount';
 import {useElementInstanceIncidentsCount} from 'modules/queries/incidents/useElementInstanceIncidentsCount';
+import {useWaitStateStatistics} from 'modules/queries/waitStateStatistics/useWaitStateStatistics';
+import {hasProcessLevelWaitState} from 'modules/utils/waitStates';
+import {getClientConfig} from 'modules/utils/getClientConfig';
 
 function useSelectionAwareIncidentsCount(
   processInstanceKey: string,
@@ -53,7 +56,16 @@ const BottomPanelTabs: React.FC<{isHistoryTabVisible: boolean}> = ({
   isHistoryTabVisible,
 }) => {
   const {hasSelection} = useProcessInstanceElementSelection();
-  const {data: processInstance} = useProcessInstance();
+  const {data: processInstance, isLoading: isProcessInstanceLoading} =
+    useProcessInstance();
+  const {data: waitStateStatistics, isLoading: isWaitStateLoading} =
+    useWaitStateStatistics({
+      enabled: getClientConfig().waitStatesEnabled,
+    });
+  const isProcessLevelWaiting = hasProcessLevelWaitState(
+    waitStateStatistics,
+    processInstance?.processDefinitionId,
+  );
   const {processInstanceId} = useProcessInstancePageParams();
   const {currentPage} = useCurrentPage();
   const location = useLocation();
@@ -80,7 +92,9 @@ const BottomPanelTabs: React.FC<{isHistoryTabVisible: boolean}> = ({
       key: 'details',
       selected: currentPage === 'process-details-details',
       title: 'Details',
-      visible: hasSelection,
+      // Shown for a selected element instance, or for the process scope only
+      // when there is a process-level wait state to surface.
+      visible: hasSelection || isProcessLevelWaiting,
     },
     {
       label: 'Variables',
@@ -138,13 +152,22 @@ const BottomPanelTabs: React.FC<{isHistoryTabVisible: boolean}> = ({
 
   const selectedTab = tabItems.find((tab) => tab.selected);
 
+  // Avoid redirecting away from the Details tab while it's still unknown
+  // whether a process-level wait state exists (process instance or wait-state
+  // query still loading) — otherwise a direct link to Details would bounce to
+  // Variables before the wait state resolves.
+  const isDeferringRedirect =
+    selectedTab?.key === 'details' &&
+    !hasSelection &&
+    (isProcessInstanceLoading || isWaitStateLoading);
+
   return (
     <Container>
       <TabListNav label="Process Instance Bottom Panel Tabs" items={tabItems} />
       <TabContent>
         <Outlet />
       </TabContent>
-      {selectedTab?.visible === false && (
+      {selectedTab?.visible === false && !isDeferringRedirect && (
         <Navigate
           to={{
             ...location,

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
@@ -113,15 +113,16 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   const hasVersionTag = !isNil(processDefinitionVersionTag);
   const hasBusinessId = !isNil(businessId);
   const processInstanceState = hasIncident ? 'INCIDENT' : state;
-  const isProcessLevelWaiting = waitStateStatistics?.some(
-    ({elementId}) => elementId === processDefinitionId,
-  );
+  const processLevelWaitingCount =
+    waitStateStatistics?.find(
+      ({elementId}) => elementId === processDefinitionId,
+    )?.waitingCount ?? 0;
   return (
     <InstanceHeader
       state={processInstanceState}
       instanceName={getProcessDefinitionName(processInstance)}
       incidentsCount={hasIncident ? incidentsCount : 0}
-      nameSubtitle={isProcessLevelWaiting ? getWaitStateLabel(1) : undefined}
+      nameSubtitle={getWaitStateLabel(processLevelWaitingCount) ?? undefined}
       headerColumns={headerColumns.filter((name) => {
         if (name === 'Tenant') {
           return isMultiTenancyEnabled;

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.tsx
@@ -20,6 +20,8 @@ import {VersionTag} from './styled';
 import {useProcessDefinitionKeyContext} from 'App/Processes/ListView/processDefinitionKeyContext';
 import {useProcessInstanceXml} from 'modules/queries/processDefinitions/useProcessInstanceXml';
 import {useProcessInstanceIncidentsCount} from 'modules/queries/incidents/useProcessInstanceIncidentsCount';
+import {useWaitStateStatistics} from 'modules/queries/waitStateStatistics/useWaitStateStatistics';
+import {getWaitStateLabel} from 'modules/utils/waitStates';
 import {hasCalledProcessInstances} from 'modules/bpmn-js/utils/hasCalledProcessInstances';
 import {type ProcessInstance} from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAvailableTenants} from 'modules/queries/useAvailableTenants';
@@ -95,6 +97,9 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
       enabled: hasIncident,
     },
   );
+  const {data: waitStateStatistics} = useWaitStateStatistics({
+    enabled: getClientConfig().waitStatesEnabled,
+  });
 
   if (processInstance === null || isPending) {
     return <Skeleton headerColumns={skeletonColumns} />;
@@ -108,12 +113,15 @@ const ProcessInstanceHeader: React.FC<Props> = ({processInstance}) => {
   const hasVersionTag = !isNil(processDefinitionVersionTag);
   const hasBusinessId = !isNil(businessId);
   const processInstanceState = hasIncident ? 'INCIDENT' : state;
-
+  const isProcessLevelWaiting = waitStateStatistics?.some(
+    ({elementId}) => elementId === processDefinitionId,
+  );
   return (
     <InstanceHeader
       state={processInstanceState}
       instanceName={getProcessDefinitionName(processInstance)}
       incidentsCount={hasIncident ? incidentsCount : 0}
+      nameSubtitle={isProcessLevelWaiting ? getWaitStateLabel(1) : undefined}
       headerColumns={headerColumns.filter((name) => {
         if (name === 'Tenant') {
           return isMultiTenancyEnabled;

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/tests/index.test.tsx
@@ -32,6 +32,8 @@ import {mockFetchCallHierarchy} from 'modules/mocks/api/v2/processInstances/fetc
 import {mockMe} from 'modules/mocks/api/v2/me';
 import {mockDeleteProcessInstance} from 'modules/mocks/api/v2/processInstances/deleteProcessInstance';
 import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByProcessInstance';
+import {mockFetchProcessInstance} from 'modules/mocks/api/v2/processInstances/fetchProcessInstance';
+import {mockFetchProcessInstanceWaitStateStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstanceWaitStateStatistics';
 
 vi.mock('modules/stores/notifications', () => ({
   notificationsStore: {
@@ -43,6 +45,8 @@ describe('InstanceHeader', () => {
   beforeEach(() => {
     mockFetchCallHierarchy().withSuccess([]);
     mockMe().withSuccess(createUser());
+    mockFetchProcessInstance().withSuccess(mockInstance);
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({items: []});
   });
 
   it('should render process instance data', async () => {
@@ -356,5 +360,56 @@ describe('InstanceHeader', () => {
         screen.queryByRole('button', {name: /Modify Instance/}),
       ).not.toBeInTheDocument(),
     );
+  });
+
+  it('should render a "Waiting" label under the process name when the process is blocked on a process-level wait state', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({
+      items: [{elementId: mockInstance.processDefinitionId, waitingCount: 1}],
+    });
+
+    render(<ProcessInstanceHeader processInstance={mockInstance} />, {
+      wrapper: Wrapper,
+    });
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('instance-header-skeleton'),
+    );
+
+    expect(await screen.findByText('Waiting')).toBeInTheDocument();
+  });
+
+  it('should render the waiting count when multiple process-level wait states exist', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({
+      items: [{elementId: mockInstance.processDefinitionId, waitingCount: 3}],
+    });
+
+    render(<ProcessInstanceHeader processInstance={mockInstance} />, {
+      wrapper: Wrapper,
+    });
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('instance-header-skeleton'),
+    );
+
+    expect(await screen.findByText('3 waiting')).toBeInTheDocument();
+  });
+
+  it('should not render a "Waiting" label when there is no process-level wait state', async () => {
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({
+      items: [{elementId: 'service-task-1', waitingCount: 1}],
+    });
+
+    render(<ProcessInstanceHeader processInstance={mockInstance} />, {
+      wrapper: Wrapper,
+    });
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('instance-header-skeleton'),
+    );
+
+    expect(screen.queryByText('Waiting')).not.toBeInTheDocument();
   });
 });

--- a/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/waitingStateOverlay.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/DiagramOverlays/waitingStateOverlay.tsx
@@ -15,6 +15,7 @@ import {
 } from 'modules/bpmn-js/badgePositions';
 import {WaitingStateOverlay as WaitingState} from 'modules/components/WaitingStateOverlay';
 import {useWaitStateStatistics} from 'modules/queries/waitStateStatistics/useWaitStateStatistics';
+import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useBusinessObjects} from 'modules/queries/processDefinitions/useBusinessObjects';
 import {getWaitStateLabel} from 'modules/utils/waitStates';
 import {getClientConfig} from 'modules/utils/getClientConfig';
@@ -56,6 +57,8 @@ const useWaitingStateOverlaysData = (
     enabled: clientConfig.waitStatesEnabled,
   });
   const {data: businessObjects} = useBusinessObjects();
+  const {data: processInstance} = useProcessInstance();
+  const processDefinitionId = processInstance?.processDefinitionId;
 
   return useMemo(() => {
     if (!waitStateStatistics?.length) {
@@ -65,6 +68,13 @@ const useWaitingStateOverlaysData = (
     const overlays: OverlayData[] = [];
 
     for (const {elementId, waitingCount} of waitStateStatistics) {
+      // The process-level wait state (e.g. a process-level start execution
+      // listener) targets the PROCESS container, which has no diagram shape.
+      // Its "Waiting" label is surfaced in the instance header instead of on
+      // the diagram.
+      if (elementId === processDefinitionId) {
+        continue;
+      }
       // Hide the waiting state when an agent instance exists for the element.
       if (elementsWithAgent.has(elementId)) {
         continue;
@@ -87,7 +97,12 @@ const useWaitingStateOverlaysData = (
     }
 
     return overlays;
-  }, [waitStateStatistics, businessObjects, elementsWithAgent]);
+  }, [
+    waitStateStatistics,
+    businessObjects,
+    elementsWithAgent,
+    processDefinitionId,
+  ]);
 };
 
 const WaitingStateOverlay: React.FC<{overlay: DiagramOverlay}> = ({

--- a/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/index.test.tsx
@@ -542,4 +542,39 @@ describe('TopPanel', () => {
     expect(await screen.findByText('5 waiting')).toBeInTheDocument();
     expect(screen.getByText('Waiting')).toBeInTheDocument();
   });
+
+  it('should not render a waiting overlay for the process-level wait state', async () => {
+    // The process-level wait state targets the PROCESS container
+    // (elementId === processDefinitionId), which has no diagram shape. Its
+    // label is surfaced in the header, not on the diagram.
+    mockFetchProcessInstanceWaitStateStatistics().withSuccess({
+      items: [
+        {elementId: mockProcessInstance.processDefinitionId, waitingCount: 1},
+        {elementId: 'service-task-1', waitingCount: 1},
+      ],
+    });
+
+    render(<TopPanel />, {wrapper: getWrapper()});
+
+    await waitForElementToBeRemoved(() =>
+      screen.queryByTestId('diagram-spinner'),
+    );
+
+    await waitFor(() => {
+      expect(
+        diagramOverlaysStore.state.overlays.some(
+          ({elementId, type}) =>
+            elementId === 'service-task-1' && type === 'waitingState',
+        ),
+      ).toBe(true);
+    });
+
+    expect(
+      diagramOverlaysStore.state.overlays.some(
+        ({elementId, type}) =>
+          elementId === mockProcessInstance.processDefinitionId &&
+          type === 'waitingState',
+      ),
+    ).toBe(false);
+  });
 });

--- a/operate/client/src/modules/components/InstanceHeader/index.tsx
+++ b/operate/client/src/modules/components/InstanceHeader/index.tsx
@@ -14,6 +14,8 @@ import {
   NameContainer,
   InstanceName,
   IncidentCount,
+  NameSubtitle,
+  SubtitleRow,
   AdditionalContent,
 } from './styled';
 import {StateIcon} from 'modules/components/StateIcon';
@@ -31,6 +33,7 @@ type Props = {
   state: React.ComponentProps<typeof StateIcon>['state'];
   instanceName: string;
   incidentsCount?: number;
+  nameSubtitle?: React.ReactNode;
   headerColumns: string[];
   bodyColumns: Column[];
   additionalContent?: React.ReactNode;
@@ -43,6 +46,7 @@ const InstanceHeader: React.FC<Props> = ({
   bodyColumns,
   instanceName,
   incidentsCount = 0,
+  nameSubtitle,
   additionalContent,
   hideBottomBorder = false,
 }) => {
@@ -55,10 +59,15 @@ const InstanceHeader: React.FC<Props> = ({
 
       <NameContainer title={instanceName}>
         <InstanceName>{instanceName}</InstanceName>
-        {incidentsCount > 0 && (
-          <IncidentCount>
-            {pluralSuffix(incidentsCount, 'incident')}
-          </IncidentCount>
+        {(incidentsCount > 0 || nameSubtitle) && (
+          <SubtitleRow>
+            {incidentsCount > 0 && (
+              <IncidentCount>
+                {pluralSuffix(incidentsCount, 'incident')}
+              </IncidentCount>
+            )}
+            {nameSubtitle && <NameSubtitle>{nameSubtitle}</NameSubtitle>}
+          </SubtitleRow>
         )}
       </NameContainer>
       <Table>

--- a/operate/client/src/modules/components/InstanceHeader/styled.ts
+++ b/operate/client/src/modules/components/InstanceHeader/styled.ts
@@ -98,9 +98,16 @@ const InstanceName = styled.span`
   white-space: nowrap;
   color: var(--cds-text-secondary);
 
-  &:has(+ span) {
+  &:has(+ *) {
     ${styles.label01};
   }
+`;
+
+const SubtitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--cds-spacing-03);
+  min-width: 0;
 `;
 
 const IncidentCount = styled.span`
@@ -109,6 +116,20 @@ const IncidentCount = styled.span`
   overflow: hidden;
   white-space: nowrap;
   color: var(--cds-support-error);
+`;
+
+const NameSubtitle = styled.span`
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--cds-label-01-font-size);
+  font-weight: var(--cds-heading-compact-01-font-weight);
+  letter-spacing: var(--cds-label-01-letter-spacing);
+  border-radius: 11px;
+  background-color: var(--cds-support-warning);
+  color: #000000;
+  padding: var(--cds-spacing-02) var(--cds-spacing-04);
+  white-space: nowrap;
 `;
 
 const SkeletonText = styled(BaseSkeletonText)`
@@ -131,4 +152,6 @@ export {
   NameContainer,
   InstanceName,
   IncidentCount,
+  NameSubtitle,
+  SubtitleRow,
 };

--- a/operate/client/src/modules/components/InstanceHeader/styled.ts
+++ b/operate/client/src/modules/components/InstanceHeader/styled.ts
@@ -12,6 +12,7 @@ import {
   SkeletonText as BaseSkeletonText,
   SkeletonIcon as BaseSkeletonIcon,
 } from '@carbon/react';
+import {WAITING_BADGE_BORDER_RADIUS} from 'modules/constants';
 
 const Table = styled.table`
   table-layout: fixed;
@@ -125,7 +126,7 @@ const NameSubtitle = styled.span`
   font-size: var(--cds-label-01-font-size);
   font-weight: var(--cds-heading-compact-01-font-weight);
   letter-spacing: var(--cds-label-01-letter-spacing);
-  border-radius: 11px;
+  border-radius: ${WAITING_BADGE_BORDER_RADIUS};
   background-color: var(--cds-support-warning);
   color: #000000;
   padding: var(--cds-spacing-02) var(--cds-spacing-04);

--- a/operate/client/src/modules/components/WaitingStateOverlay/styled.ts
+++ b/operate/client/src/modules/components/WaitingStateOverlay/styled.ts
@@ -7,6 +7,7 @@
  */
 
 import styled from 'styled-components';
+import {WAITING_BADGE_BORDER_RADIUS} from 'modules/constants';
 
 const Container = styled.div<{$centered?: boolean}>`
   display: inline-flex;
@@ -20,7 +21,7 @@ const Container = styled.div<{$centered?: boolean}>`
   font-variant-numeric: tabular-nums;
   line-height: var(--cds-label-01-line-height);
   letter-spacing: var(--cds-label-01-letter-spacing);
-  border-radius: 11px;
+  border-radius: ${WAITING_BADGE_BORDER_RADIUS};
   background-color: var(--cds-support-warning);
   color: #000000;
   padding: var(--cds-spacing-02) var(--cds-spacing-04);

--- a/operate/client/src/modules/constants.ts
+++ b/operate/client/src/modules/constants.ts
@@ -32,6 +32,7 @@ const INSTANCE_HISTORY_LEFT_PADDING = 'var(--cds-spacing-05)';
 const COLLAPSABLE_PANEL_HEADER_HEIGHT = 'var(--cds-spacing-09)';
 const ARROW_ICON_WIDTH = 'var(--cds-spacing-08)';
 const DEFAULT_TENANT = '<default>';
+const WAITING_BADGE_BORDER_RADIUS = '11px';
 
 export {
   TOKEN_OPERATIONS,
@@ -42,4 +43,5 @@ export {
   COLLAPSABLE_PANEL_HEADER_HEIGHT,
   ARROW_ICON_WIDTH,
   DEFAULT_TENANT,
+  WAITING_BADGE_BORDER_RADIUS,
 };

--- a/operate/client/src/modules/utils/waitStates.ts
+++ b/operate/client/src/modules/utils/waitStates.ts
@@ -12,11 +12,6 @@ import type {
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {formatDate} from 'modules/utils/date';
 
-/**
- * A process-level wait state (e.g. a process-level start execution listener)
- * is anchored on the PROCESS container, whose element id equals the process
- * definition id.
- */
 function hasProcessLevelWaitState(
   waitStateStatistics: WaitStateStatistic[] | undefined,
   processDefinitionId: string | undefined,

--- a/operate/client/src/modules/utils/waitStates.ts
+++ b/operate/client/src/modules/utils/waitStates.ts
@@ -6,8 +6,28 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import type {ElementInstanceInspection} from '@camunda/camunda-api-zod-schemas/8.10';
+import type {
+  ElementInstanceInspection,
+  WaitStateStatistic,
+} from '@camunda/camunda-api-zod-schemas/8.10';
 import {formatDate} from 'modules/utils/date';
+
+/**
+ * A process-level wait state (e.g. a process-level start execution listener)
+ * is anchored on the PROCESS container, whose element id equals the process
+ * definition id.
+ */
+function hasProcessLevelWaitState(
+  waitStateStatistics: WaitStateStatistic[] | undefined,
+  processDefinitionId: string | undefined,
+): boolean {
+  if (!waitStateStatistics || processDefinitionId === undefined) {
+    return false;
+  }
+  return waitStateStatistics.some(
+    ({elementId}) => elementId === processDefinitionId,
+  );
+}
 
 function getWaitStateLabel(waitingCount: number): string | null {
   if (waitingCount <= 0) {
@@ -116,4 +136,9 @@ function getEarliestTimerDueDate(
   return earliestDueDate;
 }
 
-export {getWaitStateLabel, getWaitStateStatusItems, getEarliestTimerDueDate};
+export {
+  hasProcessLevelWaitState,
+  getWaitStateLabel,
+  getWaitStateStatusItems,
+  getEarliestTimerDueDate,
+};


### PR DESCRIPTION
## Description

Based on the two committed changes on the branch:

- **Diagram → header:** the process-level wait state no longer renders a stray "Waiting" badge on the diagram root; it now shows as a "Waiting" badge in the process instance header, under the process name (alongside the incident count when both apply).
- **Details tab for the process:** the Instance History Details tab is now available when the PROCESS root row is selected (process scope) and it has wait states, showing the wait-state status.
- **Tests:** added/updated unit tests for the header waiting badge (shown only when a process-level wait state exists) and the process-scope Details tab (visibility + rendered fields).

## Related issues

related to #56132
