### PR TITLE
Generate lease token on job activation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -31,6 +31,7 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
 import org.agrona.collections.MutableInteger;
@@ -115,6 +116,9 @@ final class JobBatchCollector {
           // fill in the job record properties first in order to accurately estimate its size before
           // adding it to the batch
           jobRecord.setDeadline(deadline).setWorker(value.getWorkerBuffer());
+          if (value.isWithLease()) {
+            jobRecord.setLeaseToken(generateLeaseToken());
+          }
           jobVariablesCollector.setJobVariables(requestedVariables, jobRecord);
 
           // the expected length is based on the current record's length plus the length of the job
@@ -167,6 +171,15 @@ final class JobBatchCollector {
       final JobRecord jobRecord) {
     jobKeyIterator.add().setValue(key);
     jobIterator.add().copyFrom(jobRecord);
+  }
+
+  /**
+   * Generates a lease token for a single activated job. The token is an opaque string that callers
+   * must not parse; it is random with enough entropy that collisions between leased jobs are
+   * negligible.
+   */
+  private static String generateLeaseToken() {
+    return UUID.randomUUID().toString();
   }
 
   private Collection<DirectBuffer> collectVariableNames(final JobBatchRecord batchRecord) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.List;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ActivateJobsWithLeaseTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private String jobType;
+
+  @Before
+  public void setup() {
+    jobType = Strings.newRandomValidBpmnId();
+  }
+
+  @Test
+  public void shouldActivateJobsWithDistinctLeaseTokens() {
+    // given two activatable jobs of the same type
+    ENGINE.createJob(jobType, PROCESS_ID);
+    ENGINE.createJob(jobType, PROCESS_ID);
+
+    // when
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withLease().withMaxJobsToActivate(2).activate();
+
+    // then
+    final List<JobRecordValue> jobs = batch.getValue().getJobs();
+    assertThat(jobs).hasSize(2);
+    assertThat(jobs)
+        .extracting(JobRecordValue::getLeaseToken)
+        .describedAs("each activated job carries a distinct, non-empty lease token")
+        .allSatisfy(token -> assertThat(token).isNotEmpty())
+        .doesNotHaveDuplicates();
+  }
+
+  @Test
+  public void shouldNotSetLeaseTokenWhenActivatingWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+
+    // when activating without a lease (the default)
+    final Record<JobBatchRecordValue> batch = ENGINE.jobs().withType(jobType).activate();
+
+    // then
+    assertThat(batch.getValue().getJobs())
+        .extracting(JobRecordValue::getLeaseToken)
+        .describedAs("activating without a lease leaves the token empty")
+        .containsOnly("");
+  }
+
+  @Test
+  public void shouldGenerateNewLeaseTokenOnReactivation() {
+    // given a job that was leased, then failed back to activatable
+    final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    final String firstToken =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withLease()
+            .activate()
+            .getValue()
+            .getJobs()
+            .get(0)
+            .getLeaseToken();
+    ENGINE.job().withKey(jobKey).withRetries(1).fail();
+    jobRecords(JobIntent.FAILED).withRecordKey(jobKey).getFirst();
+
+    // when it is leased again
+    final String secondToken =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withLease()
+            .activate()
+            .getValue()
+            .getJobs()
+            .get(0)
+            .getLeaseToken();
+
+    // then
+    assertThat(firstToken).describedAs("the first activation generated a lease token").isNotEmpty();
+    assertThat(secondToken)
+        .describedAs("re-activation generates a new, distinct lease token")
+        .isNotEmpty()
+        .isNotEqualTo(firstToken);
+  }
+
+  @Test
+  public void shouldRetainLeaseTokenAfterFailure() {
+    // given a leased job
+    final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    final String leaseToken =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withLease()
+            .activate()
+            .getValue()
+            .getJobs()
+            .get(0)
+            .getLeaseToken();
+
+    // when it fails back to activatable
+    ENGINE.job().withKey(jobKey).withRetries(1).fail();
+
+    // then
+    final Record<JobRecordValue> failed =
+        jobRecords(JobIntent.FAILED).withRecordKey(jobKey).getFirst();
+    assertThat(leaseToken).describedAs("the job was leased on activation").isNotEmpty();
+    assertThat(failed.getValue().getLeaseToken())
+        .describedAs("the failed job retains its lease token")
+        .isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldRetainLeaseTokenAfterTimeout() {
+    // given a leased job
+    final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    final Duration timeout = Duration.ofSeconds(10);
+    final String leaseToken =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withLease()
+            .withTimeout(timeout.toMillis())
+            .activate()
+            .getValue()
+            .getJobs()
+            .get(0)
+            .getLeaseToken();
+
+    // when the lease times out
+    ENGINE.increaseTime(timeout.plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+
+    // then
+    final Record<JobRecordValue> timedOut =
+        jobRecords(JobIntent.TIMED_OUT).withRecordKey(jobKey).getFirst();
+    assertThat(leaseToken).describedAs("the job was leased on activation").isNotEmpty();
+    assertThat(timedOut.getValue().getLeaseToken())
+        .describedAs("the timed-out job retains its lease token")
+        .isEqualTo(leaseToken);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
@@ -168,4 +168,34 @@ public final class ActivateJobsWithLeaseTest {
         .describedAs("the timed-out job retains its lease token")
         .isEqualTo(leaseToken);
   }
+
+  @Test
+  public void shouldRetainLeaseTokenAfterReplay() {
+    // given a leased job with a timeout
+    final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    final Duration timeout = Duration.ofSeconds(10);
+    final String leaseToken =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withLease()
+            .withTimeout(timeout.toMillis())
+            .activate()
+            .getValue()
+            .getJobs()
+            .get(0)
+            .getLeaseToken();
+
+    // when the engine restarts and replays the log
+    ENGINE.replay();
+
+    // then the lease token survives, observable on a fresh event generated from the replayed state
+    ENGINE.increaseTime(timeout.plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
+    final Record<JobRecordValue> timedOut =
+        jobRecords(JobIntent.TIMED_OUT).withRecordKey(jobKey).getFirst();
+    assertThat(leaseToken).describedAs("the job was leased on activation").isNotEmpty();
+    assertThat(timedOut.getValue().getLeaseToken())
+        .describedAs("the lease token survives an engine restart and log replay")
+        .isEqualTo(leaseToken);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
@@ -91,7 +91,7 @@ public final class ActivateJobsWithLeaseTest {
             .get(0)
             .getLeaseToken();
     ENGINE.job().withKey(jobKey).withRetries(1).fail();
-    jobRecords(JobIntent.FAILED).withRecordKey(jobKey).getFirst();
+    jobRecords(JobIntent.FAILED).withRecordKey(jobKey).await();
 
     // when it is leased again
     final String secondToken =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateServiceTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateServiceTaskTest.java
@@ -203,6 +203,69 @@ public class MigrateServiceTaskTest {
   }
 
   @Test
+  public void shouldRetainLeaseTokenWhenMigratingJob() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // lease the job so it carries a lease token
+    final var leaseToken =
+        ENGINE
+            .jobs()
+            .withType("A")
+            .withLease()
+            .activate()
+            .getValue()
+            .getJobs()
+            .get(0)
+            .getLeaseToken();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    Assertions.assertThat(leaseToken).describedAs("job was leased on activation").isNotEmpty();
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the migrated job retains its lease token")
+        .hasLeaseToken(leaseToken);
+  }
+
+  @Test
   public void shouldContinueFlowInTargetProcessForMigratedJob() {
     // given
     final String processId = helper.getBpmnProcessId();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateServiceTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateServiceTaskTest.java
@@ -229,21 +229,16 @@ public class MigrateServiceTaskTest {
 
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
 
-    RecordingExporter.jobRecords(JobIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .await();
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
 
     // lease the job so it carries a lease token
-    final var leaseToken =
-        ENGINE
-            .jobs()
-            .withType("A")
-            .withLease()
-            .activate()
-            .getValue()
-            .getJobs()
-            .get(0)
-            .getLeaseToken();
+    final var activationRecord = ENGINE.jobs().withType("A").withLease().activate().getValue();
+    final int jobIndex = activationRecord.getJobKeys().indexOf(jobKey);
+    final var leaseToken = activationRecord.getJobs().get(jobIndex).getLeaseToken();
 
     // when
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
@@ -104,6 +104,11 @@ public final class JobActivationClient {
     return this;
   }
 
+  public JobActivationClient withLease() {
+    jobBatchRecord.setWithLease(true);
+    return this;
+  }
+
   public JobActivationClient expectRejection() {
     expectation = REJECTION_EXPECTATION_SUPPLIER;
     return this;


### PR DESCRIPTION
## Description

Part of the `withLease` activation work. This PR is the **write side**: when a job batch is activated with `withLease=true`, the processor generates a distinct, opaque lease token (random UUID) per activated job and writes it into the `JobBatchIntent.ACTIVATED` event. The applier persists it verbatim, so replay stays deterministic — the processor generates, the applier never does.

Once set, the token rides with the job: it survives fail, timeout, and migration for free, because it lives in job state and is carried by the `JobRecord` copy-constructor. `withLease=false` (the default) leaves the token empty, so existing activation behavior is unchanged.

Generation lives in `JobBatchCollector`, set before the record-length estimate so batch sizing accounts for the token.

Builds on the merged schema PR (#56824); this diff is only the generation + tests.

## Out of scope (stacked)

- Activate-side filter + skip metric (a `withLease=false` request skipping already-leased jobs) — the next PR in the stack.
- Response `leaseToken` mapping (#54844) and gRPC/REST exposure (#54846).

## Checklist

- [ ] Enable backports when necessary — not a bug fix, no backport needed.

## Related issues

Part of #54845
