### PR TITLE
fix: disable Optimize object variable flattening in load tests

### DIFF
--- a/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
@@ -124,6 +124,14 @@ optimize:
     - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
       value: "1000" # default 200
 
+    # Disable object variable flattening: Optimize's own default (true) turns
+    # every object variable into multiple stored variables (one per property,
+    # plus the raw serialized value), causing outsized ES storage on top of
+    # Optimize's already-higher per-variable cost. SaaS already disables this
+    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+      value: "false" # default true
+
   tolerations:
     - key: nodepool
       operator: Equal

--- a/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-87/values/camunda-platform-values-defaults.yaml
@@ -155,6 +155,14 @@ optimize:
     - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
       value: "1000" # default 200
 
+    # Disable object variable flattening: Optimize's own default (true) turns
+    # every object variable into multiple stored variables (one per property,
+    # plus the raw serialized value), causing outsized ES storage on top of
+    # Optimize's already-higher per-variable cost. SaaS already disables this
+    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+      value: "false" # default true
+
   nodeSelector:
     topology.kubernetes.io/zone: __AVAILABILITY_ZONE__
 

--- a/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-88/values/camunda-platform-values-defaults.yaml
@@ -133,6 +133,14 @@ optimize:
     - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
       value: "1000" # default 200
 
+    # Disable object variable flattening: Optimize's own default (true) turns
+    # every object variable into multiple stored variables (one per property,
+    # plus the raw serialized value), causing outsized ES storage on top of
+    # Optimize's already-higher per-variable cost. SaaS already disables this
+    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+      value: "false" # default true
+
   nodeSelector:
     component: benchmark-n2-standard-4
     topology.kubernetes.io/zone: __AVAILABILITY_ZONE__

--- a/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/stable-89/values/camunda-platform-values-defaults.yaml
@@ -102,6 +102,14 @@ optimize:
     - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
       value: "1000" # default 200
 
+    # Disable object variable flattening: Optimize's own default (true) turns
+    # every object variable into multiple stored variables (one per property,
+    # plus the raw serialized value), causing outsized ES storage on top of
+    # Optimize's already-higher per-variable cost. SaaS already disables this
+    # in production; see camunda/camunda#57127 and camunda/camunda-docs#9326.
+    - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+      value: "false" # default true
+
   tolerations:
     - key: nodepool
       operator: Equal

--- a/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -141,6 +143,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-main-elasticsearch-stable-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -141,6 +143,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-main-elasticsearch-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -83,6 +83,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -153,6 +155,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-main-opensearch-stable-identity-env-vars

--- a/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/opensearch/platform/templates/optimize/deployment.yaml
@@ -83,6 +83,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -153,6 +155,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-main-opensearch-identity-env-vars

--- a/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-optimize/platform/templates/optimize/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -141,6 +143,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-main-rdbms-optimize-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -132,6 +134,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-87-elasticsearch-stable-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-87/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -132,6 +134,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-87-elasticsearch-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -130,6 +132,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-88-elasticsearch-stable-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -130,6 +132,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-88-elasticsearch-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -138,6 +140,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-88-opensearch-stable-identity-env-vars

--- a/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-88/opensearch/platform/templates/optimize/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -138,6 +140,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-88-opensearch-identity-env-vars

--- a/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch-stable/platform/templates/optimize/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -133,6 +135,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-89-elasticsearch-stable-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/elasticsearch/platform/templates/optimize/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -133,6 +135,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-89-elasticsearch-camunda-platform-identity-env-vars

--- a/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch-stable/platform/templates/optimize/deployment.yaml
@@ -79,6 +79,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -145,6 +147,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-89-opensearch-stable-identity-env-vars

--- a/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/opensearch/platform/templates/optimize/deployment.yaml
@@ -79,6 +79,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -145,6 +147,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-89-opensearch-identity-env-vars

--- a/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/deployment.yaml
+++ b/load-tests/setup/test/golden/stable-89/rdbms-optimize/platform/templates/optimize/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           resources:
             limits:
               cpu: 2000m
@@ -133,6 +135,8 @@ spec:
               value: "3"
             - name: CAMUNDA_OPTIMIZE_ZEEBE_MAX_IMPORT_PAGE_SIZE
               value: "1000"
+            - name: CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: c8-golden-stable-89-rdbms-optimize-camunda-platform-identity-env-vars


### PR DESCRIPTION
## Summary
- Sets `CAMUNDA_OPTIMIZE_ZEEBE_INCLUDE_OBJECT_VARIABLE=false` for Optimize in `load-tests/setup/{main,stable-87,stable-88,stable-89}/values/camunda-platform-values-defaults.yaml`.
- Optimize's own shipped default is `true`, which flattens every object variable into multiple stored variables (one per property, plus the raw serialized value) on top of Optimize's already-higher per-variable storage cost. The load tests never overrode this, silently inheriting the expensive default and skewing SM-vs-SaaS comparisons, since SaaS's `camunda-operator` deployment explicitly sets this to `false`.
- Measured impact: [camunda/camunda#57127](https://github.com/camunda/camunda/issues/57127) found 5.9x-7.5x more stored variables and 31.5x-48.8x more variable bytes per instance on a load-test cluster vs. an identical-workload SaaS cluster, attributable to this flag alone.
- Storage cost mechanism write-up: [camunda/camunda-docs#9326](https://github.com/camunda/camunda-docs/pull/9326).
- Regenerated the 16 golden files affected (`load-tests/setup/test/golden/{main,stable-87,stable-88,stable-89}/*/platform/templates/optimize/deployment.yaml`) via `make update-golden`, scoped only to scenarios that actually deploy Optimize (elasticsearch, elasticsearch-stable, opensearch, opensearch-stable, rdbms-optimize).

## Test plan
- [x] YAML syntax validated for all 4 edited values files.
- [x] `make update-golden` run for all 4 active setup versions; diff reviewed, confirmed to touch only the new env var (2 lines per Optimize container, webapp + importer/archiver) in Optimize-enabled scenarios, nothing else.
- [x] Deployed the `realistic` scenario with only this flag toggled and confirmed Optimize's ES disk share drops materially: 62.8% (flag on) → 7.6% (flag off), 8.3x. Details in the comment below and in [OPTIMIZE-FLATTEN-CONTROLLED-AB-TEST.md](https://github.com/camunda/team-reliability-testing/blob/main/investigations/2026/07/comparison-saas-loadtest/OPTIMIZE-FLATTEN-CONTROLLED-AB-TEST.md).

Complements [camunda/camunda#57127](https://github.com/camunda/camunda/issues/57127), which proposes changing Optimize's own shipped default.