### PR TITLE
ci: increase Renovate timeouts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,10 +49,7 @@
     {
       "hostType": "docker",
       "matchHost": "https://docker.elastic.co",
-      "timeout": 30000
-    },
-    {
-      "timeout": 10000
+      "timeout": 150000
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Description

This PR applies the recommendations from Mend engineers to our Renovate configuration. Their statistical data suggests that our timeouts (10 seconds, added in https://github.com/camunda/camunda/pull/32216) are too strict. The [default timeout](https://docs.renovatebot.com/configuration-options/#hostrulestimeout) is 60 seconds.

Specifically `docker.elastic.co` might have slow responses that take even more than 60 seconds. Since Mend engineers should know best, I propose to apply their suggestions in order to move forward with our support case with them.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to INC-6230
