### PR TITLE
fix: validate reindex response for task migration

### DIFF
--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -22,6 +22,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.ExistsQuery;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.BulkResponse;
 import co.elastic.clients.elasticsearch.core.ReindexRequest;
+import co.elastic.clients.elasticsearch.core.ReindexResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.UpdateRequest;
@@ -513,11 +514,23 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
 
     try {
       final var reindexResponse = client.reindex(createMissingRequest);
-      return reindexResponse != null
-          && reindexResponse.total() != null
-          && reindexResponse.total() > 0;
+      validateReindexResponse(source, reindexResponse);
+      return reindexResponse.total() != null && reindexResponse.total() > 0;
     } catch (final IOException e) {
       throw new MigrationException(e);
+    }
+  }
+
+  private static void validateReindexResponse(
+      final String sourceIndex, final ReindexResponse response) {
+    if (Boolean.TRUE.equals(response.timedOut())) {
+      throw new MigrationException("Reindex request from %s timed out".formatted(sourceIndex));
+    }
+    final var failures = response.failures();
+    if (failures != null && !failures.isEmpty()) {
+      throw new MigrationException(
+          "Reindex request from %s index completed with %d failures"
+              .formatted(sourceIndex, failures.size()));
     }
   }
 

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapter.java
@@ -514,6 +514,10 @@ public class ElasticsearchAdapter implements TaskMigrationAdapter {
 
     try {
       final var reindexResponse = client.reindex(createMissingRequest);
+      if (reindexResponse == null) {
+        throw new MigrationException(
+            "Reindex request from %s returned null response".formatted(source));
+      }
       validateReindexResponse(source, reindexResponse);
       return reindexResponse.total() != null && reindexResponse.total() > 0;
     } catch (final IOException e) {

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
@@ -570,6 +570,10 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
 
     try {
       final var reindexResponse = client.reindex(createMissingRequest);
+      if (reindexResponse == null) {
+        throw new MigrationException(
+            "Reindex request from %s returned null response".formatted(source));
+      }
       validateReindexResponse(source, reindexResponse);
       return reindexResponse.total() != null && reindexResponse.total() > 0;
     } catch (final IOException e) {
@@ -583,7 +587,7 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
       throw new MigrationException("Reindex request from %s timed out".formatted(sourceIndex));
     }
     final var failures = response.failures();
-    if (!failures.isEmpty()) {
+    if (failures != null && !failures.isEmpty()) {
       throw new MigrationException(
           "Reindex request from %s index completed with %d failures"
               .formatted(sourceIndex, failures.size()));

--- a/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
+++ b/migration/task-migration/src/main/java/io/camunda/migration/task/adapter/os/OpensearchAdapter.java
@@ -57,6 +57,7 @@ import org.opensearch.client.opensearch._types.query_dsl.ExistsQuery;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
 import org.opensearch.client.opensearch.core.ReindexRequest;
+import org.opensearch.client.opensearch.core.ReindexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.UpdateRequest;
@@ -569,11 +570,23 @@ public class OpensearchAdapter implements TaskMigrationAdapter {
 
     try {
       final var reindexResponse = client.reindex(createMissingRequest);
-      return reindexResponse != null
-          && reindexResponse.total() != null
-          && reindexResponse.total() > 0;
+      validateReindexResponse(source, reindexResponse);
+      return reindexResponse.total() != null && reindexResponse.total() > 0;
     } catch (final IOException e) {
       throw new MigrationException(e);
+    }
+  }
+
+  private static void validateReindexResponse(
+      final String sourceIndex, final ReindexResponse response) {
+    if (Boolean.TRUE.equals(response.timedOut())) {
+      throw new MigrationException("Reindex request from %s timed out".formatted(sourceIndex));
+    }
+    final var failures = response.failures();
+    if (!failures.isEmpty()) {
+      throw new MigrationException(
+          "Reindex request from %s index completed with %d failures"
+              .formatted(sourceIndex, failures.size()));
     }
   }
 

--- a/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
+++ b/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/es/ElasticsearchAdapterTest.java
@@ -17,8 +17,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.BulkIndexByScrollFailure;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch.core.ReindexRequest;
+import co.elastic.clients.elasticsearch.core.ReindexResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
@@ -345,6 +348,51 @@ class ElasticsearchAdapterTest {
     // Size should match the number of unique task keys from the destination query (12 tasks)
     // This ensures we exceed the default ES search size of 10
     assertThat(sourceRequest.size()).isEqualTo(12);
+  }
+
+  @Test
+  void reindexLegacyMainIndexShouldThrowWhenResponseTimesOut() throws Exception {
+    // Given
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.timedOut()).thenReturn(true);
+    when(reindexResponse.failures()).thenReturn(List.of());
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    // When/Then
+    assertThatThrownBy(() -> adapter.reindexLegacyMainIndex())
+        .isInstanceOf(MigrationException.class)
+        .hasMessageContaining("timed out");
+  }
+
+  @Test
+  void reindexLegacyMainIndexShouldThrowWhenResponseHasFailures() throws Exception {
+    // Given
+    final BulkIndexByScrollFailure failure = mock(BulkIndexByScrollFailure.class);
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.timedOut()).thenReturn(false);
+    when(reindexResponse.failures()).thenReturn(List.of(failure));
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    // When/Then
+    assertThatThrownBy(() -> adapter.reindexLegacyMainIndex())
+        .isInstanceOf(MigrationException.class)
+        .hasMessageContaining("failures");
+  }
+
+  @Test
+  void reindexLegacyMainIndexShouldSucceedWhenResponseIsValid() throws Exception {
+    // Given
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.timedOut()).thenReturn(false);
+    when(reindexResponse.failures()).thenReturn(List.of());
+    when(reindexResponse.total()).thenReturn(5L);
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    // When - should not throw
+    adapter.reindexLegacyMainIndex();
+
+    // Then
+    verify(client, times(1)).reindex(any(ReindexRequest.class));
   }
 
   @SuppressWarnings("unchecked")

--- a/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/os/OpensearchAdapterTest.java
+++ b/migration/task-migration/src/test/java/io/camunda/migration/task/adapter/os/OpensearchAdapterTest.java
@@ -36,8 +36,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.BulkIndexByScrollFailure;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch.core.ReindexRequest;
+import org.opensearch.client.opensearch.core.ReindexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.Hit;
@@ -345,6 +348,51 @@ class OpensearchAdapterTest {
     // Size should match the number of unique task keys from the destination query (12 tasks)
     // This ensures we exceed the default OS search size of 10
     assertThat(sourceRequest.size()).isEqualTo(12);
+  }
+
+  @Test
+  void reindexLegacyMainIndexShouldThrowWhenResponseTimesOut() throws Exception {
+    // Given
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.timedOut()).thenReturn(true);
+    when(reindexResponse.failures()).thenReturn(List.of());
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    // When/Then
+    assertThatThrownBy(() -> adapter.reindexLegacyMainIndex())
+        .isInstanceOf(MigrationException.class)
+        .hasMessageContaining("timed out");
+  }
+
+  @Test
+  void reindexLegacyMainIndexShouldThrowWhenResponseHasFailures() throws Exception {
+    // Given
+    final BulkIndexByScrollFailure failure = mock(BulkIndexByScrollFailure.class);
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.timedOut()).thenReturn(false);
+    when(reindexResponse.failures()).thenReturn(List.of(failure));
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    // When/Then
+    assertThatThrownBy(() -> adapter.reindexLegacyMainIndex())
+        .isInstanceOf(MigrationException.class)
+        .hasMessageContaining("failures");
+  }
+
+  @Test
+  void reindexLegacyMainIndexShouldSucceedWhenResponseIsValid() throws Exception {
+    // Given
+    final ReindexResponse reindexResponse = mock(ReindexResponse.class);
+    when(reindexResponse.timedOut()).thenReturn(false);
+    when(reindexResponse.failures()).thenReturn(List.of());
+    when(reindexResponse.total()).thenReturn(5L);
+    when(client.reindex(any(ReindexRequest.class))).thenReturn(reindexResponse);
+
+    // When - should not throw
+    adapter.reindexLegacyMainIndex();
+
+    // Then
+    verify(client, times(1)).reindex(any(ReindexRequest.class));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Relates to https://github.com/camunda/camunda/issues/56720
Same as in https://github.com/camunda/camunda/pull/56736, we need to validate the reindex response, to verify it does not include any failures

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
