### PR TITLE
fix: bound in-flight start requests in load-tester starter

### DIFF
--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/StarterProperties.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/config/StarterProperties.java
@@ -26,6 +26,7 @@ public class StarterProperties {
   private int durationLimit = 0;
   private boolean startViaMessage = false;
   private String msgName = "msg";
+  private double maxInFlightRateMultiplier = 10; // 0 = cap off (unbounded)
 
   public String getProcessId() {
     return processId;
@@ -150,5 +151,23 @@ public class StarterProperties {
 
   public void setMsgName(final String msgName) {
     this.msgName = msgName;
+  }
+
+  public double getMaxInFlightRateMultiplier() {
+    return maxInFlightRateMultiplier;
+  }
+
+  public void setMaxInFlightRateMultiplier(final double maxInFlightRateMultiplier) {
+    this.maxInFlightRateMultiplier = maxInFlightRateMultiplier;
+  }
+
+  /**
+   * The maximum number of concurrent in-flight start requests, derived from the per-second rate and
+   * the configured multiplier. A value of 0 means the cap is disabled (unbounded).
+   */
+  public long getMaxInFlightRequests() {
+    return maxInFlightRateMultiplier <= 0
+        ? 0 // 0 => unbounded
+        : (long) Math.ceil(getRatePerSecond() * maxInFlightRateMultiplier);
   }
 }

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/StarterMetricsDoc.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/metrics/StarterMetricsDoc.java
@@ -94,6 +94,52 @@ public enum StarterMetricsDoc implements ExtendedMeterDocumentation {
     public Type getType() {
       return Type.GAUGE;
     }
+  },
+
+  /**
+   * Total number of process instance start requests skipped because the configured in-flight cap
+   * was reached. When completions cannot keep up with the fire rate, new requests are dropped
+   * instead of piling onto the client connection pool (which would otherwise grow unbounded and
+   * exhaust heap). A steadily climbing value indicates the target cannot sustain the configured
+   * rate.
+   */
+  PROCESS_INSTANCES_DROPPED {
+    @Override
+    public String getDescription() {
+      return "Total start requests skipped because the in-flight cap was reached.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.process.instances.dropped";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+  },
+
+  /**
+   * Current number of outstanding start requests: incremented before a request is submitted and
+   * decremented when it completes (success or error). Bounded by the configured in-flight cap when
+   * the cap is enabled.
+   */
+  REQUESTS_IN_FLIGHT {
+    @Override
+    public String getDescription() {
+      return "Current number of outstanding (submitted, not yet completed) start requests.";
+    }
+
+    @Override
+    public String getName() {
+      return "starter.requests.in.flight";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
   };
 
   public enum StarterMetricKeyNames implements KeyName {

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/starter/Starter.java
@@ -88,11 +88,13 @@ public class Starter implements CommandLineRunner {
   private final AtomicLong businessKey = new AtomicLong(0);
   private final AtomicLong lastProcessInstanceKey = new AtomicLong(0);
   private final AtomicInteger runFinished = new AtomicInteger(0);
+  private final AtomicInteger inFlightRequests = new AtomicInteger(0);
   private final AtomicReference<Instant> lastProcessInstanceKeyTimestamp =
       new AtomicReference<>(Instant.now());
 
   private Timer responseLatencyTimer;
   private Counter processInstancesStartedCounter;
+  private Counter processInstancesDroppedCounter;
   private ScheduledExecutorService executorService;
   private ProcessInstanceStartMeter processInstanceStartMeter;
   private DataReadMeter dataReadMeter;
@@ -141,6 +143,18 @@ public class Starter implements CommandLineRunner {
 
     Gauge.builder(StarterMetricsDoc.RUN_FINISHED.getName(), runFinished, AtomicInteger::doubleValue)
         .description(StarterMetricsDoc.RUN_FINISHED.getDescription())
+        .register(registry);
+
+    processInstancesDroppedCounter =
+        Counter.builder(StarterMetricsDoc.PROCESS_INSTANCES_DROPPED.getName())
+            .description(StarterMetricsDoc.PROCESS_INSTANCES_DROPPED.getDescription())
+            .register(registry);
+
+    Gauge.builder(
+            StarterMetricsDoc.REQUESTS_IN_FLIGHT.getName(),
+            inFlightRequests,
+            AtomicInteger::doubleValue)
+        .description(StarterMetricsDoc.REQUESTS_IN_FLIGHT.getDescription())
         .register(registry);
 
     if (properties.isMonitorDataAvailability()) {
@@ -258,11 +272,13 @@ public class Starter implements CommandLineRunner {
       final ScheduledExecutorService executorService, final CountDownLatch countDownLatch) {
 
     final long intervalNanos = (long) (NANOS_PER_SECOND / starterCfg.getRatePerSecond());
+    final long maxInFlight = starterCfg.getMaxInFlightRequests();
     LOG.info(
-        "Creating an instance every {}ns (rate: {} per {})",
+        "Creating an instance every {}ns (rate: {} per {}); max in-flight requests: {}",
         intervalNanos,
         starterCfg.getRate(),
-        starterCfg.getRateDuration());
+        starterCfg.getRateDuration(),
+        maxInFlight == 0 ? "unbounded" : maxInFlight);
 
     final String variablesString = payloadReader.readPayload(starterCfg.getPayloadPath());
     final Map<String, Object> baseVariables =
@@ -277,6 +293,17 @@ public class Starter implements CommandLineRunner {
             return;
           }
 
+          if (maxInFlight > 0 && inFlightRequests.get() >= maxInFlight) {
+            processInstancesDroppedCounter.increment();
+            THROTTLED_LOGGER.warn(
+                "Skipping start: {} in-flight requests >= cap {}",
+                inFlightRequests.get(),
+                maxInFlight);
+            return;
+          }
+
+          boolean submitted = false;
+          inFlightRequests.incrementAndGet();
           try {
             final var vars = new HashMap<>(baseVariables);
             vars.put(starterCfg.getBusinessKey(), businessKey.incrementAndGet());
@@ -293,6 +320,7 @@ public class Starter implements CommandLineRunner {
             }
             requestFuture.whenComplete(
                 (noop, error) -> {
+                  inFlightRequests.decrementAndGet();
                   final long durationNanos = System.nanoTime() - startTime;
                   responseLatencyTimer.record(durationNanos, TimeUnit.NANOSECONDS);
                   if (error instanceof final StatusRuntimeException statusRuntimeException) {
@@ -304,8 +332,15 @@ public class Starter implements CommandLineRunner {
                     }
                   }
                 });
+            submitted = true;
           } catch (final Exception e) {
             THROTTLED_LOGGER.error("Error on creating new process instance", e);
+          } finally {
+            if (!submitted) {
+              // The request was never handed off to a future, so whenComplete will not fire —
+              // decrement here to keep the in-flight count accurate.
+              inFlightRequests.decrementAndGet();
+            }
           }
         },
         0,

--- a/load-tests/load-tester/src/main/resources/application.yaml
+++ b/load-tests/load-tester/src/main/resources/application.yaml
@@ -94,6 +94,11 @@ load-tester:
     duration-limit: ${LOAD_TESTER_STARTER_DURATION_LIMIT:0}
     msg-name: msg
     start-via-message: false
+    # Caps concurrent in-flight start requests to (rate-per-second * multiplier). When completions
+    # cannot keep up with the fire rate, requests beyond the cap are dropped instead of piling onto
+    # the client connection pool (which would otherwise grow unbounded and exhaust heap). A value
+    # <= 0 disables the cap (unbounded).
+    max-in-flight-rate-multiplier: ${LOAD_TESTER_STARTER_MAX_IN_FLIGHT_RATE_MULTIPLIER:10}
   # Worker-specific properties consumed by Worker.java.
   # These control what the job handler does (completion delay, message publishing, payload).
   # Connection properties (type, name, threads, capacity, polling, streaming, timeout)

--- a/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/StarterPropertiesTest.java
+++ b/load-tests/load-tester/src/test/java/io/camunda/zeebe/config/StarterPropertiesTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+class StarterPropertiesTest {
+
+  @Test
+  void shouldDeriveMaxInFlightFromRateAndMultiplier() {
+    // given
+    final var props = new StarterProperties();
+    props.setRate(150);
+    props.setRateDuration(Duration.ofSeconds(1));
+    props.setMaxInFlightRateMultiplier(10);
+
+    // when / then
+    assertThat(props.getMaxInFlightRequests()).isEqualTo(1500);
+  }
+
+  @Test
+  void shouldRoundMaxInFlightUp() {
+    // given - non-integer rate per second
+    final var props = new StarterProperties();
+    props.setRate(1);
+    props.setRateDuration(Duration.ofSeconds(3));
+    props.setMaxInFlightRateMultiplier(2);
+
+    // when / then - ceil(0.333.. * 2) = ceil(0.666..) = 1
+    assertThat(props.getMaxInFlightRequests()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldDisableCapWhenMultiplierIsZero() {
+    // given
+    final var props = new StarterProperties();
+    props.setRate(150);
+    props.setMaxInFlightRateMultiplier(0);
+
+    // when / then
+    assertThat(props.getMaxInFlightRequests()).isZero();
+  }
+
+  @Test
+  void shouldDisableCapWhenMultiplierIsNegative() {
+    // given
+    final var props = new StarterProperties();
+    props.setRate(150);
+    props.setMaxInFlightRateMultiplier(-1);
+
+    // when / then
+    assertThat(props.getMaxInFlightRequests()).isZero();
+  }
+
+  @Test
+  void shouldDefaultMultiplierToTen() {
+    // given
+    final var props = new StarterProperties();
+
+    // when / then
+    assertThat(props.getMaxInFlightRateMultiplier()).isEqualTo(10);
+  }
+}


### PR DESCRIPTION
## Description

The load-tester `starter` fires process-instance create requests via `scheduleAtFixedRate` and never joins the returned future (fire-and-forget with only a `whenComplete()` latency callback). There is no bound on outstanding requests.

When per-request completion is slower than the fire rate (e.g. cross-region commit ~92ms + HTTP/1.1 connection churn at 150 PI/s), outstanding requests accumulate without limit. Apache HC5's async connection-lease queue grows unbounded → heap fills (`OutOfMemoryError`) and `LaxConnPool.servicePendingRequests` recurses (`StackOverflowError`). The dispatch/generator threads die and requests stop. 

## Fix

Cap concurrent in-flight requests at `rate-per-second * multiplier`. Above the cap, skip firing a new instance and count it as dropped instead of piling onto the pool.

- In-flight count tracked with an `AtomicInteger` — incremented before submit, decremented on completion (a `finally` guard covers the synchronous-throw path so the count stays accurate).
- Multiplier configurable via `LOAD_TESTER_STARTER_MAX_IN_FLIGHT_RATE_MULTIPLIER` (default `10`); `0` disables the cap (previous unbounded behavior).
- New metrics: `starter.process.instances.dropped` (counter), `starter.requests.in.flight` (gauge).


