### PR TITLE
deps: bump httpcore5 to 5.4.3

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,7 +72,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.6.2</version.httpclient5>
-    <version.httpcore5>5.4.2</version.httpcore5>
+    <version.httpcore5>5.4.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.10.0-alpha2</version.identity>
     <version.instancio>5.6.0</version.instancio>


### PR DESCRIPTION
related to INC-6424

## Description

Bump httpcore5 to 5.4.3

Also backport to 8.8 and 8.7.
[8.9 is already on 5.4.3](https://github.com/camunda/camunda/blob/4a423b32d0c863fb9d32159ea0bde92773f5e4ed/parent/pom.xml#L67)

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
