### PR TITLE
docs: capture CI and test-stability learnings in agent guidance

### DIFF
--- a/.claude/skills/ci-workflow-authoring/SKILL.md
+++ b/.claude/skills/ci-workflow-authoring/SKILL.md
@@ -16,6 +16,7 @@ Check `docs/monorepo-docs/ci.md` first.
 - Add `timeout-minutes` per job.
 - Pin all external actions to commit SHAs.
 - Ensure each job ends with `observe-build-status` step.
+- Fail fast: validate cheap preconditions (required secrets, Vault reachability, input/tag contracts) in a preflight step or job before expensive build/test steps.
 
 ## Unified CI Criteria
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,12 @@ Load extra context on demand — only when relevant, only if the files exist.
 - Prefer AssertJ for assertions. Avoid introducing new JUnit or Hamcrest assertions unless the
   surrounding test already uses them.
 - Use [Awaitility](http://www.awaitility.org/) for async waiting. Never use `Thread.sleep`.
+- Isolate tests with unique data (process/tenant/resource IDs) — never reuse fixed identifiers across
+  tests, as collisions cause flakiness.
+- Fix the root cause of a flaky race rather than masking it with retries or longer waits; if a stopgap
+  is unavoidable, mark it explicitly as temporary and track the root cause in an issue.
+- Always tear down resources you create (indices, containers, clients, clusters), even on failure, to
+  avoid cross-run flakiness.
 - Use JUnit 5. Migrate JUnit 4 tests when modifying them.
 - Detailed guide: `docs/testing.md` and `docs/testing/`.
 - Reference example: `qa/acceptance-tests/src/test/java/io/camunda/it/StandaloneCamundaTest.java`

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -143,6 +143,9 @@ Workflows that seek inclusion to the Unified CI (and thus GitHub required status
   * handle flaky tests gracefully, options:
     1. retry them 3-5 times while staying in the timeout and report them via [detailed test statistics API](https://github.com/camunda/camunda/pull/26715) to [CI health](#ci-health-metrics)
     2. disable them and create a ticket to fix them long-term
+  * new quality gates should be added **non-blocking first**:
+    1. measure its false-positive rate against real traffic and refine it
+    2. only make it blocking once the signal is trustworthy
 * use [Vault for secret management](#ci-secret-management)
 * follow the [GitHub Actions Cache strategy](#caching-strategy) for the monorepo
 * follow all [CI Security best practices](#ci-security) for the monorepo, including [SHA pinning of third-party actions](#usage-of-third-party-github-actions)
@@ -720,6 +723,9 @@ Tests are called "flaky" when they are not consistenly passing, while the circum
 GitHub Action workflows with Maven testing Java code should use the [flaky-test-extractor-maven-plugin](#flaky-test-extractor-maven-plugin) and report the resulting [detailed flaky test statistics](https://github.com/camunda/camunda/issues/26930) to our [CI health](#ci-health-metrics) database.
 
 Please use the [CI stress testing functionality](#stress-testing) to avoid introducing new flaky tests.
+
+When a flake cannot be reproduced locally, prefer adding diagnostics over guessing at a fix: capture
+container logs, thread dumps, or structured test output on failure so the next occurrence in CI is actionable.
 
 The [**Flaky Test Gate**](./flaky-test-gate.md) blocks PRs that introduce new flaky tests not already known on `main`/`stable/*`. Once a test is flagged on a PR the alert is **sticky** — it remains until either the method body is modified and 3 subsequent CI runs observe the test clean in the affected job, or the `ci:flaky-test-bypass` label is applied. A re-run that happens to pass does not silence the alert. See the [Flaky Test Gate reference](./flaky-test-gate.md) for the full rules, comment templates, and operational concerns.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -98,6 +98,25 @@ successfully before running the tests.
    }
 ```
 
+#### Do's: isolate tests with unique data
+
+When a test needs identifiers (process IDs, tenant IDs, usernames, resource keys), generate a unique
+identifier per test (or per test class) instead of reusing a constant, so tests cannot interfere with
+each other — collisions are a common source of flakiness.
+
+#### Do's: fix the root cause of a race, don't just retry around it
+
+When a test is flaky because of a timing/ordering race, prefer fixing the underlying synchronization
+(await the real precondition, close the actual ordering gap in the code under test) over masking it with
+added retries or longer sleeps. Retries and timeout bumps are acceptable as an explicitly-temporary
+stopgap to unblock, but they hide the defect rather than remove it — track the root cause in an issue.
+
+#### Don'ts: leak resources between tests
+
+Tests that create external resources (indices, containers, clients, clusters) must tear them down, even
+on failure. Leaked resources accumulate across runs and surface later as unrelated, hard-to-diagnose
+flakiness. Use lifecycle hooks / try-with-resources so cleanup runs regardless of the test outcome.
+
 ## Acceptance test
 
 > [!Note]


### PR DESCRIPTION
## Description

Distills reusable, task-independent learnings from https://github.com/camunda/product-hub/issues/3631 and https://github.com/camunda/product-hub/issues/3667 into the persistent docs and skills so humans and agents can apply them in future work:

- ci.md: fail-fast preflight validation in the Unified CI criteria; guidance to add diagnostics for non-reproducible flakes and to label stopgaps temporary; roll out blocking CI gates non-blocking-first.
- ci-workflow-authoring skill: preflight validation convention.
- testing.md: Do's/Don'ts for unique test data, fixing race root causes over retrying, and tearing down resources.
- AGENTS.md: mirror the three test conventions as one-liners.

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related to https://github.com/camunda/product-hub/issues/3631 and https://github.com/camunda/product-hub/issues/3667
