### PR TITLE
Expose leaseToken in ActivatedJob response (gRPC, REST, Java client)

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -176,4 +176,12 @@ public interface ActivatedJob {
    *     version 8.10, or when the owning process instance has no business ID)
    */
   String getBusinessId();
+
+  /**
+   * The lease token identifying this activation, used to fence commands (complete, fail,
+   * throw-error) against superseded activations of the same job.
+   *
+   * @return the lease token, or {@code null} if the job was activated without a lease
+   */
+  String getLeaseToken();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -178,8 +178,8 @@ public interface ActivatedJob {
   String getBusinessId();
 
   /**
-   * The lease token identifying this activation, used to fence commands (complete, fail,
-   * throw-error) against superseded activations of the same job.
+   * The lease token identifying this activation. Pass it along to commands (e.g. complete, fail,
+   * throw-error) to fence them against superseded activations of the same job.
    *
    * @return the lease token, or {@code null} if the job was activated without a lease
    */

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
@@ -60,6 +60,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final Set<String> tags;
   private final Long rootProcessInstanceKey;
   private final String businessId;
+  private final String leaseToken;
 
   private Map<String, Object> variablesAsMap;
 
@@ -94,6 +95,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
     rootProcessInstanceKey = null;
     // proto strings default to "" when unset; expose as null like the REST response
     businessId = job.getBusinessId().isEmpty() ? null : job.getBusinessId();
+    // leaseToken is a proto3 optional field: absence (no lease) is represented by hasLeaseToken()
+    leaseToken = job.hasLeaseToken() ? job.getLeaseToken() : null;
   }
 
   public ActivatedJobImpl(
@@ -136,6 +139,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
             ? Long.parseLong(job.getRootProcessInstanceKey())
             : null;
     businessId = job.getBusinessId();
+    leaseToken = job.getLeaseToken();
   }
 
   @Override
@@ -276,6 +280,11 @@ public final class ActivatedJobImpl implements ActivatedJob {
   @Override
   public String getBusinessId() {
     return businessId;
+  }
+
+  @Override
+  public String getLeaseToken() {
+    return leaseToken;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
@@ -66,6 +66,7 @@ public final class ActivateJobsTest extends ClientTest {
             .setKind(JobKind.BPMN_ELEMENT)
             .setListenerEventType(ListenerEventType.START)
             .setBusinessId("order-123")
+            .setLeaseToken("lease-token-1")
             .build();
 
     final ActivatedJob activatedJob2 =
@@ -134,6 +135,7 @@ public final class ActivateJobsTest extends ClientTest {
                 activatedJob1.getListenerEventType(),
                 io.camunda.client.api.search.enums.ListenerEventType.class));
     assertThat(job.getBusinessId()).isEqualTo("order-123");
+    assertThat(job.getLeaseToken()).isEqualTo("lease-token-1");
 
     job = response.getJobs().get(1);
     assertThat(job.getKey()).isEqualTo(activatedJob2.getKey());
@@ -163,6 +165,7 @@ public final class ActivateJobsTest extends ClientTest {
                 activatedJob2.getListenerEventType(),
                 io.camunda.client.api.search.enums.ListenerEventType.class));
     assertThat(job.getBusinessId()).isNull();
+    assertThat(job.getLeaseToken()).isNull();
 
     final ActivateJobsRequest request = gatewayService.getLastRequest();
     assertThat(request.getType()).isEqualTo("foo");

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -76,6 +76,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .listenerEventType(JobListenerEventTypeEnum.START)
             .rootProcessInstanceKey("321")
             .businessId("business-1")
+            .leaseToken("lease-token-1")
             .priority(15);
 
     final ActivatedJobResult activatedJob2 =
@@ -134,6 +135,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(String.valueOf(job.getRootProcessInstanceKey()))
         .isEqualTo(activatedJob1.getRootProcessInstanceKey());
     assertThat(job.getBusinessId()).isEqualTo(activatedJob1.getBusinessId());
+    assertThat(job.getLeaseToken()).isEqualTo(activatedJob1.getLeaseToken());
     assertThat(job.getCustomHeaders()).isEqualTo(activatedJob1.getCustomHeaders());
     assertThat(job.getWorker()).isEqualTo(activatedJob1.getWorker());
     assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
@@ -160,6 +162,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(String.valueOf(job.getRootProcessInstanceKey()))
         .isEqualTo(activatedJob2.getRootProcessInstanceKey());
     assertThat(job.getBusinessId()).isEqualTo(activatedJob2.getBusinessId());
+    assertThat(job.getLeaseToken()).isNull();
     assertThat(String.valueOf(job.getProcessInstanceKey()))
         .isEqualTo(activatedJob2.getProcessInstanceKey());
     assertThat(job.getCustomHeaders()).isEqualTo(activatedJob2.getCustomHeaders());

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/ResponseMapper.java
@@ -237,6 +237,7 @@ public final class ResponseMapper {
         .tags(job.getTags())
         .userTask(toUserTaskProperties(job))
         .priority(job.getPriority())
+        .leaseToken(emptyToNull(job.getLeaseToken()))
         .build();
   }
 

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/ResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/ResponseMapperTest.java
@@ -196,6 +196,79 @@ class ResponseMapperTest {
     }
 
     @Test
+    void shouldMapActivatedJobWithLeaseToken() {
+      // given
+      final JobRecord jobRecord =
+          new JobRecord()
+              .setJobKind(JobKind.BPMN_ELEMENT)
+              .setType("test-type")
+              .setBpmnProcessId("procId")
+              .setElementId("elementId")
+              .setProcessInstanceKey(456L)
+              .setProcessDefinitionVersion(1)
+              .setProcessDefinitionKey(123L)
+              .setElementInstanceKey(555L)
+              .setWorker("worker")
+              .setRetries(3)
+              .setDeadline(0L)
+              .setLeaseToken("lease-token-1")
+              .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+      final byte[] emptyVariables = MsgPackConverter.convertToMsgPack(Collections.emptyMap());
+      jobRecord.setVariables(new UnsafeBuffer(emptyVariables));
+
+      final JobBatchRecord batchRecord = buildJobBatchRecord(jobRecord);
+      final JobActivationResponse activationResponse =
+          new JobActivationResponse(123L, batchRecord, 1024 * 1024L);
+
+      // when
+      final var result = ResponseMapper.toActivateJobsResponse(activationResponse);
+
+      // then
+      final var jobs = result.getActivateJobsResponse().getJobs();
+      assertThat(jobs)
+          .singleElement()
+          .satisfies(job -> assertThat(job.getLeaseToken()).isEqualTo("lease-token-1"));
+    }
+
+    @Test
+    void shouldNotSetLeaseTokenWhenNotLeasedForActivatedJob() {
+      // given - job activated without a lease (empty string on the record)
+      final JobRecord jobRecord =
+          new JobRecord()
+              .setJobKind(JobKind.BPMN_ELEMENT)
+              .setType("test-type")
+              .setBpmnProcessId("procId")
+              .setElementId("elementId")
+              .setProcessInstanceKey(456L)
+              .setProcessDefinitionVersion(1)
+              .setProcessDefinitionKey(123L)
+              .setElementInstanceKey(555L)
+              .setWorker("worker")
+              .setRetries(3)
+              .setDeadline(0L)
+              // leaseToken defaults to an empty string when not set
+              .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+      final byte[] emptyVariables = MsgPackConverter.convertToMsgPack(Collections.emptyMap());
+      jobRecord.setVariables(new UnsafeBuffer(emptyVariables));
+
+      final JobBatchRecord batchRecord = buildJobBatchRecord(jobRecord);
+      final JobActivationResponse activationResponse =
+          new JobActivationResponse(123L, batchRecord, 1024 * 1024L);
+
+      // when
+      final var result = ResponseMapper.toActivateJobsResponse(activationResponse);
+
+      // then
+      final var jobs = result.getActivateJobsResponse().getJobs();
+      assertThat(jobs)
+          .singleElement()
+          // leaseToken should be null when the record carries an empty string
+          .satisfies(job -> assertThat(job.getLeaseToken()).isNull());
+    }
+
+    @Test
     void shouldMapPriorityToActivatedJobResult() {
       // given
       final JobRecord jobRecord =
@@ -394,7 +467,8 @@ class ResponseMapperTest {
           .setPriority(jobRecord.getPriority())
           .setDeadline(jobRecord.getDeadline())
           .setTenantId(jobRecord.getTenantId())
-          .setBusinessId(jobRecord.getBusinessId());
+          .setBusinessId(jobRecord.getBusinessId())
+          .setLeaseToken(jobRecord.getLeaseToken());
 
       // Set variables as empty MsgPack map
       final byte[] emptyVariables = MsgPackConverter.convertToMsgPack(Collections.emptyMap());

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -412,6 +412,12 @@ public final class ResponseMapper {
       builder.setUserTask(toUserTaskProperties(job.getCustomHeaders()));
     }
 
+    // leaseToken is optional on the wire: leave it unset (rather than an empty string) when the
+    // job was activated without a lease, so clients can distinguish "no lease" from a token
+    if (!job.getLeaseToken().isEmpty()) {
+      builder.setLeaseToken(job.getLeaseToken());
+    }
+
     return builder.build();
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -412,8 +412,6 @@ public final class ResponseMapper {
       builder.setUserTask(toUserTaskProperties(job.getCustomHeaders()));
     }
 
-    // leaseToken is optional on the wire: leave it unset (rather than an empty string) when the
-    // job was activated without a lease, so clients can distinguish "no lease" from a token
     if (!job.getLeaseToken().isEmpty()) {
       builder.setLeaseToken(job.getLeaseToken());
     }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/ResponseMapperTest.java
@@ -202,6 +202,34 @@ class ResponseMapperTest {
       assertThat(result.getBusinessId()).isEqualTo("order-123");
     }
 
+    @Test
+    void shouldMapLeaseTokenToActivatedJob() {
+      // given
+      final JobRecord jobRecord = mockJobRecord(JobKind.BPMN_ELEMENT, Map.of());
+      when(jobRecord.getLeaseToken()).thenReturn("lease-token-123");
+      final var activatedJob = mockActivatedJob(jobRecord);
+
+      // when
+      final var result = ResponseMapper.toActivatedJob(activatedJob);
+
+      // then
+      assertThat(result.hasLeaseToken()).isTrue();
+      assertThat(result.getLeaseToken()).isEqualTo("lease-token-123");
+    }
+
+    @Test
+    void shouldNotSetLeaseTokenWhenNotLeased() {
+      // given
+      final JobRecord jobRecord = mockJobRecord(JobKind.BPMN_ELEMENT, Map.of());
+      final var activatedJob = mockActivatedJob(jobRecord);
+
+      // when
+      final var result = ResponseMapper.toActivatedJob(activatedJob);
+
+      // then
+      assertThat(result.hasLeaseToken()).isFalse();
+    }
+
     @ParameterizedTest
     @EnumSource(JobListenerEventType.class)
     void shouldMapActivatedJobWithListenerEventType(final JobListenerEventType listenerEventType) {
@@ -240,6 +268,7 @@ class ResponseMapperTest {
       when(jobRecord.getTenantId()).thenReturn(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
       when(jobRecord.getLength()).thenReturn(1);
       when(jobRecord.getBusinessId()).thenReturn("");
+      when(jobRecord.getLeaseToken()).thenReturn("");
       return jobRecord;
     }
 

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -129,6 +129,9 @@ message ActivatedJob {
   int32 priority = 19;
   // the business ID of the owning process instance; null when the instance has none
   string businessId = 20;
+  // the lease token identifying this activation; unset when the job was activated without a
+  // lease
+  optional string leaseToken = 21;
 }
 
 message UserTaskProperties {

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -441,6 +441,7 @@ components:
         - tags
         - userTask
         - priority
+        - leaseToken
       properties:
         type:
           description: The type of the job (should match what was requested).
@@ -537,6 +538,12 @@ components:
             Jobs created before 8.10 have no stored priority; the API returns 0 for such jobs.
           type: integer
           format: int32
+        leaseToken:
+          description: |
+            The lease token identifying this activation. This is `null` when the job was
+            activated without a lease.
+          nullable: true
+          type: string
       x-properties-added-in-version:
         - propertyName: kind
           addedInVersion: "8.8"
@@ -551,6 +558,8 @@ components:
         - propertyName: priority
           addedInVersion: "8.10"
         - propertyName: businessId
+          addedInVersion: "8.10"
+        - propertyName: leaseToken
           addedInVersion: "8.10"
 
     UserTaskProperties:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -138,7 +138,8 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "rootProcessInstanceKey": null,
               "businessId": null,
               "userTask": null,
-              "priority": 80
+              "priority": 80,
+              "leaseToken": null
             },
             {
               "jobKey": "%d",
@@ -167,7 +168,8 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "rootProcessInstanceKey": null,
               "businessId": null,
               "userTask": null,
-              "priority": 80
+              "priority": 80,
+              "leaseToken": null
             }
           ]
         }"""


### PR DESCRIPTION
## Description

Closes #54844.

Wires `JobRecord.leaseToken` (added in #54841) through to all layers of the job activation response, so workers can receive the lease token once it starts being populated. This is the output-path half of the job-lease mechanism (see ADR `zeebe/docs/adr/0005-810-job-lease.md`, #56749) — it covers gRPC, REST, and the Java client. REST and the Java client normalize the internal `""` (no lease) sentinel to `null`, mirroring the existing `businessId` field (added in 8.10). gRPC represents "no lease" as an unset `optional string` field instead, so `leaseToken` is genuinely absent on the wire rather than an empty string.

**Blocked on #54845** for actual lease generation: `JobBatchActivateProcessor` doesn't populate `JobRecord.leaseToken` yet, so in production this field is `""` (→ absent/`null` on the wire) for every job today. This PR only makes the plumbing ready; tests only exercise "no lease" and a synthetically-set token at the mapper/client unit level, since there is currently no way to produce a real leased job end-to-end.

### Changes
- `gateway.proto`: `ActivatedJob.leaseToken` (field 21, `optional string` — proto3 scalars can't represent null, so `optional` is what lets "no lease" be absent rather than `""`).
- `v2/jobs.yaml`: `ActivatedJobResult.leaseToken` (nullable string, `x-properties-added-in-version: 8.10`).
- gRPC `ResponseMapper`: sets `leaseToken` only when non-empty, leaving it unset otherwise.
- REST `ResponseMapper`: `.leaseToken(emptyToNull(job.getLeaseToken()))`.
- Java client: `ActivatedJob.getLeaseToken()` + `ActivatedJobImpl` wiring — the gRPC constructor checks `hasLeaseToken()`, the REST constructor passes the already-nullable DTO field through directly.

### Tests
- gRPC mapper: token present (`hasLeaseToken()` true) / absent (`hasLeaseToken()` false).
- REST mapper: token present / absent — also fixed the existing `buildJobBatchRecord` test helper, which copied `JobRecord` fields one by one and was missing `leaseToken` (a pre-existing test-only gap, not a production bug), and updated `JobControllerRoundRobinTest`'s strict JSON response fixtures to include the new field.
- Java client, both transports: token present / absent.
- All existing activate-jobs tests pass unmodified; `leaseToken` is absent/`null` in every existing case.

### Not in scope (tracked separately, blocked on #54845)
- Actual lease token generation in `JobBatchActivateProcessor` / `JobBatchCollector`.
- The activate-side guard that skips leased jobs for non-leasing workers.
- End-to-end acceptance criteria requiring a non-empty, distinct-per-activation token.

## Test plan
- [x] `./mvnw verify -pl zeebe/gateway-grpc -Dtest=ResponseMapperTest`
- [x] `./mvnw verify -pl gateways/gateway-mapping-http -Dtest=ResponseMapperTest`
- [x] `./mvnw verify -pl zeebe/gateway-rest -Dtest=JobControllerRoundRobinTest`
- [x] `./mvnw verify -pl clients/java -Dtest=ActivateJobsTest,ActivateJobsRestTest`
- [x] `./mvnw install -Dquickly -T1C` (full repo compile)