### PR TITLE
test: reproduce partition join deadlock after failed one-shot join

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -245,6 +245,9 @@ public final class ControllableRaftContexts {
   public RaftContext createRaftContext(
       final MemberId memberId, final Random random, final RaftStorage storage) {
     final var partitionConfig = new RaftPartitionConfig();
+    // RaftPartitionConfig has no default for the configuration change timeout, it is usually
+    // provided by the broker configuration (ExperimentalRaftCfg). Use the production default.
+    partitionConfig.setConfigurationChangeTimeout(Duration.ofSeconds(10));
     partitionConfigurator.accept(partitionConfig);
     final var raft =
         new RaftContext(
@@ -252,7 +255,11 @@ public final class ControllableRaftContexts {
             new PartitionId(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, 1),
             memberId,
             mock(ClusterMembershipService.class, withSettings().stubOnly()),
-            new ControllableRaftServerProtocol(memberId, serverProtocols, messageQueue),
+            new ControllableRaftServerProtocol(
+                memberId,
+                serverProtocols,
+                messageQueue,
+                partitionConfig.getConfigurationChangeTimeout()),
             storage,
             getRaftThreadContextFactory(memberId),
             () -> random,

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -67,6 +67,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.jmock.lib.concurrent.DeterministicScheduler;
@@ -93,6 +94,7 @@ public final class ControllableRaftContexts {
   private Random random;
 
   private final int nodeCount;
+  private final Set<MemberId> bootstrappedMembers = new HashSet<>();
   private final Map<MemberId, RaftContext> raftServers = new HashMap<>();
   private final Map<MemberId, TestFileBasedSnapshotStore> snapshotStores = new HashMap<>();
   private final Map<MemberId, MeterRegistry> meterRegistries = new HashMap<>();
@@ -106,8 +108,24 @@ public final class ControllableRaftContexts {
   private final DataLossChecker dataLossChecker = new DataLossChecker(appendListener);
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
 
+  private final Consumer<RaftPartitionConfig> partitionConfigurator;
+
   public ControllableRaftContexts(final int nodeCount) {
+    this(nodeCount, config -> {});
+  }
+
+  /**
+   * @param partitionConfigurator customizes the {@link RaftPartitionConfig} of every created raft
+   *     context. Note that the leader step-down on lost quorum contact is gated on wall-clock time
+   *     ({@code maxQuorumResponseTimeout}, defaulting to two election timeouts), which does not
+   *     advance with the deterministic scheduler. Tests that need to explore leader step-down must
+   *     reduce it to a near-zero duration so that step-down is effectively controlled by {@code
+   *     minStepDownFailureCount} alone.
+   */
+  public ControllableRaftContexts(
+      final int nodeCount, final Consumer<RaftPartitionConfig> partitionConfigurator) {
     this.nodeCount = nodeCount;
+    this.partitionConfigurator = partitionConfigurator;
   }
 
   public Map<MemberId, RaftContext> getRaftServers() {
@@ -156,6 +174,8 @@ public final class ControllableRaftContexts {
     deterministicExecutors.clear();
     messageQueue.clear();
     leadersAtTerms.clear();
+    futuresToFailOnClose.clear();
+    bootstrappedMembers.clear();
     directory = null;
     MicrometerUtil.close(meterRegistry);
   }
@@ -167,6 +187,8 @@ public final class ControllableRaftContexts {
 
   private void bootstrapRaftServers(final Collection<MemberId> bootstrapServers)
       throws ExecutionException, InterruptedException, TimeoutException {
+    bootstrappedMembers.clear();
+    bootstrappedMembers.addAll(bootstrapServers);
     final Set<CompletableFuture<Void>> futures = new HashSet<>();
     final var servers =
         getRaftServers().entrySet().stream()
@@ -222,6 +244,8 @@ public final class ControllableRaftContexts {
 
   public RaftContext createRaftContext(
       final MemberId memberId, final Random random, final RaftStorage storage) {
+    final var partitionConfig = new RaftPartitionConfig();
+    partitionConfigurator.accept(partitionConfig);
     final var raft =
         new RaftContext(
             memberId.id() + "-partition-1",
@@ -233,7 +257,7 @@ public final class ControllableRaftContexts {
             getRaftThreadContextFactory(memberId),
             () -> random,
             RaftElectionConfig.ofPriorityElection(nodeCount, Integer.parseInt(memberId.id()) + 1),
-            new RaftPartitionConfig(),
+            partitionConfig,
             meterRegistries.computeIfAbsent(memberId, this::meterRegistryForMember));
     raft.setEntryValidator(new NoopEntryValidator());
     return raft;
@@ -411,16 +435,27 @@ public final class ControllableRaftContexts {
     deterministicExecutors.remove(memberId).close();
     snapshotStores.get(memberId).close();
     MicrometerUtil.close(meterRegistries.get(memberId));
-    futuresToFailOnClose.computeIfPresent(
-        memberId,
-        (ignore, future) -> {
-          future.completeExceptionally(new RuntimeException("Shutting down"));
-          return null;
-        });
+    final var pendingJoin = futuresToFailOnClose.remove(memberId);
+    if (pendingJoin != null) {
+      if (pendingJoin.isDone() && !pendingJoin.isCompletedExceptionally()) {
+        // The member completed its join, so the cluster topology includes it now. From now on it
+        // restarts via bootstrap like the original members, recovering the persisted
+        // configuration.
+        bootstrappedMembers.add(memberId);
+      } else {
+        pendingJoin.completeExceptionally(new RuntimeException("Shutting down"));
+      }
+    }
 
     final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
-    try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
-      newContext.getCluster().bootstrap(raftServers.keySet());
+    // Only members that are part of the cluster restart via bootstrap. A member whose join did
+    // not complete is torn down on restart without a running raft server, like
+    // PartitionManagerImpl removes the partition after a failed join. It only comes back when the
+    // join is retried, driven by the failed join future (see futuresToFailOnClose).
+    if (bootstrappedMembers.contains(memberId)) {
+      try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
+        newContext.getCluster().bootstrap(raftServers.keySet());
+      }
     }
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RandomizedRaftJoinTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -47,8 +48,13 @@ public class RandomizedRaftJoinTest {
     // Initialize the two member IDs for the 2-node cluster
     member0 = MemberId.from("0");
     member1 = MemberId.from("1");
-    // Create ControllableRaftContexts with 2 nodes
-    raftContexts = new ControllableRaftContexts(2);
+    // Create ControllableRaftContexts with 2 nodes. Reduce the quorum response timeout to make
+    // the wall-clock gated leader step-down reachable under the deterministic scheduler: a leader
+    // then steps down after minStepDownFailureCount consecutive failures to reach the joining
+    // member, as it does in production when the joiner is unreachable for two election timeouts.
+    raftContexts =
+        new ControllableRaftContexts(
+            2, config -> config.setMaxQuorumResponseTimeout(Duration.ofMillis(1)));
     operationsWithRestarts = RaftOperation.getRaftOperationsWithRestarts();
   }
 
@@ -71,7 +77,7 @@ public class RandomizedRaftJoinTest {
       throws Exception {
     setUpRaftNodes(new Random(seed));
 
-    var joinFuture = raftContexts.join(member1, Set.of(member0));
+    var joinFuture = raftContexts.join(member1, Set.of(member0, member1));
 
     // given - when there are failures such as message loss
     final var memberIter = raftMembers.iterator();
@@ -82,7 +88,7 @@ public class RandomizedRaftJoinTest {
       if (joinFuture.isCompletedExceptionally()) {
         // retry join
         LOG.info("Join failed. Retrying...");
-        joinFuture = raftContexts.join(member1, Set.of(member0));
+        joinFuture = raftContexts.join(member1, Set.of(member0, member1));
       }
     }
 
@@ -104,7 +110,7 @@ public class RandomizedRaftJoinTest {
       if (joinFuture.isCompletedExceptionally()) {
         // retry join
         LOG.info("Join failed. Retrying...");
-        joinFuture = raftContexts.join(member1, Set.of(member0));
+        joinFuture = raftContexts.join(member1, Set.of(member0, member1));
       }
 
       raftContexts.runUntilDone();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -261,6 +261,55 @@ final class ReconfigurationTest {
       restartedM2.join(id1).join();
     }
 
+    /**
+     * Reproduces <a href="https://github.com/camunda/camunda/issues/56808">#56808</a>: joining a
+     * single-member cluster deadlocks permanently when the configuration appended by the leader
+     * cannot be replicated to the joiner before the join attempt fails.
+     *
+     * <p>The leader appends the joint configuration and operates under it immediately
+     * (configurations take effect on append), but can never commit it without the joiner's ack.
+     * When the joiner gives up and shuts down, as {@code PartitionManagerImpl} does after a failed
+     * join, the leader steps down and no leader can be elected again: winning an election in the
+     * joint configuration requires the joiner's vote, but the joiner has no functioning raft
+     * server, and while it is briefly PASSIVE during a join attempt it rejects poll requests. Every
+     * subsequent join attempt then fails with NO_LEADER, so the deadlock is permanent even after
+     * connectivity is restored.
+     */
+    @Test
+    void joinShouldSucceedWhenRetriedAfterFailedFirstAttempt(@TempDir final Path tmp) {
+      // given - a single-member cluster, as after the bootstrap of a scaled-up partition
+      final var id1 = MemberId.from("1");
+      final var id2 = MemberId.from("2");
+
+      final var m1 = createServer(tmp, createMembershipService(id1, id2));
+      m1.bootstrap(id1).join();
+      awaitLeader(m1);
+
+      // when - m2 tries to join while replication from m1 to m2 transiently fails. The join
+      // request still reaches the leader m1, which appends the joint configuration, but m2 never
+      // receives it and the join attempt fails, either by timing out or, if m1 steps down first,
+      // with "Leader stepping down". Like RaftPartitionServer, we pass all members of the
+      // partition, including the joining member itself.
+      protocolFactory.blockMessagesTo(id2);
+      final var m2 = createServer(tmp, createMembershipService(id2, id1));
+      assertThat(m2.join(id1, id2)).failsWithin(Duration.ofSeconds(30));
+
+      // m2 gives up, like PartitionManagerImpl removes the partition after a failed join
+      m2.shutdown().join();
+
+      // m1 operates under the appended joint configuration but cannot commit it and steps down
+      awaitNoLeader(m1);
+
+      // then - once connectivity is restored, retrying the join (as the cluster topology
+      // coordinator does indefinitely) should eventually succeed
+      protocolFactory.heal(id2);
+      final var retriedM2 = createServer(tmp, createMembershipService(id2, id1));
+      assertThat(retriedM2.join(id1, id2))
+          .as("m2 can join when retrying after a failed first attempt")
+          .succeedsWithin(Duration.ofSeconds(30));
+      awaitLeader(m1, retriedM2);
+    }
+
     @Test
     void canJoinAgainAfterDataloss(@TempDir final Path tmp) throws IOException {
       // given - a cluster with 3 members

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/ControllableRaftServerProtocol.java
@@ -57,13 +57,16 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
   private final Map<CompletableFuture<?>, Long> timeoutQueue = new HashMap<>();
   private long currentTime = 0;
   private final long requestTimeoutMillis = Duration.ofSeconds(5).toMillis();
+  private final long configurationChangeTimeoutMillis;
 
   public ControllableRaftServerProtocol(
       final MemberId memberId,
       final Map<MemberId, ControllableRaftServerProtocol> servers,
-      final Map<MemberId, Queue<Tuple<Runnable, CompletableFuture<?>>>> messageQueue) {
+      final Map<MemberId, Queue<Tuple<Runnable, CompletableFuture<?>>>> messageQueue,
+      final Duration configurationChangeTimeout) {
     this.servers = servers;
     this.messageQueue = messageQueue;
+    configurationChangeTimeoutMillis = configurationChangeTimeout.toMillis();
     localMemberId = memberId;
     messageQueue.put(memberId, new LinkedList<>());
     servers.put(memberId, this);
@@ -114,14 +117,22 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
       final MemberId memberId,
       final Runnable requestHandler,
       final CompletableFuture<?> responseFuture) {
-    final var message = new Tuple<Runnable, CompletableFuture<?>>(requestHandler, responseFuture);
-    messageQueue.computeIfAbsent(memberId, m -> new LinkedList<>()).add(message);
-    addTimeOut(responseFuture);
+    send(memberId, requestHandler, responseFuture, requestTimeoutMillis);
   }
 
-  private void addTimeOut(final CompletableFuture<?> responseFuture) {
+  private void send(
+      final MemberId memberId,
+      final Runnable requestHandler,
+      final CompletableFuture<?> responseFuture,
+      final long timeoutMillis) {
+    final var message = new Tuple<Runnable, CompletableFuture<?>>(requestHandler, responseFuture);
+    messageQueue.computeIfAbsent(memberId, m -> new LinkedList<>()).add(message);
+    addTimeOut(responseFuture, timeoutMillis);
+  }
+
+  private void addTimeOut(final CompletableFuture<?> responseFuture, final long timeoutMillis) {
     if (responseFuture != null) {
-      timeoutQueue.put(responseFuture, currentTime + requestTimeoutMillis);
+      timeoutQueue.put(responseFuture, currentTime + timeoutMillis);
     }
   }
 
@@ -171,7 +182,8 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
                 .thenCompose(listener -> listener.reconfigure(request))
                 .thenAccept(
                     response -> send(localMemberId, () -> responseFuture.complete(response), null)),
-        responseFuture);
+        responseFuture,
+        configurationChangeTimeoutMillis);
     return responseFuture;
   }
 
@@ -200,7 +212,8 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
                 .thenCompose(listener -> listener.join(request))
                 .thenAccept(
                     response -> send(localMemberId, () -> responseFuture.complete(response), null)),
-        responseFuture);
+        responseFuture,
+        configurationChangeTimeoutMillis);
     return responseFuture;
   }
 
@@ -215,7 +228,8 @@ public class ControllableRaftServerProtocol implements RaftServerProtocol {
                 .thenCompose(listener -> listener.leave(request))
                 .thenAccept(
                     response -> send(localMemberId, () -> responseFuture.complete(response), null)),
-        responseFuture);
+        responseFuture,
+        configurationChangeTimeoutMillis);
     return responseFuture;
   }
 


### PR DESCRIPTION
Adds test coverage reproducing #56808, where the join of a second replica into a single-member raft group deadlocks permanently if the one-shot join handshake fails: the leader appends the joint configuration but cannot commit it without the joiner, steps down, and no leader can be elected again because the retried joiner rejects polls while `PASSIVE`. Both tests assert the desired behavior — a retried join eventually succeeds — and are expected to fail until the issue is fixed, so this branch serves as a base for the fix and must not be merged on its own.

The first commit adds a deterministic reproduction to `ReconfigurationTest`, mirroring the production sequence with `PartitionManagerImpl`-style teardown of the joiner after the failed attempt.

The second commit makes `RandomizedRaftJoinTest` able to find this class of bug at all, closing three gaps that masked it. The test joined with a member list containing only the existing member, which engages the single-member retry provision in `ReconfigurationHelper.join`; production (`RaftPartitionServer.join`) passes all partition members including the joiner itself, making each join attempt one-shot, and the test now does the same. Restarting a still-joining member bootstrapped it with all known members, fabricating a valid two-member configuration out of thin air and turning the joiner into a voting follower; now only members that bootstrapped the cluster or completed their join restart via bootstrap, while a still-joining member stays down until the join is retried. Finally, leader step-down on lost quorum contact (`LeaderAppender#failAttempt`) is gated on wall-clock time, which does not advance with the deterministic scheduler, so leaders could effectively never step down during the randomized walk; the test now reduces `maxQuorumResponseTimeout` to a near-zero duration so that step-down is deterministically gated by `minStepDownFailureCount`. With these changes the randomized test finds the deadlock in nearly every run with the default 10 tries.

relates to #56808