### PR TITLE
ci: gate check-licenses on dependency or license CI changes

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -226,6 +226,15 @@ outputs:
     description: Output whether dependency manifests (pom.xml, lock files) changed, triggering PR vulnerability scanning
     value: >-
       ${{ steps.filter-dep-manifests.outputs.dep-manifest-change == 'true' }}
+  fossa-changes:
+    description: Output whether FOSSA license analysis should be run based on GitHub event and files changed (dependency manifests or the license CI itself)
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        github.event_name == 'schedule' ||
+        steps.ci-github-actions.outputs.ci-relevant == 'true' ||
+        steps.filter-dep-manifests.outputs.dep-manifest-change == 'true'
+      }}
   c8-e2e-test-suite-changes:
     description: Output whether the C8 Orchestration Cluster E2E test suite lint check should be run based on GitHub event and files changed
     value: >-

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -24,15 +24,35 @@ env:
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
+  detect-changes:
+    name: Detect dependency file changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: read
+    outputs:
+      fossa-changes: ${{ steps.filter.outputs.fossa-changes }}
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      timeout-minutes: 1
+    - name: Detect changes
+      uses: ./.github/actions/paths-filter
+      id: filter
+
   analyze:
     name: "Analyze ${{ matrix.project.name }} dependencies"
+    needs: [detect-changes]
     permissions:
       # Needed for camunda/infra-global-github-actions/fossa/info
       actions: read
       contents: read
     runs-on: ${{ matrix.project.runner }}
-    # Skip analysis on fork PRs as they cannot access FOSSA due to lack of credentials
-    if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+    # Never run on fork PRs (no FOSSA credentials). Otherwise run when fossa-changes is true, which the
+    # paths-filter sets for every push event (keeping the base-branch FOSSA baseline current) and, on
+    # pull requests, when dependency manifests or CI-relevant GitHub Actions/workflow files changed.
+    if: >-
+      (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) &&
+      needs.detect-changes.outputs.fossa-changes == 'true'
     # If you change the job timeout, update the timeout in camunda/infra-global-github-actions/fossa/pr-check accordingly.
     # Budget = one normal run (~25m) + one retry on hang (~30m) + small scheduling margin.
     timeout-minutes: 65


### PR DESCRIPTION
## Description

_(Thanks to @panagiotisgts for the initial idea and push, @cmur2 took this PR over)_

Previously the `check-licenses` (FOSSA) job ran on every pull request regardless of content. A PR that touches no dependency manifest resolves to an identical dependency graph and therefore cannot introduce a new license, so running the full FOSSA analysis there only adds CI time and self-hosted runner cost without providing any signal.

This PR guards the `analyze` job with a new `detect-changes` job so it runs only when relevant:

- **Always on push events** (base branches `main`/`stable`, release branches, tags) to keep the FOSSA baseline that PR checks diff against up to date.
- **Never on fork PRs**, which lack FOSSA credentials (unchanged behavior).
- **On pull requests only when** dependency manifests (`pom.xml`, lock files, `go.mod`, …) **or** the license CI itself (GitHub Actions / workflow files) change.

The gating uses a new `fossa-changes` output added to the shared `paths-filter` action, following the established idiom of the other outputs (`push || schedule || ci-relevant || <specific change>`) and reusing the existing dependency-manifest filter. The `ci-relevant` signal ensures changes to this workflow (or its in-repo helper actions) still trigger a run so they can be exercised before merge.

This aligns with the CI license-detection requirements from the FOSSA epics (camunda/team-infrastructure#751 and camunda/team-infrastructure#752), which call for detecting new/updated dependency licenses on both human and automation (e.g. Renovate) PRs while optimizing for CI feedback speed.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Context: camunda/team-infrastructure#751, camunda/team-infrastructure#752
