### PR TITLE
fix: dont allow batch retry on instances with incidents

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/InstancesTableWrapper.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/InstancesTableWrapper.tsx
@@ -83,11 +83,16 @@ const InstancesTableWrapper: React.FC = observer(() => {
       )
       .map((instance) => instance.processInstanceKey);
 
+    const visibleIncidentIds = processInstances
+      .filter((instance) => instance.hasIncident)
+      .map((instance) => instance.processInstanceKey);
+
     processInstancesSelectionStore.setRuntime({
       totalCount,
       visibleIds,
       visibleRunningIds,
       visibleFinishedIds,
+      visibleIncidentIds,
     });
   }, [processInstances, totalCount]);
 

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -152,6 +152,15 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
       messages.push(
         'This permanently deletes the selected process instances and their history. This cannot be undone.',
       );
+    } else if (modalMode === 'RESOLVE_INCIDENT') {
+      const incidentInstancesCount =
+        processInstancesSelectionStore.checkedIncidentIds.length;
+
+      if (selectedInstancesCount > incidentInstancesCount) {
+        messages.push(
+          'Instances without an incident in your selection will be ignored.',
+        );
+      }
     } else if (selectedInstancesCount > runningInstancesCount) {
       messages.push('Finished instances in your selection will be ignored.');
     }
@@ -228,13 +237,13 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
             onClick={() => setModalMode('RESOLVE_INCIDENT')}
             disabled={
               batchModificationStore.state.isEnabled ||
-              !processInstancesSelectionStore.hasSelectedRunningInstances
+              !processInstancesSelectionStore.hasSelectedInstancesWithIncidents
             }
             title={
               batchModificationStore.state.isEnabled
                 ? 'Not available in batch modification mode'
-                : !processInstancesSelectionStore.hasSelectedRunningInstances
-                  ? 'No running process instances selected. Please select at least one active or incident process instance to retry.'
+                : !processInstancesSelectionStore.hasSelectedInstancesWithIncidents
+                  ? 'No process instances with an incident selected. Please select at least one process instance with an incident to retry.'
                   : undefined
             }
             data-testid="retry-batch-operation"

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/tests/index.test.tsx
@@ -89,6 +89,7 @@ describe('<ProcessOperations />', () => {
       visibleIds: ['1', '2'],
       visibleRunningIds: ['1', '2'],
       visibleFinishedIds: [],
+      visibleIncidentIds: ['1', '2'],
     });
     processInstancesSelectionStore.select('1');
     processInstancesSelectionStore.select('2');
@@ -161,6 +162,72 @@ describe('<ProcessOperations />', () => {
       }),
     ).toBeDisabled();
     expect(screen.getByRole('button', {name: 'Discard'})).toBeEnabled();
+  });
+
+  it('should disable retry when no instance with an incident is selected', async () => {
+    processInstancesSelectionStore.setRuntime({
+      totalCount: 3,
+      visibleIds: ['1', '2', '3'],
+      visibleRunningIds: ['1', '2', '3'],
+      visibleFinishedIds: [],
+      visibleIncidentIds: [],
+    });
+    // INCLUDE mode with a partial selection (selecting all would flip to ALL mode)
+    processInstancesSelectionStore.resetState();
+    processInstancesSelectionStore.select('1');
+    processInstancesSelectionStore.select('2');
+
+    render(<Toolbar selectedInstancesCount={2} />, {wrapper: Wrapper});
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Retry',
+        description:
+          'No process instances with an incident selected. Please select at least one process instance with an incident to retry.',
+      }),
+    ).toBeDisabled();
+  });
+
+  it('should enable retry when an instance with an incident is selected', async () => {
+    render(<Toolbar selectedInstancesCount={2} />, {wrapper: Wrapper});
+
+    expect(screen.getByRole('button', {name: 'Retry'})).toBeEnabled();
+  });
+
+  it('should warn that instances without an incident will be ignored', async () => {
+    processInstancesSelectionStore.setRuntime({
+      totalCount: 2,
+      visibleIds: ['1', '2'],
+      visibleRunningIds: ['1', '2'],
+      visibleFinishedIds: [],
+      visibleIncidentIds: ['1'],
+    });
+
+    const {user} = render(<Toolbar selectedInstancesCount={2} />, {
+      wrapper: Wrapper,
+    });
+
+    await user.click(screen.getByTestId('retry-batch-operation'));
+
+    expect(
+      screen.getByText(
+        /instances without an incident in your selection will be ignored/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should not warn when all selected instances have an incident', async () => {
+    const {user} = render(<Toolbar selectedInstancesCount={2} />, {
+      wrapper: Wrapper,
+    });
+
+    await user.click(screen.getByTestId('retry-batch-operation'));
+
+    expect(
+      screen.queryByText(
+        /instances without an incident in your selection will be ignored/i,
+      ),
+    ).not.toBeInTheDocument();
   });
 
   it('should perform cancel batch operation successfully', async () => {

--- a/operate/client/src/modules/stores/instancesSelection.test.ts
+++ b/operate/client/src/modules/stores/instancesSelection.test.ts
@@ -441,6 +441,101 @@ describe('InstancesSelection - checkedRunningIds', () => {
   });
 });
 
+describe('InstancesSelection - hasSelectedInstancesWithIncidents', () => {
+  beforeEach(() => {
+    processInstancesSelectionStore.setRuntime({
+      totalCount: 4,
+      visibleIds: ['1', '2', '3', '4'],
+      visibleRunningIds: ['1', '2', '3'],
+      visibleFinishedIds: ['4'],
+      visibleIncidentIds: ['1'],
+    });
+  });
+
+  afterEach(() => {
+    processInstancesSelectionStore.reset();
+  });
+
+  it('should return true when an instance with an incident is selected in INCLUDE mode', () => {
+    processInstancesSelectionStore.select('1'); // incident
+    processInstancesSelectionStore.select('2'); // running, no incident
+
+    expect(
+      processInstancesSelectionStore.hasSelectedInstancesWithIncidents,
+    ).toBe(true);
+  });
+
+  it('should return false when no instance with an incident is selected in INCLUDE mode', () => {
+    processInstancesSelectionStore.select('2'); // running, no incident
+    processInstancesSelectionStore.select('3'); // running, no incident
+    processInstancesSelectionStore.select('4'); // finished
+
+    expect(
+      processInstancesSelectionStore.hasSelectedInstancesWithIncidents,
+    ).toBe(false);
+  });
+
+  it('should return true when selectionMode is ALL', () => {
+    processInstancesSelectionStore.selectAll();
+
+    expect(
+      processInstancesSelectionStore.hasSelectedInstancesWithIncidents,
+    ).toBe(true);
+  });
+
+  it('should return true when selectionMode is EXCLUDE', () => {
+    processInstancesSelectionStore.selectAll();
+    processInstancesSelectionStore.select('1');
+
+    expect(
+      processInstancesSelectionStore.hasSelectedInstancesWithIncidents,
+    ).toBe(true);
+  });
+});
+
+describe('InstancesSelection - checkedIncidentIds', () => {
+  beforeEach(() => {
+    processInstancesSelectionStore.setRuntime({
+      totalCount: 4,
+      visibleIds: ['1', '2', '3', '4'],
+      visibleRunningIds: ['1', '2', '3', '4'],
+      visibleFinishedIds: [],
+      visibleIncidentIds: ['1', '3'],
+    });
+  });
+
+  afterEach(() => {
+    processInstancesSelectionStore.reset();
+  });
+
+  it('should return only incident ids from selectedIds in INCLUDE mode', () => {
+    processInstancesSelectionStore.select('1'); // incident
+    processInstancesSelectionStore.select('2'); // no incident
+    processInstancesSelectionStore.select('3'); // incident
+
+    expect(processInstancesSelectionStore.checkedIncidentIds).toEqual([
+      '1',
+      '3',
+    ]);
+  });
+
+  it('should return incident ids not in excludedIds in EXCLUDE mode', () => {
+    processInstancesSelectionStore.selectAll();
+    processInstancesSelectionStore.select('1'); // exclude incident id
+
+    expect(processInstancesSelectionStore.checkedIncidentIds).toEqual(['3']);
+  });
+
+  it('should return all incident ids in ALL mode', () => {
+    processInstancesSelectionStore.selectAll();
+
+    expect(processInstancesSelectionStore.checkedIncidentIds).toEqual([
+      '1',
+      '3',
+    ]);
+  });
+});
+
 describe('InstancesSelection - excludedIds', () => {
   beforeEach(() => {
     processInstancesSelectionStore.setRuntime({

--- a/operate/client/src/modules/stores/instancesSelection.ts
+++ b/operate/client/src/modules/stores/instancesSelection.ts
@@ -19,6 +19,7 @@ type Runtime = {
   visibleIds: string[];
   visibleRunningIds?: string[];
   visibleFinishedIds?: string[];
+  visibleIncidentIds?: string[];
 };
 
 type Mode = 'INCLUDE' | 'EXCLUDE' | 'ALL';
@@ -39,6 +40,7 @@ class InstancesSelection {
     visibleIds: [],
     visibleRunningIds: [],
     visibleFinishedIds: [],
+    visibleIncidentIds: [],
   };
   autorunDisposer: null | IReactionDisposer = null;
 
@@ -70,7 +72,8 @@ class InstancesSelection {
       prev.totalCount === next.totalCount &&
       isEqual(prev.visibleIds, next.visibleIds) &&
       isEqual(prev.visibleRunningIds ?? [], next.visibleRunningIds ?? []) &&
-      isEqual(prev.visibleFinishedIds ?? [], next.visibleFinishedIds ?? [])
+      isEqual(prev.visibleFinishedIds ?? [], next.visibleFinishedIds ?? []) &&
+      isEqual(prev.visibleIncidentIds ?? [], next.visibleIncidentIds ?? [])
     ) {
       return;
     }
@@ -190,6 +193,21 @@ class InstancesSelection {
     );
   }
 
+  get hasSelectedInstancesWithIncidents() {
+    const {
+      selectedIds,
+      isAllChecked,
+      state: {selectionMode},
+    } = this;
+    const visibleIncidentIds = this.runtime.visibleIncidentIds ?? [];
+
+    return (
+      isAllChecked ||
+      selectionMode === 'EXCLUDE' ||
+      visibleIncidentIds.some((id) => selectedIds.includes(id))
+    );
+  }
+
   get checkedRunningIds() {
     const {selectionMode, selectedIds} = this.state;
     const visibleRunningIds = this.runtime.visibleRunningIds ?? [];
@@ -199,6 +217,17 @@ class InstancesSelection {
     }
 
     return visibleRunningIds.filter((id) => !selectedIds.includes(id));
+  }
+
+  get checkedIncidentIds() {
+    const {selectionMode, selectedIds} = this.state;
+    const visibleIncidentIds = this.runtime.visibleIncidentIds ?? [];
+
+    if (selectionMode === 'INCLUDE') {
+      return selectedIds.filter((id) => visibleIncidentIds.includes(id));
+    }
+
+    return visibleIncidentIds.filter((id) => !selectedIds.includes(id));
   }
 
   get checkedFinishedIds() {
@@ -241,6 +270,7 @@ class InstancesSelection {
       visibleIds: [],
       visibleRunningIds: [],
       visibleFinishedIds: [],
+      visibleIncidentIds: [],
     };
     this.autorunDisposer?.();
   };


### PR DESCRIPTION
related to #40995

## Description
Gate the instance retry button based on on whether the instance selection actually contains an instance with an incident, mirroring the single-instance retry which already requires this:

- Track `visibleIncidentIds` in the selection store, plus `hasSelectedInstancesWithIncidents` / `checkedIncidentIds ` getters
- Retry is disabled unless a selected instance has an incident
- for mixed selections, the confirmation modal warns that instances without an incident will be ignored for the retry
- the gate uses the same `hasIncident` flag that renders the rows "Incident" badge

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related #40995
