### PR TITLE
Rename reprocess to replay and harden JobTimeOutTest

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerCancelTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/execution/ExecutionListenerCancelTest.java
@@ -1696,11 +1696,11 @@ public class ExecutionListenerCancelTest {
         .withType(CANCEL_EL_TYPE)
         .await();
 
-    // when: take a snapshot and reprocess (simulates a leader restart with snapshot recovery)
+    // when: take a snapshot and replay (simulates a leader restart with snapshot recovery)
     ENGINE.snapshot();
-    ENGINE.reprocess();
+    ENGINE.replay();
 
-    // then: completing the cancel-EL job after reprocess still drives the process to TERMINATED
+    // then: completing the cancel-EL job after replay still drives the process to TERMINATED
     ENGINE.job().ofInstance(processInstanceKey).withType(CANCEL_EL_TYPE).complete();
     assertThat(
             RecordingExporter.processInstanceRecords()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -63,11 +63,7 @@ public final class JobTimeOutTest {
 
     // then the job's event lifecycle is CREATED -> TIMED_OUT
     final List<Record<JobRecordValue>> jobEvents =
-        jobRecords()
-            .withType(jobType)
-            .withRecordType(RecordType.EVENT)
-            .limit(2)
-            .collect(Collectors.toList());
+        jobRecords().withType(jobType).onlyEvents().limit(2).collect(Collectors.toList());
 
     assertThat(jobEvents).extracting(Record::getKey).contains(jobKey);
     assertThat(jobEvents)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -87,7 +87,7 @@ public final class JobTimeOutTest {
     ENGINE.job().withKey(jobKey).complete();
 
     // when
-    ENGINE.reprocess();
+    ENGINE.replay();
 
     // then
     ENGINE.increaseTime(timeout.plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -76,7 +76,7 @@ public final class JobTimeOutTest {
   }
 
   @Test
-  public void shouldTimeOutAfterReprocessing() {
+  public void shouldTimeOutAfterReplay() {
     // given
     final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
     final Duration timeout = Duration.ofSeconds(10);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -61,14 +61,18 @@ public final class JobTimeOutTest {
     jobRecords(TIMED_OUT).withType(jobType).getFirst();
     ENGINE.jobs().withType(jobType).activate();
 
-    // then activated again
+    // then the job's event lifecycle is CREATED -> TIMED_OUT
     final List<Record<JobRecordValue>> jobEvents =
-        jobRecords().withType(jobType).limit(3).collect(Collectors.toList());
+        jobRecords()
+            .withType(jobType)
+            .withRecordType(RecordType.EVENT)
+            .limit(2)
+            .collect(Collectors.toList());
 
     assertThat(jobEvents).extracting(Record::getKey).contains(jobKey);
     assertThat(jobEvents)
         .extracting(Record::getIntent)
-        .containsExactly(JobIntent.CREATED, JobIntent.TIME_OUT, JobIntent.TIMED_OUT);
+        .containsExactly(JobIntent.CREATED, JobIntent.TIMED_OUT);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/KeyGeneratorAfterRestartTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/KeyGeneratorAfterRestartTest.java
@@ -79,7 +79,7 @@ public final class KeyGeneratorAfterRestartTest {
     // during replay, ReplayStateMachine.onRecordReplayed calls setKeyIfHigher(record.getKey())
     // for all record types — the rejection and its originating command both have
     // key=anomalouslyLargeKey
-    engine.reprocess();
+    engine.replay();
 
     // guard: confirm the rejection record was actually replayed (re-exported) after restart
     // if this assertion fails the test did not exercise the path under investigation

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -427,7 +427,7 @@ public final class EngineRule extends ExternalResource {
     environmentRule.getClock().addTime(duration);
   }
 
-  public void reprocess() {
+  public void replay() {
     forEachPartition(
         partitionId -> {
           try {
@@ -444,7 +444,7 @@ public final class EngineRule extends ExternalResource {
     startProcessors(StreamProcessorMode.PROCESSING, true);
     TestUtil.waitUntil(
         () -> RecordingExporter.getRecords().size() >= lastSize,
-        "Failed to reprocess all events, only re-exported %d but expected %d",
+        "Failed to replay all events, only re-exported %d but expected %d",
         RecordingExporter.getRecords().size(),
         lastSize);
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamProcessorLifecycleAware.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamProcessorLifecycleAware.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.stream.api;
 
 public interface StreamProcessorLifecycleAware {
 
-  /** Callback after reprocessing was successful and before regular processing begins */
+  /** Callback after replay was successful and before regular processing begins */
   default void onRecovered(final ReadonlyStreamProcessorContext context) {}
 
   /** Callback which is called when StreamProcessor is on closing phase. */


### PR DESCRIPTION
## Description

Modernizes Zeebe's legacy "reprocess" terminology to "replay" — groundwork for #54845, whose upcoming replay-determinism test wants a clearly-named `EngineRule.replay()` to call.

Reprocessing was a term used before we replaced it with replay. See [zeebe-io/enhancements/ZEP004-wf-stream-processing.md](https://github.com/zeebe-io/enhancements/blob/master/ZEP004-wf-stream-processing.md) for details. This happened several years ago already.

The rename itself is trivial. The one part worth a reviewer's attention: renaming the test method `shouldTimeOutAfterReprocessing` reshuffles JUnit 4's method order in `JobTimeOutTest`, which surfaced a latent coupling — `shouldTimeOutJob` was silently relying on a neighbouring test to reset the engine's timeout scheduler. Rather than isolate the whole class (`@Rule` per method, much slower), I fixed the fragile assertion: it now asserts only the **event** intents `CREATED → TIMED_OUT` instead of the incidental `TIME_OUT` **command** — which the checker can legitimately emit twice under a jumped clock, and the engine safely rejects the duplicate. That assertion fix lands *before* the rename so every commit stays green and bisectable.

**How to review:** four commits, ordered to read top-to-bottom. The `test:` commit is the only behavioural change; the other three are pure renames.

**Deliberately out of scope:** `RetryTypedRecord`'s "reprocess" wording — that means incident-retry (re-submitting a failed command), a distinct concept from log replay.

**Validation:** `JobTimeOutTest` run 25× on the post-rename order → all green.

## Checklist

- [ ] Backports / E2E suite — not applicable (refactor + test-only change).

## Related issues

Groundwork for #54845 (does not close it).
