### PR TITLE
fix: always set a load test zone to keep pods schedulable

### DIFF
--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -100,14 +100,13 @@ The rest of this section documents the `main` setup.
 Running `newLoadTest.sh` without arguments shows the `main` help:
 
 ```sh
-Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize]
 
 Arguments:
   namespace          Base namespace name. Will be prefixed with "c8-" if missing.
   secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none. Default: elasticsearch.
   ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
   enable_optimize    Optional. true|false to enable Optimize. Default: true.
-  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true
 
 Options:
   -h, --help         Show this help message.

--- a/load-tests/setup/main/newLoadTest.sh
+++ b/load-tests/setup/main/newLoadTest.sh
@@ -11,14 +11,13 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
 usage() {
   cat <<'EOF'
-Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize]
 
 Arguments:
   namespace          Base namespace name. Will be prefixed with "c8-" if missing.
   secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none. Default: elasticsearch.
   ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
   enable_optimize    Optional. true|false to enable Optimize. Default: true.
-  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true.
 
 Options:
   -h, --help         Show this help message.
@@ -101,16 +100,10 @@ if [[ "$enable_optimize" != "true" && "$enable_optimize" != "false" ]]; then
   exit 1
 fi
 
-enable_single_zone="${5:-true}"
-enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
-
 # `hashmod_zone` is deterministic, so the zone baked into namespace.yaml and
-# the values files matches any re-applied manifest after TTL deletion.
-if [[ "$enable_single_zone" == "true" ]]; then
-  availability_zone="$(hashmod_zone "$namespace")"
-else
-  availability_zone="~"
-fi
+# the values files matches any re-applied manifest after TTL deletion. Every
+# load test pins its workloads to one zone; there is no unpinned mode.
+availability_zone="$(hashmod_zone "$namespace")"
 
 git_author=${GIT_AUTHOR:-$(compute_git_author)}
 
@@ -204,7 +197,6 @@ cat <<EOF > load-test-setup-values.yaml
 name: "$namespace"
 author: "$git_author"
 deadlineDate: "$deadline_date"
-# Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
 
 # Propagated to the camunda-load-tests (load-tester) subchart via Helm global

--- a/load-tests/setup/stable-87/newLoadTest.sh
+++ b/load-tests/setup/stable-87/newLoadTest.sh
@@ -11,14 +11,13 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
 usage() {
   cat <<'EOF'
-Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone] [enable_webapps]
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_webapps]
 
 Arguments:
   namespace          Base namespace name. Will be prefixed with "c8-" if missing.
   secondaryStorage   Optional. One of: elasticsearch. Default: elasticsearch.
   ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
   enable_optimize    Optional. true|false to enable Optimize. Default: true.
-  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true.
   enable_webapps     Optional. true|false to enable Operate and Tasklist. Default: true.
 
 Options:
@@ -102,18 +101,12 @@ if [[ "$enable_optimize" != "true" && "$enable_optimize" != "false" ]]; then
   exit 1
 fi
 
-enable_single_zone="${5:-true}"
-enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
-
 # `hashmod_zone` is deterministic, so the zone baked into namespace.yaml and
-# the values files matches any re-applied manifest after TTL deletion.
-if [[ "$enable_single_zone" == "true" ]]; then
-  availability_zone="$(hashmod_zone "$namespace")"
-else
-  availability_zone="~"
-fi
+# the values files matches any re-applied manifest after TTL deletion. Every
+# load test pins its workloads to one zone; there is no unpinned mode.
+availability_zone="$(hashmod_zone "$namespace")"
 
-enable_webapps="${6:-true}"
+enable_webapps="${5:-true}"
 enable_webapps=$(echo "$enable_webapps" | tr '[:upper:]' '[:lower:]')
 if [[ "$enable_webapps" != "true" && "$enable_webapps" != "false" ]]; then
   echo "Error: Invalid enable_webapps value '$enable_webapps'"
@@ -188,7 +181,6 @@ cat <<EOF > load-test-setup-values.yaml
 name: "$namespace"
 author: "$git_author"
 deadlineDate: "$deadline_date"
-# Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
 # Propagated to the camunda-load-tests (load-tester) subchart via Helm global
 # coalescing.

--- a/load-tests/setup/stable-88/newLoadTest.sh
+++ b/load-tests/setup/stable-88/newLoadTest.sh
@@ -11,14 +11,13 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
 usage() {
   cat <<'EOF'
-Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize]
 
 Arguments:
   namespace          Base namespace name. Will be prefixed with "c8-" if missing.
   secondaryStorage   Optional. One of: elasticsearch, opensearch, none. Default: elasticsearch.
   ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
   enable_optimize    Optional. true|false to enable Optimize. Default: true.
-  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true.
 
 Options:
   -h, --help         Show this help message.
@@ -101,16 +100,10 @@ if [[ "$enable_optimize" != "true" && "$enable_optimize" != "false" ]]; then
   exit 1
 fi
 
-enable_single_zone="${5:-true}"
-enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
-
 # `hashmod_zone` is deterministic, so the zone baked into namespace.yaml and
-# the values files matches any re-applied manifest after TTL deletion.
-if [[ "$enable_single_zone" == "true" ]]; then
-  availability_zone="$(hashmod_zone "$namespace")"
-else
-  availability_zone="~"
-fi
+# the values files matches any re-applied manifest after TTL deletion. Every
+# load test pins its workloads to one zone; there is no unpinned mode.
+availability_zone="$(hashmod_zone "$namespace")"
 
 git_author=${GIT_AUTHOR:-$(compute_git_author)}
 
@@ -178,7 +171,6 @@ cat <<EOF > load-test-setup-values.yaml
 name: "$namespace"
 author: "$git_author"
 deadlineDate: "$deadline_date"
-# Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
 # Propagated to the camunda-load-tests (load-tester) subchart via Helm global
 # coalescing.

--- a/load-tests/setup/stable-89/newLoadTest.sh
+++ b/load-tests/setup/stable-89/newLoadTest.sh
@@ -11,14 +11,13 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
 usage() {
   cat <<'EOF'
-Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize] [enable_single_zone]
+Usage: newLoadTest.sh <namespace> [secondaryStorage] [ttl_days] [enable_optimize]
 
 Arguments:
   namespace          Base namespace name. Will be prefixed with "c8-" if missing.
   secondaryStorage   Optional. One of: elasticsearch, opensearch, postgresql, mysql, mariadb, mssql, oracle, none. Default: elasticsearch.
   ttl_days           Optional. Positive integer for namespace TTL in days. Default: 1.
   enable_optimize    Optional. true|false to enable Optimize. Default: true.
-  enable_single_zone Optional. true|false to deploy the cluster on a single zone. Default: true.
 
 Options:
   -h, --help         Show this help message.
@@ -101,16 +100,10 @@ if [[ "$enable_optimize" != "true" && "$enable_optimize" != "false" ]]; then
   exit 1
 fi
 
-enable_single_zone="${5:-true}"
-enable_single_zone=$(echo "$enable_single_zone" | tr '[:upper:]' '[:lower:]')
-
 # `hashmod_zone` is deterministic, so the zone baked into namespace.yaml and
-# the values files matches any re-applied manifest after TTL deletion.
-if [[ "$enable_single_zone" == "true" ]]; then
-  availability_zone="$(hashmod_zone "$namespace")"
-else
-  availability_zone="~"
-fi
+# the values files matches any re-applied manifest after TTL deletion. Every
+# load test pins its workloads to one zone; there is no unpinned mode.
+availability_zone="$(hashmod_zone "$namespace")"
 
 git_author=${GIT_AUTHOR:-$(compute_git_author)}
 
@@ -187,7 +180,6 @@ cat <<EOF > load-test-setup-values.yaml
 name: "$namespace"
 author: "$git_author"
 deadlineDate: "$deadline_date"
-# Can be unset using "topologyZone: ~"
 topologyZone: $availability_zone
 # Propagated to the camunda-load-tests (load-tester) subchart via Helm global
 # coalescing.


### PR DESCRIPTION
## Description

Scaffolding a load test with `enable_single_zone=false` set `availability_zone` to `~`, which was baked into every `topology.kubernetes.io/zone` nodeSelector (the load-tester global values and the `camunda-platform-values-*.yaml` files). On the pods this surfaced as an empty `topology.kubernetes.io/zone: ""` value — no node matches an empty zone label, so the load-tester pods stayed unschedulable (Pending). Confirmed manually.

The unpinned mode was unused, so rather than conditionally omitting the selector, this drops the `enable_single_zone` argument entirely and always computes a real zone via `hashmod_zone`. That removes the empty-zone path by construction across all versioned setups. Pre-existing bug, surfaced by a review comment on #56679.

Golden-file tests render byte-identical (single-zone was already the default).

## Checklist

- [ ] Enable backports when necessary (not needed — load-test setup tooling lives only on `main`).

## Related issues

Follows #56679.

<sub>🤖 Authored with [Claude Code](https://claude.com/claude-code)</sub>