### PR TITLE
fix: expose license endpoint under physical tenant paths

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/LicenseController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/LicenseController.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.gateway.rest.controller;
 import io.camunda.gateway.protocol.model.LicenseResponse;
 import io.camunda.service.ManagementServices;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
-import io.camunda.zeebe.gateway.rest.annotation.ClusterScoped;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -18,7 +17,6 @@ import java.time.format.DateTimeFormatter;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
-@ClusterScoped
 @RequestMapping(path = {"/v2"})
 public class LicenseController {
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/LicenseControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/LicenseControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.json.JsonCompareMode;
 public class LicenseControllerTest extends RestControllerTest {
 
   static final String LICENSE_URL = "/v2/license";
+  static final String PT_LICENSE_URL = "/physical-tenants/foo/v2/license";
 
   static final String EXPECTED_LICENSE_RESPONSE =
       """
@@ -58,6 +59,34 @@ public class LicenseControllerTest extends RestControllerTest {
     webClient
         .get()
         .uri(LICENSE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_LICENSE_RESPONSE, JsonCompareMode.STRICT);
+
+    verify(managementServices).isCamundaLicenseValid();
+    verify(managementServices).getCamundaLicenseType();
+    verify(managementServices).isCommercialCamundaLicense();
+    verify(managementServices).getCamundaLicenseExpiresAt();
+  }
+
+  @Test
+  void shouldReturnLicenseForPhysicalTenantPath() {
+    // given
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.getCamundaLicenseExpiresAt())
+        .thenReturn(OffsetDateTime.parse("2024-10-29T15:14:13Z"));
+
+    // when / then
+    webClient
+        .get()
+        .uri(PT_LICENSE_URL)
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()


### PR DESCRIPTION
`LicenseController` was annotated with `@ClusterScoped`, which prevented `PhysicalTenantRequestMappingHandlerMapping` from registering the `/physical-tenants/{id}/v2/license` route. The security layer already granted `permitAll()` for this path on each PT scoped chain (via `SecurityPathAdapter.UNPROTECTED_API_PATHS`), but Spring MVC had no handler for it, causing a "No static resource" 404.

The license value is cluster-global data with no per-tenant context, so exposing it under PT paths is correct — the webapp frontend calls GET `/v2/license` on every authenticated page load and needs it regardless of which path prefix it is running under.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56040
