### PR TITLE
pg/56729-restore-endpoint

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -221,7 +221,7 @@ public class RestoreApp implements ApplicationRunner {
   }
 
   private void validateParameters() {
-    RestoreParameterValidator.validate(hasBackupId(), from, to, hasTimeRange());
+    RestoreParameterValidator.validate(hasBackupId(), from, to);
   }
 
   private boolean hasTimeRange() {

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -22,6 +22,7 @@ import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.RestoreParameterValidator;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.dynamic.nodeid.fs.DataDirectoryProvider;
@@ -29,6 +30,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
@@ -82,6 +84,7 @@ public class RestoreApp implements ApplicationRunner {
   private final MeterRegistry meterRegistry;
   private final PostRestoreAction postRestoreAction;
   private final PreRestoreAction preRestoreAction;
+  private final Camunda camunda;
 
   @Autowired
   public RestoreApp(
@@ -98,6 +101,7 @@ public class RestoreApp implements ApplicationRunner {
       final DataDirectoryProvider dataDirectoryProvider,
       final PostRestoreAction postRestoreAction,
       final PreRestoreAction preRestoreAction) {
+    this.camunda = camunda;
     this.configuration = configuration;
     this.backupStore = backupStore;
     if (camunda.getData().getSecondaryStorage().getType() == SecondaryStorageType.rdbms) {
@@ -221,7 +225,15 @@ public class RestoreApp implements ApplicationRunner {
   }
 
   private void validateParameters() {
-    RestoreParameterValidator.validate(hasBackupId(), from, to);
+    final List<Long> backupIds =
+        hasBackupId() ? Arrays.stream(backupId).boxed().toList() : List.of();
+    final var databaseType = camunda.getData().getSecondaryStorage().getType().toString();
+    final var continuousBackups = camunda.getData().getPrimaryStorage().getBackup().isContinuous();
+    final var fromStr = from != null ? from.toString() : null;
+    final var toStr = to != null ? to.toString() : null;
+    final var restoreRequest =
+        new RestoreRequest(backupIds, fromStr, toStr, databaseType, continuousBackups, false);
+    RestoreParameterValidator.validate(restoreRequest);
   }
 
   private boolean hasTimeRange() {

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -22,6 +22,7 @@ import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.dynamic.config.api.RestoreParameterValidator;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.dynamic.nodeid.fs.DataDirectoryProvider;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -220,18 +221,7 @@ public class RestoreApp implements ApplicationRunner {
   }
 
   private void validateParameters() {
-    final boolean hasBackupId = hasBackupId();
-    final boolean hasTimeRange = hasTimeRange();
-
-    if (hasBackupId && hasTimeRange) {
-      throw new IllegalArgumentException(
-          "Cannot specify both --backupId and --from/--to parameters. Choose one approach.");
-    }
-
-    if (hasTimeRange && from != null && to != null && from.isAfter(to)) {
-      throw new IllegalArgumentException(
-          "Invalid time range: --from (%s) must be before --to (%s)".formatted(from, to));
-    }
+    RestoreParameterValidator.validate(hasBackupId(), from, to, hasTimeRange());
   }
 
   private boolean hasTimeRange() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -87,4 +88,6 @@ public interface ClusterConfigurationManagementApi {
       ClusterConfigurationManagementRequest.CancelChangeRequest cancelChangeRequest);
 
   ActorFuture<ClusterConfiguration> getTopology();
+
+  ActorFuture<ClusterConfigurationChangeResponse> restore(RestoreRequest request);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -136,9 +136,10 @@ public sealed interface ClusterConfigurationManagementRequest {
   }
 
   record RestoreRequest(
-      @Nullable List<Long> backupIds,
+      List<Long> backupIds,
       @Nullable String from,
       @Nullable String to,
+      String databaseType,
       boolean continuousBackups,
       boolean dryRun)
       implements ClusterConfigurationManagementRequest {}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -14,8 +14,10 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.jspecify.annotations.Nullable;
 
 /** Defines the supported requests for the configuration management. */
 public sealed interface ClusterConfigurationManagementRequest {
@@ -132,4 +134,12 @@ public sealed interface ClusterConfigurationManagementRequest {
       return new ModeChangeRequest(Mode.PROCESSING, dryRun);
     }
   }
+
+  record RestoreRequest(
+      @Nullable List<Long> backupIds,
+      @Nullable String from,
+      @Nullable String to,
+      boolean continuousBackups,
+      boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationRequestsSerializer;
@@ -251,6 +252,17 @@ public final class ClusterConfigurationManagementRequestSender {
         ClusterConfigurationRequestTopics.MODE_CHANGE.topic(),
         request,
         serializer::encodeModeChangeRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> restore(
+      final RestoreRequest request) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.RESTORE.topic(),
+        request,
+        serializer::encodeRestoreRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
@@ -235,6 +236,11 @@ public final class ClusterConfigurationManagementRequestsHandler
   @Override
   public ActorFuture<ClusterConfiguration> getTopology() {
     return coordinator.getClusterConfiguration();
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> restore(final RestoreRequest request) {
+    return handleRequest(request.dryRun(), new RestoreRequestTransformer(request));
   }
 
   private ActorFuture<ClusterConfigurationChangeResponse> handleRequest(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -54,6 +54,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerForceRemoveBrokersRequestHandler();
     registerPurgeRequestHandler();
     registerModeChangeHandler();
+    registerRestoreHandler();
   }
 
   @Override
@@ -231,6 +232,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.MODE_CHANGE.topic(),
         serializer::decodeModeChangeRequest,
         request -> mapResponse(clusterConfigurationManagementApi.modeChange(request)),
+        this::encodeResponse);
+  }
+
+  private void registerRestoreHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.RESTORE.topic(),
+        serializer::decodeRestoreRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.restore(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -27,7 +27,8 @@ public enum ClusterConfigurationRequestTopics {
   FORCE_REMOVE_BROKERS("topology-broker-force-remove"),
   UPDATE_ROUTING_STATE("topology-cluster-update-routing-state"),
   UPDATE_PARTITION_DISTRIBUTION("topology-cluster-update-partition-distribution"),
-  MODE_CHANGE("topology-mode-change");
+  MODE_CHANGE("topology-mode-change"),
+  RESTORE("cluster-restore");
 
   private final String topic;
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidator.java
@@ -46,20 +46,19 @@ public final class RestoreParameterValidator {
       final @Nullable Instant to,
       final boolean continuousBackups) {
     final boolean hasTimeRange = from != null || to != null;
-    illegalArgument(
-        !hasBackupId && !hasTimeRange, "Must specify either --backupId or --from/--to.");
+    illegalArgument(!hasBackupId && !hasTimeRange, "Must specify either backupId or from/to.");
 
     illegalArgument(
         hasBackupId && hasTimeRange,
-        "Cannot specify both --backupId and --from/--to parameters. Choose one approach.");
+        "Cannot specify both backupId and from/to parameters. Choose one approach.");
 
     illegalArgument(
         hasTimeRange && !continuousBackups,
-        "Time range restore (--from/--to) is only supported for continuous backups.");
+        "Time range restore (from/to) is only supported for continuous backups.");
 
     illegalArgument(
         from != null && to != null && from.isAfter(to),
-        "Invalid time range: --from (%s) must be before --to (%s)".formatted(from, to));
+        "Invalid time range: from (%s) must be before to (%s)".formatted(from, to));
   }
 
   private static @Nullable Instant parseTimestamp(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidator.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.Locale;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,48 +28,37 @@ public final class RestoreParameterValidator {
 
   private RestoreParameterValidator() {}
 
-  /**
-   * @throws IllegalArgumentException if a backup ID is combined with a time range, if a time range
-   *     is given when {@code continuousBackups} is {@code false}, or if {@code from} is after
-   *     {@code to}.
-   */
-  public static void validate(
-      final boolean hasBackupId,
-      final @Nullable String from,
-      final @Nullable String to,
-      final boolean continuousBackups) {
-    validate(
-        hasBackupId, parseTimestamp(from, "from"), parseTimestamp(to, "to"), continuousBackups);
-  }
-
-  public static void validate(
-      final boolean hasBackupId, final @Nullable Instant from, final @Nullable Instant to) {
-    final var noArgs = !hasBackupId && from == null && to == null;
-    final boolean hasTimeRange = hasTimeRange(from, to);
-    validate(hasBackupId, from, to, noArgs || hasTimeRange);
-  }
-
-  static void validate(
-      final boolean hasBackupId,
-      final @Nullable Instant from,
-      final @Nullable Instant to,
-      final boolean continuousBackups) {
-    final boolean hasTimeRange = hasTimeRange(from, to);
+  public static void validate(final RestoreRequest request) {
+    final var instantFrom = parseTimestamp(request.from(), "from");
+    final var instantTo = parseTimestamp(request.to(), "to");
+    final var hasTimeRange = hasTimeRange(instantFrom, instantTo);
+    final var hasBackupIds = !request.backupIds().isEmpty();
     illegalArgument(
-        !hasBackupId && !hasTimeRange && !continuousBackups,
-        "Must specify either backupId or from/to.");
-
-    illegalArgument(
-        hasBackupId && hasTimeRange,
+        hasBackupIds && hasTimeRange,
         "Cannot specify both backupId and from/to parameters. Choose one approach.");
 
-    illegalArgument(
-        hasTimeRange && !continuousBackups,
-        "Time range restore (from/to) is only supported for continuous backups.");
+    final var databaseType =
+        request.databaseType() == null ? "" : request.databaseType().toLowerCase(Locale.ROOT);
+    switch (databaseType) {
+      case "rdbms", "none" -> {
+        illegalArgument(
+            hasTimeRange && !request.continuousBackups(),
+            "Time range restore (from/to) is only supported for continuous backups.");
 
-    illegalArgument(
-        from != null && to != null && from.isAfter(to),
-        "Invalid time range: from (%s) must be before to (%s)".formatted(from, to));
+        illegalArgument(
+            instantFrom != null && instantTo != null && instantFrom.isAfter(instantTo),
+            "Invalid time range: from (%s) must be before to (%s)"
+                .formatted(instantFrom, instantTo));
+      }
+      case "elasticsearch", "opensearch" -> {
+        illegalArgument(
+            hasTimeRange,
+            "Time range restore (from/to) is not supported for %s.".formatted(databaseType));
+        illegalArgument(!hasBackupIds, "No backupId specified");
+      }
+      default ->
+          throw new IllegalArgumentException("Invalid database type: " + request.databaseType());
+    }
   }
 
   private static boolean hasTimeRange(@Nullable final Instant from, @Nullable final Instant to) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidator.java
@@ -41,12 +41,21 @@ public final class RestoreParameterValidator {
   }
 
   public static void validate(
+      final boolean hasBackupId, final @Nullable Instant from, final @Nullable Instant to) {
+    final var noArgs = !hasBackupId && from == null && to == null;
+    final boolean hasTimeRange = hasTimeRange(from, to);
+    validate(hasBackupId, from, to, noArgs || hasTimeRange);
+  }
+
+  static void validate(
       final boolean hasBackupId,
       final @Nullable Instant from,
       final @Nullable Instant to,
       final boolean continuousBackups) {
-    final boolean hasTimeRange = from != null || to != null;
-    illegalArgument(!hasBackupId && !hasTimeRange, "Must specify either backupId or from/to.");
+    final boolean hasTimeRange = hasTimeRange(from, to);
+    illegalArgument(
+        !hasBackupId && !hasTimeRange && !continuousBackups,
+        "Must specify either backupId or from/to.");
 
     illegalArgument(
         hasBackupId && hasTimeRange,
@@ -59,6 +68,10 @@ public final class RestoreParameterValidator {
     illegalArgument(
         from != null && to != null && from.isAfter(to),
         "Invalid time range: from (%s) must be before to (%s)".formatted(from, to));
+  }
+
+  private static boolean hasTimeRange(@Nullable final Instant from, @Nullable final Instant to) {
+    return from != null || to != null;
   }
 
   private static @Nullable Instant parseTimestamp(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Validates the parameters of a restore. A backup ID and a time range (from/to) are mutually
+ * exclusive, and when both bounds of the time range are given, {@code from} must be before {@code
+ * to}. Providing neither is allowed (e.g. restoring the latest backup). A time range is only
+ * accepted when {@code continuousBackups} is {@code true} (e.g. the configured secondary storage
+ * supports it).
+ *
+ * <p>Shared by the standalone restore application and the cluster-configuration restore request so
+ * both enforce the same rules with the same error messages.
+ */
+public final class RestoreParameterValidator {
+
+  private RestoreParameterValidator() {}
+
+  /**
+   * @throws IllegalArgumentException if a backup ID is combined with a time range, if a time range
+   *     is given when {@code continuousBackups} is {@code false}, or if {@code from} is after
+   *     {@code to}.
+   */
+  public static void validate(
+      final boolean hasBackupId,
+      final @Nullable String from,
+      final @Nullable String to,
+      final boolean continuousBackups) {
+    validate(
+        hasBackupId, parseTimestamp(from, "from"), parseTimestamp(to, "to"), continuousBackups);
+  }
+
+  public static void validate(
+      final boolean hasBackupId,
+      final @Nullable Instant from,
+      final @Nullable Instant to,
+      final boolean continuousBackups) {
+    final boolean hasTimeRange = from != null || to != null;
+    illegalArgument(
+        !hasBackupId && !hasTimeRange, "Must specify either --backupId or --from/--to.");
+
+    illegalArgument(
+        hasBackupId && hasTimeRange,
+        "Cannot specify both --backupId and --from/--to parameters. Choose one approach.");
+
+    illegalArgument(
+        hasTimeRange && !continuousBackups,
+        "Time range restore (--from/--to) is only supported for continuous backups.");
+
+    illegalArgument(
+        from != null && to != null && from.isAfter(to),
+        "Invalid time range: --from (%s) must be before --to (%s)".formatted(from, to));
+  }
+
+  private static @Nullable Instant parseTimestamp(
+      final @Nullable String value, final String field) {
+    if (value == null) {
+      return null;
+    }
+    try {
+      return OffsetDateTime.parse(value).toInstant();
+    } catch (final DateTimeParseException e) {
+      throw new IllegalArgumentException(
+          "Invalid %s timestamp '%s': must be an ISO 8601 date-time.".formatted(field, value));
+    }
+  }
+
+  private static void illegalArgument(final boolean condition, final String s) {
+    if (condition) {
+      throw new IllegalArgumentException(s);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidator.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidator.java
@@ -8,10 +8,10 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.util.Preconditions;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.Locale;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -33,28 +33,27 @@ public final class RestoreParameterValidator {
     final var instantTo = parseTimestamp(request.to(), "to");
     final var hasTimeRange = hasTimeRange(instantFrom, instantTo);
     final var hasBackupIds = !request.backupIds().isEmpty();
-    illegalArgument(
+    Preconditions.test(
         hasBackupIds && hasTimeRange,
         "Cannot specify both backupId and from/to parameters. Choose one approach.");
 
-    final var databaseType =
-        request.databaseType() == null ? "" : request.databaseType().toLowerCase(Locale.ROOT);
+    final var databaseType = request.databaseType().toLowerCase();
     switch (databaseType) {
       case "rdbms", "none" -> {
-        illegalArgument(
+        Preconditions.test(
             hasTimeRange && !request.continuousBackups(),
             "Time range restore (from/to) is only supported for continuous backups.");
 
-        illegalArgument(
+        Preconditions.test(
             instantFrom != null && instantTo != null && instantFrom.isAfter(instantTo),
             "Invalid time range: from (%s) must be before to (%s)"
                 .formatted(instantFrom, instantTo));
       }
       case "elasticsearch", "opensearch" -> {
-        illegalArgument(
+        Preconditions.test(
             hasTimeRange,
             "Time range restore (from/to) is not supported for %s.".formatted(databaseType));
-        illegalArgument(!hasBackupIds, "No backupId specified");
+        Preconditions.test(!hasBackupIds, "No backupId specified");
       }
       default ->
           throw new IllegalArgumentException("Invalid database type: " + request.databaseType());
@@ -75,12 +74,6 @@ public final class RestoreParameterValidator {
     } catch (final DateTimeParseException e) {
       throw new IllegalArgumentException(
           "Invalid %s timestamp '%s': must be an ISO 8601 date-time.".formatted(field, value));
-    }
-  }
-
-  private static void illegalArgument(final boolean condition, final String s) {
-    if (condition) {
-      throw new IllegalArgumentException(s);
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.OperationNotAllowed;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.MemberState.State;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+
+/**
+ * Validates a {@link RestoreRequest} against the current cluster configuration and produces the
+ * change plan for the restore.
+ *
+ * <p>Validation failures are returned as an {@link Either#left(Object)} carrying a {@link
+ * ClusterConfigurationRequestFailedException}, which the coordinator surfaces as an error response.
+ * When validation passes, the resulting {@link ClusterConfigurationChangeOperation} list is the
+ * restore plan. The plan is currently empty: the restore is not yet applied through the cluster
+ * configuration, so validation is the only effect.
+ */
+public final class RestoreRequestTransformer implements ConfigurationChangeRequest {
+
+  private final RestoreRequest request;
+
+  public RestoreRequestTransformer(final RestoreRequest request) {
+    this.request = request;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+
+    // Restore is only allowed in recovery
+    if (!isClusterRecovering(clusterConfiguration)) {
+      return Either.left(
+          new OperationNotAllowed(
+              "Restore is only allowed while the cluster is in recovery mode."));
+    }
+
+    // Validate input parameters
+    final boolean hasBackupId = request.backupIds() != null && !request.backupIds().isEmpty();
+    try {
+      RestoreParameterValidator.validate(
+          hasBackupId, request.from(), request.to(), request.continuousBackups());
+    } catch (final IllegalArgumentException e) {
+      return Either.left(new InvalidRequest(e.getMessage()));
+    }
+
+    resolveBackups();
+
+    // Restore sequence steps will be generated
+    return Either.right(List.of());
+  }
+
+  private static boolean isClusterRecovering(final ClusterConfiguration clusterConfiguration) {
+    final var initializedMembers =
+        clusterConfiguration.members().values().stream()
+            .filter(member -> member.state() != State.UNINITIALIZED && member.state() != State.LEFT)
+            .toList();
+    return !initializedMembers.isEmpty()
+        && initializedMembers.stream().allMatch(member -> member.state() == State.RECOVERING);
+  }
+
+  /**
+   * Backup compatibility and resolution will happen before the change plan is generated. This
+   * operation will be synchronous for better UX.
+   *
+   * <p>Placeholder
+   */
+  private void resolveBackups() {}
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.ConcurrentModificationException;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.OperationNotAllowed;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -42,7 +42,7 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
     // Restore is only allowed in recovery
     if (!isClusterRecovering(clusterConfiguration)) {
       return Either.left(
-          new OperationNotAllowed(
+          new ConcurrentModificationException(
               "Restore is only allowed while the cluster is in recovery mode."));
     }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RestoreRequestTransformer.java
@@ -47,10 +47,8 @@ public final class RestoreRequestTransformer implements ConfigurationChangeReque
     }
 
     // Validate input parameters
-    final boolean hasBackupId = request.backupIds() != null && !request.backupIds().isEmpty();
     try {
-      RestoreParameterValidator.validate(
-          hasBackupId, request.from(), request.to(), request.continuousBackups());
+      RestoreParameterValidator.validate(request);
     } catch (final IllegalArgumentException e) {
       return Either.left(new InvalidRequest(e.getMessage()));
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
@@ -121,4 +122,8 @@ public interface ClusterConfigurationRequestsSerializer {
   byte[] encodeModeChangeRequest(ModeChangeRequest modeChangeRequest);
 
   ModeChangeRequest decodeModeChangeRequest(byte[] encodedRequest);
+
+  byte[] encodeRestoreRequest(RestoreRequest request);
+
+  RestoreRequest decodeRestoreRequest(byte[] encodedRequest);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1411,20 +1411,16 @@ public class ProtoBufSerializer
   @Override
   public byte[] encodeRestoreRequest(final RestoreRequest request) {
     final var builder = Requests.RestoreRequest.newBuilder();
-    if (request.backupIds() != null) {
-      builder.addAllBackupIds(request.backupIds());
-    }
+    builder.addAllBackupIds(request.backupIds());
+    builder.setDatabaseType(request.databaseType());
+    builder.setContinuousBackups(request.continuousBackups());
+    builder.setDryRun(request.dryRun());
     if (request.from() != null) {
       builder.setFrom(request.from());
     }
     if (request.to() != null) {
       builder.setTo(request.to());
     }
-    if (request.databaseType() != null) {
-      builder.setDatabaseType(request.databaseType());
-    }
-    builder.setContinuousBackups(request.continuousBackups());
-    builder.setDryRun(request.dryRun());
 
     return builder.build().toByteArray();
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -1420,6 +1420,9 @@ public class ProtoBufSerializer
     if (request.to() != null) {
       builder.setTo(request.to());
     }
+    if (request.databaseType() != null) {
+      builder.setDatabaseType(request.databaseType());
+    }
     builder.setContinuousBackups(request.continuousBackups());
     builder.setDryRun(request.dryRun());
 
@@ -1436,6 +1439,7 @@ public class ProtoBufSerializer
           request.getBackupIdsList(),
           from,
           to,
+          request.getDatabaseType(),
           request.getContinuousBackups(),
           request.getDryRun());
     } catch (final InvalidProtocolBufferException e) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
@@ -1402,6 +1403,41 @@ public class ProtoBufSerializer
     try {
       final var request = Requests.ModeChangeRequest.parseFrom(encodedRequest);
       return new ModeChangeRequest(toMode(request.getMode()), request.getDryRun());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  @Override
+  public byte[] encodeRestoreRequest(final RestoreRequest request) {
+    final var builder = Requests.RestoreRequest.newBuilder();
+    if (request.backupIds() != null) {
+      builder.addAllBackupIds(request.backupIds());
+    }
+    if (request.from() != null) {
+      builder.setFrom(request.from());
+    }
+    if (request.to() != null) {
+      builder.setTo(request.to());
+    }
+    builder.setContinuousBackups(request.continuousBackups());
+    builder.setDryRun(request.dryRun());
+
+    return builder.build().toByteArray();
+  }
+
+  @Override
+  public RestoreRequest decodeRestoreRequest(final byte[] encodedRequest) {
+    try {
+      final var request = Requests.RestoreRequest.parseFrom(encodedRequest);
+      final String from = request.hasFrom() ? request.getFrom() : null;
+      final String to = request.hasTo() ? request.getTo() : null;
+      return new RestoreRequest(
+          request.getBackupIdsList(),
+          from,
+          to,
+          request.getContinuousBackups(),
+          request.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -106,6 +106,14 @@ message CancelTopologyChangeRequest {
   int64 changeId = 1;
 }
 
+message RestoreRequest {
+  repeated int64 backupIds = 1;
+  optional string from = 2;
+  optional string to = 3;
+  bool continuousBackups = 4;
+  bool dryRun = 5;
+}
+
 message TopologyChangeResponse {
   int64 changeId = 1;
   map<string, topology_protocol.MemberState> currentTopology = 2;

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -110,8 +110,9 @@ message RestoreRequest {
   repeated int64 backupIds = 1;
   optional string from = 2;
   optional string to = 3;
-  bool continuousBackups = 4;
-  bool dryRun = 5;
+  string databaseType = 4;
+  bool continuousBackups = 5;
+  bool dryRun = 6;
 }
 
 message TopologyChangeResponse {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -565,7 +565,7 @@ final class ClusterConfigurationManagementApiTest {
         .isLeft()
         .left()
         .extracting(ErrorResponse::code)
-        .isEqualTo(ErrorCode.OPERATION_NOT_ALLOWED);
+        .isEqualTo(ErrorCode.CONCURRENT_MODIFICATION);
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -542,7 +542,8 @@ final class ClusterConfigurationManagementApiTest {
     recordingCoordinator.setCurrentTopology(
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
-    final var request = new RestoreRequest(List.of(100L, 101L), null, null, false, false);
+    final var request =
+        new RestoreRequest(List.of(100L, 101L), null, null, "elasticsearch", false, false);
 
     // when
     final var result = clientApi.restore(request).join();
@@ -555,7 +556,8 @@ final class ClusterConfigurationManagementApiTest {
   void shouldRejectRestoreWhenClusterNotRecovering() {
     // given
     recordingCoordinator.setCurrentTopology(initialTopology); // member is ACTIVE
-    final var request = new RestoreRequest(List.of(100L), null, null, false, false);
+    final var request =
+        new RestoreRequest(List.of(100L), null, null, "elasticsearch", false, false);
 
     // when
     final var result = clientApi.restore(request).join();
@@ -575,7 +577,7 @@ final class ClusterConfigurationManagementApiTest {
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
     final var request =
-        new RestoreRequest(List.of(100L), "2024-01-01T10:00:00Z", null, false, false);
+        new RestoreRequest(List.of(100L), "2024-01-01T10:00:00Z", null, "rdbms", false, false);
 
     // when
     final var result = clientApi.restore(request).join();
@@ -595,7 +597,8 @@ final class ClusterConfigurationManagementApiTest {
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
     final var request =
-        new RestoreRequest(List.of(), "2024-01-01T12:00:00Z", "2024-01-01T10:00:00Z", true, false);
+        new RestoreRequest(
+            List.of(), "2024-01-01T12:00:00Z", "2024-01-01T10:00:00Z", "rdbms", true, false);
 
     // when
     final var result = clientApi.restore(request).join();
@@ -615,7 +618,8 @@ final class ClusterConfigurationManagementApiTest {
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
     final var request =
-        new RestoreRequest(List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z", false, false);
+        new RestoreRequest(
+            List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z", "rdbms", false, false);
 
     // when
     final var result = clientApi.restore(request).join();
@@ -634,7 +638,7 @@ final class ClusterConfigurationManagementApiTest {
     recordingCoordinator.setCurrentTopology(
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
-    final var request = new RestoreRequest(List.of(), "not-a-date", null, false, false);
+    final var request = new RestoreRequest(List.of(), "not-a-date", null, "rdbms", false, false);
 
     // when
     final var result = clientApi.restore(request).join();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -529,6 +530,117 @@ final class ClusterConfigurationManagementApiTest {
 
     // then
     EitherAssert.assertThat(changeStatus)
+        .isLeft()
+        .left()
+        .extracting(ErrorResponse::code)
+        .isEqualTo(ErrorCode.INVALID_REQUEST);
+  }
+
+  @Test
+  void shouldValidateRestoreWhenClusterRecovering() {
+    // given
+    recordingCoordinator.setCurrentTopology(
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
+    final var request = new RestoreRequest(List.of(100L, 101L), null, null, false, false);
+
+    // when
+    final var result = clientApi.restore(request).join();
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+  }
+
+  @Test
+  void shouldRejectRestoreWhenClusterNotRecovering() {
+    // given
+    recordingCoordinator.setCurrentTopology(initialTopology); // member is ACTIVE
+    final var request = new RestoreRequest(List.of(100L), null, null, false, false);
+
+    // when
+    final var result = clientApi.restore(request).join();
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .extracting(ErrorResponse::code)
+        .isEqualTo(ErrorCode.OPERATION_NOT_ALLOWED);
+  }
+
+  @Test
+  void shouldRejectRestoreWhenBackupIdsAndTimeRangeProvided() {
+    // given
+    recordingCoordinator.setCurrentTopology(
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
+    final var request =
+        new RestoreRequest(List.of(100L), "2024-01-01T10:00:00Z", null, false, false);
+
+    // when
+    final var result = clientApi.restore(request).join();
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .extracting(ErrorResponse::code)
+        .isEqualTo(ErrorCode.INVALID_REQUEST);
+  }
+
+  @Test
+  void shouldRejectRestoreWhenFromIsAfterTo() {
+    // given
+    recordingCoordinator.setCurrentTopology(
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
+    final var request =
+        new RestoreRequest(List.of(), "2024-01-01T12:00:00Z", "2024-01-01T10:00:00Z", true, false);
+
+    // when
+    final var result = clientApi.restore(request).join();
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .extracting(ErrorResponse::code)
+        .isEqualTo(ErrorCode.INVALID_REQUEST);
+  }
+
+  @Test
+  void shouldRejectRestoreWhenTimeRangeProvidedWithoutContinuousBackups() {
+    // given
+    recordingCoordinator.setCurrentTopology(
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
+    final var request =
+        new RestoreRequest(List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z", false, false);
+
+    // when
+    final var result = clientApi.restore(request).join();
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .extracting(ErrorResponse::code)
+        .isEqualTo(ErrorCode.INVALID_REQUEST);
+  }
+
+  @Test
+  void shouldRejectRestoreWhenTimestampIsInvalid() {
+    // given
+    recordingCoordinator.setCurrentTopology(
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()).toRecovering()));
+    final var request = new RestoreRequest(List.of(), "not-a-date", null, false, false);
+
+    // when
+    final var result = clientApi.restore(request).join();
+
+    // then
+    EitherAssert.assertThat(result)
         .isLeft()
         .left()
         .extracting(ErrorResponse::code)

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -566,8 +566,12 @@ final class ClusterConfigurationManagementApiTest {
     EitherAssert.assertThat(result)
         .isLeft()
         .left()
-        .extracting(ErrorResponse::code)
-        .isEqualTo(ErrorCode.CONCURRENT_MODIFICATION);
+        .satisfies(
+            error -> {
+              assertThat(error.code()).isEqualTo(ErrorCode.CONCURRENT_MODIFICATION);
+              assertThat(error.message())
+                  .isEqualTo("Restore is only allowed while the cluster is in recovery mode.");
+            });
   }
 
   @Test
@@ -586,8 +590,13 @@ final class ClusterConfigurationManagementApiTest {
     EitherAssert.assertThat(result)
         .isLeft()
         .left()
-        .extracting(ErrorResponse::code)
-        .isEqualTo(ErrorCode.INVALID_REQUEST);
+        .satisfies(
+            error -> {
+              assertThat(error.code()).isEqualTo(ErrorCode.INVALID_REQUEST);
+              assertThat(error.message())
+                  .isEqualTo(
+                      "Cannot specify both backupId and from/to parameters. Choose one approach.");
+            });
   }
 
   @Test
@@ -607,8 +616,11 @@ final class ClusterConfigurationManagementApiTest {
     EitherAssert.assertThat(result)
         .isLeft()
         .left()
-        .extracting(ErrorResponse::code)
-        .isEqualTo(ErrorCode.INVALID_REQUEST);
+        .satisfies(
+            error -> {
+              assertThat(error.code()).isEqualTo(ErrorCode.INVALID_REQUEST);
+              assertThat(error.message()).contains("Invalid time range: from", "must be before to");
+            });
   }
 
   @Test
@@ -628,8 +640,13 @@ final class ClusterConfigurationManagementApiTest {
     EitherAssert.assertThat(result)
         .isLeft()
         .left()
-        .extracting(ErrorResponse::code)
-        .isEqualTo(ErrorCode.INVALID_REQUEST);
+        .satisfies(
+            error -> {
+              assertThat(error.code()).isEqualTo(ErrorCode.INVALID_REQUEST);
+              assertThat(error.message())
+                  .isEqualTo(
+                      "Time range restore (from/to) is only supported for continuous backups.");
+            });
   }
 
   @Test
@@ -647,8 +664,13 @@ final class ClusterConfigurationManagementApiTest {
     EitherAssert.assertThat(result)
         .isLeft()
         .left()
-        .extracting(ErrorResponse::code)
-        .isEqualTo(ErrorCode.INVALID_REQUEST);
+        .satisfies(
+            error -> {
+              assertThat(error.code()).isEqualTo(ErrorCode.INVALID_REQUEST);
+              assertThat(error.message())
+                  .isEqualTo(
+                      "Invalid from timestamp 'not-a-date': must be an ISO 8601 date-time.");
+            });
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -668,8 +668,7 @@ final class ClusterConfigurationManagementApiTest {
             error -> {
               assertThat(error.code()).isEqualTo(ErrorCode.INVALID_REQUEST);
               assertThat(error.message())
-                  .isEqualTo(
-                      "Invalid from timestamp 'not-a-date': must be an ISO 8601 date-time.");
+                  .isEqualTo("Invalid from timestamp 'not-a-date': must be an ISO 8601 date-time.");
             });
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+final class RestoreParameterValidatorTest {
+
+  private static final Instant EARLIER = Instant.parse("2026-01-01T10:00:00Z");
+  private static final Instant LATER = Instant.parse("2026-01-01T12:00:00Z");
+  private static final Instant NULL_INSTANT = null;
+
+  @Test
+  void shouldAcceptBackupIdOnly() {
+    // when / then
+    assertThatCode(
+            () -> RestoreParameterValidator.validate(true, NULL_INSTANT, NULL_INSTANT, false))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldAcceptTimeRangeOnlyWhenRangesAllowed() {
+    // when / then
+    assertThatCode(() -> RestoreParameterValidator.validate(false, EARLIER, LATER, true))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectNoParameters() {
+    // when / then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () -> RestoreParameterValidator.validate(false, NULL_INSTANT, NULL_INSTANT, false))
+        .withMessage("Must specify either --backupId or --from/--to.");
+  }
+
+  @Test
+  void shouldRejectBackupIdAndTimeRangeTogether() {
+    // when / then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> RestoreParameterValidator.validate(true, EARLIER, NULL_INSTANT, true))
+        .withMessage(
+            "Cannot specify both --backupId and --from/--to parameters. Choose one approach.");
+  }
+
+  @Test
+  void shouldRejectTimeRangeWithoutContinuousBackups() {
+    // when / then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> RestoreParameterValidator.validate(false, EARLIER, LATER, false))
+        .withMessage(
+            "Time range restore (--from/--to) is not supported for the configured secondary storage.");
+  }
+
+  @Test
+  void shouldRejectSingleBoundWithContinuousBackups() {
+    // when / then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> RestoreParameterValidator.validate(false, EARLIER, NULL_INSTANT, false))
+        .withMessage(
+            "Time range restore (--from/--to) is not supported for the configured secondary storage.");
+  }
+
+  @Test
+  void shouldAcceptBackupIdWithContinuousBackups() {
+    // when / then
+    assertThatCode(
+            () -> RestoreParameterValidator.validate(true, NULL_INSTANT, NULL_INSTANT, false))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldRejectFromAfterTo() {
+    // when / then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> RestoreParameterValidator.validate(false, LATER, EARLIER, true))
+        .withMessage(
+            "Invalid time range: --from (%s) must be before --to (%s)".formatted(LATER, EARLIER));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
@@ -40,7 +40,7 @@ final class RestoreParameterValidatorTest {
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(
             () -> RestoreParameterValidator.validate(false, NULL_INSTANT, NULL_INSTANT, false))
-        .withMessage("Must specify either --backupId or --from/--to.");
+        .withMessage("Must specify either backupId or from/to.");
   }
 
   @Test
@@ -48,8 +48,7 @@ final class RestoreParameterValidatorTest {
     // when / then
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> RestoreParameterValidator.validate(true, EARLIER, NULL_INSTANT, true))
-        .withMessage(
-            "Cannot specify both --backupId and --from/--to parameters. Choose one approach.");
+        .withMessage("Cannot specify both backupId and from/to parameters. Choose one approach.");
   }
 
   @Test
@@ -57,7 +56,7 @@ final class RestoreParameterValidatorTest {
     // when / then
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> RestoreParameterValidator.validate(false, EARLIER, LATER, false))
-        .withMessage("Time range restore (--from/--to) is only supported for continuous backups.");
+        .withMessage("Time range restore (from/to) is only supported for continuous backups.");
   }
 
   @Test
@@ -65,7 +64,7 @@ final class RestoreParameterValidatorTest {
     // when / then
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> RestoreParameterValidator.validate(false, EARLIER, NULL_INSTANT, false))
-        .withMessage("Time range restore (--from/--to) is only supported for continuous backups.");
+        .withMessage("Time range restore (from/to) is only supported for continuous backups.");
   }
 
   @Test
@@ -82,6 +81,6 @@ final class RestoreParameterValidatorTest {
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> RestoreParameterValidator.validate(false, LATER, EARLIER, true))
         .withMessage(
-            "Invalid time range: --from (%s) must be before --to (%s)".formatted(LATER, EARLIER));
+            "Invalid time range: from (%s) must be before to (%s)".formatted(LATER, EARLIER));
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
@@ -39,6 +39,16 @@ final class RestoreParameterValidatorTest {
     return new RestoreRequest(backupIds, from, to, databaseType, continuousBackups, false);
   }
 
+  @Test
+  void shouldAcceptDatabaseTypeCaseInsensitively() {
+    // when / then
+    assertThatCode(
+            () ->
+                RestoreParameterValidator.validate(
+                    request(BACKUP_ID, null, null, "ElasticSearch", false)))
+        .doesNotThrowAnyException();
+  }
+
   @Nested
   final class Rdbms {
 
@@ -169,16 +179,6 @@ final class RestoreParameterValidatorTest {
               () -> RestoreParameterValidator.validate(request(BACKUP_ID, EARLIER, null, DB, true)))
           .withMessage(BOTH_MESSAGE);
     }
-  }
-
-  @Test
-  void shouldAcceptDatabaseTypeCaseInsensitively() {
-    // when / then
-    assertThatCode(
-            () ->
-                RestoreParameterValidator.validate(
-                    request(BACKUP_ID, null, null, "ElasticSearch", false)))
-        .doesNotThrowAnyException();
   }
 
   @Nested

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
@@ -10,85 +10,198 @@ package io.camunda.zeebe.dynamic.config.api;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import java.time.Instant;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class RestoreParameterValidatorTest {
 
-  private static final Instant EARLIER = Instant.parse("2026-01-01T10:00:00Z");
-  private static final Instant LATER = Instant.parse("2026-01-01T12:00:00Z");
-  private static final Instant NULL_INSTANT = null;
+  private static final String EARLIER = "2026-01-01T10:00:00Z";
+  private static final String LATER = "2026-01-01T12:00:00Z";
+  private static final List<Long> BACKUP_ID = List.of(1L);
+  private static final List<Long> NO_BACKUP_IDS = List.of();
+
+  private static final String BOTH_MESSAGE =
+      "Cannot specify both backupId and from/to parameters. Choose one approach.";
+  private static final String CONTINUOUS_MESSAGE =
+      "Time range restore (from/to) is only supported for continuous backups.";
+  private static final String NO_BACKUP_ID_MESSAGE = "No backupId specified";
+
+  private static RestoreRequest request(
+      final List<Long> backupIds,
+      final @Nullable String from,
+      final @Nullable String to,
+      final String databaseType,
+      final boolean continuousBackups) {
+    return new RestoreRequest(backupIds, from, to, databaseType, continuousBackups, false);
+  }
+
+  @Nested
+  final class Rdbms {
+
+    private static final String DB = "rdbms";
+
+    @Test
+    void shouldAcceptBackupIdOnly() {
+      // when / then
+      assertThatCode(
+              () -> RestoreParameterValidator.validate(request(BACKUP_ID, null, null, DB, false)))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldAcceptTimeRangeWithContinuousBackups() {
+      // when / then
+      assertThatCode(
+              () ->
+                  RestoreParameterValidator.validate(
+                      request(NO_BACKUP_IDS, EARLIER, LATER, DB, true)))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldAcceptNoParameters() {
+      // when / then
+      assertThatCode(
+              () ->
+                  RestoreParameterValidator.validate(request(NO_BACKUP_IDS, null, null, DB, false)))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldRejectBackupIdAndTimeRangeTogether() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () -> RestoreParameterValidator.validate(request(BACKUP_ID, EARLIER, null, DB, true)))
+          .withMessage(BOTH_MESSAGE);
+    }
+
+    @Test
+    void shouldRejectTimeRangeWithoutContinuousBackups() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () ->
+                  RestoreParameterValidator.validate(
+                      request(NO_BACKUP_IDS, EARLIER, LATER, DB, false)))
+          .withMessage(CONTINUOUS_MESSAGE);
+    }
+
+    @Test
+    void shouldRejectSingleBoundWithoutContinuousBackups() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () ->
+                  RestoreParameterValidator.validate(
+                      request(NO_BACKUP_IDS, EARLIER, null, DB, false)))
+          .withMessage(CONTINUOUS_MESSAGE);
+    }
+
+    @Test
+    void shouldRejectFromAfterTo() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () ->
+                  RestoreParameterValidator.validate(
+                      request(NO_BACKUP_IDS, LATER, EARLIER, DB, true)))
+          .withMessage(
+              "Invalid time range: from (%s) must be before to (%s)"
+                  .formatted(Instant.parse(LATER), Instant.parse(EARLIER)));
+    }
+
+    @Test
+    void shouldRejectInvalidTimestamp() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () ->
+                  RestoreParameterValidator.validate(
+                      request(NO_BACKUP_IDS, "not-a-timestamp", null, DB, true)))
+          .withMessage("Invalid from timestamp 'not-a-timestamp': must be an ISO 8601 date-time.");
+    }
+  }
+
+  @Nested
+  final class Elasticsearch {
+
+    private static final String DB = "elasticsearch";
+
+    @Test
+    void shouldAcceptBackupIdOnly() {
+      // when / then
+      assertThatCode(
+              () -> RestoreParameterValidator.validate(request(BACKUP_ID, null, null, DB, false)))
+          .doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldRejectNoParameters() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () ->
+                  RestoreParameterValidator.validate(request(NO_BACKUP_IDS, null, null, DB, false)))
+          .withMessage(NO_BACKUP_ID_MESSAGE);
+    }
+
+    @Test
+    void shouldRejectTimeRange() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () ->
+                  RestoreParameterValidator.validate(
+                      request(NO_BACKUP_IDS, EARLIER, LATER, DB, true)))
+          .withMessage("Time range restore (from/to) is not supported for elasticsearch.");
+    }
+
+    @Test
+    void shouldRejectBackupIdAndTimeRangeTogether() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () -> RestoreParameterValidator.validate(request(BACKUP_ID, EARLIER, null, DB, true)))
+          .withMessage(BOTH_MESSAGE);
+    }
+  }
 
   @Test
-  void shouldAcceptBackupIdOnly() {
+  void shouldAcceptDatabaseTypeCaseInsensitively() {
     // when / then
     assertThatCode(
-            () -> RestoreParameterValidator.validate(true, NULL_INSTANT, NULL_INSTANT, false))
+            () ->
+                RestoreParameterValidator.validate(
+                    request(BACKUP_ID, null, null, "ElasticSearch", false)))
         .doesNotThrowAnyException();
   }
 
-  @Test
-  void shouldAcceptTimeRangeWithContinuousBackups() {
-    // when / then
-    assertThatCode(() -> RestoreParameterValidator.validate(false, EARLIER, LATER, true))
-        .doesNotThrowAnyException();
-  }
+  @Nested
+  final class InvalidDatabaseType {
 
-  @Test
-  void shouldRejectNoParametersWhenNoContinuousBackups() {
-    // when / then
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(
-            () -> RestoreParameterValidator.validate(false, NULL_INSTANT, NULL_INSTANT, false))
-        .withMessage("Must specify either backupId or from/to.");
-  }
+    @Test
+    void shouldRejectNullDatabaseType() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () -> RestoreParameterValidator.validate(request(BACKUP_ID, null, null, null, false)))
+          .withMessage("Invalid database type: null");
+    }
 
-  @Test
-  void shouldAllowNoParametersWithContinuousBackups() {
-    // when / then
-    assertThatCode(
-            () -> RestoreParameterValidator.validate(false, NULL_INSTANT, NULL_INSTANT, true))
-        .doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldRejectBackupIdAndTimeRangeTogether() {
-    // when / then
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> RestoreParameterValidator.validate(true, EARLIER, NULL_INSTANT, true))
-        .withMessage("Cannot specify both backupId and from/to parameters. Choose one approach.");
-  }
-
-  @Test
-  void shouldRejectTimeRangeWithoutContinuousBackups() {
-    // when / then
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> RestoreParameterValidator.validate(false, EARLIER, LATER, false))
-        .withMessage("Time range restore (from/to) is only supported for continuous backups.");
-  }
-
-  @Test
-  void shouldRejectSingleBoundWithoutContinuousBackups() {
-    // when / then
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> RestoreParameterValidator.validate(false, EARLIER, NULL_INSTANT, false))
-        .withMessage("Time range restore (from/to) is only supported for continuous backups.");
-  }
-
-  @Test
-  void shouldAcceptBackupIdWithContinuousBackups() {
-    // when / then
-    assertThatCode(
-            () -> RestoreParameterValidator.validate(true, NULL_INSTANT, NULL_INSTANT, false))
-        .doesNotThrowAnyException();
-  }
-
-  @Test
-  void shouldRejectFromAfterTo() {
-    // when / then
-    assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> RestoreParameterValidator.validate(false, LATER, EARLIER, true))
-        .withMessage(
-            "Invalid time range: from (%s) must be before to (%s)".formatted(LATER, EARLIER));
+    @Test
+    void shouldRejectUnknownDatabaseType() {
+      // when / then
+      assertThatExceptionOfType(IllegalArgumentException.class)
+          .isThrownBy(
+              () ->
+                  RestoreParameterValidator.validate(
+                      request(BACKUP_ID, null, null, "mongodb", false)))
+          .withMessage("Invalid database type: mongodb");
+    }
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
@@ -185,15 +185,6 @@ final class RestoreParameterValidatorTest {
   final class InvalidDatabaseType {
 
     @Test
-    void shouldRejectNullDatabaseType() {
-      // when / then
-      assertThatExceptionOfType(IllegalArgumentException.class)
-          .isThrownBy(
-              () -> RestoreParameterValidator.validate(request(BACKUP_ID, null, null, null, false)))
-          .withMessage("Invalid database type: null");
-    }
-
-    @Test
     void shouldRejectUnknownDatabaseType() {
       // when / then
       assertThatExceptionOfType(IllegalArgumentException.class)

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
@@ -57,8 +57,7 @@ final class RestoreParameterValidatorTest {
     // when / then
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> RestoreParameterValidator.validate(false, EARLIER, LATER, false))
-        .withMessage(
-            "Time range restore (--from/--to) is not supported for the configured secondary storage.");
+        .withMessage("Time range restore (--from/--to) is only supported for continuous backups.");
   }
 
   @Test
@@ -66,8 +65,7 @@ final class RestoreParameterValidatorTest {
     // when / then
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> RestoreParameterValidator.validate(false, EARLIER, NULL_INSTANT, false))
-        .withMessage(
-            "Time range restore (--from/--to) is not supported for the configured secondary storage.");
+        .withMessage("Time range restore (--from/--to) is only supported for continuous backups.");
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
@@ -60,7 +60,7 @@ final class RestoreParameterValidatorTest {
   }
 
   @Test
-  void shouldRejectSingleBoundWithContinuousBackups() {
+  void shouldRejectSingleBoundWithoutContinuousBackups() {
     // when / then
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> RestoreParameterValidator.validate(false, EARLIER, NULL_INSTANT, false))

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
@@ -35,7 +35,7 @@ final class RestoreParameterValidatorTest {
   }
 
   @Test
-  void shouldRejectNoParameters() {
+  void shouldRejectNoParametersWhenNoContinuousBackups() {
     // when / then
     assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RestoreParameterValidatorTest.java
@@ -28,7 +28,7 @@ final class RestoreParameterValidatorTest {
   }
 
   @Test
-  void shouldAcceptTimeRangeOnlyWhenRangesAllowed() {
+  void shouldAcceptTimeRangeWithContinuousBackups() {
     // when / then
     assertThatCode(() -> RestoreParameterValidator.validate(false, EARLIER, LATER, true))
         .doesNotThrowAnyException();
@@ -41,6 +41,14 @@ final class RestoreParameterValidatorTest {
         .isThrownBy(
             () -> RestoreParameterValidator.validate(false, NULL_INSTANT, NULL_INSTANT, false))
         .withMessage("Must specify either backupId or from/to.");
+  }
+
+  @Test
+  void shouldAllowNoParametersWithContinuousBackups() {
+    // when / then
+    assertThatCode(
+            () -> RestoreParameterValidator.validate(false, NULL_INSTANT, NULL_INSTANT, true))
+        .doesNotThrowAnyException();
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -98,6 +98,45 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.10"
 
+  /restore:
+    post:
+      x-eventually-consistent: false
+      tags:
+        - Recovery
+      operationId: restore
+      x-required-permissions: []
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Restore from a backup
+      description: >-
+        Restores the cluster from a backup. The restore is described either by a single backup ID
+        or by a time range (`from`/`to`) that selects the backups to restore. This endpoint is only
+        accessible while the cluster is in recovery mode; requests are rejected otherwise. The
+        request is validated and acknowledged, but the restore itself is performed asynchronously.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RestoreRequest'
+        required: true
+      responses:
+        "202":
+          description: The restore request was accepted; returns the planned cluster changes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterModeChangeResponse'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "409":
+          description: The cluster is not in recovery mode, so the restore cannot be accepted.
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
 ## Schema definitions
 
 components:
@@ -259,3 +298,30 @@ components:
           type: string
           nullable: true
           example: RECOVERING
+
+    RestoreRequest:
+      description: >-
+        Describes a restore request. Provide either a list of backup IDs or a time range
+        (`from`/`to`) that selects the backups to restore; the two are mutually exclusive.
+      type: object
+      properties:
+        from:
+          description: The start of the time range to restore from, as an ISO 8601 timestamp.
+          type: string
+          format: date-time
+          nullable: true
+          example: "2024-01-01T10:00:00Z"
+        to:
+          description: The end of the time range to restore from, as an ISO 8601 timestamp.
+          type: string
+          format: date-time
+          nullable: true
+          example: "2024-01-01T12:00:00Z"
+        backupIds:
+          description: The IDs of the backups to restore from, one per partition.
+          type: array
+          nullable: true
+          items:
+            type: integer
+            format: int64
+          example: [100, 101]

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -448,6 +448,8 @@ paths:
     $ref: 'cluster.yaml#/paths/~1topology'
   /mode:
     $ref: 'cluster.yaml#/paths/~1mode'
+  /restore:
+    $ref: 'cluster.yaml#/paths/~1restore'
 
   # User endpoints
   /users:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +78,7 @@ public final class RecoveryController {
       @RequestBody(required = false)
           final io.camunda.gateway.protocol.model.RestoreRequest restoreRequest,
       @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
-    LOG.debug("Requested restore for physical tenant {}: {}", physicalTenantId, restoreRequest);
+    LOG.info("Requested restore for physical tenant {}: {}", physicalTenantId, restoreRequest);
     return RequestExecutor.executeServiceMethod(
         () ->
             clusterConfigurationRequestSender
@@ -93,8 +92,7 @@ public final class RecoveryController {
       final io.camunda.gateway.protocol.model.RestoreRequest restoreRequest, final boolean dryRun) {
     final String databaseType = DatabaseTypeUtils.getDatabaseTypeOrDefault(environment);
     final boolean continuousBackups =
-        Optional.ofNullable(environment.getProperty(CONTINUOUS_BACKUPS_PROPERTY, Boolean.class))
-            .orElse(false);
+        environment.getProperty(CONTINUOUS_BACKUPS_PROPERTY, Boolean.class, false);
     if (restoreRequest == null) {
       return new RestoreRequest(List.of(), null, null, databaseType, continuousBackups, dryRun);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -11,6 +11,7 @@ import io.camunda.gateway.protocol.model.ClusterModeChangeOperation;
 import io.camunda.gateway.protocol.model.ClusterModeChangeResponse;
 import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
+import io.camunda.spring.utils.DatabaseTypeUtils;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
@@ -90,13 +91,22 @@ public final class RecoveryController {
 
   private RestoreRequest toRestoreRequest(
       final io.camunda.gateway.protocol.model.RestoreRequest restoreRequest, final boolean dryRun) {
+    final String databaseType = DatabaseTypeUtils.getDatabaseTypeOrDefault(environment);
+    final boolean continuousBackups =
+        Optional.ofNullable(environment.getProperty(CONTINUOUS_BACKUPS_PROPERTY, Boolean.class))
+            .orElse(false);
     if (restoreRequest == null) {
-      return new RestoreRequest(List.of(), null, null, continuousBackups(), dryRun);
+      return new RestoreRequest(List.of(), null, null, databaseType, continuousBackups, dryRun);
     }
     final List<Long> backupIds =
         restoreRequest.getBackupIds() == null ? List.of() : restoreRequest.getBackupIds();
     return new RestoreRequest(
-        backupIds, restoreRequest.getFrom(), restoreRequest.getTo(), continuousBackups(), dryRun);
+        backupIds,
+        restoreRequest.getFrom(),
+        restoreRequest.getTo(),
+        databaseType,
+        continuousBackups,
+        dryRun);
   }
 
   private static ClusterConfigurationChangeResponse unwrapOrThrow(
@@ -141,11 +151,5 @@ public final class RecoveryController {
         .operation(operation.getClass().getSimpleName())
         .mode(mode)
         .build();
-  }
-
-  /** Returns true if continuous backups are enabled. */
-  private boolean continuousBackups() {
-    return Optional.ofNullable(environment.getProperty(CONTINUOUS_BACKUPS_PROPERTY, Boolean.class))
-        .orElse(false);
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -75,7 +75,8 @@ public final class RecoveryController {
   @CamundaPostMapping(path = "/restore")
   public CompletableFuture<ResponseEntity<Object>> restore(
       @PhysicalTenantId final String physicalTenantId,
-      @RequestBody final io.camunda.gateway.protocol.model.RestoreRequest restoreRequest,
+      @RequestBody(required = false)
+          final io.camunda.gateway.protocol.model.RestoreRequest restoreRequest,
       @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
     LOG.debug("Requested restore for physical tenant {}: {}", physicalTenantId, restoreRequest);
     return RequestExecutor.executeServiceMethod(
@@ -89,6 +90,9 @@ public final class RecoveryController {
 
   private RestoreRequest toRestoreRequest(
       final io.camunda.gateway.protocol.model.RestoreRequest restoreRequest, final boolean dryRun) {
+    if (restoreRequest == null) {
+      return new RestoreRequest(List.of(), null, null, continuousBackups(), dryRun);
+    }
     final List<Long> backupIds =
         restoreRequest.getBackupIds() == null ? List.of() : restoreRequest.getBackupIds();
     return new RestoreRequest(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -13,6 +13,7 @@ import io.camunda.service.exception.ServiceException;
 import io.camunda.service.exception.ServiceException.Status;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -20,15 +21,19 @@ import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.annotation.PhysicalTenantId;
 import io.camunda.zeebe.gateway.rest.mapper.RequestExecutor;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -37,12 +42,17 @@ import org.springframework.web.bind.annotation.RequestParam;
 public final class RecoveryController {
 
   private static final Logger LOG = LoggerFactory.getLogger(RecoveryController.class);
+  private static final String CONTINUOUS_BACKUPS_PROPERTY =
+      "camunda.data.primary-storage.backup.continous";
 
   private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
+  private final Environment environment;
 
   public RecoveryController(
-      final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender) {
+      final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender,
+      final Environment environment) {
     this.clusterConfigurationRequestSender = clusterConfigurationRequestSender;
+    this.environment = environment;
   }
 
   @CamundaPatchMapping(
@@ -60,6 +70,29 @@ public final class RecoveryController {
                 .thenApply(RecoveryController::unwrapOrThrow),
         RecoveryController::toClusterModeChangeResponse,
         HttpStatus.OK);
+  }
+
+  @CamundaPostMapping(path = "/restore")
+  public CompletableFuture<ResponseEntity<Object>> restore(
+      @PhysicalTenantId final String physicalTenantId,
+      @RequestBody final io.camunda.gateway.protocol.model.RestoreRequest restoreRequest,
+      @RequestParam(name = "dryRun", defaultValue = "false") final boolean dryRun) {
+    LOG.debug("Requested restore for physical tenant {}: {}", physicalTenantId, restoreRequest);
+    return RequestExecutor.executeServiceMethod(
+        () ->
+            clusterConfigurationRequestSender
+                .restore(toRestoreRequest(restoreRequest, dryRun))
+                .thenApply(RecoveryController::unwrapOrThrow),
+        RecoveryController::toClusterModeChangeResponse,
+        HttpStatus.ACCEPTED);
+  }
+
+  private RestoreRequest toRestoreRequest(
+      final io.camunda.gateway.protocol.model.RestoreRequest restoreRequest, final boolean dryRun) {
+    final List<Long> backupIds =
+        restoreRequest.getBackupIds() == null ? List.of() : restoreRequest.getBackupIds();
+    return new RestoreRequest(
+        backupIds, restoreRequest.getFrom(), restoreRequest.getTo(), continuousBackups(), dryRun);
   }
 
   private static ClusterConfigurationChangeResponse unwrapOrThrow(
@@ -104,5 +137,11 @@ public final class RecoveryController {
         .operation(operation.getClass().getSimpleName())
         .mode(mode)
         .build();
+  }
+
+  /** Returns true if continuous backups are enabled. */
+  private boolean continuousBackups() {
+    return Optional.ofNullable(environment.getProperty(CONTINUOUS_BACKUPS_PROPERTY, Boolean.class))
+        .orElse(false);
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/RecoveryController.java
@@ -43,7 +43,7 @@ public final class RecoveryController {
 
   private static final Logger LOG = LoggerFactory.getLogger(RecoveryController.class);
   private static final String CONTINUOUS_BACKUPS_PROPERTY =
-      "camunda.data.primary-storage.backup.continous";
+      "camunda.data.primary-storage.backup.continuous";
 
   private final ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
   private final Environment environment;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -227,6 +228,26 @@ public class RecoveryControllerTest extends RestControllerTest {
         .exchange()
         .expectStatus()
         .isEqualTo(HttpStatus.CONFLICT);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+  void shouldAllowNoParameter(final String baseUrl) {
+    // given
+    stubValidationSuccess();
+
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isAccepted();
+
+    // then
+    Mockito.verify(clusterConfigurationRequestSender)
+        .restore(new RestoreRequest(List.of(), null, null, false, false));
   }
 
   @Nested

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -38,6 +38,14 @@ public class RecoveryControllerTest extends RestControllerTest {
 
   @MockitoBean ClusterConfigurationManagementRequestSender clusterConfigurationRequestSender;
 
+  private void stubValidationSuccess() {
+    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    new ClusterConfigurationChangeResponse(0L, Map.of(), Map.of(), List.of()))));
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {"/v2/mode", "/physical-tenants/default/v2/mode"})
   void shouldChangeClusterModeAndReturnPlannedChanges(final String baseUrl) {
@@ -98,62 +106,6 @@ public class RecoveryControllerTest extends RestControllerTest {
         .is4xxClientError();
   }
 
-  private void stubValidationSuccess() {
-    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                Either.right(
-                    new ClusterConfigurationChangeResponse(0L, Map.of(), Map.of(), List.of()))));
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-  void shouldForwardBackupIdsRestoreAndReturnAccepted(final String baseUrl) {
-    // given
-    stubValidationSuccess();
-
-    // when / then
-    webClient
-        .post()
-        .uri(baseUrl)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue("{\"backupIds\": [100, 101]}")
-        .exchange()
-        .expectStatus()
-        .isAccepted()
-        .expectBody()
-        .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
-
-    // then
-    Mockito.verify(clusterConfigurationRequestSender)
-        .restore(new RestoreRequest(List.of(100L, 101L), null, null, false, false));
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-  void shouldForwardTimeRangeRestoreAndReturnAccepted(final String baseUrl) {
-    // given
-    stubValidationSuccess();
-
-    // when / then
-    webClient
-        .post()
-        .uri(baseUrl)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue("{\"from\": \"2024-01-01T10:00:00Z\", \"to\": \"2024-01-01T12:00:00Z\"}")
-        .exchange()
-        .expectStatus()
-        .isAccepted()
-        .expectBody()
-        .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
-
-    // then
-    Mockito.verify(clusterConfigurationRequestSender)
-        .restore(
-            new RestoreRequest(
-                List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z", false, false));
-  }
-
   @Test
   void shouldMapInvalidRequestErrorFromCoordinator() {
     // given
@@ -171,25 +123,6 @@ public class RecoveryControllerTest extends RestControllerTest {
         .exchange()
         .expectStatus()
         .isBadRequest();
-  }
-
-  @Test
-  void shouldMapOperationNotAllowedErrorWhenClusterNotRecovering() {
-    // given
-    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                Either.left(new ErrorResponse(ErrorCode.OPERATION_NOT_ALLOWED, "not recovering"))));
-
-    // when / then
-    webClient
-        .post()
-        .uri("/v2/restore")
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue("{\"backupIds\": [100]}")
-        .exchange()
-        .expectStatus()
-        .isForbidden();
   }
 
   @Test
@@ -230,29 +163,110 @@ public class RecoveryControllerTest extends RestControllerTest {
         .isEqualTo(HttpStatus.CONFLICT);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-  void shouldAllowNoParameter(final String baseUrl) {
-    // given
-    stubValidationSuccess();
+  @Nested
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=elasticsearch"})
+  class Elasticsearch {
 
-    // when / then
-    webClient
-        .post()
-        .uri(baseUrl)
-        .contentType(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isAccepted();
+    @ParameterizedTest
+    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+    void shouldForwardBackupIdsWithElasticsearchType(final String baseUrl) {
+      // given
+      stubValidationSuccess();
 
-    // then
-    Mockito.verify(clusterConfigurationRequestSender)
-        .restore(new RestoreRequest(List.of(), null, null, false, false));
+      // when / then
+      webClient
+          .post()
+          .uri(baseUrl)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"backupIds\": [100, 101]}")
+          .exchange()
+          .expectStatus()
+          .isAccepted()
+          .expectBody()
+          .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
+
+      // then
+      Mockito.verify(clusterConfigurationRequestSender)
+          .restore(
+              new RestoreRequest(List.of(100L, 101L), null, null, "elasticsearch", false, false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+    void shouldForwardNoParameterWithElasticsearchType(final String baseUrl) {
+      // given
+      stubValidationSuccess();
+
+      // when / then
+      webClient
+          .post()
+          .uri(baseUrl)
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isAccepted();
+
+      // then
+      Mockito.verify(clusterConfigurationRequestSender)
+          .restore(new RestoreRequest(List.of(), null, null, "elasticsearch", false, false));
+    }
   }
 
   @Nested
-  @TestPropertySource(properties = {"camunda.data.primary-storage.backup.continuous=true"})
-  class RestoreWithContinuousBackups {
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=rdbms"})
+  class Rdbms {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+    void shouldForwardBackupIdsWithRdbmsType(final String baseUrl) {
+      // given
+      stubValidationSuccess();
+
+      // when / then
+      webClient
+          .post()
+          .uri(baseUrl)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"backupIds\": [100, 101]}")
+          .exchange()
+          .expectStatus()
+          .isAccepted()
+          .expectBody()
+          .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
+
+      // then
+      Mockito.verify(clusterConfigurationRequestSender)
+          .restore(new RestoreRequest(List.of(100L, 101L), null, null, "rdbms", false, false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+    void shouldForwardNoParameterWithRdbmsType(final String baseUrl) {
+      // given
+      stubValidationSuccess();
+
+      // when / then
+      webClient
+          .post()
+          .uri(baseUrl)
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isAccepted();
+
+      // then
+      Mockito.verify(clusterConfigurationRequestSender)
+          .restore(new RestoreRequest(List.of(), null, null, "rdbms", false, false));
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=rdbms",
+        "camunda.data.primary-storage.backup.continuous=true"
+      })
+  class RdbmsWithContinuousBackups {
 
     @ParameterizedTest
     @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
@@ -272,7 +286,7 @@ public class RecoveryControllerTest extends RestControllerTest {
 
       // then
       Mockito.verify(clusterConfigurationRequestSender)
-          .restore(new RestoreRequest(List.of(100L, 101L), null, null, true, false));
+          .restore(new RestoreRequest(List.of(100L, 101L), null, null, "rdbms", true, false));
     }
 
     @ParameterizedTest
@@ -295,7 +309,7 @@ public class RecoveryControllerTest extends RestControllerTest {
       Mockito.verify(clusterConfigurationRequestSender)
           .restore(
               new RestoreRequest(
-                  List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z", true, false));
+                  List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z", "rdbms", true, false));
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -210,6 +210,25 @@ public class RecoveryControllerTest extends RestControllerTest {
         .is5xxServerError();
   }
 
+  @Test
+  void shouldMapConcurrentModificationFromCoordinator() {
+    // given
+    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(new ErrorResponse(ErrorCode.CONCURRENT_MODIFICATION, "boom"))));
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/restore")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100]}")
+        .exchange()
+        .expectStatus()
+        .isEqualTo(HttpStatus.CONFLICT);
+  }
+
   @Nested
   @TestPropertySource(properties = {"camunda.data.primary-storage.backup.continuous=true"})
   class RestoreWithContinuousBackups {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
@@ -20,10 +21,14 @@ import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.json.JsonCompareMode;
 
@@ -90,5 +95,167 @@ public class RecoveryControllerTest extends RestControllerTest {
         .exchange()
         .expectStatus()
         .is4xxClientError();
+  }
+
+  private void stubValidationSuccess() {
+    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.right(
+                    new ClusterConfigurationChangeResponse(0L, Map.of(), Map.of(), List.of()))));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+  void shouldForwardBackupIdsRestoreAndReturnAccepted(final String baseUrl) {
+    // given
+    stubValidationSuccess();
+
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100, 101]}")
+        .exchange()
+        .expectStatus()
+        .isAccepted()
+        .expectBody()
+        .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
+
+    // then
+    Mockito.verify(clusterConfigurationRequestSender)
+        .restore(new RestoreRequest(List.of(100L, 101L), null, null, false, false));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+  void shouldForwardTimeRangeRestoreAndReturnAccepted(final String baseUrl) {
+    // given
+    stubValidationSuccess();
+
+    // when / then
+    webClient
+        .post()
+        .uri(baseUrl)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"from\": \"2024-01-01T10:00:00Z\", \"to\": \"2024-01-01T12:00:00Z\"}")
+        .exchange()
+        .expectStatus()
+        .isAccepted()
+        .expectBody()
+        .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
+
+    // then
+    Mockito.verify(clusterConfigurationRequestSender)
+        .restore(
+            new RestoreRequest(
+                List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z", false, false));
+  }
+
+  @Test
+  void shouldMapInvalidRequestErrorFromCoordinator() {
+    // given
+    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(new ErrorResponse(ErrorCode.INVALID_REQUEST, "bad params"))));
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/restore")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100], \"from\": \"2024-01-01T10:00:00Z\"}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest();
+  }
+
+  @Test
+  void shouldMapOperationNotAllowedErrorWhenClusterNotRecovering() {
+    // given
+    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(new ErrorResponse(ErrorCode.OPERATION_NOT_ALLOWED, "not recovering"))));
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/restore")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100]}")
+        .exchange()
+        .expectStatus()
+        .isForbidden();
+  }
+
+  @Test
+  void shouldMapInternalErrorFromCoordinator() {
+    // given
+    Mockito.when(clusterConfigurationRequestSender.restore(Mockito.any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                Either.left(new ErrorResponse(ErrorCode.INTERNAL_ERROR, "boom"))));
+
+    // when / then
+    webClient
+        .post()
+        .uri("/v2/restore")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{\"backupIds\": [100]}")
+        .exchange()
+        .expectStatus()
+        .is5xxServerError();
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.data.primary-storage.backup.continous=true"})
+  class RestoreWithContinuousBackups {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+    void shouldForwardContinuousFlagWithBackupIds(final String baseUrl) {
+      // given
+      stubValidationSuccess();
+
+      // when / then
+      webClient
+          .post()
+          .uri(baseUrl)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"backupIds\": [100, 101]}")
+          .exchange()
+          .expectStatus()
+          .isAccepted();
+
+      // then
+      Mockito.verify(clusterConfigurationRequestSender)
+          .restore(new RestoreRequest(List.of(100L, 101L), null, null, true, false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+    void shouldForwardContinuousFlagWithTimeRange(final String baseUrl) {
+      // given
+      stubValidationSuccess();
+
+      // when / then
+      webClient
+          .post()
+          .uri(baseUrl)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"from\": \"2024-01-01T10:00:00Z\", \"to\": \"2024-01-01T12:00:00Z\"}")
+          .exchange()
+          .expectStatus()
+          .isAccepted();
+
+      // then
+      Mockito.verify(clusterConfigurationRequestSender)
+          .restore(
+              new RestoreRequest(
+                  List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z", true, false));
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -165,98 +165,41 @@ public class RecoveryControllerTest extends RestControllerTest {
 
   @Nested
   @TestPropertySource(properties = {"camunda.data.secondary-storage.type=elasticsearch"})
-  class Elasticsearch {
+  class Elasticsearch extends DocumentSecondaryStorage {
 
-    @ParameterizedTest
-    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-    void shouldForwardBackupIdsWithElasticsearchType(final String baseUrl) {
-      // given
-      stubValidationSuccess();
-
-      // when / then
-      webClient
-          .post()
-          .uri(baseUrl)
-          .contentType(MediaType.APPLICATION_JSON)
-          .bodyValue("{\"backupIds\": [100, 101]}")
-          .exchange()
-          .expectStatus()
-          .isAccepted()
-          .expectBody()
-          .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
-
-      // then
-      Mockito.verify(clusterConfigurationRequestSender)
-          .restore(
-              new RestoreRequest(List.of(100L, 101L), null, null, "elasticsearch", false, false));
+    @Override
+    String expectedDatabaseType() {
+      return "elasticsearch";
     }
+  }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-    void shouldForwardNoParameterWithElasticsearchType(final String baseUrl) {
-      // given
-      stubValidationSuccess();
+  @Nested
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=opensearch"})
+  class OpenSearch extends DocumentSecondaryStorage {
 
-      // when / then
-      webClient
-          .post()
-          .uri(baseUrl)
-          .contentType(MediaType.APPLICATION_JSON)
-          .exchange()
-          .expectStatus()
-          .isAccepted();
-
-      // then
-      Mockito.verify(clusterConfigurationRequestSender)
-          .restore(new RestoreRequest(List.of(), null, null, "elasticsearch", false, false));
+    @Override
+    String expectedDatabaseType() {
+      return "opensearch";
     }
   }
 
   @Nested
   @TestPropertySource(properties = {"camunda.data.secondary-storage.type=rdbms"})
-  class Rdbms {
+  class Rdbms extends RdbmsSecondaryStorage {
 
-    @ParameterizedTest
-    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-    void shouldForwardBackupIdsWithRdbmsType(final String baseUrl) {
-      // given
-      stubValidationSuccess();
-
-      // when / then
-      webClient
-          .post()
-          .uri(baseUrl)
-          .contentType(MediaType.APPLICATION_JSON)
-          .bodyValue("{\"backupIds\": [100, 101]}")
-          .exchange()
-          .expectStatus()
-          .isAccepted()
-          .expectBody()
-          .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
-
-      // then
-      Mockito.verify(clusterConfigurationRequestSender)
-          .restore(new RestoreRequest(List.of(100L, 101L), null, null, "rdbms", false, false));
+    @Override
+    String expectedDatabaseType() {
+      return "rdbms";
     }
+  }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
-    void shouldForwardNoParameterWithRdbmsType(final String baseUrl) {
-      // given
-      stubValidationSuccess();
+  @Nested
+  @TestPropertySource(properties = {"camunda.data.secondary-storage.type=none"})
+  class None extends RdbmsSecondaryStorage {
 
-      // when / then
-      webClient
-          .post()
-          .uri(baseUrl)
-          .contentType(MediaType.APPLICATION_JSON)
-          .exchange()
-          .expectStatus()
-          .isAccepted();
-
-      // then
-      Mockito.verify(clusterConfigurationRequestSender)
-          .restore(new RestoreRequest(List.of(), null, null, "rdbms", false, false));
+    @Override
+    String expectedDatabaseType() {
+      return "none";
     }
   }
 
@@ -266,7 +209,79 @@ public class RecoveryControllerTest extends RestControllerTest {
         "camunda.data.secondary-storage.type=rdbms",
         "camunda.data.primary-storage.backup.continuous=true"
       })
-  class RdbmsWithContinuousBackups {
+  class RdbmsWithContinuousBackups extends RdbmsSecondaryStorageWithContinuousBackups {
+
+    @Override
+    String expectedDatabaseType() {
+      return "rdbms";
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.data.secondary-storage.type=none",
+        "camunda.data.primary-storage.backup.continuous=true"
+      })
+  class NoneWithContinuousBackups extends RdbmsSecondaryStorageWithContinuousBackups {
+
+    @Override
+    String expectedDatabaseType() {
+      return "none";
+    }
+  }
+
+  abstract class RdbmsSecondaryStorage {
+
+    abstract String expectedDatabaseType();
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+    void shouldForwardBackupIds(final String baseUrl) {
+      // given
+      stubValidationSuccess();
+
+      // when / then
+      webClient
+          .post()
+          .uri(baseUrl)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"backupIds\": [100, 101]}")
+          .exchange()
+          .expectStatus()
+          .isAccepted()
+          .expectBody()
+          .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
+
+      Mockito.verify(clusterConfigurationRequestSender)
+          .restore(
+              new RestoreRequest(
+                  List.of(100L, 101L), null, null, expectedDatabaseType(), false, false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+    void shouldForwardNoParameters(final String baseUrl) {
+      // given
+      stubValidationSuccess();
+
+      // when / then
+      webClient
+          .post()
+          .uri(baseUrl)
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isAccepted();
+
+      Mockito.verify(clusterConfigurationRequestSender)
+          .restore(new RestoreRequest(List.of(), null, null, expectedDatabaseType(), false, false));
+    }
+  }
+
+  abstract class RdbmsSecondaryStorageWithContinuousBackups {
+
+    abstract String expectedDatabaseType();
 
     @ParameterizedTest
     @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
@@ -284,9 +299,10 @@ public class RecoveryControllerTest extends RestControllerTest {
           .expectStatus()
           .isAccepted();
 
-      // then
       Mockito.verify(clusterConfigurationRequestSender)
-          .restore(new RestoreRequest(List.of(100L, 101L), null, null, "rdbms", true, false));
+          .restore(
+              new RestoreRequest(
+                  List.of(100L, 101L), null, null, expectedDatabaseType(), true, false));
     }
 
     @ParameterizedTest
@@ -305,11 +321,63 @@ public class RecoveryControllerTest extends RestControllerTest {
           .expectStatus()
           .isAccepted();
 
-      // then
       Mockito.verify(clusterConfigurationRequestSender)
           .restore(
               new RestoreRequest(
-                  List.of(), "2024-01-01T10:00:00Z", "2024-01-01T12:00:00Z", "rdbms", true, false));
+                  List.of(),
+                  "2024-01-01T10:00:00Z",
+                  "2024-01-01T12:00:00Z",
+                  expectedDatabaseType(),
+                  true,
+                  false));
+    }
+  }
+
+  abstract class DocumentSecondaryStorage {
+
+    abstract String expectedDatabaseType();
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+    void shouldForwardBackupIds(final String baseUrl) {
+      // given
+      stubValidationSuccess();
+
+      // when / then
+      webClient
+          .post()
+          .uri(baseUrl)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue("{\"backupIds\": [100, 101]}")
+          .exchange()
+          .expectStatus()
+          .isAccepted()
+          .expectBody()
+          .json("{\"changeId\": \"0\", \"plannedChanges\": []}", JsonCompareMode.STRICT);
+
+      Mockito.verify(clusterConfigurationRequestSender)
+          .restore(
+              new RestoreRequest(
+                  List.of(100L, 101L), null, null, expectedDatabaseType(), false, false));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/v2/restore", "/physical-tenants/default/v2/restore"})
+    void shouldForwardNoParameters(final String baseUrl) {
+      // given
+      stubValidationSuccess();
+
+      // when / then
+      webClient
+          .post()
+          .uri(baseUrl)
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isAccepted();
+
+      Mockito.verify(clusterConfigurationRequestSender)
+          .restore(new RestoreRequest(List.of(), null, null, expectedDatabaseType(), false, false));
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/RecoveryControllerTest.java
@@ -211,7 +211,7 @@ public class RecoveryControllerTest extends RestControllerTest {
   }
 
   @Nested
-  @TestPropertySource(properties = {"camunda.data.primary-storage.backup.continous=true"})
+  @TestPropertySource(properties = {"camunda.data.primary-storage.backup.continuous=true"})
   class RestoreWithContinuousBackups {
 
     @ParameterizedTest

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/RdbmsRangeRestoreIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/RdbmsRangeRestoreIT.java
@@ -326,6 +326,7 @@ final class RdbmsRangeRestoreIT implements ClockSupport {
     fsConfig.setBasePath(backupDir.toAbsolutePath().toString());
     cfg.getData().getPrimaryStorage().getBackup().setFilesystem(fsConfig);
     cfg.getData().getPrimaryStorage().getBackup().setStore(BackupStoreType.FILESYSTEM);
+    cfg.getData().getPrimaryStorage().getBackup().setContinuous(true);
   }
 
   private static void configureRdbms(final Camunda cfg) {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Preconditions.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Preconditions.java
@@ -35,4 +35,10 @@ public final class Preconditions {
   public static Consumer<String> assertNonEmpty(final String fieldName) {
     return s -> assertNonEmpty(s, fieldName);
   }
+
+  public static void test(final boolean condition, final String errorMessage) {
+    if (condition) {
+      throw new IllegalArgumentException(errorMessage);
+    }
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduce the `/v2/restore` endpoint. This is the per-tenant restore operation endpoint accepting the regular 
```json
{
  "from": "2024-01-01T10:00:00Z",  
  "to": "2024-01-01T10:00:00Z",  
  "backupIds": [12,13],
}
```

The validation of the restore operation is split in two parts first is the parameter and member state validation which is included in this PR and then the validation of the parameters against the actual backup store contents - which will be a follow up. This step is performed synchronously by the coordinator so that any validation error can be returned directly to the operator for better UX.

The generation of the Cluster Change plan to perform the sequenced restore will be generated after all validation steps are passed. For now the backup store validation is a placeholder and the operation returns an empty list of change operations.

The `RestoreParameterValidator` currently resides in the dynamic config module and reused by the old `RestoreApp`. Ideally this would be part of the `zeebe-restore` module but right now it will introduce a dependency cycle. It's something we can re-evaluate when the restore procedure is refined throughout the context of this epic.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56729 
