### PR TITLE
test: add test to verify adding a zone to a zoned cluster

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/AddZoneToClusterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/AddZoneToClusterIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering.zoneaware;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.Zone;
+import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
+import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
+import io.camunda.zeebe.management.cluster.ZoneSpec;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import java.util.List;
+import java.util.stream.Stream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies that a new zone can be added to a running zone-aware cluster via {@code PUT
+ * /actuator/cluster/partition-distribution}.
+ *
+ * <p>Adding a zone requires the new zone's broker(s) to already be members of the persisted cluster
+ * topology before the distribution is updated, otherwise {@code ZoneAwarePartitionDistributor}
+ * rejects the request because the zone has no brokers. Each test therefore:
+ *
+ * <ul>
+ *   <li>starts a zone-aware
+ *   <li>cluster over the initial zone(s)
+ *   <li>starts a standalone broker in the new zone that joins the cluster
+ *   <li>adds it to the topology via the cluster actuator
+ *   <li>updates the partition distribution to include the new zone
+ * </ul>
+ */
+@ZeebeIntegration
+@Timeout(2 * 60)
+final class AddZoneToClusterIT extends ZoneHelpers {
+
+  private static final int PARTITIONS_COUNT = 2;
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("addZoneScenarios")
+  void shouldAddZoneToCluster(final AddZoneScenario scenario) {
+    // given - a zone-aware cluster over the initial zones
+    try (final var cluster =
+        createCluster(scenario.clusterName(), scenario.initialZones(), PARTITIONS_COUNT, 2)) {
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      // when - start a broker in the new zone, add it to the topology, then add the zone to the
+      // partition distribution
+      addBrokerInZone(
+          cluster,
+          actuator,
+          scenario.clusterName(),
+          scenario.newZone(),
+          0,
+          3,
+          scenario.targetZones());
+
+      final var config =
+          new PartitionDistributionConfig()
+              .type(TypeEnum.ZONE_AWARE)
+              .zones(
+                  scenario.targetZones().stream()
+                      .map(
+                          z ->
+                              new ZoneSpec()
+                                  .name(z.name())
+                                  .numberOfReplicas(z.numberOfReplicas())
+                                  .priority(z.priority()))
+                      .toList());
+      final var response = actuator.patchPartitionDistribution(config, false);
+
+      // then - the new distribution is applied and the new zone hosts partitions
+      Awaitility.await()
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(response));
+      assertThat(actuator.getTopology().getPartitionDistribution()).isEqualTo(config);
+      assertZoneHostsPartitions(actuator, scenario.newZone(), 0);
+    }
+  }
+
+  private static Stream<Arguments> addZoneScenarios() {
+    return Stream.of(
+        Arguments.of(
+            new AddZoneScenario(
+                "add-zone-single",
+                List.of(new Zone("zoneA", 2, 2, 100)),
+                List.of(new Zone("zoneA", 2, 2, 100), new Zone("zoneB", 1, 1, 10)),
+                "zoneB")),
+        Arguments.of(
+            new AddZoneScenario(
+                "add-zone-two",
+                List.of(new Zone("zoneA", 1, 1, 100), new Zone("zoneB", 1, 1, 10)),
+                List.of(
+                    new Zone("zoneA", 1, 1, 100),
+                    new Zone("zoneB", 1, 1, 10),
+                    new Zone("zoneC", 1, 1, 5)),
+                "zoneC")));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneAwarePartitionDistributionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneAwarePartitionDistributionIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.it.cluster.clustering;
+package io.camunda.zeebe.it.cluster.clustering.zoneaware;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/zoneaware/ZoneHelpers.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.cluster.clustering.zoneaware;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.configuration.Partitioning.Scheme;
+import io.camunda.configuration.Zone;
+import io.camunda.configuration.ZoneAware;
+import io.camunda.zeebe.management.cluster.BrokerId;
+import io.camunda.zeebe.management.cluster.PartitionState;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.DynamicAutoCloseable;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+
+public class ZoneHelpers {
+
+  @AutoClose protected final DynamicAutoCloseable closeables = new DynamicAutoCloseable();
+
+  @SuppressWarnings("resource")
+  protected TestCluster createCluster(
+      final String name,
+      final List<Zone> zones,
+      final int partitionCount,
+      final int replicationFactor) {
+    return TestCluster.builder()
+        .withName(name)
+        .withEmbeddedGateway(true)
+        .withBrokersCount(zones.stream().mapToInt(Zone::numberOfBrokers).sum())
+        .withPartitionsCount(partitionCount)
+        .withReplicationFactor(replicationFactor)
+        .multiZone(zones)
+        .build()
+        .start();
+  }
+
+  /**
+   * Starts a standalone broker in {@code zone} (static node id, joining the running cluster), adds
+   * it to the persisted topology, and waits for the change to be applied. The broker's blocking
+   * {@link TestStandaloneBroker#start()} runs on a virtual thread because it only returns once the
+   * broker has joined the topology (i.e. after {@code addBroker}).
+   */
+  protected void addBrokerInZone(
+      final TestCluster cluster,
+      final ClusterActuator actuator,
+      final String clusterName,
+      final String zone,
+      final int nodeId,
+      final int newTotalSize,
+      final List<Zone> targetZones) {
+    final var contactPoint =
+        cluster.brokers().values().iterator().next().address(TestZeebePort.CLUSTER);
+    final var broker =
+        new TestStandaloneBroker()
+            .withUnauthenticatedAccess()
+            .withUnifiedConfig(
+                cfg -> {
+                  final var clusterCfg = cfg.getCluster();
+                  clusterCfg.setName(clusterName);
+                  clusterCfg.setInitialContactPoints(List.of(contactPoint));
+                  clusterCfg.setZone(zone);
+                  clusterCfg.setNodeId(nodeId);
+                  clusterCfg.setSize(newTotalSize);
+                  clusterCfg.getPartitioning().setScheme(Scheme.ZONE_AWARE);
+                  clusterCfg.getPartitioning().setZoneAware(new ZoneAware(targetZones));
+                  cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
+                });
+
+    final var startThread =
+        Thread.ofVirtual().name("start-" + zone + "-" + nodeId).start(broker::start);
+    // Close the broker first to unblock the (potentially still blocked) start() call, then join the
+    // virtual thread so it does not leak beyond the test.
+    closeables.manage(
+        () -> {
+          broker.close();
+          startThread.interrupt();
+          startThread.join(Duration.ofSeconds(30));
+        });
+
+    final var added = actuator.addBroker(MemberId.from(zone, nodeId).toString());
+    Awaitility.await()
+        .untilAsserted(() -> ClusterActuatorAssert.assertThat(actuator).hasAppliedChanges(added));
+  }
+
+  protected static void assertZoneHostsPartitions(
+      final ClusterActuator actuator, final String zone, final int nodeId) {
+    final var brokerId = new BrokerId.String(MemberId.from(zone, nodeId).toString());
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final var broker =
+                  actuator.getTopology().getBrokers().stream()
+                      .filter(b -> brokerId.equals(b.getId()))
+                      .findFirst()
+                      .orElseThrow();
+              assertThat(broker.getPartitions())
+                  .as("the added zone's broker hosts all partitions")
+                  .extracting(PartitionState::getId)
+                  .containsExactlyInAnyOrder(1, 2);
+            });
+  }
+
+  /**
+   * start a cluster over {@code initialZones}, add a broker in {@code newZone}, then update the
+   * partition distribution to {@code targetZones}.
+   */
+  protected record AddZoneScenario(
+      String clusterName, List<Zone> initialZones, List<Zone> targetZones, String newZone) {
+    @Override
+    public String toString() {
+      return clusterName;
+    }
+  }
+}


### PR DESCRIPTION
## Description
Adds a new test `AddZoneToClusterIT` to verify that you can add a new zone to an already zoned cluster by firstadding the brokers and doing a  `PUT /cluster/partition-distribution/`. 

Test covers going from 1->2 and 2->3.
