### PR TITLE
test: verify export handlers only write to a single index

### DIFF
--- a/qa/archunit-tests/pom.xml
+++ b/qa/archunit-tests/pom.xml
@@ -73,6 +73,12 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-bpmn-model</artifactId>
       <scope>test</scope>
     </dependency>

--- a/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter;
+
+import com.tngtech.archunit.core.domain.JavaCall;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.BatchRequest;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@AnalyzeClasses(packages = "io.camunda.exporter", importOptions = DoNotIncludeTestsOrTestJars.class)
+public class ExportHandlerArchTest {
+  @ArchTest
+  static final ArchRule EXPORT_HANDLERS_SHOULD_ONLY_WRITE_TO_ONE_INDEX =
+      ArchRuleDefinition.classes()
+          .that()
+          .areAssignableTo(ExportHandler.class)
+          .should(
+              new ArchCondition<>("only write to a single index") {
+                @Override
+                public void check(final JavaClass item, final ConditionEvents events) {
+                  // this is not a perfect verification - essentially we are checking that handlers
+                  // only call methods on BatchRequest once. We assume that multiple calls
+                  // mean we are trying to write to multiple indexes
+                  final List<JavaCall<?>> batchRequestCalls =
+                      item.getMethods().stream()
+                          .flatMap(method -> method.getCallsFromSelf().stream())
+                          .filter(call -> call.getTargetOwner().isAssignableTo(BatchRequest.class))
+                          .toList();
+                  if (batchRequestCalls.size() > 1) {
+                    // we will specifically allow a single delete call combined
+                    // with another non-delete call as this is a pattern used in
+                    // UserTaskJobBasedHandler which only writes to a single index
+                    int deleteCounts = 0;
+                    int otherCounts = 0;
+                    for (final JavaCall<?> call : batchRequestCalls) {
+                      if (call.getTarget().getName().startsWith("delete")) {
+                        deleteCounts++;
+                      } else {
+                        otherCounts++;
+                      }
+                    }
+
+                    if (deleteCounts == 1 && otherCounts == 1) {
+                      return;
+                    }
+
+                    final String message =
+                        batchRequestCalls.stream()
+                            .map(JavaCall::getDescription)
+                            .collect(Collectors.joining(" and "));
+                    events.add(SimpleConditionEvent.violated(item, message));
+                  }
+                }
+              });
+}

--- a/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
+++ b/qa/archunit-tests/src/test/java/io/camunda/exporter/ExportHandlerArchTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter;
 
+import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaCall;
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.junit.AnalyzeClasses;
@@ -17,18 +18,28 @@ import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import io.camunda.archunit.DoNotIncludeTestsOrTestJars;
+import io.camunda.exporter.handlers.AuditLogHandler;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.UsageMetricExportedHandler;
 import io.camunda.exporter.store.BatchRequest;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @AnalyzeClasses(packages = "io.camunda.exporter", importOptions = DoNotIncludeTestsOrTestJars.class)
 public class ExportHandlerArchTest {
+  // TODO remove these once the violations are fixed
+  private static final DescribedPredicate<JavaClass> VIOLATING_EXPORTERS =
+      DescribedPredicate.or(
+          JavaClass.Predicates.type(AuditLogHandler.class),
+          JavaClass.Predicates.type(UsageMetricExportedHandler.class));
+
   @ArchTest
   static final ArchRule EXPORT_HANDLERS_SHOULD_ONLY_WRITE_TO_ONE_INDEX =
       ArchRuleDefinition.classes()
           .that()
           .areAssignableTo(ExportHandler.class)
+          .and()
+          .areNotAssignableTo(VIOLATING_EXPORTERS)
           .should(
               new ArchCondition<>("only write to a single index") {
                 @Override


### PR DESCRIPTION
## Description

We want to enforce ExportHandlers only writing to a single index, to help with future refactoring for the archiver-less work.

## Related issues

refs #56991
