### PR TITLE
[Backport stable/8.7] [E2E:test] Add Operate process-instance Incidents test

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateProcessInstancePage.ts
@@ -8,6 +8,7 @@
 
 import {Page, Locator, expect} from '@playwright/test';
 import {sleep} from 'utils/sleep';
+import {waitForAssertion} from 'utils/waitForAssertion';
 
 class OperateProcessInstancePage {
   private page: Page;
@@ -84,6 +85,14 @@ class OperateProcessInstancePage {
   readonly deleteVariableModificationButton: Locator;
   readonly cancelModificationSummaryButton: Locator;
   readonly undoButton: Locator;
+  readonly metadataPopover: Locator;
+  readonly incidentSection: Locator;
+  readonly rootCauseProcessName: Locator;
+  readonly rootCauseProcessId: Locator;
+  readonly incidentErrorType: Locator;
+  readonly incidentErrorIndicators: Locator;
+  readonly incidentErrorMessage: Locator;
+  readonly calledProcessInstanceLink: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -229,6 +238,20 @@ class OperateProcessInstancePage {
       .getByRole('dialog')
       .getByRole('button', {name: 'Cancel'});
     this.undoButton = page.getByRole('button', {name: /undo/i});
+    this.incidentErrorIndicators = page.getByTestId('incident-error-indicator');
+    this.metadataPopover = page.getByTestId('popover');
+    this.incidentErrorType = this.metadataPopover
+      .getByText('Type')
+      .locator('xpath=following-sibling::*[1]');
+    this.incidentErrorMessage = this.metadataPopover.locator('text=/error/i');
+    this.incidentSection = page.getByText(/incident\s*view/i);
+    this.rootCauseProcessName = this.metadataPopover.getByText(
+      /root cause process name/i,
+    );
+    this.rootCauseProcessId = this.metadataPopover.getByRole('link').first();
+    this.calledProcessInstanceLink = this.metadataPopover
+      .getByTestId('called-process-instance')
+      .getByRole('link');
   }
 
   async connectorResultVariableName(name: string): Promise<Locator> {
@@ -476,6 +499,73 @@ class OperateProcessInstancePage {
     for (const elementId of elementIds) {
       await expect(this.getDiagramElement(elementId)).toBeVisible();
     }
+  }
+
+  async clickIncidentsBanner(): Promise<void> {
+    await this.incidentsBanner.click();
+  }
+
+  async countIncidentErrorIndicators(): Promise<number> {
+    return await this.incidentErrorIndicators.count();
+  }
+
+  async clickOnElementInDiagram(elementId: string): Promise<void> {
+    await this.clickDiagramElement(elementId);
+  }
+
+  async closeIncidentsPanel(): Promise<void> {
+    await expect(this.incidentsBanner).toContainText(/hide/i, {
+      timeout: 10000,
+    });
+
+    await waitForAssertion({
+      assertion: async () => {
+        await expect(this.incidentsBanner).toContainText(/view/i, {
+          timeout: 3000,
+        });
+      },
+      onFailure: async () => {
+        await this.incidentsBanner.scrollIntoViewIfNeeded();
+        await this.incidentsBanner.click();
+      },
+      maxRetries: 3,
+    });
+  }
+
+  async getIncidentCount(): Promise<number> {
+    const headingText = await this.incidentsViewHeader.textContent();
+    if (!headingText) {
+      return 0;
+    }
+
+    const match = headingText.match(/(\d+)\s+results?/i);
+    return match ? parseInt(match[1], 10) : 0;
+  }
+
+  async verifyIncidentCount(expectedCount: number): Promise<void> {
+    const actualCount = await this.getIncidentCount();
+    expect(actualCount).toBe(expectedCount);
+  }
+
+  getCalledProcessLink(processName: string): Locator {
+    return this.page.getByRole('link', {name: processName});
+  }
+
+  async clickOnRootCauseProcessName(): Promise<void> {
+    await expect(this.rootCauseProcessName).toBeVisible();
+    await this.rootCauseProcessId.click();
+  }
+
+  async clickCalledProcessLink(processName: string): Promise<void> {
+    await this.getCalledProcessLink(processName).click();
+  }
+
+  async clickCalledProcessInstanceLink(): Promise<void> {
+    await this.calledProcessInstanceLink.click();
+  }
+
+  getIncidentErrorMessageByText(errorText: string): Locator {
+    return this.metadataPopover.getByText(errorText);
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/callProcess_with Incident.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/callProcess_with Incident.bpmn
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:ns1="modeler" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:ns0="xmlns" id="bpmn_copilot_Definition_id" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="a8d7898" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0" ns0:modeler="http://camunda.org/schema/modeler/1.0" ns1:executionPlatform="Camunda Cloud" ns1:executionPlatformVersion="8.6">
+  <bpmn:process id="call-level-1-process" name="Call Activity Level 1 Process" processType="None" isClosed="false" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Level1" name="Start Level 1">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=if required_variable != null then required_variable else error(&#34;Input variable &#39;required_variable&#39; is mandatory and was not provided.&#34;)" target="required_variable" />
+          <zeebe:output source="=test" target="OutputVariable_2r18fea" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_to_preprocess_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_to_preprocess_1" sourceRef="StartEvent_Level1" targetRef="Task_PreProcessing_Level1" />
+    <bpmn:sequenceFlow id="Flow_to_call_2" sourceRef="Task_PreProcessing_Level1" targetRef="EndEvent_Level1" />
+    <bpmn:endEvent id="EndEvent_Level1" name="End Level 1">
+      <bpmn:incoming>Flow_to_call_2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Task_PreProcessing_Level1" name="Level 1 Pre-Processing">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:output source="=1" target="test" />
+        </zeebe:ioMapping>
+        <zeebe:calledElement processId="Not" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_to_preprocess_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_to_call_2</bpmn:outgoing>
+    </bpmn:callActivity>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_call-level-1-process">
+    <bpmndi:BPMNPlane id="BPMNPlane_call-level-1-process" bpmnElement="call-level-1-process">
+      <bpmndi:BPMNShape id="StartEvent_Level1_di" bpmnElement="StartEvent_Level1">
+        <dc:Bounds x="57" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_Level1_di" bpmnElement="EndEvent_Level1">
+        <dc:Bounds x="357" y="52" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jnllr1_di" bpmnElement="Task_PreProcessing_Level1">
+        <dc:Bounds x="175" y="30" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_to_preprocess_1_di" bpmnElement="Flow_to_preprocess_1">
+        <di:waypoint x="93" y="70" />
+        <di:waypoint x="175" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_to_call_2_di" bpmnElement="Flow_to_call_2">
+        <di:waypoint x="275" y="70" />
+        <di:waypoint x="357" y="70" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/decision_to_test-incident.dmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/decision_to_test-incident.dmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_decision_chain_a" name="Decision Chain A=>B=>C" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+
+  <!-- Decision C: Root cause - always fails with assertion error -->
+  <decision id="decision-c" name="Decision C (Root Cause)">
+    <literalExpression id="LiteralExpression_C">
+      <text>assert(false, "Decision C assertion failed - this is the root cause")</text>
+    </literalExpression>
+  </decision>
+
+  <!-- Decision B: Depends on Decision C -->
+  <decision id="decision-b" name="Decision B">
+    <informationRequirement id="InformationRequirement_B_requires_C">
+      <requiredDecision href="#decision-c" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_B">
+      <input id="Input_B" label="Result from C">
+        <inputExpression id="InputExpression_B" typeRef="string">
+          <text>decision-c</text>
+        </inputExpression>
+      </input>
+      <output id="Output_B" name="resultB" typeRef="string" />
+      <rule id="Rule_B_1">
+        <inputEntry id="InputEntry_B_1">
+          <text>"success"</text>
+        </inputEntry>
+        <outputEntry id="OutputEntry_B_1">
+          <text>"B processed successfully"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+
+  <!-- Decision A: Top-level decision, depends on Decision B -->
+  <decision id="decision-a" name="Decision A">
+    <informationRequirement id="InformationRequirement_A_requires_B">
+      <requiredDecision href="#decision-b"/>
+    </informationRequirement>
+    <decisionTable id="DecisionTable_A">
+      <input id="Input_A" label="Result from B">
+        <inputExpression id="InputExpression_A" typeRef="string">
+          <text>resultB</text>
+        </inputExpression>
+      </input>
+      <output id="Output_A" name="finalResult" typeRef="string"/>
+      <rule id="Rule_A_1">
+        <inputEntry id="InputEntry_A_1">
+          <text>"B processed successfully"</text>
+        </inputEntry>
+        <outputEntry id="OutputEntry_A_1">
+          <text>"All decisions passed"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="decision-c">
+        <dc:Bounds height="80" width="180" x="160" y="200" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape dmnElementRef="decision-b">
+        <dc:Bounds height="80" width="180" x="390" y="200" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape dmnElementRef="decision-a">
+        <dc:Bounds height="80" width="180" x="620" y="200" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge dmnElementRef="InformationRequirement_B_requires_C">
+        <di:waypoint x="340" y="240" />
+        <di:waypoint x="390" y="240" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge dmnElementRef="InformationRequirement_A_requires_B">
+        <di:waypoint x="570" y="240" />
+        <di:waypoint x="620" y="240" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/process_to_test_incidents.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/process_to_test_incidents.bpmn
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:ns1="http://camunda.org/schema/modeler/1.0" id="Definitions_root_cause" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1" ns1:executionPlatform="Camunda Cloud" ns1:executionPlatformVersion="8.8.0">
+  <bpmn:process id="root-cause-test" name="Process-Incident" isExecutable="true">
+    <bpmn:startEvent id="Start" name="Start">
+      <bpmn:outgoing>Flow_Start</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_Start" sourceRef="Start" targetRef="Gateway_Split" />
+    <bpmn:parallelGateway id="Gateway_Split">
+      <bpmn:incoming>Flow_Start</bpmn:incoming>
+      <bpmn:outgoing>Flow_A</bpmn:outgoing>
+      <bpmn:outgoing>Flow_B</bpmn:outgoing>
+      <bpmn:outgoing>Flow_D</bpmn:outgoing>
+      <bpmn:outgoing>Flow_E</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_A" sourceRef="Gateway_Split" targetRef="Task_Decision" />
+    <bpmn:businessRuleTask id="Task_Decision" name="A: Decision Chain">
+      <bpmn:extensionElements>
+        <zeebe:calledDecision decisionId="decision-a" resultVariable="test" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_A</bpmn:incoming>
+      <bpmn:outgoing>Flow_A_Merge</bpmn:outgoing>
+    </bpmn:businessRuleTask>
+    <bpmn:sequenceFlow id="Flow_A_Merge" sourceRef="Task_Decision" targetRef="Gateway_Merge" />
+    <bpmn:sequenceFlow id="Flow_B" sourceRef="Gateway_Split" targetRef="Task_CallActivity" />
+    <bpmn:callActivity id="Task_CallActivity" name="B: Call Activity Level 1">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="call-level-1-process" propagateAllChildVariables="true" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=1" target="demoFail" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_B</bpmn:incoming>
+      <bpmn:outgoing>Flow_B_Merge</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_B_Merge" sourceRef="Task_CallActivity" targetRef="Gateway_Merge" />
+    <bpmn:sequenceFlow id="Flow_D" sourceRef="Gateway_Split" targetRef="Task_IOMapping" />
+    <bpmn:serviceTask id="Task_IOMapping" name="D: IO Mapping Failure">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="rootCauseIOMapping" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=assert(false, &#34;IO mapping failed&#34;)" target="result" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_D</bpmn:incoming>
+      <bpmn:outgoing>Flow_D_Merge</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_D_Merge" sourceRef="Task_IOMapping" targetRef="Gateway_Merge" />
+    <bpmn:sequenceFlow id="Flow_E" sourceRef="Gateway_Split" targetRef="Gateway_Expression" />
+    <bpmn:exclusiveGateway id="Gateway_Expression" name="E: Expression Test" default="Flow_E_Default">
+      <bpmn:incoming>Flow_E</bpmn:incoming>
+      <bpmn:outgoing>Flow_E_Condition</bpmn:outgoing>
+      <bpmn:outgoing>Flow_E_Default</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_E_Condition" name="Bad Expression" sourceRef="Gateway_Expression" targetRef="Task_E_Bad">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=assert(false, "Expression evaluation failed")</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_E_Default" sourceRef="Gateway_Expression" targetRef="Task_E_Good" />
+    <bpmn:serviceTask id="Task_E_Bad" name="Bad Path">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="rootCauseBadPath" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_E_Condition</bpmn:incoming>
+      <bpmn:outgoing>Flow_E_Bad_Merge</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Task_E_Good" name="Default Path">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="rootCauseGoodPath" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_E_Default</bpmn:incoming>
+      <bpmn:outgoing>Flow_E_Good_Merge</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_E_Bad_Merge" sourceRef="Task_E_Bad" targetRef="Gateway_E_Join" />
+    <bpmn:sequenceFlow id="Flow_E_Good_Merge" sourceRef="Task_E_Good" targetRef="Gateway_E_Join" />
+    <bpmn:exclusiveGateway id="Gateway_E_Join">
+      <bpmn:incoming>Flow_E_Bad_Merge</bpmn:incoming>
+      <bpmn:incoming>Flow_E_Good_Merge</bpmn:incoming>
+      <bpmn:outgoing>Flow_E_Merge</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_E_Merge" sourceRef="Gateway_E_Join" targetRef="Gateway_Merge" />
+    <bpmn:parallelGateway id="Gateway_Merge">
+      <bpmn:incoming>Flow_A_Merge</bpmn:incoming>
+      <bpmn:incoming>Flow_B_Merge</bpmn:incoming>
+      <bpmn:incoming>Flow_D_Merge</bpmn:incoming>
+      <bpmn:incoming>Flow_E_Merge</bpmn:incoming>
+      <bpmn:outgoing>Flow_End</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_End" sourceRef="Gateway_Merge" targetRef="End" />
+    <bpmn:endEvent id="End" name="End">
+      <bpmn:incoming>Flow_End</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="root-cause-test">
+      <bpmndi:BPMNShape id="Shape_Start" bpmnElement="Start">
+        <dc:Bounds x="152" y="282" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="325" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Split" bpmnElement="Gateway_Split">
+        <dc:Bounds x="245" y="275" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Decision" bpmnElement="Task_Decision">
+        <dc:Bounds x="410" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Call" bpmnElement="Task_CallActivity">
+        <dc:Bounds x="410" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_IO" bpmnElement="Task_IOMapping">
+        <dc:Bounds x="410" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Gateway_E" bpmnElement="Gateway_Expression" isMarkerVisible="true">
+        <dc:Bounds x="305" y="385" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="246" y="356" width="68" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_E_Bad" bpmnElement="Task_E_Bad">
+        <dc:Bounds x="400" y="370" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_E_Good" bpmnElement="Task_E_Good">
+        <dc:Bounds x="400" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_E_Join" bpmnElement="Gateway_E_Join" isMarkerVisible="true">
+        <dc:Bounds x="565" y="385" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_Merge" bpmnElement="Gateway_Merge">
+        <dc:Bounds x="565" y="275" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Shape_End" bpmnElement="End">
+        <dc:Bounds x="672" y="282" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="680" y="325" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Edge_Start" bpmnElement="Flow_Start">
+        <di:waypoint x="188" y="300" />
+        <di:waypoint x="245" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_A" bpmnElement="Flow_A">
+        <di:waypoint x="270" y="275" />
+        <di:waypoint x="270" y="210" />
+        <di:waypoint x="410" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_A_Merge" bpmnElement="Flow_A_Merge">
+        <di:waypoint x="510" y="210" />
+        <di:waypoint x="590" y="210" />
+        <di:waypoint x="590" y="275" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_B" bpmnElement="Flow_B">
+        <di:waypoint x="270" y="275" />
+        <di:waypoint x="270" y="120" />
+        <di:waypoint x="410" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_B_Merge" bpmnElement="Flow_B_Merge">
+        <di:waypoint x="510" y="120" />
+        <di:waypoint x="590" y="120" />
+        <di:waypoint x="590" y="275" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_D" bpmnElement="Flow_D">
+        <di:waypoint x="295" y="300" />
+        <di:waypoint x="410" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_D_Merge" bpmnElement="Flow_D_Merge">
+        <di:waypoint x="510" y="300" />
+        <di:waypoint x="565" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E" bpmnElement="Flow_E">
+        <di:waypoint x="270" y="325" />
+        <di:waypoint x="270" y="410" />
+        <di:waypoint x="305" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E_Condition" bpmnElement="Flow_E_Condition">
+        <di:waypoint x="355" y="410" />
+        <di:waypoint x="400" y="410" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="231" y="413" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E_Default" bpmnElement="Flow_E_Default">
+        <di:waypoint x="330" y="435" />
+        <di:waypoint x="330" y="500" />
+        <di:waypoint x="400" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E_Bad_Merge" bpmnElement="Flow_E_Bad_Merge">
+        <di:waypoint x="500" y="410" />
+        <di:waypoint x="565" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E_Good_Merge" bpmnElement="Flow_E_Good_Merge">
+        <di:waypoint x="500" y="500" />
+        <di:waypoint x="590" y="500" />
+        <di:waypoint x="590" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_E_Merge" bpmnElement="Flow_E_Merge">
+        <di:waypoint x="590" y="385" />
+        <di:waypoint x="590" y="325" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Edge_End" bpmnElement="Flow_End">
+        <di:waypoint x="615" y="300" />
+        <di:waypoint x="672" y="300" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
@@ -8,7 +8,7 @@
 
 import {test} from 'fixtures';
 import {expect} from '@playwright/test';
-import {deploy, createSingleInstance} from 'utils/zeebeClient';
+import {deploy, createInstances, createSingleInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {DATE_REGEX} from 'utils/constants';
@@ -339,6 +339,129 @@ test.describe('Process Instance', () => {
       await operateProcessInstancePage.verifyExecutionCountBadgesNotVisible(
         elementIds,
       );
+    });
+  });
+});
+
+test.beforeAll(async () => {
+  await deploy([
+    './resources/decision_to_test-incident.dmn',
+    './resources/process_to_test_incidents.bpmn',
+    './resources/callProcess_with Incident.bpmn',
+  ]);
+  await createInstances('root-cause-test', 1, 1);
+  await createInstances('call-level-1-process', 1, 1, {shouldFail: true});
+
+  await sleep(5000);
+});
+
+test.describe('Process Instance Incident', () => {
+  test.beforeEach(async ({page, loginPage, operateHomePage}) => {
+    await navigateToApp(page, 'operate');
+    await loginPage.login('demo', 'demo');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Verify Incident root cause instance', async ({
+    operateProcessInstancePage,
+    operateHomePage,
+    operateProcessesPage,
+  }) => {
+    test.slow();
+
+    await test.step('Navigate to Processes tab and open the process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateProcessesPage.filterByProcessName('Process-Incident');
+      await operateProcessesPage.clickProcessInstanceLink();
+    });
+
+    await test.step('Verify error indicators on all affected elements', async () => {
+      await expect(operateProcessInstancePage.diagram).toBeVisible();
+      await expect(operateProcessInstancePage.diagramSpinner).toBeHidden({
+        timeout: 30000,
+      });
+
+      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
+      await operateProcessInstancePage.clickIncidentsBanner();
+
+      await expect(
+        operateProcessInstancePage.incidentsViewHeader,
+      ).toBeVisible();
+
+      const incidentCount = await operateProcessInstancePage.getIncidentCount();
+      expect(incidentCount).toBeGreaterThan(0);
+
+      await operateProcessInstancePage.verifyIncidentCount(4);
+
+      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
+      await operateProcessInstancePage.closeIncidentsPanel();
+    });
+
+    await test.step('Click IO mapping Error and verify Error Type', async () => {
+      await operateProcessInstancePage.clickOnElementInDiagram(
+        'Task_IOMapping',
+      );
+
+      await expect(operateProcessInstancePage.metadataPopover).toBeVisible();
+
+      await expect(operateProcessInstancePage.incidentSection).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getIncidentErrorMessageByText(
+          'I/O mapping error',
+        ),
+      ).toBeVisible();
+      await operateProcessInstancePage.clickOnElementInDiagram(
+        'Task_IOMapping',
+      );
+      await expect(operateProcessInstancePage.metadataPopover).toBeHidden();
+    });
+
+    await test.step('Click ExclusiveGatewayError and verify Error Type', async () => {
+      await operateProcessInstancePage.clickOnElementInDiagram(
+        'Gateway_Expression',
+      );
+
+      await expect(operateProcessInstancePage.metadataPopover).toBeVisible();
+
+      await expect(operateProcessInstancePage.incidentSection).toBeVisible();
+      await expect(
+        operateProcessInstancePage.getIncidentErrorMessageByText(
+          'Extract value error',
+        ),
+      ).toBeVisible();
+    });
+
+    await operateProcessInstancePage.clickOnElementInDiagram(
+      'Gateway_Expression',
+    );
+
+    await expect(operateProcessInstancePage.metadataPopover).toBeHidden();
+
+    await test.step('Click Call Activity and verify the root cause in the called process', async () => {
+      await operateProcessInstancePage.clickOnElementInDiagram(
+        'Task_CallActivity',
+      );
+
+      await expect(operateProcessInstancePage.metadataPopover).toBeVisible();
+
+      await expect(
+        operateProcessInstancePage.calledProcessInstanceLink,
+      ).toBeVisible();
+      await operateProcessInstancePage.clickCalledProcessInstanceLink();
+
+      await expect(operateProcessInstancePage.diagram).toBeVisible();
+      await expect(operateProcessInstancePage.diagramSpinner).toBeHidden({
+        timeout: 30000,
+      });
+      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
+
+      await operateProcessInstancePage.clickViewParentInstance();
+      await expect(operateProcessInstancePage.diagram).toBeVisible();
     });
   });
 });


### PR DESCRIPTION
## Description

Backport of #46976 to `stable/8.7` (implements #42658 for 8.7).

Adds the Operate "different incident types" E2E scenario to `c8-orchestration-cluster-e2e-test-suite`: new BPMN/DMN resources that generate call-activity, DMN, IO-mapping and exclusive-gateway incidents, plus `OperateProcessInstancePage` helpers to open the incidents panel, read the incident count, and assert incident metadata popover content.

## Backport adaptations for 8.7

- **Page object**: layered onto the diverged 8.7 file — added the `waitForAssertion` import and the incident locators/helpers, plus `clickIncidentsBanner` (8.7 only had the singular `clickIncidentBanner`); fixed a missing closing brace in `getIncidentErrorMessageByText` carried over from the source PR.
- The shared "Process Instance" describe block keeps 8.7 conventions.
- **Call Activity step** reworked for 8.7's Operate UI: the element metadata popover renders the incident inline for IO-mapping/gateway elements, but for a call activity the root cause lives in the called process and is reached via the "Called Process Instance" link. The test follows that link and verifies the incident there, then returns to the parent instance. (In 8.9+ the popover was rewritten to surface `hasIncident` inline; that rewrite is not in 8.7.)
- **Error-type assertions** use the exact incident type display names shown in 8.7's popover "Type" field (`I/O mapping error`, `Extract value error`); the source PR's message-based strings depended on 8.9 engine incident wording.

## Verification

Ran the full spec locally against the 8.7 self-managed stack (operate/tasklist/zeebe 8.7-SNAPSHOT) — **8 passed**, including "Verify Incident root cause instance".

Relates to #42658
Backport of #46976

Test Run [link](https://github.com/camunda/camunda/actions/runs/28949082022)