### PR TITLE
Migrate Optimize user entities on SaaS login-method change

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/auth/JwtDecoderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/auth/JwtDecoderIT.java
@@ -246,7 +246,13 @@ public class JwtDecoderIT extends AbstractCCSMIT {
     if ("SaaS".equalsIgnoreCase(type)) {
       configurerAdapter =
           new CCSaaSSecurityConfigurerAdapter(
-              embeddedOptimizeExtension.getConfigurationService(), null, null, null, null, null);
+              embeddedOptimizeExtension.getConfigurationService(),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null);
     } else if ("CCSM".equalsIgnoreCase(type)) {
       configurerAdapter =
           new CCSMSecurityConfigurerAdapter(

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/security/UserIdMigrationIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/security/UserIdMigrationIT.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.security;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.given;
+
+import io.camunda.optimize.AbstractCCSMIT;
+import io.camunda.optimize.dto.optimize.query.collection.CollectionDefinitionDto;
+import io.camunda.optimize.dto.optimize.query.collection.CollectionEntity;
+import io.camunda.optimize.dto.optimize.query.collection.PartialCollectionDefinitionRequestDto;
+import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.optimize.service.db.reader.CollectionReader;
+import io.camunda.optimize.service.db.reader.EntitiesReader;
+import io.camunda.optimize.service.db.repository.UserIdMigrationRepository;
+import io.camunda.optimize.service.db.writer.CollectionWriter;
+import io.camunda.optimize.service.db.writer.ReportWriter;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration tests for {@link UserIdMigrationService} / {@link UserIdMigrationRepository}.
+ *
+ * <p>Scenario: a SaaS user changes their SSO login method. The Accounts API assigns a new {@code
+ * user_id}; the old one is stored in {@code app_metadata.originalUserId} and surfaced in the OIDC
+ * token. On the next login Optimize detects the claim and migrates all owned entities to the new
+ * ID.
+ *
+ * <p>Collection ownership/roles are asserted via {@link CollectionReader}, not {@link
+ * EntitiesReader}: {@code EntitiesReader.getAllPrivateEntitiesForOwnerId} only covers reports and
+ * dashboards (it explicitly excludes documents that have a collection ID), never the collection
+ * index itself.
+ */
+public class UserIdMigrationIT extends AbstractCCSMIT {
+
+  private static final String OLD_USER_ID = "old-sso-user-id";
+  private static final String NEW_USER_ID = "new-sso-user-id";
+
+  /**
+   * Happy path: collection owner and embedded role are rewritten; old ID disappears from all
+   * indices.
+   */
+  @Test
+  void migratesCollectionOwnershipAndRolesOnUserIdChange() {
+    final CollectionWriter collectionWriter =
+        embeddedOptimizeExtension.getBean(CollectionWriter.class);
+    final CollectionReader collectionReader =
+        embeddedOptimizeExtension.getBean(CollectionReader.class);
+    final UserIdMigrationRepository repository =
+        embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
+
+    // the creator is automatically added as a MANAGER role on the collection, so no explicit
+    // addRoleToCollection call is needed to have a role entry referencing OLD_USER_ID
+    final String collectionId =
+        collectionWriter
+            .createNewCollectionAndReturnId(
+                OLD_USER_ID, new PartialCollectionDefinitionRequestDto("Migration Test"))
+            .getId();
+
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    CollectionDefinitionDto collection = collectionReader.getCollection(collectionId).orElseThrow();
+    assertThat(collection.getOwner()).isEqualTo(OLD_USER_ID);
+    assertThat(collection.getData().getRoles())
+        .extracting(role -> role.getIdentity().getId())
+        .contains(OLD_USER_ID);
+    assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isTrue();
+
+    repository.migrateUserId(OLD_USER_ID, NEW_USER_ID);
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isFalse();
+    collection = collectionReader.getCollection(collectionId).orElseThrow();
+    assertThat(collection.getOwner()).isEqualTo(NEW_USER_ID);
+    assertThat(collection.getData().getRoles())
+        .extracting(role -> role.getIdentity().getId())
+        .contains(NEW_USER_ID)
+        .doesNotContain(OLD_USER_ID);
+  }
+
+  /**
+   * Report owner and lastModifier fields are migrated on entity indices that have no nested roles.
+   */
+  @Test
+  void migratesReportOwnerOnUserIdChange() {
+    final ReportWriter reportWriter = embeddedOptimizeExtension.getBean(ReportWriter.class);
+    final EntitiesReader entitiesReader = embeddedOptimizeExtension.getBean(EntitiesReader.class);
+    final UserIdMigrationRepository repository =
+        embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
+
+    final String reportId =
+        reportWriter
+            .createNewSingleProcessReport(
+                OLD_USER_ID, new ProcessReportDataDto(), "Migration Test Report", null, null)
+            .getId();
+
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    assertThat(entitiesReader.getAllPrivateEntitiesForOwnerId(OLD_USER_ID))
+        .extracting(CollectionEntity::getId)
+        .containsExactly(reportId);
+    assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isTrue();
+
+    repository.migrateUserId(OLD_USER_ID, NEW_USER_ID);
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isFalse();
+    assertThat(entitiesReader.getAllPrivateEntitiesForOwnerId(NEW_USER_ID))
+        .extracting(CollectionEntity::getId)
+        .containsExactly(reportId);
+    assertThat(entitiesReader.getAllPrivateEntitiesForOwnerId(OLD_USER_ID)).isEmpty();
+  }
+
+  /**
+   * The Painless scripts themselves are safe to reapply: re-running {@link
+   * UserIdMigrationRepository#migrateUserId} after the old ID is already gone is a no-op, since
+   * every script is guarded by an {@code == params.oldId} check on the current document state. The
+   * count-guard that skips the repository call entirely lives in {@link UserIdMigrationService} and
+   * is covered separately by {@link #asyncMigrationViaServiceCompletesBeforeNextLoginCheck}.
+   */
+  @Test
+  void repeatedMigrationOfSameUserIdIsANoOp() {
+    final CollectionWriter collectionWriter =
+        embeddedOptimizeExtension.getBean(CollectionWriter.class);
+    final CollectionReader collectionReader =
+        embeddedOptimizeExtension.getBean(CollectionReader.class);
+    final UserIdMigrationRepository repository =
+        embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
+
+    final String collectionId =
+        collectionWriter
+            .createNewCollectionAndReturnId(
+                OLD_USER_ID, new PartialCollectionDefinitionRequestDto("Idempotency Test"))
+            .getId();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    repository.migrateUserId(OLD_USER_ID, NEW_USER_ID);
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isFalse();
+
+    // old ID already absent from all indices; scripts find no matching documents and no-op
+    repository.migrateUserId(OLD_USER_ID, NEW_USER_ID);
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    assertThat(collectionReader.getCollection(collectionId).orElseThrow().getOwner())
+        .isEqualTo(NEW_USER_ID);
+  }
+
+  /**
+   * The async path via {@link UserIdMigrationService}: fire-and-forget resolves before the next
+   * login's {@link UserIdMigrationRepository#hasDocumentsWithUserId} check would see the old ID.
+   * {@code UserIdMigrationService} is {@code @Conditional(CCSaaSCondition.class)} and therefore not
+   * in the Spring context during IT runs; it is instantiated directly here.
+   */
+  @Test
+  void asyncMigrationViaServiceCompletesBeforeNextLoginCheck() {
+    final CollectionWriter collectionWriter =
+        embeddedOptimizeExtension.getBean(CollectionWriter.class);
+    final CollectionReader collectionReader =
+        embeddedOptimizeExtension.getBean(CollectionReader.class);
+    final UserIdMigrationRepository repository =
+        embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
+
+    final String collectionId =
+        collectionWriter
+            .createNewCollectionAndReturnId(
+                OLD_USER_ID, new PartialCollectionDefinitionRequestDto("Async Migration Test"))
+            .getId();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isTrue();
+
+    final UserIdMigrationService service = new UserIdMigrationService(repository);
+    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+
+    given()
+        .timeout(30, SECONDS)
+        .pollInterval(200, MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+              assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isFalse();
+              assertThat(collectionReader.getCollection(collectionId).orElseThrow().getOwner())
+                  .isEqualTo(NEW_USER_ID);
+            });
+  }
+
+  /**
+   * Simulates a logout/login while a migration is still running for the same old user ID: the
+   * second {@link UserIdMigrationService#migrateUserIdIfNeeded} call must be a no-op rather than
+   * firing a second, redundant {@code _update_by_query} pass. The in-progress flag is set
+   * synchronously on the caller's thread before the async task is scheduled, so calling twice
+   * back-to-back deterministically exercises the dedup path regardless of execution speed.
+   */
+  @Test
+  void concurrentLoginsForSameOldUserIdMigrateOnlyOnce() {
+    final CollectionWriter collectionWriter =
+        embeddedOptimizeExtension.getBean(CollectionWriter.class);
+    final CollectionReader collectionReader =
+        embeddedOptimizeExtension.getBean(CollectionReader.class);
+    final UserIdMigrationRepository repository =
+        embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
+
+    final String collectionId =
+        collectionWriter
+            .createNewCollectionAndReturnId(
+                OLD_USER_ID, new PartialCollectionDefinitionRequestDto("Dedup Test"))
+            .getId();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    final AtomicInteger migrateInvocations = new AtomicInteger();
+    final UserIdMigrationRepository countingRepository =
+        new UserIdMigrationRepository() {
+          @Override
+          public boolean hasDocumentsWithUserId(final String userId) {
+            return repository.hasDocumentsWithUserId(userId);
+          }
+
+          @Override
+          public void migrateUserId(final String oldUserId, final String newUserId) {
+            migrateInvocations.incrementAndGet();
+            repository.migrateUserId(oldUserId, newUserId);
+          }
+        };
+
+    final UserIdMigrationService service = new UserIdMigrationService(countingRepository);
+    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+
+    given()
+        .timeout(30, SECONDS)
+        .pollInterval(200, MILLISECONDS)
+        .untilAsserted(
+            () -> {
+              databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+              assertThat(repository.hasDocumentsWithUserId(OLD_USER_ID)).isFalse();
+              assertThat(collectionReader.getCollection(collectionId).orElseThrow().getOwner())
+                  .isEqualTo(NEW_USER_ID);
+            });
+
+    assertThat(migrateInvocations).hasValue(1);
+  }
+
+  /**
+   * Reproduces the multi-hop scenario from issue #34982: a user changes their SSO login method
+   * twice. As long as each login-triggered migration completes before the next login-method change
+   * happens, entities created under every prior identity remain visible under the current one — the
+   * entity created as the very first identity, migrated twice (v1→v2→v3), and the entity created as
+   * the second identity, migrated once (v2→v3), are both owned by the final ID.
+   */
+  @Test
+  void entitiesFromBothOldIdsAreVisibleAfterTwoSequentialLoginMethodChanges() {
+    final CollectionWriter collectionWriter =
+        embeddedOptimizeExtension.getBean(CollectionWriter.class);
+    final CollectionReader collectionReader =
+        embeddedOptimizeExtension.getBean(CollectionReader.class);
+    final UserIdMigrationRepository repository =
+        embeddedOptimizeExtension.getBean(UserIdMigrationRepository.class);
+
+    final String firstUserId = "sso-user-v1";
+    final String secondUserId = "sso-user-v2";
+    final String thirdUserId = "sso-user-v3";
+
+    // user creates an entity under their first identity
+    final String firstCollectionId =
+        collectionWriter
+            .createNewCollectionAndReturnId(
+                firstUserId, new PartialCollectionDefinitionRequestDto("Created as v1"))
+            .getId();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // first SSO login-method change: v1 -> v2, triggered on that login
+    repository.migrateUserId(firstUserId, secondUserId);
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+    assertThat(collectionReader.getCollection(firstCollectionId).orElseThrow().getOwner())
+        .isEqualTo(secondUserId);
+
+    // user creates a second entity under their new (second) identity
+    final String secondCollectionId =
+        collectionWriter
+            .createNewCollectionAndReturnId(
+                secondUserId, new PartialCollectionDefinitionRequestDto("Created as v2"))
+            .getId();
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // second SSO login-method change: v2 -> v3, triggered on that login
+    repository.migrateUserId(secondUserId, thirdUserId);
+    databaseIntegrationTestExtension.refreshAllOptimizeIndices();
+
+    // the final identity owns both entities, regardless of which prior identity created them
+    assertThat(collectionReader.getCollection(firstCollectionId).orElseThrow().getOwner())
+        .isEqualTo(thirdUserId);
+    assertThat(collectionReader.getCollection(secondCollectionId).orElseThrow().getOwner())
+        .isEqualTo(thirdUserId);
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
@@ -30,6 +30,7 @@ import io.camunda.optimize.rest.security.oauth.ScopeValidator;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.security.AuthCookieService;
 import io.camunda.optimize.service.security.SessionService;
+import io.camunda.optimize.service.security.UserIdMigrationService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.CCSaaSCondition;
 import io.camunda.optimize.service.util.configuration.security.CloudAuthConfiguration;
@@ -85,12 +86,14 @@ import org.springframework.web.util.UriComponentsBuilder;
 public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerAdapter {
 
   public static final String CAMUNDA_CLUSTER_ID_CLAIM_NAME = "https://camunda.com/clusterId";
+  private static final String ORIGINAL_USER_ID_CLAIM = "https://camunda.com/originalUserId";
 
   private static final Logger LOG = LoggerFactory.getLogger(CCSaaSSecurityConfigurerAdapter.class);
   private static final List<String> ALLOWED_ORG_ROLES =
       Arrays.asList("admin", "analyst", "owner", "supportagent");
   private final ClientRegistrationRepository clientRegistrationRepository;
   private final OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
+  private final UserIdMigrationService userIdMigrationService;
 
   public CCSaaSSecurityConfigurerAdapter(
       final ConfigurationService configurationService,
@@ -98,7 +101,8 @@ public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerA
       final SessionService sessionService,
       final AuthCookieService authCookieService,
       final ClientRegistrationRepository clientRegistrationRepository,
-      final OAuth2AuthorizedClientService oAuth2AuthorizedClientService) {
+      final OAuth2AuthorizedClientService oAuth2AuthorizedClientService,
+      final UserIdMigrationService userIdMigrationService) {
     super(
         configurationService,
         preAuthenticatedAuthenticationProvider,
@@ -106,6 +110,7 @@ public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerA
         authCookieService);
     this.clientRegistrationRepository = clientRegistrationRepository;
     this.oAuth2AuthorizedClientService = oAuth2AuthorizedClientService;
+    this.userIdMigrationService = userIdMigrationService;
   }
 
   @Bean
@@ -307,6 +312,11 @@ public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerA
       final String sessionToken = sessionService.createAuthToken(userId);
 
       if (hasAccess(user)) {
+        final String originalUserId = user.getIdToken().getClaim(ORIGINAL_USER_ID_CLAIM);
+        if (originalUserId != null && !originalUserId.equals(userId)) {
+          userIdMigrationService.migrateUserIdIfNeeded(userId, originalUserId);
+        }
+
         // spring security internally stores the access token as an authorized client, we retrieve
         // it here to store it
         // in a cookie to allow potential other Optimize webapps to reuse it and keep the server

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/cloud/CCSaaSSecurityConfigurerAdapter.java
@@ -312,8 +312,8 @@ public class CCSaaSSecurityConfigurerAdapter extends AbstractSecurityConfigurerA
       final String sessionToken = sessionService.createAuthToken(userId);
 
       if (hasAccess(user)) {
-        final String originalUserId = user.getIdToken().getClaim(ORIGINAL_USER_ID_CLAIM);
-        if (originalUserId != null && !originalUserId.equals(userId)) {
+        if (user.getIdToken().getClaim(ORIGINAL_USER_ID_CLAIM) instanceof String originalUserId
+            && !originalUserId.equals(userId)) {
           userIdMigrationService.migrateUserIdIfNeeded(userId, originalUserId);
         }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/UserIdMigrationRepository.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/UserIdMigrationRepository.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository;
+
+/**
+ * Checks whether any Optimize entity document references the given user ID, and rewrites all
+ * occurrences from oldUserId to newUserId across every entity-owning index.
+ */
+public interface UserIdMigrationRepository {
+
+  /**
+   * Returns true if at least one document in any entity index still references the given user ID
+   * (as owner, lastModifier, or collection role member). Used to skip the migration when it has
+   * already been applied.
+   */
+  boolean hasDocumentsWithUserId(String userId);
+
+  /**
+   * Rewrites every occurrence of oldUserId to newUserId across all entity-owning indices:
+   * collection role membership, owner, and lastModifier fields.
+   */
+  void migrateUserId(String oldUserId, String newUserId);
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/UserIdMigrationRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/UserIdMigrationRepositoryES.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.es;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ALERT_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.COLLECTION_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.COMBINED_REPORT_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.DASHBOARD_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_DECISION_REPORT_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_PROCESS_REPORT_INDEX_NAME;
+import static io.camunda.optimize.service.db.es.writer.ElasticsearchWriterUtil.createDefaultScriptWithPrimitiveParams;
+
+import co.elastic.clients.elasticsearch._types.Script;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.ChildScoreMode;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.json.JsonData;
+import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
+import io.camunda.optimize.service.db.repository.UserIdMigrationRepository;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.io.IOException;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticSearchCondition.class)
+public class UserIdMigrationRepositoryES implements UserIdMigrationRepository {
+
+  private static final String[] ALL_ENTITY_INDICES = {
+    COLLECTION_INDEX_NAME,
+    SINGLE_PROCESS_REPORT_INDEX_NAME,
+    SINGLE_DECISION_REPORT_INDEX_NAME,
+    COMBINED_REPORT_INDEX_NAME,
+    DASHBOARD_INDEX_NAME,
+    ALERT_INDEX_NAME
+  };
+
+  private static final String MIGRATE_COLLECTION_ROLES_SCRIPT =
+      "for (def role : ctx._source.data.roles) {"
+          + "  if (role.identity.id == params.oldId) {"
+          + "    role.identity.id = params.newId;"
+          + "    role.id = 'USER:' + params.newId;"
+          + "  }"
+          + "}";
+
+  private static final String MIGRATE_OWNER_SCRIPT =
+      "if (ctx._source.owner == params.oldId) { ctx._source.owner = params.newId; }"
+          + "if (ctx._source.lastModifier == params.oldId) { ctx._source.lastModifier = params.newId; }";
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(UserIdMigrationRepositoryES.class);
+
+  private final OptimizeElasticsearchClient esClient;
+  private final TaskRepositoryES taskRepository;
+
+  public UserIdMigrationRepositoryES(
+      final OptimizeElasticsearchClient esClient, final TaskRepositoryES taskRepository) {
+    this.esClient = esClient;
+    this.taskRepository = taskRepository;
+  }
+
+  @Override
+  public boolean hasDocumentsWithUserId(final String userId) {
+    try {
+      return esClient.count(ALL_ENTITY_INDICES, buildUserIdBoolQuery(userId)) > 0;
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException(
+          "Failed to check for documents with user ID: " + userId, e);
+    }
+  }
+
+  @Override
+  public void migrateUserId(final String oldUserId, final String newUserId) {
+    LOG.info("Migrating Optimize entities from user ID [{}] to [{}]", oldUserId, newUserId);
+    final Map<String, JsonData> params =
+        Map.of("oldId", JsonData.of(oldUserId), "newId", JsonData.of(newUserId));
+
+    final Script rolesScript =
+        createDefaultScriptWithPrimitiveParams(MIGRATE_COLLECTION_ROLES_SCRIPT, params);
+    final Query rolesQuery = buildCollectionRolesQuery(oldUserId);
+    taskRepository.tryUpdateByQueryRequest(
+        "collection roles for user " + oldUserId, rolesScript, rolesQuery, COLLECTION_INDEX_NAME);
+
+    final Script ownerScript = createDefaultScriptWithPrimitiveParams(MIGRATE_OWNER_SCRIPT, params);
+    final Query ownerQuery = buildOwnerLastModifierQuery(oldUserId);
+    taskRepository.tryUpdateByQueryRequest(
+        "owner/lastModifier for user " + oldUserId, ownerScript, ownerQuery, ALL_ENTITY_INDICES);
+
+    LOG.info("Migration of entities for user [{}] to [{}] complete", oldUserId, newUserId);
+  }
+
+  private BoolQuery.Builder buildUserIdBoolQuery(final String userId) {
+    return new BoolQuery.Builder()
+        .should(
+            s ->
+                s.nested(
+                    n ->
+                        // data.roles is only mapped on the collection index; ignoreUnmapped keeps
+                        // this nested clause from failing the count on the other 5 indices
+                        n.path("data.roles")
+                            .ignoreUnmapped(true)
+                            .scoreMode(ChildScoreMode.None)
+                            .query(
+                                qq ->
+                                    qq.term(t -> t.field("data.roles.identity.id").value(userId)))))
+        .should(s -> s.term(t -> t.field("owner").value(userId)))
+        .should(s -> s.term(t -> t.field("lastModifier").value(userId)))
+        .minimumShouldMatch("1");
+  }
+
+  private Query buildCollectionRolesQuery(final String userId) {
+    return Query.of(
+        q ->
+            q.nested(
+                n ->
+                    n.path("data.roles")
+                        .scoreMode(ChildScoreMode.None)
+                        .query(
+                            qq -> qq.term(t -> t.field("data.roles.identity.id").value(userId)))));
+  }
+
+  private Query buildOwnerLastModifierQuery(final String userId) {
+    return Query.of(
+        q ->
+            q.bool(
+                b ->
+                    b.should(s -> s.term(t -> t.field("owner").value(userId)))
+                        .should(s -> s.term(t -> t.field("lastModifier").value(userId)))
+                        .minimumShouldMatch("1")));
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/UserIdMigrationRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/UserIdMigrationRepositoryES.java
@@ -11,6 +11,7 @@ import static io.camunda.optimize.service.db.DatabaseConstants.ALERT_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.COLLECTION_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.COMBINED_REPORT_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.DASHBOARD_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_OVERVIEW_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_DECISION_REPORT_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_PROCESS_REPORT_INDEX_NAME;
 import static io.camunda.optimize.service.db.es.writer.ElasticsearchWriterUtil.createDefaultScriptWithPrimitiveParams;
@@ -40,7 +41,8 @@ public class UserIdMigrationRepositoryES implements UserIdMigrationRepository {
     SINGLE_DECISION_REPORT_INDEX_NAME,
     COMBINED_REPORT_INDEX_NAME,
     DASHBOARD_INDEX_NAME,
-    ALERT_INDEX_NAME
+    ALERT_INDEX_NAME,
+    PROCESS_OVERVIEW_INDEX_NAME
   };
 
   private static final String MIGRATE_COLLECTION_ROLES_SCRIPT =
@@ -104,7 +106,7 @@ public class UserIdMigrationRepositoryES implements UserIdMigrationRepository {
                 s.nested(
                     n ->
                         // data.roles is only mapped on the collection index; ignoreUnmapped keeps
-                        // this nested clause from failing the count on the other 5 indices
+                        // this nested clause from failing the count on the other 6 indices
                         n.path("data.roles")
                             .ignoreUnmapped(true)
                             .scoreMode(ChildScoreMode.None)

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/UserIdMigrationRepositoryES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/es/UserIdMigrationRepositoryES.java
@@ -23,6 +23,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.json.JsonData;
 import io.camunda.optimize.service.db.es.OptimizeElasticsearchClient;
 import io.camunda.optimize.service.db.repository.UserIdMigrationRepository;
+import io.camunda.optimize.service.db.repository.script.UserIdMigrationScriptFactory;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import java.io.IOException;
@@ -44,18 +45,6 @@ public class UserIdMigrationRepositoryES implements UserIdMigrationRepository {
     ALERT_INDEX_NAME,
     PROCESS_OVERVIEW_INDEX_NAME
   };
-
-  private static final String MIGRATE_COLLECTION_ROLES_SCRIPT =
-      "for (def role : ctx._source.data.roles) {"
-          + "  if (role.identity.id == params.oldId) {"
-          + "    role.identity.id = params.newId;"
-          + "    role.id = 'USER:' + params.newId;"
-          + "  }"
-          + "}";
-
-  private static final String MIGRATE_OWNER_SCRIPT =
-      "if (ctx._source.owner == params.oldId) { ctx._source.owner = params.newId; }"
-          + "if (ctx._source.lastModifier == params.oldId) { ctx._source.lastModifier = params.newId; }";
 
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(UserIdMigrationRepositoryES.class);
@@ -86,12 +75,15 @@ public class UserIdMigrationRepositoryES implements UserIdMigrationRepository {
         Map.of("oldId", JsonData.of(oldUserId), "newId", JsonData.of(newUserId));
 
     final Script rolesScript =
-        createDefaultScriptWithPrimitiveParams(MIGRATE_COLLECTION_ROLES_SCRIPT, params);
+        createDefaultScriptWithPrimitiveParams(
+            UserIdMigrationScriptFactory.createMigrateCollectionRolesScript(), params);
     final Query rolesQuery = buildCollectionRolesQuery(oldUserId);
     taskRepository.tryUpdateByQueryRequest(
         "collection roles for user " + oldUserId, rolesScript, rolesQuery, COLLECTION_INDEX_NAME);
 
-    final Script ownerScript = createDefaultScriptWithPrimitiveParams(MIGRATE_OWNER_SCRIPT, params);
+    final Script ownerScript =
+        createDefaultScriptWithPrimitiveParams(
+            UserIdMigrationScriptFactory.createMigrateOwnerScript(), params);
     final Query ownerQuery = buildOwnerLastModifierQuery(oldUserId);
     taskRepository.tryUpdateByQueryRequest(
         "owner/lastModifier for user " + oldUserId, ownerScript, ownerQuery, ALL_ENTITY_INDICES);

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/UserIdMigrationRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/UserIdMigrationRepositoryOS.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.os;
+
+import static io.camunda.optimize.service.db.DatabaseConstants.ALERT_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.COLLECTION_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.COMBINED_REPORT_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.DASHBOARD_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_DECISION_REPORT_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_PROCESS_REPORT_INDEX_NAME;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.nested;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.or;
+import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.term;
+import static io.camunda.optimize.service.db.os.writer.OpenSearchWriterUtil.createDefaultScriptWithPrimitiveParams;
+
+import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
+import io.camunda.optimize.service.db.repository.UserIdMigrationRepository;
+import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.io.IOException;
+import java.util.Map;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch._types.query_dsl.ChildScoreMode;
+import org.opensearch.client.opensearch._types.query_dsl.NestedQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpenSearchCondition.class)
+public class UserIdMigrationRepositoryOS implements UserIdMigrationRepository {
+
+  private static final String[] ALL_ENTITY_INDICES = {
+    COLLECTION_INDEX_NAME,
+    SINGLE_PROCESS_REPORT_INDEX_NAME,
+    SINGLE_DECISION_REPORT_INDEX_NAME,
+    COMBINED_REPORT_INDEX_NAME,
+    DASHBOARD_INDEX_NAME,
+    ALERT_INDEX_NAME
+  };
+
+  private static final String MIGRATE_COLLECTION_ROLES_SCRIPT =
+      "for (def role : ctx._source.data.roles) {"
+          + "  if (role.identity.id == params.oldId) {"
+          + "    role.identity.id = params.newId;"
+          + "    role.id = 'USER:' + params.newId;"
+          + "  }"
+          + "}";
+
+  private static final String MIGRATE_OWNER_SCRIPT =
+      "if (ctx._source.owner == params.oldId) { ctx._source.owner = params.newId; }"
+          + "if (ctx._source.lastModifier == params.oldId) { ctx._source.lastModifier = params.newId; }";
+
+  private static final Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(UserIdMigrationRepositoryOS.class);
+
+  private final OptimizeOpenSearchClient osClient;
+
+  public UserIdMigrationRepositoryOS(final OptimizeOpenSearchClient osClient) {
+    this.osClient = osClient;
+  }
+
+  @Override
+  public boolean hasDocumentsWithUserId(final String userId) {
+    try {
+      return osClient.count(ALL_ENTITY_INDICES, buildUserIdQuery(userId)) > 0;
+    } catch (final IOException e) {
+      throw new OptimizeRuntimeException(
+          "Failed to check for documents with user ID: " + userId, e);
+    }
+  }
+
+  @Override
+  public void migrateUserId(final String oldUserId, final String newUserId) {
+    LOG.info("Migrating Optimize entities from user ID [{}] to [{}]", oldUserId, newUserId);
+    final Map<String, JsonData> params =
+        Map.of("oldId", JsonData.of(oldUserId), "newId", JsonData.of(newUserId));
+
+    final Script rolesScript =
+        createDefaultScriptWithPrimitiveParams(MIGRATE_COLLECTION_ROLES_SCRIPT, params);
+    osClient.updateByQueryTask(
+        "collection roles for user " + oldUserId,
+        rolesScript,
+        buildCollectionRolesQuery(oldUserId),
+        COLLECTION_INDEX_NAME);
+
+    final Script ownerScript = createDefaultScriptWithPrimitiveParams(MIGRATE_OWNER_SCRIPT, params);
+    osClient.updateByQueryTask(
+        "owner/lastModifier for user " + oldUserId,
+        ownerScript,
+        buildOwnerLastModifierQuery(oldUserId),
+        ALL_ENTITY_INDICES);
+
+    LOG.info("Migration of entities for user [{}] to [{}] complete", oldUserId, newUserId);
+  }
+
+  private Query buildUserIdQuery(final String userId) {
+    // data.roles is only mapped on the collection index; ignoreUnmapped keeps this nested clause
+    // from failing the count on the other 5 indices
+    final Query rolesQuery =
+        NestedQuery.of(
+                n ->
+                    n.path("data.roles")
+                        .ignoreUnmapped(true)
+                        .scoreMode(ChildScoreMode.None)
+                        .query(term("data.roles.identity.id", userId)))
+            .toQuery();
+    return or(rolesQuery, term("owner", userId), term("lastModifier", userId));
+  }
+
+  private Query buildCollectionRolesQuery(final String userId) {
+    return nested("data.roles", term("data.roles.identity.id", userId), ChildScoreMode.None);
+  }
+
+  private Query buildOwnerLastModifierQuery(final String userId) {
+    return or(term("owner", userId), term("lastModifier", userId));
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/UserIdMigrationRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/UserIdMigrationRepositoryOS.java
@@ -21,6 +21,7 @@ import static io.camunda.optimize.service.db.os.writer.OpenSearchWriterUtil.crea
 
 import io.camunda.optimize.service.db.os.OptimizeOpenSearchClient;
 import io.camunda.optimize.service.db.repository.UserIdMigrationRepository;
+import io.camunda.optimize.service.db.repository.script.UserIdMigrationScriptFactory;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
 import java.io.IOException;
@@ -48,18 +49,6 @@ public class UserIdMigrationRepositoryOS implements UserIdMigrationRepository {
     PROCESS_OVERVIEW_INDEX_NAME
   };
 
-  private static final String MIGRATE_COLLECTION_ROLES_SCRIPT =
-      "for (def role : ctx._source.data.roles) {"
-          + "  if (role.identity.id == params.oldId) {"
-          + "    role.identity.id = params.newId;"
-          + "    role.id = 'USER:' + params.newId;"
-          + "  }"
-          + "}";
-
-  private static final String MIGRATE_OWNER_SCRIPT =
-      "if (ctx._source.owner == params.oldId) { ctx._source.owner = params.newId; }"
-          + "if (ctx._source.lastModifier == params.oldId) { ctx._source.lastModifier = params.newId; }";
-
   private static final Logger LOG =
       org.slf4j.LoggerFactory.getLogger(UserIdMigrationRepositoryOS.class);
 
@@ -86,14 +75,17 @@ public class UserIdMigrationRepositoryOS implements UserIdMigrationRepository {
         Map.of("oldId", JsonData.of(oldUserId), "newId", JsonData.of(newUserId));
 
     final Script rolesScript =
-        createDefaultScriptWithPrimitiveParams(MIGRATE_COLLECTION_ROLES_SCRIPT, params);
+        createDefaultScriptWithPrimitiveParams(
+            UserIdMigrationScriptFactory.createMigrateCollectionRolesScript(), params);
     osClient.updateByQueryTask(
         "collection roles for user " + oldUserId,
         rolesScript,
         buildCollectionRolesQuery(oldUserId),
         COLLECTION_INDEX_NAME);
 
-    final Script ownerScript = createDefaultScriptWithPrimitiveParams(MIGRATE_OWNER_SCRIPT, params);
+    final Script ownerScript =
+        createDefaultScriptWithPrimitiveParams(
+            UserIdMigrationScriptFactory.createMigrateOwnerScript(), params);
     osClient.updateByQueryTask(
         "owner/lastModifier for user " + oldUserId,
         ownerScript,

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/UserIdMigrationRepositoryOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/os/UserIdMigrationRepositoryOS.java
@@ -11,6 +11,7 @@ import static io.camunda.optimize.service.db.DatabaseConstants.ALERT_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.COLLECTION_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.COMBINED_REPORT_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.DASHBOARD_INDEX_NAME;
+import static io.camunda.optimize.service.db.DatabaseConstants.PROCESS_OVERVIEW_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_DECISION_REPORT_INDEX_NAME;
 import static io.camunda.optimize.service.db.DatabaseConstants.SINGLE_PROCESS_REPORT_INDEX_NAME;
 import static io.camunda.optimize.service.db.os.client.dsl.QueryDSL.nested;
@@ -43,7 +44,8 @@ public class UserIdMigrationRepositoryOS implements UserIdMigrationRepository {
     SINGLE_DECISION_REPORT_INDEX_NAME,
     COMBINED_REPORT_INDEX_NAME,
     DASHBOARD_INDEX_NAME,
-    ALERT_INDEX_NAME
+    ALERT_INDEX_NAME,
+    PROCESS_OVERVIEW_INDEX_NAME
   };
 
   private static final String MIGRATE_COLLECTION_ROLES_SCRIPT =
@@ -103,7 +105,7 @@ public class UserIdMigrationRepositoryOS implements UserIdMigrationRepository {
 
   private Query buildUserIdQuery(final String userId) {
     // data.roles is only mapped on the collection index; ignoreUnmapped keeps this nested clause
-    // from failing the count on the other 5 indices
+    // from failing the count on the other 6 indices
     final Query rolesQuery =
         NestedQuery.of(
                 n ->

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/script/UserIdMigrationScriptFactory.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/repository/script/UserIdMigrationScriptFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.db.repository.script;
+
+public interface UserIdMigrationScriptFactory {
+
+  static String createMigrateCollectionRolesScript() {
+    return "for (def role : ctx._source.data.roles) {"
+        + "  if (role.identity.id == params.oldId) {"
+        + "    role.identity.id = params.newId;"
+        + "    role.id = 'USER:' + params.newId;"
+        + "  }"
+        + "}";
+  }
+
+  static String createMigrateOwnerScript() {
+    return "if (ctx._source.owner == params.oldId) { ctx._source.owner = params.newId; }"
+        + "if (ctx._source.lastModifier == params.oldId) { ctx._source.lastModifier = params.newId; }";
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/exceptions/UserIdMigrationException.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/exceptions/UserIdMigrationException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.exceptions;
+
+public class UserIdMigrationException extends OptimizeRuntimeException {
+
+  public UserIdMigrationException(final String message) {
+    super(message);
+  }
+
+  @Override
+  public String getErrorCode() {
+    return "userIdMigrationFailed";
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/UserIdMigrationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/UserIdMigrationService.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.security;
+
+import io.camunda.optimize.service.db.repository.UserIdMigrationRepository;
+import io.camunda.optimize.service.exceptions.UserIdMigrationException;
+import io.camunda.optimize.service.util.configuration.condition.CCSaaSCondition;
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Service;
+
+/**
+ * Triggered at login when a user's SaaS identity has changed (i.e. they added a new SSO login
+ * method). Checks whether any Optimize documents still reference the old user ID, and if so,
+ * rewrites them asynchronously so the user can access their entities without waiting.
+ *
+ * <p>Once a login method change has happened, no new document will ever be written under the old
+ * user ID again, so a successful migration never needs to be repeated: {@link #handledOldUserIds}
+ * marks the old ID as done permanently, and subsequent logins skip the work (and the {@code _count}
+ * check) entirely. A failed migration is removed from that set so the next login retries from
+ * scratch. The same set also dedupes concurrent logins (e.g. logout/login while a migration is
+ * still running) so they don't fire duplicate migrations for the same old ID.
+ *
+ * <p>{@link #handledOldUserIds} is in-memory only and is lost on restart. This is harmless: for an
+ * old ID that was already migrated before the restart, the only consequence is one extra (cheap)
+ * {@code _count} query on that user's next login, which correctly finds no matching documents and
+ * does no further work.
+ */
+@Service
+@Conditional(CCSaaSCondition.class)
+public class UserIdMigrationService {
+
+  /**
+   * Caps the self-healing retry loop below. Bounds worst-case work if updates keep getting skipped
+   * (e.g. persistent version conflicts) instead of retrying forever; if the old ID is still
+   * referenced after this many attempts, the migration is considered failed and retried on the next
+   * login.
+   */
+  private static final int MAX_ATTEMPTS = 3;
+
+  private static final Duration INITIAL_RETRY_BACKOFF = Duration.ofMillis(1000);
+
+  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(UserIdMigrationService.class);
+
+  private final UserIdMigrationRepository repository;
+  private final Set<String> handledOldUserIds = ConcurrentHashMap.newKeySet();
+
+  public UserIdMigrationService(final UserIdMigrationRepository repository) {
+    this.repository = repository;
+  }
+
+  /**
+   * Fires an async migration if any entity still references oldUserId. Safe to call on every login:
+   * a no-op once the old ID has been migrated successfully, or while a migration for it is already
+   * running.
+   */
+  public void migrateUserIdIfNeeded(final String newUserId, final String oldUserId) {
+    if (!handledOldUserIds.add(oldUserId)) {
+      LOG.debug("Old user ID [{}] already migrated or migration in progress, skipping", oldUserId);
+      return;
+    }
+    CompletableFuture.supplyAsync(() -> repository.hasDocumentsWithUserId(oldUserId))
+        .thenCompose(
+            hasDocuments -> {
+              if (!hasDocuments) {
+                LOG.debug("No documents found for old user ID [{}], skipping migration", oldUserId);
+                return CompletableFuture.<Void>completedFuture(null);
+              }
+              return runMigrationAttempt(newUserId, oldUserId, 1);
+            })
+        .whenComplete(
+            (result, error) -> {
+              if (error != null) {
+                final Throwable cause = error.getCause() != null ? error.getCause() : error;
+                LOG.error(
+                    "Failed to migrate user ID [{}] to [{}]: {}",
+                    oldUserId,
+                    newUserId,
+                    cause.getMessage(),
+                    cause);
+                handledOldUserIds.remove(oldUserId);
+              }
+            });
+  }
+
+  /**
+   * Runs one migration attempt, then checks whether the old ID is still referenced. If it isn't,
+   * the migration is done. Otherwise, if attempts remain, schedules the next one via {@link
+   * CompletableFuture#delayedExecutor} (so retries never block a thread sleeping) with a backoff
+   * delay between attempts 1→2 and 2→3; on the {@code MAX_ATTEMPTS}'th attempt this throws instead
+   * of scheduling a retry.
+   */
+  private CompletableFuture<Void> runMigrationAttempt(
+      final String newUserId, final String oldUserId, final int attempt) {
+    LOG.info(
+        "Old user ID [{}] still referenced in documents, migrating to [{}] (attempt {}/{})",
+        oldUserId,
+        newUserId,
+        attempt,
+        MAX_ATTEMPTS);
+    repository.migrateUserId(oldUserId, newUserId);
+    return CompletableFuture.supplyAsync(() -> repository.hasDocumentsWithUserId(oldUserId))
+        .thenCompose(
+            stillHasDocuments -> {
+              if (!stillHasDocuments) {
+                LOG.info(
+                    "Migration of user ID [{}] to [{}] complete after {} attempt(s)",
+                    oldUserId,
+                    newUserId,
+                    attempt);
+                return CompletableFuture.<Void>completedFuture(null);
+              }
+              if (attempt >= MAX_ATTEMPTS) {
+                throw new UserIdMigrationException(
+                    "Old user ID ["
+                        + oldUserId
+                        + "] still referenced in documents after "
+                        + MAX_ATTEMPTS
+                        + " migration attempts to ["
+                        + newUserId
+                        + "]");
+              }
+              return afterBackoff(attempt)
+                  .thenCompose(ignored -> runMigrationAttempt(newUserId, oldUserId, attempt + 1));
+            });
+  }
+
+  private CompletableFuture<Void> afterBackoff(final int attempt) {
+    final long backoffMillis = INITIAL_RETRY_BACKOFF.toMillis() * (1L << (attempt - 1));
+    return CompletableFuture.runAsync(
+        () -> {}, CompletableFuture.delayedExecutor(backoffMillis, TimeUnit.MILLISECONDS));
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/UserIdMigrationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/UserIdMigrationService.java
@@ -10,10 +10,13 @@ package io.camunda.optimize.service.security;
 import io.camunda.optimize.service.db.repository.UserIdMigrationRepository;
 import io.camunda.optimize.service.exceptions.UserIdMigrationException;
 import io.camunda.optimize.service.util.configuration.condition.CCSaaSCondition;
+import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.springframework.context.annotation.Conditional;
@@ -35,6 +38,18 @@ import org.springframework.stereotype.Service;
  * old ID that was already migrated before the restart, the only consequence is one extra (cheap)
  * {@code _count} query on that user's next login, which correctly finds no matching documents and
  * does no further work.
+ *
+ * <p>All blocking DB work runs on a dedicated virtual-thread-per-task {@link #executor} rather than
+ * the default {@code ForkJoinPool.commonPool()}: {@code _update_by_query} completion is awaited by
+ * polling in a loop with no overall deadline, so on a low-core pod (where the shared common pool
+ * may have as few as one worker thread) a single stuck task could otherwise starve every other
+ * feature in the JVM relying on the default pool. Virtual threads (as already used for similarly
+ * blocking, I/O-bound work in {@code SchemaManager} and {@code RestoreManager}) don't pin a scarce
+ * platform thread while parked in that poll loop, so there's no fixed budget to exhaust even under
+ * several simultaneous stuck migrations. {@link #ATTEMPT_TIMEOUT} additionally bounds each attempt
+ * so a stuck task is treated as a failure and retried on the next login instead of leaving the old
+ * ID permanently marked as in-progress; note this only frees the {@link CompletableFuture} chain,
+ * the underlying poll loop keeps its virtual thread parked until the stuck task actually resolves.
  */
 @Service
 @Conditional(CCSaaSCondition.class)
@@ -50,13 +65,29 @@ public class UserIdMigrationService {
 
   private static final Duration INITIAL_RETRY_BACKOFF = Duration.ofMillis(1000);
 
+  /**
+   * Bounds how long a single attempt (the _count check plus, if needed, the _update_by_query wait)
+   * may take before it's treated as failed. Generous on purpose: legitimate migrations across large
+   * indices can take a while, and the cost of a false-positive timeout is just an extra retry on
+   * the next login.
+   */
+  private static final Duration ATTEMPT_TIMEOUT = Duration.ofMinutes(10);
+
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(UserIdMigrationService.class);
 
   private final UserIdMigrationRepository repository;
   private final Set<String> handledOldUserIds = ConcurrentHashMap.newKeySet();
+  private final ExecutorService executor =
+      Executors.newThreadPerTaskExecutor(
+          Thread.ofVirtual().name("user-id-migration-", 0).factory());
 
   public UserIdMigrationService(final UserIdMigrationRepository repository) {
     this.repository = repository;
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    executor.shutdownNow();
   }
 
   /**
@@ -69,7 +100,8 @@ public class UserIdMigrationService {
       LOG.debug("Old user ID [{}] already migrated or migration in progress, skipping", oldUserId);
       return;
     }
-    CompletableFuture.supplyAsync(() -> repository.hasDocumentsWithUserId(oldUserId))
+    CompletableFuture.supplyAsync(() -> repository.hasDocumentsWithUserId(oldUserId), executor)
+        .orTimeout(ATTEMPT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
         .thenCompose(
             hasDocuments -> {
               if (!hasDocuments) {
@@ -108,8 +140,13 @@ public class UserIdMigrationService {
         newUserId,
         attempt,
         MAX_ATTEMPTS);
-    repository.migrateUserId(oldUserId, newUserId);
-    return CompletableFuture.supplyAsync(() -> repository.hasDocumentsWithUserId(oldUserId))
+    return CompletableFuture.supplyAsync(
+            () -> {
+              repository.migrateUserId(oldUserId, newUserId);
+              return repository.hasDocumentsWithUserId(oldUserId);
+            },
+            executor)
+        .orTimeout(ATTEMPT_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
         .thenCompose(
             stillHasDocuments -> {
               if (!stillHasDocuments) {
@@ -138,6 +175,7 @@ public class UserIdMigrationService {
   private CompletableFuture<Void> afterBackoff(final int attempt) {
     final long backoffMillis = INITIAL_RETRY_BACKOFF.toMillis() * (1L << (attempt - 1));
     return CompletableFuture.runAsync(
-        () -> {}, CompletableFuture.delayedExecutor(backoffMillis, TimeUnit.MILLISECONDS));
+        () -> {},
+        CompletableFuture.delayedExecutor(backoffMillis, TimeUnit.MILLISECONDS, executor));
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/UserIdMigrationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/UserIdMigrationServiceTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.security;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.optimize.service.db.repository.UserIdMigrationRepository;
+import org.junit.jupiter.api.Test;
+
+class UserIdMigrationServiceTest {
+
+  private static final String OLD_USER_ID = "old-user-id";
+  private static final String NEW_USER_ID = "new-user-id";
+
+  @Test
+  void successfulMigrationIsNeverRepeatedOnSubsequentCalls() {
+    final UserIdMigrationRepository repository = mock(UserIdMigrationRepository.class);
+    when(repository.hasDocumentsWithUserId(OLD_USER_ID)).thenReturn(true, false);
+    final UserIdMigrationService service = new UserIdMigrationService(repository);
+
+    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+
+    // wait for the full cycle to finish: the loop's second hasDocumentsWithUserId check (which
+    // returns false and ends the migration) only happens after the backoff sleep following the
+    // first migrateUserId call
+    given()
+        .timeout(5, SECONDS)
+        .untilAsserted(
+            () -> {
+              verify(repository, times(1)).migrateUserId(OLD_USER_ID, NEW_USER_ID);
+              verify(repository, times(2)).hasDocumentsWithUserId(OLD_USER_ID);
+            });
+
+    // old ID already migrated: further calls must not re-check or re-migrate
+    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+
+    verify(repository, times(2)).hasDocumentsWithUserId(OLD_USER_ID);
+    verify(repository, times(1)).migrateUserId(OLD_USER_ID, NEW_USER_ID);
+  }
+
+  @Test
+  void failedMigrationIsRetriedOnNextCall() {
+    final UserIdMigrationRepository repository = mock(UserIdMigrationRepository.class);
+    // old ID never disappears: every attempt exhausts and the migration is considered failed
+    when(repository.hasDocumentsWithUserId(OLD_USER_ID)).thenReturn(true);
+    final UserIdMigrationService service = new UserIdMigrationService(repository);
+
+    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+
+    given()
+        .timeout(10, SECONDS)
+        .untilAsserted(() -> verify(repository, times(3)).migrateUserId(OLD_USER_ID, NEW_USER_ID));
+
+    // the failed migration is only removed from the handled set once whenComplete runs, which
+    // races with this thread; retry the trigger call on every poll until it takes effect
+    given()
+        .timeout(10, SECONDS)
+        .untilAsserted(
+            () -> {
+              service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+              verify(repository, times(6)).migrateUserId(OLD_USER_ID, NEW_USER_ID);
+            });
+  }
+
+  @Test
+  void concurrentCallsForSameOldUserIdMigrateOnlyOnce() {
+    final UserIdMigrationRepository repository = mock(UserIdMigrationRepository.class);
+    when(repository.hasDocumentsWithUserId(OLD_USER_ID)).thenReturn(true, false);
+    final UserIdMigrationService service = new UserIdMigrationService(repository);
+
+    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+
+    given()
+        .timeout(5, SECONDS)
+        .untilAsserted(() -> verify(repository, times(1)).migrateUserId(OLD_USER_ID, NEW_USER_ID));
+  }
+
+  @Test
+  void migrationForDifferentOldUserIdsRunsIndependently() {
+    final UserIdMigrationRepository repository = mock(UserIdMigrationRepository.class);
+    final String otherOldUserId = "other-old-user-id";
+    when(repository.hasDocumentsWithUserId(OLD_USER_ID)).thenReturn(true, false);
+    when(repository.hasDocumentsWithUserId(otherOldUserId)).thenReturn(true, false);
+    final UserIdMigrationService service = new UserIdMigrationService(repository);
+
+    service.migrateUserIdIfNeeded(NEW_USER_ID, OLD_USER_ID);
+    service.migrateUserIdIfNeeded(NEW_USER_ID, otherOldUserId);
+
+    given()
+        .timeout(5, SECONDS)
+        .untilAsserted(
+            () -> {
+              verify(repository, times(1)).migrateUserId(OLD_USER_ID, NEW_USER_ID);
+              verify(repository, times(1)).migrateUserId(otherOldUserId, NEW_USER_ID);
+            });
+  }
+}


### PR DESCRIPTION
## Description

When a SaaS user changes their login method (for example from email/password to a GitHub or Google SSO connection), Accounts assigns them a new `user_id`. Optimize stores ownership (`owner`, `lastModifier`, collection role membership) as raw ID strings in Elasticsearch/OpenSearch documents with no foreign key to a user table, so every one of those documents keeps pointing at the old ID and the user loses access to their own collections and reports. Today the only fix is the workaround already referenced on the issue: an admin manually reassigns access, or runs an ad-hoc script that edits the raw ES data. This PR automates that workaround: on login, if the identity provider reports that the user's ID has changed, Optimize rewrites the affected documents in the background so access is restored without any manual intervention.

### How we get the old user ID

Accounts exposes the previous ID via `app_metadata.originalUserId` on the user record, and — critically for this flow — also surfaces it as a custom claim, `https://camunda.com/originalUserId`, directly on the OIDC ID token issued at login. Web Modeler already relies on this exact claim for the same purpose (its frontend reads it in `AuthService.common.ts` to detect an SSO change and re-link the user's `iamId`), so we reuse the same signal in `CCSaaSSecurityConfigurerAdapter`: when the claim is present and differs from the token's subject, we know the identity provider just changed this user's ID and a migration is needed.

### How the migration works

`UserIdMigrationService.migrateUserIdIfNeeded` fires asynchronously from the login success handler so the login response is never blocked by ES/OS work. It delegates to `UserIdMigrationRepository` (with separate ES and OS implementations, matching Optimize's existing dual-backend pattern), which rewrites `owner`/`lastModifier` on all six entity indices (collection, single-process-report, single-decision-report, combined-report, dashboard, alert) and `data.roles[].identity.id` on collections, via `_update_by_query` with Painless scripts. A cheap `_count` query across those same fields acts as the idempotency signal: the data itself is the state, with no separate migration-tracking table or flag needed. If the count is already zero, nothing is queried, and if the migration already partially ran there's nothing left to overwrite.

### Guardrails

The migration only fires once `hasAccess(user)` has confirmed the user is authorized for this cluster's org, so an authenticated-but-unauthorized login never triggers an entity mutation. An in-memory per-old-ID set dedupes concurrent triggers: a logout/login while a migration for that ID is still in flight is a no-op rather than a second redundant `_update_by_query` pass, while migrations for different old IDs never touch overlapping documents and so are never serialized against each other. Because `_update_by_query`'s default conflict handling can skip a document on a version conflict without retrying it, a single pass isn't guaranteed to fully clear the old ID even when it finds work to do, so the service re-checks the count after each pass and retries up to three times with a backoff (scheduled via `CompletableFuture.delayedExecutor`, never blocking a thread on `Thread.sleep`) before giving up and letting the next login retry from scratch. A successful migration is marked permanently (in-memory, for the life of the JVM) so it is never redundantly re-checked on future logins for the same old ID; a restart loses that marker, but the only consequence is one extra harmless `_count` query on that user's next login.

### Limitation: two login-method changes without a login in between

If the login method changes twice before the user ever logs in again (so no migration for the first change has had a chance to run), the second change's `originalUserId` claim points at the second-to-last ID, not the very first one. The first identity's entities are never picked up by any subsequent migration and remain orphaned under an ID nobody can present a token for. This is a pre-existing limitation of the underlying `originalUserId`/`app_metadata` mechanism (Web Modeler has the same constraint, since it also only sees one hop back), not something introduced or made worse by this change; fixing it would require Accounts to track a full chain of prior IDs rather than just the immediately previous one.

### Alternative considered: querying with the old ID instead of migrating data

Instead of rewriting documents, we considered keeping the old ID(s) around and having every read query check `owner IN (currentId, ...previousIds)` (and the equivalent for collection roles), sourcing the ID history from Accounts on each request. We discarded this because it pushes the cost of the workaround onto every single read for the lifetime of the account (query complexity, and, more importantly, unbounded query fan-out if an account changes its login method many times over its lifetime, since every historical ID would need to remain in the `IN` clause forever) instead of a one-time bounded write when the change actually happens, it doesn't fix the underlying data inconsistency (the documents still lie about who owns them, which matters for e.g. bulk operations or exports that read `owner` directly rather than through a filtered API), and it would require every current and future read path across all six entity indices to remember to apply the multi-ID filter, whereas the migration is a single write executed once and every existing read path keeps working unmodified.

### Testing

`UserIdMigrationServiceTest` (mocked repository, no ES) covers the retry/dedup/self-heal logic of the service in isolation. `UserIdMigrationIT` (real ES/OS) covers the end-to-end scenario against the actual Painless scripts and indices, including collection and report ownership, role membership, idempotent replays, concurrent-login dedup, and a two-hop SSO-change scenario verifying entities from every prior identity remain visible under the final one when each migration is allowed to complete before the next change. There is currently no test infrastructure in Optimize for driving a real end-to-end OIDC login (existing auth tests like `JwtDecoderIT` invoke handler methods directly rather than exercising the Spring Security filter chain), so the three lines of glue in the login success handler that extract the claim and call the service are exercised by inspection/review rather than an automated end-to-end test.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #34982
