### PR TITLE
fix: add case for detecting connector references with omitted optional metadata

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.test.ts
@@ -50,6 +50,33 @@ describe('parseDocumentVariable', () => {
     });
   });
 
+  it('should detect a connector reference that omits optional metadata fields', () => {
+    const value = JSON.stringify({
+      'camunda.document.type': 'camunda',
+      storeId: 'in-memory',
+      documentId: 'doc-123',
+      contentHash: 'sha256:abc',
+      metadata: {
+        contentType: 'image/png',
+        fileName: 'photo.png',
+        size: 109748,
+      },
+    });
+    const result = parseDocumentVariable(value, false);
+
+    expect(result).toEqual({
+      type: 'single',
+      document: {
+        link: '/v2/documents/doc-123?storeId=in-memory&contentHash=sha256%3Aabc',
+        fileName: 'photo.png',
+        type: 'image',
+        contentType: 'image/png',
+        size: 109748,
+        isExpired: false,
+      },
+    });
+  });
+
   it('should detect an array with a single document as single', () => {
     const value = JSON.stringify([makeDocRef()]);
     const result = parseDocumentVariable(value, false);

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/VariablesTab/Variables/DocumentValueCell/parseDocumentVariable.ts
@@ -6,15 +6,27 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {z} from 'zod';
 import {safeJsonParse} from 'modules/utils';
 import {untruncateJson} from 'modules/utils/editor/untruncateJSON';
 import {mergePathname} from 'modules/request/mergePathname';
 import {getClientConfig} from 'modules/utils/getClientConfig';
 import {
   endpoints,
+  documentMetadataSchema,
   documentReferenceSchema,
-  type DocumentReference,
 } from '@camunda/camunda-api-zod-schemas/8.10';
+
+// connector-written references in variables may omit optional metadata keys.
+const relaxedDocumentReferenceSchema = documentReferenceSchema.extend({
+  metadata: documentMetadataSchema.partial({
+    expiresAt: true,
+    processDefinitionId: true,
+    processInstanceKey: true,
+    customProperties: true,
+  }),
+});
+type DocumentReference = z.infer<typeof relaxedDocumentReferenceSchema>;
 
 type DocumentType = 'image' | 'pdf' | 'json' | 'unknown';
 
@@ -32,7 +44,7 @@ type DocumentParseResult =
   | {type: 'list'; documents: DocumentInfo[]; isLowerBound: boolean};
 
 function isDocumentReference(value: unknown): value is DocumentReference {
-  return documentReferenceSchema.safeParse(value).success;
+  return relaxedDocumentReferenceSchema.safeParse(value).success;
 }
 
 const MIME_TYPE_MAP: Record<string, DocumentType> = {
@@ -61,9 +73,9 @@ function toDocumentInfo(ref: DocumentReference): DocumentInfo {
         )
       : null;
 
-  const isExpired =
-    ref.metadata.expiresAt !== null &&
-    Date.parse(ref.metadata.expiresAt) < Date.now();
+  const isExpired = ref.metadata.expiresAt
+    ? Date.parse(ref.metadata.expiresAt) < Date.now()
+    : false;
 
   return {
     link,


### PR DESCRIPTION


## Description
<!-- Describe the goal and purpose of this PR. -->
This supersedes #56658, which loosened the shared schema directly. That change was approved but diverged from the OpenAPI contract — as noted in review, once schemas are generated from the OpenAPI spec, the shared schema would regain the strict fields and reintroduce the bug.


Relaxation is now scoped to where it's actually needed in the operate document reference parsing

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56658
