### PR TITLE
refactor: remove entries from UNPROTECTED_PATHS

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
@@ -48,9 +48,6 @@ public class SecurityPathAdapter implements SecurityPathPort {
           "/swagger/**",
           "/swagger-ui/**",
           "/v3/api-docs/**",
-          "/v2/rest-api.yaml",
-          "/new/**",
-          "/tasklist/new/**",
           "/favicon.ico");
 
   private static final Set<String> WEBAPP_PATHS =

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -23,7 +23,7 @@ public class TestApiController {
   public static final String DUMMY_V2_API_ENDPOINT = "/v2/foo";
   public static final String DUMMY_V2_API_AUTH_ENDPOINT = "/v2/auth";
   public static final String DUMMY_WEBAPP_ENDPOINT = "/operate/decisions";
-  public static final String DUMMY_UNPROTECTED_ENDPOINT = "/new/foo";
+  public static final String DUMMY_UNPROTECTED_ENDPOINT = "/favicon.ico";
   public static final String DUMMY_UNHANDLED_ENDPOINT = "/non-existent-endpoint";
 
   private final CamundaAuthenticationProvider testAuthenticationProvider;

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
@@ -48,9 +48,6 @@ class SecurityPathAdapterTest {
             "/swagger/**",
             "/swagger-ui/**",
             "/v3/api-docs/**",
-            "/v2/rest-api.yaml",
-            "/new/**",
-            "/tasklist/new/**",
             "/favicon.ico");
   }
 


### PR DESCRIPTION
Remove `/v2/rest-api.yaml`, `/new/**` and `/tasklist/new/**` from `SecurityPathAdapter.UNPROTECTED_PATHS` and update the matching test.

`/v2/rest-api.yaml` has no URL handler (returns 404 on the main port; the OpenAPI spec is served via /v3/api-docs). `/new/**` and `/tasklist/new/**` are dropped from the global unprotected chain.

Refs #56119

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
