### PR TITLE
ci: verify load-test-setup Helm chart lockfile is up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,6 +262,40 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  load-test-helm-lockfile:
+    if: needs.detect-changes.outputs.load-test-setup-changes == 'true'
+    name: "Load Test / Helm Chart Lock"
+    needs: [ detect-changes ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: camunda/infra-global-github-actions/start-build-monitor@7a9c6f3e477321400802c88290068f88a7ed5684 # main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        timeout-minutes: 1
+        with:
+          persist-credentials: false
+      - name: Set up Helm
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
+      - name: Update Helm dependencies
+        run: helm dependency update load-tests/setup/charts/load-test-setup/
+      - name: Check Chart.lock is up to date
+        run: |
+          if ! git diff --exit-code load-tests/setup/charts/load-test-setup/Chart.lock; then
+            echo "::error::Chart.lock is out of date. Run 'helm dependency update load-tests/setup/charts/load-test-setup/' and commit the updated Chart.lock."
+            exit 1
+          fi
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   validate-pom-metadata:
     if: needs.detect-changes.outputs.validate-pom-metadata == 'true'
     name: "Lint / Flattened POM Metadata"
@@ -2349,6 +2383,7 @@ jobs:
       - java-checks
       - junit-vintage-check
       - load-test-golden-tests
+      - load-test-helm-lockfile
       - maven-spotless-linter
       - openapi-lint
       - openapi-x-added-in-version-check


### PR DESCRIPTION
## Summary

- Adds a new mandatory CI job (`load-test-helm-lockfile`) that runs `helm dependency update` on `load-tests/setup/charts/load-test-setup/` and fails if `Chart.lock` is modified by the update
- Registers the job in the `check-results` gate so PRs and the merge queue are blocked if the lockfile is stale

## Related

* https://github.com/camunda/camunda/pull/50790#discussion_r3536462667

🤖 Generated with [Claude Code](https://claude.com/claude-code)