### PR TITLE
feat: disable job record export by default in ES/OS exporters

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebePositionBasedImportIndexIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebePositionBasedImportIndexIT.java
@@ -233,9 +233,8 @@ public class ZeebePositionBasedImportIndexIT extends AbstractCCSMIT {
         .singleElement()
         .satisfies(instance -> assertThat(instance.getFlowNodeInstances()).isEmpty());
 
-    // when importing the second and third record based on position (note only records with relevant
+    // when importing the second record based on position (note only records with relevant
     // intent are imported)
-    importAllZeebeEntitiesFromLastIndex(); // process activated - fetched but not imported
     importAllZeebeEntitiesFromLastIndex(); // startEvent activating (first record with sequence) -
     // imported
 
@@ -255,8 +254,6 @@ public class ZeebePositionBasedImportIndexIT extends AbstractCCSMIT {
             + "Zeebe records will now be fetched based on sequence.");
 
     // when
-    importAllZeebeEntitiesFromLastIndex(); // start event activated - fetched but not imported
-    importAllZeebeEntitiesFromLastIndex(); // start event completing - fetched but not imported
     importAllZeebeEntitiesFromLastIndex(); // start event completed - imported
     embeddedOptimizeExtension.storeImportIndexesToElasticsearch();
     databaseIntegrationTestExtension.refreshAllOptimizeIndices();

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
@@ -181,7 +181,6 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
             });
 
     // when
-    importAllZeebeEntitiesFromLastIndex(); // fetch process activated event - not imported
     importAllZeebeEntitiesFromLastIndex(); // fetch and import flownode activating event
 
     // then

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/ExporterMigrationTestHelper.java
@@ -351,7 +351,11 @@ public class ExporterMigrationTestHelper {
                       Map.of(
                           "url", containerAddress,
                           "bulk", Map.of("size", 1),
-                          "index", Map.of("createTemplate", false)));
+                          "index",
+                              Map.of(
+                                  "createTemplate", false,
+                                  "job", true,
+                                  "optimizeModeEnabled", false)));
                 })
             .withCreateSchema(false)
             .withProperty("camunda.database.type", "NONE")

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -282,7 +282,8 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     private List<String> variableValueTypeInclusion = new ArrayList<>();
     private List<String> variableValueTypeExclusion = new ArrayList<>();
 
-    // optimize mode
+    // Optimize mode takes precedence over the per-value-type flags above: even with job=true, the
+    // OptimizeModeFilter still rejects JOB records while this is enabled.
     private boolean optimizeModeEnabled = true;
 
     // export local variables flag

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -209,7 +209,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     public boolean deployment = true;
     public boolean error = true;
     public boolean incident = true;
-    public boolean job = true;
+    public boolean job = false;
     public boolean jobBatch = false;
     public boolean message = true;
     public boolean messageBatch = false;
@@ -283,7 +283,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     private List<String> variableValueTypeExclusion = new ArrayList<>();
 
     // optimize mode
-    private boolean optimizeModeEnabled = false;
+    private boolean optimizeModeEnabled = true;
 
     // export local variables flag
     private boolean exportLocalVariablesEnabled = true;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -236,7 +236,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     public boolean deployment = true;
     public boolean error = true;
     public boolean incident = true;
-    public boolean job = true;
+    public boolean job = false;
     public boolean jobBatch = false;
     public boolean message = true;
     public boolean messageBatch = false;
@@ -312,7 +312,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     private List<String> variableValueTypeExclusion = new ArrayList<>();
 
     // optimize mode
-    private boolean optimizeModeEnabled = false;
+    private boolean optimizeModeEnabled = true;
 
     // export local variables flag
     private boolean exportLocalVariablesEnabled = true;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -311,7 +311,8 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     private List<String> variableValueTypeInclusion = new ArrayList<>();
     private List<String> variableValueTypeExclusion = new ArrayList<>();
 
-    // optimize mode
+    // Optimize mode takes precedence over the per-value-type flags above: even with job=true, the
+    // OptimizeModeFilter still rejects JOB records while this is enabled.
     private boolean optimizeModeEnabled = true;
 
     // export local variables flag


### PR DESCRIPTION
## Description

Enable optimize mode (`optimizeModeEnabled`) by default so exported records match what Optimize actually needs, and set `job=false` as a sensible default value.

## Why
JOB records add export/storage cost with no downstream Optimize consumer. Restricting the default to the Optimize-relevant subset reduces the load on ES/OS.

SaaS clusters that still need JOB records must now set both:
```
index.optimizeModeEnabled: false
index.job: true
```

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55853
