### PR TITLE
test: prevent web server startup race in integration tests

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/clustering/dynamic/ScaleUpPartitionsTest.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -58,6 +59,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -68,6 +70,10 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ZeebeIntegration
+// Interrupt any test method hanging longer than 10 minutes so the remaining tests still run and
+// the failure is attributed with a stack trace, instead of the CI job timing out with no test
+// results at all (see https://github.com/camunda/camunda/issues/56666).
+@Timeout(value = 10, unit = TimeUnit.MINUTES)
 public class ScaleUpPartitionsTest {
   private static final Logger LOG = LoggerFactory.getLogger(ScaleUpPartitionsTest.class);
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -20,6 +20,9 @@ import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.zeebe.qa.util.cluster.util.ContextOverrideInitializer;
 import io.camunda.zeebe.qa.util.cluster.util.ContextOverrideInitializer.Bean;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -84,6 +87,15 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     // randomize ports to allow multiple concurrent instances
     overridePropertyIfAbsent("server.port", SocketUtil.getNextAddress().getPort());
     overridePropertyIfAbsent("management.server.port", SocketUtil.getNextAddress().getPort());
+
+    // give each application a Tomcat base directory that survives until the JVM exits. Since
+    // Spring Boot 4.1, auto-generated base directories are deleted when the owning web server is
+    // destroyed, but Tomcat publishes the first server's base directory as the JVM-global
+    // catalina.home; once that directory is missing, concurrently starting web servers (e.g. a
+    // TestCluster restart) race to re-create it, and the losers fail startup with "Unable to
+    // create the directory [...] to use as the home directory" (see #56666). Configured base
+    // directories are not managed (and thus not deleted) by Spring Boot.
+    overridePropertyIfAbsent("server.tomcat.basedir", createJvmLifetimeTomcatBaseDir());
     overridePropertyIfAbsent("spring.lifecycle.timeout-per-shutdown-phase", "1s");
 
     overridePropertyIfAbsent("camunda.rest.response-validation.enabled", "true");
@@ -356,6 +368,15 @@ public abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   private void overridePropertyIfAbsent(final String key, final Object value) {
     if (!propertyOverrides.containsKey(key)) {
       propertyOverrides.put(key, value);
+    }
+  }
+
+  private static String createJvmLifetimeTomcatBaseDir() {
+    try {
+      // intentionally never deleted; see the comment on the server.tomcat.basedir override
+      return Files.createTempDirectory("tomcat-basedir").toString();
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
     }
   }
 


### PR DESCRIPTION
Fixes a race that could fail any integration test starting several web servers concurrently in the same JVM, most visibly `ScaleUpPartitionsTest.shouldBePossibleToRestoreFromBackupBeforeScaling`.

The first embedded Tomcat started in a JVM publishes its base directory as the JVM-global `catalina.home` system property. Since the Spring Boot 4.1 upgrade (98c008bb1c8), auto-generated base directories are deleted again when the owning web server is destroyed. Once that directory is gone, web servers starting concurrently afterwards (e.g. a `TestCluster` restart after a restore) race to re-create it in `Tomcat#initBaseDir`, whose unsynchronized `isDirectory`/`mkdirs` check makes the losers fail startup with "Unable to create the directory [...] to use as the home directory". The failed brokers never join the cluster, so `TestCluster#start` waited until the CI job timed out at 30 minutes with no test results at all — which is how #56666 surfaced; since `TestCluster#start` was bounded to two minutes (ca7496afffc) the same failure shows up as a flaky `TimeoutException` instead.

The fix gives every `TestSpringApplication` a configured `server.tomcat.basedir` that lives until the JVM exits. Spring Boot does not manage (and thus never deletes) configured base directories, so whichever directory ends up published as `catalina.home` stays valid, restoring the pre-4.1 lifecycle for test applications without touching global state. In a standalone reproducer against Tomcat 11.0.23, three concurrent Tomcat starts against a deleted `catalina.home` failed in 188 of 200 rounds; the previously flaky test passed 40 of 40 stress runs with the fix (baseline: ~2 failures per 30 runs). An alternative — pinning the `catalina.home` system property — was rejected as it mutates JVM-global state for unrelated tests.

On top of the fix, `ScaleUpPartitionsTest` methods are now bounded by a 10 minute timeout so a hung method fails with a stack trace instead of eating the CI job's 30 minute timeout and cancelling the run with no test results.

closes #56666