### PR TITLE
test: regenerate API response assertions from latest main OpenAPI spec

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
     "sourceRepo": "https://github.com/camunda/camunda",
-    "commit": "7e28eeef5fabc1842fbf6e6854699a13b9e37517",
-    "generatedAt": "2026-06-29T13:29:14.708Z",
+    "commit": "690f8c26c694d127e81cb6197680f6de018b62c1",
+    "generatedAt": "2026-07-08T12:35:33.562Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "0eaed7462781f2ed6afc8ecb56bf7533646dee4bd22b4f93b434dc28c81b0e3d"
+    "specSha256": "d5158781a0406452dd9affa12dab15852a21986b58e189bb4ea4936ae3e19cb9"
   },
   "responses": [
     {
@@ -4762,6 +4762,11 @@
                   "wrapper": true
                 },
                 {
+                  "name": "leaseToken",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
                   "name": "listenerEventType",
                   "type": "string",
                   "enumValues": [
@@ -5034,6 +5039,7 @@
                     "MIGRATED",
                     "PRIORITY_UPDATED",
                     "RETRIES_UPDATED",
+                    "TIMEOUT_UPDATED",
                     "TIMED_OUT"
                   ]
                 },
@@ -6999,6 +7005,33 @@
       }
     },
     {
+      "path": "/process-instances/{processInstanceKey}/statistics/wait-states",
+      "method": "GET",
+      "status": "200",
+      "schema": {
+        "required": [
+          {
+            "name": "items",
+            "type": "array<object>",
+            "children": {
+              "required": [
+                {
+                  "name": "elementId",
+                  "type": "string"
+                },
+                {
+                  "name": "waitingCount",
+                  "type": "number"
+                }
+              ],
+              "optional": []
+            }
+          }
+        ],
+        "optional": []
+      }
+    },
+    {
       "path": "/resources/search",
       "method": "POST",
       "status": "200",
@@ -8170,6 +8203,38 @@
           {
             "name": "replicationFactor",
             "type": "number"
+          }
+        ],
+        "optional": []
+      }
+    },
+    {
+      "path": "/mode",
+      "method": "PATCH",
+      "status": "200",
+      "schema": {
+        "required": [
+          {
+            "name": "changeId",
+            "type": "string"
+          },
+          {
+            "name": "plannedChanges",
+            "type": "array<object>",
+            "children": {
+              "required": [
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "operation",
+                  "type": "string"
+                }
+              ],
+              "optional": []
+            }
           }
         ],
         "optional": []


### PR DESCRIPTION
Automated regeneration of the JSON body response assertions via `npm run responses:regenerate` (followed by `npm run lint:fix`).

This PR was opened because the **response schemas** in `json-body-assertions/_generated/responses.json` changed.
Metadata-only differences (`generatedAt`, `commit`, `specSha256`) do not trigger a PR.

Please review the schema changes against the upstream REST API spec.

_Opened by the C8 Orchestration Cluster responses-regeneration workflow for main._
