### PR TITLE
Add withLease to the job batch record schema

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
@@ -44,6 +45,7 @@ final class BulkIndexRequest {
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(JobRecordValue.class, JobMixin.class)
+          .addMixIn(JobBatchRecordValue.class, JobBatchMixin.class)
           .addMixIn(UserTaskRecordValue.class, BusinessIdMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, BusinessIdMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
@@ -61,6 +63,7 @@ final class BulkIndexRequest {
   private static final String ELEMENT_TYPE_PROPERTY = "elementType";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
   private static final String LEASE_TOKEN_PROPERTY = "leaseToken";
+  private static final String WITH_LEASE_PROPERTY = "withLease";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -187,6 +190,9 @@ final class BulkIndexRequest {
     LEASE_TOKEN_PROPERTY
   })
   private static final class JobMixin {}
+
+  @JsonIgnoreProperties({WITH_LEASE_PROPERTY})
+  private static final class JobBatchMixin {}
 
   /** Shared by record values that only need to strip {@code businessId} for previous versions. */
   @JsonIgnoreProperties({BUSINESS_ID_PROPERTY})

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-job-batch-template.json
@@ -181,6 +181,9 @@
             "truncated": {
               "type": "boolean"
             },
+            "withLease": {
+              "type": "boolean"
+            },
             "tenantIds": {
               "type": "keyword"
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/BulkIndexRequestTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.exporter.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
@@ -551,6 +552,58 @@ final class BulkIndexRequestTest {
           .extracting(source -> ((Map<String, Object>) source).get("leaseToken"))
           .describedAs("Expect that job records are serialized with leaseToken on current version")
           .containsExactly("lease-abc-123");
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithoutWithLeaseOnPreviousVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB_BATCH,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new JobBatchRecord().setType("test-type").setWithLease(true)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .describedAs(
+              "Expect that job batch records are NOT serialized with withLease on previous version")
+          .allSatisfy(
+              value -> assertThat((Map<String, Object>) value).doesNotContainKey("withLease"));
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithWithLeaseOnCurrentVersion() {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB_BATCH,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new JobBatchRecord().setType("test-type").setWithLease(true)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("withLease"))
+          .describedAs(
+              "Expect that job batch records are serialized with withLease on current version")
+          .containsExactly(true);
     }
 
     @Test

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.util.SemanticVersion;
@@ -44,6 +45,7 @@ final class BulkIndexRequest {
           .addMixIn(CommandDistributionRecordValue.class, CommandDistributionMixin.class)
           .addMixIn(EvaluatedDecisionValue.class, EvaluatedDecisionMixin.class)
           .addMixIn(JobRecordValue.class, JobMixin.class)
+          .addMixIn(JobBatchRecordValue.class, JobBatchMixin.class)
           .addMixIn(UserTaskRecordValue.class, BusinessIdMixin.class)
           .addMixIn(DecisionEvaluationRecordValue.class, BusinessIdMixin.class)
           .enable(Feature.ALLOW_SINGLE_QUOTES);
@@ -61,6 +63,7 @@ final class BulkIndexRequest {
   private static final String ELEMENT_TYPE_PROPERTY = "elementType";
   private static final String BUSINESS_ID_PROPERTY = "businessId";
   private static final String LEASE_TOKEN_PROPERTY = "leaseToken";
+  private static final String WITH_LEASE_PROPERTY = "withLease";
   private final List<IndexOperation> operations = new ArrayList<>();
   private BulkIndexAction lastIndexedMetadata;
   private int memoryUsageBytes = 0;
@@ -187,6 +190,9 @@ final class BulkIndexRequest {
     LEASE_TOKEN_PROPERTY
   })
   private static final class JobMixin {}
+
+  @JsonIgnoreProperties({WITH_LEASE_PROPERTY})
+  private static final class JobBatchMixin {}
 
   /** Shared by record values that only need to strip {@code businessId} for previous versions. */
   @JsonIgnoreProperties({BUSINESS_ID_PROPERTY})

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-job-batch-template.json
@@ -187,6 +187,9 @@
             "truncated": {
               "type": "boolean"
             },
+            "withLease": {
+              "type": "boolean"
+            },
             "tenantIds": {
               "type": "keyword"
             },

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequestTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
@@ -564,6 +565,58 @@ final class BulkIndexRequestTest {
           .extracting(source -> ((Map<String, Object>) source).get("leaseToken"))
           .describedAs("Expect that job records are serialized with leaseToken on current version")
           .containsExactly("lease-abc-123");
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithoutWithLeaseOnPreviousVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB_BATCH,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getPreviousVersion())
+                      .withValue(new JobBatchRecord().setType("test-type").setWithLease(true)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .describedAs(
+              "Expect that job batch records are NOT serialized with withLease on previous version")
+          .allSatisfy(
+              value -> assertThat((Map<String, Object>) value).doesNotContainKey("withLease"));
+    }
+
+    @Test
+    void shouldIndexJobBatchRecordWithWithLeaseOnCurrentVersion() throws IOException {
+      // given
+      final var record =
+          recordFactory.generateRecord(
+              ValueType.JOB_BATCH,
+              r ->
+                  r.withBrokerVersion(VersionUtil.getVersion())
+                      .withValue(new JobBatchRecord().setType("test-type").setWithLease(true)));
+
+      final var actions = List.of(new BulkIndexAction("index", "id", "routing"));
+
+      // when
+      request.index(actions.getFirst(), record, new RecordSequence(PARTITION_ID, 10));
+
+      // then
+      assertThat(request.bulkOperations())
+          .hasSize(1)
+          .map(operation -> MAPPER.readValue(operation.source(), MAP_TYPE_REFERENCE))
+          .extracting(source -> source.get("value"))
+          .extracting(source -> ((Map<String, Object>) source).get("withLease"))
+          .describedAs(
+              "Expect that job batch records are serialized with withLease on current version")
+          .containsExactly(true);
     }
 
     @Test

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
@@ -40,6 +40,7 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private static final StringValue TENANT_IDS_KEY = new StringValue("tenantIds");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TRUNCATED_KEY = new StringValue("truncated");
+  private static final StringValue WITH_LEASE_KEY = new StringValue("withLease");
   private static final StringValue TENANT_FILTER_KEY = new StringValue("tenantFilter");
 
   private final StringProperty typeProp = new StringProperty(TYPE_KEY);
@@ -55,11 +56,12 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private final ArrayProperty<StringValue> variablesProp =
       new ArrayProperty<>(VARIABLES_KEY, StringValue::new);
   private final BooleanProperty truncatedProp = new BooleanProperty(TRUNCATED_KEY, false);
+  private final BooleanProperty withLeaseProp = new BooleanProperty(WITH_LEASE_KEY, false);
   private final EnumProperty<TenantFilter> tenantFilterProp =
       new EnumProperty<>(TENANT_FILTER_KEY, TenantFilter.class, TenantFilter.PROVIDED);
 
   public JobBatchRecord() {
-    super(10);
+    super(11);
     declareProperty(typeProp)
         .declareProperty(workerProp)
         .declareProperty(timeoutProp)
@@ -68,6 +70,7 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
         .declareProperty(jobsProp)
         .declareProperty(variablesProp)
         .declareProperty(truncatedProp)
+        .declareProperty(withLeaseProp)
         .declareProperty(tenantIdsProp)
         .declareProperty(tenantFilterProp);
   }
@@ -148,6 +151,11 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   }
 
   @Override
+  public boolean isWithLease() {
+    return withLeaseProp.getValue();
+  }
+
+  @Override
   public List<String> getTenantIds() {
     return StreamSupport.stream(tenantIdsProp.spliterator(), false)
         .map(StringValue::getValue)
@@ -173,6 +181,11 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
 
   public JobBatchRecord setTruncated(final boolean truncated) {
     truncatedProp.setValue(truncated);
+    return this;
+  }
+
+  public JobBatchRecord setWithLease(final boolean withLease) {
+    withLeaseProp.setValue(withLease);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -791,7 +791,8 @@ final class JsonSerializableToJsonTest {
                       .setTimeout(timeout)
                       .setType(type)
                       .setWorker(worker)
-                      .setTruncated(true);
+                      .setTruncated(true)
+                      .setWithLease(true);
 
               record.jobKeys().add().setValue(3L);
               final JobRecord jobRecord = record.jobs().add();
@@ -867,6 +868,7 @@ final class JsonSerializableToJsonTest {
                   "type": "type",
                   "worker": "worker",
                   "truncated": true,
+                  "withLease": true,
                   "jobKeys": [
                     3
                   ],
@@ -965,6 +967,7 @@ final class JsonSerializableToJsonTest {
                   "type": "type",
                   "maxJobsToActivate": -1,
                   "truncated": false,
+                  "withLease": false,
                   "jobKeys": [],
                   "jobs": [],
                   "timeout": -1,

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobBatchRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/JobBatchRecord.golden
@@ -40,6 +40,7 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private static final StringValue TENANT_IDS_KEY = new StringValue("tenantIds");
   private static final StringValue VARIABLES_KEY = new StringValue("variables");
   private static final StringValue TRUNCATED_KEY = new StringValue("truncated");
+  private static final StringValue WITH_LEASE_KEY = new StringValue("withLease");
   private static final StringValue TENANT_FILTER_KEY = new StringValue("tenantFilter");
 
   private final StringProperty typeProp = new StringProperty(TYPE_KEY);
@@ -55,11 +56,12 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private final ArrayProperty<StringValue> variablesProp =
       new ArrayProperty<>(VARIABLES_KEY, StringValue::new);
   private final BooleanProperty truncatedProp = new BooleanProperty(TRUNCATED_KEY, false);
+  private final BooleanProperty withLeaseProp = new BooleanProperty(WITH_LEASE_KEY, false);
   private final EnumProperty<TenantFilter> tenantFilterProp =
       new EnumProperty<>(TENANT_FILTER_KEY, TenantFilter.class, TenantFilter.PROVIDED);
 
   public JobBatchRecord() {
-    super(10);
+    super(11);
     declareProperty(typeProp)
         .declareProperty(workerProp)
         .declareProperty(timeoutProp)
@@ -68,6 +70,7 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
         .declareProperty(jobsProp)
         .declareProperty(variablesProp)
         .declareProperty(truncatedProp)
+        .declareProperty(withLeaseProp)
         .declareProperty(tenantIdsProp)
         .declareProperty(tenantFilterProp);
   }
@@ -148,6 +151,11 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   }
 
   @Override
+  public boolean isWithLease() {
+    return withLeaseProp.getValue();
+  }
+
+  @Override
   public List<String> getTenantIds() {
     return StreamSupport.stream(tenantIdsProp.spliterator(), false)
         .map(StringValue::getValue)
@@ -173,6 +181,11 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
 
   public JobBatchRecord setTruncated(final boolean truncated) {
     truncatedProp.setValue(truncated);
+    return this;
+  }
+
+  public JobBatchRecord setWithLease(final boolean withLease) {
+    withLeaseProp.setValue(withLease);
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobBatchRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobBatchRecordValue.java
@@ -67,6 +67,15 @@ public interface JobBatchRecordValue extends RecordValue {
   boolean isTruncated();
 
   /**
+   * When a batch is activated with a lease, the engine generates a distinct lease token for each
+   * activated job and carries it on the job. The token lets the engine distinguish items produced
+   * by this activation from those of a superseded one.
+   *
+   * @return whether the jobs in this batch are activated with a lease
+   */
+  boolean isWithLease();
+
+  /**
    * Since a job batch contains many jobs, it is possible that the jobs belong to different tenants.
    *
    * <p>This can be useful when requesting jobs for multiple tenants at once. Each of the activated


### PR DESCRIPTION
## Description

First slice of the stack implementing #54845 (lease-aware job activation). It adds a `withLease` boolean to the `JobBatchRecord` protocol plus the exporter plumbing, so later PRs can build lease generation and the activate-side guard on top. The field defaults to `false` and is not yet read by the engine, so **engine behavior is unchanged** here — this is protocol + exporter plumbing only.

It mirrors the `leaseToken` plumbing already merged for `JobRecord` (dep #54841).

Worth calling out, since the diff doesn't make it obvious:

- **`withLease` is added to the previous-version export strip, not only mapped.** The ES/OS job-batch value mappings are `dynamic: strict`, so a field that isn't in the index template is rejected. A previous-version broker's record re-serialized against an older template would otherwise break during a rolling upgrade. The strip (a `JobBatchMixin` wired into `PREVIOUS_VERSION_MAPPER` only) is therefore **version-compat, not sensitivity** — which is why the field is still mapped and exported for current-version records.
- The serialization test and the schema change are one commit on purpose: a schema field has no compiling-but-failing red state (declaring the property provides both the setter the test calls and the serialized output it asserts), so splitting would leave a non-compiling intermediate and break `git bisect`.

**Stacked PR:** targets `korthout/54845-rename-reprocess-to-replay` (#56816), not `main`, so this diff shows only its own slice. Merge order follows the stack.

**Out of scope** (later slices): lease generation + persistence and the activate-side filter (engine), the skip metric, gRPC/REST exposure (#54846), and response `leaseToken` mapping (#54844).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

Relates to #54845
