### PR TITLE
ci: implement the preview-env internal auth bypass as source-IP satisfy-any (INC-6469)

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/httproute.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/httproute.yml
@@ -13,11 +13,12 @@
 # because the backend service names, ports and context paths are derived from
 # the camunda-platform subchart templates.
 #
-# Known gap: the `global.preview.ingress.internalAuthBypass.enabled` source-IP
-# Vouch bypass (non-default) has no faithful Traefik Gateway API equivalent —
-# Traefik's ipAllowList rejects non-listed IPs rather than letting them skip
-# auth — and is therefore intentionally not translated here; revisit if a
-# consumer enables it.
+# Internal auth bypass: when `global.preview.ingress.internalAuthBypass.enabled`
+# is true (non-default; CI/testing only), a Traefik IngressRoute
+# (templates/internal-bypass-ingressroute.yml) lets requests from the internal
+# source ranges skip Vouch entirely — the nginx-era `satisfy: any` +
+# `whitelist-source-range` semantics, which Gateway API cannot express (no
+# source-IP match; Traefik's ipAllowList rejects instead of falling through).
 ---
 {{- $camundaPlatform := deepCopy (index .Subcharts "camunda-platform") -}}
 {{- $_ := set .Values "camundaPlatform" (deepCopy (index .Values "camunda-platform")) -}}
@@ -177,4 +178,3 @@ spec:
     backendRefs:
     - name: {{ template "connectors.fullname" $camundaPlatform }}
       port: {{ .Values.camundaPlatform.connectors.service.serverPort }}
-

--- a/.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml
@@ -1,0 +1,64 @@
+# Internal auth bypass for CI/testing: requests from the internal source ranges
+# (Teleport tunnel / in-cluster network) skip Vouch/Okta entirely — nginx-era
+# `satisfy: any` + `whitelist-source-range` semantics. Source-IP matching is the
+# only selector that also covers browser-internal requests (service-worker
+# script fetches and service-worker-issued requests), which cannot carry
+# client-injected headers; Management Identity depends on its service worker to
+# remap its root-path /static and /api references under /identity, where its
+# path-scoped IDENTITY_JWT cookie applies.
+#
+# A Traefik IngressRoute rather than a Gateway API HTTPRoute because Gateway API
+# has no source-IP match and Traefik's ipAllowList middleware rejects
+# non-matching requests instead of falling through to the next rule. The
+# kubernetesCRD provider also permits ExternalName services (the shared-ns
+# Keycloak), which the Gateway API provider refuses.
+#
+# External traffic (public source IPs) never matches and is served by the
+# Vouch-protected HTTPRoute (templates/httproute.yml).
+{{- $iab := .Values.global.preview.ingress.internalAuthBypass | default dict -}}
+{{- if $iab.enabled }}
+{{- $camundaPlatform := deepCopy (index .Subcharts "camunda-platform") -}}
+{{- $_ := set .Values "camundaPlatform" (deepCopy (index .Values "camunda-platform")) -}}
+{{- $gateway := required "infra-preview-environments-gateway-api values block must be set" (index .Values "infra-preview-environments-gateway-api") -}}
+{{- $tlsSecret := required "infra-preview-environments-gateway-api.gateway.tls.secretName must be set" $gateway.gateway.tls.secretName -}}
+{{- $sourceRanges := required "internalAuthBypass.sourceRange must be set when the bypass is enabled" $iab.sourceRange -}}
+{{- $clientIP := printf "ClientIP(`%s`)" (join "`, `" $sourceRanges) -}}
+{{- $host := include "ingress.domain" $ -}}
+{{- $backends := list
+    (dict "path" .Values.camundaPlatform.console.contextPath "name" (include "console.fullname" $camundaPlatform) "port" .Values.camundaPlatform.console.service.port)
+    (dict "path" .Values.camundaPlatform.orchestration.contextPath "name" (printf "%s-gateway" (include "orchestration.fullname" $camundaPlatform)) "port" .Values.camundaPlatform.orchestration.service.httpPort)
+    (dict "path" (include "identity.keycloak.contextPath" $camundaPlatform) "name" (include "identity.keycloak.service" $camundaPlatform) "port" (include "identity.keycloak.port" $camundaPlatform | int))
+    (dict "path" .Values.camundaPlatform.identity.contextPath "name" (include "identity.fullname" $camundaPlatform) "port" .Values.camundaPlatform.identity.service.port)
+    (dict "path" .Values.camundaPlatform.optimize.contextPath "name" (include "optimize.fullname" $camundaPlatform) "port" .Values.camundaPlatform.optimize.service.port)
+    (dict "path" .Values.camundaPlatform.webModeler.contextPath "name" (include "webModeler.restapi.fullname" $camundaPlatform) "port" .Values.camundaPlatform.webModeler.restapi.service.port)
+    (dict "path" (include "webModeler.websocketContextPath" $camundaPlatform) "name" (include "webModeler.websockets.fullname" $camundaPlatform) "port" .Values.camundaPlatform.webModeler.websockets.service.port)
+    (dict "path" .Values.camundaPlatform.connectors.contextPath "name" (include "connectors.fullname" $camundaPlatform) "port" .Values.camundaPlatform.connectors.service.serverPort)
+}}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "camundaPlatform.fullname" $camundaPlatform }}-internal-bypass
+  labels: {{ include "commonLabels" $ | nindent 4 }}
+  annotations: {{ include "commonAnnotations" $ | nindent 4 }}
+spec:
+  entryPoints:
+  # The internal Traefik entrypoint terminating TLS for preview domains.
+  - websecure
+  tls:
+    secretName: {{ $tlsSecret }}
+  routes:
+  {{- range $b := $backends }}
+  - kind: Rule
+    # Outrank the Gateway API routers (Traefik computes their priorities from
+    # match specificity; an explicit high value wins deterministically).
+    priority: 42000000
+    match: Host(`{{ $host }}`) && {{ $clientIP }} && PathPrefix(`{{ $b.path }}`)
+    services:
+    # The Keycloak entry resolves to the chart's ExternalName Service pointing at
+    # the shared keycloak-operator namespace (global.identity.keycloak.internal),
+    # which the kubernetesCRD provider allows (allowExternalNameServices).
+    - name: {{ $b.name }}
+      port: {{ $b.port }}
+  {{- end }}
+{{- end }}

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -32,13 +32,23 @@ global:
     ingress:
       # The domain name under which to expose the preview environment
       domain: camunda.camunda.cloud
-      # WARNING: When enabled, this bypasses Vouch/Okta authentication for all
-      # requests originating from the 10.0.0.0/8 internal IP range, granting
-      # unauthenticated access to any client within that network. This is
-      # intended only for tightly controlled CI/testing scenarios (for example,
-      # CI access via a Teleport TCP tunnel).
+      # WARNING: When enabled, requests from the `sourceRange` networks (the
+      # in-cluster / Teleport tunnel network) bypass Vouch/Okta authentication
+      # ENTIRELY via a high-priority Traefik IngressRoute
+      # (templates/internal-bypass-ingressroute.yml) — the nginx-era
+      # `satisfy: any` + `whitelist-source-range` semantics. This deliberately
+      # covers browser-internal requests (service-worker script fetches and
+      # service-worker-issued requests) that a header-based bypass can never
+      # reach, which Management Identity depends on. External traffic never
+      # matches and keeps the Vouch flow. Intended only for tightly controlled
+      # CI/testing scenarios (for example, CI access via a Teleport TCP tunnel).
       internalAuthBypass:
         enabled: false
+        # Source ranges permitted to skip Vouch. This is where security is
+        # enforced: nothing a client sends (headers, cookies) grants access —
+        # only the network it connects from.
+        sourceRange:
+        - 10.0.0.0/8
     secrets:
       name: camunda-credentials
 
@@ -274,8 +284,6 @@ camunda-platform:
     fullnameOverride: identity
     contextPath: /identity
     fullURL: https://{{ include "ingress.domain" . }}{{ .Values.identity.contextPath }}
-    # image:
-    #     repository: camunda/identity
     firstUser:
       enabled: true
       username: demo

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -25,6 +25,23 @@ on:
         required: false
         type: boolean
         default: false
+      existing-host:
+        description: |
+          Iteration shortcut (8.10 only): reuse an already-deployed preview env
+          (host FQDN, e.g. smoke810-123.camunda.camunda.cloud) instead of
+          building images and deploying. Chart changes reach the existing env
+          via ArgoCD branch tracking, so a push + this input skips ~20min of
+          build/deploy per iteration.
+        required: false
+        type: string
+        default: ''
+      fast-feedback:
+        description: |
+          Iteration shortcut: run Playwright with --retries=0 so a red result
+          arrives in minutes instead of retry-multiplied timeouts.
+        required: false
+        type: boolean
+        default: false
 
 env:
   TEST_OWNER: '@camunda/monorepo-devops-team'
@@ -63,7 +80,7 @@ jobs:
 
   deploy-8-10:
     name: Deploy 8.10 Preview Environment
-    if: contains(fromJSON('["all", "8.10", ""]'), inputs.version)
+    if: contains(fromJSON('["all", "8.10", ""]'), inputs.version) && inputs.existing-host == ''
     uses: ./.github/workflows/preview-env-build-and-deploy.yml
     secrets: inherit
     with:
@@ -81,8 +98,8 @@ jobs:
     - deploy-8-8
     - deploy-8-9
     - deploy-8-10
-    # Run if at least one deploy succeeded
-    if: always() && (needs.deploy-8-10.result == 'success' || needs.deploy-8-9.result == 'success' || needs.deploy-8-8.result == 'success')
+    # Run if at least one deploy succeeded (or an existing preview is reused)
+    if: always() && (needs.deploy-8-10.result == 'success' || needs.deploy-8-9.result == 'success' || needs.deploy-8-8.result == 'success' || inputs.existing-host != '')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -100,8 +117,8 @@ jobs:
           host: ${{ needs.deploy-8-9.outputs.host-name }}
           run: ${{ needs.deploy-8-9.result == 'success' }}
         - version: '8.10'
-          host: ${{ needs.deploy-8-10.outputs.host-name }}
-          run: ${{ needs.deploy-8-10.result == 'success' }}
+          host: ${{ inputs.existing-host || needs.deploy-8-10.outputs.host-name }}
+          run: ${{ inputs.existing-host != '' || needs.deploy-8-10.result == 'success' }}
         exclude:
         - deployment:
             run: false
@@ -144,6 +161,27 @@ jobs:
           # Map preview hostname to localhost
           echo "127.0.0.1 ${PREVIEW_HOST}" | sudo tee -a /etc/hosts
           echo "✅ Added ${PREVIEW_HOST} to /etc/hosts"
+
+          # Backends behind Traefik emit absolute http:// Locations for their
+          # trailing-slash redirects (they ignore X-Forwarded-Proto). In production
+          # Traefik's :80 entrypoint bounces those back to https; the tsh tunnel
+          # only serves :443, so mirror that bounce with a tiny redirector on :80.
+          sudo python3 -c '
+          import http.server, socketserver
+          class R(http.server.BaseHTTPRequestHandler):
+              def _r(self):
+                  self.send_response(308)
+                  self.send_header("Location", "https://" + (self.headers.get("Host") or "") + self.path)
+                  self.end_headers()
+              do_GET = do_POST = do_HEAD = do_PUT = do_DELETE = do_PATCH = _r
+              def log_message(self, *a): pass
+          socketserver.TCPServer(("127.0.0.1", 80), R).serve_forever()' &
+          sleep 2
+          if ! nc -z 127.0.0.1 80; then
+            echo "::error::Failed to start http->https redirector on port 80"
+            exit 1
+          fi
+          echo "✅ http->https redirector running on port 80"
 
       - name: Generate GitHub Token
         id: github-token
@@ -199,6 +237,11 @@ jobs:
           PLAYWRIGHT_BASE_URL: https://${{ matrix.deployment.host }}
           PROJECT: chromium
           CI: true
+          # Preview envs are deployed with internalAuthBypass.enabled=true: the
+          # client tunnels in from the internal (10/8) network via Teleport, and
+          # internal source IPs skip Vouch at the gateway (see c8sm chart
+          # global.preview.ingress.internalAuthBypass). No client-side header is
+          # required.
           DISTRO_QA_E2E_TESTS_IDENTITY_FIRSTUSER_PASSWORD: demo
           DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET: admin
           DISTRO_QA_E2E_TESTS_KEYCLOAK_PASSWORD: admin
@@ -207,7 +250,7 @@ jobs:
           npx playwright test "tests/${MINOR_VERSION}/smoke-tests.spec.ts" \
             --project=chromium \
             --reporter=list,html \
-            --retries=2
+            --retries=${{ inputs.fast-feedback && '0' || '2' }}
 
       - name: Upload Test Artifacts
         if: failure()

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -98,8 +98,9 @@ jobs:
     - deploy-8-8
     - deploy-8-9
     - deploy-8-10
-    # Run if at least one deploy succeeded (or an existing preview is reused)
-    if: always() && (needs.deploy-8-10.result == 'success' || needs.deploy-8-9.result == 'success' || needs.deploy-8-8.result == 'success' || inputs.existing-host != '')
+    # Run if at least one deploy succeeded (or an existing 8.10 preview is
+    # reused; existing-host only applies when the version selection includes 8.10)
+    if: always() && (needs.deploy-8-10.result == 'success' || needs.deploy-8-9.result == 'success' || needs.deploy-8-8.result == 'success' || (inputs.existing-host != '' && contains(fromJSON('["all", "8.10", ""]'), inputs.version)))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -118,7 +119,7 @@ jobs:
           run: ${{ needs.deploy-8-9.result == 'success' }}
         - version: '8.10'
           host: ${{ inputs.existing-host || needs.deploy-8-10.outputs.host-name }}
-          run: ${{ inputs.existing-host != '' || needs.deploy-8-10.result == 'success' }}
+          run: ${{ needs.deploy-8-10.result == 'success' || (inputs.existing-host != '' && contains(fromJSON('["all", "8.10", ""]'), inputs.version)) }}
         exclude:
         - deployment:
             run: false
@@ -158,7 +159,13 @@ jobs:
           fi
           echo "✅ Teleport TCP tunnel running on port 443"
 
-          # Map preview hostname to localhost
+          # Map preview hostname to localhost. PREVIEW_HOST may come from the
+          # user-provided existing-host dispatch input, so allow only hostname
+          # characters before writing it to /etc/hosts.
+          if [[ ! "${PREVIEW_HOST}" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?$ ]]; then
+            echo "::error::Invalid preview host: ${PREVIEW_HOST}"
+            exit 1
+          fi
           echo "127.0.0.1 ${PREVIEW_HOST}" | sudo tee -a /etc/hosts
           echo "✅ Added ${PREVIEW_HOST} to /etc/hosts"
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -100,6 +100,7 @@ paths:
 
   /restore:
     post:
+      x-added-in-version: "8.10"
       x-eventually-consistent: false
       tags:
         - Recovery

--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -100,7 +100,6 @@ paths:
 
   /restore:
     post:
-      x-added-in-version: "8.10"
       x-eventually-consistent: false
       tags:
         - Recovery


### PR DESCRIPTION
## Description

The preview smoke tests reach preview environments through a Teleport TCP tunnel terminating inside the cluster. Under ingress-nginx this traffic skipped Vouch/Okta via `satisfy: any` + `whitelist-source-range: 10.0.0.0/8`. The Traefik/Gateway API migration lost that capability — **Gateway API has no source-IP match**, and Traefik's `ipAllowList` middleware *rejects* non-matching requests instead of falling through to authentication — so the smoke tests hit the Vouch wall (INC-6469).

## What
- **`templates/internal-bypass-ingressroute.yml`** (new): a high-priority Traefik IngressRoute (kubernetesCRD provider) routing requests matching `ClientIP(sourceRange)` to the backends **without** the Vouch filter — restoring the nginx-era satisfy-any semantics. Gated behind `internalAuthBypass.enabled` (default **off**). `sourceRange` is the single security control: nothing a client sends (headers/cookies) grants access; external traffic never matches and keeps the Vouch flow via the Gateway API HTTPRoute.
- **Smoke-test workflow**:
  - an http→https redirector on the runner's port 80 (backends emit absolute `http://` Locations for trailing-slash redirects; in production Traefik's :80 entrypoint bounces them; the tsh tunnel serves only :443)
  - `workflow_dispatch` iteration shortcuts: `existing-host` (reuse a deployed preview, skips ~20 min build+deploy) and `fast-feedback` (`--retries=0`) — defaults unchanged, scheduled runs unaffected

## Why source-IP instead of a client-sent header
A header-selected bypass was fully built and validated first, and abandoned on evidence: client-injected headers **cannot reach browser-internal requests** (service-worker script fetches, service-worker-issued requests — Playwright's `extraHTTPHeaders` don't apply there). Management Identity depends on its service worker to remap its root-path `/static` and `/api` references under `/identity`, where its path-scoped `IDENTITY_JWT` cookie applies (hardcoded in `CookieService`). Source-IP matching is the only selector that covers that traffic class. It is also exactly the trust model that ran for years under nginx.

Note on Gateway API purity: the bypass is one vendor-specific object, CI-only and flag-gated; all regular routing stays Gateway API. A spec-clean alternative (dedicated internal entrypoint + second listener) is recorded as a follow-up in camunda/team-infrastructure#1107.

## Validation
- All four 8.10 smoke tests pass in 2.8 min through the tunnel, with **no client-side header** and the e2e suite on plain `main` ([run 29037836935](https://github.com/camunda/camunda/actions/runs/29037836935), [run 29040106803](https://github.com/camunda/camunda/actions/runs/29040106803))
- `Basic Login` 33s / `Basic Navigation` 51s / `Most Common Flow With All Apps` 2.4m / setup 23s
- Bypass disabled ⇒ zero additional objects render (verified)

Related: camunda/team-infrastructure#1107 · INC-6469 · builds on #57189 (8.10 operator-CR migration). Replaces the header approach; camunda/c8-cross-component-e2e-tests#2761 was closed as superseded. 8.8/8.9 preview charts need the same routing backported on their stable branches (tracked in #1107).

🤖 Generated with [Claude Code](https://claude.com/claude-code)