### PR TITLE
Strip content/toolCalls/metrics from AGENT_HISTORY primary storage

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitProcessor.java
@@ -34,6 +34,8 @@ public final class AgentHistoryCommitProcessor implements TypedRecordProcessor<A
   public void processRecord(final TypedRecord<AgentHistoryRecord> command) {
     final long jobKey = command.getValue().getJobKey();
     final String jobLease = command.getValue().getJobLease();
+    // Items in state are already trimmed to identity fields by AgentHistoryCreatedApplier,
+    // so the COMMITTED/DISCARDED events emitted here carry that same trimmed shape for free.
     final AgentHistoryState.AgentHistoryVisitor visitor =
         item ->
             stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardProcessor.java
@@ -36,6 +36,8 @@ public final class AgentHistoryDiscardProcessor
   public void processRecord(final TypedRecord<AgentHistoryRecord> command) {
     final long jobKey = command.getValue().getJobKey();
     final String jobLease = command.getValue().getJobLease();
+    // Items in state are already trimmed to identity fields by AgentHistoryCreatedApplier,
+    // so the DISCARDED event emitted here carries that same trimmed shape for free.
     final AgentHistoryState.AgentHistoryVisitor visitor =
         item ->
             stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
@@ -24,6 +24,8 @@ public final class AgentHistoryCreatedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
-    agentHistoryState.insert(key, value);
+    // content/toolCalls/metrics/producedAt already reached secondary storage via the CREATED event
+    // itself — primary storage only needs identity fields to later match and delete the item.
+    agentHistoryState.insert(key, value.onlyIdentityFields());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AgentHistoryCreatedApplier.java
@@ -24,8 +24,34 @@ public final class AgentHistoryCreatedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
-    // content/toolCalls/metrics/producedAt already reached secondary storage via the CREATED event
-    // itself — primary storage only needs identity fields to later match and delete the item.
-    agentHistoryState.insert(key, value.onlyIdentityFields());
+    // Store only the identity fields in primary storage (RocksDB). content/toolCalls/metrics/
+    // producedAt have already reached secondary storage via the CREATED event itself; nothing reads
+    // them back out of primary storage — matching a COMMIT/DISCARD only needs jobKey/jobLease, and
+    // deleting the item needs the same two fields. Storing the trimmed copy also means the
+    // COMMITTED/DISCARDED events re-emitted from state carry only identity fields, with no extra
+    // stripping needed at those emit sites.
+    //
+    // This is an explicit allow-list (not a full copy with payload cleared afterward) so that a
+    // field added to AgentHistoryRecord in the future is excluded from primary storage by default —
+    // someone has to deliberately add it here for it to be persisted past CREATED. Keeping the
+    // selection inline rather than in a shared helper also means any future change to which fields
+    // are stored requires a new applier version with its own golden file, preventing silent
+    // behavior
+    // changes to already-released appliers.
+    final var identityRecord =
+        new AgentHistoryRecord()
+            .setAgentHistoryKey(value.getAgentHistoryKey())
+            .setAgentInstanceKey(value.getAgentInstanceKey())
+            .setElementInstanceKey(value.getElementInstanceKey())
+            .setProcessInstanceKey(value.getProcessInstanceKey())
+            .setRootProcessInstanceKey(value.getRootProcessInstanceKey())
+            .setBpmnProcessId(value.getBpmnProcessId())
+            .setProcessDefinitionKey(value.getProcessDefinitionKey())
+            .setTenantId(value.getTenantId())
+            .setJobKey(value.getJobKey())
+            .setJobLease(value.getJobLease())
+            .setLoopIteration(value.getLoopIteration())
+            .setRole(value.getRole());
+    agentHistoryState.insert(key, identityRecord);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -49,12 +49,42 @@ public class AgentHistoryCommitTest {
 
     final var committed = ENGINE.agentHistories().withJobKey(jobKey).commit();
 
-    // AgentHistoryCommitProcessor emits COMMITTED carrying the full stored record
+    // AgentHistoryCommitProcessor emits COMMITTED carrying only identity/routing fields
     assertThat(committed.getRecordType()).isEqualTo(RecordType.EVENT);
     assertThat(committed.getKey()).isEqualTo(itemKey);
     assertThat(committed.getValue().getJobKey()).isEqualTo(jobKey);
     assertThat(committed.getValue().getAgentInstanceKey()).isEqualTo(agentInstanceKey);
     assertThat(committed.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+  }
+
+  @Test
+  public void shouldStripContentToolCallsAndMetricsFromCommittedEvent() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    ENGINE
+        .agentHistories()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withJobKey(jobKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withRole(AgentHistoryRole.ASSISTANT)
+        .withTextContent("some large response text")
+        .withToolCall("call-1", "http-tool", "call-activity")
+        .withMetrics(100, 50, 1234)
+        .create();
+
+    final var committed = ENGINE.agentHistories().withJobKey(jobKey).commit();
+
+    // The item was created with content/toolCalls/metrics, but they are stripped at primary-storage
+    // insert — the emitted COMMITTED event must carry none of them.
+    assertThat(committed.getValue().getContent()).isEmpty();
+    assertThat(committed.getValue().getToolCalls()).isEmpty();
+    assertThat(committed.getValue().getMetrics().getInputTokens()).isZero();
+    assertThat(committed.getValue().getMetrics().getOutputTokens()).isZero();
+    assertThat(committed.getValue().getMetrics().getDurationMs()).isZero();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
@@ -102,7 +102,7 @@ public class AgentHistoryDiscardTest {
   }
 
   @Test
-  public void shouldEmitDiscardedEventCarryingStoredRecord() {
+  public void shouldEmitDiscardedEventCarryingIdentityFieldsOnly() {
     final var serviceTaskInstance = deployAndCreateProcessInstance();
     final var elementInstanceKey = serviceTaskInstance.getKey();
     final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
@@ -117,6 +117,36 @@ public class AgentHistoryDiscardTest {
     assertThat(discarded.getValue().getJobKey()).isEqualTo(jobKey);
     assertThat(discarded.getValue().getAgentInstanceKey()).isEqualTo(agentInstanceKey);
     assertThat(discarded.getValue().getElementInstanceKey()).isEqualTo(elementInstanceKey);
+  }
+
+  @Test
+  public void shouldStripContentToolCallsAndMetricsFromDiscardedEvent() {
+    final var serviceTaskInstance = deployAndCreateProcessInstance();
+    final var elementInstanceKey = serviceTaskInstance.getKey();
+    final var processInstanceKey = serviceTaskInstance.getValue().getProcessInstanceKey();
+    final var agentInstanceKey = createAgentInstance(elementInstanceKey).getKey();
+    final var jobKey = activateJobForProcessInstance(processInstanceKey);
+
+    ENGINE
+        .agentHistories()
+        .withAgentInstanceKey(agentInstanceKey)
+        .withJobKey(jobKey)
+        .withElementInstanceKey(elementInstanceKey)
+        .withRole(AgentHistoryRole.ASSISTANT)
+        .withTextContent("some large response text")
+        .withToolCall("call-1", "http-tool", "call-activity")
+        .withMetrics(100, 50, 1234)
+        .create();
+
+    final var discarded = ENGINE.agentHistories().withJobKey(jobKey).discard();
+
+    // The item was created with content/toolCalls/metrics, but they are stripped at primary-storage
+    // insert — the emitted DISCARDED event must carry none of them.
+    assertThat(discarded.getValue().getContent()).isEmpty();
+    assertThat(discarded.getValue().getToolCalls()).isEmpty();
+    assertThat(discarded.getValue().getMetrics().getInputTokens()).isZero();
+    assertThat(discarded.getValue().getMetrics().getOutputTokens()).isZero();
+    assertThat(discarded.getValue().getMetrics().getDurationMs()).isZero();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AgentHistoryClient.java
@@ -7,14 +7,20 @@
  */
 package io.camunda.zeebe.engine.util.client;
 
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryEmbeddedToolCall;
+import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryMessageContent;
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.AgentHistoryIntent;
+import io.camunda.zeebe.protocol.record.value.AgentHistoryContentType;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue;
 import io.camunda.zeebe.protocol.record.value.AgentHistoryRole;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 public final class AgentHistoryClient {
@@ -85,6 +91,35 @@ public final class AgentHistoryClient {
 
   public AgentHistoryClient withTenantId(final String tenantId) {
     record.setTenantId(tenantId);
+    return this;
+  }
+
+  public AgentHistoryClient withTextContent(final String text) {
+    record.addContent(
+        new AgentHistoryMessageContent()
+            .setContentType(AgentHistoryContentType.TEXT)
+            .setText(text));
+    return this;
+  }
+
+  public AgentHistoryClient withToolCall(
+      final String toolCallId, final String toolName, final String elementId) {
+    record.addToolCall(
+        new AgentHistoryEmbeddedToolCall()
+            .setToolCallId(toolCallId)
+            .setToolName(toolName)
+            .setElementId(elementId)
+            .setArguments(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(Map.of()))));
+    return this;
+  }
+
+  public AgentHistoryClient withMetrics(
+      final long inputTokens, final long outputTokens, final long durationMs) {
+    record
+        .getMetrics()
+        .setInputTokens(inputTokens)
+        .setOutputTokens(outputTokens)
+        .setDurationMs(durationMs);
     return this;
   }
 

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
@@ -24,6 +24,8 @@ public final class AgentHistoryCreatedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
-    agentHistoryState.insert(key, value);
+    // content/toolCalls/metrics/producedAt already reached secondary storage via the CREATED event
+    // itself — primary storage only needs identity fields to later match and delete the item.
+    agentHistoryState.insert(key, value.onlyIdentityFields());
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/AgentHistory_CREATED_v1.golden
@@ -24,8 +24,34 @@ public final class AgentHistoryCreatedApplier
 
   @Override
   public void applyState(final long key, final AgentHistoryRecord value) {
-    // content/toolCalls/metrics/producedAt already reached secondary storage via the CREATED event
-    // itself — primary storage only needs identity fields to later match and delete the item.
-    agentHistoryState.insert(key, value.onlyIdentityFields());
+    // Store only the identity fields in primary storage (RocksDB). content/toolCalls/metrics/
+    // producedAt have already reached secondary storage via the CREATED event itself; nothing reads
+    // them back out of primary storage — matching a COMMIT/DISCARD only needs jobKey/jobLease, and
+    // deleting the item needs the same two fields. Storing the trimmed copy also means the
+    // COMMITTED/DISCARDED events re-emitted from state carry only identity fields, with no extra
+    // stripping needed at those emit sites.
+    //
+    // This is an explicit allow-list (not a full copy with payload cleared afterward) so that a
+    // field added to AgentHistoryRecord in the future is excluded from primary storage by default —
+    // someone has to deliberately add it here for it to be persisted past CREATED. Keeping the
+    // selection inline rather than in a shared helper also means any future change to which fields
+    // are stored requires a new applier version with its own golden file, preventing silent
+    // behavior
+    // changes to already-released appliers.
+    final var identityRecord =
+        new AgentHistoryRecord()
+            .setAgentHistoryKey(value.getAgentHistoryKey())
+            .setAgentInstanceKey(value.getAgentInstanceKey())
+            .setElementInstanceKey(value.getElementInstanceKey())
+            .setProcessInstanceKey(value.getProcessInstanceKey())
+            .setRootProcessInstanceKey(value.getRootProcessInstanceKey())
+            .setBpmnProcessId(value.getBpmnProcessId())
+            .setProcessDefinitionKey(value.getProcessDefinitionKey())
+            .setTenantId(value.getTenantId())
+            .setJobKey(value.getJobKey())
+            .setJobLease(value.getJobLease())
+            .setLoopIteration(value.getLoopIteration())
+            .setRole(value.getRole());
+    agentHistoryState.insert(key, identityRecord);
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -258,34 +258,4 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   public AgentHistoryRecord ignoreLease() {
     return setJobLease(JobRecord.EMPTY_LEASE);
   }
-
-  /**
-   * Returns a copy carrying only identity fields, dropping {@code content}, {@code toolCalls},
-   * {@code metrics}, and {@code producedAt}. This is what {@code AgentHistoryCreatedApplier}
-   * inserts into primary storage (RocksDB) for a {@code PENDING} item: once the {@code CREATED}
-   * event has carried the full payload to secondary storage, nothing reads it back out of primary
-   * storage — matching a {@code COMMIT}/{@code DISCARD} against an item only needs {@code
-   * jobKey}/{@code jobLease}, and deleting it only needs the same two fields. Storing the trimmed
-   * copy means the {@code COMMITTED}/{@code DISCARDED} events later read back out of state are
-   * trimmed too, with no extra stripping needed at emit time.
-   *
-   * <p>This is an explicit allow-list rather than a full copy with the payload cleared afterward,
-   * so a field added to this record in the future is excluded from primary storage by default —
-   * someone has to deliberately add it here for it to be persisted past {@code CREATED}.
-   */
-  public AgentHistoryRecord onlyIdentityFields() {
-    return new AgentHistoryRecord()
-        .setAgentHistoryKey(getAgentHistoryKey())
-        .setAgentInstanceKey(getAgentInstanceKey())
-        .setElementInstanceKey(getElementInstanceKey())
-        .setProcessInstanceKey(getProcessInstanceKey())
-        .setRootProcessInstanceKey(getRootProcessInstanceKey())
-        .setBpmnProcessId(getBpmnProcessId())
-        .setProcessDefinitionKey(getProcessDefinitionKey())
-        .setTenantId(getTenantId())
-        .setJobKey(getJobKey())
-        .setJobLease(getJobLease())
-        .setLoopIteration(getLoopIteration())
-        .setRole(getRole());
-  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecord.java
@@ -258,4 +258,34 @@ public final class AgentHistoryRecord extends UnifiedRecordValue
   public AgentHistoryRecord ignoreLease() {
     return setJobLease(JobRecord.EMPTY_LEASE);
   }
+
+  /**
+   * Returns a copy carrying only identity fields, dropping {@code content}, {@code toolCalls},
+   * {@code metrics}, and {@code producedAt}. This is what {@code AgentHistoryCreatedApplier}
+   * inserts into primary storage (RocksDB) for a {@code PENDING} item: once the {@code CREATED}
+   * event has carried the full payload to secondary storage, nothing reads it back out of primary
+   * storage — matching a {@code COMMIT}/{@code DISCARD} against an item only needs {@code
+   * jobKey}/{@code jobLease}, and deleting it only needs the same two fields. Storing the trimmed
+   * copy means the {@code COMMITTED}/{@code DISCARDED} events later read back out of state are
+   * trimmed too, with no extra stripping needed at emit time.
+   *
+   * <p>This is an explicit allow-list rather than a full copy with the payload cleared afterward,
+   * so a field added to this record in the future is excluded from primary storage by default —
+   * someone has to deliberately add it here for it to be persisted past {@code CREATED}.
+   */
+  public AgentHistoryRecord onlyIdentityFields() {
+    return new AgentHistoryRecord()
+        .setAgentHistoryKey(getAgentHistoryKey())
+        .setAgentInstanceKey(getAgentInstanceKey())
+        .setElementInstanceKey(getElementInstanceKey())
+        .setProcessInstanceKey(getProcessInstanceKey())
+        .setRootProcessInstanceKey(getRootProcessInstanceKey())
+        .setBpmnProcessId(getBpmnProcessId())
+        .setProcessDefinitionKey(getProcessDefinitionKey())
+        .setTenantId(getTenantId())
+        .setJobKey(getJobKey())
+        .setJobLease(getJobLease())
+        .setLoopIteration(getLoopIteration())
+        .setRole(getRole());
+  }
 }


### PR DESCRIPTION
## Summary

`AgentHistoryCreatedApplier` inserted the full `AGENT_HISTORY:CREATED` record — including `content`, `toolCalls`, and `metrics` — into primary storage (RocksDB). That payload has no reader in primary storage: matching a `COMMIT`/`DISCARD` against a pending item, and later deleting it, both only need `jobKey`/`jobLease`. The full payload already reached secondary storage via the `CREATED` event itself, so keeping it in primary storage past that point durably grows RocksDB for no reason, and re-surfaces on every `COMMITTED`/`DISCARDED` follow-up event that reads the item back out of state — pushing every downstream consumer (the ES/OS and RDBMS exporters, any raw-record importer) into filtering it back out themselves.

### What changed

- **`AgentHistoryRecord.onlyIdentityFields()`** (new): an explicit allow-list clone that keeps only identity fields (`agentHistoryKey`, `agentInstanceKey`, `elementInstanceKey`, `processInstanceKey`, `rootProcessInstanceKey`, `bpmnProcessId`, `processDefinitionKey`, `tenantId`, `jobKey`, `jobLease`, `iteration`) and leaves `content`/`toolCalls`/`metrics` at their defaults. Building it as an allow-list rather than a full copy with the payload cleared afterward means a field added to the record in the future is excluded from primary storage by default — someone has to deliberately add it here.
- **`AgentHistoryCreatedApplier`**: inserts `value.onlyIdentityFields()` into `MutableAgentHistoryState` instead of the full `CREATED`-event value. This is the single point an item enters primary storage, so trimming here means every later read — including what `AgentHistoryCommitProcessor` / `AgentHistoryDiscardProcessor` re-emit as `COMMITTED`/`DISCARDED` — is trimmed for free, with no stripping logic needed at those emit sites.
- **`AgentHistoryClient`** (test util): adds `withTextContent`, `withToolCall`, `withMetrics` builders — the existing helper never set these fields, so a test could not previously tell a trimmed record apart from an untrimmed one.
- **`AgentHistoryCommitTest`** / **`AgentHistoryDiscardTest`**: adds a case per event type asserting the emitted `COMMITTED`/`DISCARDED` event carries none of a non-empty content/toolCalls/metrics payload the item was created with.

### Not affected

`AGENT_HISTORY:CREATED` is unchanged — it still carries the full payload, which is exactly what secondary storage needs at creation time. Only what gets inserted into primary storage afterward is trimmed.

## Test plan

- `AgentHistoryCommitTest.shouldStripContentToolCallsAndMetricsFromCommittedEvent` — creates an item with text content, a tool call, and non-zero metrics; asserts the `COMMITTED` event's `content`/`toolCalls` are empty and `metrics` are zeroed.
- `AgentHistoryDiscardTest.shouldStripContentToolCallsAndMetricsFromDiscardedEvent` — same, for `DISCARDED`.
- Existing identity-field assertions (`getJobKey`, `getAgentInstanceKey`, `getElementInstanceKey`) on both terminal events are unchanged and still pass, proving the trim does not drop anything a consumer needs to route or key an update by.
- `AgentHistoryCreateTest` and `DbAgentHistoryStateTest` unaffected — the `CREATED` event and the state layer's own insert/delete mechanics do not change, only what the applier chooses to pass to `insert()`.
- All 25 tests across `AgentHistoryCommitTest`, `AgentHistoryDiscardTest`, `AgentHistoryDiscardOnJobDestructionTest`, `AgentHistoryCreateTest`, and `DbAgentHistoryStateTest` pass.

## Related issues

- Sub-issue of: https://github.com/camunda/product-hub/issues/3462
- Fixes: https://github.com/camunda/camunda/issues/57037

🤖 Generated with [Claude Code](https://claude.com/claude-code)
