### PR TITLE
feat: Add Archive Pending PI Metric

### DIFF
--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/AbstractProcessInstancesArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/AbstractProcessInstancesArchiverJob.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import io.camunda.operate.Metrics;
+import io.camunda.operate.schema.templates.ListViewTemplate;
+import io.camunda.operate.schema.templates.ProcessInstanceDependant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+
+public abstract class AbstractProcessInstancesArchiverJob extends AbstractArchiverJob {
+
+  private final List<Integer> partitionIds;
+  private final Archiver archiver;
+  private final ListViewTemplate processInstanceTemplate;
+  private final List<ProcessInstanceDependant> processInstanceDependantTemplates;
+  private final Metrics metrics;
+  private final ArchiverRepository archiverRepository;
+  private final Logger logger;
+
+  private final Map<Integer, Long> totalPendingByPartition = new ConcurrentHashMap<>();
+
+  protected AbstractProcessInstancesArchiverJob(
+      final Archiver archiver,
+      final List<Integer> partitionIds,
+      final ListViewTemplate processInstanceTemplate,
+      final List<ProcessInstanceDependant> processInstanceDependantTemplates,
+      final Metrics metrics,
+      final ArchiverRepository archiverRepository,
+      final Logger logger) {
+    this.archiver = archiver;
+    this.partitionIds = partitionIds;
+    this.processInstanceTemplate = processInstanceTemplate;
+    this.processInstanceDependantTemplates = processInstanceDependantTemplates;
+    this.metrics = metrics;
+    this.archiverRepository = archiverRepository;
+    this.logger = logger;
+
+    partitionIds.forEach(
+        partitionId -> {
+          totalPendingByPartition.put(partitionId, 0L);
+          metrics.registerGauge(
+              Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES,
+              totalPendingByPartition,
+              (pendingTotals) -> pendingTotals.getOrDefault(partitionId, 0L),
+              Metrics.TAG_KEY_PARTITION,
+              Integer.toString(partitionId));
+        });
+  }
+
+  @Override
+  public CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
+    if (archiveBatch == null) {
+      logger.debug("Nothing to archive");
+      updateTotalPendingByPartition(Map.of());
+      return CompletableFuture.completedFuture(0);
+    }
+
+    logger.debug("Following process instances are found for archiving: {}", archiveBatch);
+    updateTotalPendingByPartition(archiveBatch.getTotalPendingByPartition());
+
+    return archiveProcessInstances(archiveBatch)
+        .thenApply(
+            count -> {
+              metrics.recordCounts(Metrics.COUNTER_NAME_PROCESS_INSTANCES_ARCHIVED, count);
+              return count;
+            });
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getNextBatch() {
+    return archiverRepository.getProcessInstancesNextBatch(partitionIds);
+  }
+
+  public Archiver getArchiver() {
+    return archiver;
+  }
+
+  public List<ProcessInstanceDependant> getProcessInstanceDependantTemplates() {
+    return processInstanceDependantTemplates;
+  }
+
+  public ListViewTemplate getProcessInstanceTemplate() {
+    return processInstanceTemplate;
+  }
+
+  public ArchiverRepository getArchiverRepository() {
+    return archiverRepository;
+  }
+
+  private void updateTotalPendingByPartition(final Map<Integer, Long> pendingByPartition) {
+    // if a partition has no entry, archiving has caught up; set pending to 0L.
+    partitionIds.forEach(
+        partitionId ->
+            totalPendingByPartition.put(
+                partitionId, pendingByPartition.getOrDefault(partitionId, 0L)));
+  }
+
+  /**
+   * Archives the instances of the given non-null batch. The returned count is recorded under {@link
+   * Metrics#COUNTER_NAME_PROCESS_INSTANCES_ARCHIVED} and returned to the scheduler.
+   */
+  protected abstract CompletableFuture<Integer> archiveProcessInstances(ArchiveBatch archiveBatch);
+}

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiveBatch.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ArchiveBatch.java
@@ -8,35 +8,49 @@
 package io.camunda.operate.archiver;
 
 import java.util.List;
+import java.util.Map;
 
 public class ArchiveBatch {
 
-  private String finishDate;
-  private List<Object> ids;
+  private final List<Object> ids;
+  private final String finishDate;
+  private final Map<Integer, Long> totalPendingByPartition;
 
-  public ArchiveBatch(String finishDate, List<Object> ids) {
-    this.finishDate = finishDate;
+  public ArchiveBatch(final String finishDate, final List<Object> ids) {
+    this(finishDate, ids, Map.of());
+  }
+
+  public ArchiveBatch(
+      final String finishDate,
+      final List<Object> ids,
+      final Map<Integer, Long> totalPendingByPartition) {
     this.ids = ids;
+    this.totalPendingByPartition = totalPendingByPartition;
+    this.finishDate = finishDate;
+  }
+
+  public Map<Integer, Long> getTotalPendingByPartition() {
+    return totalPendingByPartition;
   }
 
   public String getFinishDate() {
     return finishDate;
   }
 
-  public void setFinishDate(String finishDate) {
-    this.finishDate = finishDate;
-  }
-
   public List<Object> getIds() {
     return ids;
   }
 
-  public void setIds(List<Object> ids) {
-    this.ids = ids;
-  }
-
   @Override
   public String toString() {
-    return "ArchiveBatch{" + "finishDate='" + finishDate + '\'' + ", ids=" + ids + '}';
+    return "ArchiveBatch{"
+        + "totalPendingByPartition="
+        + totalPendingByPartition
+        + ", finishDate='"
+        + finishDate
+        + '\''
+        + ", ids="
+        + ids
+        + '}';
   }
 }

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
@@ -73,8 +74,12 @@ import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.Aggregations;
+import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
 import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongTerms;
 import org.elasticsearch.search.aggregations.metrics.TopHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.FieldSortBuilder;
@@ -93,6 +98,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
 
   public static final int INTERNAL_SCROLL_KEEP_ALIVE_MS =
       30000; // this scroll timeout value is used for reindex and delete queries
+  public static final String TOTALS_AGG_NAME = "total_pending_archive_count";
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ElasticsearchArchiverRepository.class);
   private static final int UPDATE_RETRY_COUNT = 3;
@@ -171,7 +177,24 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                 hit -> ((String) hit.field(dateField).getValue()).compareTo(nextBucketStart) < 0)
             .map(hit -> (Object) hit.getId())
             .toList();
-    return new ArchiveBatch(bucketStart, ids);
+    return new ArchiveBatch(bucketStart, ids, getTotalPendingCount(searchResponse));
+  }
+
+  private AggregationBuilder getTotalPendingCountAggregation(final List<Integer> partitionIds) {
+    return AggregationBuilders.terms(TOTALS_AGG_NAME)
+        .field(ListViewTemplate.PARTITION_ID)
+        .size(partitionIds.size());
+  }
+
+  private Map<Integer, Long> getTotalPendingCount(final SearchResponse searchResponse) {
+    final Aggregations aggs = searchResponse.getAggregations();
+    if (aggs != null
+        && aggs.get(TOTALS_AGG_NAME) instanceof final ParsedLongTerms totalsByPartition) {
+      return totalsByPartition.getBuckets().stream()
+          .collect(
+              Collectors.toMap(bucket -> bucket.getKeyAsNumber().intValue(), Bucket::getDocCount));
+    }
+    return Map.of();
   }
 
   private CompletableFuture<SearchResponse> sendSearchRequest(final SearchRequest searchRequest) {
@@ -641,7 +664,8 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
                         ListViewTemplate.END_DATE,
                         operateProperties.getArchiver().getElsRolloverDateFormat())
                     .size(operateProperties.getArchiver().getRolloverBatchSize())
-                    .sort(ListViewTemplate.END_DATE, SortOrder.ASC))
+                    .sort(ListViewTemplate.END_DATE, SortOrder.ASC)
+                    .aggregation(getTotalPendingCountAggregation(partitionIds)))
             .requestCache(false); // we don't need to cache this, as each time we need new data
 
     LOGGER.debug("Finished process instances for archiving request: \n{}", q.toString());

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -96,9 +96,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class ElasticsearchArchiverRepository implements ArchiverRepository {
 
-  public static final int INTERNAL_SCROLL_KEEP_ALIVE_MS =
+  private static final int INTERNAL_SCROLL_KEEP_ALIVE_MS =
       30000; // this scroll timeout value is used for reindex and delete queries
-  public static final String TOTALS_AGG_NAME = "total_pending_archive_count";
+  private static final String TOTALS_AGG_NAME = "total_pending_archive_count";
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ElasticsearchArchiverRepository.class);
   private static final int UPDATE_RETRY_COUNT = 3;

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -13,6 +13,7 @@ import static io.camunda.operate.schema.SchemaManager.OPERATE_DELETE_ARCHIVED_IN
 import static io.camunda.operate.schema.templates.BatchOperationTemplate.END_DATE;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.bucketSortAggregation;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.dateHistogramAggregation;
+import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.termAggregation;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.topHitsAggregation;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.withSubaggregations;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.and;
@@ -55,9 +56,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.Conflicts;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.aggregations.LongTermsBucket;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
@@ -80,6 +83,7 @@ import org.springframework.stereotype.Component;
 public class OpensearchArchiverRepository implements ArchiverRepository {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchArchiverRepository.class);
+  private static final String TOTALS_AGG_NAME = "total_pending_archive_count";
 
   private final RichOpenSearchClient richOpenSearchClient;
   private final OpenSearchAsyncClient osAsyncClient;
@@ -222,7 +226,10 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
 
     final var searchRequestBuilder =
         finishedInstancesSearchRequestBuilder(
-            processInstanceTemplate.getFullQualifiedName(), ListViewTemplate.END_DATE, query);
+            processInstanceTemplate.getFullQualifiedName(),
+            ListViewTemplate.END_DATE,
+            query,
+            partitionIds);
 
     final var interval = operateProperties.getArchiver().getRolloverInterval();
     final var dateFormat = operateProperties.getArchiver().getElsRolloverDateFormat();
@@ -574,8 +581,26 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     return operateProperties.getOpensearch().getNumberOfShards();
   }
 
+  private Aggregation getTotalPendingCountAggregation(final List<Integer> partitionIds) {
+    return Aggregation.of(
+        a -> a.terms(termAggregation(ListViewTemplate.PARTITION_ID, partitionIds.size())));
+  }
+
+  private Map<Integer, Long> getTotalPendingCount(final SearchResponse<?> searchResponse) {
+    final var aggs = searchResponse.aggregations();
+    if (aggs != null && aggs.containsKey(TOTALS_AGG_NAME)) {
+      return aggs.get(TOTALS_AGG_NAME).lterms().buckets().array().stream()
+          .collect(
+              Collectors.toMap(bucket -> Integer.valueOf(bucket.key()), LongTermsBucket::docCount));
+    }
+    return Map.of();
+  }
+
   private SearchRequest.Builder finishedInstancesSearchRequestBuilder(
-      final String index, final String endDateField, final Query query) {
+      final String index,
+      final String endDateField,
+      final Query query,
+      final List<Integer> partitionIds) {
     final var format = operateProperties.getArchiver().getElsRolloverDateFormat();
     final var batchSize = operateProperties.getArchiver().getRolloverBatchSize();
     return searchRequestBuilder(index)
@@ -584,6 +609,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
         .fields(f -> f.field(endDateField).format(format))
         .size(batchSize)
         .sort(sortOptions(endDateField, Asc))
+        .aggregations(TOTALS_AGG_NAME, getTotalPendingCountAggregation(partitionIds))
         .requestCache(false); // we don't need to cache this, as each time we need new data
   }
 
@@ -608,7 +634,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
             .takeWhile(hit -> endDateOf(hit, dateField).compareTo(nextBucketStart) < 0)
             .map(hit -> (Object) hit.id())
             .toList();
-    return new ArchiveBatch(bucketStart, ids);
+    return new ArchiveBatch(bucketStart, ids, getTotalPendingCount(searchResponse));
   }
 
   private static String endDateOf(final Hit<?> hit, final String dateField) {

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -59,6 +59,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.Conflicts;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate.Kind;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.LongTermsBucket;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
@@ -588,7 +589,9 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
 
   private Map<Integer, Long> getTotalPendingCount(final SearchResponse<?> searchResponse) {
     final var aggs = searchResponse.aggregations();
-    if (aggs != null && aggs.containsKey(TOTALS_AGG_NAME)) {
+    if (aggs != null
+        && aggs.containsKey(TOTALS_AGG_NAME)
+        && aggs.get(TOTALS_AGG_NAME)._kind().equals(Kind.Lterms)) {
       return aggs.get(TOTALS_AGG_NAME).lterms().buckets().array().stream()
           .collect(
               Collectors.toMap(bucket -> Integer.valueOf(bucket.key()), LongTermsBucket::docCount));

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesArchiverJob.java
@@ -14,7 +14,9 @@ import io.camunda.operate.schema.templates.ListViewTemplate;
 import io.camunda.operate.schema.templates.ProcessInstanceDependant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +35,8 @@ public class ProcessInstancesArchiverJob extends AbstractArchiverJob {
   private final Metrics metrics;
   private final ArchiverRepository archiverRepository;
 
+  private final Map<Integer, Long> totalPendingByPartition = new ConcurrentHashMap<>();
+
   @Autowired
   public ProcessInstancesArchiverJob(
       final Archiver archiver,
@@ -47,6 +51,17 @@ public class ProcessInstancesArchiverJob extends AbstractArchiverJob {
     this.processInstanceDependantTemplates = processInstanceDependantTemplates;
     this.metrics = metrics;
     this.archiverRepository = archiverRepository;
+
+    partitionIds.forEach(
+        partitionId -> {
+          totalPendingByPartition.put(partitionId, 0L);
+          metrics.registerGauge(
+              Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES,
+              totalPendingByPartition,
+              (pendingTotals) -> totalPendingByPartition.getOrDefault(partitionId, 0L),
+              Metrics.TAG_KEY_PARTITION,
+              Integer.toString(partitionId));
+        });
   }
 
   @Override
@@ -55,6 +70,12 @@ public class ProcessInstancesArchiverJob extends AbstractArchiverJob {
 
     if (archiveBatch != null) {
       LOGGER.debug("Following process instances are found for archiving: {}", archiveBatch);
+      // if a partition has no entry, archiving has caught up; set pending to 0L.
+      final var pendingByPartition = archiveBatch.getTotalPendingByPartition();
+      partitionIds.forEach(
+          partitionId ->
+              totalPendingByPartition.put(
+                  partitionId, pendingByPartition.getOrDefault(partitionId, 0L)));
 
       archiveBatchFuture = new CompletableFuture<Integer>();
       final var finishDate = archiveBatch.getFinishDate();
@@ -79,6 +100,10 @@ public class ProcessInstancesArchiverJob extends AbstractArchiverJob {
     } else {
       LOGGER.debug("Nothing to archive");
       archiveBatchFuture = CompletableFuture.completedFuture(0);
+      partitionIds.forEach(
+          (partitionId) -> {
+            totalPendingByPartition.put(partitionId, 0L);
+          });
     }
 
     return archiveBatchFuture;

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesArchiverJob.java
@@ -14,9 +14,7 @@ import io.camunda.operate.schema.templates.ListViewTemplate;
 import io.camunda.operate.schema.templates.ProcessInstanceDependant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,17 +23,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class ProcessInstancesArchiverJob extends AbstractArchiverJob {
+public class ProcessInstancesArchiverJob extends AbstractProcessInstancesArchiverJob {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstancesArchiverJob.class);
-
-  private final List<Integer> partitionIds;
-  private final Archiver archiver;
-  private final ListViewTemplate processInstanceTemplate;
-  private final List<ProcessInstanceDependant> processInstanceDependantTemplates;
-  private final Metrics metrics;
-  private final ArchiverRepository archiverRepository;
-
-  private final Map<Integer, Long> totalPendingByPartition = new ConcurrentHashMap<>();
 
   @Autowired
   public ProcessInstancesArchiverJob(
@@ -45,86 +35,37 @@ public class ProcessInstancesArchiverJob extends AbstractArchiverJob {
       final List<ProcessInstanceDependant> processInstanceDependantTemplates,
       final Metrics metrics,
       final ArchiverRepository archiverRepository) {
-    this.archiver = archiver;
-    this.partitionIds = partitionIds;
-    this.processInstanceTemplate = processInstanceTemplate;
-    this.processInstanceDependantTemplates = processInstanceDependantTemplates;
-    this.metrics = metrics;
-    this.archiverRepository = archiverRepository;
-
-    partitionIds.forEach(
-        partitionId -> {
-          totalPendingByPartition.put(partitionId, 0L);
-          metrics.registerGauge(
-              Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES,
-              totalPendingByPartition,
-              (pendingTotals) -> totalPendingByPartition.getOrDefault(partitionId, 0L),
-              Metrics.TAG_KEY_PARTITION,
-              Integer.toString(partitionId));
-        });
+    super(
+        archiver,
+        partitionIds,
+        processInstanceTemplate,
+        processInstanceDependantTemplates,
+        metrics,
+        archiverRepository,
+        LOGGER);
   }
 
   @Override
-  public CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
-    final CompletableFuture<Integer> archiveBatchFuture;
+  protected CompletableFuture<Integer> archiveProcessInstances(final ArchiveBatch archiveBatch) {
+    final var finishDate = archiveBatch.getFinishDate();
+    final var processInstanceKeys = archiveBatch.getIds();
 
-    if (archiveBatch != null) {
-      LOGGER.debug("Following process instances are found for archiving: {}", archiveBatch);
-      // if a partition has no entry, archiving has caught up; set pending to 0L.
-      final var pendingByPartition = archiveBatch.getTotalPendingByPartition();
-      partitionIds.forEach(
-          partitionId ->
-              totalPendingByPartition.put(
-                  partitionId, pendingByPartition.getOrDefault(partitionId, 0L)));
-
-      archiveBatchFuture = new CompletableFuture<Integer>();
-      final var finishDate = archiveBatch.getFinishDate();
-      final var processInstanceKeys = archiveBatch.getIds();
-
-      moveDependableDocuments(finishDate, processInstanceKeys)
-          .thenCompose(
-              (v) -> {
-                return moveProcessInstanceDocuments(finishDate, processInstanceKeys);
-              })
-          .thenAccept(
-              (i) -> {
-                metrics.recordCounts(Metrics.COUNTER_NAME_PROCESS_INSTANCES_ARCHIVED, i);
-                archiveBatchFuture.complete(i);
-              })
-          .exceptionally(
-              (t) -> {
-                archiveBatchFuture.completeExceptionally(t);
-                return null;
-              });
-
-    } else {
-      LOGGER.debug("Nothing to archive");
-      archiveBatchFuture = CompletableFuture.completedFuture(0);
-      partitionIds.forEach(
-          (partitionId) -> {
-            totalPendingByPartition.put(partitionId, 0L);
-          });
-    }
-
-    return archiveBatchFuture;
-  }
-
-  @Override
-  public CompletableFuture<ArchiveBatch> getNextBatch() {
-    return archiverRepository.getProcessInstancesNextBatch(partitionIds);
+    return moveDependableDocuments(finishDate, processInstanceKeys)
+        .thenCompose((v) -> moveProcessInstanceDocuments(finishDate, processInstanceKeys));
   }
 
   private CompletableFuture<Void> moveDependableDocuments(
       final String finishDate, final List<Object> processInstanceKeys) {
     final var dependableFutures = new ArrayList<CompletableFuture<Void>>();
 
-    for (final ProcessInstanceDependant template : processInstanceDependantTemplates) {
+    for (final ProcessInstanceDependant template : getProcessInstanceDependantTemplates()) {
       final var moveDocumentsFuture =
-          archiver.moveDocuments(
-              template.getFullQualifiedName(),
-              ProcessInstanceDependant.PROCESS_INSTANCE_KEY,
-              finishDate,
-              processInstanceKeys);
+          getArchiver()
+              .moveDocuments(
+                  template.getFullQualifiedName(),
+                  ProcessInstanceDependant.PROCESS_INSTANCE_KEY,
+                  finishDate,
+                  processInstanceKeys);
       dependableFutures.add(moveDocumentsFuture);
     }
 
@@ -136,9 +77,9 @@ public class ProcessInstancesArchiverJob extends AbstractArchiverJob {
       final String finishDate, final List<Object> processInstanceKeys) {
     final var future = new CompletableFuture<Integer>();
 
-    archiver
+    getArchiver()
         .moveDocuments(
-            processInstanceTemplate.getFullQualifiedName(),
+            getProcessInstanceTemplate().getFullQualifiedName(),
             ListViewTemplate.PROCESS_INSTANCE_KEY,
             finishDate,
             processInstanceKeys)

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,7 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
   private final Metrics metrics;
   private final ArchiverRepository archiverRepository;
   private final ThreadPoolTaskScheduler executor;
+  private final Map<Integer, Long> totalPendingByPartition = new ConcurrentHashMap<>();
 
   @Autowired
   public ProcessInstancesByIdArchiverJob(
@@ -55,16 +57,38 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
     this.metrics = metrics;
     this.archiverRepository = archiverRepository;
     this.executor = executor;
+
+    partitionIds.forEach(
+        partitionId -> {
+          totalPendingByPartition.put(partitionId, 0L);
+          metrics.registerGauge(
+              Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES,
+              totalPendingByPartition,
+              (pendingTotals) -> totalPendingByPartition.getOrDefault(partitionId, 0L),
+              Metrics.TAG_KEY_PARTITION,
+              Integer.toString(partitionId));
+        });
   }
 
   @Override
   public CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
     if (archiveBatch == null) {
       LOGGER.debug("Nothing to archive");
+      partitionIds.forEach(
+          (partitionId) -> {
+            totalPendingByPartition.put(partitionId, 0L);
+          });
       return CompletableFuture.completedFuture(0);
     }
 
     LOGGER.debug("Following process instances are found for archiving: {}", archiveBatch);
+
+    // if a partition has no entry, archiving has caught up; set pending to 0L.
+    final Map<Integer, Long> pendingByPartition = archiveBatch.getTotalPendingByPartition();
+    partitionIds.forEach(
+        partitionId ->
+            totalPendingByPartition.put(
+                partitionId, pendingByPartition.getOrDefault(partitionId, 0L)));
 
     final String finishDate = archiveBatch.getFinishDate();
     final List<Object> keys = archiveBatch.getIds();

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJob.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,19 +26,12 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Scope(SCOPE_PROTOTYPE)
-public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
+public class ProcessInstancesByIdArchiverJob extends AbstractProcessInstancesArchiverJob {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ProcessInstancesByIdArchiverJob.class);
 
-  private final List<Integer> partitionIds;
-  private final Archiver archiver;
-  private final ListViewTemplate processInstanceTemplate;
-  private final List<ProcessInstanceDependant> processInstanceDependantTemplates;
-  private final Metrics metrics;
-  private final ArchiverRepository archiverRepository;
   private final ThreadPoolTaskScheduler executor;
-  private final Map<Integer, Long> totalPendingByPartition = new ConcurrentHashMap<>();
 
   @Autowired
   public ProcessInstancesByIdArchiverJob(
@@ -50,52 +42,27 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
       final Metrics metrics,
       final ArchiverRepository archiverRepository,
       @Qualifier("archiverThreadPoolExecutor") final ThreadPoolTaskScheduler executor) {
-    this.archiver = archiver;
-    this.partitionIds = partitionIds;
-    this.processInstanceTemplate = processInstanceTemplate;
-    this.processInstanceDependantTemplates = processInstanceDependantTemplates;
-    this.metrics = metrics;
-    this.archiverRepository = archiverRepository;
+    super(
+        archiver,
+        partitionIds,
+        processInstanceTemplate,
+        processInstanceDependantTemplates,
+        metrics,
+        archiverRepository,
+        LOGGER);
     this.executor = executor;
-
-    partitionIds.forEach(
-        partitionId -> {
-          totalPendingByPartition.put(partitionId, 0L);
-          metrics.registerGauge(
-              Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES,
-              totalPendingByPartition,
-              (pendingTotals) -> totalPendingByPartition.getOrDefault(partitionId, 0L),
-              Metrics.TAG_KEY_PARTITION,
-              Integer.toString(partitionId));
-        });
   }
 
   @Override
-  public CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
-    if (archiveBatch == null) {
-      LOGGER.debug("Nothing to archive");
-      partitionIds.forEach(
-          (partitionId) -> {
-            totalPendingByPartition.put(partitionId, 0L);
-          });
-      return CompletableFuture.completedFuture(0);
-    }
-
-    LOGGER.debug("Following process instances are found for archiving: {}", archiveBatch);
-
-    // if a partition has no entry, archiving has caught up; set pending to 0L.
-    final Map<Integer, Long> pendingByPartition = archiveBatch.getTotalPendingByPartition();
-    partitionIds.forEach(
-        partitionId ->
-            totalPendingByPartition.put(
-                partitionId, pendingByPartition.getOrDefault(partitionId, 0L)));
-
+  protected CompletableFuture<Integer> archiveProcessInstances(final ArchiveBatch archiveBatch) {
     final String finishDate = archiveBatch.getFinishDate();
     final List<Object> keys = archiveBatch.getIds();
 
     final String listViewDest =
-        archiver.getDestinationIndexName(
-            processInstanceTemplate.getFullQualifiedName(), finishDate);
+        getArchiver()
+            .getDestinationIndexName(
+                getProcessInstanceTemplate().getFullQualifiedName(), finishDate);
+
     final Map<String, List<Object>> piKeyFilter =
         Map.of(ListViewTemplate.PROCESS_INSTANCE_KEY, keys);
 
@@ -108,7 +75,7 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
         .thenComposeAsync(
             v ->
                 archive(
-                    processInstanceTemplate.getFullQualifiedName(),
+                    getProcessInstanceTemplate().getFullQualifiedName(),
                     listViewDest,
                     piKeyFilter,
                     Map.of(),
@@ -120,7 +87,7 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
         .thenComposeAsync(
             v ->
                 archive(
-                    processInstanceTemplate.getFullQualifiedName(),
+                    getProcessInstanceTemplate().getFullQualifiedName(),
                     listViewDest,
                     piKeyFilter,
                     Map.of(
@@ -128,17 +95,7 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
                         ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION),
                     Map.of()),
             executor)
-        .thenApplyAsync(
-            v -> {
-              metrics.recordCounts(Metrics.COUNTER_NAME_PROCESS_INSTANCES_ARCHIVED, keys.size());
-              return keys.size();
-            },
-            executor);
-  }
-
-  @Override
-  public CompletableFuture<ArchiveBatch> getNextBatch() {
-    return archiverRepository.getProcessInstancesNextBatch(partitionIds);
+        .thenApplyAsync(v -> keys.size(), executor);
   }
 
   private CompletableFuture<Void> archiveProcessDependants(
@@ -150,25 +107,25 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
 
     // archive dependent indices and list-view variables + activities in parallel
     final var futures = new ArrayList<CompletableFuture<Void>>();
-    for (final ProcessInstanceDependant template : processInstanceDependantTemplates) {
+    for (final ProcessInstanceDependant template : getProcessInstanceDependantTemplates()) {
       futures.add(
           archive(
               template.getFullQualifiedName(),
-              archiver.getDestinationIndexName(template.getFullQualifiedName(), finishDate),
+              getArchiver().getDestinationIndexName(template.getFullQualifiedName(), finishDate),
               Map.of(ProcessInstanceDependant.PROCESS_INSTANCE_KEY, keys),
               Map.of(),
               Map.of()));
     }
     futures.add(
         archive(
-            processInstanceTemplate.getFullQualifiedName(),
+            getProcessInstanceTemplate().getFullQualifiedName(),
             listViewDest,
             piKeyFilter,
             Map.of(ListViewTemplate.JOIN_RELATION, ListViewTemplate.VARIABLES_JOIN_RELATION),
             Map.of()));
     futures.add(
         archive(
-            processInstanceTemplate.getFullQualifiedName(),
+            getProcessInstanceTemplate().getFullQualifiedName(),
             listViewDest,
             piKeyFilter,
             Map.of(ListViewTemplate.JOIN_RELATION, ListViewTemplate.ACTIVITIES_JOIN_RELATION),
@@ -182,12 +139,13 @@ public class ProcessInstancesByIdArchiverJob extends AbstractArchiverJob {
       final Map<String, List<Object>> keysByField,
       final Map<String, String> inclusionFilters,
       final Map<String, String> exclusionFilters) {
-    return archiverRepository.moveDocumentsById(
-        sourceIndexName,
-        destinationIndexName,
-        keysByField,
-        inclusionFilters,
-        exclusionFilters,
-        executor);
+    return getArchiverRepository()
+        .moveDocumentsById(
+            sourceIndexName,
+            destinationIndexName,
+            keysByField,
+            inclusionFilters,
+            exclusionFilters,
+            executor);
   }
 }

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/AbstractProcessInstancesArchiverJobTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/AbstractProcessInstancesArchiverJobTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.Metrics;
+import io.camunda.operate.schema.templates.ListViewTemplate;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Common test suite for {@link AbstractProcessInstancesArchiverJob} implementations. Concrete
+ * subclasses supply the job under test via {@link #buildJob(List)} and stub the archiving mocks via
+ * {@link #mockSuccessfulArchiving()}.
+ */
+@ExtendWith(MockitoExtension.class)
+abstract class AbstractProcessInstancesArchiverJobTest {
+
+  @Mock protected Archiver archiver;
+  @Mock protected ListViewTemplate processInstanceTemplate;
+  @Mock protected ArchiverRepository archiverRepository;
+
+  protected MeterRegistry meterRegistry;
+  protected Metrics metrics;
+
+  @BeforeEach
+  void setUpMetrics() {
+    meterRegistry = new SimpleMeterRegistry();
+    metrics = new Metrics(meterRegistry);
+  }
+
+  /** Creates the job under test for the given partition IDs. */
+  protected abstract AbstractProcessInstancesArchiverJob buildJob(List<Integer> partitionIds);
+
+  /** Stubs the mocks so that archiving a non-null batch completes successfully. */
+  protected abstract void mockSuccessfulArchiving();
+
+  private double gaugeValue(final int partitionId) {
+    return meterRegistry
+        .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+        .tag(Metrics.TAG_KEY_PARTITION, Integer.toString(partitionId))
+        .gauge()
+        .value();
+  }
+
+  @Test
+  void gaugesRegisteredForEachPartition() {
+    buildJob(List.of(1, 2));
+
+    assertThat(gaugeValue(1)).isEqualTo(0.0);
+    assertThat(gaugeValue(2)).isEqualTo(0.0);
+  }
+
+  @Test
+  void archiveBatchUpdatesGaugeValues() {
+    mockSuccessfulArchiving();
+    final AbstractProcessInstancesArchiverJob job = buildJob(List.of(1, 2));
+
+    final ArchiveBatch batch =
+        new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 42L, 2, 17L));
+    job.archiveBatch(batch).join();
+
+    assertThat(gaugeValue(1)).isEqualTo(42.0);
+    assertThat(gaugeValue(2)).isEqualTo(17.0);
+  }
+
+  @Test
+  void archiveBatchWithNullReturnsZero() {
+    final AbstractProcessInstancesArchiverJob job = buildJob(List.of(1));
+
+    final Integer result = job.archiveBatch(null).join();
+
+    assertThat(result).isEqualTo(0);
+  }
+
+  @Test
+  void archiveBatchReturnsArchivedCount() {
+    mockSuccessfulArchiving();
+    final AbstractProcessInstancesArchiverJob job = buildJob(List.of(1));
+
+    final ArchiveBatch batch =
+        new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 2L));
+    final Integer result = job.archiveBatch(batch).join();
+
+    assertThat(result).isEqualTo(2);
+  }
+
+  @Test
+  void archiveBatchWithNullResetsPreviouslyNonZeroPendingToZero() {
+    mockSuccessfulArchiving();
+    final AbstractProcessInstancesArchiverJob job = buildJob(List.of(1, 2));
+
+    // first set pending counts > 0 via a real batch
+    job.archiveBatch(
+            new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 42L, 2, 17L)))
+        .join();
+    assertThat(gaugeValue(1)).isEqualTo(42.0);
+
+    // null batch (nothing to archive) must reset all partitions to 0
+    job.archiveBatch(null).join();
+
+    assertThat(gaugeValue(1)).isEqualTo(0.0);
+    assertThat(gaugeValue(2)).isEqualTo(0.0);
+  }
+
+  @Test
+  void archiveBatchResetsPartitionMissingFromAggregationToZero() {
+    mockSuccessfulArchiving();
+    final AbstractProcessInstancesArchiverJob job = buildJob(List.of(1, 2));
+
+    // batch 1: both partitions have pending
+    job.archiveBatch(new ArchiveBatch("2024-01-01", List.of("key1"), Map.of(1, 42L, 2, 17L)))
+        .join();
+    assertThat(gaugeValue(2)).isEqualTo(17.0);
+
+    // batch 2: partition 2 dropped to zero -> omitted from terms aggregation result
+    job.archiveBatch(new ArchiveBatch("2024-01-02", List.of("key2"), Map.of(1, 5L))).join();
+
+    assertThat(gaugeValue(1)).isEqualTo(5.0);
+    assertThat(gaugeValue(2)).isEqualTo(0.0);
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
@@ -63,6 +63,8 @@ import org.opensearch.client.opensearch._types.aggregations.BucketSortAggregatio
 import org.opensearch.client.opensearch._types.aggregations.Buckets;
 import org.opensearch.client.opensearch._types.aggregations.DateHistogramAggregate;
 import org.opensearch.client.opensearch._types.aggregations.DateHistogramAggregation;
+import org.opensearch.client.opensearch._types.aggregations.LongTermsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.LongTermsBucket;
 import org.opensearch.client.opensearch._types.aggregations.TopHitsAggregation;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.BulkRequest;
@@ -513,6 +515,8 @@ public class OpensearchArchiverRepositoryTest {
     when(searchRequestBuilder.size(anyInt())).thenReturn(searchRequestBuilder);
     when(searchRequestBuilder.sort((SortOptions) any())).thenReturn(searchRequestBuilder);
     when(searchRequestBuilder.requestCache(false)).thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.aggregations(anyString(), (Aggregation) any()))
+        .thenReturn(searchRequestBuilder);
   }
 
   @SuppressWarnings("unchecked")
@@ -556,5 +560,58 @@ public class OpensearchArchiverRepositoryTest {
     when(archiverProperties.getArchivingTimepoint()).thenReturn("now-1s");
     when(archiverProperties.getElsRolloverDateFormat()).thenReturn("format");
     when(decisionInstanceTemplate.getFullQualifiedName()).thenReturn("decisionsQualifiedName");
+  }
+
+  @Test
+  public void testGetProcessInstancesNextBatchIncludesTotalPendingByPartition() {
+    setProcessInstancesMocks();
+    try (final MockedStatic<RequestDSL> requestDSLMockedStatic = mockStatic(RequestDSL.class);
+        final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class);
+        final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class);
+        final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
+      setupPISearchRequestBuilderMock(requestDSLMockedStatic, queryDSLMockedStatic);
+
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      timerMockedStatic.when(Timer::start).thenReturn(timerSample);
+      when(metrics.getTimer(any())).thenReturn(mock(Timer.class));
+
+      // one hit so the batch is non-null and we reach getTotalPendingCount
+      final Hit<Object> hitA = hitWithEndDate("a", "2024-01-01");
+      final HitsMetadata<Object> hitsMeta = mock(HitsMetadata.class);
+      final SearchResponse<Object> resp = mock(SearchResponse.class);
+      when(resp.hits()).thenReturn(hitsMeta);
+      when(hitsMeta.hits()).thenReturn(List.of(hitA));
+
+      // set up aggregations with partition counts
+      final LongTermsAggregate ltermsAggregate = mock(LongTermsAggregate.class);
+      final Aggregate totalsAggregate = mock(Aggregate.class);
+      when(totalsAggregate.lterms()).thenReturn(ltermsAggregate);
+
+      final LongTermsBucket bucket1 = mock(LongTermsBucket.class);
+      when(bucket1.key()).thenReturn("1");
+      when(bucket1.docCount()).thenReturn(42L);
+      final LongTermsBucket bucket2 = mock(LongTermsBucket.class);
+      when(bucket2.key()).thenReturn("2");
+      when(bucket2.docCount()).thenReturn(17L);
+
+      final Buckets<LongTermsBucket> buckets = mock(Buckets.class);
+      when(buckets.array()).thenReturn(List.of(bucket1, bucket2));
+      when(ltermsAggregate.buckets()).thenReturn(buckets);
+
+      final Map<String, Aggregate> aggregations = new HashMap<>();
+      aggregations.put("total_pending_archive_count", totalsAggregate);
+      when(resp.aggregations()).thenReturn(aggregations);
+
+      opensearchUtil
+          .when(() -> OpensearchUtil.searchAsync(any(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(resp));
+
+      final CompletableFuture<ArchiveBatch> result =
+          underTest.getProcessInstancesNextBatch(PARTITION_IDS);
+      final ArchiveBatch batch = result.join();
+      assertThat(batch).isNotNull();
+      assertThat(batch.getTotalPendingByPartition()).containsEntry(1, 42L);
+      assertThat(batch.getTotalPendingByPartition()).containsEntry(2, 17L);
+    }
   }
 }

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
@@ -585,6 +585,7 @@ public class OpensearchArchiverRepositoryTest {
       // set up aggregations with partition counts
       final LongTermsAggregate ltermsAggregate = mock(LongTermsAggregate.class);
       final Aggregate totalsAggregate = mock(Aggregate.class);
+      when(totalsAggregate._kind()).thenReturn(Aggregate.Kind.Lterms);
       when(totalsAggregate.lterms()).thenReturn(ltermsAggregate);
 
       final LongTermsBucket bucket1 = mock(LongTermsBucket.class);

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesArchiverJobTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesArchiverJobTest.java
@@ -7,206 +7,25 @@
  */
 package io.camunda.operate.archiver;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import io.camunda.operate.Metrics;
-import io.camunda.operate.schema.templates.ListViewTemplate;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class ProcessInstancesArchiverJobTest {
+class ProcessInstancesArchiverJobTest extends AbstractProcessInstancesArchiverJobTest {
 
-  @Mock private Archiver archiver;
-  @Mock private ListViewTemplate processInstanceTemplate;
-  @Mock private ArchiverRepository archiverRepository;
-
-  private ProcessInstancesArchiverJob buildJob(
-      final List<Integer> partitionIds, final Metrics metrics) {
+  @Override
+  protected AbstractProcessInstancesArchiverJob buildJob(final List<Integer> partitionIds) {
     return new ProcessInstancesArchiverJob(
         archiver, partitionIds, processInstanceTemplate, List.of(), metrics, archiverRepository);
   }
 
-  @Test
-  void gaugesRegisteredForEachPartition() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-    final List<Integer> partitionIds = List.of(1, 2);
-
-    buildJob(partitionIds, metrics);
-
-    final double gauge1 =
-        meterRegistry
-            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-            .tag(Metrics.TAG_KEY_PARTITION, "1")
-            .gauge()
-            .value();
-    final double gauge2 =
-        meterRegistry
-            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-            .tag(Metrics.TAG_KEY_PARTITION, "2")
-            .gauge()
-            .value();
-
-    assertThat(gauge1).isEqualTo(0.0);
-    assertThat(gauge2).isEqualTo(0.0);
-  }
-
-  @Test
-  void archiveBatchUpdatesGaugeValues() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-    final List<Integer> partitionIds = List.of(1, 2);
-
+  @Override
+  protected void mockSuccessfulArchiving() {
     when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
     when(archiver.moveDocuments(anyString(), anyString(), anyString(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
-
-    final ProcessInstancesArchiverJob job = buildJob(partitionIds, metrics);
-
-    final ArchiveBatch batch =
-        new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 42L, 2, 17L));
-    job.archiveBatch(batch).join();
-
-    final double gauge1 =
-        meterRegistry
-            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-            .tag(Metrics.TAG_KEY_PARTITION, "1")
-            .gauge()
-            .value();
-    final double gauge2 =
-        meterRegistry
-            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-            .tag(Metrics.TAG_KEY_PARTITION, "2")
-            .gauge()
-            .value();
-
-    assertThat(gauge1).isEqualTo(42.0);
-    assertThat(gauge2).isEqualTo(17.0);
-  }
-
-  @Test
-  void archiveBatchWithNullReturnsZero() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-
-    final ProcessInstancesArchiverJob job = buildJob(List.of(1), metrics);
-
-    final Integer result = job.archiveBatch(null).join();
-
-    assertThat(result).isEqualTo(0);
-  }
-
-  @Test
-  void archiveBatchReturnsArchivedCount() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-
-    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
-    when(archiver.moveDocuments(anyString(), anyString(), anyString(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
-
-    final ProcessInstancesArchiverJob job = buildJob(List.of(1), metrics);
-
-    final ArchiveBatch batch =
-        new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 2L));
-    final Integer result = job.archiveBatch(batch).join();
-
-    assertThat(result).isEqualTo(2);
-  }
-
-  @Test
-  void archiveBatchWithNullResetsPreviouslyNonZeroPendingToZero() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-    final List<Integer> partitionIds = List.of(1, 2);
-
-    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
-    when(archiver.moveDocuments(anyString(), anyString(), anyString(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
-
-    final ProcessInstancesArchiverJob job = buildJob(partitionIds, metrics);
-
-    // first set pending counts > 0 via a real batch
-    job.archiveBatch(
-            new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 42L, 2, 17L)))
-        .join();
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "1")
-                .gauge()
-                .value())
-        .isEqualTo(42.0);
-
-    // null batch (nothing to archive) must reset all partitions to 0
-    job.archiveBatch(null).join();
-
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "1")
-                .gauge()
-                .value())
-        .isEqualTo(0.0);
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "2")
-                .gauge()
-                .value())
-        .isEqualTo(0.0);
-  }
-
-  @Test
-  void archiveBatchResetsPartitionMissingFromAggregationToZero() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-    final List<Integer> partitionIds = List.of(1, 2);
-
-    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
-    when(archiver.moveDocuments(anyString(), anyString(), anyString(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
-
-    final ProcessInstancesArchiverJob job = buildJob(partitionIds, metrics);
-
-    // batch 1: both partitions have pending
-    job.archiveBatch(new ArchiveBatch("2024-01-01", List.of("key1"), Map.of(1, 42L, 2, 17L)))
-        .join();
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "2")
-                .gauge()
-                .value())
-        .isEqualTo(17.0);
-
-    // batch 2: partition 2 dropped to zero -> omitted from terms aggregation result
-    job.archiveBatch(new ArchiveBatch("2024-01-02", List.of("key2"), Map.of(1, 5L))).join();
-
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "1")
-                .gauge()
-                .value())
-        .isEqualTo(5.0);
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "2")
-                .gauge()
-                .value())
-        .isEqualTo(0.0);
   }
 }

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesArchiverJobTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesArchiverJobTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.Metrics;
+import io.camunda.operate.schema.templates.ListViewTemplate;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessInstancesArchiverJobTest {
+
+  @Mock private Archiver archiver;
+  @Mock private ListViewTemplate processInstanceTemplate;
+  @Mock private ArchiverRepository archiverRepository;
+
+  private ProcessInstancesArchiverJob buildJob(
+      final List<Integer> partitionIds, final Metrics metrics) {
+    return new ProcessInstancesArchiverJob(
+        archiver, partitionIds, processInstanceTemplate, List.of(), metrics, archiverRepository);
+  }
+
+  @Test
+  void gaugesRegisteredForEachPartition() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+    final List<Integer> partitionIds = List.of(1, 2);
+
+    buildJob(partitionIds, metrics);
+
+    final double gauge1 =
+        meterRegistry
+            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+            .tag(Metrics.TAG_KEY_PARTITION, "1")
+            .gauge()
+            .value();
+    final double gauge2 =
+        meterRegistry
+            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+            .tag(Metrics.TAG_KEY_PARTITION, "2")
+            .gauge()
+            .value();
+
+    assertThat(gauge1).isEqualTo(0.0);
+    assertThat(gauge2).isEqualTo(0.0);
+  }
+
+  @Test
+  void archiveBatchUpdatesGaugeValues() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+    final List<Integer> partitionIds = List.of(1, 2);
+
+    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
+    when(archiver.moveDocuments(anyString(), anyString(), anyString(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final ProcessInstancesArchiverJob job = buildJob(partitionIds, metrics);
+
+    final ArchiveBatch batch =
+        new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 42L, 2, 17L));
+    job.archiveBatch(batch).join();
+
+    final double gauge1 =
+        meterRegistry
+            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+            .tag(Metrics.TAG_KEY_PARTITION, "1")
+            .gauge()
+            .value();
+    final double gauge2 =
+        meterRegistry
+            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+            .tag(Metrics.TAG_KEY_PARTITION, "2")
+            .gauge()
+            .value();
+
+    assertThat(gauge1).isEqualTo(42.0);
+    assertThat(gauge2).isEqualTo(17.0);
+  }
+
+  @Test
+  void archiveBatchWithNullReturnsZero() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+
+    final ProcessInstancesArchiverJob job = buildJob(List.of(1), metrics);
+
+    final Integer result = job.archiveBatch(null).join();
+
+    assertThat(result).isEqualTo(0);
+  }
+
+  @Test
+  void archiveBatchReturnsArchivedCount() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+
+    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
+    when(archiver.moveDocuments(anyString(), anyString(), anyString(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final ProcessInstancesArchiverJob job = buildJob(List.of(1), metrics);
+
+    final ArchiveBatch batch =
+        new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 2L));
+    final Integer result = job.archiveBatch(batch).join();
+
+    assertThat(result).isEqualTo(2);
+  }
+
+  @Test
+  void archiveBatchWithNullResetsPreviouslyNonZeroPendingToZero() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+    final List<Integer> partitionIds = List.of(1, 2);
+
+    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
+    when(archiver.moveDocuments(anyString(), anyString(), anyString(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final ProcessInstancesArchiverJob job = buildJob(partitionIds, metrics);
+
+    // first set pending counts > 0 via a real batch
+    job.archiveBatch(
+            new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 42L, 2, 17L)))
+        .join();
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "1")
+                .gauge()
+                .value())
+        .isEqualTo(42.0);
+
+    // null batch (nothing to archive) must reset all partitions to 0
+    job.archiveBatch(null).join();
+
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "1")
+                .gauge()
+                .value())
+        .isEqualTo(0.0);
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "2")
+                .gauge()
+                .value())
+        .isEqualTo(0.0);
+  }
+
+  @Test
+  void archiveBatchResetsPartitionMissingFromAggregationToZero() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+    final List<Integer> partitionIds = List.of(1, 2);
+
+    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
+    when(archiver.moveDocuments(anyString(), anyString(), anyString(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final ProcessInstancesArchiverJob job = buildJob(partitionIds, metrics);
+
+    // batch 1: both partitions have pending
+    job.archiveBatch(new ArchiveBatch("2024-01-01", List.of("key1"), Map.of(1, 42L, 2, 17L)))
+        .join();
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "2")
+                .gauge()
+                .value())
+        .isEqualTo(17.0);
+
+    // batch 2: partition 2 dropped to zero -> omitted from terms aggregation result
+    job.archiveBatch(new ArchiveBatch("2024-01-02", List.of("key2"), Map.of(1, 5L))).join();
+
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "1")
+                .gauge()
+                .value())
+        .isEqualTo(5.0);
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "2")
+                .gauge()
+                .value())
+        .isEqualTo(0.0);
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJobTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJobTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.Metrics;
+import io.camunda.operate.schema.templates.ListViewTemplate;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessInstancesByIdArchiverJobTest {
+
+  @Mock private Archiver archiver;
+  @Mock private ListViewTemplate processInstanceTemplate;
+  @Mock private ArchiverRepository archiverRepository;
+
+  private ProcessInstancesByIdArchiverJob buildJob(
+      final List<Integer> partitionIds, final Metrics metrics) {
+    final ThreadPoolTaskScheduler executor = new ThreadPoolTaskScheduler();
+    executor.setPoolSize(1);
+    executor.setThreadNamePrefix("archiver-test-");
+    executor.setDaemon(true);
+    executor.initialize();
+    return new ProcessInstancesByIdArchiverJob(
+        archiver,
+        partitionIds,
+        processInstanceTemplate,
+        List.of(),
+        metrics,
+        archiverRepository,
+        executor);
+  }
+
+  @Test
+  void gaugesRegisteredForEachPartition() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+    final List<Integer> partitionIds = List.of(1, 2);
+
+    buildJob(partitionIds, metrics);
+
+    final double gauge1 =
+        meterRegistry
+            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+            .tag(Metrics.TAG_KEY_PARTITION, "1")
+            .gauge()
+            .value();
+    final double gauge2 =
+        meterRegistry
+            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+            .tag(Metrics.TAG_KEY_PARTITION, "2")
+            .gauge()
+            .value();
+
+    assertThat(gauge1).isEqualTo(0.0);
+    assertThat(gauge2).isEqualTo(0.0);
+  }
+
+  @Test
+  void archiveBatchUpdatesGaugeValues() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+    final List<Integer> partitionIds = List.of(1, 2);
+
+    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
+    when(archiver.getDestinationIndexName(anyString(), anyString())).thenReturn("dest-index");
+    when(archiverRepository.moveDocumentsById(anyString(), anyString(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final ProcessInstancesByIdArchiverJob job = buildJob(partitionIds, metrics);
+
+    final ArchiveBatch batch =
+        new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 42L, 2, 17L));
+    job.archiveBatch(batch).join();
+
+    final double gauge1 =
+        meterRegistry
+            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+            .tag(Metrics.TAG_KEY_PARTITION, "1")
+            .gauge()
+            .value();
+    final double gauge2 =
+        meterRegistry
+            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+            .tag(Metrics.TAG_KEY_PARTITION, "2")
+            .gauge()
+            .value();
+
+    assertThat(gauge1).isEqualTo(42.0);
+    assertThat(gauge2).isEqualTo(17.0);
+  }
+
+  @Test
+  void archiveBatchWithNullReturnsZero() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+
+    final ProcessInstancesByIdArchiverJob job = buildJob(List.of(1), metrics);
+
+    final Integer result = job.archiveBatch(null).join();
+
+    assertThat(result).isEqualTo(0);
+  }
+
+  @Test
+  void archiveBatchReturnsArchivedCount() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+
+    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
+    when(archiver.getDestinationIndexName(anyString(), anyString())).thenReturn("dest-index");
+    when(archiverRepository.moveDocumentsById(anyString(), anyString(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final ProcessInstancesByIdArchiverJob job = buildJob(List.of(1), metrics);
+
+    final ArchiveBatch batch =
+        new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 2L));
+    final Integer result = job.archiveBatch(batch).join();
+
+    assertThat(result).isEqualTo(2);
+  }
+
+  @Test
+  void archiveBatchWithNullResetsPreviouslyNonZeroPendingToZero() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+    final List<Integer> partitionIds = List.of(1, 2);
+
+    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
+    when(archiver.getDestinationIndexName(anyString(), anyString())).thenReturn("dest-index");
+    when(archiverRepository.moveDocumentsById(anyString(), anyString(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final ProcessInstancesByIdArchiverJob job = buildJob(partitionIds, metrics);
+
+    // first set pending counts > 0 via a real batch
+    job.archiveBatch(
+            new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 42L, 2, 17L)))
+        .join();
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "1")
+                .gauge()
+                .value())
+        .isEqualTo(42.0);
+
+    // null batch (nothing to archive) must reset all partitions to 0
+    job.archiveBatch(null).join();
+
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "1")
+                .gauge()
+                .value())
+        .isEqualTo(0.0);
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "2")
+                .gauge()
+                .value())
+        .isEqualTo(0.0);
+  }
+
+  @Test
+  void archiveBatchResetsPartitionMissingFromAggregationToZero() {
+    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+    final Metrics metrics = new Metrics(meterRegistry);
+    final List<Integer> partitionIds = List.of(1, 2);
+
+    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
+    when(archiver.getDestinationIndexName(anyString(), anyString())).thenReturn("dest-index");
+    when(archiverRepository.moveDocumentsById(anyString(), anyString(), any(), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final ProcessInstancesByIdArchiverJob job = buildJob(partitionIds, metrics);
+
+    // batch 1: both partitions have pending
+    job.archiveBatch(new ArchiveBatch("2024-01-01", List.of("key1"), Map.of(1, 42L, 2, 17L)))
+        .join();
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "2")
+                .gauge()
+                .value())
+        .isEqualTo(17.0);
+
+    // batch 2: partition 2 dropped to zero -> omitted from terms aggregation result
+    job.archiveBatch(new ArchiveBatch("2024-01-02", List.of("key2"), Map.of(1, 5L))).join();
+
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "1")
+                .gauge()
+                .value())
+        .isEqualTo(5.0);
+    assertThat(
+            meterRegistry
+                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
+                .tag(Metrics.TAG_KEY_PARTITION, "2")
+                .gauge()
+                .value())
+        .isEqualTo(0.0);
+  }
+}

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJobTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ProcessInstancesByIdArchiverJobTest.java
@@ -7,33 +7,18 @@
  */
 package io.camunda.operate.archiver;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import io.camunda.operate.Metrics;
-import io.camunda.operate.schema.templates.ListViewTemplate;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
-@ExtendWith(MockitoExtension.class)
-class ProcessInstancesByIdArchiverJobTest {
+class ProcessInstancesByIdArchiverJobTest extends AbstractProcessInstancesArchiverJobTest {
 
-  @Mock private Archiver archiver;
-  @Mock private ListViewTemplate processInstanceTemplate;
-  @Mock private ArchiverRepository archiverRepository;
-
-  private ProcessInstancesByIdArchiverJob buildJob(
-      final List<Integer> partitionIds, final Metrics metrics) {
+  @Override
+  protected AbstractProcessInstancesArchiverJob buildJob(final List<Integer> partitionIds) {
     final ThreadPoolTaskScheduler executor = new ThreadPoolTaskScheduler();
     executor.setPoolSize(1);
     executor.setThreadNamePrefix("archiver-test-");
@@ -49,180 +34,11 @@ class ProcessInstancesByIdArchiverJobTest {
         executor);
   }
 
-  @Test
-  void gaugesRegisteredForEachPartition() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-    final List<Integer> partitionIds = List.of(1, 2);
-
-    buildJob(partitionIds, metrics);
-
-    final double gauge1 =
-        meterRegistry
-            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-            .tag(Metrics.TAG_KEY_PARTITION, "1")
-            .gauge()
-            .value();
-    final double gauge2 =
-        meterRegistry
-            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-            .tag(Metrics.TAG_KEY_PARTITION, "2")
-            .gauge()
-            .value();
-
-    assertThat(gauge1).isEqualTo(0.0);
-    assertThat(gauge2).isEqualTo(0.0);
-  }
-
-  @Test
-  void archiveBatchUpdatesGaugeValues() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-    final List<Integer> partitionIds = List.of(1, 2);
-
+  @Override
+  protected void mockSuccessfulArchiving() {
     when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
     when(archiver.getDestinationIndexName(anyString(), anyString())).thenReturn("dest-index");
     when(archiverRepository.moveDocumentsById(anyString(), anyString(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(null));
-
-    final ProcessInstancesByIdArchiverJob job = buildJob(partitionIds, metrics);
-
-    final ArchiveBatch batch =
-        new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 42L, 2, 17L));
-    job.archiveBatch(batch).join();
-
-    final double gauge1 =
-        meterRegistry
-            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-            .tag(Metrics.TAG_KEY_PARTITION, "1")
-            .gauge()
-            .value();
-    final double gauge2 =
-        meterRegistry
-            .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-            .tag(Metrics.TAG_KEY_PARTITION, "2")
-            .gauge()
-            .value();
-
-    assertThat(gauge1).isEqualTo(42.0);
-    assertThat(gauge2).isEqualTo(17.0);
-  }
-
-  @Test
-  void archiveBatchWithNullReturnsZero() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-
-    final ProcessInstancesByIdArchiverJob job = buildJob(List.of(1), metrics);
-
-    final Integer result = job.archiveBatch(null).join();
-
-    assertThat(result).isEqualTo(0);
-  }
-
-  @Test
-  void archiveBatchReturnsArchivedCount() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-
-    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
-    when(archiver.getDestinationIndexName(anyString(), anyString())).thenReturn("dest-index");
-    when(archiverRepository.moveDocumentsById(anyString(), anyString(), any(), any(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
-
-    final ProcessInstancesByIdArchiverJob job = buildJob(List.of(1), metrics);
-
-    final ArchiveBatch batch =
-        new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 2L));
-    final Integer result = job.archiveBatch(batch).join();
-
-    assertThat(result).isEqualTo(2);
-  }
-
-  @Test
-  void archiveBatchWithNullResetsPreviouslyNonZeroPendingToZero() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-    final List<Integer> partitionIds = List.of(1, 2);
-
-    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
-    when(archiver.getDestinationIndexName(anyString(), anyString())).thenReturn("dest-index");
-    when(archiverRepository.moveDocumentsById(anyString(), anyString(), any(), any(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
-
-    final ProcessInstancesByIdArchiverJob job = buildJob(partitionIds, metrics);
-
-    // first set pending counts > 0 via a real batch
-    job.archiveBatch(
-            new ArchiveBatch("2024-01-01", List.of("key1", "key2"), Map.of(1, 42L, 2, 17L)))
-        .join();
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "1")
-                .gauge()
-                .value())
-        .isEqualTo(42.0);
-
-    // null batch (nothing to archive) must reset all partitions to 0
-    job.archiveBatch(null).join();
-
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "1")
-                .gauge()
-                .value())
-        .isEqualTo(0.0);
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "2")
-                .gauge()
-                .value())
-        .isEqualTo(0.0);
-  }
-
-  @Test
-  void archiveBatchResetsPartitionMissingFromAggregationToZero() {
-    final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-    final Metrics metrics = new Metrics(meterRegistry);
-    final List<Integer> partitionIds = List.of(1, 2);
-
-    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("list-view");
-    when(archiver.getDestinationIndexName(anyString(), anyString())).thenReturn("dest-index");
-    when(archiverRepository.moveDocumentsById(anyString(), anyString(), any(), any(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(null));
-
-    final ProcessInstancesByIdArchiverJob job = buildJob(partitionIds, metrics);
-
-    // batch 1: both partitions have pending
-    job.archiveBatch(new ArchiveBatch("2024-01-01", List.of("key1"), Map.of(1, 42L, 2, 17L)))
-        .join();
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "2")
-                .gauge()
-                .value())
-        .isEqualTo(17.0);
-
-    // batch 2: partition 2 dropped to zero -> omitted from terms aggregation result
-    job.archiveBatch(new ArchiveBatch("2024-01-02", List.of("key2"), Map.of(1, 5L))).join();
-
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "1")
-                .gauge()
-                .value())
-        .isEqualTo(5.0);
-    assertThat(
-            meterRegistry
-                .get(Metrics.GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES)
-                .tag(Metrics.TAG_KEY_PARTITION, "2")
-                .gauge()
-                .value())
-        .isEqualTo(0.0);
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -74,6 +74,9 @@ public class Metrics {
   public static final String GAUGE_NAME_IMPORT_FNI_TREE_PATH_CACHE_SIZE =
       OPERATE_NAMESPACE + "import.fni.tree.path.cache.size";
 
+  public static final String GAUGE_NAME_TOTAL_PENDING_ARCHIVE_INSTANCES =
+      OPERATE_NAMESPACE + "archive.pending.process.instances";
+
   // Tags
   // -----
   //  Keys:


### PR DESCRIPTION

## Description

We do not have a metric to determine if there are process instances awaiting archival in 8.7. This simply tap in to teh get next batch call to get pending counts by partition and publishes the metric.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
