### PR TITLE
fix: suppress side nav on nav V2 forbidden pages

### DIFF
--- a/operate/client/src/App/Layout/AppHeader/AppHeaderV2/index.tsx
+++ b/operate/client/src/App/Layout/AppHeader/AppHeaderV2/index.tsx
@@ -30,100 +30,102 @@ import {useCamundaToolsConfig} from './useCamundaToolsConfig';
 const SKIP_TO_CONTENT_TARGET_ID = 'main-content';
 const LOGOUT_DELAY = 1000;
 
-const AppHeaderV2: React.FC = observer(() => {
-  const {data: currentUser} = useCurrentUser();
-  const clientConfig = getClientConfig();
-  const isSaas = typeof clientConfig.organizationId === 'string';
-  const {currentPage} = useCurrentPage();
-  const {isTagVisible, isProductionLicense, isCommercial, expiresAt} =
-    licenseTagStore.state;
-  const selectedTheme = currentTheme.state.selectedTheme;
+const AppHeaderV2: React.FC<{hideNavLinks?: boolean}> = observer(
+  ({hideNavLinks = false}) => {
+    const {data: currentUser} = useCurrentUser();
+    const clientConfig = getClientConfig();
+    const isSaas = typeof clientConfig.organizationId === 'string';
+    const {currentPage} = useCurrentPage();
+    const {isTagVisible, isProductionLicense, isCommercial, expiresAt} =
+      licenseTagStore.state;
+    const selectedTheme = currentTheme.state.selectedTheme;
 
-  useEffect(() => {
-    if (currentUser !== undefined) {
-      tracking.identifyUser({
-        username: currentUser.username,
-        salesPlanType: currentUser.salesPlanType,
-        roles: currentUser.roles,
-      });
-    }
-  }, [currentUser]);
+    useEffect(() => {
+      if (currentUser !== undefined) {
+        tracking.identifyUser({
+          username: currentUser.username,
+          salesPlanType: currentUser.salesPlanType,
+          roles: currentUser.roles,
+        });
+      }
+    }, [currentUser]);
 
-  useEffect(() => {
-    licenseTagStore.fetchLicense();
-    return licenseTagStore.reset;
-  }, []);
+    useEffect(() => {
+      licenseTagStore.fetchLicense();
+      return licenseTagStore.reset;
+    }, []);
 
-  const isPaidPlan =
-    typeof currentUser?.salesPlanType === 'string' &&
-    ['paid-cc', 'enterprise'].includes(currentUser.salesPlanType);
+    const isPaidPlan =
+      typeof currentUser?.salesPlanType === 'string' &&
+      ['paid-cc', 'enterprise'].includes(currentUser.salesPlanType);
 
-  const breadcrumbs = useClusterWebappBreadcrumbs({currentApp: 'operate'});
-  const sidebarChildren = useSidebarChildren();
-  const {tools, ToolsProvider} = useCamundaToolsConfig({
-    isSaas,
-    isPaidPlan,
-    userName: currentUser?.displayName ?? '',
-    userEmail: currentUser?.email ?? '',
-    canLogout: clientConfig.canLogout,
-    onLogout: () => {
-      notificationsStore.displayNotification({
-        kind: 'info',
-        title: 'Log Out',
-        subtitle: 'You are being logged out...',
-        isDismissable: true,
-      });
-      setTimeout(authenticationStore.handleLogout, LOGOUT_DELAY);
-    },
-    selectedTheme,
-    onThemeChange: (theme) => currentTheme.changeTheme(theme),
-  });
+    const breadcrumbs = useClusterWebappBreadcrumbs({currentApp: 'operate'});
+    const sidebarChildren = useSidebarChildren(hideNavLinks);
+    const {tools, ToolsProvider} = useCamundaToolsConfig({
+      isSaas,
+      isPaidPlan,
+      userName: currentUser?.displayName ?? '',
+      userEmail: currentUser?.email ?? '',
+      canLogout: clientConfig.canLogout,
+      onLogout: () => {
+        notificationsStore.displayNotification({
+          kind: 'info',
+          title: 'Log Out',
+          subtitle: 'You are being logged out...',
+          isDismissable: true,
+        });
+        setTimeout(authenticationStore.handleLogout, LOGOUT_DELAY);
+      },
+      selectedTheme,
+      onThemeChange: (theme) => currentTheme.changeTheme(theme),
+    });
 
-  const options = useMemo(
-    (): Parameters<typeof useC3NavigationV2>[0] => ({
-      app: {
-        ariaLabel: 'Camunda Operate',
-        linkProps: {
-          to: Paths.dashboard(),
-          onClick: () => {
-            tracking.track({eventName: 'navigation', link: 'header-logo'});
+    const options = useMemo(
+      (): Parameters<typeof useC3NavigationV2>[0] => ({
+        app: {
+          ariaLabel: 'Camunda Operate',
+          linkProps: {
+            to: Paths.dashboard(),
+            onClick: () => {
+              tracking.track({eventName: 'navigation', link: 'header-logo'});
+            },
           },
         },
-      },
-      skipToContentTargetId: SKIP_TO_CONTENT_TARGET_ID,
-      activeItemKey: currentPage ?? '',
-      sidebarChildren,
-      breadcrumbs,
-      tools,
-      // @ts-expect-error - we need to fix it from the C3 side
-      linkComponent: Link,
-      headerTrailingContent: isTagVisible ? (
-        <C3LicenseTag
-          isProductionLicense={isProductionLicense}
-          isCommercial={isCommercial}
-          expiresAt={expiresAt ?? undefined}
-        />
-      ) : undefined,
-    }),
-    [
-      currentPage,
-      sidebarChildren,
-      breadcrumbs,
-      tools,
-      isTagVisible,
-      isProductionLicense,
-      isCommercial,
-      expiresAt,
-    ],
-  );
+        skipToContentTargetId: SKIP_TO_CONTENT_TARGET_ID,
+        activeItemKey: currentPage ?? '',
+        sidebarChildren,
+        breadcrumbs,
+        tools,
+        // @ts-expect-error - we need to fix it from the C3 side
+        linkComponent: Link,
+        headerTrailingContent: isTagVisible ? (
+          <C3LicenseTag
+            isProductionLicense={isProductionLicense}
+            isCommercial={isCommercial}
+            expiresAt={expiresAt ?? undefined}
+          />
+        ) : undefined,
+      }),
+      [
+        currentPage,
+        sidebarChildren,
+        breadcrumbs,
+        tools,
+        isTagVisible,
+        isProductionLicense,
+        isCommercial,
+        expiresAt,
+      ],
+    );
 
-  const {navProps} = useC3NavigationV2(options);
+    const {navProps} = useC3NavigationV2(options);
 
-  return (
-    <ToolsProvider>
-      <C3NavigationV2 {...navProps} />
-    </ToolsProvider>
-  );
-});
+    return (
+      <ToolsProvider>
+        <C3NavigationV2 {...navProps} />
+      </ToolsProvider>
+    );
+  },
+);
 
 export {AppHeaderV2};

--- a/operate/client/src/App/Layout/AppHeader/AppHeaderV2/useSidebarChildren.tsx
+++ b/operate/client/src/App/Layout/AppHeader/AppHeaderV2/useSidebarChildren.tsx
@@ -22,14 +22,14 @@ import {useCurrentPage} from 'modules/hooks/useCurrentPage';
 import {useCurrentUser} from 'modules/queries/useCurrentUser';
 import {isForbidden} from 'modules/auth/isForbidden';
 
-function useSidebarChildren(): SidebarNodeDescriptor[] {
+function useSidebarChildren(hideNavLinks = false): SidebarNodeDescriptor[] {
   const {data: currentUser} = useCurrentUser();
   const {currentPage} = useCurrentPage();
   const forbidden = isForbidden(currentUser);
 
   // @ts-expect-error - we need to fix it from the C3 side
   return useMemo(() => {
-    if (forbidden) {
+    if (forbidden || hideNavLinks) {
       return [];
     }
 
@@ -134,7 +134,7 @@ function useSidebarChildren(): SidebarNodeDescriptor[] {
     ];
 
     return children;
-  }, [forbidden, currentPage]);
+  }, [forbidden, hideNavLinks, currentPage]);
 }
 
 export {useSidebarChildren};

--- a/operate/client/src/App/Layout/AppHeader/index.tsx
+++ b/operate/client/src/App/Layout/AppHeader/index.tsx
@@ -10,7 +10,13 @@ import {IS_NAV_V2_ENABLED} from 'modules/feature-flags';
 import {AppHeaderV2} from './AppHeaderV2';
 import {LegacyAppHeader} from './LegacyAppHeader';
 
-const AppHeader: React.FC = () =>
-  IS_NAV_V2_ENABLED ? <AppHeaderV2 /> : <LegacyAppHeader />;
+const AppHeader: React.FC<{hideNavLinks?: boolean}> = ({
+  hideNavLinks = false,
+}) =>
+  IS_NAV_V2_ENABLED ? (
+    <AppHeaderV2 hideNavLinks={hideNavLinks} />
+  ) : (
+    <LegacyAppHeader />
+  );
 
 export {AppHeader};

--- a/operate/client/src/modules/components/ForbiddenPage/index.tsx
+++ b/operate/client/src/modules/components/ForbiddenPage/index.tsx
@@ -14,7 +14,7 @@ import {Description, Title, Grid, Content, ForbiddenIcon} from './styled';
 const ForbiddenPage: React.FC = () => {
   return (
     <>
-      <AppHeader />
+      <AppHeader hideNavLinks />
       <Grid>
         <Content gap={6}>
           <ForbiddenIcon />

--- a/operate/client/src/modules/components/ForbiddenPage/styled.tsx
+++ b/operate/client/src/modules/components/ForbiddenPage/styled.tsx
@@ -15,10 +15,14 @@ const Grid = styled.div`
   display: grid;
   align-content: center;
   padding: var(--cds-spacing-11);
-  margin-block: var(--cds-spacing-07) var(--cds-spacing-09);
+  margin-block: calc(var(--c3-header-height, 0px) + var(--cds-spacing-07))
+    var(--cds-spacing-09);
   margin-inline: var(--cds-spacing-08);
   background-color: var(--cds-layer);
-  height: calc(100vh - var(--cds-spacing-07) - 2 * var(--cds-spacing-09));
+  height: calc(
+    100vh - var(--c3-header-height, 0px) - var(--cds-spacing-07) - 2 *
+      var(--cds-spacing-09)
+  );
 `;
 
 const Content = styled(Stack)`

--- a/tasklist/client/src/pages/Layout/Header/HeaderV2/index.tsx
+++ b/tasklist/client/src/pages/Layout/Header/HeaderV2/index.tsx
@@ -39,7 +39,9 @@ function useActiveKey(): 'processes' | `tasks:${string}` {
   return `tasks:${rawFilterParam}`;
 }
 
-const HeaderV2: React.FC = () => {
+const HeaderV2: React.FC<{hideNavLinks?: boolean}> = ({
+  hideNavLinks = false,
+}) => {
   const {t} = useTranslation();
   const {data: currentUser} = useCurrentUser();
   const {data: license} = useLicense();
@@ -55,6 +57,7 @@ const HeaderV2: React.FC = () => {
 
   const sidebarChildren = useSidebarChildren({
     currentUser,
+    hideNavLinks,
   });
   const breadcrumbs = useClusterWebappBreadcrumbs({currentApp: 'tasklist'});
   const {tools, ToolsProvider} = useCamundaToolsConfig({

--- a/tasklist/client/src/pages/Layout/Header/HeaderV2/useSidebarChildren.tsx
+++ b/tasklist/client/src/pages/Layout/Header/HeaderV2/useSidebarChildren.tsx
@@ -38,8 +38,9 @@ const stopRowNavigation = (e: React.SyntheticEvent) => {
 
 function useSidebarChildren(params: {
   currentUser: CurrentUser | undefined;
+  hideNavLinks: boolean;
 }): SidebarNodeDescriptor[] {
-  const {currentUser} = params;
+  const {currentUser, hideNavLinks} = params;
   const location = useLocation();
   const {customFilters, startEditing, startDeleting, startAdding, status} =
     useCustomFiltersContext();
@@ -211,7 +212,7 @@ function useSidebarChildren(params: {
 
   // @ts-expect-error - we need to fix it from the C3 side
   return useMemo(() => {
-    if (isForbidden(currentUser)) {
+    if (isForbidden(currentUser) || hideNavLinks) {
       return [];
     }
 
@@ -245,7 +246,7 @@ function useSidebarChildren(params: {
         },
       },
     ];
-  }, [currentUser, isProcessesPage, tasksChildren]);
+  }, [currentUser, hideNavLinks, isProcessesPage, tasksChildren]);
 }
 
 export {useSidebarChildren};

--- a/tasklist/client/src/pages/Layout/Header/index.tsx
+++ b/tasklist/client/src/pages/Layout/Header/index.tsx
@@ -11,10 +11,10 @@ import {HeaderV2} from './HeaderV2';
 import {LegacyHeader} from './LegacyHeader';
 import {CustomFiltersProvider} from 'modules/tasks/available-tasks/CollapsiblePanel/CustomFiltersModal/CustomFiltersProvider';
 
-const Header: React.FC = () =>
+const Header: React.FC<{hideNavLinks?: boolean}> = ({hideNavLinks = false}) =>
   IS_NAV_V2_ENABLED ? (
     <CustomFiltersProvider>
-      <HeaderV2 />
+      <HeaderV2 hideNavLinks={hideNavLinks} />
     </CustomFiltersProvider>
   ) : (
     <LegacyHeader />

--- a/tasklist/client/src/pages/Layout/index.tsx
+++ b/tasklist/client/src/pages/Layout/index.tsx
@@ -8,7 +8,7 @@
 
 /* istanbul ignore file */
 
-import {Outlet} from 'react-router-dom';
+import {Outlet, useLocation} from 'react-router-dom';
 import {Header} from './Header';
 import {AuthenticationCheck} from 'modules/auth/AuthenticationCheck';
 import {AuthorizationCheck} from 'modules/auth/AuthorizationCheck';
@@ -18,12 +18,15 @@ import {C3Provider} from './C3Provider';
 import styles from './styles.module.scss';
 
 const Layout: React.FC = () => {
+  const location = useLocation();
+  const isForbiddenRoute = location.pathname.includes(pages.forbidden);
+
   return (
     <C3Provider>
       <AuthenticationCheck redirectPath={pages.login}>
         <AuthorizationCheck>
           <OSNotifications />
-          <Header />
+          <Header hideNavLinks={isForbiddenRoute} />
           <div id="main-content" tabIndex={-1} className={styles.mainContent}>
             <Outlet />
           </div>

--- a/tasklist/client/src/pages/Layout/index.tsx
+++ b/tasklist/client/src/pages/Layout/index.tsx
@@ -8,7 +8,7 @@
 
 /* istanbul ignore file */
 
-import {Outlet, useLocation} from 'react-router-dom';
+import {Outlet, useMatch} from 'react-router-dom';
 import {Header} from './Header';
 import {AuthenticationCheck} from 'modules/auth/AuthenticationCheck';
 import {AuthorizationCheck} from 'modules/auth/AuthorizationCheck';
@@ -18,8 +18,7 @@ import {C3Provider} from './C3Provider';
 import styles from './styles.module.scss';
 
 const Layout: React.FC = () => {
-  const location = useLocation();
-  const isForbiddenRoute = location.pathname.includes(pages.forbidden);
+  const isForbiddenRoute = useMatch(pages.forbidden) !== null;
 
   return (
     <C3Provider>


### PR DESCRIPTION
## What
Suppress the app side nav on the nav V2 forbidden state so it no longer overlaps the "no access" message, and fix the missing fixed-header top offset on Operate's forbidden page.

## Why
V2's nav renders a fixed sidebar (via `--c3-sidebar-width`). Operate's `ForbiddenPage` renders its own header outside the Layout, so the full sidebar overlapped the centered message and the card tucked under the fixed header. Tasklist's `/forbidden` route showed the same overlap when reached by an authorized user (in prod, forbidden users are redirected there with an empty sidebar, but a direct-nav lands with the full sidebar). Mirrors Identity's existing `hideNavLinks` pattern.

## Changes
- Operate: thread `hideNavLinks` through the header barrel, `AppHeaderV2`, and `useSidebarChildren` (empty sidebar when set); `ForbiddenPage` passes it; `ForbiddenPage/styled.tsx` adds the `--c3-header-height` top offset (V2 only, 0 in V1).
- Tasklist: `useSidebarChildren` returns `[]` on the `/forbidden` route.

V2-only; the V1 path is unchanged. Identity already handles this (same `hideNavLinks` + `--c3-header-height`); Optimize has no forbidden page.

Closes #57166
Part of camunda/camunda-hub#25826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)