### PR TITLE
feat: export cluster variable metadata in Camunda exporter

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandler.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.util.ClusterVariableUtil;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.MetadataEntry;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class ClusterVariableCreatedUpdatedHandler
@@ -87,6 +89,17 @@ public class ClusterVariableCreatedUpdatedHandler
       entity.setFullValue(null);
       entity.setIsPreview(false);
     }
+
+    final Map<String, Object> metadata = recordValue.getMetadata();
+    entity.setMetadata(
+        metadata.entrySet().stream()
+            .map(
+                e ->
+                    new MetadataEntry(
+                        e.getKey(),
+                        String.valueOf(e.getValue()),
+                        e.getValue() instanceof Number n ? n.doubleValue() : null))
+            .toList());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ClusterVariableCreatedUpdatedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity;
+import io.camunda.webapps.schema.entities.clustervariable.ClusterVariableEntity.MetadataEntry;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ClusterVariableIntent;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.protocol.record.value.ClusterVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClusterVariableScope;
 import io.camunda.zeebe.protocol.record.value.ImmutableClusterVariableRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -204,6 +206,7 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
             .withValue("v".repeat(variableSizeThreshold))
             .withScope(ClusterVariableScope.TENANT)
             .withTenantId("tenantId")
+            .withMetadata(Map.of())
             .build();
 
     final Record<ClusterVariableRecordValue> variableRecord =
@@ -226,6 +229,7 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
     assertThat(clusterVariableEntity.getValue()).isEqualTo(clusterVariableRecordValue.getValue());
     assertThat(clusterVariableEntity.getIsPreview()).isFalse();
     assertThat(clusterVariableEntity.getFullValue()).isNull();
+    assertThat(clusterVariableEntity.getMetadata()).isEmpty();
   }
 
   @ParameterizedTest
@@ -241,6 +245,7 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
             .from(factory.generateObject(ClusterVariableRecordValue.class))
             .withValue("v".repeat(variableSizeThreshold + 1))
             .withTenantId("tenantId")
+            .withMetadata(Map.of("kind", "CREDENTIALS"))
             .build();
 
     final Record<ClusterVariableRecordValue> variableRecord =
@@ -257,5 +262,45 @@ public class ClusterVariableCreatedUpdatedHandlerTest {
     assertThat(clusterVariableEntity.getFullValue())
         .isEqualTo("v".repeat(variableSizeThreshold + 1));
     assertThat(clusterVariableEntity.getIsPreview()).isTrue();
+    assertThat(clusterVariableEntity.getMetadata())
+        .containsExactly(new MetadataEntry("kind", "CREDENTIALS", null));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ClusterVariableIntent.class,
+      names = {"CREATED", "UPDATED"},
+      mode = Mode.INCLUDE)
+  void shouldMapMetadataWithNumericAndStringValues(final ClusterVariableIntent intent) {
+    // given
+    final ClusterVariableRecordValue clusterVariableRecordValue =
+        ImmutableClusterVariableRecordValue.builder()
+            .from(factory.generateObject(ClusterVariableRecordValue.class))
+            .withValue("v")
+            .withScope(ClusterVariableScope.GLOBAL)
+            .withMetadata(
+                Map.ofEntries(
+                    Map.entry("kind", "test"),
+                    Map.entry("schemaVersion", 10),
+                    Map.entry("long", 10L),
+                    Map.entry("double", 1.2)))
+            .build();
+
+    final Record<ClusterVariableRecordValue> variableRecord =
+        factory.generateRecord(
+            ValueType.CLUSTER_VARIABLE,
+            r -> r.withIntent(intent).withValue(clusterVariableRecordValue));
+
+    // when
+    final ClusterVariableEntity entity = new ClusterVariableEntity();
+    underTest.updateEntity(variableRecord, entity);
+
+    // then
+    assertThat(entity.getMetadata())
+        .containsExactlyInAnyOrder(
+            new MetadataEntry("kind", "test", null),
+            new MetadataEntry("schemaVersion", "10", 10.0),
+            new MetadataEntry("long", "10", 10.0),
+            new MetadataEntry("double", "1.2", 1.2));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Exports cluster variable metadata in Camunda exporter and adds tests to the handler.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55087
