### PR TITLE
feat: prefix unified webapp baseName for physical-tenant requests

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebappContextPathInterceptor.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebappContextPathInterceptor.java
@@ -14,15 +14,17 @@ import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
- * Prefixes the {@code contextPath} model attribute set by the webapp index controllers (operate,
- * tasklist, admin) so a physical-tenant-prefixed request renders an SPA whose {@code <base href>}
+ * Prefixes the {@code contextPath} and {@code baseName} model attributes set by the webapp index
+ * controllers so a physical-tenant-prefixed request renders an SPA whose {@code <base href>}
  * carries the PT prefix.
  *
- * <p>The index controllers set {@code contextPath = servletContextPath + "/<app>/"} unconditionally
- * (e.g. {@code /operate/}). Without this interceptor the rendered shell's base href would always be
- * {@code /operate/}, so even when entered through {@code /physical-tenants/<id>/operate} the
- * browser would resolve assets and API calls back to the unprefixed URL space, where the PT session
- * cookie does not apply and the SPA breaks.
+ * <p>The legacy index controllers (operate, tasklist, admin) set {@code contextPath =
+ * servletContextPath + "/<app>/"} unconditionally (e.g. {@code /operate/}). The unified webapp's
+ * {@code WebappIndexController} additionally sets {@code baseName = servletContextPath +
+ * "/webapp/"}, which drives the rendered shell's {@code <base href>} and the SPA boot config.
+ * Without this interceptor those values would always be unprefixed, so even when entered through
+ * {@code /physical-tenants/<id>/<app>} the browser would resolve assets and API calls back to the
+ * unprefixed URL space, where the PT session cookie does not apply and the SPA breaks.
  *
  * <p>The physical tenant id is resolved from the request via {@link
  * PhysicalTenantContext#getPhysicalTenantId(HttpServletRequest)}, which {@code
@@ -36,6 +38,7 @@ import org.springframework.web.servlet.ModelAndView;
 public class PhysicalTenantWebappContextPathInterceptor implements HandlerInterceptor {
 
   private static final String CONTEXT_PATH_ATTRIBUTE = "contextPath";
+  private static final String BASE_NAME_ATTRIBUTE = "baseName";
 
   @Override
   public void postHandle(
@@ -50,11 +53,20 @@ public class PhysicalTenantWebappContextPathInterceptor implements HandlerInterc
     if (physicalTenantId == null) {
       return;
     }
-    final Object existing = modelAndView.getModel().get(CONTEXT_PATH_ATTRIBUTE);
+    prefixAttribute(request, modelAndView, CONTEXT_PATH_ATTRIBUTE, physicalTenantId);
+    prefixAttribute(request, modelAndView, BASE_NAME_ATTRIBUTE, physicalTenantId);
+  }
+
+  private void prefixAttribute(
+      final HttpServletRequest request,
+      final ModelAndView modelAndView,
+      final String attribute,
+      final String physicalTenantId) {
+    final Object existing = modelAndView.getModel().get(attribute);
     if (existing instanceof final String existingPath) {
       // PT routes are servlet-context-relative, so the external path is
       // <contextPath>/physical-tenants/<id>/<webapp>/. The index controllers set the model's
-      // contextPath to <contextPath>/<webapp>/, so the PT segment must be inserted after the
+      // path attributes to <contextPath>/<webapp>/, so the PT segment must be inserted after the
       // servlet context path (which is empty in the common case) — not before it.
       final String contextPath = request.getContextPath();
       final String afterContextPath =
@@ -62,7 +74,7 @@ public class PhysicalTenantWebappContextPathInterceptor implements HandlerInterc
               ? existingPath.substring(contextPath.length())
               : existingPath;
       modelAndView.addObject(
-          CONTEXT_PATH_ATTRIBUTE,
+          attribute,
           contextPath
               + PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT
               + physicalTenantId

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebappContextPathInterceptorTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/config/PhysicalTenantWebappContextPathInterceptorTest.java
@@ -94,6 +94,73 @@ class PhysicalTenantWebappContextPathInterceptorTest {
   }
 
   @Test
+  void shouldPrefixBaseNameForPhysicalTenantRequest() {
+    // given — the unified webapp's model shape: contextPath is the bare servlet context path,
+    // baseName carries the /webapp/ suffix
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final ModelAndView modelAndView = new ModelAndView("webapp/index");
+    modelAndView.addObject("contextPath", "");
+    modelAndView.addObject("baseName", "/webapp/");
+
+    // when
+    interceptor.postHandle(request, new MockHttpServletResponse(), new Object(), modelAndView);
+
+    // then
+    assertThat(modelAndView.getModel().get("contextPath")).isEqualTo("/physical-tenants/tenanta");
+    assertThat(modelAndView.getModel().get("baseName"))
+        .isEqualTo("/physical-tenants/tenanta/webapp/");
+  }
+
+  @Test
+  void shouldInsertBaseNamePrefixAfterServletContextPath() {
+    // given — a non-empty servlet context path; the index controller's baseName includes it
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setContextPath("/camunda");
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final ModelAndView modelAndView = new ModelAndView("webapp/index");
+    modelAndView.addObject("baseName", "/camunda/webapp/");
+
+    // when
+    interceptor.postHandle(request, new MockHttpServletResponse(), new Object(), modelAndView);
+
+    // then — the PT segment is inserted after the context path, not before it
+    assertThat(modelAndView.getModel().get("baseName"))
+        .isEqualTo("/camunda/physical-tenants/tenanta/webapp/");
+  }
+
+  @Test
+  void shouldNotChangeBaseNameForClusterRequest() {
+    // given — no physical tenant id stamped on the request
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    final ModelAndView modelAndView = new ModelAndView("webapp/index");
+    modelAndView.addObject("baseName", "/webapp/");
+
+    // when
+    interceptor.postHandle(request, new MockHttpServletResponse(), new Object(), modelAndView);
+
+    // then
+    assertThat(modelAndView.getModel().get("baseName")).isEqualTo("/webapp/");
+  }
+
+  @Test
+  void shouldNoOpWhenModelHasNoBaseName() {
+    // given — a legacy index controller model that only sets contextPath
+    final MockHttpServletRequest request = new MockHttpServletRequest();
+    PhysicalTenantContext.setPhysicalTenantId(request, "tenanta");
+    final ModelAndView modelAndView = new ModelAndView("operate/index");
+    modelAndView.addObject("contextPath", "/operate/");
+
+    // when
+    interceptor.postHandle(request, new MockHttpServletResponse(), new Object(), modelAndView);
+
+    // then
+    assertThat(modelAndView.getModel())
+        .doesNotContainKey("baseName")
+        .containsEntry("contextPath", "/physical-tenants/tenanta/operate/");
+  }
+
+  @Test
   void shouldNoOpWhenModelHasNoContextPath() {
     // given
     final MockHttpServletRequest request = new MockHttpServletRequest();


### PR DESCRIPTION
## Description

Under the physical-tenant URL scheme (`/physical-tenants/<id>/webapp/...`), the unified webapp's `WebappIndexController` emits a `baseName` model attribute that drives the rendered SPA shell's `<base href>` and the boot config. `PhysicalTenantWebappContextPathInterceptor` previously rewrote only the `contextPath` attribute, so `baseName` stayed unprefixed (`/webapp/`). The SPA then booted with a base URL outside the per-tenant cookie scope, and react-router refused to match the PT-prefixed entry URL.

This generalizes the interceptor to prefix **both** `contextPath` and `baseName` with `/physical-tenants/<id>` (inserted after the servlet context path) when a physical tenant is bound to the request, via a shared `prefixAttribute` helper. Cluster (unprefixed) requests and legacy index controllers that emit no `baseName` are unaffected.

Most of the PT-webapp machinery this issue asked for already landed on `main` (PT filter, request-mapping prefixing, PT-prefixed static assets, and the interceptor itself); `baseName` was the remaining gap.

## Testing

- `PhysicalTenantWebappContextPathInterceptorTest` — 4 new `baseName` cases (PT prefix, insert-after-context-path, cluster no-op, missing-attribute no-op); 10/10 pass.
- `webapp/server` module — 13 unit + 8 IT pass, no regressions.

Closes #53810

🤖 Generated with [Claude Code](https://claude.com/claude-code)