### PR TITLE
feat: add DRAINING process definition state

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -245,6 +245,7 @@ public final class EventAppliers implements EventApplier {
     register(ProcessIntent.CREATED, 2, new ProcessCreatedV2Applier(state));
     register(ProcessIntent.DELETING, new ProcessDeletingApplier(state));
     register(ProcessIntent.DELETED, new ProcessDeletedApplier(state));
+    register(ProcessIntent.DRAINING, new ProcessDrainingApplier(state));
   }
 
   private void registerTimeEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessDrainingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessDrainingApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+
+public class ProcessDrainingApplier implements TypedEventApplier<ProcessIntent, ProcessRecord> {
+
+  private final MutableProcessState processState;
+
+  public ProcessDrainingApplier(final MutableProcessingState state) {
+    processState = state.getProcessState();
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessRecord value) {
+    processState.updateProcessState(value, PersistedProcessState.DRAINING);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
@@ -126,7 +126,8 @@ public final class PersistedProcess extends UnpackedObject
 
   public enum PersistedProcessState {
     ACTIVE(0),
-    PENDING_DELETION(1);
+    PENDING_DELETION(1),
+    DRAINING(2);
 
     byte value;
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -825,6 +825,23 @@ public final class ProcessStateTest {
   }
 
   @Test
+  public void shouldMarkProcessAsDrainingAndKeepItRetrievable() {
+    // given
+    final long processDefinitionKey = 100L;
+    final var processRecord = creatingProcessRecord(processingState).setKey(processDefinitionKey);
+    processState.putProcess(processDefinitionKey, processRecord);
+
+    // when
+    processState.updateProcessState(processRecord, PersistedProcessState.DRAINING);
+
+    // then - the process is still retrievable by key and tenant, now in the DRAINING state
+    final var drainingProcess =
+        processState.getProcessByKeyAndTenant(processDefinitionKey, processRecord.getTenantId());
+    assertThat(drainingProcess).isNotNull();
+    assertThat(drainingProcess.getState()).isEqualTo(PersistedProcessState.DRAINING);
+  }
+
+  @Test
   public void shouldDeleteLatestProcess() {
     // given
     final String processId = Strings.newRandomValidBpmnId();

--- a/zeebe/engine/src/test/resources/state/appliers/golden/Process_DRAINING_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/Process_DRAINING_v1.golden
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+
+public class ProcessDrainingApplier implements TypedEventApplier<ProcessIntent, ProcessRecord> {
+
+  private final MutableProcessState processState;
+
+  public ProcessDrainingApplier(final MutableProcessingState state) {
+    processState = state.getProcessState();
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessRecord value) {
+    processState.updateProcessState(value, PersistedProcessState.DRAINING);
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessIntent.java
@@ -18,7 +18,8 @@ package io.camunda.zeebe.protocol.record.intent;
 public enum ProcessIntent implements Intent {
   CREATED((short) 0),
   DELETING((short) 1),
-  DELETED((short) 2);
+  DELETED((short) 2),
+  DRAINING((short) 3);
 
   private final short value;
 
@@ -38,6 +39,8 @@ public enum ProcessIntent implements Intent {
         return DELETING;
       case 2:
         return DELETED;
+      case 3:
+        return DRAINING;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description

Introduce a new ProcessIntent.DRAINING event, a PersistedProcessState.DRAINING value, and a ProcessDrainingApplier that marks a process definition as draining while keeping it retrievable by key.

This is the inert protocol/state foundation for draining deletion (#55930). A resource deletion with active instances will later mark the definition DRAINING instead of blocking the shared DEPLOYMENT distribution queue, and finalize the physical deletion per partition once the last instance drains. Nothing writes DRAINING yet, so this change has no runtime effect on its own.

The existing DELETING/DELETED intents and their appliers are unchanged; DRAINING is inserted before them in the lifecycle ACTIVE -> DRAINING -> DELETING -> DELETED.

## Related issues

closes #56975
