### PR TITLE
[Backport stable/8.7] test: add E2E scenarios for decision instance navigation and DRD traversal

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionInstancePage.ts
@@ -12,6 +12,8 @@ class OperateDecisionInstancePage {
   private page: Page;
   readonly decisionPanel: Locator;
   readonly closeDrdPanelButton: Locator;
+  readonly openDrdButton: Locator;
+  readonly drd: Locator;
   readonly instanceHeader: Locator;
   readonly decisionInstanceIdCell: Locator;
   readonly viewProcessInstanceLink: (processInstanceKey: string) => Locator;
@@ -22,6 +24,10 @@ class OperateDecisionInstancePage {
     this.closeDrdPanelButton = page.getByRole('button', {
       name: /close drd panel/i,
     });
+    this.openDrdButton = page.getByRole('button', {
+      name: 'Open Decision Requirements Diagram',
+    });
+    this.drd = page.getByTestId('drd');
     this.instanceHeader = page.getByTestId('instance-header');
     this.decisionInstanceIdCell = this.instanceHeader
       .locator('tbody td')
@@ -34,6 +40,14 @@ class OperateDecisionInstancePage {
 
   async closeDrdPanel(): Promise<void> {
     await this.closeDrdPanelButton.click();
+  }
+
+  async openDrdPanel(): Promise<void> {
+    await this.openDrdButton.click();
+  }
+
+  async clickDrdDecisionNode(decisionName: string): Promise<void> {
+    await this.drd.getByText(decisionName).first().click();
   }
 
   async getDecisionInstanceId(): Promise<string> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionNavigation.spec.ts
@@ -12,12 +12,14 @@ import {deploy, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
 
 type ProcessInstance = {
   processInstanceKey: string;
 };
 
 let processInstanceWithFailedDecision: ProcessInstance;
+let processInstanceWithSuccessfulDecision: ProcessInstance;
 let calledDecisionInstanceId: string;
 
 test.beforeAll(async () => {
@@ -26,7 +28,15 @@ test.beforeAll(async () => {
     './resources/invoice.bpmn',
   ]);
 
+  // No variables → decision evaluation error → FAILED decision instance
   processInstanceWithFailedDecision = await createSingleInstance('invoice', 1);
+
+  // Valid inputs → decision evaluates successfully → EVALUATED decision instance
+  processInstanceWithSuccessfulDecision = await createSingleInstance(
+    'invoice',
+    1,
+    {amount: 500, invoiceCategory: 'Misc'},
+  );
 
   await sleep(2000);
 });
@@ -134,6 +144,128 @@ test.describe('Decision Navigation', () => {
 
     await test.step('Verify decision panel is visible again', async () => {
       await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+      await expect(
+        operateDecisionInstancePage.decisionPanel.getByText('Invoice Amount'),
+      ).toBeVisible();
+    });
+  });
+
+  test('should navigate to process instance from decision instances list', async ({
+    operateDecisionsPage,
+    operateProcessInstancePage,
+    operateHomePage,
+  }) => {
+    const processInstanceKey =
+      processInstanceWithSuccessfulDecision.processInstanceKey;
+
+    await test.step('Navigate to Decisions page', async () => {
+      await operateHomePage.clickDecisionsTab();
+    });
+
+    await test.step('Filter decision instances by Invoice Classification', async () => {
+      await operateDecisionsPage.selectDecisionName('Invoice Classification');
+      // Wait for the filtered results to load — Assign Approver Group rows must be gone
+      // before interacting, since both share the same processInstanceKey
+      await expect(
+        operateDecisionsPage.decisionInstancesList.getByText(
+          'Assign Approver Group',
+        ),
+      ).toHaveCount(0);
+    });
+
+    await test.step('Click the Process Instance Key link for the evaluated instance', async () => {
+      await operateDecisionsPage.decisionInstancesList
+        .getByRole('link', {
+          name: `View process instance ${processInstanceKey}`,
+        })
+        .first()
+        .click();
+    });
+
+    await test.step('Verify navigation to the corresponding process instance', async () => {
+      await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(
+          processInstanceKey,
+          {
+            exact: true,
+          },
+        ),
+      ).toBeVisible();
+    });
+  });
+
+  test('should navigate through DRD to another decision instance', async ({
+    page,
+    operateDecisionsPage,
+    operateDecisionInstancePage,
+    operateHomePage,
+  }) => {
+    await test.step('Navigate to Decisions page', async () => {
+      await operateHomePage.clickDecisionsTab();
+    });
+
+    await test.step('Filter by Assign Approver Group decision', async () => {
+      await operateDecisionsPage.selectDecisionName('Assign Approver Group');
+      await expect(operateDecisionsPage.decisionInstancesList).toBeVisible();
+      await expect(
+        operateDecisionsPage.decisionInstancesList.getByRole('row'),
+      ).not.toHaveCount(0);
+    });
+
+    await test.step('Open the Assign Approver Group decision instance', async () => {
+      // Scope to this run's Assign Approver Group row explicitly, so the correct
+      // decision instance is selected even if the name filter has not fully applied.
+      const decisionInstanceLink = operateDecisionsPage.decisionInstancesList
+        .getByRole('row')
+        .filter({
+          hasText: processInstanceWithSuccessfulDecision.processInstanceKey,
+        })
+        .filter({hasText: 'Assign Approver Group'})
+        .getByRole('link', {name: /View decision instance/})
+        .first();
+      // Wait for the freshly created decision instance to be indexed and rendered.
+      await expect(decisionInstanceLink).toBeVisible({timeout: 30_000});
+      // The decision instances list live-polls and re-renders, which can drop a
+      // click before it navigates. Retry the click until the decision instance
+      // page is actually opened.
+      await waitForAssertion({
+        assertion: async () => {
+          await decisionInstanceLink.click();
+          await expect(page).toHaveURL(/\/operate\/decisions\/[^/?]+/, {
+            timeout: 10_000,
+          });
+        },
+        onFailure: async () => {},
+      });
+    });
+
+    await test.step('Verify we are on the Assign Approver Group decision instance', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible({
+        timeout: 30_000,
+      });
+      // Input column header for Assign Approver Group is "Invoice Classification"
+      await expect(
+        operateDecisionInstancePage.decisionPanel.getByText(
+          'Invoice Classification',
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify the DRD panel is open', async () => {
+      await expect(operateDecisionInstancePage.drd).toBeVisible();
+    });
+
+    await test.step('Click Invoice Classification node in the DRD', async () => {
+      await operateDecisionInstancePage.clickDrdDecisionNode(
+        'Invoice Classification',
+      );
+    });
+
+    await test.step('Verify navigation to Invoice Classification instance with updated input data', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible({
+        timeout: 30000,
+      });
       await expect(
         operateDecisionInstancePage.decisionPanel.getByText('Invoice Amount'),
       ).toBeVisible();


### PR DESCRIPTION
⤵️ Backport of #53806 → `stable/8.7` (partial — decision **navigation** scenarios only; the filter tests were already backported separately).

relates to #33948

### What this adds
The two decision-navigation scenarios from #33948 to `stable/8.7`:
- **Scenario 1** — navigate to a process instance from a decision instances list entry
- **Scenario 2** — navigate through the DRD to another decision instance

### Adaptation notes (why this isn't a clean cherry-pick)
`stable/8.7` had already received the DMN filter tests (`decisionFilters.spec.ts`, `OperateDecisionsPage` changes) via a separate backport, and its `decisionNavigation.spec.ts` had diverged (explicit `demo` login, `sleep`-based indexing, no v2 `decision-instances` polling / `jsonHeaders`). This PR therefore ports only the missing navigation coverage, adapted to 8.7 conventions:
- explicit `loginPage.login('demo','demo')` + `navigateToApp` in `beforeEach`
- `sleep`-based indexing wait instead of `jsonHeaders` + `/v2/decision-instances/search` polling (neither exists on 8.7)
- added `openDrdButton`/`drd` locators + `openDrdPanel()`/`clickDrdDecisionNode()` to `OperateDecisionInstancePage`

Hardened against flakiness observed on a slow local cluster: wait for the freshly indexed row, scope the row to the *Assign Approver Group* decision, retry the click until the decision instance page opens, and allow extra time for the decision panel to render.

### Verification
Ran locally against a Camunda 8.7-SNAPSHOT self-managed cluster (Elasticsearch): full `decisionNavigation.spec.ts` green — `6 passed`, all three navigation tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)