### PR TITLE
docs: link repo code with stable GitHub permalinks, not raw path:line

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -130,6 +130,9 @@ GitHub form UI produces. For each item in the template's `body:` list:
 
 Append a **Links** section at the end with the parent issue URL if one was provided.
 
+When the body points at specific lines of repository code, use a **stable GitHub permalink** rather
+than a bare `path:line` (see "Referencing code in issues, PRs, and comments" in `AGENTS.md`).
+
 Do not invent sections or use any structure other than what the template defines.
 
 ### Step 6 — Propose summary and ask for approval

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,35 @@ Types: `build`, `ci`, `deps`, `docs`, `feat`, `fix`, `merge`, `perf`, `refactor`
 - Commit messages should explain *why*, not just *what* changed
 - Do not use commit scopes — commitlint enforces `scope-empty`. Use `fix: ...` not `fix(ci): ...`
 
+### Referencing code in issues, PRs, and comments
+
+When pointing at specific lines of repository code in any GitHub-rendered or shared artifact — issue,
+PR description, PR/review comment, or a linked note — use a **stable GitHub permalink** instead of a
+bare `path:line` reference. GitHub renders the linked lines inline, and pinning a commit SHA keeps the
+reference correct even after the file changes later. A bare `path:line` is only acceptable in local,
+throwaway context (never in something a teammate will read on GitHub).
+
+Derive the link locally — no API calls, no `gh`:
+
+```bash
+slug=$(git remote get-url origin | sed -E 's#^(git@github\.com:|https?://github\.com/)##; s#\.git$##')
+sha=$(git log -1 --format=%H -- "<path>")   # commit that last touched the file
+echo "https://github.com/$slug/blob/$sha/<path>#L<start>-L<end>"   # single line: #L<start>
+```
+
+- **SHA choice:** default to the file's last-touching commit (`git log -1 --format=%H -- <path>`). The
+  file content at that commit equals the current committed content, so the line numbers are valid, and
+  for existing code that commit is already on the remote. Use `git rev-parse HEAD` when linking code
+  from the current PR branch. Always use the full 40-char SHA — a branch name or short SHA is less
+  stable and can 404.
+- **Format:** `https://github.com/<slug>/blob/<sha>/<path>#L<start>` for one line, `#L<start>-L<end>`
+  for a range. `<path>` is repo-root-relative.
+- **The SHA must already be pushed to the remote**, otherwise the link 404s — verify with
+  `git branch -r --contains <sha>` (non-empty). The file's last-touching commit satisfies this once the
+  code is merged. If the file has local edits that are not pushed yet, do not link an unpushed SHA: pick
+  a SHA that is already on `main` (e.g. `git rev-parse origin/main`) and select the line range against
+  that version of the file.
+
 ### Build pipeline
 
 All builds use the Maven wrapper (`./mvnw`). Use `-T1C` (one thread per CPU core) for standalone


### PR DESCRIPTION
Referencing repository code by bare `path:line` in issues, PRs, and comments loses context the moment the file changes and forces the reader to go find the lines themselves. A GitHub permalink pinned to a commit SHA is strictly better: GitHub renders the referenced lines inline in the artifact, and pinning the SHA keeps the reference correct even as the file evolves later.

This documents the convention in `AGENTS.md` under a new "Referencing code in issues, PRs, and comments" subsection, with a recipe for deriving the link locally with no API calls — `git remote` for the `owner/repo` slug, `git log -1 --format=%H -- <path>` for a commit SHA where the line numbers are provably valid — plus the rule that the SHA must already be pushed to the remote (falling back to a `main` SHA when a file has unpushed local edits). It also applies the same convention to issue bodies in the `create-issue` skill.