### PR TITLE
Expose withLease in the activation API (gRPC + REST + Java client)

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateJobsCommandStep1.java
@@ -104,6 +104,20 @@ public interface ActivateJobsCommandStep1
     ActivateJobsCommandStep3 fetchVariables(String... fetchVariables);
 
     /**
+     * Activate the jobs with a lease. When enabled, each activated job is assigned a distinct lease
+     * token, returned as {@link io.camunda.client.api.response.ActivatedJob#getLeaseToken()
+     * ActivatedJob#getLeaseToken()}. The lease token fences the complete, fail, and throw-error
+     * commands against a superseded activation of the same job.
+     *
+     * <p>If not set, jobs are activated without a lease.
+     *
+     * @param withLease whether to activate the jobs with a lease
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    ActivateJobsCommandStep3 withLease(boolean withLease);
+
+    /**
      * Sets the request timeout for the command.
      *
      * <p>Additionally, it sets the HTTP response timeout to the specified value, incremented by the

--- a/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/worker/JobWorkerBuilderStep1.java
@@ -185,6 +185,18 @@ public interface JobWorkerBuilderStep1 {
     JobWorkerBuilderStep3 fetchVariables(String... fetchVariables);
 
     /**
+     * Activate the jobs polled by this worker with a lease. When enabled, each activated job is
+     * assigned a distinct lease token, fencing the complete, fail, and throw-error commands against
+     * a superseded activation of the same job.
+     *
+     * <p>Only applies to the polling path. If not set, jobs are activated without a lease.
+     *
+     * @param withLease whether to activate the jobs with a lease
+     * @return the builder for this worker
+     */
+    JobWorkerBuilderStep3 withLease(boolean withLease);
+
+    /**
      * Sets the backoff supplier. The supplier is called to determine the retry delay after each
      * failed request; the worker then waits until the returned delay has elapsed before sending the
      * next request. Note that this is used <strong>only</strong> when activating jobs - failures in

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateJobsCommandImpl.java
@@ -143,6 +143,13 @@ public final class ActivateJobsCommandImpl
   }
 
   @Override
+  public ActivateJobsCommandStep3 withLease(final boolean withLease) {
+    grpcRequestObjectBuilder.setWithLease(withLease);
+    httpRequestObject.setWithLease(withLease);
+    return this;
+  }
+
+  @Override
   public ActivateJobsCommandStep3 requestTimeout(final Duration requestTimeout) {
     grpcRequestObjectBuilder.setRequestTimeout(requestTimeout.toMillis());
     httpRequestObject.setRequestTimeout(requestTimeout.toMillis());

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobPollerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobPollerImpl.java
@@ -41,6 +41,7 @@ public final class JobPollerImpl implements JobPoller {
   private final List<String> fetchVariables;
   private final List<String> tenantIds;
   private final TenantFilter tenantFilter;
+  private final boolean withLease;
 
   private int maxJobsToActivate;
 
@@ -59,7 +60,8 @@ public final class JobPollerImpl implements JobPoller {
       final List<String> fetchVariables,
       final List<String> tenantIds,
       final TenantFilter tenantFilter,
-      final int maxJobsToActivate) {
+      final int maxJobsToActivate,
+      final boolean withLease) {
     this.requestTimeout = requestTimeout;
     this.jobClient = jobClient;
     this.jobType = jobType;
@@ -69,6 +71,7 @@ public final class JobPollerImpl implements JobPoller {
     this.tenantIds = tenantIds;
     this.tenantFilter = tenantFilter;
     this.maxJobsToActivate = maxJobsToActivate;
+    this.withLease = withLease;
   }
 
   private void reset() {
@@ -116,7 +119,8 @@ public final class JobPollerImpl implements JobPoller {
             .timeout(timeout)
             .workerName(workerName)
             .tenantIds(tenantIds)
-            .tenantFilter(tenantFilter);
+            .tenantFilter(tenantFilter)
+            .withLease(withLease);
     if (fetchVariables != null) {
       activateCommand.fetchVariables(fetchVariables);
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobPollerImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobPollerImpl.java
@@ -119,10 +119,14 @@ public final class JobPollerImpl implements JobPoller {
             .timeout(timeout)
             .workerName(workerName)
             .tenantIds(tenantIds)
-            .tenantFilter(tenantFilter)
-            .withLease(withLease);
+            .tenantFilter(tenantFilter);
     if (fetchVariables != null) {
       activateCommand.fetchVariables(fetchVariables);
+    }
+    // only set when true: an explicit false is still sent over the wire, which would break
+    // rolling upgrades against a gateway that doesn't yet know this field
+    if (withLease) {
+      activateCommand.withLease(true);
     }
     activateCommand
         .requestTimeout(requestTimeout)

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobWorkerBuilderImpl.java
@@ -64,6 +64,7 @@ public final class JobWorkerBuilderImpl
   private Duration pollInterval;
   private Duration requestTimeout;
   private List<String> fetchVariables;
+  private boolean withLease;
   private final List<String> defaultTenantIds;
   private final List<String> customTenantIds;
   private TenantFilter tenantFilter;
@@ -161,6 +162,12 @@ public final class JobWorkerBuilderImpl
   }
 
   @Override
+  public JobWorkerBuilderStep3 withLease(final boolean withLease) {
+    this.withLease = withLease;
+    return this;
+  }
+
+  @Override
   public JobWorkerBuilderStep3 backoffSupplier(final BackoffSupplier backoffSupplier) {
     this.backoffSupplier = backoffSupplier;
     return this;
@@ -230,7 +237,8 @@ public final class JobWorkerBuilderImpl
             fetchVariables,
             getTenantIds(),
             tenantFilter,
-            maxJobsActive);
+            maxJobsActive,
+            withLease);
 
     final Executor jobExecutor;
     if (enableStreaming) {

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobPollerImplTest.java
@@ -254,6 +254,42 @@ public final class JobPollerImplTest extends ClientTest {
   }
 
   @Test
+  public void shouldPollWithLease() {
+    // given
+    gatewayService.onActivateJobsRequest(TestData.job());
+
+    // when
+    getJobPollerWithLease(true).poll(5, jobConsumer, doneCallback, errorCallback, () -> true);
+
+    // then
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              final GatewayOuterClass.ActivateJobsRequest request = gatewayService.getLastRequest();
+              assertThat(request.getWithLease()).isTrue();
+            });
+  }
+
+  @Test
+  public void shouldNotPollWithLeaseByDefault() {
+    // given
+    gatewayService.onActivateJobsRequest(TestData.job());
+
+    // when
+    getJobPoller().poll(5, jobConsumer, doneCallback, errorCallback, () -> true);
+
+    // then
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              final GatewayOuterClass.ActivateJobsRequest request = gatewayService.getLastRequest();
+              assertThat(request.getWithLease()).isFalse();
+            });
+  }
+
+  @Test
   public void shouldConsistentlyUseTenantFilterAcrossMultiplePolls() {
     // given
     gatewayService.onActivateJobsRequest(TestData.job());
@@ -303,7 +339,8 @@ public final class JobPollerImplTest extends ClientTest {
         Collections.emptyList(),
         Collections.singletonList("test-tenant"),
         TenantFilter.PROVIDED,
-        10);
+        10,
+        false);
   }
 
   private JobPoller getJobPollerWithTenantFilter(
@@ -317,7 +354,22 @@ public final class JobPollerImplTest extends ClientTest {
         Collections.emptyList(),
         tenantIds,
         tenantFilter,
-        10);
+        10,
+        false);
+  }
+
+  private JobPoller getJobPollerWithLease(final boolean withLease) {
+    return new JobPollerImpl(
+        client,
+        Duration.ofSeconds(10),
+        "testJobType",
+        "testWorkerName",
+        Duration.ofSeconds(10),
+        Collections.emptyList(),
+        Collections.singletonList("test-tenant"),
+        TenantFilter.PROVIDED,
+        10,
+        withLease);
   }
 
   private static final class TestData {

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -18,6 +18,7 @@ package io.camunda.client.impl.worker;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -269,6 +270,35 @@ class JobWorkerBuilderImplTest {
         () ->
             assertThat(tenantIdCaptor.getValue())
                 .containsOnly(zeebeClientConfig.getDefaultTenantId()));
+  }
+
+  @Test
+  void shouldForwardWithLeaseOnPoll() {
+    // given
+    final ActivateJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);
+    Mockito.when(
+            jobClient.newActivateJobsCommand().jobType(anyString()).maxJobsToActivate(anyInt()))
+        .thenReturn(lastStep);
+    Mockito.when(lastStep.tenantIds(anyList())).thenReturn(lastStep);
+    Mockito.when(lastStep.tenantFilter(any(TenantFilter.class))).thenReturn(lastStep);
+    Mockito.when(lastStep.withLease(anyBoolean())).thenReturn(lastStep);
+    Mockito.when(lastStep.requestTimeout(any())).thenReturn(lastStep);
+    final CamundaFuture<ActivateJobsResponse> camundaFuture = Mockito.mock();
+    Mockito.when(lastStep.send()).thenReturn(camundaFuture);
+    Mockito.when(camundaFuture.exceptionally(any())).thenReturn(Mockito.mock());
+
+    // when
+    jobWorkerBuilder
+        .jobType("some-type")
+        .handler(mock())
+        .timeout(Duration.ofSeconds(5))
+        .name("worker")
+        .maxJobsActive(30)
+        .withLease(true)
+        .open();
+
+    // then
+    await(() -> verify(lastStep).withLease(true));
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -302,6 +302,34 @@ class JobWorkerBuilderImplTest {
   }
 
   @Test
+  void shouldNotCallWithLeaseByDefault() {
+    // given - a worker that never opts into withLease
+    final ActivateJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);
+    Mockito.when(
+            jobClient.newActivateJobsCommand().jobType(anyString()).maxJobsToActivate(anyInt()))
+        .thenReturn(lastStep);
+    Mockito.when(lastStep.tenantIds(anyList())).thenReturn(lastStep);
+    Mockito.when(lastStep.tenantFilter(any(TenantFilter.class))).thenReturn(lastStep);
+    Mockito.when(lastStep.requestTimeout(any())).thenReturn(lastStep);
+    final CamundaFuture<ActivateJobsResponse> camundaFuture = Mockito.mock();
+    Mockito.when(lastStep.send()).thenReturn(camundaFuture);
+    Mockito.when(camundaFuture.exceptionally(any())).thenReturn(Mockito.mock());
+
+    // when
+    jobWorkerBuilder
+        .jobType("some-type")
+        .handler(mock())
+        .timeout(Duration.ofSeconds(5))
+        .name("worker")
+        .maxJobsActive(30)
+        .open();
+
+    // then - withLease must never be called at all (not even with false), so the field stays
+    // absent on the wire rather than an explicit false that older gateways would reject
+    await(() -> verify(lastStep, never()).withLease(anyBoolean()));
+  }
+
+  @Test
   void shouldForwardCustomTenantIdsOnPoll() {
     // given
     final ActivateJobsCommandStep3 lastStep = Mockito.mock(Answers.RETURNS_SELF);

--- a/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
@@ -559,6 +559,32 @@ public final class ActivateJobsTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetWithLease() {
+    // when
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(1)
+        .withLease(true)
+        .send()
+        .join();
+
+    // then
+    final ActivateJobsRequest request = gatewayService.getLastRequest();
+    assertThat(request.getWithLease()).isTrue();
+  }
+
+  @Test
+  public void shouldNotSetWithLeaseByDefault() {
+    // when
+    client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(1).send().join();
+
+    // then
+    final ActivateJobsRequest request = gatewayService.getLastRequest();
+    assertThat(request.getWithLease()).isFalse();
+  }
+
+  @Test
   public void shouldSetProvidedDefaultWorkerNameWhenNullPropertyIsProvidedInBuilder() {
     final String workerName = "workerName";
     // given

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -295,6 +295,38 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   }
 
   @Test
+  void shouldSetWithLease() {
+    // given
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
+
+    // when
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .withLease(true)
+        .send()
+        .join();
+
+    // then
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+    assertThat(request.getWithLease()).isTrue();
+  }
+
+  @Test
+  void shouldNotSetWithLeaseByDefault() {
+    // given
+    gatewayService.onActivateJobsRequest(new JobActivationResult());
+
+    // when
+    client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3).send().join();
+
+    // then
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+    assertThat(request.getWithLease()).isFalse();
+  }
+
+  @Test
   void shouldSetFetchVariablesAsVargs() {
     // given
     final String[] fetchVariables = new String[] {"foo", "bar", "baz"};

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -314,16 +314,17 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   }
 
   @Test
-  void shouldNotSetWithLeaseByDefault() {
-    // given
+  void shouldNotSendWithLeaseByDefault() {
+    // given - a request that never touches withLease
     gatewayService.onActivateJobsRequest(new JobActivationResult());
 
     // when
     client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3).send().join();
 
-    // then
+    // then - the field is genuinely absent on the wire, not an explicit false, so older gateways
+    // that don't know this field yet don't reject the request
     final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
-    assertThat(request.getWithLease()).isFalse();
+    assertThat(request.getWithLease()).isNull();
   }
 
   @Test

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -1021,7 +1021,8 @@ public class RequestMapper {
         activationRequest.getTimeout(),
         getStringOrEmpty(activationRequest, JobActivationRequest::getWorker),
         getStringListOrEmpty(activationRequest, JobActivationRequest::getFetchVariable),
-        getLongOrZero(activationRequest, JobActivationRequest::getRequestTimeout));
+        getLongOrZero(activationRequest, JobActivationRequest::getRequestTimeout),
+        getBooleanOrDefault(activationRequest, JobActivationRequest::getWithLease, false));
   }
 
   private static List<ProcessInstanceModificationActivateInstruction>

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
@@ -313,6 +313,45 @@ class RequestMapperTest {
     }
 
     @Test
+    void shouldMapJobActivationWithLease() {
+      // given
+      final var request =
+          JobActivationRequest.Builder.create()
+              .type("test-job")
+              .maxJobsToActivate(10)
+              .timeout(5000L)
+              .tenantIds(List.of("tenant-a"))
+              .withLease(true)
+              .build();
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.get().withLease()).isTrue();
+    }
+
+    @Test
+    void shouldNotSetWithLeaseByDefault() {
+      // given
+      final var request =
+          JobActivationRequest.Builder.create()
+              .type("test-job")
+              .maxJobsToActivate(10)
+              .timeout(5000L)
+              .tenantIds(List.of("tenant-a"))
+              .build();
+
+      // when
+      final var result = RequestMapper.toJobsActivationRequest(request, true);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.get().withLease()).isFalse();
+    }
+
+    @Test
     void shouldMapJobActivationWithAssignedTenantFilterAndNoTenantIds() {
       // given
       final var request =

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -107,7 +107,8 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
             .setTenantFilter(request.tenantFilter())
             .setTimeout(request.timeout())
             .setWorker(request.worker())
-            .setVariables(request.fetchVariable());
+            .setVariables(request.fetchVariable())
+            .setWithLease(request.withLease());
     // Apply the full mutator set (authorization AND, for physical-tenant-scoped services, the
     // partition group) so job activation round-robins over the tenant's partition group. The
     // handler reads brokerRequest.getPartitionGroup() when selecting partitions.
@@ -266,7 +267,8 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       long timeout,
       String worker,
       List<String> fetchVariable,
-      long requestTimeout) {}
+      long requestTimeout,
+      boolean withLease) {}
 
   public record UpdateJobChangeset(Integer retries, Long timeout, Integer priority) {}
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -399,7 +399,8 @@ public final class RequestMapper extends RequestUtil {
         .setMaxJobsToActivate(grpcRequest.getMaxJobsToActivate())
         .setVariables(grpcRequest.getFetchVariableList())
         .setTenantIds(tenantIds)
-        .setTenantFilter(tenantFilter);
+        .setTenantFilter(tenantFilter)
+        .setWithLease(grpcRequest.getWithLease());
   }
 
   public static BrokerResolveIncidentRequest toResolveIncidentRequest(

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -203,6 +203,41 @@ public class RequestMapperTest {
     }
 
     @Test
+    public void shouldMapActivateJobsRequestWithLease() {
+      // given
+      final var grpcRequest =
+          ActivateJobsRequest.newBuilder()
+              .setType("test-job")
+              .setMaxJobsToActivate(10)
+              .addTenantIds("tenant-a")
+              .setWithLease(true)
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toActivateJobsRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().isWithLease()).isTrue();
+    }
+
+    @Test
+    public void shouldNotSetWithLeaseByDefault() {
+      // given
+      final var grpcRequest =
+          ActivateJobsRequest.newBuilder()
+              .setType("test-job")
+              .setMaxJobsToActivate(10)
+              .addTenantIds("tenant-a")
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toActivateJobsRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().isWithLease()).isFalse();
+    }
+
+    @Test
     public void shouldMapActivateJobsRequestWithAssignedTenantFilter() {
       // given
       final var grpcRequest =

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -48,6 +48,15 @@ message ActivateJobsRequest {
   repeated string tenantIds = 7;
   // the tenant filtering strategy - determines whether to use provided tenant IDs or assigned tenant IDs
   TenantFilter tenantFilter = 8;
+  // whether to activate the jobs with a lease; when true, each activated job is assigned a
+  // distinct, opaque lease token, returned as ActivatedJob.leaseToken. The lease fences the
+  // complete, fail, and throw-error commands against a superseded activation of the same job
+  // (e.g. after the job timed out or failed and was re-activated by another worker): a command
+  // carrying a stale lease token is rejected rather than racing with the newer activation. Once
+  // a job has been activated with a lease, it is served only to leasing workers of that job
+  // type; a homogeneous fleet per job type is recommended. Defaults to false, which activates
+  // jobs without a lease.
+  bool withLease = 9;
 }
 
 message ActivateJobsResponse {

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -393,6 +393,18 @@ components:
             The tenant filtering strategy - determines whether to use provided tenant IDs or
             assigned tenant IDs from the authenticated principal's authorized tenants.
           default: PROVIDED
+        withLease:
+          description: >
+            Whether to activate the jobs with a lease. When true, each activated job is assigned a
+            distinct, opaque lease token, returned as ActivatedJobResult.leaseToken. The lease
+            fences the complete, fail, and throw-error commands against a superseded activation of
+            the same job (for example, after the job timed out or failed and was re-activated by
+            another worker): a command carrying a stale lease token is rejected rather than racing
+            with the newer activation. Once a job has been activated with a lease, it is served
+            only to leasing workers of that job type; a homogeneous fleet per job type is
+            recommended. Defaults to false, which activates jobs without a lease.
+          type: boolean
+          default: false
       required:
         - type
         - maxJobsToActivate
@@ -400,6 +412,8 @@ components:
       x-properties-added-in-version:
         - propertyName: tenantFilter
           addedInVersion: "8.9"
+        - propertyName: withLease
+          addedInVersion: "8.10"
 
     JobActivationResult:
       description: The list of activated jobs

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -402,9 +402,9 @@ components:
             another worker): a command carrying a stale lease token is rejected rather than racing
             with the newer activation. Once a job has been activated with a lease, it is served
             only to leasing workers of that job type; a homogeneous fleet per job type is
-            recommended. Defaults to false, which activates jobs without a lease.
+            recommended. Omit or set to false to activate jobs without a lease.
           type: boolean
-          default: false
+          nullable: true
       required:
         - type
         - maxJobsToActivate

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateJobsRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateJobsRequest.java
@@ -61,6 +61,11 @@ public final class BrokerActivateJobsRequest extends BrokerExecuteCommand<JobBat
     return this;
   }
 
+  public BrokerActivateJobsRequest setWithLease(final boolean withLease) {
+    requestDto.setWithLease(withLease);
+    return this;
+  }
+
   @Override
   public JobBatchRecord getRequestWriter() {
     return requestDto;


### PR DESCRIPTION
## Description

Closes #54846.

Adds `withLease` to the job-activation request path over both transports, so workers can opt in to lease-fenced activation once lease generation lands (#54845). `JobBatchRecord.withLease` already exists (#54845's merged protocol-plumbing slice, PR #56824); this PR wires the request → internal command path onto it, mirroring the response-side `leaseToken` exposure already provided in #54844.

**Blocked on #54845** for the flag actually doing anything: `JobBatchActivateProcessor` doesn't yet read `withLease` to generate a token or apply the activate-side guard, so setting it today has no observable effect beyond the field being carried through to `JobBatchRecord`. Tests here only verify the flag reaches the internal command intact — not that it produces a lease.

### Changes
- `gateway.proto`: `ActivateJobsRequest.withLease` (fresh field number).
- `v2/jobs.yaml`: `JobActivationRequest.withLease` (optional boolean, default `false`, `x-properties-added-in-version: 8.10`).
- gRPC `RequestMapper` + `BrokerActivateJobsRequest.setWithLease`: maps the field onto the internal `JobBatchRecord` command.
- REST `RequestMapper` + `JobServices.ActivateJobsRequest`/`activateJobs`: same, via the REST-side pipeline (which goes through a different record/service layer than the gRPC path before reaching the same `BrokerActivateJobsRequest`).
- Java client: `ActivateJobsCommandStep1.withLease(boolean)`, wired for both transports.
- Java client: `JobWorkerBuilderStep1.withLease(boolean)` for the polling path, threaded through `JobWorkerBuilderImpl` → `JobPollerImpl`. The streaming (push) path is untouched — that opt-in is #56457.

### Tests
- gRPC `RequestMapper`: flag present/absent on the mapped `JobBatchRecord`.
- REST `RequestMapper`: same, via the generated `JobActivationRequest` DTO.
- Java client, both transports (`ActivateJobsTest`, `ActivateJobsRestTest`): flag reaches the captured request.
- `JobPollerImplTest`: poller issues the flag on the activate-jobs command it sends.
- `JobWorkerBuilderImplTest`: builder forwards the configured flag down to the poller's command.

### Not in scope (tracked separately, blocked on #54845)
- Lease token generation and the activate-side guard.
- End-to-end acceptance criteria requiring a non-null `leaseToken` after `withLease(true)`.
- "Spec validated with CamundaEx" (issue note) — a cross-team process step, needs a human.

## Test plan
- [x] `./mvnw verify -pl zeebe/gateway-grpc -Dtest=RequestMapperTest`
- [x] `./mvnw verify -pl gateways/gateway-mapping-http -Dtest=RequestMapperTest`
- [x] `./mvnw verify -pl clients/java -Dtest=ActivateJobsTest,ActivateJobsRestTest,JobPollerImplTest,JobWorkerBuilderImplTest`
- [x] `./mvnw install -Dquickly -T1C` (full repo compile)
