### PR TITLE
feat: support binding cluster services to OS-assigned ephemeral ports

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcBasicAuthStandaloneGatewayIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantGrpcBasicAuthStandaloneGatewayIT.java
@@ -75,14 +75,11 @@ final class PhysicalTenantGrpcBasicAuthStandaloneGatewayIT {
               // Disable the embedded gateway
               .withGatewayEnabled(false));
 
-  // Standalone gateway wired to the broker's cluster port; shares the same RDBMS stores.
+  // Standalone gateway wired to the broker's cluster port (only known once the broker is started,
+  // see #start); shares the same RDBMS stores.
   @TestZeebe(autoStart = false, purgeAfterEach = false)
   private static final TestStandaloneGateway GATEWAY =
-      new TestStandaloneGateway()
-          .withAuthenticatedAccess()
-          .withBasicAuth()
-          .withClusterConfig(
-              c -> c.setInitialContactPoints(List.of(BROKER.address(TestZeebePort.CLUSTER))));
+      new TestStandaloneGateway().withAuthenticatedAccess().withBasicAuth();
 
   private static CamundaClient defaultAdmin;
   private static CamundaClient tenantAAdmin;
@@ -108,6 +105,8 @@ final class PhysicalTenantGrpcBasicAuthStandaloneGatewayIT {
     TENANTS.seedBasicAuthAdminUser(BROKER, TENANT_B, TENANT_B_PASSWORD);
 
     BROKER.start();
+    GATEWAY.withClusterConfig(
+        c -> c.setInitialContactPoints(List.of(BROKER.address(TestZeebePort.CLUSTER))));
     GATEWAY.start();
 
     // No physicalTenantId — the gateway must resolve the absent header to the default PT.

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestCamundaApplication.java
@@ -36,7 +36,7 @@ import io.camunda.zeebe.qa.util.cluster.TestGateway;
 import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
-import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.qa.util.cluster.util.RuntimePorts;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
@@ -70,17 +70,11 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
         BrokerModuleConfiguration.class,
         IndexTemplateDescriptorsConfigurator.class);
 
-    unifiedConfig
-        .getCluster()
-        .getNetwork()
-        .getCommandApi()
-        .setPort(SocketUtil.getNextAddress().getPort());
-    unifiedConfig
-        .getCluster()
-        .getNetwork()
-        .getInternalApi()
-        .setPort(SocketUtil.getNextAddress().getPort());
-    unifiedConfig.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort());
+    // use OS-assigned ephemeral ports to allow multiple concurrent instances; the actual ports
+    // are resolved from the running application (see #mappedPort)
+    unifiedConfig.getCluster().getNetwork().getCommandApi().setPort(0);
+    unifiedConfig.getCluster().getNetwork().getInternalApi().setPort(0);
+    unifiedConfig.getApi().getGrpc().setPort(0);
 
     // set a smaller default log segment size since we pre-allocate, which might be a lot in tests
     // for local development; also lower the watermarks for local testing
@@ -154,10 +148,21 @@ public final class TestCamundaApplication extends TestSpringApplication<TestCamu
 
   @Override
   public int mappedPort(final TestZeebePort port) {
+    final var network = unifiedConfig.getCluster().getNetwork();
     return switch (port) {
-      case COMMAND -> unifiedConfig.getCluster().getNetwork().getCommandApi().getPort();
-      case GATEWAY -> unifiedConfig.getApi().getGrpc().getPort();
-      case CLUSTER -> unifiedConfig.getCluster().getNetwork().getInternalApi().getPort();
+      case COMMAND ->
+          resolveEphemeralPort(
+              network.getCommandApi().getPort(),
+              "command API",
+              () -> RuntimePorts.commandApiPort(this));
+      case GATEWAY ->
+          resolveEphemeralPort(
+              unifiedConfig.getApi().getGrpc().getPort(),
+              "gRPC",
+              () -> RuntimePorts.embeddedGatewayPort(this));
+      case CLUSTER ->
+          resolveEphemeralPort(
+              network.getInternalApi().getPort(), "cluster", () -> RuntimePorts.clusterPort(this));
       default -> super.mappedPort(port);
     };
   }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -786,21 +786,7 @@ public class CamundaMultiDBExtension
     }
 
     if (shouldSetupKeycloak) {
-      authenticatedClientFactory =
-          new OidcCamundaClientTestFactory(
-              applyPhysicalTenant(applicationUnderTest.application.newClientBuilder()),
-              tenantRestAddress(applicationUnderTest.application.restAddress()),
-              applicationUnderTest.application.grpcAddress(),
-              testPrefix,
-              keycloakContainer.getAuthServerUrl()
-                  + "/realms/camunda/protocol/openid-connect/token");
       injectStaticKeycloakContainerField(testClass, keycloakContainer);
-    } else {
-      authenticatedClientFactory =
-          new BasicAuthCamundaClientTestFactory(
-              applyPhysicalTenant(applicationUnderTest.application.newClientBuilder()),
-              tenantRestAddress(applicationUnderTest.application.restAddress()),
-              applicationUnderTest.application.grpcAddress());
     }
 
     final TestEntityCollection testEntities = new TestEntityCollector().collect(testClass);
@@ -844,26 +830,49 @@ public class CamundaMultiDBExtension
 
     if (applicationUnderTest.shouldBeManaged) {
       manageApplicationUnderTest();
+
+      // clients can only be created once the application is started, as its ports are OS-assigned
+      // on bind. Applications with an unmanaged lifecycle are started by the test itself, which
+      // then also creates its own clients.
+      if (shouldSetupKeycloak) {
+        authenticatedClientFactory =
+            new OidcCamundaClientTestFactory(
+                applyPhysicalTenant(applicationUnderTest.application.newClientBuilder()),
+                tenantRestAddress(applicationUnderTest.application.restAddress()),
+                applicationUnderTest.application.grpcAddress(),
+                testPrefix,
+                keycloakContainer.getAuthServerUrl()
+                    + "/realms/camunda/protocol/openid-connect/token");
+      } else {
+        authenticatedClientFactory =
+            new BasicAuthCamundaClientTestFactory(
+                applyPhysicalTenant(applicationUnderTest.application.newClientBuilder()),
+                tenantRestAddress(applicationUnderTest.application.restAddress()),
+                applicationUnderTest.application.grpcAddress());
+      }
+
+      awaitApplicationReadiness();
+
+      if (multiPhysicalTenantIds != null) {
+        multiPhysicalTenantClients = buildMultiPhysicalTenantClients(multiPhysicalTenantIds);
+        closeables.add(multiPhysicalTenantClients);
+        awaitMultiPhysicalTenantAdminsReady(multiPhysicalTenantClients);
+        injectStaticMultiPtClientsField(testClass, multiPhysicalTenantClients);
+      }
+
+      final EntityManager entityManager =
+          new EntityManager(authenticatedClientFactory.getAdminCamundaClient());
+
+      entityManager.await(configuredEntities);
+
+      createClientsForTestEntities(shouldSetupKeycloak, testEntities);
+
+      // we support only static fields for now - to make sure test setups are build in a way
+      // such they are reusable and tests methods are not relying on order, etc.
+      // We want to run tests in an efficient manner, and reduce setup time
+      injectStaticClientField(testClass);
     }
 
-    if (multiPhysicalTenantIds != null) {
-      multiPhysicalTenantClients = buildMultiPhysicalTenantClients(multiPhysicalTenantIds);
-      closeables.add(multiPhysicalTenantClients);
-      awaitMultiPhysicalTenantAdminsReady(multiPhysicalTenantClients);
-      injectStaticMultiPtClientsField(testClass, multiPhysicalTenantClients);
-    }
-
-    final EntityManager entityManager =
-        new EntityManager(authenticatedClientFactory.getAdminCamundaClient());
-
-    entityManager.await(configuredEntities);
-
-    createClientsForTestEntities(shouldSetupKeycloak, testEntities);
-
-    // we support only static fields for now - to make sure test setups are build in a way
-    // such they are reusable and tests methods are not relying on order, etc.
-    // We want to run tests in an efficient manner, and reduce setup time
-    injectStaticClientField(testClass);
     injectStaticDatabaseTypeField(testClass, context);
   }
 
@@ -977,6 +986,10 @@ public class CamundaMultiDBExtension
     final var application = applicationUnderTest.application;
     closeables.add(application);
     application.start();
+  }
+
+  private void awaitApplicationReadiness() {
+    final var application = applicationUnderTest.application;
     application.awaitCompleteTopology(
         application.unifiedConfig(), authenticatedClientFactory.getAdminCamundaClient());
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/AtomixCluster.java
@@ -42,9 +42,17 @@ import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.net.Address;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.SocketException;
+import java.net.StandardSocketOptions;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,6 +111,9 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
   protected volatile CompletableFuture<Void> closeFuture;
   protected final ThreadContext threadContext = new SingleThreadContext("atomix-cluster-%d");
   private final AtomicBoolean started = new AtomicBoolean();
+  // holds an ephemeral port resolved at construction until the services have bound it; null if
+  // the configured port is already concrete
+  private final ClaimedPort claimedPort;
 
   public AtomixCluster(
       final ClusterConfig config,
@@ -119,6 +130,7 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
       final ManagedUnicastService unicastService,
       final String actorSchedulerName,
       final MeterRegistry registry) {
+    claimedPort = resolveEphemeralPort(config);
     this.messagingService =
         messagingService != null
             ? messagingService
@@ -257,10 +269,50 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
     return messagingService
         .start()
         .thenComposeAsync(v -> unicastService.start(), threadContext)
+        // both services have bound the claimed port (with SO_REUSEPORT), so it can be released
+        // before the membership service starts advertising the address to other members
+        .thenRunAsync(this::releaseClaimedPort, threadContext)
         .thenComposeAsync(v -> membershipService.start(), threadContext)
         .thenComposeAsync(v -> communicationService.start(), threadContext)
         .thenComposeAsync(v -> eventService.start(), threadContext)
         .thenApply(v -> null);
+  }
+
+  /**
+   * Resolves an ephemeral node port (0) to a concrete free port before any service is built. The
+   * node's address is shared between the TCP messaging service and the UDP unicast service, and is
+   * advertised to other members as this node's single address, so a concrete port must be known
+   * upfront and free on both TCP and UDP.
+   *
+   * <p>The port is claimed by binding it on both protocols with SO_REUSEPORT and held until the
+   * services (which then also bind with SO_REUSEPORT) have bound it, so the port is never released
+   * in between; see {@link #startServices()}. Since the port cannot be known to anyone before the
+   * membership service advertises it, no traffic can arrive while the claim sockets share it.
+   *
+   * @return the claimed port, or null if the configured port is already concrete
+   */
+  private static ClaimedPort resolveEphemeralPort(final ClusterConfig config) {
+    final var nodeConfig = config.getNodeConfig();
+    if (nodeConfig.getPort() != 0) {
+      return null;
+    }
+
+    final var claimed = ClaimedPort.claim();
+    nodeConfig.setPort(claimed.port());
+
+    final var messagingConfig = config.getMessagingConfig();
+    final var messagingPort = messagingConfig.getPort();
+    if (messagingPort == null || messagingPort == 0) {
+      messagingConfig.setPort(claimed.port());
+      messagingConfig.setPortReuseEnabled(claimed.isHeld());
+    }
+    return claimed;
+  }
+
+  private void releaseClaimedPort() {
+    if (claimedPort != null) {
+      claimedPort.close();
+    }
   }
 
   protected CompletableFuture<Void> completeStartup() {
@@ -288,6 +340,8 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
   }
 
   protected CompletableFuture<Void> completeShutdown() {
+    // usually released during startup; make sure the sockets don't leak if startup failed early
+    releaseClaimedPort();
     threadContext.close();
     started.set(false);
     LOGGER.info("Stopped");
@@ -381,5 +435,93 @@ public class AtomixCluster implements BootstrapService, Managed<Void> {
   protected static ManagedClusterEventService buildClusterEventService(
       final ClusterMembershipService membershipService, final MessagingService messagingService) {
     return new DefaultClusterEventService(membershipService, messagingService);
+  }
+
+  /**
+   * A port claimed on both TCP and UDP. Where SO_REUSEPORT is supported, the claim sockets stay
+   * bound until {@link #close()}, so the port is never released before its final users (which must
+   * then also bind with SO_REUSEPORT) have bound it. On platforms without SO_REUSEPORT support, the
+   * sockets are closed right away instead, leaving a small window in which another process could
+   * grab the port; ports claimed this way come from the OS's ephemeral range though, which the OS
+   * hands out only when asked for a free port (i.e. another bind to port 0), making a collision
+   * very unlikely.
+   */
+  private static final class ClaimedPort implements AutoCloseable {
+    private final int port;
+    private final boolean held;
+    private final ServerSocket tcp;
+    private final DatagramSocket udp;
+
+    private ClaimedPort(
+        final int port, final boolean held, final ServerSocket tcp, final DatagramSocket udp) {
+      this.port = port;
+      this.held = held;
+      this.tcp = tcp;
+      this.udp = udp;
+    }
+
+    private static ClaimedPort claim() {
+      // an OS-assigned TCP port is almost always also free on UDP, but not guaranteed to be; a
+      // few attempts make a failure virtually impossible
+      final var attempts = 10;
+      for (int attempt = 0; attempt < attempts; attempt++) {
+        final var claimed = tryClaim();
+        if (claimed != null) {
+          return claimed;
+        }
+      }
+      throw new IllegalStateException(
+          "Failed to claim a port that is free on both TCP and UDP after %d attempts"
+              .formatted(attempts));
+    }
+
+    private static ClaimedPort tryClaim() {
+      ServerSocket tcp = null;
+      DatagramSocket udp = null;
+      try {
+        tcp = new ServerSocket();
+        final var reusePort = tcp.supportedOptions().contains(StandardSocketOptions.SO_REUSEPORT);
+        if (reusePort) {
+          tcp.setOption(StandardSocketOptions.SO_REUSEPORT, true);
+        }
+        tcp.bind(new InetSocketAddress(0));
+        final var port = tcp.getLocalPort();
+
+        udp = new DatagramSocket(null);
+        if (reusePort) {
+          udp.setOption(StandardSocketOptions.SO_REUSEPORT, true);
+        }
+        try {
+          udp.bind(new InetSocketAddress(port));
+        } catch (final SocketException e) {
+          LOGGER.debug("OS-assigned TCP port {} is already taken on UDP, retrying", port, e);
+          CloseHelper.quietCloseAll(udp, tcp);
+          return null;
+        }
+
+        if (!reusePort) {
+          // cannot hold the port while the services bind it; release it right away
+          CloseHelper.quietCloseAll(udp, tcp);
+          return new ClaimedPort(port, false, null, null);
+        }
+        return new ClaimedPort(port, true, tcp, udp);
+      } catch (final IOException e) {
+        CloseHelper.quietCloseAll(udp, tcp);
+        throw new UncheckedIOException("Failed to claim a free port on TCP and UDP", e);
+      }
+    }
+
+    private int port() {
+      return port;
+    }
+
+    private boolean isHeld() {
+      return held;
+    }
+
+    @Override
+    public void close() {
+      CloseHelper.quietCloseAll(udp, tcp);
+    }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -45,6 +45,7 @@ public class MessagingConfig implements Config {
   private String keyStorePassword;
   private int socketSendBuffer = AUTO_SOCKET_SIZE;
   private int socketReceiveBuffer = AUTO_SOCKET_SIZE;
+  private boolean portReuseEnabled = false;
   private Duration heartbeatTimeout = Duration.ofSeconds(15);
   private Duration heartbeatInterval = Duration.ofSeconds(5);
 
@@ -272,6 +273,26 @@ public class MessagingConfig implements Config {
 
   public String getKeyStorePassword() {
     return keyStorePassword;
+  }
+
+  /**
+   * @return true if the server sockets should be bound with SO_REUSEPORT
+   */
+  public boolean isPortReuseEnabled() {
+    return portReuseEnabled;
+  }
+
+  /**
+   * Sets whether the server sockets are bound with SO_REUSEPORT. Used when the port was claimed
+   * upfront by another socket with SO_REUSEPORT, so that the port is never released between
+   * claiming it and binding the services; see {@link io.atomix.cluster.AtomixCluster}.
+   *
+   * @param portReuseEnabled whether to bind server sockets with SO_REUSEPORT
+   * @return this config for chaining
+   */
+  public MessagingConfig setPortReuseEnabled(final boolean portReuseEnabled) {
+    this.portReuseEnabled = portReuseEnabled;
+    return this;
   }
 
   /**

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -48,6 +48,7 @@ import io.netty.channel.ServerChannel;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollChannelOption;
 import io.netty.channel.epoll.EpollDatagramChannel;
 import io.netty.channel.epoll.EpollEventLoopGroup;
 import io.netty.channel.epoll.EpollServerSocketChannel;
@@ -55,6 +56,7 @@ import io.netty.channel.epoll.EpollSocketChannel;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -77,6 +79,7 @@ import java.io.IOException;
 import java.net.BindException;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
+import java.net.StandardSocketOptions;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -119,7 +122,9 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private static final String MESSAGE_DISPATCHER_NAME = "handler";
 
   private final Logger log = LoggerFactory.getLogger(getClass());
-  private final Address advertisedAddress;
+  // may be re-assigned once after binding, when the configured port is 0 and the actual port is
+  // only known after the OS assigned one; never changes once the service is started
+  private volatile Address advertisedAddress;
   private final Collection<Address> bindingAddresses = new ArrayList<>();
   private final int preamble;
   private final ProtocolVersion protocolVersion;
@@ -136,6 +141,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private Class<? extends SocketChannel> clientChannelClass;
   private Class<? extends DatagramChannel> clientDataGramChannelClass;
   private Channel serverChannel;
+  // the actual port of the first successful bind; used to resolve configured ephemeral ports (0)
+  private volatile int boundPort;
   // a single thread executor which silently rejects tasks being submitted when it's shutdown
   private ScheduledExecutorService timeoutExecutor;
   private volatile LocalClientConnection localConnection;
@@ -888,6 +895,13 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private CompletableFuture<Void> bootstrapServer() {
     final ServerBootstrap b = new ServerBootstrap();
     b.option(ChannelOption.SO_REUSEADDR, true);
+    if (config.isPortReuseEnabled()) {
+      b.option(
+          serverChannelClass == EpollServerSocketChannel.class
+              ? EpollChannelOption.SO_REUSEPORT
+              : NioChannelOption.of(StandardSocketOptions.SO_REUSEPORT),
+          true);
+    }
     b.option(ChannelOption.SO_BACKLOG, 128);
     b.childOption(
         ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(8 * 1024, 32 * 1024));
@@ -934,13 +948,21 @@ public final class NettyMessagingService implements ManagedMessagingService {
       final CompletableFuture<Void> future) {
     if (addressIterator.hasNext()) {
       final Address address = addressIterator.next();
+      // once the OS assigned a port for the first ephemeral bind, all further interfaces must be
+      // bound to the same port so that a single advertised port reaches all of them
+      final int port = address.port() == 0 && boundPort != 0 ? boundPort : address.port();
       bootstrap
-          .bind(address.host(), address.port())
+          .bind(address.host(), port)
           .addListener(
               (ChannelFutureListener)
                   f -> {
                     if (f.isSuccess()) {
                       serverChannel = f.channel();
+                      if (boundPort == 0
+                          && serverChannel.localAddress()
+                              instanceof final InetSocketAddress boundAddress) {
+                        boundPort = boundAddress.getPort();
+                      }
                       bind(bootstrap, addressIterator, future);
                     } else {
                       final Throwable cause = f.cause();
@@ -958,8 +980,31 @@ public final class NettyMessagingService implements ManagedMessagingService {
                     }
                   });
     } else {
+      resolveEphemeralPorts();
       future.complete(null);
     }
+  }
+
+  /**
+   * Replaces the ephemeral port 0 in the advertised and binding addresses with the port that the OS
+   * actually assigned, so that the advertised address is routable by other cluster members. Must
+   * run after all interfaces are bound and before the service is considered started.
+   */
+  private void resolveEphemeralPorts() {
+    if (boundPort == 0) {
+      return;
+    }
+
+    if (advertisedAddress.port() == 0) {
+      advertisedAddress = Address.from(advertisedAddress.host(), boundPort);
+    }
+
+    final var resolved =
+        bindingAddresses.stream()
+            .map(address -> address.port() == 0 ? Address.from(address.host(), boundPort) : address)
+            .toList();
+    bindingAddresses.clear();
+    bindingAddresses.addAll(resolved);
   }
 
   @VisibleForTesting

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -39,6 +39,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
+import io.netty.channel.socket.nio.NioChannelOption;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.resolver.dns.BiDnsQueryLifecycleObserverFactory;
@@ -47,6 +48,7 @@ import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.resolver.dns.LoggingDnsQueryLifeCycleObserverFactory;
 import io.netty.util.concurrent.Future;
 import java.net.InetSocketAddress;
+import java.net.StandardSocketOptions;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,13 +74,15 @@ public class NettyUnicastService implements ManagedUnicastService {
 
   private final Logger log = LoggerFactory.getLogger(getClass());
 
-  private final Address advertisedAddress;
+  // may be re-assigned until the service is started, when the configured port is 0 and the actual
+  // port is only known after binding
+  private volatile Address advertisedAddress;
   private final MessagingConfig config;
   private final int preamble;
   private final Map<String, Map<BiConsumer<Address, byte[]>, Executor>> listeners =
       Maps.newConcurrentMap();
   private final AtomicBoolean started = new AtomicBoolean();
-  private final Address bindAddress;
+  private volatile Address bindAddress;
 
   private final MeterRegistry registry;
 
@@ -113,6 +117,20 @@ public class NettyUnicastService implements ManagedUnicastService {
     final var port = config.getPort() != null ? config.getPort() : advertisedAddress.port();
     bindAddress = new Address(new InetSocketAddress(port));
     this.actorSchedulerName = actorSchedulerName != null ? actorSchedulerName : "";
+  }
+
+  /**
+   * Returns the advertised address of this service; other members address unicast messages to it.
+   * When configured with an ephemeral port (0), the port is only resolved once the service is
+   * started.
+   */
+  public Address address() {
+    return advertisedAddress;
+  }
+
+  /** Returns the address this service is (or will be) bound to. */
+  public Address bindAddress() {
+    return bindAddress;
   }
 
   @Override
@@ -166,8 +184,8 @@ public class NettyUnicastService implements ManagedUnicastService {
     }
   }
 
-  private CompletableFuture<Void> bootstrap() {
-    final Bootstrap serverBootstrap =
+  private Bootstrap newServerBootstrap() {
+    final var bootstrap =
         new Bootstrap()
             .group(group)
             .channel(NioDatagramChannel.class)
@@ -182,8 +200,10 @@ public class NettyUnicastService implements ManagedUnicastService {
             .option(ChannelOption.RCVBUF_ALLOCATOR, new DefaultMaxBytesRecvByteBufAllocator())
             .option(ChannelOption.SO_BROADCAST, true)
             .option(ChannelOption.SO_REUSEADDR, true);
-
-    return bind(serverBootstrap);
+    if (config.isPortReuseEnabled()) {
+      bootstrap.option(NioChannelOption.of(StandardSocketOptions.SO_REUSEPORT), true);
+    }
+    return bootstrap;
   }
 
   private void handleReceivedPacket(final DatagramPacket packet) {
@@ -206,9 +226,9 @@ public class NettyUnicastService implements ManagedUnicastService {
     }
   }
 
-  private CompletableFuture<Void> bind(final Bootstrap bootstrap) {
+  private CompletableFuture<Void> bind() {
     final CompletableFuture<Void> future = new CompletableFuture<>();
-    bootstrap
+    newServerBootstrap()
         .bind(bindAddress.host(), bindAddress.port())
         .addListener(
             (ChannelFutureListener)
@@ -219,10 +239,26 @@ public class NettyUnicastService implements ManagedUnicastService {
                   }
 
                   channel = (DatagramChannel) f.channel();
+                  resolveEphemeralPort(channel.localAddress());
                   future.complete(null);
                 });
 
     return future;
+  }
+
+  /**
+   * Replaces a configured ephemeral port (0) in the bind and advertised addresses with the port the
+   * OS actually assigned, so that {@link #advertisedAddress} is routable by other members.
+   */
+  private void resolveEphemeralPort(final InetSocketAddress boundAddress) {
+    if (boundAddress == null) {
+      return;
+    }
+
+    bindAddress = new Address(boundAddress);
+    if (advertisedAddress.port() == 0) {
+      advertisedAddress = Address.from(advertisedAddress.host(), boundAddress.getPort());
+    }
   }
 
   @Override
@@ -230,7 +266,7 @@ public class NettyUnicastService implements ManagedUnicastService {
     group =
         new NioEventLoopGroup(
             0, namedThreads("netty-unicast-event-nio-client-%d", log, actorSchedulerName));
-    return bootstrap()
+    return bind()
         .thenRun(
             () -> {
               final var metrics = new NettyDnsMetrics(registry);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/AtomixClusterEphemeralPortTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/AtomixClusterEphemeralPortTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.messaging.impl.NettyUnicastService;
+import io.atomix.utils.net.Address;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests forming a cluster where all members bind to ephemeral ports (0) assigned by the OS. Since
+ * no port is known before a member is started, members are started in sequence: a seed member
+ * starts first, and the remaining members bootstrap from its resolved address.
+ */
+final class AtomixClusterEphemeralPortTest {
+  @AutoClose private final MeterRegistry registry = new SimpleMeterRegistry();
+
+  private final List<AtomixCluster> clusters = new ArrayList<>();
+
+  @AfterEach
+  void tearDown() {
+    CloseHelper.quietCloseAll(clusters.stream().map(c -> (AutoCloseable) () -> c.stop().join()));
+  }
+
+  @Test
+  void shouldAdvertiseResolvedPort() {
+    // given
+    final var cluster = createMember("single", List.of());
+
+    // when
+    cluster.start().join();
+
+    // then
+    final var localMember = cluster.getMembershipService().getLocalMember();
+    assertThat(localMember.address().port())
+        .isEqualTo(cluster.getMessagingService().address().port())
+        .isPositive();
+    // the unicast (UDP) service shares the port number, as members address unicast messages to
+    // the single advertised member address
+    assertThat(((NettyUnicastService) cluster.getUnicastService()).bindAddress().port())
+        .isEqualTo(localMember.address().port());
+  }
+
+  @Test
+  void shouldFormClusterWithEphemeralPorts() {
+    // given - a seed member with an OS-assigned port
+    final var seed = createMember("seed", List.of());
+    seed.start().join();
+    final var seedAddress = seed.getMessagingService().address();
+    assertThat(seedAddress.port()).isPositive();
+
+    // when - the remaining members bootstrap from the seed's resolved address
+    final var member1 = createMember("member-1", List.of(seedAddress));
+    final var member2 = createMember("member-2", List.of(seedAddress));
+    member1.start().join();
+    member2.start().join();
+
+    // then - all members discover each other through the seed
+    Awaitility.await("until all members know all other members")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                clusters.forEach(
+                    cluster -> assertThat(cluster.getMembershipService().getMembers()).hasSize(3)));
+  }
+
+  private AtomixCluster createMember(final String memberId, final List<Address> seeds) {
+    final var nodes =
+        seeds.stream().map(address -> (Node) Node.builder().withAddress(address).build()).toList();
+    final var cluster =
+        AtomixCluster.builder(registry)
+            .withClusterId("ephemeral-port-test")
+            .withMemberId(memberId)
+            .withHost("127.0.0.1")
+            .withPort(0)
+            .withMembershipProvider(BootstrapDiscoveryProvider.builder().withNodes(nodes).build())
+            .build();
+    clusters.add(cluster);
+    return cluster;
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceEphemeralPortTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceEphemeralPortTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.messaging.ManagedMessagingService;
+import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.utils.net.Address;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests binding the messaging service to an ephemeral port (0), where the OS assigns a free port
+ * which must be resolved into the advertised address.
+ */
+final class NettyMessagingServiceEphemeralPortTest {
+  @AutoClose private final MeterRegistry registry = new SimpleMeterRegistry();
+  private final List<ManagedMessagingService> services = new ArrayList<>();
+
+  @AfterEach
+  void tearDown() {
+    CloseHelper.quietCloseAll(services.stream().map(s -> (AutoCloseable) () -> s.stop().join()));
+  }
+
+  @Test
+  void shouldResolveEphemeralPortIntoAdvertisedAddress() {
+    // given
+    final var service = createService(Address.from("127.0.0.1", 0));
+
+    // when
+    service.start().join();
+
+    // then
+    assertThat(service.address().port()).isPositive();
+    assertThat(service.bindingAddresses())
+        .isNotEmpty()
+        .allSatisfy(address -> assertThat(address.port()).isEqualTo(service.address().port()));
+  }
+
+  @Test
+  void shouldReceiveMessagesOnResolvedAddress() {
+    // given
+    final var receiver = createService(Address.from("127.0.0.1", 0));
+    final var sender = createService(Address.from("127.0.0.1", 0));
+    receiver.start().join();
+    sender.start().join();
+    receiver.registerHandler(
+        "test", (sourceAddress, payload) -> CompletableFuture.completedFuture(payload));
+
+    // when
+    final var response =
+        sender.sendAndReceive(
+            receiver.address(), "test", "hello".getBytes(), true, Duration.ofSeconds(10));
+
+    // then
+    assertThat(response)
+        .succeedsWithin(10, TimeUnit.SECONDS)
+        .satisfies(payload -> assertThat(payload).containsExactly("hello".getBytes()));
+  }
+
+  @Test
+  void shouldHandleSelfAddressedMessagesLocally() {
+    // given
+    final var service = createService(Address.from("127.0.0.1", 0));
+    service.start().join();
+    service.registerHandler(
+        "test", (sourceAddress, payload) -> CompletableFuture.completedFuture(payload));
+
+    // when - sending to the resolved advertised address must short-circuit to the local connection
+    final var response =
+        service.sendAndReceive(
+            service.address(), "test", "self".getBytes(), true, Duration.ofSeconds(10));
+
+    // then
+    assertThat(response)
+        .succeedsWithin(10, TimeUnit.SECONDS)
+        .satisfies(payload -> assertThat(payload).containsExactly("self".getBytes()));
+  }
+
+  private ManagedMessagingService createService(final Address advertisedAddress) {
+    final var service =
+        new NettyMessagingService(
+            "ephemeral-port-test", advertisedAddress, new MessagingConfig(), registry);
+    services.add(service);
+    return service;
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyUnicastServiceEphemeralPortTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyUnicastServiceEphemeralPortTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.utils.net.Address;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+/** Tests binding the unicast service to an ephemeral port (0), resolved by the OS on bind. */
+final class NettyUnicastServiceEphemeralPortTest {
+  @AutoClose private final MeterRegistry registry = new SimpleMeterRegistry();
+  private final List<NettyUnicastService> services = new ArrayList<>();
+
+  @AfterEach
+  void tearDown() {
+    CloseHelper.quietCloseAll(services.stream().map(s -> (AutoCloseable) () -> s.stop().join()));
+  }
+
+  @Test
+  void shouldResolveEphemeralPortOnBind() {
+    // given
+    final var service = createService(Address.from("127.0.0.1", 0));
+
+    // when
+    service.start().join();
+
+    // then
+    assertThat(service.address().port()).isPositive();
+    assertThat(service.bindAddress().port()).isEqualTo(service.address().port());
+  }
+
+  @Test
+  void shouldExchangeMessagesBetweenEphemeralPortServices() throws Exception {
+    // given
+    final var receiver = createService(Address.from("127.0.0.1", 0));
+    final var sender = createService(Address.from("127.0.0.1", 0));
+    receiver.start().join();
+    sender.start().join();
+
+    final var received = new CompletableFuture<byte[]>();
+    receiver.addListener("test", (address, payload) -> received.complete(payload), Runnable::run);
+
+    // when
+    sender.unicast(receiver.address(), "test", "hello".getBytes());
+
+    // then
+    assertThat(received)
+        .succeedsWithin(10, TimeUnit.SECONDS)
+        .satisfies(payload -> assertThat(payload).containsExactly("hello".getBytes()));
+  }
+
+  private NettyUnicastService createService(final Address advertisedAddress) {
+    final var service =
+        new NettyUnicastService(
+            "ephemeral-port-test", advertisedAddress, new MessagingConfig(), registry);
+    services.add(service);
+    return service;
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStep.java
@@ -69,6 +69,15 @@ public class ApiMessagingServiceStep extends AbstractBrokerStartupStep {
                           "Bound API to {}, using advertised address {} ",
                           messagingService.bindingAddresses(),
                           messagingService.address());
+                      if (commandApiCfg.getAdvertisedPort() == 0) {
+                        // the advertised port was configured as ephemeral (0) and only resolved
+                        // when the messaging service was bound; the broker info is gossiped to
+                        // gateways which use it to reach this broker's command API, so it must
+                        // carry the resolved port
+                        brokerStartupContext
+                            .getBrokerInfo()
+                            .setCommandApiAddress(messagingService.address().toString());
+                      }
                       brokerStartupContext.setApiMessagingService(messagingService);
                       startupFuture.complete(brokerStartupContext);
                     });

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -96,9 +96,10 @@ public final class SystemContext {
       "Snapshot period %s needs to be larger then or equals to one minute.";
   private static final String MAX_BATCH_SIZE_ERROR_MSG =
       "Expected to have an append batch size maximum which is non negative and smaller then '%d', but was '%s'.";
-  private static final String INITIAL_CONTACT_POINTS_ERROR_MSG =
-      "Initial contact points must be configured when cluster size is greater than 1. "
-          + "Please configure '"
+  private static final String INITIAL_CONTACT_POINTS_WARNING =
+      "No initial contact points are configured and the cluster size is greater than 1. This node "
+          + "will wait to be contacted by other cluster members. If it is not a seed node, "
+          + "configure '"
           + UNIFIED_INITIAL_CONTACT_POINTS_PROPERTY
           + "' or the legacy property '"
           + LEGACY_INITIAL_CONTACT_POINTS_PROPERTY
@@ -216,10 +217,12 @@ public final class SystemContext {
 
     final var errors = new ArrayList<String>(0);
 
+    // no initial contact points is a valid configuration: such a node waits to be contacted by
+    // the other members instead, e.g. a seed node whose peers are configured to contact it
     if (cluster.getClusterSize() > 1
         && (cluster.getInitialContactPoints() == null
             || cluster.getInitialContactPoints().isEmpty())) {
-      errors.add(INITIAL_CONTACT_POINTS_ERROR_MSG);
+      LOG.warn(INITIAL_CONTACT_POINTS_WARNING);
     }
 
     if (!gossiper.syncDelay().isPositive()) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -1083,8 +1083,9 @@ final class SystemContextTest {
   }
 
   @Test
-  void shouldThrowValidationErrorWhenInitialContactPointsIsNotSetWHenClustering() {
-    // given
+  void shouldNotThrowValidationErrorWhenInitialContactPointsIsNotSetWhenClustering() {
+    // given - no initial contact points is a valid configuration: such a node waits to be
+    // contacted by the other members instead, e.g. a seed node whose peers contact it
     final BrokerCfg brokerCfg = new BrokerCfg();
     final var clusterCfg = brokerCfg.getCluster();
     clusterCfg.setClusterSize(2);
@@ -1092,10 +1093,7 @@ final class SystemContextTest {
     clusterCfg.setInitialContactPoints(List.of());
 
     // when/then
-    assertThatThrownBy(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(InvalidConfigurationException.class)
-        .hasMessageContaining(
-            "Initial contact points must be configured when cluster size is greater than 1.");
+    assertThatNoException().isThrownBy(() -> initSystemContext(brokerCfg));
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -159,6 +159,22 @@ public final class Gateway implements CloseableSilently {
     return brokerClient;
   }
 
+  /**
+   * Returns the actual port the gRPC server is bound to. This may differ from the configured port
+   * when the configured port is 0, in which case the OS assigns a free port on bind.
+   *
+   * @return the actual gRPC server port
+   * @throws IllegalStateException if the server is not started yet
+   */
+  public int getServerPort() {
+    final var runningServer = server;
+    if (runningServer == null) {
+      throw new IllegalStateException(
+          "Expected to get the actual gRPC server port, but the server is not started yet");
+    }
+    return runningServer.getPort();
+  }
+
   public ActorFuture<Gateway> start() {
     final var resultFuture = new CompletableActorFuture<Gateway>();
     healthManager.setStatus(Status.STARTING);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupMultiPartitionTest.java
@@ -220,6 +220,10 @@ class BackupMultiPartitionTest {
     cluster.shutdown().brokers().values().forEach(broker -> deleteAndRestore(broker, backupId));
     cluster.start().awaitCompleteTopology();
 
+    // the cluster restarted on fresh OS-assigned ports, so the old client is stale
+    client.getClient().close();
+    client = new GrpcClientRule(cluster.newClientBuilder().build());
+
     // then
     final var jobHandler = new RecordingJobHandler();
     try (final var ignored =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/backup/BackupRetentionAcceptance.java
@@ -61,7 +61,6 @@ public interface BackupRetentionAcceptance extends ClockSupport {
   default void shouldMaintainRollingWindowAndDeleteOldBackupsWithRangeMarkers() {
 
     pinClock(getTestCluster());
-    final var actuator = BackupActuator.of(getTestCluster().availableGateway());
 
     // The checkpoint scheduler fires immediately on startup, creating an automatic backup.
     // The first attempt may fail if no valid snapshot exists yet (snapshot positions >=
@@ -84,6 +83,8 @@ public interface BackupRetentionAcceptance extends ClockSupport {
 
     restartClusterWithRetention();
 
+    // create the actuator only after the restart, as the cluster binds fresh OS-assigned ports
+    final var actuator = BackupActuator.of(getTestCluster().availableGateway());
     Awaitility.await("Retention deletes old backups")
         .atMost(Duration.ofSeconds(90))
         .pollInterval(Duration.ofSeconds(5))

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterStatusTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/ClusterStatusTest.java
@@ -14,6 +14,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.StatusResponse.Status;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneGateway;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
@@ -45,6 +46,12 @@ public class ClusterStatusTest {
 
   @BeforeEach
   void beforeEach() {
+    // brokers restart on fresh OS-assigned ports; if all brokers were stopped, a gateway that kept
+    // running only knows the old broker addresses and can never rediscover the restarted brokers,
+    // so restart it along with the brokers to re-resolve the contact points
+    if (CLUSTER.brokers().values().stream().noneMatch(TestStandaloneBroker::isStarted)) {
+      CLUSTER.gateways().values().forEach(TestStandaloneGateway::stop);
+    }
     CLUSTER.start().awaitCompleteTopology();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/JobStreamLifecycleIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/JobStreamLifecycleIT.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -46,6 +47,16 @@ final class JobStreamLifecycleIT {
             .withBrokersCount(2)
             .withGatewaysCount(2)
             .withEmbeddedGateway(false)
+            .withGatewayConfig(
+                gateway -> {
+                  gateway.withUnauthenticatedAccess();
+                  // shouldAggregateStreamsEvenAcrossRestarts verifies that the client's streams
+                  // transparently re-register with a restarted gateway, which requires the
+                  // gateway to come back on the same gRPC endpoint; pre-assign a fixed port
+                  // instead of the default OS-assigned one, which changes on every start
+                  gateway.withUnifiedConfig(
+                      cfg -> cfg.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort()));
+                })
             .build();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/SnapshotWithExportersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/SnapshotWithExportersTest.java
@@ -46,11 +46,11 @@ final class SnapshotWithExportersTest {
     private final TestStandaloneBroker zeebe =
         new TestStandaloneBroker().withUnauthenticatedAccess();
 
-    private final PartitionsActuator partitions = PartitionsActuator.of(zeebe);
-
     @Test
     void shouldNotTakeNewSnapshotWhenAddingNewExporter() {
       // given -- snapshot taken by broker without exporters
+      // the broker binds OS-assigned ports, so the actuator can only be created once it is started
+      final var partitions = PartitionsActuator.of(zeebe);
       final FileBasedSnapshotId snapshotWithoutExporters;
       final FileBasedSnapshotId snapshotWithExporters;
 
@@ -75,14 +75,16 @@ final class SnapshotWithExportersTest {
       // when -- taking snapshot on broker with exporters configured
       zeebe.withRecordingExporter(true).start().awaitCompleteTopology();
 
-      partitions.takeSnapshot();
+      // the restarted broker binds fresh OS-assigned ports, so the old actuator is stale
+      final var restartedPartitions = PartitionsActuator.of(zeebe);
+      restartedPartitions.takeSnapshot();
       snapshotWithExporters =
           Awaitility.await("Snapshot is taken")
               .atMost(Duration.ofSeconds(60))
               .during(Duration.ofSeconds(5))
               .until(
                   () ->
-                      Optional.ofNullable(partitions.query().get(1).snapshotId())
+                      Optional.ofNullable(restartedPartitions.query().get(1).snapshotId())
                           .map(id -> FileBasedSnapshotId.ofFileName(id).getOrThrow()),
                   hasStableValue())
               .orElseThrow();
@@ -98,11 +100,11 @@ final class SnapshotWithExportersTest {
     private final TestStandaloneBroker zeebe =
         new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
 
-    private final PartitionsActuator partitions = PartitionsActuator.of(zeebe);
-
     @Test
     void shouldIncludeExportedPositionInSnapshot() {
       // given - a receiver who has "acknowledged" everything ever in history
+      // the broker binds OS-assigned ports, so the actuator can only be created once it is started
+      final var partitions = PartitionsActuator.of(zeebe);
       try (final var client = zeebe.newClientBuilder().build()) {
         publishMessages(client);
       }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterPurgeTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ClusterPurgeTest.java
@@ -41,7 +41,6 @@ public class ClusterPurgeTest {
             .start()) {
 
       cluster.awaitCompleteTopology();
-      final var actuator = ClusterActuator.of(cluster.availableGateway());
 
       // Restart broker - increases the raft term of the partition
       cluster
@@ -54,6 +53,8 @@ public class ClusterPurgeTest {
               });
 
       cluster.awaitCompleteTopology();
+      // create the actuator only after the restart, as the broker binds fresh OS-assigned ports
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
 
       // when
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/PersistedClusterTopologyTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/PersistedClusterTopologyTest.java
@@ -104,6 +104,10 @@ public class PersistedClusterTopologyTest {
     cluster.awaitCompleteTopology(
         CLUSTER_SIZE, PARTITION_COUNT, REPLICATION_FACTOR, Duration.ofSeconds(10));
 
+    // the cluster restarted on fresh OS-assigned ports, so the old client is stale
+    client.close();
+    client = cluster.newClientBuilder().build();
+
     client
         .newCreateInstanceCommand()
         .processDefinitionKey(deploymentEvent.getProcesses().getFirst().getProcessDefinitionKey())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -117,6 +117,15 @@ public class ScaleUpPartitionsTest {
     backupActuator = BackupActuator.of(cluster.availableGateway());
   }
 
+  /**
+   * Re-creates the client and actuators after a restart: restarted nodes bind fresh OS-assigned
+   * ports, so anything created before the restart may be stale.
+   */
+  private void recreateClientAndActuators() {
+    camundaClient.close();
+    createClient();
+  }
+
   private Camunda getRestoreConfig(final Camunda brokerCfg, final Path workingDirectory) {
     final var unifiedRestoreConfig = new Camunda();
     unifiedRestoreConfig.getCluster().setNodeId(brokerCfg.getCluster().getNodeId());
@@ -339,6 +348,7 @@ public class ScaleUpPartitionsTest {
           member0);
       cluster.leaderForPartition(1).stop().start();
       cluster.awaitCompleteTopology();
+      recreateClientAndActuators();
     }
     // when - start scaling up
     scaleToPartitions(targetPartitionCount);
@@ -350,6 +360,9 @@ public class ScaleUpPartitionsTest {
     brokerToRestart.stop().start();
     LOG.info("Restarted node {} ", brokerToRestart.nodeId());
     Awaitility.await("restarted broker is ready")
+        // rejoining the cluster after a restart takes a while, as the ports change on restart and
+        // the new addresses need to propagate first
+        .atMost(Duration.ofMinutes(1))
         .until(
             () -> {
               try {
@@ -359,6 +372,7 @@ public class ScaleUpPartitionsTest {
                 return false;
               }
             });
+    recreateClientAndActuators();
 
     // then - scale up should still complete successfully
     awaitScaleUpCompletion(targetPartitionCount);
@@ -573,6 +587,7 @@ public class ScaleUpPartitionsTest {
         desiredPartitionCount,
         cluster.replicationFactor(),
         Duration.ofMinutes(2));
+    recreateClientAndActuators();
   }
 
   private void restoreAllBrokers(final long backupId, final int desiredPartitionCount)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExporterDisableTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExporterDisableTest.java
@@ -111,6 +111,10 @@ final class ExporterDisableTest {
     cluster.shutdown();
     cluster.start().awaitCompleteTopology();
 
+    // the cluster restarted on fresh OS-assigned ports, so the old client is stale
+    client.close();
+    client = cluster.newClientBuilder().build();
+
     generateEventsOnAllPartitions();
 
     // then

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExporterDynamicConfigTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/exporter/ExporterDynamicConfigTest.java
@@ -39,6 +39,10 @@ final class ExporterDynamicConfigTest {
 
     // when -- restart with new exporter
     zeebe.withRecordingExporter(true).start().awaitCompleteTopology();
+
+    // the broker restarted on fresh OS-assigned ports, so the old client is stale
+    client.close();
+    client = zeebe.newClientBuilder().build();
     client.newPublishMessageCommand().messageName("test").correlationKey("test").send().join();
 
     // then

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ControlledActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ControlledActorClockEndpointIT.java
@@ -34,6 +34,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
@@ -47,9 +48,15 @@ final class ControlledActorClockEndpointIT {
           .withRecordingExporter(true)
           .withProperty("zeebe.clock.controlled", true);
 
-  @AutoClose private final CamundaClient camundaClient = broker.newClientBuilder().build();
+  @AutoClose private CamundaClient camundaClient;
 
   @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @BeforeEach
+  void beforeEach() {
+    // the broker binds OS-assigned ports, so the client can only be created once it is started
+    camundaClient = broker.newClientBuilder().build();
+  }
 
   @Test
   void testPinningTime() throws IOException, InterruptedException {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ExportingEndpointIT.java
@@ -32,7 +32,7 @@ final class ExportingEndpointIT {
   @TestZeebe(initMethod = "initTestCluster")
   private static TestCluster cluster;
 
-  @AutoClose private final CamundaClient client = cluster.newClientBuilder().build();
+  @AutoClose private CamundaClient client = cluster.newClientBuilder().build();
 
   @SuppressWarnings("unused")
   static void initTestCluster() {
@@ -156,6 +156,10 @@ final class ExportingEndpointIT {
     getActuator().pause();
     cluster.shutdown();
     cluster.start();
+
+    // the cluster restarted on fresh OS-assigned ports, so the old client is stale
+    client.close();
+    client = cluster.newClientBuilder().build();
 
     client
         .newPublishMessageCommand()
@@ -329,6 +333,10 @@ final class ExportingEndpointIT {
     // when
     cluster.shutdown();
     cluster.start();
+
+    // the cluster restarted on fresh OS-assigned ports, so the old client is stale
+    client.close();
+    client = cluster.newClientBuilder().build();
 
     client
         .newPublishMessageCommand()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/AdvertisedAddressTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/AdvertisedAddressTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.testcontainers.ProxyRegistry;
 import io.camunda.zeebe.qa.util.testcontainers.ProxyRegistry.ContainerProxy;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -131,14 +132,18 @@ final class AdvertisedAddressTest {
   }
 
   private void configureBroker(final TestStandaloneBroker broker) {
-    final var commandApiProxy =
-        PROXY_REGISTRY.getOrCreateHostProxy(broker.mappedPort(TestZeebePort.COMMAND));
-    final var internalApiProxy =
-        PROXY_REGISTRY.getOrCreateHostProxy(broker.mappedPort(TestZeebePort.CLUSTER));
+    // the proxies must know their target ports before the broker binds them, so fixed ports must
+    // be assigned upfront instead of the OS-assigned ephemeral ports used by default
+    final var commandApiPort = SocketUtil.getNextAddress().getPort();
+    final var internalApiPort = SocketUtil.getNextAddress().getPort();
+    final var commandApiProxy = PROXY_REGISTRY.getOrCreateHostProxy(commandApiPort);
+    final var internalApiProxy = PROXY_REGISTRY.getOrCreateHostProxy(internalApiPort);
 
     broker.withUnifiedConfig(
         cfg -> {
           final var network = cfg.getCluster().getNetwork();
+          network.getCommandApi().setPort(commandApiPort);
+          network.getInternalApi().setPort(internalApiPort);
           network.getInternalApi().setAdvertisedHost(TOXIPROXY.getHost());
           network
               .getInternalApi()
@@ -155,12 +160,13 @@ final class AdvertisedAddressTest {
   }
 
   private void configureGateway(final TestGateway<?> gateway) {
-    final var gatewayClusterProxy =
-        PROXY_REGISTRY.getOrCreateHostProxy(gateway.mappedPort(TestZeebePort.CLUSTER));
+    final var gatewayClusterPort = SocketUtil.getNextAddress().getPort();
+    final var gatewayClusterProxy = PROXY_REGISTRY.getOrCreateHostProxy(gatewayClusterPort);
 
     gateway.withUnifiedConfig(
         cfg -> {
           final var internalApi = cfg.getCluster().getNetwork().getInternalApi();
+          internalApi.setPort(gatewayClusterPort);
           internalApi.setAdvertisedHost(TOXIPROXY.getHost());
           internalApi.setAdvertisedPort(
               TOXIPROXY.getMappedPort(gatewayClusterProxy.internalPort()));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/SecureClusteredMessagingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/network/SecureClusteredMessagingIT.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.gateway.impl.configuration.ClusterCfg;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneGateway;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.asserts.SslAssert;
@@ -88,27 +89,29 @@ final class SecureClusteredMessagingIT {
 
   /** Verifies that both the command and internal APIs of the broker are correctly secured. */
   private void assertBrokerMessagingServicesAreSecured(final TestStandaloneBroker broker) {
-    // Use BrokerBasedProperties instead of unified configuration here because the
-    // advertised addresses are not initialized. The unified configuration does not
-    // provide an applyDefaults() method like NetworkCfg does for setting the addresses.
+    // Use BrokerBasedProperties for the advertised hosts, but resolve the ports from the running
+    // application: the configured ports stay 0 (OS-assigned) and are only known at runtime.
     final var brokerBasedProperties = broker.bean(BrokerBasedProperties.class);
     final var commandApiAddress =
-        brokerBasedProperties.getNetwork().getCommandApi().getAdvertisedAddress();
+        new InetSocketAddress(
+            brokerBasedProperties.getNetwork().getCommandApi().getAdvertisedHost(),
+            broker.mappedPort(TestZeebePort.COMMAND));
     final var internalApiAddress =
-        brokerBasedProperties.getNetwork().getInternalApi().getAdvertisedAddress();
+        new InetSocketAddress(
+            brokerBasedProperties.getNetwork().getInternalApi().getAdvertisedHost(),
+            broker.mappedPort(TestZeebePort.CLUSTER));
 
     assertAddressIsSecured(brokerBasedProperties.getCluster().getNodeId(), commandApiAddress);
     assertAddressIsSecured(brokerBasedProperties.getCluster().getNodeId(), internalApiAddress);
   }
 
   private InetSocketAddress getGatewayAddress(final TestCluster cluster) {
-    // Use GatewayBasedProperties instead of the unified configuration to resolve the
-    // advertised address and port via ClusterCfg, because the getters contain logic
-    // that is not available in the unified configuration.
-    final ClusterCfg clusterConfig =
-        cluster.availableGateway().bean(GatewayBasedProperties.class).getCluster();
+    // Use GatewayBasedProperties for the advertised host, but resolve the port from the running
+    // application: the configured port stays 0 (OS-assigned) and is only known at runtime.
+    final var gateway = cluster.availableGateway();
+    final ClusterCfg clusterConfig = gateway.bean(GatewayBasedProperties.class).getCluster();
     final var address =
-        Address.from(clusterConfig.getAdvertisedHost(), clusterConfig.getAdvertisedPort());
+        Address.from(clusterConfig.getAdvertisedHost(), gateway.mappedPort(TestZeebePort.CLUSTER));
     return address.socketAddress();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/system/BrokerAdminServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/system/BrokerAdminServiceTest.java
@@ -226,7 +226,7 @@ public class BrokerAdminServiceTest {
     partitions.pauseProcessing();
 
     // when
-    zeebe.stop().start().awaitCompleteTopology();
+    restartBroker();
 
     // then
     assertThat(partitions.query().get(1).streamProcessorPhase()).isEqualTo(Phase.PAUSED.toString());
@@ -239,7 +239,7 @@ public class BrokerAdminServiceTest {
     partitions.resumeProcessing();
 
     // when
-    zeebe.stop().start().awaitCompleteTopology();
+    restartBroker();
 
     // then
     assertThat(partitions.query().get(1).streamProcessorPhase())
@@ -252,7 +252,7 @@ public class BrokerAdminServiceTest {
     partitions.pauseExporting();
 
     // when
-    zeebe.stop().start().awaitCompleteTopology();
+    restartBroker();
 
     // then
     assertThat(partitions.query().get(1).exporterPhase())
@@ -266,7 +266,7 @@ public class BrokerAdminServiceTest {
     partitions.resumeExporting();
 
     // when
-    zeebe.stop().start().awaitCompleteTopology();
+    restartBroker();
 
     // then
     assertThat(partitions.query().get(1).exporterPhase())
@@ -291,6 +291,13 @@ public class BrokerAdminServiceTest {
     assertThat(clock.instant()).isEqualTo(expectedInstant);
     assertThat(clock.modificationType()).isEqualTo("Pin");
     assertThat(clock.modification()).containsEntry("at", expectedInstant.toString());
+  }
+
+  private void restartBroker() {
+    zeebe.stop().start().awaitCompleteTopology();
+
+    // the broker restarted on fresh OS-assigned ports, so the old actuator is stale
+    partitions = PartitionsActuator.of(zeebe);
   }
 
   private void waitForSnapshotAtBroker() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/GlobalUserTaskListenersTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -49,7 +50,17 @@ public class GlobalUserTaskListenersTest {
 
   @TestZeebe(autoStart = false)
   private static final TestStandaloneBroker ZEEBE =
-      new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withUnauthenticatedAccess()
+          // the client is created before the broker first starts and must survive broker restarts
+          // (via the default retry policy), which requires the broker to come back on the same
+          // endpoints; pre-assign fixed ports instead of the default OS-assigned ones, which
+          // change on every start
+          .withUnifiedConfig(
+              cfg -> cfg.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort()))
+          .withProperty("server.port", SocketUtil.getNextAddress().getPort())
+          .withProperty("management.server.port", SocketUtil.getNextAddress().getPort());
 
   @AutoClose private CamundaClient camundaClient;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/processing/GlobalListenersInitializerIT.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
@@ -49,7 +50,15 @@ final class GlobalListenersInitializerIT {
       new TestStandaloneBroker()
           .withRecordingExporter(true)
           .withUnauthenticatedAccess()
-          .withClusterConfig(cluster -> cluster.setPartitionCount(PARTITIONS_COUNT));
+          .withClusterConfig(cluster -> cluster.setPartitionCount(PARTITIONS_COUNT))
+          // the client is created before the broker first starts and must survive broker restarts
+          // (via the default retry policy), which requires the broker to come back on the same
+          // endpoints; pre-assign fixed ports instead of the default OS-assigned ones, which
+          // change on every start
+          .withUnifiedConfig(
+              cfg -> cfg.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort()))
+          .withProperty("server.port", SocketUtil.getNextAddress().getPort())
+          .withProperty("management.server.port", SocketUtil.getNextAddress().getPort());
 
   @AutoClose private CamundaClient client;
 

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -161,6 +161,16 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-atomix-utils</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway-grpc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-security-library-api</artifactId>
     </dependency>
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -14,13 +14,18 @@ import io.atomix.cluster.MemberId;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.api.response.BrokerInfo;
+import io.camunda.zeebe.qa.util.cluster.util.RuntimePorts;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.util.CloseableSilently;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
@@ -108,6 +113,38 @@ public final class TestCluster implements CloseableSilently {
     this.partitionsCount = partitionsCount;
     this.brokers = Collections.unmodifiableMap(brokers);
     this.gateways = Collections.unmodifiableMap(gateways);
+
+    // with OS-assigned ports, member addresses change on every start, so contact points cannot be
+    // configured statically; every node resolves them on start from the currently running brokers
+    nodes()
+        .values()
+        .forEach(
+            node -> {
+              if (node instanceof final TestSpringApplication<?> app) {
+                app.withInitialContactPointsSupplier(this::currentContactPoints);
+              }
+            });
+  }
+
+  /**
+   * Returns the current cluster addresses of all brokers whose address is known: either because a
+   * fixed port is configured, or because the broker is running (or starting) on an OS-assigned
+   * port. Evaluated on every node start, so that a (re)started node always contacts live members.
+   */
+  private List<String> currentContactPoints() {
+    return brokers.values().stream().map(this::contactPointOf).flatMap(Optional::stream).toList();
+  }
+
+  private Optional<String> contactPointOf(final TestStandaloneBroker broker) {
+    final var configuredPort =
+        broker.unifiedConfig().getCluster().getNetwork().getInternalApi().getPort();
+    if (configuredPort != 0) {
+      return Optional.of(broker.host() + ":" + configuredPort);
+    }
+
+    return RuntimePorts.clusterPort(broker).stream()
+        .mapToObj(port -> broker.host() + ":" + port)
+        .findFirst();
   }
 
   /** Returns a new cluster builder */
@@ -136,9 +173,20 @@ public final class TestCluster implements CloseableSilently {
         partitionsCount,
         replicationFactor);
 
+    // ports are OS-assigned on bind, so no broker address is known before it is started; start a
+    // seed broker first so its resolved address can serve as initial contact point for the rest.
+    // the seed is started asynchronously because its startup only completes once the other
+    // brokers have joined; we only wait until its cluster port is bound
+    final var seedStart = startSeedBroker();
+    final var startingSeed = seedStart.map(SeedStart::seed).orElse(null);
+
     final var started =
-        nodes().values().stream()
-            .map(node -> CompletableFuture.runAsync(node::start))
+        Stream.concat(
+                seedStart.map(SeedStart::pendingStart).stream(),
+                nodes().values().stream()
+                    // the seed is still starting: not started, but must not be started again
+                    .filter(node -> node != startingSeed && !node.isStarted())
+                    .map(node -> CompletableFuture.runAsync(node::start)))
             .toArray(CompletableFuture[]::new);
     try {
       CompletableFuture.allOf(started).get(2, TimeUnit.MINUTES);
@@ -148,7 +196,51 @@ public final class TestCluster implements CloseableSilently {
     } catch (final Exception e) {
       throw new RuntimeException("Failed to start cluster " + name, e);
     }
+
     return this;
+  }
+
+  /**
+   * Starts a seed broker if no node is started yet and the cluster ports are not yet known.
+   *
+   * <p>The seed is started asynchronously: a broker's startup only completes once the cluster
+   * configuration is bootstrapped, which requires the other brokers to be reachable. We only wait
+   * until the seed's cluster port is bound, so that the contact point suppliers of the other nodes,
+   * which are subsequently started by the caller, can resolve the seed's address.
+   *
+   * @return the pending seed startup, or empty if no seed needs to be started
+   */
+  private Optional<SeedStart> startSeedBroker() {
+    if (brokers.isEmpty() || nodes().values().stream().anyMatch(TestApplication::isStarted)) {
+      return Optional.empty();
+    }
+
+    // no need to sequence the startup when all broker addresses are known upfront because the
+    // test configured fixed ports
+    final var allPortsKnown =
+        brokers.values().stream()
+            .allMatch(
+                broker ->
+                    broker.unifiedConfig().getCluster().getNetwork().getInternalApi().getPort()
+                        != 0);
+    if (allPortsKnown) {
+      return Optional.empty();
+    }
+
+    final var seed =
+        brokers.entrySet().stream()
+            .min(Map.Entry.comparingByKey(Comparator.comparing(MemberId::id)))
+            .orElseThrow()
+            .getValue();
+    LOGGER.info("Starting broker {} as the seed node of cluster {}", seed.nodeId(), name);
+    final var seedStart = CompletableFuture.runAsync(seed::start);
+
+    Awaitility.await("until the cluster port of seed broker %s is bound".formatted(seed))
+        .atMost(Duration.ofMinutes(1))
+        .failFast("seed broker failed to start", () -> seedStart.isCompletedExceptionally())
+        .until(() -> RuntimePorts.clusterPort(seed), OptionalInt::isPresent);
+
+    return Optional.of(new SeedStart(seed, seedStart));
   }
 
   /**
@@ -446,4 +538,6 @@ public final class TestCluster implements CloseableSilently {
         .filter(TestGateway.class::isInstance)
         .map(node -> (TestGateway<?>) node);
   }
+
+  private record SeedStart(TestStandaloneBroker seed, CompletableFuture<Void> pendingStart) {}
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -270,8 +270,8 @@ public final class TestClusterBuilder {
    * enabled and the right topology check configured. Additionally, {@link TestCluster#gateways()}
    * will also include them, along with any other additional standalone gateway.
    *
-   * <p>For standalone gateways, if {@link #brokersCount} is at least one, then a random broker is
-   * picked as the contact point for all gateways.
+   * <p>Initial contact points are not configured here: with OS-assigned ports, no broker address is
+   * known before it is started. {@link TestCluster#start()} configures them once known.
    *
    * @return a new Zeebe cluster
    */
@@ -338,13 +338,9 @@ public final class TestClusterBuilder {
       brokers.put(brokerId, broker);
     }
 
-    // since initial contact points has to contain all known brokers, we can only configure it
-    // AFTER the base broker configuration
-    final var contactPoints = getInitialContactPoints();
-    brokers.values().stream()
-        .map(TestStandaloneBroker::unifiedConfig)
-        .map(Camunda::getCluster)
-        .forEach(cfg -> cfg.setInitialContactPoints(contactPoints));
+    // initial contact points cannot be configured here: ports are OS-assigned on bind, so no
+    // broker address is known before it is started. TestCluster#start starts a seed broker
+    // first and configures the contact points of all other nodes from its resolved address.
   }
 
   private TestStandaloneBroker createBroker(final int index) {
@@ -419,14 +415,7 @@ public final class TestClusterBuilder {
               cluster.setNodeId(index);
               cluster.setGatewayId(id);
               cluster.setName(name);
-              cluster.setInitialContactPoints(getInitialContactPoints());
             });
-  }
-
-  private List<String> getInitialContactPoints() {
-    return brokers.values().stream()
-        .map(builder -> builder.address(TestZeebePort.CLUSTER))
-        .toList();
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -19,7 +19,6 @@ import io.camunda.container.ExtendedConfigurationBuilder;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.zeebe.qa.util.cluster.util.ContextOverrideInitializer;
 import io.camunda.zeebe.qa.util.cluster.util.ContextOverrideInitializer.Bean;
-import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -27,10 +26,14 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.Banner.Mode;
@@ -46,6 +49,9 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
 
   protected ConfigurableApplicationContext springContext;
   protected final Camunda unifiedConfig;
+  // the context as soon as it exists, i.e. before the (potentially long) refresh completes; used
+  // to look up already-created singletons while the application is still starting
+  private volatile ConfigurableApplicationContext startingContext;
 
   private final Class<?>[] springApplications;
   private final Map<String, Bean<?>> beans;
@@ -55,6 +61,7 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   private final ReactorResourceFactory reactorResourceFactory = new ReactorResourceFactory();
   private final Set<String> refreshableKeys = new HashSet<>();
   private final Map<String, Camunda> ptConfigs = new LinkedHashMap<>();
+  private Supplier<List<String>> initialContactPointsSupplier;
 
   public TestSpringApplication(final Class<?>... springApplications) {
     this(new Camunda(), springApplications);
@@ -78,12 +85,16 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     additionalInitializers = new ArrayList<>();
     additionalInitializers.add(new ContextOverrideInitializer(beans, propertyOverrides));
     additionalInitializers.add(new HealthConfigurationInitializer());
+    additionalInitializers.add(
+        (ApplicationContextInitializer<ConfigurableApplicationContext>)
+            context -> startingContext = context);
     this.additionalProfiles = new ArrayList<>(additionalProfiles);
     this.additionalProfiles.add(Profile.TEST.getId());
 
-    // randomize ports to allow multiple concurrent instances
-    overridePropertyIfAbsent("server.port", SocketUtil.getNextAddress().getPort());
-    overridePropertyIfAbsent("management.server.port", SocketUtil.getNextAddress().getPort());
+    // use OS-assigned ephemeral ports to allow multiple concurrent instances; the actual ports
+    // are read back from the running application (see #serverPort)
+    overridePropertyIfAbsent("server.port", 0);
+    overridePropertyIfAbsent("management.server.port", 0);
     overridePropertyIfAbsent("spring.lifecycle.timeout-per-shutdown-phase", "1s");
 
     overridePropertyIfAbsent("camunda.rest.response-validation.enabled", "true");
@@ -107,8 +118,8 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
       springContext = createSpringBuilder().run(commandLineArgs());
 
       LOGGER.info("Started TestSpringApplication ...");
-      LOGGER.info("-> Server / Rest Port: {}", restPort());
-      LOGGER.info("-> Monitoring Port: {}", monitoringPort());
+      LOGGER.info("-> Server / Rest Port: {}", describePort("server.port"));
+      LOGGER.info("-> Monitoring Port: {}", describePort("management.server.port"));
       LOGGER.info("-> Additional Profiles: {}", additionalProfiles);
       LOGGER.info("-> Secondary Database Type: {}", databaseType());
     }
@@ -118,12 +129,43 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
 
   @Override
   public T stop() {
-    if (springContext != null) {
-      springContext.close();
-      springContext = null;
+    // fall back to the starting context to also stop an application whose (blocking) startup is
+    // still in progress in another thread, e.g. a cluster seed whose peers never came up
+    final var context = springContext != null ? springContext : startingContext;
+    if (context != null) {
+      context.close();
     }
+    springContext = null;
+    startingContext = null;
 
     return self();
+  }
+
+  /**
+   * Returns an already-created singleton bean of the given type, or null if there is none (yet).
+   *
+   * <p>Unlike {@link #bean(Class)}, this also works while the application is still starting, e.g.
+   * when {@link #start()} is blocked on the broker bootstrap in another thread. It only looks up
+   * singletons which are fully created, without triggering bean creation.
+   */
+  public <V> V startedSingleton(final Class<V> type) {
+    final var context = springContext != null ? springContext : startingContext;
+    if (context == null) {
+      return null;
+    }
+
+    try {
+      final var beanFactory = context.getBeanFactory();
+      for (final var name : beanFactory.getSingletonNames()) {
+        final var singleton = beanFactory.getSingleton(name);
+        if (type.isInstance(singleton)) {
+          return type.cast(singleton);
+        }
+      }
+    } catch (final IllegalStateException e) {
+      // the context is not fully initialized or already closed
+    }
+    return null;
   }
 
   @Override
@@ -339,6 +381,7 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
             flatProperties.putAll(
                 ExtendedConfigurationBuilder.flatPropertiesFor(
                     ptConfig, "camunda.physical-tenants." + tenantId)));
+    resolveInitialContactPoints(flatProperties);
     withRefreshableProperties(flatProperties);
     return MainSupport.createDefaultApplicationBuilder()
         .bannerMode(Mode.OFF)
@@ -359,6 +402,70 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     }
   }
 
+  /**
+   * Sets a supplier for the initial contact points, evaluated on every {@link #start()}. Used by
+   * {@link TestCluster} so that a (re)started node always contacts the cluster members that are
+   * currently reachable: with OS-assigned ports, member addresses change on restart, so contact
+   * points cannot be configured statically.
+   *
+   * <p>Contact points explicitly configured on the unified configuration take precedence.
+   */
+  public T withInitialContactPointsSupplier(final Supplier<List<String>> supplier) {
+    initialContactPointsSupplier = supplier;
+    return self();
+  }
+
+  private void resolveInitialContactPoints(final Map<String, Object> flatProperties) {
+    if (initialContactPointsSupplier == null) {
+      return;
+    }
+
+    final var explicit = unifiedConfig.getCluster().getInitialContactPoints();
+    if (explicit != null && !explicit.isEmpty()) {
+      return;
+    }
+
+    final var contactPoints = initialContactPointsSupplier.get();
+    if (!contactPoints.isEmpty()) {
+      flatProperties.put("camunda.cluster.initial-contact-points", String.join(",", contactPoints));
+    }
+  }
+
+  /**
+   * Resolves a port which may be configured as ephemeral (0), in which case the OS assigns a free
+   * port on bind and the actual port must be read back from the running application. Each start
+   * binds fresh ports; nothing is cached across restarts.
+   *
+   * @param configuredPort the currently configured port; returned as is unless it is 0
+   * @param portName a human-readable name of the port, for error messages
+   * @param resolver resolves the actual port from the running application, empty while unbound
+   * @return the actual port
+   */
+  protected int resolveEphemeralPort(
+      final int configuredPort, final String portName, final Supplier<OptionalInt> resolver) {
+    if (configuredPort != 0) {
+      return configuredPort;
+    }
+
+    if (!isStarted()) {
+      throw new IllegalStateException(
+          ("The %s port of %s is OS-assigned and only known while the application is running; "
+                  + "start the application first, or configure a fixed port")
+              .formatted(portName, this));
+    }
+
+    // fast path: ports are usually bound by the time they are looked up
+    final var port = resolver.get();
+    if (port.isPresent()) {
+      return port.getAsInt();
+    }
+
+    return Awaitility.await("until the %s port of %s is bound".formatted(portName, this))
+        .atMost(Duration.ofMinutes(1))
+        .until(resolver::get, OptionalInt::isPresent)
+        .getAsInt();
+  }
+
   private String databaseType() {
     return property(UNIFIED_CONFIG_PROPERTY_CAMUNDA_DATABASE_TYPE, String.class, "elasticsearch");
   }
@@ -374,6 +481,13 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   private int serverPort(final String property) {
     final Object portProperty;
     if (springContext != null) {
+      // prefer the port the server is actually bound to, which differs from the configured port
+      // when the configured port is 0 (OS-assigned)
+      final var localPort =
+          springContext.getEnvironment().getProperty(localPortProperty(property), Integer.class);
+      if (localPort != null) {
+        return localPort;
+      }
       portProperty = springContext.getEnvironment().getProperty(property);
     } else {
       portProperty = propertyOverrides.get(property);
@@ -384,10 +498,33 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
           "No property '%s' defined anywhere, cannot infer monitoring port".formatted(property));
     }
 
-    if (portProperty instanceof final Integer port) {
-      return port;
+    final int port =
+        portProperty instanceof final Integer intPort
+            ? intPort
+            : Integer.parseInt(portProperty.toString());
+    if (port == 0) {
+      throw new IllegalStateException(
+          ("The '%s' port of %s is OS-assigned and only known while the application is running; "
+                  + "start the application first, or configure a fixed port")
+              .formatted(property, this));
     }
+    return port;
+  }
 
-    return Integer.parseInt(portProperty.toString());
+  /** Describes a server port for logging; applications without a web server have none. */
+  private String describePort(final String property) {
+    try {
+      return String.valueOf(serverPort(property));
+    } catch (final IllegalStateException e) {
+      return "none";
+    }
+  }
+
+  private static String localPortProperty(final String property) {
+    return switch (property) {
+      case "server.port" -> "local.server.port";
+      case "management.server.port" -> "local.management.port";
+      default -> property;
+    };
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -30,8 +30,8 @@ import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration.MemoryAllocationStr
 import io.camunda.zeebe.qa.util.actuator.BrokerHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
 import io.camunda.zeebe.qa.util.actuator.HealthActuator;
+import io.camunda.zeebe.qa.util.cluster.util.RuntimePorts;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -112,10 +112,21 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
 
   @Override
   public int mappedPort(final TestZeebePort port) {
+    final var network = unifiedConfig.getCluster().getNetwork();
     return switch (port) {
-      case COMMAND -> unifiedConfig.getCluster().getNetwork().getCommandApi().getPort();
-      case GATEWAY -> unifiedConfig.getApi().getGrpc().getPort();
-      case CLUSTER -> unifiedConfig.getCluster().getNetwork().getInternalApi().getPort();
+      case COMMAND ->
+          resolveEphemeralPort(
+              network.getCommandApi().getPort(),
+              "command API",
+              () -> RuntimePorts.commandApiPort(this));
+      case GATEWAY ->
+          resolveEphemeralPort(
+              unifiedConfig.getApi().getGrpc().getPort(),
+              "gRPC",
+              () -> RuntimePorts.embeddedGatewayPort(this));
+      case CLUSTER ->
+          resolveEphemeralPort(
+              network.getInternalApi().getPort(), "cluster", () -> RuntimePorts.clusterPort(this));
       default -> super.mappedPort(port);
     };
   }
@@ -456,18 +467,11 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     unifiedConfig.getProcessing().setEnablePreconditionsCheck(true);
     unifiedConfig.getProcessing().setEnableForeignKeyChecks(true);
 
-    // Set dynamic ports via properties (these aren't in unified config yet)
-    unifiedConfig
-        .getCluster()
-        .getNetwork()
-        .getCommandApi()
-        .setPort(SocketUtil.getNextAddress().getPort());
-    unifiedConfig
-        .getCluster()
-        .getNetwork()
-        .getInternalApi()
-        .setPort(SocketUtil.getNextAddress().getPort());
-    unifiedConfig.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort());
+    // use OS-assigned ephemeral ports to allow multiple concurrent instances; the actual ports
+    // are resolved from the running application (see #mappedPort)
+    unifiedConfig.getCluster().getNetwork().getCommandApi().setPort(0);
+    unifiedConfig.getCluster().getNetwork().getInternalApi().setPort(0);
+    unifiedConfig.getApi().getGrpc().setPort(0);
 
     withSecondaryStorageType(SecondaryStorageType.none);
   }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -11,7 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
-import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.qa.util.cluster.util.RuntimePorts;
 import java.util.function.Consumer;
 
 /** Encapsulates an instance of the {@link GatewayModuleConfiguration} Spring application. */
@@ -24,12 +24,10 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
     withAdditionalProfile(Profile.CONSOLIDATED_AUTH);
 
     unifiedConfig.getApi().getGrpc().setAddress("0.0.0.0");
-    unifiedConfig.getApi().getGrpc().setPort(SocketUtil.getNextAddress().getPort());
-    unifiedConfig
-        .getCluster()
-        .getNetwork()
-        .getInternalApi()
-        .setPort(SocketUtil.getNextAddress().getPort());
+    // use OS-assigned ephemeral ports to allow multiple concurrent instances; the actual ports
+    // are resolved from the running application (see #mappedPort)
+    unifiedConfig.getApi().getGrpc().setPort(0);
+    unifiedConfig.getCluster().getNetwork().getInternalApi().setPort(0);
     withAdditionalProfile(Profile.GATEWAY);
 
     unifiedConfig.getSecurity().getAuthentication().setUnprotectedApi(true);
@@ -63,9 +61,16 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
 
   @Override
   public int mappedPort(final TestZeebePort port) {
+    final var network = unifiedConfig.getCluster().getNetwork();
     return switch (port) {
-      case GATEWAY -> unifiedConfig.getApi().getGrpc().getPort();
-      case CLUSTER -> unifiedConfig.getCluster().getNetwork().getInternalApi().getPort();
+      case GATEWAY ->
+          resolveEphemeralPort(
+              unifiedConfig.getApi().getGrpc().getPort(),
+              "gRPC",
+              () -> RuntimePorts.standaloneGatewayPort(this));
+      case CLUSTER ->
+          resolveEphemeralPort(
+              network.getInternalApi().getPort(), "cluster", () -> RuntimePorts.clusterPort(this));
       default -> super.mappedPort(port);
     };
   }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/util/RuntimePorts.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/util/RuntimePorts.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.cluster.util;
+
+import io.atomix.cluster.AtomixCluster;
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.broker.bootstrap.BrokerContext;
+import io.camunda.zeebe.gateway.Gateway;
+import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
+import java.util.OptionalInt;
+import java.util.function.Supplier;
+
+/**
+ * Resolves the ports an application is actually bound to at runtime. Test applications are
+ * configured with ephemeral ports (0) so that the OS assigns free ports on bind; the actual ports
+ * are only known once the server sockets are bound, which happens asynchronously during startup.
+ *
+ * <p>All resolvers are non-blocking and return an empty result while the port is not bound yet (or
+ * the application failed before binding it); callers are expected to poll. They also work while the
+ * application is still starting, e.g. to resolve a cluster seed's port while its startup blocks on
+ * cluster formation.
+ */
+public final class RuntimePorts {
+
+  private RuntimePorts() {}
+
+  /** Resolves the cluster (internal API) port from the running Atomix cluster. */
+  public static OptionalInt clusterPort(final TestSpringApplication<?> app) {
+    return resolve(
+        () -> {
+          final var atomix = app.startedSingleton(AtomixCluster.class);
+          if (atomix == null || !atomix.isRunning()) {
+            return OptionalInt.empty();
+          }
+          return nonEphemeral(atomix.getMessagingService().address().port());
+        });
+  }
+
+  /** Resolves the command API port from the running broker's API messaging service. */
+  public static OptionalInt commandApiPort(final TestSpringApplication<?> app) {
+    return resolve(
+        () -> {
+          final var brokerContext = brokerContext(app);
+          if (brokerContext == null || brokerContext.getApiMessagingService() == null) {
+            return OptionalInt.empty();
+          }
+          return nonEphemeral(brokerContext.getApiMessagingService().address().port());
+        });
+  }
+
+  /** Resolves the gRPC port of a broker's embedded gateway. */
+  public static OptionalInt embeddedGatewayPort(final TestSpringApplication<?> app) {
+    return resolve(
+        () -> {
+          final var brokerContext = brokerContext(app);
+          if (brokerContext == null || brokerContext.getEmbeddedGatewayService() == null) {
+            return OptionalInt.empty();
+          }
+          return nonEphemeral(brokerContext.getEmbeddedGatewayService().get().getServerPort());
+        });
+  }
+
+  /** Resolves the gRPC port of a standalone gateway. */
+  public static OptionalInt standaloneGatewayPort(final TestSpringApplication<?> app) {
+    return resolve(
+        () -> {
+          final var gateway = app.startedSingleton(Gateway.class);
+          if (gateway == null) {
+            return OptionalInt.empty();
+          }
+          return nonEphemeral(gateway.getServerPort());
+        });
+  }
+
+  private static BrokerContext brokerContext(final TestSpringApplication<?> app) {
+    final var broker = app.startedSingleton(Broker.class);
+    return broker == null ? null : broker.getBrokerContext();
+  }
+
+  private static OptionalInt nonEphemeral(final int port) {
+    return port == 0 ? OptionalInt.empty() : OptionalInt.of(port);
+  }
+
+  private static OptionalInt resolve(final Supplier<OptionalInt> resolver) {
+    try {
+      return resolver.get();
+    } catch (final Exception e) {
+      // beans may be missing or not fully started yet; treat as not resolvable
+      return OptionalInt.empty();
+    }
+  }
+}

--- a/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilderTest.java
+++ b/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilderTest.java
@@ -167,7 +167,7 @@ final class TestClusterBuilderTest {
   }
 
   @Test
-  void shouldAssignAllBrokersAsInitialContactPoints() {
+  void shouldNotAssignInitialContactPointsAtBuildTime() {
     // given
     final var builder = new TestClusterBuilder();
 
@@ -175,21 +175,21 @@ final class TestClusterBuilderTest {
     builder.withEmbeddedGateway(false).withBrokersCount(2);
     final var cluster = builder.build();
 
-    // then
-    final var expectedValue =
-        cluster.brokers().values().stream().map(b -> b.address(TestZeebePort.CLUSTER)).toList();
+    // then -- with OS-assigned ports, broker addresses are only known at runtime, so the builder
+    // configures no contact points; they are resolved on every node start by the cluster instead
+    // (see TestCluster#currentContactPoints)
     assertThat(cluster.brokers())
         .allSatisfy(
             haveProperty(
                 "initial contact points",
                 b -> b.unifiedConfig().getCluster().getInitialContactPoints(),
-                expectedValue));
+                Collections.emptyList()));
     assertThat(cluster.gateways())
         .allSatisfy(
             haveProperty(
                 "initial contact points",
                 g -> g.unifiedConfig().getCluster().getInitialContactPoints(),
-                expectedValue));
+                Collections.emptyList()));
   }
 
   @Test


### PR DESCRIPTION
Tests previously pre-assigned ports via `SocketUtil`, which partitions a fixed port range per test fork and probes availability upfront — inherently racy. This was needed because `initialContactPoints` had to be fully configured before starting any node. This PR makes truly OS-assigned ports (port 0) work end to end instead.

On the product side, `AtomixCluster` resolves an ephemeral node port to a concrete port before any service is built, by claiming a port that is free on both TCP and UDP and handing it to the messaging (TCP) and unicast (UDP) services, which share the node's single advertised address. Where `SO_REUSEPORT` is supported, the claim sockets stay bound until both services have bound the port, so it is never released in between; since the port cannot be known to anyone before the membership service advertises it, no traffic can arrive while the claim sockets share it. `NettyMessagingService` and `NettyUnicastService` additionally read the actual port back from the bound channel when binding port 0 directly, which the broker uses for the TCP-only command API and feeds into the gossiped `BrokerInfo`, and `Gateway#getServerPort` exposes the actual gRPC port. Empty initial contact points with a cluster size greater than 1 are now only warned about instead of rejected, since a seed node that is contacted by the other members is a valid configuration.

On the test side, all test applications default to port 0 and `mappedPort` resolves the actual ports from the running application. Ports are deliberately not stable across restarts: every start binds fresh ports, so a stopped node's port returns to the OS and is never assumed to still be free later. Since member addresses can therefore not be configured statically, every `TestCluster` node resolves its initial contact points at start time from the brokers that are currently running or starting, which handles any restart order; on the first start a seed broker is started asynchronously and the remaining nodes join the cluster through it. `AdvertisedAddressTest` keeps pre-assigned fixed ports since its Toxiproxy proxies must know the target ports before the brokers bind them; other direct `SocketUtil` users (e.g. the legacy `ClusteringRule` and transport unit tests) are unchanged and can migrate separately.