### PR TITLE
ci: destroy previous ecs load test

### DIFF
--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -270,6 +270,8 @@ jobs:
     with:
       image_tag: ${{ needs.test-data.outputs.image-tag }}
       environment: prod
+      skip_destroy_previous: false
+
 
   notify:
     name: Notify on failure


### PR DESCRIPTION
## Description
Destroy the benchmark from the previous week. This means that EFS/Aurora are destroyed as there is no compatibility guarantee between SNAPSHOTS images.

This was raised in the context of incident [#inc-weekly-medic-ecs-benchmark-failing-due-to-liquibase-checksum-mismatch](https://camunda.slack.com/archives/C0BFKD05BAA)
as a changeset was modified instead of a new one being created

