### PR TITLE
fix: increase topology check timeout

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/health/DiskSpaceRecoveryIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/health/DiskSpaceRecoveryIT.java
@@ -98,6 +98,7 @@ final class DiskSpaceRecoveryIT {
                   cfg.getCluster().getNetwork().setMaxMessageSize(DataSize.ofMegabytes(1));
                   cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
                 })
+            .withStartupTimeout(Duration.ofSeconds(90))
             .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
             .withEnv(UNPROTECTED_API_ENV_VAR, "true")
             .withEnv(AUTHORIZATION_CHECKS_ENV_VAR, "false");

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/health/DiskSpaceRecoveryIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/health/DiskSpaceRecoveryIT.java
@@ -98,6 +98,7 @@ final class DiskSpaceRecoveryIT {
                   cfg.getCluster().getNetwork().setMaxMessageSize(DataSize.ofMegabytes(1));
                   cfg.getData().getSecondaryStorage().setType(SecondaryStorageType.none);
                 })
+            // Increase startup timeout to reduce CI slow-start flakes; see #55457.
             .withStartupTimeout(Duration.ofSeconds(90))
             .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
             .withEnv(UNPROTECTED_API_ENV_VAR, "true")


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Increase topology check timeout to 90sec. The test flakes due to resource contention as it always passes on the second run. Also, based on logs the partition starts up normally but after the timeout so the test fails.

Only increasing this timeout and not the global topology check to avoid obscuring other issues that may arise in delayed startups.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55457
