### PR TITLE
build: enable compact object headers in docker images

### DIFF
--- a/zeebe/docker/utils/jvm.options
+++ b/zeebe/docker/utils/jvm.options
@@ -1,1 +1,1 @@
---sun-misc-unsafe-memory-access=allow
+-XX:+UseCompactObjectHeaders --sun-misc-unsafe-memory-access=allow


### PR DESCRIPTION
This is available since JDK25 which we use in our docker images. We can't yet enable it for non-docker deployments because JDK21 is still supported.

Enabling compact object headers will reduce memory usage, which has secondary benefits too (cache locality etc.).
While it is opt-in, it's already well-tested and considered safe enough for several large companies to make use of.