### PR TITLE
fix: improve archiver IT flakiness on shared OpenSearch cluster

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ArchiverJobIT.java
@@ -8,7 +8,6 @@
 package io.camunda.exporter.tasks.archiver;
 
 import static io.camunda.exporter.utils.CamundaExporterSchemaUtils.createSchemas;
-import static io.camunda.search.test.utils.SearchDBExtension.CUSTOM_PREFIX;
 import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -76,7 +75,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
   protected CamundaExporterMetrics exporterMetrics;
   protected ExecutorService executor;
   protected Context context;
-  private String testPrefix;
+  protected String testPrefix;
 
   private final List<AutoCloseable> resourcesToClose = new ArrayList<>();
   private LifecyclePolicyNameVerifier lifecyclePolicyNameVerifier;
@@ -96,9 +95,9 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
     final var openSearchAwsInstanceUrl =
         Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL)).orElse("");
     if (openSearchAwsInstanceUrl.isEmpty()) {
-      searchDB.esClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+      searchDB.esClient().indices().delete(req -> req.index(testPrefix + "*"));
     }
-    searchDB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+    searchDB.osClient().indices().delete(req -> req.index(testPrefix + "*"));
 
     if (executor != null) {
       executor.shutdown();
@@ -129,7 +128,9 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
       throws Exception {
     config.getHistory().getRetention().setEnabled(true);
     config.getHistory().getRetention().setPolicyName(testPrefix + "-camunda-retention-policy");
+    config.getConnect().setIndexPrefix(testPrefix);
     config.getIndex().setNumberOfShards(3);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
 
     final ExporterResourceProvider exporterResourceProvider = exporterResourceProvider(config);
@@ -324,7 +325,7 @@ public abstract class ArchiverJobIT<T extends ArchiverJob<?>> {
         return;
       }
       Awaitility.await()
-          .atMost(Duration.ofSeconds(10L))
+          .atMost(ARCHIVE_TIMEOUT)
           .untilAsserted(
               () -> {
                 final var policy = client.getLifecyclePolicyNameForIndex(indexName);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobIT.java
@@ -20,11 +20,9 @@ import io.camunda.webapps.schema.entities.auditlog.AuditLogCleanupEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
 import java.io.IOException;
-import java.time.Duration;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestTemplate;
@@ -79,34 +77,16 @@ public class AuditLogArchiverJobIT extends ArchiverJobIT<AuditLogArchiverJob> {
           store(cleanupIndex, client, cleanupEntity);
           store(auditLogTemplate, client, auditLog);
           store(auditLogTemplate, client, unrelatedAuditLog);
-          client.refresh();
-
-          // explicit wait after store() calls and client.refresh(). This is needed to keep nudging
-          // OpenSearch until the documents are provably visible before the job runs.
-          Awaitility.await()
-              .atMost(Duration.ofSeconds(30))
-              .pollInterval(Duration.ofMillis(200))
-              .untilAsserted(
-                  () -> {
-                    client.refresh();
-                    assertThat(
-                            client.searchAll(
-                                cleanupIndex.getFullQualifiedName(), AuditLogCleanupEntity.class))
-                        .hasSize(1);
-                    assertThat(
-                            client.searchAll(
-                                auditLogTemplate.getFullQualifiedName(), AuditLogEntity.class))
-                        .hasSize(2);
-                  });
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then - should archive 1 audit log + delete 1 cleanup = 2
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(30L)).isEqualTo(2);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(2);
 
           // then - matching audit log should be moved to the dated index
-          client.refresh();
+          client.refresh(testPrefix);
           verifyMoved(auditLogTemplate, client, auditLog, todayDateSuffix());
 
           // then - unrelated audit log should remain in the original index
@@ -134,16 +114,16 @@ public class AuditLogArchiverJobIT extends ArchiverJobIT<AuditLogArchiverJob> {
                   .setPartitionId(PARTITION_ID);
 
           store(cleanupIndex, client, cleanupEntity);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then - should delete the cleanup entry even though there were no audit logs to move
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(30L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
           // then - cleanup metadata should be deleted
-          client.refresh();
+          client.refresh(testPrefix);
           verifyCleanupDeleted(cleanupIndex, client, cleanupEntity);
         });
   }
@@ -179,7 +159,7 @@ public class AuditLogArchiverJobIT extends ArchiverJobIT<AuditLogArchiverJob> {
           store(cleanupIndex, client, cleanupEntity);
           store(auditLogTemplate, client, auditLog1);
           store(auditLogTemplate, client, auditLog2);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -187,11 +167,11 @@ public class AuditLogArchiverJobIT extends ArchiverJobIT<AuditLogArchiverJob> {
           // then - should archive audit logs but not delete the cleanup metadata since
           // the number of archived audit logs >= rolloverBatchSize, indicating more work remains
           assertThat(archived)
-              .succeedsWithin(Duration.ofSeconds(30L))
+              .succeedsWithin(ARCHIVE_TIMEOUT)
               .satisfies(count -> assertThat((int) count).isGreaterThanOrEqualTo(1));
 
           // then - cleanup metadata should NOT be deleted because batch size was reached
-          client.refresh();
+          client.refresh(testPrefix);
           verifyCleanupNotDeleted(cleanupIndex, client, cleanupEntity);
         });
   }
@@ -233,16 +213,16 @@ public class AuditLogArchiverJobIT extends ArchiverJobIT<AuditLogArchiverJob> {
           store(cleanupIndex, client, cleanupEntity2);
           store(auditLogTemplate, client, auditLog1);
           store(auditLogTemplate, client, auditLog2);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then - should archive both audit logs and delete both cleanup entries
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(30L)).isEqualTo(4);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(4);
 
           // then - both audit logs should be moved
-          client.refresh();
+          client.refresh(testPrefix);
           verifyMoved(auditLogTemplate, client, auditLog1, todayDateSuffix());
           verifyMoved(auditLogTemplate, client, auditLog2, todayDateSuffix());
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobIT.java
@@ -19,7 +19,6 @@ import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
-import java.time.Duration;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -66,13 +65,13 @@ public class BatchOperationArchiverJobIT extends ArchiverJobIT<BatchOperationArc
 
           store(batchOpTemplate, client, batchOp);
           store(auditLogTemplate, client, auditLog);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
           verifyMoved(batchOpTemplate, client, batchOp, "2020-01-01");
           verifyMoved(auditLogTemplate, client, auditLog, "2020-01-01");
         });
@@ -96,13 +95,13 @@ public class BatchOperationArchiverJobIT extends ArchiverJobIT<BatchOperationArc
 
           store(batchOpTemplate, client, batchOp);
           store(auditLogTemplate, client, auditLog);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when - should complete without number_format_exception
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
           verifyMoved(batchOpTemplate, client, batchOp, "2020-01-01");
           verifyNotMoved(auditLogTemplate, client, auditLog);
         });
@@ -130,13 +129,13 @@ public class BatchOperationArchiverJobIT extends ArchiverJobIT<BatchOperationArc
           store(batchOpTemplate, client, guidBatchOp);
           store(auditLogTemplate, client, matchingAuditLog);
           store(auditLogTemplate, client, unrelatedAuditLog);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when - should complete without error, GUID filtered out for dependant query
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(2);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(2);
           verifyMoved(batchOpTemplate, client, numericBatchOp, "2020-01-01");
           verifyMoved(batchOpTemplate, client, guidBatchOp, "2020-01-01");
           verifyMoved(auditLogTemplate, client, matchingAuditLog, "2020-01-01");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobIT.java
@@ -14,7 +14,6 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.entities.jobmetricsbatch.JobMetricsBatchEntity;
-import java.time.Duration;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -47,13 +46,13 @@ public class JobBatchMetricsArchiverJobIT extends ArchiverJobIT<JobBatchMetricsA
 
           final var metric = jobBatchMetric("2020-03-15T10:00:00+00:00");
           store(template, client, metric);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
           verifyMoved(template, client, metric, "2020-03-15");
         });
   }
@@ -73,13 +72,13 @@ public class JobBatchMetricsArchiverJobIT extends ArchiverJobIT<JobBatchMetricsA
 
           store(template, client, oldMetric);
           store(template, client, recentMetric);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then - only the old metric should be archived
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
           verifyMoved(template, client, oldMetric, "2020-03-15");
           verifyNotMoved(template, client, recentMetric);
         });
@@ -101,13 +100,13 @@ public class JobBatchMetricsArchiverJobIT extends ArchiverJobIT<JobBatchMetricsA
 
           store(template, client, ownPartitionMetric);
           store(template, client, otherPartitionMetric);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then - only the metric from this partition should be archived
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
           verifyMoved(template, client, ownPartitionMetric, "2020-03-15");
           verifyNotMoved(template, client, otherPartitionMetric);
         });
@@ -130,13 +129,13 @@ public class JobBatchMetricsArchiverJobIT extends ArchiverJobIT<JobBatchMetricsA
           store(template, client, metric1);
           store(template, client, metric2);
           store(template, client, metric3);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then - all old metrics should be archived
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(3);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(3);
           verifyMoved(template, client, metric1, "2020-06-01");
           verifyMoved(template, client, metric2, "2020-06-01");
           verifyMoved(template, client, metric3, "2020-06-01");
@@ -158,15 +157,15 @@ public class JobBatchMetricsArchiverJobIT extends ArchiverJobIT<JobBatchMetricsA
 
           store(template, client, metric1);
           store(template, client, metric2);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when - execute twice since batches are grouped by date
           final var firstRun = job.execute();
-          assertThat(firstRun).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(firstRun).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
-          client.refresh();
+          client.refresh(testPrefix);
           final var secondRun = job.execute();
-          assertThat(secondRun).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(secondRun).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
 
           // then - metrics should be moved to their respective dated indices
           verifyMoved(template, client, metric1, "2020-01-10");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobIT.java
@@ -19,7 +19,6 @@ import io.camunda.webapps.schema.entities.auditlog.AuditLogEntity;
 import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceState;
-import java.time.Duration;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -61,13 +60,13 @@ public class StandaloneDecisionArchiverJobIT extends ArchiverJobIT<StandaloneDec
 
           final var decisionInstance = decisionInstance("2020-01-01T00:00:00+00:00");
           store(decisionInstanceTemplate, client, decisionInstance);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
           verifyMoved(decisionInstanceTemplate, client, decisionInstance, "2020-01-01");
         });
   }
@@ -90,13 +89,13 @@ public class StandaloneDecisionArchiverJobIT extends ArchiverJobIT<StandaloneDec
 
           store(decisionInstanceTemplate, client, standaloneDecision);
           store(decisionInstanceTemplate, client, processDecision);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then - only the standalone decision should be archived
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
           verifyMoved(decisionInstanceTemplate, client, standaloneDecision, "2020-01-01");
           verifyNotMoved(decisionInstanceTemplate, client, processDecision);
         });
@@ -117,13 +116,13 @@ public class StandaloneDecisionArchiverJobIT extends ArchiverJobIT<StandaloneDec
 
           store(decisionInstanceTemplate, client, oldDecision);
           store(decisionInstanceTemplate, client, recentDecision);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
           verifyMoved(decisionInstanceTemplate, client, oldDecision, "2020-01-01");
           verifyNotMoved(decisionInstanceTemplate, client, recentDecision);
         });
@@ -149,13 +148,13 @@ public class StandaloneDecisionArchiverJobIT extends ArchiverJobIT<StandaloneDec
 
           store(decisionInstanceTemplate, client, decisionInstance);
           store(auditLogTemplate, client, auditLogEntry);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
           verifyMoved(decisionInstanceTemplate, client, decisionInstance, "2020-01-01");
           verifyMoved(auditLogTemplate, client, auditLogEntry, "2020-01-01");
         });
@@ -181,13 +180,13 @@ public class StandaloneDecisionArchiverJobIT extends ArchiverJobIT<StandaloneDec
 
           store(decisionInstanceTemplate, client, decisionInstance);
           store(auditLogTemplate, client, unrelatedAuditLog);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
 
           // then
-          assertThat(archived).succeedsWithin(Duration.ofSeconds(5L)).isEqualTo(1);
+          assertThat(archived).succeedsWithin(ARCHIVE_TIMEOUT).isEqualTo(1);
           verifyMoved(decisionInstanceTemplate, client, decisionInstance, "2020-01-01");
           verifyNotMoved(auditLogTemplate, client, unrelatedAuditLog);
         });


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
* The static index prefix `CUSTOM_PREFIX` has been replaced for some tests with an instance-level `testPrefix` that is computed at the beginning of each test, to avoid overlapping and accidental deletions done by other tests that are sharing the OS cluster.
* In some tests, instead of calling `client.refresh()`, that works against every index, we're using the new `client.refresh(testPrefix)` that is much more lightweight. This reduces the pressure on the OS cluster we have on AWS.
* setting the number of replicas = 0 also helps with some shards not being ready at the moment of the tests, as well as the general pressure on the node. This has showed a lower rate of errors, so far.

Sample failed job run:
https://github.com/camunda/camunda/actions/runs/28791073220/job/85369967780

Latest job run:
https://github.com/camunda/camunda/actions/runs/29030628601/job/86162386896

Note: While there still are errors, the errors related to the race conditions are no longer visible.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
