### PR TITLE
deps: update httpcore5 to v5.4.3 (stable/optimize-8.7)

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -49,7 +49,7 @@
     <jackson.version>2.18.1</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <apache.http5-client.version>5.5</apache.http5-client.version>
-    <apache.http5-core.version>5.3.6</apache.http5-core.version>
+    <apache.http5-core.version>5.4.3</apache.http5-core.version>
     <guava.version>33.3.1-jre</guava.version>
     <spring.boot.version>3.5.15</spring.boot.version>
     <!-- Override Spring Boot's opentelemetry version to address CVE-2026-45292 -->
@@ -127,6 +127,22 @@
         <version>${opentelemetry.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <!-- Override Spring Boot's httpcomponents-client5/core5 versions to address CVE-2026-54399 -->
+      <dependency>
+        <groupId>org.apache.httpcomponents.client5</groupId>
+        <artifactId>httpclient5</artifactId>
+        <version>${apache.http5-client.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5</artifactId>
+        <version>${apache.http5-core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents.core5</groupId>
+        <artifactId>httpcore5-h2</artifactId>
+        <version>${apache.http5-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -62,7 +62,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.5</version.httpclient5>
-    <version.httpcore5>5.3.4</version.httpcore5>
+    <version.httpcore5>5.4.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.5.5</version.identity>
     <version.surefire>3.5.0</version.surefire>


### PR DESCRIPTION
## Description

fixes CVE-2026-54399

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
