### PR TITLE
deps: migrate keycloak image from bitnami to bitnamilegacy

### DIFF
--- a/operate/config/docker-compose.identity.yml
+++ b/operate/config/docker-compose.identity.yml
@@ -34,7 +34,7 @@ services:
     depends_on:
       - postgres
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3
+    image: bitnamilegacy/keycloak:26.3.3
     volumes:
       - keycloak-theme:/opt/bitnami/keycloak/themes/identity
     ports:

--- a/operate/config/docker-compose.mt.yml
+++ b/operate/config/docker-compose.mt.yml
@@ -34,7 +34,7 @@ services:
     depends_on:
       - postgres
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3
+    image: bitnamilegacy/keycloak:26.3.3
     volumes:
       - keycloak-theme:/opt/bitnami/keycloak/themes/identity
     ports:

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -45,7 +45,7 @@ services:
     depends_on:
       - postgres
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3
+    image: bitnamilegacy/keycloak:26.3.3
     volumes:
       - keycloak-theme:/opt/bitnami/keycloak/themes/identity
     ports:

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -36,7 +36,7 @@ services:
     depends_on:
       - postgres
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3
+    image: bitnamilegacy/keycloak:26.3.3
     volumes:
       - keycloak-theme:/opt/bitnami/keycloak/themes/identity
     ports:

--- a/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/config/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     depends_on:
       - postgres
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3
+    image: bitnamilegacy/keycloak:26.3.3
     ports:
       - '18080:8080'
     environment:

--- a/qa/orchestration-cluster-smoke-tests/config/docker-compose.yml
+++ b/qa/orchestration-cluster-smoke-tests/config/docker-compose.yml
@@ -75,7 +75,7 @@ services:
     depends_on:
       - postgres
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3
+    image: bitnamilegacy/keycloak:26.3.3
     ports:
       - '18080:8080'
     environment:

--- a/tasklist/config/docker-compose.yml
+++ b/tasklist/config/docker-compose.yml
@@ -78,7 +78,7 @@ services:
     depends_on:
       - postgres
     container_name: keycloak
-    image: bitnami/keycloak:26.3.3
+    image: bitnamilegacy/keycloak:26.3.3
     ports:
       - "18080:8080"
     environment:

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestContainerUtil.java
@@ -190,7 +190,7 @@ public class TestContainerUtil {
   public void startKeyCloak(final TestContext testContext) {
     LOGGER.info("************ Starting Keycloak ************");
     keycloakContainer =
-        new GenericContainer<>(DockerImageName.parse("bitnami/keycloak:22.0.1"))
+        new GenericContainer<>(DockerImageName.parse("bitnamilegacy/keycloak:22.0.1"))
             .withExposedPorts(KEYCLOAK_PORT)
             .withEnv(
                 Map.of(


### PR DESCRIPTION
## Description

Bitnami removed versioned tags from the `docker.io/bitnami` namespace as part of the [Bitnami Secure Images migration](https://github.com/bitnami/containers/issues/83267) (Sep 2025). The pinned tags we use are already gone:

- `bitnami/keycloak:26.3.3` → **404**
- `bitnami/keycloak:22.0.1` → **404**

This breaks every dev/test setup that pulls them (Operate/Tasklist identity compose files, QA & smoke-test compose, and the Tasklist QA testcontainer). **Renovate also can no longer resolve the datasource**, so the images are stuck (empty results on `main` and all stable branches) and this prolongs Renovate runs unnecessarily.

This PR repoints all references at the frozen `bitnamilegacy` archive, where these exact tags still exist and remain pullable:

- 7 `docker-compose` files: `bitnami/keycloak:26.3.3` → `bitnamilegacy/keycloak:26.3.3`
- `TestContainerUtil.java`: `bitnami/keycloak:22.0.1` → `bitnamilegacy/keycloak:22.0.1`

**Those docker-compose setups were broken and nobody complained, can we just delete them?** Maybe, but I mainly want to speed up Renovate without too much overhead → this PR focusses on that aspect.

### Notes

- `bitnamilegacy` is a frozen archive (no new tags), so Renovate still won't produce version bumps for Keycloak here — but the images will keep pulling, which they currently do not. **This will speed up Renovate again due to not enumerating empty registries.**
- Golden helm fixtures under `load-tests/setup/test/golden/**` are excluded (Renovate-ignored, generated output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)