### PR TITLE
fix: resolve license-header path from eslint config dir

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/eslint.config.js
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/eslint.config.js
@@ -78,7 +78,10 @@ export default [
       'license-header': licenseHeaderPlugin,
     },
     rules: {
-      'license-header/header': ['error', './license-header.js'],
+      'license-header/header': [
+        'error',
+        path.join(__dirname, 'license-header.js'),
+      ],
     },
   },
 


### PR DESCRIPTION
## Why

The nightly `C8 Orchestration Cluster V2 Stateless Tests Nightly` workflow has failed on every run since it was created on 2025-09-25 (commit 4d89c2c22f3) at the **Regenerate request validation tests** step, with:

```
Error: Error while loading rule 'license-header/header':
could not read license header from <./license-header.js>
```

Latest failing run: https://github.com/camunda/camunda/actions/runs/28760408351

## Root cause

`qa/c8-orchestration-cluster-e2e-test-suite/eslint.config.js` declared the license-header rule with a cwd-relative path:

```js
'license-header/header': ['error', './license-header.js'],
```

`eslint-plugin-license-header@0.9.0` reads that path with `fs.readFileSync` against `process.cwd()` — not against the config file. The workflow step runs `npm run generate` from `v2-stateless-tests/request-validation-test-generator/`, whose `npm run lint:generated` invokes `eslint generated/**/*.ts`. That subdirectory has no eslint config of its own, so ESLint 9 walks up to the QA suite's flat config and then crashes because `./license-header.js` doesn't exist relative to the generator subdir (it only exists at the suite root).

## Fix

Resolve the license-header file path from the config's own directory using the already-derived `__dirname` (already imported/computed at the top of the file). This makes the rule load correctly no matter where ESLint is invoked from.

## Verification

Reproduced the failure locally, applied the fix, and re-ran the same command chain the workflow uses:

- `npm run lint:generated` from `v2-stateless-tests/request-validation-test-generator/` now exits 0 on a properly-headered generated file.
- The rule still fires with `Missing license header` on a file without the header (verified with a throwaway `generated/bad.spec.ts`).
- `npx eslint eslint.config.js` from the suite root is still clean.

## Notes

- Minimal diff — only the rule option is changed.
- No skip / no continue-on-error; this is the workflow-level fix.