### PR TITLE
fix: stop double-prefixing c8- in release load test namespaces

### DIFF
--- a/.github/workflows/camunda-release-load-test.yaml
+++ b/.github/workflows/camunda-release-load-test.yaml
@@ -80,7 +80,7 @@ jobs:
     timeout-minutes: 5
     permissions: {}
     outputs:
-      sanitized-name: c8-${{ steps.sanitize.outputs.branch_name }}
+      sanitized-name: ${{ steps.sanitize.outputs.branch_name }}
     steps:
       - id: sanitize
         uses: camunda/infra-global-github-actions/sanitize-branch-name@f7e888c5b7d9220bb4a549306c1cbaf798670d0e # sanitize-branch-name: v1.0.0


### PR DESCRIPTION
## Description

`camunda-release-load-test.yaml`'s `sanitize-inputs` job unconditionally prepends `c8-` to its
output:

```yaml
sanitized-name: c8-${{ steps.sanitize.outputs.branch_name }}
```

If a caller's `name` input already starts with `c8-`, this duplicates the prefix (e.g.
`c8-c8-release-8-8-x`). The downstream `camunda-load-test.yml` already guards against this with
`startsWith(inputs.name, 'c8-')` before adding its own prefix — removing the unconditional prepend
here makes that guard the single place the prefix is applied, so the result is correct regardless
of what the caller passes in.

The same bug exists identically on stable/8.7, 8.8, and 8.9.

### Reproduction

Found while recreating release load-test namespaces. Each run below was dispatched with a `name`
input that already included the `c8-` prefix (matching this workflow's usual naming convention,
e.g. `c8-release-8-8-x`), which is exactly the condition that triggers the double prefix:

| Run | Resulting namespace |
|-----|----------------------|
| [Run 28841704823](https://github.com/camunda/camunda/actions/runs/28841704823) | `c8-c8-release-8-8-x` |
| [Run 28841844082](https://github.com/camunda/camunda/actions/runs/28841844082) | `c8-c8-release-8-9-x` |
| [Run 28841999403](https://github.com/camunda/camunda/actions/runs/28841999403) | `c8-c8-release-8-10-0-alpha3-rc2` |

Full internal discussion (namespace naming caught by @multani):
https://camunda.slack.com/archives/C0BE8SZBYJC/p1783400776528929?thread_ts=1783395913.001979&cid=C0BE8SZBYJC

## Checklist
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #