### PR TITLE
fix: match team-zeebe Docker image by exact package name in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -504,7 +504,7 @@
         "docker"
       ],
       "matchPackageNames": [
-        "/^registry\\.camunda\\.cloud\\/team-zeebe\\//",
+        "registry.camunda.cloud/team-zeebe",
         "europe-west1-docker.pkg.dev/camunda-benchmark/quayio/prometheuscommunity/elasticsearch-exporter"
       ],
       "enabled": false


### PR DESCRIPTION
## Description

This PR is follow up of https://github.com/camunda/camunda/pull/56747

The package rule disabling Renovate lookups for the unreachable internal image `registry.camunda.cloud/team-zeebe` used a regex that required a trailing slash:

```
/^registry\.camunda\.cloud\/team-zeebe\//
```

The `helm-values` manager extracts the image's `image.repository` as the exact dependency name `registry.camunda.cloud/team-zeebe` — with **no** image suffix (it's the Helm chart's root repository, not a per-image path). The regex therefore never matched, so `enabled: false` was never applied and Renovate kept trying (and failing) to look the image up, keeping the dashboard lookup warnings around.

This changes the match to the plain exact-string form, identical to the adjacent `elasticsearch-exporter` entry in the same rule.

## Validation

Verified against a Renovate trace log under `baseBranch: main` (same rule, same datasource, only the match form differs):

- `europe-west1-docker.pkg.dev/.../elasticsearch-exporter` (exact string) → `Dependency: ..., is disabled` — no lookup, no warning.
- `registry.camunda.cloud/team-zeebe` (regex) → `Failed to look up docker package registry.camunda.cloud/team-zeebe: no-result` — never matched, still looked up.

With the exact string, team-zeebe will be disabled the same way the exporter already is.


🤖 Generated with [Claude Code](https://claude.com/claude-code)