### PR TITLE
chore: reflect dissolving camundaex team in codeowners

### DIFF
--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -29,11 +29,13 @@ lookupTeamMedic["Distributed Systems"]=$distributedSystemsMedic
 lookupTeamMedic["DistributedSystems"]=$distributedSystemsMedic
 lookupTeamMedic["@camunda/zeebe-distributed-platform"]=$distributedSystemsMedic
 
-# @camunda-ex-medic
-camundaExMedic="<!subteam^S064J3N99A5|camunda-ex-medic>"
-lookupTeamMedic["Camunda Ex"]=$camundaExMedic
-lookupTeamMedic["CamundaEx"]=$camundaExMedic
-lookupTeamMedic["@camunda/camundaex"]=$camundaExMedic
+# @cpt-medic
+cptMedic="<!subteam^S0BGRACEPPS|cpt-medic>"
+lookupTeamMedic["@camunda/c8-testing"]=$cptMedic
+
+# @clients-sdks-ai-first-tooling-medic
+clientsSdksAiFirstToolingMedic="<!subteam^S0BFV0L5R2S|clients-sdks-ai-first-tooling-medic>"
+lookupTeamMedic["@camunda/clients-sdks-ai-first-tooling"]=$clientsSdksAiFirstToolingMedic
 
 # @distro-medic
 distroMedic="<!subteam^S053K7C7QKU|distro-medic>"

--- a/.codeowners
+++ b/.codeowners
@@ -57,7 +57,11 @@ zeebe/pom.xml               @camunda/orchestration-cluster
 zeebe/qa/pom.xml            @camunda/orchestration-cluster
 buf.yaml                    @camunda/orchestration-cluster
 
-# see /qa/ ownership below in the qa-engineering section
+# Camunda Client & SB Starter
+/clients/                   @camunda/core-features
+
+# Spring utilities
+/spring-utils/              @camunda/core-features
 
 ################################
 ## @camunda/monorepo-devops-team
@@ -111,29 +115,27 @@ mwnw*                       @camunda/monorepo-devops-team
 /qa/acceptance-tests/src/test/java/io/camunda/it/util/       @camunda/qa-engineering @camunda/orchestration-cluster
 /qa/acceptance-tests/src/main/java/io/camunda/it/util/       @camunda/qa-engineering @camunda/orchestration-cluster
 
-################################
-## @camunda/camundaex
-################################
+# Acceptance tests overrides for orchestration-cluster
+/qa/acceptance-tests/src/test/java/io/camunda/it/client/     @camunda/core-features
+/qa/acceptance-tests/src/test/java/io/camunda/it/spring/     @camunda/core-features
 
-# Clients and SDKs
-/clients/                   @camunda/camundaex
+################################
+## @camunda/c8-testing
+################################
 
 # Testing frameworks
-/testing/                   @camunda/camundaex
-
-# Spring utilities
-/spring-utils/              @camunda/camundaex
-
-# Acceptance tests
-/qa/acceptance-tests/src/test/java/io/camunda/it/client/     @camunda/camundaex
-/qa/acceptance-tests/src/test/java/io/camunda/it/spring/     @camunda/camundaex
+/testing/                   @camunda/c8-testing
 
 # CI
-/.github/workflows/camunda8-getting-started-bundle.yaml @camunda/camundaex
-/.github/workflows/camunda-client-compatibility-test* @camunda/camundaex
-/.github/workflows/camunda-process-test-compatibility* @camunda/camundaex
-/.github/workflows/camunda-spring-boot-starter-compatibility-test* @camunda/camundaex
+/.github/workflows/camunda-process-test-compatibility* @camunda/c8-testing
 
+################################
+## @camunda/clients-sdks-ai-first-tooling
+################################
+
+# CI
+/.github/workflows/camunda8-getting-started-bundle.yaml @camunda/clients-sdks-ai-first-tooling
+/.github/workflows/camunda-client-compatibility-test* @camunda/clients-sdks-ai-first-tooling
 
 ################################
 ## @camunda/connectors-agentic-ai
@@ -320,6 +322,7 @@ optimize.Dockerfile         @camunda/core-features
 /.github/workflows/gh-inherit-core-fields.yml @camunda/core-features
 /.github/workflows/publish-zod-schemas.yml @camunda/core-features
 /.github/workflows/verify-x-added-in-version-annotations.yml @camunda/core-features
+/.github/workflows/camunda-spring-boot-starter-compatibility-test* @camunda/core-features
 
 ################################
 ## @camunda/reliability-testing
@@ -422,7 +425,7 @@ optimize.Dockerfile         @camunda/core-features
 # earlier rule (e.g. `/.github/workflows/zeebe*`) needs to be reverted to a
 # different team for a particular file.
 /.github/workflows/c8-orchestration-cluster-e2e-nightly-triage.yml @camunda/test-automation-team
-/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml @camunda/camundaex
+/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml @camunda/core-features
 /.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml @camunda/qa-engineering
 /.github/workflows/zeebe-release-stable-dry-run.yml @camunda/monorepo-devops-team
 /.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml    @camunda/test-automation-team

--- a/.github/scripts/test-codeowners.sh
+++ b/.github/scripts/test-codeowners.sh
@@ -154,19 +154,19 @@ assert_owner \
   "qa/acceptance-tests/src/test/java/io/camunda/it/util/TestHelper.java" \
   "@camunda/qa-engineering" "@camunda/orchestration-cluster"
 
-# ── /qa/acceptance-tests → camundaex ─────────────────────────────────────────
+# ── /qa/acceptance-tests → core-features ─────────────────────────────────────────
 echo ""
-echo "── /qa/acceptance-tests → camundaex ──"
+echo "── /qa/acceptance-tests → core-features ──"
 
 assert_owner \
-  "acceptance-tests client/ → camundaex" \
+  "acceptance-tests client/ → core-features" \
   "qa/acceptance-tests/src/test/java/io/camunda/it/client/UnassignClientFromTenantIT.java" \
-  "@camunda/camundaex"
+  "@camunda/core-features"
 
 assert_owner \
-  "acceptance-tests spring/ → camundaex" \
+  "acceptance-tests spring/ → core-features" \
   "qa/acceptance-tests/src/test/java/io/camunda/it/spring/AbstractSpringDependenciesTest.java" \
-  "@camunda/camundaex"
+  "@camunda/core-features"
 
 # ── /qa/acceptance-tests → identity ──────────────────────────────────────────
 echo ""

--- a/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml
@@ -3,7 +3,7 @@
 # to ensure forward compatibility of REST endpoints across versions.
 # Scheduled nightly and supports manual dispatch for custom branch combinations.
 # type: CI
-# owner: @camunda/camundaex
+# owner: @camunda/core-features
 ---
 name: C8 REST API Forward Compatibility Tests
 
@@ -29,7 +29,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/camundaex'
+  TEST_OWNER: '@camunda/core-features'
 
 jobs:
   prepare-matrix:

--- a/.github/workflows/camunda-client-compatibility-test-trigger.yml
+++ b/.github/workflows/camunda-client-compatibility-test-trigger.yml
@@ -1,6 +1,6 @@
 # description: trigger workflow to run the camunda-client-compatibility-test.yml workflow on a schedule
 # type: CI
-# owner: @camunda/camundaex
+# owner: @camunda/core-features
 name: Camunda Compatibility Tests - Trigger
 
 on:
@@ -9,7 +9,7 @@ on:
     - cron: "0 2 * * *"
 
 env:
-  TEST_OWNER: '@camunda/camundaex'
+  TEST_OWNER: '@camunda/core-features'
 
 jobs:
   trigger-stable-8-8:

--- a/.github/workflows/camunda-client-compatibility-test.yml
+++ b/.github/workflows/camunda-client-compatibility-test.yml
@@ -1,6 +1,6 @@
 # description: Daily compatibility tests for Camunda components across versions
 # type: CI
-# owner: @camunda/camundaex
+# owner: @camunda/core-features
 name: Camunda Compatibility Tests
 
 on:
@@ -31,7 +31,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/camundaex'
+  TEST_OWNER: '@camunda/core-features'
   FLAKY_TEST_RERUN_COUNT: '3'
 
 jobs:

--- a/.github/workflows/camunda-process-test-compatibility-trigger.yml
+++ b/.github/workflows/camunda-process-test-compatibility-trigger.yml
@@ -14,7 +14,7 @@ permissions:
   actions: write
 
 env:
-  TEST_OWNER: '@camunda/camundaex'
+  TEST_OWNER: '@camunda/c8-testing'
 
 jobs:
   trigger:

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test-trigger.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test-trigger.yml
@@ -1,6 +1,6 @@
 # description: trigger workflow to run the camunda-spring-boot-starter-compatibility-test.yml workflow on a schedule
 # type: CI
-# owner: @camunda/camundaex
+# owner: @camunda/core-features
 name: Camunda Spring Boot Starter Compatibility Tests - Trigger
 
 on:
@@ -9,7 +9,7 @@ on:
     - cron: "0 2 * * *"
 
 env:
-  TEST_OWNER: '@camunda/camundaex'
+  TEST_OWNER: '@camunda/core-features'
 
 jobs:
   trigger-stable-8-8:

--- a/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
+++ b/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml
@@ -1,6 +1,6 @@
 # description: Daily compatibility tests for Camunda Spring Boot Starter across server versions
 # type: CI
-# owner: @camunda/camundaex
+# owner: @camunda/core-features
 name: Camunda Spring Boot Starter Compatibility Tests
 
 on:
@@ -31,7 +31,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/camundaex'
+  TEST_OWNER: '@camunda/core-features'
   FLAKY_TEST_RERUN_COUNT: '3'
 
 jobs:

--- a/.github/workflows/camunda8-getting-started-bundle.yaml
+++ b/.github/workflows/camunda8-getting-started-bundle.yaml
@@ -1,5 +1,5 @@
 # type: Release
-# owner: @camunda/camundaex
+# owner: @camunda/clients-sdks-ai-first-tooling
 ---
 name: "Camunda 8: Getting Started Bundle"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,7 +647,7 @@ jobs:
       ZEEBE_BACKUP_MODULES: ${{ steps.set-constants.outputs.backup }}
       # Zeebe modules owned by the @camunda/zeebe-distributed-platform team
       ZEEBE_DISTRIBUTED_MODULES: ${{ steps.set-constants.outputs.distributed }}
-      # Zeebe modules owned by the @camunda/camundaex team
+      # Zeebe modules owned by the @camunda/core-features team
       ZEEBE_CLIENT_MODULES: ${{ steps.set-constants.outputs.client }}
       # Extra modules for skipping in general-unit-tests, these modules are used in ZEEBE_EXPORTER_MODULES instead
       GENERAL_UT_EXTRA_SKIP_MODULES: ${{ steps.set-constants.outputs.general_ut_extra_skip }}
@@ -683,7 +683,7 @@ jobs:
           # Zeebe modules owned by @camunda/zeebe-distributed-platform
           DISTRIBUTED="':zeebe-atomix-cluster',':zeebe-atomix-utils',':zeebe-broker',':zeebe-broker-client',':zeebe-cluster-config',':dynamic-node-id-provider',':zeebe-journal',':zeebe-logstreams',':zeebe-restore',':zeebe-scheduler',':zeebe-snapshots',':zeebe-stream-platform',':zeebe-transport'"
 
-          # Zeebe modules owned by @camunda/camundaex
+          # Zeebe modules owned by @camunda/core-features
           CLIENT="':camunda-client-java'"
 
           # General UT configuration
@@ -881,7 +881,7 @@ jobs:
               "runs-on": "gcp-perf-core-8-default",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "@camunda/camundaex",
+              "owner": "@camunda/c8-testing",
               "module": "Testing",
               "stressRun": 1
             },
@@ -892,7 +892,7 @@ jobs:
               "maven-build-threads": 1,
               "maven-test-fork-count": 1,
               "runs-on": "gcp-perf-core-8-default",
-              "owner": "@camunda/camundaex",
+              "owner": "@camunda/core-features",
               "module": "Clients",
               "stressRun": 1
             },
@@ -1046,7 +1046,7 @@ jobs:
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_DISTRIBUTED_MODULES }}
           - component: Client
             suite: CamundaEx
-            owner: '@camunda/camundaex'
+            owner: '@camunda/core-features'
             maven-modules: ${{ needs.setup-tests.outputs.ZEEBE_CLIENT_MODULES }}
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@92af67132b5592ee29838ae6b4615a93acd2992b # main

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -206,12 +206,14 @@
 /testing/        @camunda/c8-testing
 
 # CI Files
-/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml          @camunda/camundaex
-/.github/workflows/camunda-client-compatibility-test.yml                             @camunda/camundaex
-/.github/workflows/camunda-client-compatibility-test-trigger.yml                     @camunda/camundaex
-/.github/workflows/camunda-process-test-compatibility-trigger.yml                    @camunda/camundaex
-/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml               @camunda/camundaex
-/.github/workflows/camunda-spring-boot-starter-compatibility-test-trigger.yml       @camunda/camundaex
+/.github/workflows/c8-orchestration-cluster-forward-compatibility-tests.yml          @camunda/core-features
+/.github/workflows/camunda-client-compatibility-test.yml                             @camunda/core-features
+/.github/workflows/camunda-client-compatibility-test-trigger.yml                     @camunda/core-features
+/.github/workflows/camunda-process-test-compatibility.yml                            @camunda/c8-testing
+/.github/workflows/camunda-process-test-compatibility-trigger.yml                    @camunda/c8-testing
+/.github/workflows/camunda-process-test-compatibility.yml                                 @camunda/c8-testing
+/.github/workflows/camunda-spring-boot-starter-compatibility-test.yml               @camunda/core-features
+/.github/workflows/camunda-spring-boot-starter-compatibility-test-trigger.yml       @camunda/core-features
 
 # C8 REST OpenAPI specification
 /zeebe/gateway-protocol/src/main/proto/v2/ @camunda/c8-api-team

--- a/docs/rest-api-endpoint-guidelines.md
+++ b/docs/rest-api-endpoint-guidelines.md
@@ -1625,7 +1625,7 @@ Failures are reported to Slack and visible in the [Actions tab](https://github.c
 **What this means for contributors:**
 
 - If you change an endpoint's response shape, remove a field, or alter error codes, the forward compatibility tests will detect it.
-- If your PR intentionally introduces a breaking change (see §2.7), coordinate with `@camunda/camundaex` to update the test expectations on the affected older branches _before_ merging.
+- If your PR intentionally introduces a breaking change (see §2.7), coordinate with `@camunda/core-features` to update the test expectations on the affected older branches _before_ merging.
 
 There is also an **on-demand workflow** ([`c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml`](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-api-test-branch-on-demand.yml)) that builds the server _and_ runs the tests from the same branch. This is useful for verifying that a feature branch passes all API tests — both against Elasticsearch _and_ H2/RDBMS — before merging. It also detects differential behavior between storage engines.
 

--- a/scripts/codeowners-utils/README.md
+++ b/scripts/codeowners-utils/README.md
@@ -109,7 +109,7 @@ Example:
 
 ```
 zeebe/engine/src/test/java/io/camunda/zeebe/engine/EngineTest.java | @camunda/core-features | unit
-qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientIT.java | @camunda/camundaex | acceptance
+qa/acceptance-tests/src/test/java/io/camunda/it/client/ClientIT.java | @camunda/core-features | acceptance
 ```
 
 ### JSON Format


### PR DESCRIPTION
## Description

See Slack thread for context:
https://camunda.slack.com/archives/C01H4NG9XDY/p1783322628119029

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
