### PR TITLE
feat: select details tab by default for elements

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
@@ -26,6 +26,7 @@ import {mockSearchIncidentsByProcessInstance} from 'modules/mocks/api/v2/inciden
 import {mockSearchIncidentsByElementInstance} from 'modules/mocks/api/v2/incidents/searchIncidentsByElementInstance';
 import {mockFetchElementInstance} from 'modules/mocks/api/v2/elementInstances/fetchElementInstance';
 import {LocationLog} from 'modules/utils/LocationLog';
+import {modificationsStore} from 'modules/stores/modifications';
 
 const PROCESS_INSTANCE_ID = '123';
 
@@ -870,6 +871,35 @@ describe('<BottomPanelTabs />', () => {
     );
     expect(await screen.findByTestId('pathname')).toHaveTextContent(
       Paths.processInstanceInputMappings({
+        processInstanceId: PROCESS_INSTANCE_ID,
+      }),
+    );
+  });
+
+  it('should not switch to the details tab in modification mode', async () => {
+    modificationsStore.enableModificationMode();
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+    mockSearchElementInstances().withSuccess(searchResult([]));
+
+    const path = Paths.processInstanceVariables({
+      processInstanceId: PROCESS_INSTANCE_ID,
+    });
+    const {user} = render(<BottomPanelTabs isHistoryTabVisible />, {
+      wrapper: getWrapper(path),
+    });
+
+    await user.click(screen.getByRole('button', {name: 'Select element'}));
+
+    expect(await screen.findByTestId('search')).toHaveTextContent(
+      '?elementId=someElement',
+    );
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceVariables({
         processInstanceId: PROCESS_INSTANCE_ID,
       }),
     );

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.test.tsx
@@ -12,6 +12,7 @@ import {
   Navigate,
   RouterProvider,
   useLocation,
+  useNavigate,
 } from 'react-router-dom';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
@@ -35,13 +36,27 @@ const RedirectToVariables: React.FC = () => {
   );
 };
 
+const SelectElement: React.FC = () => {
+  const navigate = useNavigate();
+  return (
+    <button onClick={() => navigate({search: '?elementId=someElement'})}>
+      Select element
+    </button>
+  );
+};
+
 function getWrapper(initialPath?: string) {
   const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
     const router = createMemoryRouter(
       [
         {
           path: Paths.processInstance(undefined, true),
-          element: children,
+          element: (
+            <>
+              <SelectElement />
+              {children}
+            </>
+          ),
           children: [
             {index: true, element: <RedirectToVariables />},
             {
@@ -635,7 +650,7 @@ describe('<BottomPanelTabs />', () => {
     expect(await screen.findByText('3')).toBeVisible();
   });
 
-  it('should redirect incidents tab when process instance has no incidents', async () => {
+  it('should redirect incidents tab to variables tab when process instance has no incidents', async () => {
     mockFetchProcessInstance().withSuccess(
       createProcessInstance({
         processInstanceKey: PROCESS_INSTANCE_ID,
@@ -657,7 +672,28 @@ describe('<BottomPanelTabs />', () => {
     );
   });
 
-  it('should redirect incidents tab when selected element has no incidents', async () => {
+  it('should redirect incidents tab with a selection to details tab when process instance has no incidents', async () => {
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+    mockSearchElementInstances().withSuccess(searchResult([]));
+
+    const path = `${Paths.processInstanceIncidents({processInstanceId: PROCESS_INSTANCE_ID})}?elementId=someElement`;
+    render(<BottomPanelTabs isHistoryTabVisible />, {
+      wrapper: getWrapper(path),
+    });
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceDetails({
+        processInstanceId: PROCESS_INSTANCE_ID,
+      }),
+    );
+  });
+
+  it('should redirect incidents tab to details tab when selected element has no incidents', async () => {
     const elementInstanceKey = '456';
     mockFetchProcessInstance().withSuccess(
       createProcessInstance({
@@ -691,7 +727,7 @@ describe('<BottomPanelTabs />', () => {
     });
 
     expect(await screen.findByTestId('pathname')).toHaveTextContent(
-      Paths.processInstanceVariables({
+      Paths.processInstanceDetails({
         processInstanceId: PROCESS_INSTANCE_ID,
       }),
     );
@@ -785,5 +821,57 @@ describe('<BottomPanelTabs />', () => {
     });
 
     expect(await screen.findByTestId('pathname')).toHaveTextContent(path);
+  });
+
+  it('should switch to details tab when an element gets selected', async () => {
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+    mockSearchElementInstances().withSuccess(searchResult([]));
+
+    const path = Paths.processInstanceVariables({
+      processInstanceId: PROCESS_INSTANCE_ID,
+    });
+    const {user} = render(<BottomPanelTabs isHistoryTabVisible />, {
+      wrapper: getWrapper(path),
+    });
+
+    await user.click(screen.getByRole('button', {name: 'Select element'}));
+
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceDetails({
+        processInstanceId: PROCESS_INSTANCE_ID,
+      }),
+    );
+  });
+
+  it('should keep the current tab when switching between elements', async () => {
+    mockFetchProcessInstance().withSuccess(
+      createProcessInstance({
+        processInstanceKey: PROCESS_INSTANCE_ID,
+        hasIncident: false,
+      }),
+    );
+    mockSearchElementInstances().withSuccess(searchResult([]));
+    mockSearchElementInstances().withSuccess(searchResult([]));
+
+    const path = `${Paths.processInstanceInputMappings({processInstanceId: PROCESS_INSTANCE_ID})}?elementId=otherElement`;
+    const {user} = render(<BottomPanelTabs isHistoryTabVisible />, {
+      wrapper: getWrapper(path),
+    });
+
+    await user.click(screen.getByRole('button', {name: 'Select element'}));
+
+    expect(await screen.findByTestId('search')).toHaveTextContent(
+      '?elementId=someElement',
+    );
+    expect(await screen.findByTestId('pathname')).toHaveTextContent(
+      Paths.processInstanceInputMappings({
+        processInstanceId: PROCESS_INSTANCE_ID,
+      }),
+    );
   });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
@@ -195,9 +195,10 @@ const BottomPanelTabs: React.FC<{isHistoryTabVisible: boolean}> = ({
         <Navigate
           to={{
             ...location,
-            pathname: hasSelection || isProcessLevelWaiting
-              ? Paths.processInstanceDetails({processInstanceId})
-              : Paths.processInstanceVariables({processInstanceId}),
+            pathname:
+              hasSelection || isProcessLevelWaiting
+                ? Paths.processInstanceDetails({processInstanceId})
+                : Paths.processInstanceVariables({processInstanceId}),
           }}
           replace
         />

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
@@ -195,7 +195,7 @@ const BottomPanelTabs: React.FC<{isHistoryTabVisible: boolean}> = ({
         <Navigate
           to={{
             ...location,
-            pathname: hasSelection
+            pathname: hasSelection || isProcessLevelWaiting
               ? Paths.processInstanceDetails({processInstanceId})
               : Paths.processInstanceVariables({processInstanceId}),
           }}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
@@ -20,6 +20,7 @@ import {useElementInstanceIncidentsCount} from 'modules/queries/incidents/useEle
 import {useWaitStateStatistics} from 'modules/queries/waitStateStatistics/useWaitStateStatistics';
 import {hasProcessLevelWaitState} from 'modules/utils/waitStates';
 import {getClientConfig} from 'modules/utils/getClientConfig';
+import {modificationsStore} from 'modules/stores/modifications';
 
 function useSelectionAwareIncidentsCount(
   processInstanceKey: string,
@@ -79,7 +80,11 @@ const BottomPanelTabs: React.FC<{isHistoryTabVisible: boolean}> = ({
     // select an element without a previous selection.
     const prevHasSelection = prevHasSelectionRef.current;
     prevHasSelectionRef.current = hasSelection;
-    if (!hasSelection || prevHasSelection) {
+    if (
+      !hasSelection ||
+      prevHasSelection ||
+      modificationsStore.isModificationModeEnabled
+    ) {
       return;
     }
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/index.tsx
@@ -6,7 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Navigate, Outlet, useLocation} from 'react-router-dom';
+import {Navigate, Outlet, useLocation, useNavigate} from 'react-router-dom';
+import {useLayoutEffect, useRef} from 'react';
 import {Paths} from 'modules/Routes';
 import {Container, TabContent} from './styled';
 import {TabListNav} from './TabListNav';
@@ -69,7 +70,25 @@ const BottomPanelTabs: React.FC<{isHistoryTabVisible: boolean}> = ({
   const {processInstanceId} = useProcessInstancePageParams();
   const {currentPage} = useCurrentPage();
   const location = useLocation();
+  const navigate = useNavigate();
   const hasIncident = processInstance?.hasIncident === true;
+
+  const prevHasSelectionRef = useRef(hasSelection);
+  useLayoutEffect(() => {
+    // Switches to the default element tab when users
+    // select an element without a previous selection.
+    const prevHasSelection = prevHasSelectionRef.current;
+    prevHasSelectionRef.current = hasSelection;
+    if (!hasSelection || prevHasSelection) {
+      return;
+    }
+
+    const pathname = hasIncident
+      ? Paths.processInstanceIncidents({processInstanceId})
+      : Paths.processInstanceDetails({processInstanceId});
+    navigate({pathname, search: location.search}, {replace: true});
+  }, [hasSelection, hasIncident, processInstanceId, location.search, navigate]);
+
   const incidentsCount = useSelectionAwareIncidentsCount(
     processInstanceId ?? '',
     hasIncident,
@@ -171,7 +190,9 @@ const BottomPanelTabs: React.FC<{isHistoryTabVisible: boolean}> = ({
         <Navigate
           to={{
             ...location,
-            pathname: Paths.processInstanceVariables({processInstanceId}),
+            pathname: hasSelection
+              ? Paths.processInstanceDetails({processInstanceId})
+              : Paths.processInstanceVariables({processInstanceId}),
           }}
           replace
         />

--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -36,15 +36,31 @@ import {ReactQueryProvider} from 'modules/react-query/ReactQueryProvider';
 import {PageErrorBoundary} from 'modules/components/PageErrorBoundary';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
 import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
+import {useWaitStateStatistics} from 'modules/queries/waitStateStatistics/useWaitStateStatistics';
+import {hasProcessLevelWaitState} from 'modules/utils/waitStates';
 
 const DefaultTabRedirect: React.FC = () => {
   const location = useLocation();
-  const {data: processInstance} = useProcessInstance();
+  const {data: processInstance, isLoading: isProcessInstanceLoading} =
+    useProcessInstance();
   const {hasSelection} = useProcessInstanceElementSelection();
+  const {data: waitStateStatistics, isLoading: isWaitStateLoading} =
+    useWaitStateStatistics({
+      enabled: getClientConfig().waitStatesEnabled,
+    });
+
+  if (isProcessInstanceLoading || isWaitStateLoading) {
+    return null;
+  }
+
+  const isProcessLevelWaiting = hasProcessLevelWaitState(
+    waitStateStatistics,
+    processInstance?.processDefinitionId,
+  );
   const pathname =
     processInstance?.hasIncident === true
       ? 'incidents'
-      : hasSelection
+      : hasSelection || isProcessLevelWaiting
         ? 'details'
         : 'variables';
   return <Navigate to={{pathname, search: location.search}} replace />;

--- a/operate/client/src/App/index.tsx
+++ b/operate/client/src/App/index.tsx
@@ -35,12 +35,18 @@ import {ForbiddenPage} from 'modules/components/ForbiddenPage';
 import {ReactQueryProvider} from 'modules/react-query/ReactQueryProvider';
 import {PageErrorBoundary} from 'modules/components/PageErrorBoundary';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
+import {useProcessInstanceElementSelection} from 'modules/hooks/useProcessInstanceElementSelection';
 
 const DefaultTabRedirect: React.FC = () => {
   const location = useLocation();
   const {data: processInstance} = useProcessInstance();
+  const {hasSelection} = useProcessInstanceElementSelection();
   const pathname =
-    processInstance?.hasIncident === true ? 'incidents' : 'variables';
+    processInstance?.hasIncident === true
+      ? 'incidents'
+      : hasSelection
+        ? 'details'
+        : 'variables';
   return <Navigate to={{pathname, search: location.search}} replace />;
 };
 


### PR DESCRIPTION
## Description

This PR changes the `BottomPanelTabs` to select the "Details" tab by default when an element gets selected. The "Incidents" tab takes precedence if an element has incidents (**up for discussion**). It keeps the current tab when users switch between elements **(up for discussion)**. Opened discussion: https://camunda.slack.com/archives/C0AH08C7UA2/p1783428788314739

This is part of the [Agent Visibility design direction](https://docs.google.com/document/d/1El0H-4MjfIvq3eSkE-xaJbVEDEDnI8An-Y4EoDJUMLw/edit?tab=t.0) (part 5). The goal of this change is to make it easier to discover AI agents.

Aside: The solution uses `useLayoutEffect` to switch to the default tab. I find that only mildly optimal... I would prefer to use a `loader` to redirect the route before any tab tries to render. But the redirect decisions depends on Query data, and the solution aligns with the existing `BottomPanelTabs`, which already handles redirect concerns.

## Related issues

relates #56101