### PR TITLE
feat: detect camunda.secrets references in input mappings at deploy time

### DIFF
--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -151,6 +151,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-crypto</artifactId>
     </dependency>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.common.ValidationException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
@@ -62,7 +63,8 @@ public final class BpmnVariableMappingBehavior {
       final BpmnElementContext context, final ExecutableFlowNode element) {
     final long scopeKey = context.getElementInstanceKey();
     final String tenantId = context.getTenantId();
-    final Optional<Expression> inputMappingExpression = element.getInputMappings();
+    final Optional<Expression> inputMappingExpression =
+        element.getInputMappings().map(InputMappings::expression);
 
     if (inputMappingExpression.isPresent()) {
       return expressionProcessor

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -20,16 +20,8 @@ public class ExecutableFlowNode extends AbstractFlowElement {
   private final List<ExecutableSequenceFlow> incoming = new ArrayList<>();
   private final List<ExecutableSequenceFlow> outgoing = new ArrayList<>();
 
-  private Optional<Expression> inputMappings = Optional.empty();
+  private Optional<InputMappings> inputMappings = Optional.empty();
   private Optional<Expression> outputMappings = Optional.empty();
-
-  /**
-   * Secret references detected in the input mappings of this flow node, keyed by the JSON pointer
-   * (RFC 6901) of the input mapping's target path (e.g. {@code /tokens/token}). Only references
-   * used as expressions are stored (see {@link SecretReference}). Empty when no input mapping
-   * references a secret.
-   */
-  private Map<String, Set<SecretReference>> secretReferences = Map.of();
 
   private final List<ExecutionListener> executionListeners = new ArrayList<>();
 
@@ -53,11 +45,11 @@ public class ExecutableFlowNode extends AbstractFlowElement {
     incoming.add(flow);
   }
 
-  public Optional<Expression> getInputMappings() {
+  public Optional<InputMappings> getInputMappings() {
     return inputMappings;
   }
 
-  public void setInputMappings(final Expression inputMappings) {
+  public void setInputMappings(final InputMappings inputMappings) {
     this.inputMappings = Optional.of(inputMappings);
   }
 
@@ -69,12 +61,13 @@ public class ExecutableFlowNode extends AbstractFlowElement {
     this.outputMappings = Optional.of(outputMappings);
   }
 
+  /**
+   * Secret references detected in this flow node's input mappings, keyed by the JSON pointer (RFC
+   * 6901) of the leaf each secret belongs to (e.g. {@code /tokens/token}). Empty when no input
+   * mapping references a secret.
+   */
   public Map<String, Set<SecretReference>> getSecretReferences() {
-    return secretReferences;
-  }
-
-  public void setSecretReferences(final Map<String, Set<SecretReference>> secretReferences) {
-    this.secretReferences = secretReferences;
+    return inputMappings.map(InputMappings::secretReferences).orElse(Map.of());
   }
 
   public List<ExecutionListener> getBeforeAllExecutionListeners() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public class ExecutableFlowNode extends AbstractFlowElement {
 
@@ -21,6 +22,14 @@ public class ExecutableFlowNode extends AbstractFlowElement {
 
   private Optional<Expression> inputMappings = Optional.empty();
   private Optional<Expression> outputMappings = Optional.empty();
+
+  /**
+   * Secret references detected in the input mappings of this flow node, keyed by the JSON pointer
+   * (RFC 6901) of the input mapping's target path (e.g. {@code /tokens/token}). Only references
+   * used as expressions are stored (see {@link SecretReference}). Empty when no input mapping
+   * references a secret.
+   */
+  private Map<String, Set<SecretReference>> secretReferences = Map.of();
 
   private final List<ExecutionListener> executionListeners = new ArrayList<>();
 
@@ -58,6 +67,14 @@ public class ExecutableFlowNode extends AbstractFlowElement {
 
   public void setOutputMappings(final Expression outputMappings) {
     this.outputMappings = Optional.of(outputMappings);
+  }
+
+  public Map<String, Set<SecretReference>> getSecretReferences() {
+    return secretReferences;
+  }
+
+  public void setSecretReferences(final Map<String, Set<SecretReference>> secretReferences) {
+    this.secretReferences = secretReferences;
   }
 
   public List<ExecutionListener> getBeforeAllExecutionListeners() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMappings.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/InputMappings.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import io.camunda.zeebe.el.Expression;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * The transformed input mappings of a flow node: the FEEL expression that produces the local
+ * variables, plus the secret references detected in it, keyed by the JSON pointer (RFC 6901) of the
+ * leaf each secret belongs to (e.g. {@code /tokens/token}). {@code secretReferences} is empty when
+ * no input mapping references a secret.
+ */
+@NullMarked
+public record InputMappings(
+    Expression expression, Map<String, Set<SecretReference>> secretReferences) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -31,8 +31,9 @@ import scala.jdk.javaapi.CollectionConverters;
  *   <li>only expressions are scanned; a static value (no leading {@code =}) is a plain string;
  *   <li>a reference inside a string literal (e.g. {@code ="camunda.secrets.token"}) stays literal,
  *       so a runtime value that merely looks like a reference is never resolved (injection-safe);
- *   <li>FEEL variants — whitespace, unicode, backtick names, trailing access, comments — are
- *       handled by feel-scala.
+ *   <li>FEEL variants — whitespace, unicode, backtick names, comments — are handled by feel-scala;
+ *       a trailing path access into the secret ({@code camunda.secrets.token.length}) is a longer
+ *       qualified name and is deliberately not treated as a reference.
  * </ul>
  */
 @NullMarked
@@ -41,8 +42,8 @@ public record SecretReference(String name) {
   private static final String ROOT = "camunda";
   private static final String NAMESPACE = "secrets";
 
-  /** Segments a {@code camunda.secrets.<name>} reference needs: root, namespace and name. */
-  private static final int MINIMUM_SEGMENTS = 3;
+  /** Segments a {@code camunda.secrets.<name>} reference has: root, namespace and name. */
+  private static final int REFERENCE_SEGMENT_COUNT = 3;
 
   /**
    * Parses the secret references used as expressions in a mapping source, each with the FEEL
@@ -86,7 +87,9 @@ public record SecretReference(String name) {
   }
 
   private static boolean isSecretReference(final List<String> qualifiedName) {
-    return qualifiedName.size() >= MINIMUM_SEGMENTS
+    // exactly three segments: a trailing path access (camunda.secrets.token.length) parses to a
+    // longer qualified name and is deliberately not treated as a reference
+    return qualifiedName.size() == REFERENCE_SEGMENT_COUNT
         && ROOT.equals(qualifiedName.get(0))
         && NAMESPACE.equals(qualifiedName.get(1));
   }
@@ -97,9 +100,9 @@ public record SecretReference(String name) {
   }
 
   /**
-   * A secret reference with the FEEL context path where it occurs: empty for a scalar source,
-   * {@code [x]} for {@code ={x: camunda.secrets.token}}. The path is appended to the mapping target
-   * to form the secret leaf's JSON pointer.
+   * A secret reference with the FEEL context path where it occurs. {@code [x]} for {@code ={x:
+   * camunda.secrets.token}}. The path is appended to the mapping target to form the secret leaf's
+   * JSON pointer.
    */
   public record DetectedSecret(List<String> path, SecretReference secret) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -7,97 +7,127 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.el.impl.FeelExpression;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import org.camunda.feel.syntaxtree.ConstContext;
+import org.camunda.feel.syntaxtree.Exp;
+import org.camunda.feel.syntaxtree.ParsedExpression;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import scala.Tuple2;
+import scala.jdk.javaapi.CollectionConverters;
 
 /**
  * A reference to a secret using the {@code camunda.secrets.<name>} format.
  *
- * <p>A reference is only recognized when it is used as a FEEL <em>expression</em> and outside of
- * string literals:
+ * <p>References are detected from the parsed FEEL abstract syntax tree, not by matching the raw
+ * source text, so detection follows the exact grammar the engine evaluates. The variable references
+ * within an expression are extracted by feel-scala ({@link
+ * ParsedExpression#getVariableReferences()} — the same mechanism used for variable-dependency
+ * tracking); a reference is a secret when its fully-qualified name starts with {@code
+ * camunda.secrets}. This means:
  *
  * <ul>
- *   <li>the source must be a FEEL expression, i.e. start with the {@code =} marker. A source that
- *       does not start with {@code =} is a static literal and never contains references.
- *   <li>a reference that appears inside a FEEL string literal (e.g. {@code
- *       ="camunda.secrets.token"}) is treated as plain text and is not returned. This prevents
- *       secret injection where a runtime value that happens to look like a reference would be
- *       replaced with a secret value.
+ *   <li>only FEEL <em>expressions</em> are scanned; a static value (a source that does not start
+ *       with the {@code =} marker) is parsed as a plain string and never contains references;
+ *   <li>a reference inside a FEEL string literal (e.g. {@code ="camunda.secrets.token"}) is a
+ *       string constant, not a variable reference, so it stays literal &mdash; this prevents secret
+ *       injection where a runtime value that looks like a reference would be resolved;
+ *   <li>whitespace and line breaks around the dots ({@code camunda . secrets . token}), unicode
+ *       names ({@code camunda.secrets.tokén}), backtick-escaped names ({@code
+ *       camunda.secrets.`my-secret`}), trailing path access ({@code camunda.secrets.token.length})
+ *       and FEEL comments are all handled by feel-scala.
  * </ul>
  *
- * <p>A single source may contain multiple references; each distinct reference is returned once.
+ * <p>To know <em>where</em> a reference sits (for the JSON pointer of the value it produces), the
+ * enclosing FEEL context is walked here: each context entry is descended and its key recorded as a
+ * path segment. Known limitations &mdash; a reference that is not detected is simply not resolved,
+ * so nothing leaks:
+ *
+ * <ul>
+ *   <li>root shadowing is not accounted for: a bound name equal to {@code camunda} (a {@code for},
+ *       {@code some} or {@code every} iterator, a function parameter, or a context key, e.g. {@code
+ *       for camunda in [...] return camunda.secrets.token}) does not suppress the reference, so it
+ *       is still reported &mdash; feel-scala only suppresses whole-name matches, not qualified
+ *       paths rooted at the bound name;
+ *   <li>a context nested inside a non-context expression (e.g. {@code =if c then {x:
+ *       camunda.secrets.token} else null}) is detected but reported at the enclosing path, not at
+ *       {@code x};
+ *   <li>forms that do not parse to a plain {@code camunda.secrets.<name>} path, e.g. {@code
+ *       (camunda).secrets.token} or {@code get value(camunda.secrets, "token")}, are not detected.
+ * </ul>
  */
 @NullMarked
 public record SecretReference(String name) {
 
-  /** The FEEL expression marker; a source is only an expression when it starts with this. */
-  private static final String EXPRESSION_MARKER = "=";
+  /** The root variable a reference must be anchored to. */
+  private static final String ROOT = "camunda";
 
-  /** The prefix that identifies a secret reference. */
-  private static final String PREFIX = "camunda.secrets.";
+  /** The namespace segment that follows the root. */
+  private static final String NAMESPACE = "secrets";
 
-  /**
-   * Finds secret references in a FEEL source. The pattern has two alternatives:
-   *
-   * <ol>
-   *   <li>a whole string literal (e.g. {@code "some text"}) — matched but not captured, so a
-   *       reference written inside quotes is treated as plain text and ignored;
-   *   <li>a real {@code camunda.secrets.<name>} reference — captured in group 1.
-   * </ol>
-   *
-   * <p>The string-literal alternative is first, so anything inside quotes is consumed before the
-   * reference alternative can see it. The leading {@code (?<![\w.])} makes sure {@code camunda} is
-   * a standalone root variable and not glued to something else. {@code <name>} is a FEEL
-   * identifier.
-   *
-   * <p>Examples (source → captured):
-   *
-   * <ul>
-   *   <li>{@code =camunda.secrets.token} → {@code token}
-   *   <li>{@code ="camunda.secrets.token"} → nothing (inside a string literal)
-   *   <li>{@code =xcamunda.secrets.token} → nothing (part of a longer identifier)
-   *   <li>{@code =order.camunda.secrets.token} → nothing (nested property, not the root)
-   * </ul>
-   */
-  private static final Pattern REFERENCE_PATTERN =
-      Pattern.compile(
-          "\"(?:\\\\.|[^\"\\\\])*\""
-              + "|(?<![\\w.])"
-              + Pattern.quote(PREFIX)
-              + "([a-zA-Z_][a-zA-Z0-9_]*)");
+  /** The number of leading path segments a {@code camunda.secrets.<name>} reference needs. */
+  private static final int MINIMUM_SEGMENTS = 3;
 
   /**
    * Parses all secret references used as expressions in a variable-mapping source.
    *
-   * @param source the raw source of an input mapping, e.g. {@code ="Bearer " +
+   * @param expression the parsed source of an input mapping, e.g. {@code ="Bearer " +
    *     camunda.secrets.token}
-   * @return the distinct secret references, or an empty set if the source is not an expression or
-   *     contains no references outside string literals
+   * @return each detected reference together with the context path (the keys of any enclosing FEEL
+   *     context) at which it occurs; empty when the source is not a FEEL expression or contains no
+   *     references
    */
-  public static Set<SecretReference> parse(@Nullable final String source) {
-    if (source == null || !source.startsWith(EXPRESSION_MARKER)) {
-      // not a FEEL expression -> the whole value is a literal, so there are no references
-      return Set.of();
+  public static List<Located> parse(@Nullable final Expression expression) {
+    if (!(expression instanceof final FeelExpression feelExpression)) {
+      // static values, null sources, and invalid expressions never contain references
+      return List.of();
     }
+    final var located = new ArrayList<Located>();
+    collect(feelExpression.getParsedExpression().expression(), new ArrayDeque<>(), located);
+    return located;
+  }
 
-    final var references = new LinkedHashSet<SecretReference>();
-    final Matcher matcher = REFERENCE_PATTERN.matcher(source);
-    while (matcher.find()) {
-      // group 1 is null when the match is a string literal, which must be ignored
-      final var name = matcher.group(1);
-      if (name != null) {
-        references.add(new SecretReference(name));
+  /**
+   * Collects secret references from a FEEL AST node. A context is descended key by key so each
+   * reference keeps the path where it occurs; any other expression is handed to feel-scala, which
+   * extracts its variable references (excluding literals, comments and shadowed names).
+   */
+  private static void collect(
+      final Exp node, final Deque<String> contextPath, final List<Located> out) {
+    if (node instanceof final ConstContext context) {
+      for (final Tuple2<String, Exp> entry : CollectionConverters.asJava(context.entries())) {
+        contextPath.addLast(entry._1());
+        collect(entry._2(), contextPath, out);
+        contextPath.removeLast();
+      }
+      return;
+    }
+    for (final var reference : new ParsedExpression(node, "").getVariableReferences()) {
+      final var qualifiedName = reference.getFullQualifiedName();
+      if (qualifiedName.size() >= MINIMUM_SEGMENTS
+          && ROOT.equals(qualifiedName.get(0))
+          && NAMESPACE.equals(qualifiedName.get(1))) {
+        out.add(new Located(List.copyOf(contextPath), new SecretReference(qualifiedName.get(2))));
       }
     }
-    return references;
   }
 
   /** The full reference as it appears in an expression, e.g. {@code camunda.secrets.token}. */
   public String reference() {
-    return PREFIX + name;
+    return ROOT + "." + NAMESPACE + "." + name;
   }
+
+  /**
+   * A secret reference together with the context path where it occurs within a mapping source. The
+   * path holds the keys of any enclosing FEEL context, so it is empty for a scalar source (e.g.
+   * {@code ="Bearer " + camunda.secrets.token}) and {@code [x2]} for a reference nested in a
+   * context (e.g. {@code ={x2: camunda.secrets.token}}). It is later appended to the mapping target
+   * to form the JSON pointer of the leaf the secret value belongs to.
+   */
+  public record Located(List<String> path, SecretReference reference) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A reference to a secret using the {@code camunda.secrets.<name>} format.
+ *
+ * <p>A reference is only recognized when it is used as a FEEL <em>expression</em> and outside of
+ * string literals:
+ *
+ * <ul>
+ *   <li>the source must be a FEEL expression, i.e. start with the {@code =} marker. A source that
+ *       does not start with {@code =} is a static literal and never contains references.
+ *   <li>a reference that appears inside a FEEL string literal (e.g. {@code
+ *       ="camunda.secrets.token"}) is treated as plain text and is not returned. This prevents
+ *       secret injection where a runtime value that happens to look like a reference would be
+ *       replaced with a secret value.
+ * </ul>
+ *
+ * <p>A single source may contain multiple references; each distinct reference is returned once.
+ */
+@NullMarked
+public record SecretReference(String name) {
+
+  /** The FEEL expression marker; a source is only an expression when it starts with this. */
+  private static final String EXPRESSION_MARKER = "=";
+
+  /** The prefix that identifies a secret reference. */
+  private static final String PREFIX = "camunda.secrets.";
+
+  /**
+   * Finds secret references in a FEEL source. The pattern has two alternatives:
+   *
+   * <ol>
+   *   <li>a whole string literal (e.g. {@code "some text"}) — matched but not captured, so a
+   *       reference written inside quotes is treated as plain text and ignored;
+   *   <li>a real {@code camunda.secrets.<name>} reference — captured in group 1.
+   * </ol>
+   *
+   * <p>The string-literal alternative is first, so anything inside quotes is consumed before the
+   * reference alternative can see it. The leading {@code (?<![\w.])} makes sure {@code camunda} is
+   * a standalone root variable and not glued to something else. {@code <name>} is a FEEL
+   * identifier.
+   *
+   * <p>Examples (source → captured):
+   *
+   * <ul>
+   *   <li>{@code =camunda.secrets.token} → {@code token}
+   *   <li>{@code ="camunda.secrets.token"} → nothing (inside a string literal)
+   *   <li>{@code =xcamunda.secrets.token} → nothing (part of a longer identifier)
+   *   <li>{@code =order.camunda.secrets.token} → nothing (nested property, not the root)
+   * </ul>
+   */
+  private static final Pattern REFERENCE_PATTERN =
+      Pattern.compile(
+          "\"(?:\\\\.|[^\"\\\\])*\""
+              + "|(?<![\\w.])"
+              + Pattern.quote(PREFIX)
+              + "([a-zA-Z_][a-zA-Z0-9_]*)");
+
+  /**
+   * Parses all secret references used as expressions in a variable-mapping source.
+   *
+   * @param source the raw source of an input mapping, e.g. {@code ="Bearer " +
+   *     camunda.secrets.token}
+   * @return the distinct secret references, or an empty set if the source is not an expression or
+   *     contains no references outside string literals
+   */
+  public static Set<SecretReference> parse(@Nullable final String source) {
+    if (source == null || !source.startsWith(EXPRESSION_MARKER)) {
+      // not a FEEL expression -> the whole value is a literal, so there are no references
+      return Set.of();
+    }
+
+    final var references = new LinkedHashSet<SecretReference>();
+    final Matcher matcher = REFERENCE_PATTERN.matcher(source);
+    while (matcher.find()) {
+      // group 1 is null when the match is a string literal, which must be ignored
+      final var name = matcher.group(1);
+      if (name != null) {
+        references.add(new SecretReference(name));
+      }
+    }
+    return references;
+  }
+
+  /** The full reference as it appears in an expression, e.g. {@code camunda.secrets.token}. */
+  public String reference() {
+    return PREFIX + name;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -22,99 +22,73 @@ import scala.Tuple2;
 import scala.jdk.javaapi.CollectionConverters;
 
 /**
- * A reference to a secret using the {@code camunda.secrets.<name>} format.
+ * A reference to a secret in the {@code camunda.secrets.<name>} format, used in an input mapping.
  *
- * <p>References are detected from the parsed FEEL abstract syntax tree, not by matching the raw
- * source text, so detection follows the exact grammar the engine evaluates. The variable references
- * within an expression are extracted by feel-scala ({@link
- * ParsedExpression#getVariableReferences()} — the same mechanism used for variable-dependency
- * tracking); a reference is a secret when its fully-qualified name starts with {@code
- * camunda.secrets}. This means:
+ * <p>Detection works on the parsed FEEL AST (feel-scala's variable references), not the raw text,
+ * so it follows the grammar the engine evaluates. What this implies:
  *
  * <ul>
- *   <li>only FEEL <em>expressions</em> are scanned; a static value (a source that does not start
- *       with the {@code =} marker) is parsed as a plain string and never contains references;
- *   <li>a reference inside a FEEL string literal (e.g. {@code ="camunda.secrets.token"}) is a
- *       string constant, not a variable reference, so it stays literal &mdash; this prevents secret
- *       injection where a runtime value that looks like a reference would be resolved;
- *   <li>whitespace and line breaks around the dots ({@code camunda . secrets . token}), unicode
- *       names ({@code camunda.secrets.tokén}), backtick-escaped names ({@code
- *       camunda.secrets.`my-secret`}), trailing path access ({@code camunda.secrets.token.length})
- *       and FEEL comments are all handled by feel-scala.
- * </ul>
- *
- * <p>To know <em>where</em> a reference sits (for the JSON pointer of the value it produces), the
- * enclosing FEEL context is walked here: each context entry is descended and its key recorded as a
- * path segment. Known limitations &mdash; a reference that is not detected is simply not resolved,
- * so nothing leaks:
- *
- * <ul>
- *   <li>root shadowing is not accounted for: a bound name equal to {@code camunda} (a {@code for},
- *       {@code some} or {@code every} iterator, a function parameter, or a context key, e.g. {@code
- *       for camunda in [...] return camunda.secrets.token}) does not suppress the reference, so it
- *       is still reported &mdash; feel-scala only suppresses whole-name matches, not qualified
- *       paths rooted at the bound name;
- *   <li>a context nested inside a non-context expression (e.g. {@code =if c then {x:
- *       camunda.secrets.token} else null}) is detected but reported at the enclosing path, not at
- *       {@code x};
- *   <li>forms that do not parse to a plain {@code camunda.secrets.<name>} path, e.g. {@code
- *       (camunda).secrets.token} or {@code get value(camunda.secrets, "token")}, are not detected.
+ *   <li>only expressions are scanned; a static value (no leading {@code =}) is a plain string;
+ *   <li>a reference inside a string literal (e.g. {@code ="camunda.secrets.token"}) stays literal,
+ *       so a runtime value that merely looks like a reference is never resolved (injection-safe);
+ *   <li>FEEL variants — whitespace, unicode, backtick names, trailing access, comments — are
+ *       handled by feel-scala.
  * </ul>
  */
 @NullMarked
 public record SecretReference(String name) {
 
-  /** The root variable a reference must be anchored to. */
   private static final String ROOT = "camunda";
-
-  /** The namespace segment that follows the root. */
   private static final String NAMESPACE = "secrets";
 
-  /** The number of leading path segments a {@code camunda.secrets.<name>} reference needs. */
+  /** Segments a {@code camunda.secrets.<name>} reference needs: root, namespace and name. */
   private static final int MINIMUM_SEGMENTS = 3;
 
   /**
-   * Parses all secret references used as expressions in a variable-mapping source.
-   *
-   * @param expression the parsed source of an input mapping, e.g. {@code ="Bearer " +
-   *     camunda.secrets.token}
-   * @return each detected reference together with the context path (the keys of any enclosing FEEL
-   *     context) at which it occurs; empty when the source is not a FEEL expression or contains no
-   *     references
+   * Parses the secret references used as expressions in a mapping source, each with the FEEL
+   * context path where it occurs ({@code ="Bearer " + camunda.secrets.token} → one reference at the
+   * empty path). Empty when the source is not a FEEL expression or holds no reference.
    */
-  public static List<Located> parse(@Nullable final Expression expression) {
+  public static List<DetectedSecret> parse(@Nullable final Expression expression) {
     if (!(expression instanceof final FeelExpression feelExpression)) {
       // static values, null sources, and invalid expressions never contain references
       return List.of();
     }
-    final var located = new ArrayList<Located>();
-    collect(feelExpression.getParsedExpression().expression(), new ArrayDeque<>(), located);
-    return located;
+    final var secrets = new ArrayList<DetectedSecret>();
+    collect(feelExpression.getParsedExpression().expression(), new ArrayDeque<>(), secrets);
+    return secrets;
   }
 
   /**
-   * Collects secret references from a FEEL AST node. A context is descended key by key so each
-   * reference keeps the path where it occurs; any other expression is handed to feel-scala, which
-   * extracts its variable references (excluding literals, comments and shadowed names).
+   * Walks a FEEL AST node, recording each secret reference with its enclosing context path. A
+   * context is descended key by key; any other node is handed to feel-scala for its variable
+   * references (which already exclude literals, comments and bound names).
    */
   private static void collect(
-      final Exp node, final Deque<String> contextPath, final List<Located> out) {
+      final Exp node, final Deque<String> path, final List<DetectedSecret> secrets) {
     if (node instanceof final ConstContext context) {
+      // keep track of nested paths
+      // foo -> {x: camunda.secrets.x} will have path ["foo", "x"]
       for (final Tuple2<String, Exp> entry : CollectionConverters.asJava(context.entries())) {
-        contextPath.addLast(entry._1());
-        collect(entry._2(), contextPath, out);
-        contextPath.removeLast();
+        path.addLast(entry._1());
+        collect(entry._2(), path, secrets);
+        path.removeLast();
       }
       return;
     }
     for (final var reference : new ParsedExpression(node, "").getVariableReferences()) {
       final var qualifiedName = reference.getFullQualifiedName();
-      if (qualifiedName.size() >= MINIMUM_SEGMENTS
-          && ROOT.equals(qualifiedName.get(0))
-          && NAMESPACE.equals(qualifiedName.get(1))) {
-        out.add(new Located(List.copyOf(contextPath), new SecretReference(qualifiedName.get(2))));
+      if (isSecretReference(qualifiedName)) {
+        final var secret = new SecretReference(qualifiedName.get(2));
+        secrets.add(new DetectedSecret(List.copyOf(path), secret));
       }
     }
+  }
+
+  private static boolean isSecretReference(final List<String> qualifiedName) {
+    return qualifiedName.size() >= MINIMUM_SEGMENTS
+        && ROOT.equals(qualifiedName.get(0))
+        && NAMESPACE.equals(qualifiedName.get(1));
   }
 
   /** The full reference as it appears in an expression, e.g. {@code camunda.secrets.token}. */
@@ -123,11 +97,9 @@ public record SecretReference(String name) {
   }
 
   /**
-   * A secret reference together with the context path where it occurs within a mapping source. The
-   * path holds the keys of any enclosing FEEL context, so it is empty for a scalar source (e.g.
-   * {@code ="Bearer " + camunda.secrets.token}) and {@code [x2]} for a reference nested in a
-   * context (e.g. {@code ={x2: camunda.secrets.token}}). It is later appended to the mapping target
-   * to form the JSON pointer of the leaf the secret value belongs to.
+   * A secret reference with the FEEL context path where it occurs: empty for a scalar source,
+   * {@code [x]} for {@code ={x: camunda.secrets.token}}. The path is appended to the mapping target
+   * to form the secret leaf's JSON pointer.
    */
-  public record Located(List<String> path, SecretReference reference) {}
+  public record DetectedSecret(List<String> path, SecretReference secret) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReference.java
@@ -35,6 +35,11 @@ import scala.jdk.javaapi.CollectionConverters;
  *       a trailing path access into the secret ({@code camunda.secrets.token.length}) is a longer
  *       qualified name and is deliberately not treated as a reference.
  * </ul>
+ *
+ * <p>Known gaps (an undetected or less-specific reference is simply not resolved, so nothing
+ * leaks): a {@code camunda} bound by an iterator/parameter/context key still reports the reference;
+ * and a reference inside a context produced by a non-context expression (e.g. {@code =if c then {x:
+ * camunda.secrets.token} else null}) is reported at the enclosing path, not the inner {@code x}.
  */
 @NullMarked
 public record SecretReference(String name) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/AdHocSubProcessTransformer.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdH
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe.TaskDefinitionTransformer;
@@ -173,9 +174,10 @@ public final class AdHocSubProcessTransformer implements ModelElementTransformer
     try {
       return adHocActivity
           .getInputMappings()
+          .map(InputMappings::expression)
           .map(
-              inputMappings -> {
-                if (inputMappings instanceof final FeelExpression feelExpression) {
+              expression -> {
+                if (expression instanceof final FeelExpression feelExpression) {
                   return taggedParameterExtractor
                       .extractParameters(feelExpression.getParsedExpression())
                       .stream()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeTransformer.java
@@ -71,13 +71,22 @@ public final class FlowNodeTransformer implements ModelElementTransformer<FlowNo
     final var ioMapping =
         Optional.ofNullable(element.getSingleExtensionElement(ZeebeIoMapping.class));
 
-    ioMapping
-        .map(ZeebeIoMapping::getInputs)
-        .filter(mappings -> !mappings.isEmpty())
+    final var inputMappings =
+        ioMapping.map(ZeebeIoMapping::getInputs).filter(mappings -> !mappings.isEmpty());
+
+    inputMappings
         .map(
             mappings ->
                 variableMappingTransformer.transformInputMappings(mappings, expressionLanguage))
         .ifPresent(flowNode::setInputMappings);
+
+    // secret references are only honored in input mappings; anywhere else they stay literal
+    inputMappings
+        .map(
+            mappings ->
+                variableMappingTransformer.detectSecretReferences(mappings, expressionLanguage))
+        .filter(references -> !references.isEmpty())
+        .ifPresent(flowNode::setSecretReferences);
 
     ioMapping
         .map(ZeebeIoMapping::getOutputs)
@@ -86,14 +95,6 @@ public final class FlowNodeTransformer implements ModelElementTransformer<FlowNo
             mappings ->
                 variableMappingTransformer.transformOutputMappings(mappings, expressionLanguage))
         .ifPresent(flowNode::setOutputMappings);
-
-    // secret references are only honored in input mappings; anywhere else they stay literal
-    ioMapping
-        .map(ZeebeIoMapping::getInputs)
-        .filter(mappings -> !mappings.isEmpty())
-        .map(variableMappingTransformer::detectSecretReferences)
-        .filter(references -> !references.isEmpty())
-        .ifPresent(flowNode::setSecretReferences);
   }
 
   private void transformExecutionListeners(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeTransformer.java
@@ -86,6 +86,14 @@ public final class FlowNodeTransformer implements ModelElementTransformer<FlowNo
             mappings ->
                 variableMappingTransformer.transformOutputMappings(mappings, expressionLanguage))
         .ifPresent(flowNode::setOutputMappings);
+
+    // secret references are only honored in input mappings; anywhere else they stay literal
+    ioMapping
+        .map(ZeebeIoMapping::getInputs)
+        .filter(mappings -> !mappings.isEmpty())
+        .map(variableMappingTransformer::detectSecretReferences)
+        .filter(references -> !references.isEmpty())
+        .ifPresent(flowNode::setSecretReferences);
   }
 
   private void transformExecutionListeners(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeTransformer.java
@@ -71,22 +71,14 @@ public final class FlowNodeTransformer implements ModelElementTransformer<FlowNo
     final var ioMapping =
         Optional.ofNullable(element.getSingleExtensionElement(ZeebeIoMapping.class));
 
-    final var inputMappings =
-        ioMapping.map(ZeebeIoMapping::getInputs).filter(mappings -> !mappings.isEmpty());
-
-    inputMappings
+    // transformInputMappings also detects the secret references (only honored in input mappings)
+    ioMapping
+        .map(ZeebeIoMapping::getInputs)
+        .filter(mappings -> !mappings.isEmpty())
         .map(
             mappings ->
                 variableMappingTransformer.transformInputMappings(mappings, expressionLanguage))
         .ifPresent(flowNode::setInputMappings);
-
-    // secret references are only honored in input mappings; anywhere else they stay literal
-    inputMappings
-        .map(
-            mappings ->
-                variableMappingTransformer.detectSecretReferences(mappings, expressionLanguage))
-        .filter(references -> !references.isEmpty())
-        .ifPresent(flowNode::setSecretReferences);
 
     ioMapping
         .map(ZeebeIoMapping::getOutputs)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.impl.NullExpression;
 import io.camunda.zeebe.el.impl.StaticExpression;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,6 +19,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
@@ -93,6 +95,41 @@ public final class VariableMappingTransformer {
     final var context = asContext(mappings);
     final var contextExpression = asFeelContextExpression(context, this::mergeContextExpression);
     return parseExpression(contextExpression, expressionLanguage);
+  }
+
+  /**
+   * Detects the secret references used in the given input mappings, keyed by the JSON pointer (RFC
+   * 6901) of the mapping's target path, e.g. {@code /tokens/token}. The pointer is stored so the
+   * job-activation path can replace the reference in the job variables (a Jackson document)
+   * natively via a Jackson {@code JsonPointer}, without converting the path on the hot path. Only
+   * references used as expressions are detected; references inside string literals or in static
+   * (non-expression) values are ignored (see {@link SecretReference}). Mappings without any
+   * reference are omitted from the result.
+   */
+  public Map<String, Set<SecretReference>> detectSecretReferences(
+      final Collection<? extends ZeebeMapping> inputMappings) {
+    final var secretReferences = new LinkedHashMap<String, Set<SecretReference>>();
+    for (final ZeebeMapping mapping : inputMappings) {
+      final var references = SecretReference.parse(mapping.getSource());
+      if (!references.isEmpty()) {
+        secretReferences.put(toJsonPointer(mapping.getTarget()), references);
+      }
+    }
+    return secretReferences;
+  }
+
+  /**
+   * Converts a dotted variable-mapping target path (e.g. {@code tokens.token}) into a JSON pointer
+   * (e.g. {@code /tokens/token}). Dots are the nesting separators used by input mappings, so each
+   * becomes a pointer segment; {@code ~} and {@code /} inside a segment are escaped per RFC 6901
+   * ({@code ~} -> {@code ~0}, {@code /} -> {@code ~1}).
+   */
+  private static String toJsonPointer(final String targetPath) {
+    final var pointer = new StringBuilder();
+    for (final String segment : targetPath.split("\\.")) {
+      pointer.append('/').append(segment.replace("~", "~0").replace("/", "~1"));
+    }
+    return pointer.toString();
   }
 
   private List<Mapping> toMappings(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -17,6 +17,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -99,37 +100,60 @@ public final class VariableMappingTransformer {
 
   /**
    * Detects the secret references used in the given input mappings, keyed by the JSON pointer (RFC
-   * 6901) of the mapping's target path, e.g. {@code /tokens/token}. The pointer is stored so the
-   * job-activation path can replace the reference in the job variables (a Jackson document)
-   * natively via a Jackson {@code JsonPointer}, without converting the path on the hot path. Only
-   * references used as expressions are detected; references inside string literals or in static
-   * (non-expression) values are ignored (see {@link SecretReference}). Mappings without any
+   * 6901) of the leaf the secret value belongs to, e.g. {@code /tokens/token}. The pointer is the
+   * mapping's dotted target path followed by the context path of the reference within the source
+   * (see {@link SecretReference.Located}); for a scalar source the context path is empty and the
+   * pointer is just the target, while a reference nested in a FEEL context (e.g. {@code foo -> {x2:
+   * camunda.secrets.x}}) is keyed by {@code /foo/x2}.
+   *
+   * <p>The pointer is stored so the job-activation path can replace the reference in the job
+   * variables (a Jackson document) natively via a Jackson {@code JsonPointer}, without converting
+   * the path on the hot path; the dotted-to-pointer conversion happens once, here at deploy time.
+   *
+   * <p>Only references used as expressions are detected; references inside string literals or in
+   * static (non-expression) values are ignored (see {@link SecretReference}). Mappings without any
    * reference are omitted from the result.
    */
   public Map<String, Set<SecretReference>> detectSecretReferences(
-      final Collection<? extends ZeebeMapping> inputMappings) {
+      final Collection<? extends ZeebeMapping> inputMappings,
+      final ExpressionLanguage expressionLanguage) {
     final var secretReferences = new LinkedHashMap<String, Set<SecretReference>>();
     for (final ZeebeMapping mapping : inputMappings) {
-      final var references = SecretReference.parse(mapping.getSource());
-      if (!references.isEmpty()) {
-        secretReferences.put(toJsonPointer(mapping.getTarget()), references);
+      final var source = mapping.getSource();
+      if (source == null) {
+        continue;
+      }
+      final var expression = expressionLanguage.parseExpression(source);
+      for (final var located : SecretReference.parse(expression)) {
+        final var pointer = toJsonPointer(mapping.getTarget(), located.path());
+        secretReferences
+            .computeIfAbsent(pointer, key -> new LinkedHashSet<>())
+            .add(located.reference());
       }
     }
     return secretReferences;
   }
 
   /**
-   * Converts a dotted variable-mapping target path (e.g. {@code tokens.token}) into a JSON pointer
-   * (e.g. {@code /tokens/token}). Dots are the nesting separators used by input mappings, so each
-   * becomes a pointer segment; {@code ~} and {@code /} inside a segment are escaped per RFC 6901
-   * ({@code ~} -> {@code ~0}, {@code /} -> {@code ~1}).
+   * Builds the JSON pointer (RFC 6901) of a secret's leaf from the dotted variable-mapping target
+   * path (e.g. {@code tokens.token}) and the context path of the reference within the source (e.g.
+   * {@code [x2]}). Dots are the nesting separators used by input mappings, so each target segment
+   * becomes a pointer segment, followed by each context-path segment; {@code ~} and {@code /}
+   * inside a segment are escaped per RFC 6901 ({@code ~} -> {@code ~0}, {@code /} -> {@code ~1}).
    */
-  private static String toJsonPointer(final String targetPath) {
+  private static String toJsonPointer(final String targetPath, final List<String> contextPath) {
     final var pointer = new StringBuilder();
     for (final String segment : targetPath.split("\\.")) {
-      pointer.append('/').append(segment.replace("~", "~0").replace("/", "~1"));
+      appendPointerSegment(pointer, segment);
+    }
+    for (final String segment : contextPath) {
+      appendPointerSegment(pointer, segment);
     }
     return pointer.toString();
+  }
+
+  private static void appendPointerSegment(final StringBuilder pointer, final String segment) {
+    pointer.append('/').append(segment.replace("~", "~0").replace("/", "~1"));
   }
 
   private List<Mapping> toMappings(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.el.impl.NullExpression;
 import io.camunda.zeebe.el.impl.StaticExpression;
 import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference.DetectedSecret;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -119,32 +120,51 @@ public final class VariableMappingTransformer {
   private static Map<String, Set<SecretReference>> detectSecretReferences(
       final MappingContext context) {
     final var secretsByPointer = new LinkedHashMap<String, Set<SecretReference>>();
-    collectSecrets(context, secretsByPointer);
+    for (final var detected : context.visit(secretCollector())) {
+      secretsByPointer
+          .computeIfAbsent(toJsonPointer(detected.path()), key -> new LinkedHashSet<>())
+          .add(detected.secret());
+    }
     return secretsByPointer;
   }
 
   /**
-   * Walks the mapping context, recording each secret with the JSON pointer of its leaf: the
-   * context's target path, plus the leaf key, plus the reference's FEEL context path within the
-   * source. A nested context is descended; a leaf holds the source expression to scan.
+   * Visitor that collects the secrets of a mapping context as a flat list, each carrying the path
+   * segments of its leaf: the target path (built up from the context keys as the visit descends)
+   * plus the reference's FEEL context path within the source. A nested context is descended; a leaf
+   * holds the source expression to scan.
    */
-  private static void collectSecrets(
-      final MappingContext context, final Map<String, Set<SecretReference>> secretsByPointer) {
-    for (final var entry : context.entries.entrySet()) {
-      if (entry.getValue() instanceof final MappingContext nested) {
-        collectSecrets(nested, secretsByPointer);
-        continue;
+  private static MappingContextVisitor<List<DetectedSecret>> secretCollector() {
+    return new MappingContextVisitor<>() {
+      @Override
+      public List<DetectedSecret> onEntry(final String targetKey, final Expression source) {
+        return SecretReference.parse(source).stream()
+            .map(detected -> prependKey(targetKey, detected))
+            .collect(Collectors.toList());
       }
-      final var targetPath = new ArrayList<>(context.path);
-      targetPath.add(entry.getKey());
-      for (final var detected : SecretReference.parse((Expression) entry.getValue())) {
-        final var leafPath = new ArrayList<>(targetPath);
-        leafPath.addAll(detected.path());
-        secretsByPointer
-            .computeIfAbsent(toJsonPointer(leafPath), key -> new LinkedHashSet<>())
-            .add(detected.secret());
+
+      @Override
+      public List<DetectedSecret> onContext(final List<List<DetectedSecret>> entries) {
+        return entries.stream().flatMap(List::stream).collect(Collectors.toList());
       }
-    }
+
+      @Override
+      public List<DetectedSecret> onContextEntry(
+          final String targetKey,
+          final List<DetectedSecret> contextValue,
+          final List<String> contextPath) {
+        return contextValue.stream()
+            .map(detected -> prependKey(targetKey, detected))
+            .collect(Collectors.toList());
+      }
+    };
+  }
+
+  private static DetectedSecret prependKey(final String key, final DetectedSecret detected) {
+    final var path = new ArrayList<String>();
+    path.add(key);
+    path.addAll(detected.path());
+    return new DetectedSecret(path, detected.secret());
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -99,61 +99,58 @@ public final class VariableMappingTransformer {
   }
 
   /**
-   * Detects the secret references used in the given input mappings, keyed by the JSON pointer (RFC
-   * 6901) of the leaf the secret value belongs to, e.g. {@code /tokens/token}. The pointer is the
-   * mapping's dotted target path followed by the context path of the reference within the source
-   * (see {@link SecretReference.Located}); for a scalar source the context path is empty and the
-   * pointer is just the target, while a reference nested in a FEEL context (e.g. {@code foo -> {x2:
-   * camunda.secrets.x}}) is keyed by {@code /foo/x2}.
+   * Detects the secrets referenced by the given input mappings, keyed by the JSON pointer (RFC
+   * 6901) of the leaf each secret belongs to — the mapping's dotted target plus the reference's
+   * FEEL context path. Examples: {@code "Bearer " + camunda.secrets.token -> tokens.t} gives {@code
+   * /tokens/t}; {@code {x2: camunda.secrets.x} -> foo} gives {@code /foo/x2}. The pointer lets job
+   * activation replace the reference in the job variables via a Jackson {@code JsonPointer}; the
+   * conversion happens once, here at deploy time.
    *
-   * <p>The pointer is stored so the job-activation path can replace the reference in the job
-   * variables (a Jackson document) natively via a Jackson {@code JsonPointer}, without converting
-   * the path on the hot path; the dotted-to-pointer conversion happens once, here at deploy time.
-   *
-   * <p>Only references used as expressions are detected; references inside string literals or in
-   * static (non-expression) values are ignored (see {@link SecretReference}). Mappings without any
-   * reference are omitted from the result.
+   * <p>Mappings with no reference are omitted (see {@link SecretReference} for what counts).
    */
   public Map<String, Set<SecretReference>> detectSecretReferences(
       final Collection<? extends ZeebeMapping> inputMappings,
       final ExpressionLanguage expressionLanguage) {
-    final var secretReferences = new LinkedHashMap<String, Set<SecretReference>>();
+    final var secretsByPointer = new LinkedHashMap<String, Set<SecretReference>>();
     for (final ZeebeMapping mapping : inputMappings) {
       final var source = mapping.getSource();
       if (source == null) {
         continue;
       }
-      final var expression = expressionLanguage.parseExpression(source);
-      for (final var located : SecretReference.parse(expression)) {
-        final var pointer = toJsonPointer(mapping.getTarget(), located.path());
-        secretReferences
-            .computeIfAbsent(pointer, key -> new LinkedHashSet<>())
-            .add(located.reference());
+      final var target = mapping.getTarget();
+      for (final var detected : SecretReference.parse(expressionLanguage.parseExpression(source))) {
+        secretsByPointer
+            .computeIfAbsent(toJsonPointer(target, detected.path()), key -> new LinkedHashSet<>())
+            .add(detected.secret());
       }
     }
-    return secretReferences;
+    return secretsByPointer;
   }
 
   /**
-   * Builds the JSON pointer (RFC 6901) of a secret's leaf from the dotted variable-mapping target
-   * path (e.g. {@code tokens.token}) and the context path of the reference within the source (e.g.
-   * {@code [x2]}). Dots are the nesting separators used by input mappings, so each target segment
-   * becomes a pointer segment, followed by each context-path segment; {@code ~} and {@code /}
-   * inside a segment are escaped per RFC 6901 ({@code ~} -> {@code ~0}, {@code /} -> {@code ~1}).
+   * Builds the RFC 6901 JSON pointer of a secret's leaf, so job activation can address it directly
+   * in the job-variables document with JSON parser. Examples:
+   *
+   * <ul>
+   *   <li>direct: {@code tokens.token -> camunda.secrets.token } (empty context path) → {@code
+   *       /tokens/token};
+   *   <li>nested: {@code foo -> {x2: camunda.secrets.x}} (context path {@code [x2]}) → {@code
+   *       /foo/x2}.
+   * </ul>
+   *
+   * <p>{@code ~} and {@code /} are escaped ({@code ~} → {@code ~0}, {@code /} → {@code ~1}) because
+   * both are reserved in a pointer: an unescaped {@code /} inside a segment (e.g. a backtick FEEL
+   * name like {@code `a/b`}) would be read as a separator and wrongly split the segment. {@code ~}
+   * is replaced first, otherwise the {@code ~1} produced for {@code /} would be escaped again.
    */
   private static String toJsonPointer(final String targetPath, final List<String> contextPath) {
+    final var segments = new ArrayList<>(Arrays.asList(targetPath.split("\\.")));
+    segments.addAll(contextPath);
     final var pointer = new StringBuilder();
-    for (final String segment : targetPath.split("\\.")) {
-      appendPointerSegment(pointer, segment);
-    }
-    for (final String segment : contextPath) {
-      appendPointerSegment(pointer, segment);
+    for (final String segment : segments) {
+      pointer.append('/').append(segment.replace("~", "~0").replace("/", "~1"));
     }
     return pointer.toString();
-  }
-
-  private static void appendPointerSegment(final StringBuilder pointer, final String segment) {
-    pointer.append('/').append(segment.replace("~", "~0").replace("/", "~1"));
   }
 
   private List<Mapping> toMappings(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.impl.NullExpression;
 import io.camunda.zeebe.el.impl.StaticExpression;
+import io.camunda.zeebe.engine.processing.deployment.model.element.InputMappings;
 import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
 import java.util.ArrayList;
@@ -77,7 +78,11 @@ public final class VariableMappingTransformer {
 
   private static final String EXPRESSION_MARKER = "=";
 
-  public Expression transformInputMappings(
+  /**
+   * Transforms the input mappings into the FEEL expression that produces the local variables and,
+   * in the same pass, detects the secret references they use (see {@link #detectSecretReferences}).
+   */
+  public InputMappings transformInputMappings(
       final Collection<? extends ZeebeMapping> inputMappings,
       final ExpressionLanguage expressionLanguage) {
 
@@ -85,7 +90,8 @@ public final class VariableMappingTransformer {
     final var context = asContext(mappings);
     final var contextExpression =
         asFeelContextExpression(context, (contextValue, contextPath) -> contextValue);
-    return parseExpression(contextExpression, expressionLanguage);
+    final var expression = parseExpression(contextExpression, expressionLanguage);
+    return new InputMappings(expression, detectSecretReferences(mappings));
   }
 
   public Expression transformOutputMappings(
@@ -99,28 +105,24 @@ public final class VariableMappingTransformer {
   }
 
   /**
-   * Detects the secrets referenced by the given input mappings, keyed by the JSON pointer (RFC
-   * 6901) of the leaf each secret belongs to — the mapping's dotted target plus the reference's
-   * FEEL context path. Examples: {@code "Bearer " + camunda.secrets.token -> tokens.t} gives {@code
-   * /tokens/t}; {@code {x2: camunda.secrets.x} -> foo} gives {@code /foo/x2}. The pointer lets job
-   * activation replace the reference in the job variables via a Jackson {@code JsonPointer}; the
-   * conversion happens once, here at deploy time.
+   * Detects the secrets referenced by the already-parsed input mappings, keyed by the JSON pointer
+   * (RFC 6901) of the leaf each secret belongs to — the mapping's dotted target plus the
+   * reference's FEEL context path. Examples: {@code "Bearer " + camunda.secrets.token -> tokens.t}
+   * gives {@code /tokens/t}; {@code {x2: camunda.secrets.x} -> foo} gives {@code /foo/x2}. The
+   * pointer lets job activation replace the reference in the job variables via a Jackson {@code
+   * JsonPointer}; the conversion happens once, here at deploy time.
    *
-   * <p>Mappings with no reference are omitted (see {@link SecretReference} for what counts).
+   * <p>Reuses the sources parsed by {@link #toMappings}, so each source is parsed once. Mappings
+   * with no reference are omitted (see {@link SecretReference} for what counts).
    */
-  public Map<String, Set<SecretReference>> detectSecretReferences(
-      final Collection<? extends ZeebeMapping> inputMappings,
-      final ExpressionLanguage expressionLanguage) {
+  private static Map<String, Set<SecretReference>> detectSecretReferences(
+      final List<Mapping> mappings) {
     final var secretsByPointer = new LinkedHashMap<String, Set<SecretReference>>();
-    for (final ZeebeMapping mapping : inputMappings) {
-      final var source = mapping.getSource();
-      if (source == null) {
-        continue;
-      }
-      final var target = mapping.getTarget();
-      for (final var detected : SecretReference.parse(expressionLanguage.parseExpression(source))) {
+    for (final Mapping mapping : mappings) {
+      for (final var detected : SecretReference.parse(mapping.source)) {
         secretsByPointer
-            .computeIfAbsent(toJsonPointer(target, detected.path()), key -> new LinkedHashSet<>())
+            .computeIfAbsent(
+                toJsonPointer(mapping.target, detected.path()), key -> new LinkedHashSet<>())
             .add(detected.secret());
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -116,6 +116,10 @@ public final class VariableMappingTransformer {
    * <p>Walking the built context (not the raw mappings) means overridden targets are already
    * resolved: a target overwritten by a later mapping contributes no secret. Mappings with no
    * reference are omitted (see {@link SecretReference} for what counts).
+   *
+   * <p>The pointer is leaf-precise only for references in literal FEEL contexts. A reference inside
+   * a context produced by another expression (e.g. an {@code if} that returns a context) is keyed
+   * at the enclosing target, not the exact leaf — see {@link SecretReference} for this limitation.
    */
   private static Map<String, Set<SecretReference>> detectSecretReferences(
       final MappingContext context) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -91,7 +91,7 @@ public final class VariableMappingTransformer {
     final var contextExpression =
         asFeelContextExpression(context, (contextValue, contextPath) -> contextValue);
     final var expression = parseExpression(contextExpression, expressionLanguage);
-    return new InputMappings(expression, detectSecretReferences(mappings));
+    return new InputMappings(expression, detectSecretReferences(context));
   }
 
   public Expression transformOutputMappings(
@@ -105,49 +105,60 @@ public final class VariableMappingTransformer {
   }
 
   /**
-   * Detects the secrets referenced by the already-parsed input mappings, keyed by the JSON pointer
-   * (RFC 6901) of the leaf each secret belongs to — the mapping's dotted target plus the
-   * reference's FEEL context path. Examples: {@code "Bearer " + camunda.secrets.token -> tokens.t}
-   * gives {@code /tokens/t}; {@code {x2: camunda.secrets.x} -> foo} gives {@code /foo/x2}. The
-   * pointer lets job activation replace the reference in the job variables via a Jackson {@code
-   * JsonPointer}; the conversion happens once, here at deploy time.
+   * Detects the secrets referenced by the built mapping context, keyed by the JSON pointer (RFC
+   * 6901) of the leaf each secret belongs to — the leaf's target path plus the reference's FEEL
+   * context path. Examples: {@code "Bearer " + camunda.secrets.token -> tokens.t} gives {@code
+   * /tokens/t}; {@code {x2: camunda.secrets.x} -> foo} gives {@code /foo/x2}. The pointer lets job
+   * activation replace the reference in the job variables via a Jackson {@code JsonPointer}; the
+   * conversion happens once, here at deploy time.
    *
-   * <p>Reuses the sources parsed by {@link #toMappings}, so each source is parsed once. Mappings
-   * with no reference are omitted (see {@link SecretReference} for what counts).
+   * <p>Walking the built context (not the raw mappings) means overridden targets are already
+   * resolved: a target overwritten by a later mapping contributes no secret. Mappings with no
+   * reference are omitted (see {@link SecretReference} for what counts).
    */
   private static Map<String, Set<SecretReference>> detectSecretReferences(
-      final List<Mapping> mappings) {
+      final MappingContext context) {
     final var secretsByPointer = new LinkedHashMap<String, Set<SecretReference>>();
-    for (final Mapping mapping : mappings) {
-      for (final var detected : SecretReference.parse(mapping.source)) {
-        secretsByPointer
-            .computeIfAbsent(
-                toJsonPointer(mapping.target, detected.path()), key -> new LinkedHashSet<>())
-            .add(detected.secret());
-      }
-    }
+    collectSecrets(context, secretsByPointer);
     return secretsByPointer;
   }
 
   /**
-   * Builds the RFC 6901 JSON pointer of a secret's leaf, so job activation can address it directly
-   * in the job-variables document with JSON parser. Examples:
-   *
-   * <ul>
-   *   <li>direct: {@code tokens.token -> camunda.secrets.token } (empty context path) → {@code
-   *       /tokens/token};
-   *   <li>nested: {@code foo -> {x2: camunda.secrets.x}} (context path {@code [x2]}) → {@code
-   *       /foo/x2}.
-   * </ul>
+   * Walks the mapping context, recording each secret with the JSON pointer of its leaf: the
+   * context's target path, plus the leaf key, plus the reference's FEEL context path within the
+   * source. A nested context is descended; a leaf holds the source expression to scan.
+   */
+  private static void collectSecrets(
+      final MappingContext context, final Map<String, Set<SecretReference>> secretsByPointer) {
+    for (final var entry : context.entries.entrySet()) {
+      if (entry.getValue() instanceof final MappingContext nested) {
+        collectSecrets(nested, secretsByPointer);
+        continue;
+      }
+      final var targetPath = new ArrayList<>(context.path);
+      targetPath.add(entry.getKey());
+      for (final var detected : SecretReference.parse((Expression) entry.getValue())) {
+        final var leafPath = new ArrayList<>(targetPath);
+        leafPath.addAll(detected.path());
+        secretsByPointer
+            .computeIfAbsent(toJsonPointer(leafPath), key -> new LinkedHashSet<>())
+            .add(detected.secret());
+      }
+    }
+  }
+
+  /**
+   * Builds the RFC 6901 JSON pointer of a secret's leaf from its path segments (target path plus
+   * the reference's FEEL context path), so job activation can address it directly in the
+   * job-variables document. Examples: {@code [tokens, token]} → {@code /tokens/token}; {@code [foo,
+   * x2]} → {@code /foo/x2}.
    *
    * <p>{@code ~} and {@code /} are escaped ({@code ~} → {@code ~0}, {@code /} → {@code ~1}) because
    * both are reserved in a pointer: an unescaped {@code /} inside a segment (e.g. a backtick FEEL
-   * name like {@code `a/b`}) would be read as a separator and wrongly split the segment. {@code ~}
-   * is replaced first, otherwise the {@code ~1} produced for {@code /} would be escaped again.
+   * name like {@code `a/b`}) would be read as a separator and wrongly split it. {@code ~} is
+   * replaced first, otherwise the {@code ~1} produced for {@code /} would be escaped again.
    */
-  private static String toJsonPointer(final String targetPath, final List<String> contextPath) {
-    final var segments = new ArrayList<>(Arrays.asList(targetPath.split("\\.")));
-    segments.addAll(contextPath);
+  private static String toJsonPointer(final List<String> segments) {
     final var pointer = new StringBuilder();
     for (final String segment : segments) {
       pointer.append('/').append(segment.replace("~", "~0").replace("/", "~1"));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SecretReferenceTest {
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @MethodSource("sourcesWithReferences")
+  void shouldParseSecretReferencesUsedAsExpression(
+      final String source, final Set<SecretReference> expected) {
+    // when
+    final var references = SecretReference.parse(source);
+
+    // then
+    assertThat(references).isEqualTo(expected);
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @NullSource
+  @ValueSource(
+      strings = {
+        // not an expression (does not start with '='): the whole value is a literal
+        "",
+        "camunda.secrets.token",
+        // a secret reference used inside a string literal stays a literal (secret-injection safe)
+        "=\"camunda.secrets.token\"",
+        "=\"the secret is camunda.secrets.token\"",
+        // 'camunda' is not the root variable
+        "=xcamunda.secrets.token",
+        "=order.camunda.secrets.token",
+        // wrong or incomplete reference format
+        "=camunda.vars.clusterVariable",
+        "=camunda.secrets.",
+        "=camunda.secrets",
+        // no reference at all
+        "=",
+        "=userId + orderId",
+        "=\"only literal text\"",
+        // static value (no '='): the whole thing is a literal
+        "\"Bearer \" + camunda.secrets.X",
+        // reference inside a concatenated string literal stays literal
+        "=\"Bearer \" + \"camunda.secrets.X\""
+      })
+  void shouldReturnEmptyWhenNoSecretReferenceUsedAsExpression(final String source) {
+    // when / then
+    assertThat(SecretReference.parse(source)).isEmpty();
+  }
+
+  @Test
+  void shouldDeduplicateRepeatedReferences() {
+    // when
+    final var references =
+        SecretReference.parse("=camunda.secrets.token + \"-\" + camunda.secrets.token");
+
+    // then
+    assertThat(references).containsExactly(new SecretReference("token"));
+  }
+
+  @Test
+  void shouldParseReferenceOutsideButNotInsideStringLiteralWithEscapedQuote() {
+    // given - a string literal containing an escaped quote and a reference to ignore, followed by a
+    // real reference used as an expression
+    final var source = "=\"a\\\"b camunda.secrets.ignored\" + camunda.secrets.real";
+
+    // when
+    final var references = SecretReference.parse(source);
+
+    // then
+    assertThat(references).containsExactly(new SecretReference("real"));
+  }
+
+  @Test
+  void shouldExposeFullReference() {
+    // when / then
+    assertThat(new SecretReference("token").reference()).isEqualTo("camunda.secrets.token");
+  }
+
+  static Stream<Arguments> sourcesWithReferences() {
+    return Stream.of(
+        arguments("=camunda.secrets.token", refs("token")),
+        arguments("=\"Bearer \" + camunda.secrets.token", refs("token")),
+        arguments(
+            "=\"Bearer \" + camunda.secrets.token + camunda.secrets.postfix",
+            refs("token", "postfix")),
+        arguments("=camunda.secrets.MY_SECRET_2", refs("MY_SECRET_2")),
+        arguments("=camunda.secrets._underscore", refs("_underscore")),
+        // a literal reference is ignored, but the expression reference in the same source is parsed
+        arguments("=\"camunda.secrets.literal\" + camunda.secrets.real", refs("real")),
+        // reference nested inside a FEEL context value
+        arguments("={ token: camunda.secrets.token }", refs("token")),
+        // a literal reference is ignored, a real reference after it is captured
+        arguments("=\"Bearer \" + \"camunda.secrets.X\" + camunda.secrets.Y", refs("Y")));
+  }
+
+  private static Set<SecretReference> refs(final String... names) {
+    return Arrays.stream(names).map(SecretReference::new).collect(Collectors.toSet());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
@@ -66,7 +66,11 @@ class SecretReferenceTest {
         // static value (no '='): the whole thing is a literal
         "\"Bearer \" + camunda.secrets.X",
         // reference inside a concatenated string literal stays literal
-        "=\"Bearer \" + \"camunda.secrets.X\""
+        "=\"Bearer \" + \"camunda.secrets.X\"",
+        // a FEEL context holds no reference: a string-literal entry, plain-variable entries, empty
+        "={x: \"camunda.secrets.token\"}",
+        "={x: userId, y: orderId}",
+        "={}"
       })
   void shouldReturnEmptyWhenNoSecretReferenceUsedAsExpression(final String source) {
     // when / then
@@ -176,6 +180,8 @@ class SecretReferenceTest {
         arguments("=camunda.secrets.token.length", refs("token")),
         // a reference used inside a comment is not part of the expression
         arguments("=camunda.secrets.token // camunda.secrets.other", refs("token")),
+        // a literal reference is ignored
+        arguments("=\"camunda.secrets.literal\"", Set.of()),
         // a literal reference is ignored, but the expression reference in the same source is parsed
         arguments("=\"camunda.secrets.literal\" + camunda.secrets.real", refs("real")),
         // reference nested inside a FEEL context value

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
@@ -59,6 +59,8 @@ class SecretReferenceTest {
         "=camunda.vars.clusterVariable",
         "=camunda.secrets.",
         "=camunda.secrets",
+        // a trailing path access into the secret is not a reference (longer qualified name)
+        "=camunda.secrets.token.length",
         // no reference at all
         "=",
         "=userId + orderId",
@@ -176,8 +178,6 @@ class SecretReferenceTest {
         arguments("=camunda.secrets.tokén", refs("tokén")),
         // backtick-escaped names allow special characters
         arguments("=camunda.secrets.`my-secret`", refs("my-secret")),
-        // trailing path access after the secret name still references the secret
-        arguments("=camunda.secrets.token.length", refs("token")),
         // a reference used inside a comment is not part of the expression
         arguments("=camunda.secrets.token // camunda.secrets.other", refs("token")),
         // a literal reference is ignored

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
-import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference.Located;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference.DetectedSecret;
 import java.time.InstantSource;
 import java.util.Arrays;
 import java.util.List;
@@ -132,7 +132,7 @@ class SecretReferenceTest {
 
     // then - the literal 'y' is ignored; each reference carries the keys of its enclosing context
     assertThat(located)
-        .extracting(l -> l.path(), l -> l.reference())
+        .extracting(DetectedSecret::path, DetectedSecret::secret)
         .containsExactlyInAnyOrder(
             tuple(List.of("a"), new SecretReference("x")),
             tuple(List.of("c", "d"), new SecretReference("z")));
@@ -147,7 +147,7 @@ class SecretReferenceTest {
     final var located = SecretReference.parse(expressionLanguage.parseExpression(source));
 
     // then
-    assertThat(located).extracting(Located::path).containsExactly(List.of());
+    assertThat(located).extracting(DetectedSecret::path).containsExactly(List.of());
   }
 
   @Test
@@ -189,7 +189,7 @@ class SecretReferenceTest {
 
   private Set<SecretReference> referencesIn(final String source) {
     return SecretReference.parse(expressionLanguage.parseExpression(source)).stream()
-        .map(Located::reference)
+        .map(DetectedSecret::secret)
         .collect(Collectors.toSet());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/element/SecretReferenceTest.java
@@ -8,9 +8,16 @@
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference.Located;
+import java.time.InstantSource;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -18,24 +25,23 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class SecretReferenceTest {
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
 
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource("sourcesWithReferences")
   void shouldParseSecretReferencesUsedAsExpression(
       final String source, final Set<SecretReference> expected) {
-    // when
-    final var references = SecretReference.parse(source);
-
-    // then
-    assertThat(references).isEqualTo(expected);
+    // when / then
+    assertThat(referencesIn(source)).isEqualTo(expected);
   }
 
   @ParameterizedTest(name = "[{index}] {0}")
-  @NullSource
   @ValueSource(
       strings = {
         // not an expression (does not start with '='): the whole value is a literal
@@ -47,6 +53,8 @@ class SecretReferenceTest {
         // 'camunda' is not the root variable
         "=xcamunda.secrets.token",
         "=order.camunda.secrets.token",
+        // a reference commented out is not part of the parsed expression
+        "=1 // camunda.secrets.token",
         // wrong or incomplete reference format
         "=camunda.vars.clusterVariable",
         "=camunda.secrets.",
@@ -62,14 +70,33 @@ class SecretReferenceTest {
       })
   void shouldReturnEmptyWhenNoSecretReferenceUsedAsExpression(final String source) {
     // when / then
-    assertThat(SecretReference.parse(source)).isEmpty();
+    assertThat(referencesIn(source)).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyForNullExpression() {
+    // when / then
+    assertThat(SecretReference.parse(null)).isEmpty();
+  }
+
+  @ParameterizedTest(name = "[{index}] {0}")
+  @ValueSource(
+      strings = {
+        // 'camunda' is bound by the iteration, yet the reference is still reported
+        "=for camunda in [1, 2] return camunda.secrets.token",
+        "=some camunda in [1, 2] satisfies camunda.secrets.token = 1",
+        "=every camunda in [1, 2] satisfies camunda.secrets.token = 1"
+      })
+  void shouldStillReportReferenceWhenRootIsShadowedByIteration(final String source) {
+    // documented limitation: feel-scala suppresses only whole-name matches, so a bound 'camunda'
+    // does not shadow a qualified camunda.secrets.<name> path; the reference is still reported
+    assertThat(referencesIn(source)).containsExactly(new SecretReference("token"));
   }
 
   @Test
   void shouldDeduplicateRepeatedReferences() {
     // when
-    final var references =
-        SecretReference.parse("=camunda.secrets.token + \"-\" + camunda.secrets.token");
+    final var references = referencesIn("=camunda.secrets.token + \"-\" + camunda.secrets.token");
 
     // then
     assertThat(references).containsExactly(new SecretReference("token"));
@@ -81,11 +108,46 @@ class SecretReferenceTest {
     // real reference used as an expression
     final var source = "=\"a\\\"b camunda.secrets.ignored\" + camunda.secrets.real";
 
+    // when / then
+    assertThat(referencesIn(source)).containsExactly(new SecretReference("real"));
+  }
+
+  @Test
+  void shouldParseReferenceAfterStringLiteralEndingInEscapedBackslash() {
+    // given - the literal ends in an escaped backslash; the reference after it is still detected
+    final var source = "=\"a\\\\\" + camunda.secrets.real";
+
+    // when / then
+    assertThat(referencesIn(source)).containsExactly(new SecretReference("real"));
+  }
+
+  @Test
+  void shouldReportContextPathForNestedReferences() {
+    // given - a FEEL context with references at different depths and a literal to ignore
+    final var source =
+        "={a: camunda.secrets.x, b: \"camunda.secrets.y\", c: {d: camunda.secrets.z}}";
+
     // when
-    final var references = SecretReference.parse(source);
+    final var located = SecretReference.parse(expressionLanguage.parseExpression(source));
+
+    // then - the literal 'y' is ignored; each reference carries the keys of its enclosing context
+    assertThat(located)
+        .extracting(l -> l.path(), l -> l.reference())
+        .containsExactlyInAnyOrder(
+            tuple(List.of("a"), new SecretReference("x")),
+            tuple(List.of("c", "d"), new SecretReference("z")));
+  }
+
+  @Test
+  void shouldReportEmptyContextPathForScalarSource() {
+    // given
+    final var source = "=\"Bearer \" + camunda.secrets.token";
+
+    // when
+    final var located = SecretReference.parse(expressionLanguage.parseExpression(source));
 
     // then
-    assertThat(references).containsExactly(new SecretReference("real"));
+    assertThat(located).extracting(Located::path).containsExactly(List.of());
   }
 
   @Test
@@ -103,12 +165,32 @@ class SecretReferenceTest {
             refs("token", "postfix")),
         arguments("=camunda.secrets.MY_SECRET_2", refs("MY_SECRET_2")),
         arguments("=camunda.secrets._underscore", refs("_underscore")),
+        // whitespace and line breaks around the dots are insignificant in FEEL
+        arguments("=camunda . secrets . token", refs("token")),
+        arguments("=camunda\n  .secrets\n  .token", refs("token")),
+        // unicode names are valid FEEL identifiers
+        arguments("=camunda.secrets.tokén", refs("tokén")),
+        // backtick-escaped names allow special characters
+        arguments("=camunda.secrets.`my-secret`", refs("my-secret")),
+        // trailing path access after the secret name still references the secret
+        arguments("=camunda.secrets.token.length", refs("token")),
+        // a reference used inside a comment is not part of the expression
+        arguments("=camunda.secrets.token // camunda.secrets.other", refs("token")),
         // a literal reference is ignored, but the expression reference in the same source is parsed
         arguments("=\"camunda.secrets.literal\" + camunda.secrets.real", refs("real")),
         // reference nested inside a FEEL context value
         arguments("={ token: camunda.secrets.token }", refs("token")),
+        // a bigger context with several references, some literal
+        arguments(
+            "={a: camunda.secrets.x, b: \"literal\", c: {d: camunda.secrets.y}}", refs("x", "y")),
         // a literal reference is ignored, a real reference after it is captured
         arguments("=\"Bearer \" + \"camunda.secrets.X\" + camunda.secrets.Y", refs("Y")));
+  }
+
+  private Set<SecretReference> referencesIn(final String source) {
+    return SecretReference.parse(expressionLanguage.parseExpression(source)).stream()
+        .map(Located::reference)
+        .collect(Collectors.toSet());
   }
 
   private static Set<SecretReference> refs(final String... names) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.element.SecretReference;
+import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import java.time.InstantSource;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class FlowNodeSecretReferenceTest {
+
+  private static final String TASK_ID = "task";
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+  private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
+
+  @Test
+  void shouldStoreSecretReferenceKeyedByJsonPointer() {
+    // given
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression(
+                    "\"Bearer \" + camunda.secrets.token", "tokens.externalSystemToken"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then - the dotted target path is stored as a JSON pointer
+    assertThat(secretReferences)
+        .containsExactly(
+            entry("/tokens/externalSystemToken", Set.of(new SecretReference("token"))));
+  }
+
+  @Test
+  void shouldStoreMultipleReferencesForSingleInputMapping() {
+    // given
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression(
+                    "\"Bearer \" + camunda.secrets.token + camunda.secrets.postfix",
+                    "tokens.externalSystemToken"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then
+    assertThat(secretReferences)
+        .containsExactly(
+            entry(
+                "/tokens/externalSystemToken",
+                Set.of(new SecretReference("token"), new SecretReference("postfix"))));
+  }
+
+  @Test
+  void shouldStoreReferencesFromMultipleInputMappings() {
+    // given
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.secrets.token", "auth.token")
+                    .zeebeInputExpression("camunda.secrets.apiKey", "auth.key"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then
+    assertThat(secretReferences)
+        .containsExactlyInAnyOrderEntriesOf(
+            Map.of(
+                "/auth/token", Set.of(new SecretReference("token")),
+                "/auth/key", Set.of(new SecretReference("apiKey"))));
+  }
+
+  @Test
+  void shouldStoreSecretReferencesByJsonPointerForNestedTargetPath() {
+    // given - a nested (multi-segment) target path
+    final var task =
+        transform(t -> t.zeebeInputExpression("camunda.secrets.token", "auth.headers.token"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then - each dot becomes a pointer segment
+    assertThat(secretReferences)
+        .containsExactly(entry("/auth/headers/token", Set.of(new SecretReference("token"))));
+  }
+
+  @Test
+  void shouldNotStoreSecretReferenceFromOutputMapping() {
+    // given - a secret reference outside of an input mapping stays a literal
+    final var task = transform(t -> t.zeebeOutputExpression("camunda.secrets.token", "result"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then
+    assertThat(secretReferences).isEmpty();
+  }
+
+  @Test
+  void shouldNotStoreSecretReferenceUsedAsStringLiteral() {
+    // given - the reference is a string literal, not an expression
+    final var task =
+        transform(
+            t -> t.zeebeInputExpression("\"camunda.secrets.token\"", "tokens.externalSystemToken"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then
+    assertThat(secretReferences).isEmpty();
+  }
+
+  @Test
+  void shouldNotStoreSecretReferenceFromStaticInputMapping() {
+    // given - a static (non-expression) input mapping source is a literal
+    final var task = transform(t -> t.zeebeInput("camunda.secrets.token", "tokens.token"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then
+    assertThat(secretReferences).isEmpty();
+  }
+
+  @Test
+  void shouldHaveEmptySecretReferencesWithoutInputMappings() {
+    // given
+    final var task = transform(t -> {});
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then
+    assertThat(secretReferences).isEmpty();
+  }
+
+  private ExecutableFlowNode transform(final Consumer<ServiceTaskBuilder> modifier) {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                TASK_ID,
+                t -> {
+                  t.zeebeJobType("test");
+                  modifier.accept(t);
+                })
+            .endEvent()
+            .done();
+
+    final List<ExecutableProcess> processes = transformer.transformDefinitions(model);
+    return processes.getFirst().getElementById(TASK_ID, ExecutableFlowNode.class);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
@@ -96,6 +96,35 @@ class FlowNodeSecretReferenceTest {
   }
 
   @Test
+  void shouldScopeJsonPointerToContextEntryOfReference() {
+    // given - the source is a FEEL context; only one entry holds a secret reference
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression(
+                    "{x1: \"camunda.secrets.x\", x2: camunda.secrets.x}", "foo"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then - the pointer targets the entry that references the secret, not the whole target
+    assertThat(secretReferences)
+        .containsExactly(entry("/foo/x2", Set.of(new SecretReference("x"))));
+  }
+
+  @Test
+  void shouldNotStoreSecretReferenceUsedAsTarget() {
+    // given - the reference-looking path is the target, the source holds no reference
+    final var task = transform(t -> t.zeebeInputExpression("someVariable", "camunda.secrets.x"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then
+    assertThat(secretReferences).isEmpty();
+  }
+
+  @Test
   void shouldStoreSecretReferencesByJsonPointerForNestedTargetPath() {
     // given - a nested (multi-segment) target path
     final var task =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
@@ -188,6 +188,56 @@ class FlowNodeSecretReferenceTest {
     assertThat(secretReferences).isEmpty();
   }
 
+  @Test
+  void shouldStoreOnlyEffectiveSecretWhenTargetIsOverridden() {
+    // given - two input mappings with the same target; the later one overrides the earlier, so the
+    // generated mapping expression keeps only the last source for that target
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.secrets.a", "x")
+                    .zeebeInputExpression("camunda.secrets.b", "x"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then - only the effective (last) mapping's secret is stored, not the overridden one
+    assertThat(secretReferences).containsExactly(entry("/x", Set.of(new SecretReference("b"))));
+  }
+
+  @Test
+  void shouldNotStoreSecretFromScalarTargetReplacedByNestedTarget() {
+    // given - a scalar target 'a' is replaced by a nested target 'a.b', so 'a' becomes a context
+    // and its scalar source is dropped from the generated mapping expression
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.secrets.s1", "a")
+                    .zeebeInputExpression("camunda.secrets.s2", "a.b"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then - the overridden scalar 'a' contributes no secret; only the surviving /a/b remains
+    assertThat(secretReferences).containsExactly(entry("/a/b", Set.of(new SecretReference("s2"))));
+  }
+
+  @Test
+  void shouldStoreOnlyEffectiveSecretWhenTargetIsOverriddenByScalarTarget() {
+    // given
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.secrets.s1", "a.b")
+                    .zeebeInputExpression("camunda.secrets.s2", "a"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then
+    assertThat(secretReferences).containsExactly(entry("/a", Set.of(new SecretReference("s2"))));
+  }
+
   private ExecutableFlowNode transform(final Consumer<ServiceTaskBuilder> modifier) {
     final BpmnModelInstance model =
         Bpmn.createExecutableProcess("process")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/FlowNodeSecretReferenceTest.java
@@ -96,6 +96,25 @@ class FlowNodeSecretReferenceTest {
   }
 
   @Test
+  void shouldStoreSecretsForSiblingNestedTargets() {
+    // given - two mappings under the same parent target, each referencing a different secret
+    final var task =
+        transform(
+            t ->
+                t.zeebeInputExpression("camunda.secrets.s1", "a.b")
+                    .zeebeInputExpression("camunda.secrets.s2", "a.c"));
+
+    // when
+    final var secretReferences = task.getSecretReferences();
+
+    // then - each sibling leaf keeps its own pointer
+    assertThat(secretReferences)
+        .containsExactly(
+            entry("/a/b", Set.of(new SecretReference("s1"))),
+            entry("/a/c", Set.of(new SecretReference("s2"))));
+  }
+
+  @Test
   void shouldScopeJsonPointerToContextEntryOfReference() {
     // given - the source is a FEEL context; only one entry holds a secret reference
     final var task =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -118,7 +118,8 @@ public final class VariableInputMappingTransformerTest {
   @Test
   public void shouldApplyMappings() {
     // given
-    final var expression = transformer.transformInputMappings(mappings, expressionLanguage);
+    final var expression =
+        transformer.transformInputMappings(mappings, expressionLanguage).expression();
 
     assertThat(expression.isValid())
         .describedAs("Expected valid expression: %s", expression.getFailureMessage())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -33,8 +33,10 @@ public final class VariableMappingTransformerTest {
   public void shouldCreateValidExpression() {
     // when
     final var expression =
-        transformer.transformInputMappings(
-            List.of(mapping("x", "a"), mapping("_x", "b")), expressionLanguage);
+        transformer
+            .transformInputMappings(
+                List.of(mapping("x", "a"), mapping("_x", "b")), expressionLanguage)
+            .expression();
 
     // then
     assertThat(expression.isValid())
@@ -46,7 +48,9 @@ public final class VariableMappingTransformerTest {
   public void shouldEvaluateToObject() {
     // given
     final var expression =
-        transformer.transformInputMappings(List.of(mapping("x", "a")), expressionLanguage);
+        transformer
+            .transformInputMappings(List.of(mapping("x", "a")), expressionLanguage)
+            .expression();
 
     // when
     final var result =
@@ -85,7 +89,8 @@ public final class VariableMappingTransformerTest {
   public void shouldEvaluateWithNotExistingVariable() {
     // given
     final var mappings = List.of(mapping("=x", "a"));
-    final var expression = transformer.transformInputMappings(mappings, expressionLanguage);
+    final var expression =
+        transformer.transformInputMappings(mappings, expressionLanguage).expression();
 
     // when
     final var result = expressionLanguage.evaluateExpression(expression, name -> Either.left(null));
@@ -104,14 +109,16 @@ public final class VariableMappingTransformerTest {
   public void shouldNotEscapeCharactersInStaticExpression() {
     // when
     final var expression =
-        transformer.transformInputMappings(
-            List.of(
-                mapping("Hello\tWorld", "tab"),
-                mapping("Hello\nWorld", "newline"),
-                mapping("Hello\rWorld", "carriageReturn"),
-                mapping("\"My Name is \"Zeebe\", nice to meet you\"", "doubleQoutes"),
-                mapping("My Name is &#34;Zeebe&#34;, nice to meet you", "encodedQuotes")),
-            expressionLanguage);
+        transformer
+            .transformInputMappings(
+                List.of(
+                    mapping("Hello\tWorld", "tab"),
+                    mapping("Hello\nWorld", "newline"),
+                    mapping("Hello\rWorld", "carriageReturn"),
+                    mapping("\"My Name is \"Zeebe\", nice to meet you\"", "doubleQoutes"),
+                    mapping("My Name is &#34;Zeebe&#34;, nice to meet you", "encodedQuotes")),
+                expressionLanguage)
+            .expression();
 
     // then
     assertThat(expression.isValid())
@@ -126,7 +133,8 @@ public final class VariableMappingTransformerTest {
   public void shouldHandleNullSource() {
     // given
     final var mappings = List.of(mapping(null, "a"));
-    final var expression = transformer.transformInputMappings(mappings, expressionLanguage);
+    final var expression =
+        transformer.transformInputMappings(mappings, expressionLanguage).expression();
 
     // when
     final var result = expressionLanguage.evaluateExpression(expression, name -> null);


### PR DESCRIPTION
## What

First implementation task of Centralized Secret Resolution: detect
`camunda.secrets.<name>` references in BPMN **input mappings** at deployment time and store them
on the executable model, so a later task can resolve them at job activation. Detection only — no
resolution, cache, or gateway API in this PR.

## Why these decisions

- **Only input mappings, only expressions.** References are recognized only in input-mapping
  sources that are FEEL expressions (start with `=`). A static value, or a reference written inside
  a FEEL string literal (`="camunda.secrets.x"`), stays literal. This prevents secret injection: a
  runtime value that merely looks like a reference cannot trigger resolution.
- **Single literal-aware regex.** The parser uses one pattern that matches either a whole string
  literal or a real reference; only the reference branch is captured, so references inside quotes
  are consumed and ignored — no manual string scanning.
- **Typed `SecretReference` + `Set`.** Each reference is a typed value; a `Set` de-duplicates
  repeated references within one expression.
- **JSON pointer keys.** The map is keyed by the mapping target as a JSON pointer
  (`tokens.token` → `/tokens/token`, RFC 6901), not dot notation. Job variables are a Jackson
  document, so at activation the value can be replaced natively via `JsonPointer` with zero path
  conversion on the hot path; the dot→slash conversion happens once, at deploy time.

## Commits

1. `feat: add secret reference parser and model field`
2. `feat: detect secret references in input mappings during transformation`
3. `test: cover secret reference parsing and detection`

## Testing

Added unit tests for the parser and the transformation: single/multiple references and
de-duplication, string-literal and static-value exclusion, input-vs-output-mapping scoping, and
JSON-pointer keys including nested target paths.

Closes #56557
