### PR TITLE
feat: add MySQL 9.7 (LTS) to test matrix

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -45,6 +45,7 @@ postgresql:
 
 mysql:
   - "8.4"
+  - "9.7"
 
 mariadb:
   - "10.11"

--- a/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
+++ b/.github/workflows/c8-orchestration-cluster-e2e-tests-release.yml
@@ -509,6 +509,12 @@ jobs:
             jdbc-url: "jdbc:mysql://localhost:3306/camunda"
             jdbc-username: "camunda"
             jdbc-password: "camunda"
+          - database-name: "MySQL 9.7"
+            database-type: "mysql"
+            database-image-version: "9.7"
+            jdbc-url: "jdbc:mysql://localhost:3306/camunda"
+            jdbc-username: "camunda"
+            jdbc-password: "camunda"
           # MariaDB
           - database-name: "MariaDB 10.11"
             database-type: "mariadb"
@@ -668,7 +674,7 @@ jobs:
             mysql)
               echo "Installing MySQL driver"
               curl -L -o dev-dist/lib/mysql-connector.jar \
-                https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.4.0/mysql-connector-j-8.4.0.jar
+                https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.7.0/mysql-connector-j-9.7.0.jar
               ;;
 
             mariadb)

--- a/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
+++ b/.github/workflows/c8-orchestration-cluster-reusable-rdbms-api-tests.yml
@@ -118,6 +118,12 @@ jobs:
             jdbc-url: "jdbc:mysql://localhost:3306/camunda"
             jdbc-username: "camunda"
             jdbc-password: "camunda"
+          - database-name: "MySQL 9.7"
+            database-type: "mysql"
+            database-image-version: "9.7"
+            jdbc-url: "jdbc:mysql://localhost:3306/camunda"
+            jdbc-username: "camunda"
+            jdbc-password: "camunda"
           # MariaDB
           - database-name: "MariaDB 10.11"
             database-type: "mariadb"
@@ -260,7 +266,7 @@ jobs:
             mysql)
               echo "Installing MySQL driver"
               curl -L -o dev-dist/lib/mysql-connector.jar \
-                https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.4.0/mysql-connector-j-8.4.0.jar
+                https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.7.0/mysql-connector-j-9.7.0.jar
               ;;
             mariadb)
               echo "Installing MariaDB driver"

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - ./docker-compose-init/02-grant-camunda-create-mysql.sql:/docker-entrypoint-initdb.d/02-grant-camunda-create-mysql.sql:ro
 
   mysql:
-    image: mysql:${IMAGE_VERSION:-9.6}
+    image: mysql:${IMAGE_VERSION:-9.7}
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: example

--- a/load-tests/setup/main/values/camunda-platform-values-mysql.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-mysql.yaml
@@ -38,7 +38,7 @@ orchestration:
         - sh
         - -c
         - >
-          wget https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.6.0/mysql-connector-j-9.6.0.jar
+          wget https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.7.0/mysql-connector-j-9.7.0.jar
           -O /driver-lib/mysql-driver.jar
       volumeMounts:
         - name: jdbcdrivers

--- a/load-tests/setup/stable-89/values/camunda-platform-values-mysql.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-mysql.yaml
@@ -38,7 +38,7 @@ orchestration:
         - sh
         - -c
         - >
-          wget https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.6.0/mysql-connector-j-9.6.0.jar
+          wget https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/9.7.0/mysql-connector-j-9.7.0.jar
           -O /driver-lib/mysql-driver.jar
       volumeMounts:
         - name: jdbcdrivers

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/testcontainers/TestSearchContainers.java
@@ -34,7 +34,7 @@ public final class TestSearchContainers {
       DockerImageName.parse("postgres").withTag("15.3-alpine");
   private static final DockerImageName MARIADB_IMAGE =
       DockerImageName.parse("mariadb").withTag("12.3");
-  private static final DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql").withTag("8.4");
+  private static final DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql").withTag("9.7");
   private static final DockerImageName MSSQLSERVER_IMAGE =
       DockerImageName.parse("mcr.microsoft.com/mssql/server").withTag("2022-latest");
   private static final DockerImageName ORACLE_IMAGE =


### PR DESCRIPTION
Adds MySQL 9.7 LTS (released 2026-04-21, EOL 2034-04-21) to the RDBMS test matrix alongside the existing 8.4 LTS entry.

Closes #56839

## Changes

- `.ci/db-versions.yml` — adds `9.7`; auto-creates a second matrix job in `zeebe-rdbms-integration-tests.yml`
- Both orchestration cluster workflows — hardcoded matrices updated with explicit `MySQL 9.7` entries; Connector/J JAR download bumped from `8.4.0` to `9.7.0` (Spring Boot 4.1 BOM already manages `9.7.0` for Maven builds)
- `TestSearchContainers.java` — Testcontainers image bumped to `9.7`, following the `MARIADB_IMAGE` pattern (newest LTS in Testcontainers, all versions covered by docker-compose matrix)
- Load test Helm values — connector download `9.6.0` → `9.7.0`
- `db/docker-compose.yml` — local-dev default `9.6` → `9.7`

## Compatibility

No Java or SQL changes required. Key 8.4→9.7 breaking changes assessed:

| Change | Impact |
|---|---|
| `mysql_native_password` removed (9.0) | None — no references in codebase |
| Inline FK enforcement (9.0) | None — Liquibase uses explicit `CONSTRAINT … FOREIGN KEY` |
| `INSERT IGNORE` / `ER_SUBQUERY_NO_1_ROW` (9.0) | None — `VariableMapper.xml` uses `INSERT IGNORE … VALUES`, not a correlated subquery |
| Connector/J default auth → `caching_sha2_password` | None — Spring Boot 4.1 BOM already at Connector/J 9.7.0 |