### PR TITLE
ci: restore per-test BigQuery verify query in the flaky-gate PR comment

### DIFF
--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -174,6 +174,16 @@ WHERE  ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 20 DAY)
   AND  bs.ci_url IS NOT NULL
 ```
 
+## Per-test verify query in the comment
+
+Each active alert in the PR comment carries a collapsible `Verify in
+BigQuery` block with a ready-to-run query scoped to that one test
+(`test_class_name` + `test_name`, last 60 days). The author runs it to see
+whether the test already produced `flaky`/`failure`/`error` rows on
+`main`/`stable/*` or other PRs — prior rows mean a pre-existing intermittent
+flake (likely a false alarm); no rows mean this PR genuinely introduced it.
+The FQN is read from the sticky state entry, so the block survives re-runs.
+
 ## False-positive suppression
 
 A post-merge pilot audit (618 PRs, 2026-06-04 → 2026-06-15) found a 56%

--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -180,9 +180,11 @@ Each active alert in the PR comment carries a collapsible `Verify in
 BigQuery` block with a ready-to-run query scoped to that one test
 (`test_class_name` + `test_name`, last 60 days). The author runs it to see
 whether the test already produced `flaky`/`failure`/`error` rows on
-`main`/`stable/*` or other PRs — prior rows mean a pre-existing intermittent
-flake (likely a false alarm); no rows mean this PR genuinely introduced it.
-The FQN is read from the sticky state entry, so the block survives re-runs.
+`main`/`stable/*` or other PRs — prior failing rows mean a pre-existing
+intermittent flake (likely a false alarm); no prior failing rows mean this PR
+genuinely introduced it. All statuses are returned (not just failures) so the
+pass-vs-fail counts reveal how rare the flake is. The FQN is read from the
+sticky state entry, so the block survives re-runs.
 
 ## False-positive suppression
 

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -50,6 +50,13 @@ STATE_MARKER_PREFIX = "<!-- flaky-gate-state: "
 SCHEMA_VERSION = 1
 MIN_CLEAN_RUNS = 3
 
+# BigQuery source for the per-test "is this a real flake?" verify query surfaced
+# in the PR comment. Mirrors the baseline pull in ci.yml (same tables/ci_url).
+BQ_TEST_STATUS_TABLE = "ci-30-162810.prod_ci_analytics.test_status_v1"
+BQ_BUILD_STATUS_TABLE = "ci-30-162810.prod_ci_analytics.build_status_v2"
+CI_URL = "https://github.com/camunda/camunda"
+VERIFY_QUERY_DAYS = 60
+
 
 # ---------------------------------------------------------------------------
 # Test-name parsing (kept compatible with parse_test_name in helpers.js)
@@ -467,6 +474,47 @@ def _render_state_block(entry: dict) -> list[str]:
     ]
 
 
+def _render_verify_query(entry: dict) -> list[str]:
+    """A collapsible per-test BigQuery snippet so the author can check whether
+    the flagged test is a genuinely new flake or a pre-existing intermittent
+    one (a false alarm). Requires package + class + method to build the FQN."""
+    package = entry.get("package")
+    class_name = entry.get("class_name")
+    method_name = entry.get("method_name")
+    if not (package and class_name and method_name):
+        return []
+    fqn_class = f"{package}.{class_name}"
+    query = (
+        "SELECT DATE(report_time) AS day, build_trigger, test_status, COUNT(*) AS occurrences\n"
+        f"FROM `{BQ_TEST_STATUS_TABLE}` ts\n"
+        f"LEFT OUTER JOIN `{BQ_BUILD_STATUS_TABLE}` bs\n"
+        "  ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name\n"
+        f"WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {VERIFY_QUERY_DAYS} DAY)\n"
+        f'  AND ts.ci_url = "{CI_URL}"\n'
+        f'  AND test_class_name = "{fqn_class}"\n'
+        f'  AND test_name = "{method_name}"\n'
+        "GROUP BY day, build_trigger, test_status\n"
+        "ORDER BY day DESC, occurrences DESC"
+    )
+    lines = [
+        "",
+        "  <details><summary>Verify in BigQuery — is this a real new flake or a false alarm?</summary>",
+        "",
+        "  ```sql",
+    ]
+    lines.extend(f"  {q_line}" for q_line in query.split("\n"))
+    lines.extend([
+        "  ```",
+        "",
+        f"  Rows with `flaky`/`failure`/`error` status on `main`/`stable/*` (or "
+        f"other PRs) over the last {VERIFY_QUERY_DAYS} days indicate a "
+        "pre-existing intermittent flake — likely a false alarm. No prior rows "
+        "means this PR genuinely introduced it.",
+        "  </details>",
+    ])
+    return lines
+
+
 def _render_active_test(entry: dict) -> list[str]:
     lines = [f"- **{entry['method_name']}**"]
     lines.append(f"  - Jobs: `{', '.join(entry.get('flagged_jobs', []))}`")
@@ -475,6 +523,7 @@ def _render_active_test(entry: dict) -> list[str]:
     if entry.get("class_name"):
         lines.append(f"  - Class: `{entry['class_name']}`")
     lines.extend(_render_state_block(entry))
+    lines.extend(_render_verify_query(entry))
     return lines
 
 

--- a/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/detect_new_flaky_tests.py
@@ -484,6 +484,9 @@ def _render_verify_query(entry: dict) -> list[str]:
     if not (package and class_name and method_name):
         return []
     fqn_class = f"{package}.{class_name}"
+    # All statuses are returned on purpose: the pass-vs-fail counts per day let
+    # the author gauge how rare the flake is (2/2 runs = real problem, 2/2000 =
+    # rare intermittent). Filtering to failures only would hide that ratio.
     query = (
         "SELECT DATE(report_time) AS day, build_trigger, test_status, COUNT(*) AS occurrences\n"
         f"FROM `{BQ_TEST_STATUS_TABLE}` ts\n"
@@ -493,23 +496,23 @@ def _render_verify_query(entry: dict) -> list[str]:
         f'  AND ts.ci_url = "{CI_URL}"\n'
         f'  AND test_class_name = "{fqn_class}"\n'
         f'  AND test_name = "{method_name}"\n'
-        "GROUP BY day, build_trigger, test_status\n"
+        "GROUP BY day, build_trigger, test_status  -- inspect the test_status column for flaky/failure/error rows\n"
         "ORDER BY day DESC, occurrences DESC"
     )
     lines = [
-        "",
+        "  ",
         "  <details><summary>Verify in BigQuery — is this a real new flake or a false alarm?</summary>",
-        "",
+        "  ",
         "  ```sql",
     ]
     lines.extend(f"  {q_line}" for q_line in query.split("\n"))
     lines.extend([
         "  ```",
-        "",
-        f"  Rows with `flaky`/`failure`/`error` status on `main`/`stable/*` (or "
-        f"other PRs) over the last {VERIFY_QUERY_DAYS} days indicate a "
-        "pre-existing intermittent flake — likely a false alarm. No prior rows "
-        "means this PR genuinely introduced it.",
+        "  ",
+        f"  In the `test_status` column, prior `flaky`/`failure`/`error` rows on "
+        f"`main`/`stable/*` (or other PRs) over the last {VERIFY_QUERY_DAYS} days "
+        "indicate a pre-existing intermittent flake — likely a false alarm. No "
+        "prior failing rows means this PR genuinely introduced it.",
         "  </details>",
     ])
     return lines

--- a/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
+++ b/.github/actions/detect-new-flaky-tests/test_detect_new_flaky_tests.py
@@ -406,6 +406,21 @@ class TestRenderComment(unittest.TestCase):
         self.assertIn("Method last modified at: `abcdef0`", body)
         self.assertIn(d.STATE_MARKER_PREFIX, body)
 
+    def test_active_comment_contains_verify_query(self):
+        state = _make_state(_make_entry(
+            package="io.camunda.foo", class_name="BarTest", method_name="shouldBaz",
+        ))
+        body = d.render_comment(state)
+        self.assertIn("Verify in BigQuery", body)
+        self.assertIn(d.BQ_TEST_STATUS_TABLE, body)
+        self.assertIn('test_class_name = "io.camunda.foo.BarTest"', body)
+        self.assertIn('test_name = "shouldBaz"', body)
+
+    def test_verify_query_omitted_when_fqn_incomplete(self):
+        state = _make_state(_make_entry(package="", class_name="", method_name="m"))
+        body = d.render_comment(state)
+        self.assertNotIn("Verify in BigQuery", body)
+
     def test_all_clear_template(self):
         state = _make_state(_make_entry(
             status="cleared_via_fix",


### PR DESCRIPTION
## What

Restores the collapsible **Verify in BigQuery** block on each active alert in the flaky-gate PR comment. The block carries a ready-to-run query scoped to that single test (`test_class_name` + `test_name`, last 60 days).

## Why

The sticky-alert rewrite in #56732 dropped this block. Without it, a PR author has no quick way to tell a genuinely new flake from a pre-existing intermittent one (a false alarm). Prior `flaky`/`failure`/`error` rows on `main`/`stable/*` or other PRs ⇒ pre-existing ⇒ likely false alarm; no prior rows ⇒ this PR introduced it.

## Notes

- FQN is read from the sticky-state entry (`package`/`class_name`/`method_name`, already persisted in the base64 comment marker), so the block survives re-runs.
- BQ table names + `ci_url` lifted into module constants mirroring the `ci.yml` baseline pull.
- Guarded: block omitted when the FQN is incomplete.
- 2 unit tests added; 58 pass.

## Example — rendered comment

An active alert renders like this (hidden state markers omitted):

<table><tr><td>

# ⚠️ New Flaky Tests Detected

This PR introduces **1 new flaky test(s)** that are not currently flaky on `main`, `stable/*`, or in any other open PR.

- **shouldWork**
  - Jobs: `zeebe-unit-tests/Unit`
  - Package: `io.camunda.zeebe`
  - Class: `MyTest`
  - **State:**
    - First flagged at: `a1b2c3d`
    - Method last modified at: — (no fix detected)
    - Clean re-runs since fix: 0 / 3
    - Last observed: 2026-07-08T10:00:00Z
  
  <details><summary>Verify in BigQuery — is this a real new flake or a false alarm?</summary>
  
  ```sql
  SELECT DATE(report_time) AS day, build_trigger, test_status, COUNT(*) AS occurrences
  FROM `ci-30-162810.prod_ci_analytics.test_status_v1` ts
  LEFT OUTER JOIN `ci-30-162810.prod_ci_analytics.build_status_v2` bs
    ON ts.ci_url=bs.ci_url AND ts.build_id=bs.build_id AND ts.job_name=bs.job_name
  WHERE ts.report_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 60 DAY)
    AND ts.ci_url = "https://github.com/camunda/camunda"
    AND test_class_name = "io.camunda.zeebe.MyTest"
    AND test_name = "shouldWork"
  GROUP BY day, build_trigger, test_status  -- inspect the test_status column for flaky/failure/error rows
  ORDER BY day DESC, occurrences DESC
  ```
  
  In the `test_status` column, prior `flaky`/`failure`/`error` rows on `main`/`stable/*` (or other PRs) over the last 60 days indicate a pre-existing intermittent flake — likely a false alarm. No prior failing rows means this PR genuinely introduced it.
  </details>

---

**What to do:**
1. Fix the flaky test method, push the commit, then let CI run 3 times. The counter advances only when the originally affected job runs clean (no Maven retries).
2. If unrelated to your changes: add the `ci:flaky-test-bypass` label and create a `kind/flake` issue.

_This check compares flaky tests in this PR against tests known to be flaky on `main`/`stable/*` or other PRs in the last 20 days. Once flagged, the alert is sticky — a passing re-run does not clear it._

</td></tr></table>

The restored part is the **Verify in BigQuery** collapsible — everything else already existed.
