### PR TITLE
docs: add auth method

### DIFF
--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -28,7 +28,7 @@ Some of the necessary steps you need to take are:
 
 ```sh
 ## Authenticate to the benchmark cluster via Teleport
-tsh login --proxy=camunda.teleport.sh:443
+tsh login --proxy=camunda.teleport.sh:443 --auth=okta
 tsh kube login camunda-benchmark-prod
 
 ## Log in to the Harbor container registry


### PR DESCRIPTION
## Description

I lost access and I was not able to log in

```
~ k8s:zeebe-cluster:ck-migration-test-3
$ tsh login --proxy=camunda.teleport.sh:443
Enter password for Teleport user cqjawa:
```

It asks for a PW idk what to fill in.

## Fix

- update authentication for tsh command to include Okta option

Similar to https://confluence.camunda.com/spaces/HAN/pages/178591579/Accessing+SaaS+Kubernetes+Clusters
<!-- Describe the goal and purpose of this PR. -->
