### PR TITLE
test: wait for process-instance index in wait-state statistics IT

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/waitstate/ProcessInstanceWaitStateStatisticsIT.java
@@ -313,22 +313,24 @@ public class ProcessInstanceWaitStateStatisticsIT {
     assertThat(problemException.code()).isEqualTo(404);
   }
 
-  // Barrier: wait until the expected number of wait states for this instance are visible in
-  // secondary storage before asserting on the statistics endpoint.
+  // Wait for both the process-instance and wait-state indices, since they lag independently and the
+  // statistics endpoint needs both (it 404s until the process instance is visible).
   private static void waitForWaitStates(final long processInstanceKey, final int expected) {
     Awaitility.await(
             "%d wait states visible for instance %d".formatted(expected, processInstanceKey))
         .atMost(TIMEOUT_DATA_AVAILABILITY)
         .ignoreExceptions()
         .until(
-            () ->
-                camundaClient
-                    .newElementInstanceWaitStateSearchRequest()
-                    .filter(f -> f.processInstanceKey(processInstanceKey))
-                    .send()
-                    .join()
-                    .items()
-                    .size(),
+            () -> {
+              camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
+              return camundaClient
+                  .newElementInstanceWaitStateSearchRequest()
+                  .filter(f -> f.processInstanceKey(processInstanceKey))
+                  .send()
+                  .join()
+                  .items()
+                  .size();
+            },
             size -> size == expected);
   }
 


### PR DESCRIPTION
## Description

The wait-state statistics endpoint validates process-instance existence before aggregating, reading the process-instance index. The test barrier only waited on the wait-state index, which is populated by a separate export path and lags independently. When the wait-state index caught up first, the subsequent statistics call 404'd, making the test flaky.

Have the barrier also wait for the process instance to be visible so both indices are caught up before asserting on statistics.

## Related issues

closes #57022
