### PR TITLE
test: add cross-backend parity assertions for search tests

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/DecisionInstanceSearchIT.java
@@ -873,6 +873,57 @@ class DecisionInstanceSearchIT {
             "'%s' is not a valid decision evaluation instance key".formatted(decisionInstanceId));
   }
 
+  @Test
+  void shouldFilterByTenantIdReturnsAllInstances() {
+    // when
+    final var result =
+        camundaClient
+            .newDecisionInstanceSearchRequest()
+            .filter(f -> f.tenantId("<default>"))
+            .page(p -> p.limit(10))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.page().totalItems()).isEqualTo(5);
+    assertThat(result.items()).allMatch(di -> "<default>".equals(di.getTenantId()));
+  }
+
+  @Test
+  void shouldReturnEmptyForNonExistentDecisionDefinitionId() {
+    // when
+    final var result =
+        camundaClient
+            .newDecisionInstanceSearchRequest()
+            .filter(f -> f.decisionDefinitionId("non-existent-definition-id"))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldSortByEvaluationDateAscProducesChronologicalOrder() {
+    // when
+    final var result =
+        camundaClient
+            .newDecisionInstanceSearchRequest()
+            .sort(s -> s.evaluationDate().asc())
+            .page(p -> p.limit(10))
+            .send()
+            .join();
+
+    // then - each evaluationDate must not be after the next
+    final var dates = result.items().stream().map(DecisionInstance::getEvaluationDate).toList();
+    assertThat(dates).hasSizeGreaterThanOrEqualTo(2);
+    for (int i = 0; i < dates.size() - 1; i++) {
+      assertThat(dates.get(i))
+          .as("evaluationDate at index %d should not be after index %d", i, i + 1)
+          .isBeforeOrEqualTo(dates.get(i + 1));
+    }
+  }
+
   private static EvaluateDecisionResponse evaluateDecision(
       final CamundaClient camundaClient,
       final String decisionDefinitionId,

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/IncidentSearchIT.java
@@ -575,6 +575,61 @@ class IncidentSearchIT {
   }
 
   @Test
+  void shouldReturnEmptyForNonExistentIncidentKey() {
+    // when
+    final var result =
+        camundaClient
+            .newIncidentSearchRequest()
+            .filter(f -> f.incidentKey(Long.MAX_VALUE))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyWhenFiltersAreContradictory() {
+    // incident_process_v1 incidents have EXTRACT_VALUE_ERROR type, not JOB_NO_RETRIES;
+    // combining both predicates is impossible, so AND semantics must yield no results
+    // when
+    final var result =
+        camundaClient
+            .newIncidentSearchRequest()
+            .filter(
+                f ->
+                    f.processDefinitionId(incident.getProcessDefinitionId())
+                        .errorType(IncidentErrorType.JOB_NO_RETRIES))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldNarrowResultsWhenCombiningFilters() {
+    // state=ACTIVE alone returns 4 incidents; processDefinitionId=incident_process_v1 returns 3;
+    // AND of both must return 3 (the incident_process_v1 subset, which are all ACTIVE)
+    // when
+    final var result =
+        camundaClient
+            .newIncidentSearchRequest()
+            .filter(
+                f ->
+                    f.state(IncidentState.ACTIVE)
+                        .processDefinitionId(incident.getProcessDefinitionId()))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(3);
+    assertThat(result.items())
+        .allMatch(i -> i.getProcessDefinitionId().equals(incident.getProcessDefinitionId()));
+    assertThat(result.items()).extracting(Incident::getState).containsOnly(ACTIVE);
+  }
+
+  @Test
   void shouldSearchByFromWithLimit() {
     // when
     final var resultAll = camundaClient.newIncidentSearchRequest().send().join();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/JobSearchIT.java
@@ -1238,6 +1238,49 @@ public class JobSearchIT {
         .isEqualTo(taskABpmnJob.getLastUpdateTime());
   }
 
+  @Test
+  void shouldReturnEmptyForNonExistentJobKey() {
+    // when
+    final var result =
+        camundaClient.newJobSearchRequest().filter(f -> f.jobKey(Long.MAX_VALUE)).send().join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldNarrowResultsWhenCombiningTypeAndStateFilters() {
+    // type=taskABpmn alone returns 1; state=COMPLETED alone returns 5;
+    // AND of both must return 1 (taskABpmn is COMPLETED)
+    // when
+    final var result =
+        camundaClient
+            .newJobSearchRequest()
+            .filter(f -> f.type(o -> o.eq("taskABpmn")).state(o -> o.eq(JobState.COMPLETED)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getType()).isEqualTo("taskABpmn");
+    assertThat(result.items().getFirst().getState()).isEqualTo(JobState.COMPLETED);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenTypeAndStateAreContradictory() {
+    // taskABpmn is COMPLETED; filtering for it with state=CREATED is impossible
+    // when
+    final var result =
+        camundaClient
+            .newJobSearchRequest()
+            .filter(f -> f.type(o -> o.eq("taskABpmn")).state(o -> o.eq(JobState.CREATED)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
   private static void waitUntilNewJobHasBeenCreated(final int expectedCount) {
     Awaitility.await("should wait until job has been created")
         .atMost(TIMEOUT_DATA_AVAILABILITY)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -1508,6 +1508,96 @@ public class ProcessInstanceSearchIT {
   }
 
   @Test
+  void shouldFilterByTenantIdAloneReturnsAllInstances() {
+    // given - all seeded instances belong to the default tenant
+    final int expectedTotal = PROCESS_INSTANCES.size() + 1; // +1 for spawned child_process_v1
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.tenantId("<default>"))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(expectedTotal);
+    assertThat(result.items()).allMatch(pi -> "<default>".equals(pi.getTenantId()));
+  }
+
+  @Test
+  void shouldReturnEmptyForNonExistentProcessDefinitionId() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(b -> b.eq("non-existent-process-id")))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldCombineStateAndProcessDefinitionIdFilterToNarrowResults() {
+    // given
+    final long expectedKey =
+        PROCESS_INSTANCES.stream()
+            .filter(p -> Objects.equals("service_tasks_v2", p.getBpmnProcessId()))
+            .findFirst()
+            .orElseThrow()
+            .getProcessInstanceKey();
+
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.state(ACTIVE).processDefinitionId(b -> b.eq("service_tasks_v2")))
+            .send()
+            .join();
+
+    // then - AND semantics: both predicates must match simultaneously
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getProcessInstanceKey()).isEqualTo(expectedKey);
+    assertThat(result.items().getFirst().getState()).isEqualTo(ACTIVE);
+  }
+
+  @Test
+  void shouldReturnEmptyWhenStateAndProcessDefinitionIdAreContradictory() {
+    // service_tasks_v2 has only ACTIVE instances; COMPLETED + service_tasks_v2 is impossible
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.state(COMPLETED).processDefinitionId(b -> b.eq("service_tasks_v2")))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldSortByStartDateAscProducesChronologicalOrder() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .sort(s -> s.startDate().asc())
+            .send()
+            .join();
+
+    // then - each startDate must not be after the next
+    final var startDates = result.items().stream().map(ProcessInstance::getStartDate).toList();
+    for (int i = 0; i < startDates.size() - 1; i++) {
+      assertThat(startDates.get(i))
+          .as("startDate at index %d should not be after index %d", i, i + 1)
+          .isBeforeOrEqualTo(startDates.get(i + 1));
+    }
+  }
+
+  @Test
   void shouldReturnEmptyResultForIncorrectIncidentErrorHashCode() {
     final var result =
         camundaClient

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchIT.java
@@ -1517,11 +1517,12 @@ public class ProcessInstanceSearchIT {
         camundaClient
             .newProcessInstanceSearchRequest()
             .filter(f -> f.tenantId("<default>"))
+            .page(p -> p.limit(100))
             .send()
             .join();
 
     // then
-    assertThat(result.items()).hasSize(expectedTotal);
+    assertThat(result.page().totalItems()).isEqualTo(expectedTotal);
     assertThat(result.items()).allMatch(pi -> "<default>".equals(pi.getTenantId()));
   }
 
@@ -1585,11 +1586,13 @@ public class ProcessInstanceSearchIT {
         camundaClient
             .newProcessInstanceSearchRequest()
             .sort(s -> s.startDate().asc())
+            .page(p -> p.limit(100))
             .send()
             .join();
 
     // then - each startDate must not be after the next
     final var startDates = result.items().stream().map(ProcessInstance::getStartDate).toList();
+    assertThat(startDates).hasSizeGreaterThanOrEqualTo(2);
     for (int i = 0; i < startDates.size() - 1; i++) {
       assertThat(startDates.get(i))
           .as("startDate at index %d should not be after index %d", i, i + 1)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableSearchIT.java
@@ -385,6 +385,35 @@ class VariableSearchIT {
     assertThat(resultSearchFrom.items().size()).isEqualTo(6);
   }
 
+  @Test
+  void shouldReturnEmptyForNonExistentVariableKey() {
+    // when
+    final var result =
+        camundaClient
+            .newVariableSearchRequest()
+            .filter(f -> f.variableKey(Long.MAX_VALUE))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+
+  @Test
+  void shouldSortByNameDescProducesReverseAlphabeticalOrder() {
+    // when
+    final var resultAsc =
+        camundaClient.newVariableSearchRequest().sort(s -> s.name().asc()).send().join();
+    final var resultDesc =
+        camundaClient.newVariableSearchRequest().sort(s -> s.name().desc()).send().join();
+
+    // then - desc must be exact reverse of asc
+    final var namesAsc = resultAsc.items().stream().map(Variable::getName).toList();
+    final var namesDesc = resultDesc.items().stream().map(Variable::getName).toList();
+    assertThat(namesAsc).isSorted();
+    assertThat(namesDesc).isEqualTo(namesAsc.reversed());
+  }
+
   private static void waitForTasksBeingExported() {
     Awaitility.await("should receive data from ES")
         .atMost(TIMEOUT_DATA_AVAILABILITY)


### PR DESCRIPTION
## Summary

Claude helped identify some gaps in our search tests, so adding them here across various entity search endpoints