### PR TITLE
fix: per-physical-tenant broker configuration

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -9,6 +9,7 @@ package io.camunda.configuration.beanoverrides;
 
 import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
 import io.camunda.configuration.Azure;
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.CommandApi;
 import io.camunda.configuration.Data;
 import io.camunda.configuration.Export;
@@ -110,46 +111,77 @@ public class BrokerBasedPropertiesOverride {
     final BrokerBasedProperties override = new BrokerBasedProperties();
     BeanUtils.copyProperties(legacyBrokerBasedProperties, override);
 
-    populateFromCluster(override);
-
-    populateFromLongPolling(override);
-
-    populateFromRestFilters(override);
-
-    populateFromSystem(override);
-
-    populateFromPrimaryStorage(override);
-
-    populateFromGrpc(override);
-
-    populateFromData(override);
-
-    if (unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getType()
-        == SecondaryStorageType.rdbms) {
-      populateRdbmsExporter(override);
-    } else {
-      populateCamundaExporter(override);
-    }
-
-    populateFromExporters(override);
-
-    populateFromMonitoring(override);
-
-    populateFromProcessing(override);
-
-    populateFromFlowControl(override);
-
-    populateFromSecurity(override);
-
-    override.setLicenseKey(unifiedConfiguration.getCamunda().getLicense().getKey());
+    populateFromCamunda(override, unifiedConfiguration.getCamunda());
 
     return override;
   }
 
-  private void populateFromSecurity(final BrokerBasedProperties override) {
+  /**
+   * Builds a per-physical-tenant {@link BrokerBasedProperties} entirely from the supplied
+   * per-tenant {@link Camunda} object, using the same population logic as the root {@link
+   * #brokerBasedProperties()} bean.
+   *
+   * <p>The per-tenant {@code Camunda} is produced by {@code PhysicalTenantResolver} via a two-step
+   * bind: it inherits root values for every un-overridden key, so cluster-wide sections come out
+   * identical to the root while per-tenant overrides apply on top.
+   *
+   * <p>Unlike the root bean, the legacy {@code zeebe.broker.*} properties that do not have a
+   * corresponding unified configuration property are not inherited. The default tenant keeps legacy
+   * support by reusing the root bean directly instead of this method.
+   *
+   * <p>The caller must stamp {@code cluster.nodeId} / {@code cluster.nodeVersion} (from {@code
+   * NodeIdProvider}) and call {@code init()}, just as {@code BrokerBasedConfiguration} does for the
+   * root bean.
+   */
+  public static BrokerBasedProperties convert(final Camunda perTenant) {
+    final BrokerBasedProperties props = new BrokerBasedProperties();
+    populateFromCamunda(props, perTenant);
+    return props;
+  }
+
+  /**
+   * Populates the given {@link BrokerBasedProperties} from a {@link Camunda} object. Single code
+   * path shared by the root bean and the per-tenant build so the two cannot drift.
+   */
+  private static void populateFromCamunda(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    populateFromCluster(override, camunda);
+
+    populateFromLongPolling(override, camunda);
+
+    populateFromRestFilters(override, camunda);
+
+    populateFromSystem(override, camunda);
+
+    populateFromPrimaryStorage(override, camunda);
+
+    populateFromGrpc(override, camunda);
+
+    populateFromData(override, camunda);
+
+    if (camunda.getData().getSecondaryStorage().getType() == SecondaryStorageType.rdbms) {
+      populateRdbmsExporter(override, camunda);
+    } else {
+      populateCamundaExporter(override, camunda);
+    }
+
+    populateFromExporters(override, camunda);
+
+    populateFromMonitoring(override, camunda);
+
+    populateFromProcessing(override, camunda);
+
+    populateFromFlowControl(override, camunda);
+
+    populateFromSecurity(override, camunda);
+
+    override.setLicenseKey(camunda.getLicense().getKey());
+  }
+
+  private static void populateFromSecurity(
+      final BrokerBasedProperties override, final Camunda camunda) {
     final var tlsCluster =
-        unifiedConfiguration
-            .getCamunda()
+        camunda
             .getSecurity()
             .getTransportLayerSecurity()
             .getCluster()
@@ -169,8 +201,9 @@ public class BrokerBasedPropertiesOverride {
             tlsCluster.getKeyStore().withBrokerTlsClusterKeyStoreProperties().getPassword());
   }
 
-  private void populateFromProcessing(final BrokerBasedProperties override) {
-    final Processing processing = unifiedConfiguration.getCamunda().getProcessing();
+  private static void populateFromProcessing(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Processing processing = camunda.getProcessing();
 
     // processing
     override.getProcessing().setMaxCommandsInBatch(processing.getMaxCommandsInBatch());
@@ -213,29 +246,30 @@ public class BrokerBasedPropertiesOverride {
         .getFeatures()
         .setEnableMessageBodyOnExpired(processing.isEnableMessageBodyOnExpired());
 
-    populateFromEngine(override);
+    populateFromEngine(override, camunda);
   }
 
-  private void populateFromEngine(final BrokerBasedProperties override) {
-    populateFromDistribution(override);
-    populateFromBatchOperations(override);
-    populateFromExpression(override);
-    populateFromProcessInstanceCreation(override);
-    populateFromJobs(override);
+  private static void populateFromEngine(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    populateFromDistribution(override, camunda);
+    populateFromBatchOperations(override, camunda);
+    populateFromExpression(override, camunda);
+    populateFromProcessInstanceCreation(override, camunda);
+    populateFromJobs(override, camunda);
   }
 
-  private void populateFromDistribution(final BrokerBasedProperties override) {
-    final var distribution =
-        unifiedConfiguration.getCamunda().getProcessing().getEngine().getDistribution();
+  private static void populateFromDistribution(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var distribution = camunda.getProcessing().getEngine().getDistribution();
 
     final var distributionCfg = override.getExperimental().getEngine().getDistribution();
     distributionCfg.setMaxBackoffDuration(distribution.getMaxBackoffDuration());
     distributionCfg.setRedistributionInterval(distribution.getRedistributionInterval());
   }
 
-  private void populateFromBatchOperations(final BrokerBasedProperties override) {
-    final var engineBatchOperation =
-        unifiedConfiguration.getCamunda().getProcessing().getEngine().getBatchOperations();
+  private static void populateFromBatchOperations(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var engineBatchOperation = camunda.getProcessing().getEngine().getBatchOperations();
     final var batchOperationsCfg = override.getExperimental().getEngine().getBatchOperations();
     batchOperationsCfg.setSchedulerInterval(engineBatchOperation.getSchedulerInterval());
     batchOperationsCfg.setChunkSize(engineBatchOperation.getChunkSize());
@@ -248,19 +282,21 @@ public class BrokerBasedPropertiesOverride {
         engineBatchOperation.getQueryRetryBackoffFactor());
   }
 
-  private void populateFromExpression(final BrokerBasedProperties override) {
-    final var expression = unifiedConfiguration.getCamunda().getExpression();
+  private static void populateFromExpression(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var expression = camunda.getExpression();
     override.getExperimental().getEngine().getExpression().setTimeout(expression.getTimeout());
   }
 
-  private void populateFromFlowControl(final BrokerBasedProperties override) {
-    populateFromBackpressureLimitRequest(override);
-    populateFromWrite(override);
+  private static void populateFromFlowControl(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    populateFromBackpressureLimitRequest(override, camunda);
+    populateFromWrite(override, camunda);
   }
 
-  private void populateFromBackpressureLimitRequest(final BrokerBasedProperties override) {
-    final Limit request =
-        unifiedConfiguration.getCamunda().getProcessing().getFlowControl().getRequest();
+  private static void populateFromBackpressureLimitRequest(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Limit request = camunda.getProcessing().getFlowControl().getRequest();
 
     if (request == null) {
       return;
@@ -311,9 +347,9 @@ public class BrokerBasedPropertiesOverride {
     override.getFlowControl().setRequest(limitCfg);
   }
 
-  private void populateFromWrite(final BrokerBasedProperties override) {
-    final Write write =
-        unifiedConfiguration.getCamunda().getProcessing().getFlowControl().getWrite();
+  private static void populateFromWrite(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Write write = camunda.getProcessing().getFlowControl().getWrite();
 
     if (write == null) {
       return;
@@ -326,12 +362,12 @@ public class BrokerBasedPropertiesOverride {
     rateLimitCfg.setRampUp(write.getRampUp());
     override.getFlowControl().setWrite(rateLimitCfg);
 
-    populateFromThrottle(override);
+    populateFromThrottle(override, camunda);
   }
 
-  private void populateFromThrottle(final BrokerBasedProperties override) {
-    final Throttle throttle =
-        unifiedConfiguration.getCamunda().getProcessing().getFlowControl().getWrite().getThrottle();
+  private static void populateFromThrottle(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Throttle throttle = camunda.getProcessing().getFlowControl().getWrite().getThrottle();
 
     final ThrottleCfg throttleCfg = override.getFlowControl().getWrite().getThrottling();
     throttleCfg.setEnabled(throttle.isEnabled());
@@ -340,49 +376,44 @@ public class BrokerBasedPropertiesOverride {
     throttleCfg.setResolution(throttle.getResolution());
   }
 
-  private void populateFromGrpc(final BrokerBasedProperties override) {
-    final var grpc =
-        unifiedConfiguration.getCamunda().getApi().getGrpc().withBrokerNetworkProperties();
+  private static void populateFromGrpc(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var grpc = camunda.getApi().getGrpc().withBrokerNetworkProperties();
 
     final NetworkCfg networkCfg = override.getGateway().getNetwork();
     networkCfg.setHost(grpc.getAddress());
     networkCfg.setPort(grpc.getPort());
     networkCfg.setMinKeepAliveInterval(grpc.getMinKeepAliveInterval());
 
-    populateFromSsl(override);
-    populateFromInterceptors(override);
+    populateFromSsl(override, camunda);
+    populateFromInterceptors(override, camunda);
 
     final io.camunda.zeebe.gateway.impl.configuration.ThreadsCfg threadsCfg =
         override.getGateway().getThreads();
     threadsCfg.setManagementThreads(grpc.getManagementThreads());
   }
 
-  private void populateFromSsl(final BrokerBasedProperties override) {
-    final Ssl ssl =
-        unifiedConfiguration.getCamunda().getApi().getGrpc().getSsl().withBrokerSslProperties();
+  private static void populateFromSsl(final BrokerBasedProperties override, final Camunda camunda) {
+    final Ssl ssl = camunda.getApi().getGrpc().getSsl().withBrokerSslProperties();
     final SecurityCfg securityCfg = override.getGateway().getSecurity();
     securityCfg.setEnabled(ssl.isEnabled());
     securityCfg.setCertificateChainPath(ssl.getCertificate());
     securityCfg.setPrivateKeyPath(ssl.getCertificatePrivateKey());
 
-    populateFromKeyStore(override);
+    populateFromKeyStore(override, camunda);
   }
 
-  private void populateFromKeyStore(final BrokerBasedProperties override) {
+  private static void populateFromKeyStore(
+      final BrokerBasedProperties override, final Camunda camunda) {
     final KeyStore keyStore =
-        unifiedConfiguration
-            .getCamunda()
-            .getApi()
-            .getGrpc()
-            .getSsl()
-            .getKeyStore()
-            .withBrokerKeyStoreProperties();
+        camunda.getApi().getGrpc().getSsl().getKeyStore().withBrokerKeyStoreProperties();
     final KeyStoreCfg keyStoreCfg = override.getGateway().getSecurity().getKeyStore();
     keyStoreCfg.setFilePath(keyStore.getFilePath());
     keyStoreCfg.setPassword(keyStore.getPassword());
   }
 
-  private void populateFromInterceptors(final BrokerBasedProperties override) {
+  private static void populateFromInterceptors(
+      final BrokerBasedProperties override, final Camunda camunda) {
     // Order between legacy and new interceptor props is not guaranteed.
     // Log common interceptors warning instead of using UnifiedConfigurationHelper logging.
     if (!override.getGateway().getInterceptors().isEmpty()) {
@@ -393,8 +424,7 @@ public class BrokerBasedPropertiesOverride {
       LOGGER.warn(warningMessage);
     }
 
-    final List<Interceptor> interceptors =
-        unifiedConfiguration.getCamunda().getApi().getGrpc().getInterceptors();
+    final List<Interceptor> interceptors = camunda.getApi().getGrpc().getInterceptors();
     if (!interceptors.isEmpty()) {
       final List<InterceptorCfg> interceptorCfgList =
           interceptors.stream().map(Interceptor::toInterceptorCfg).toList();
@@ -402,8 +432,9 @@ public class BrokerBasedPropertiesOverride {
     }
   }
 
-  private void populateFromCluster(final BrokerBasedProperties override) {
-    final var cluster = unifiedConfiguration.getCamunda().getCluster().withBrokerProperties();
+  private static void populateFromCluster(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var cluster = camunda.getCluster().withBrokerProperties();
 
     override.getCluster().setInitialContactPoints(cluster.getInitialContactPoints());
     if (cluster.getNodeIdProvider().getType() == Type.FIXED) {
@@ -416,27 +447,27 @@ public class BrokerBasedPropertiesOverride {
     override.getCluster().setClusterId(cluster.getClusterId());
     override.getCluster().setZone(cluster.getZone());
 
-    populateFromMembership(override);
-    populateFromRaftProperties(override);
-    populateFromClusterMetadata(override);
-    populateFromClusterNetwork(override);
+    populateFromMembership(override, camunda);
+    populateFromRaftProperties(override, camunda);
+    populateFromClusterMetadata(override, camunda);
+    populateFromClusterNetwork(override, camunda);
 
     override
         .getCluster()
         .setMessageCompression(
             CompressionAlgorithm.valueOf(cluster.getCompressionAlgorithm().name()));
 
-    populateFromGlobalListeners(override);
+    populateFromGlobalListeners(override, camunda);
 
-    populateFromPartitioning(override);
+    populateFromPartitioning(override, camunda);
 
     override.getExperimental().setReceiveOnLegacySubject(cluster.isReceiveOnLegacySubject());
   }
 
   @SuppressWarnings("MissingSwitchDefault")
-  private void populateFromPartitioning(final BrokerBasedProperties override) {
-    final Partitioning partitioning =
-        unifiedConfiguration.getCamunda().getCluster().getPartitioning();
+  private static void populateFromPartitioning(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Partitioning partitioning = camunda.getCluster().getPartitioning();
 
     // Order between legacy and new partitioning props is not guaranteed.
     // Log common partitioning warning instead of using UnifiedConfigurationHelper logging.
@@ -467,13 +498,9 @@ public class BrokerBasedPropertiesOverride {
     }
   }
 
-  private void populateFromLongPolling(final BrokerBasedProperties override) {
-    final var longPolling =
-        unifiedConfiguration
-            .getCamunda()
-            .getApi()
-            .getLongPolling()
-            .withBrokerLongPollingProperties();
+  private static void populateFromLongPolling(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var longPolling = camunda.getApi().getLongPolling().withBrokerLongPollingProperties();
     final var longPollingCfg = override.getGateway().getLongPolling();
     longPollingCfg.setEnabled(longPolling.isEnabled());
     longPollingCfg.setTimeout(longPolling.getTimeout());
@@ -481,13 +508,10 @@ public class BrokerBasedPropertiesOverride {
     longPollingCfg.setMinEmptyResponses(longPolling.getMinEmptyResponses());
   }
 
-  private void populateFromMembership(final BrokerBasedProperties override) {
+  private static void populateFromMembership(
+      final BrokerBasedProperties override, final Camunda camunda) {
     final Membership membership =
-        unifiedConfiguration
-            .getCamunda()
-            .getCluster()
-            .getMembership()
-            .withBrokerMembershipProperties();
+        camunda.getCluster().getMembership().withBrokerMembershipProperties();
     final MembershipCfg membershipCfg = override.getCluster().getMembership();
     membershipCfg.setBroadcastUpdates(membership.isBroadcastUpdates());
     membershipCfg.setBroadcastDisputes(membership.isBroadcastDisputes());
@@ -501,8 +525,9 @@ public class BrokerBasedPropertiesOverride {
     membershipCfg.setSyncInterval(membership.getSyncInterval());
   }
 
-  private void populateFromRaftProperties(final BrokerBasedProperties override) {
-    final var raft = unifiedConfiguration.getCamunda().getCluster().getRaft();
+  private static void populateFromRaftProperties(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var raft = camunda.getCluster().getRaft();
     override.getCluster().setHeartbeatInterval(raft.getHeartbeatInterval());
     override.getCluster().setElectionTimeout(raft.getElectionTimeout());
     override.getCluster().getRaft().setEnablePriorityElection(raft.isPriorityElectionEnabled());
@@ -545,8 +570,9 @@ public class BrokerBasedPropertiesOverride {
         .setSegmentPreallocationStrategy(raft.getSegmentPreallocationStrategy());
   }
 
-  private void populateFromClusterMetadata(final BrokerBasedProperties override) {
-    final var metadata = unifiedConfiguration.getCamunda().getCluster().getMetadata();
+  private static void populateFromClusterMetadata(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var metadata = camunda.getCluster().getMetadata();
     final var syncDelay = metadata.getSyncDelay();
     final var syncTimeout = metadata.getSyncRequestTimeout();
     final var gossipFanout = metadata.getGossipFanout();
@@ -557,9 +583,9 @@ public class BrokerBasedPropertiesOverride {
     override.getCluster().setConfigManager(new ConfigManagerCfg(configManagerGossipConfig));
   }
 
-  private void populateFromClusterNetwork(final BrokerBasedProperties override) {
-    final var network =
-        unifiedConfiguration.getCamunda().getCluster().getNetwork().withBrokerNetworkProperties();
+  private static void populateFromClusterNetwork(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var network = camunda.getCluster().getNetwork().withBrokerNetworkProperties();
 
     final var brokerNetwork = override.getNetwork();
     brokerNetwork.setHost(network.getHost());
@@ -571,22 +597,16 @@ public class BrokerBasedPropertiesOverride {
     brokerNetwork.setHeartbeatTimeout(network.getHeartbeatTimeout());
     brokerNetwork.setHeartbeatInterval(network.getHeartbeatInterval());
 
-    final var ucNetwork =
-        unifiedConfiguration.getCamunda().getCluster().getNetwork().withBrokerNetworkProperties();
-    override.getGateway().getNetwork().setMaxMessageSize(ucNetwork.getMaxMessageSize());
+    override.getGateway().getNetwork().setMaxMessageSize(network.getMaxMessageSize());
 
-    populateFromCommandApi(override);
-    populateFromInternalApi(override);
+    populateFromCommandApi(override, camunda);
+    populateFromInternalApi(override, camunda);
   }
 
-  private void populateFromInternalApi(final BrokerBasedProperties override) {
+  private static void populateFromInternalApi(
+      final BrokerBasedProperties override, final Camunda camunda) {
     final InternalApi internalApi =
-        unifiedConfiguration
-            .getCamunda()
-            .getCluster()
-            .getNetwork()
-            .getInternalApi()
-            .withBrokerInternalApiProperties();
+        camunda.getCluster().getNetwork().getInternalApi().withBrokerInternalApiProperties();
 
     final SocketBindingCfg socketBindingCfg = override.getNetwork().getInternalApi();
 
@@ -597,9 +617,9 @@ public class BrokerBasedPropertiesOverride {
         .ifPresent(socketBindingCfg::setAdvertisedPort);
   }
 
-  private void populateFromCommandApi(final BrokerBasedProperties override) {
-    final CommandApi commandApi =
-        unifiedConfiguration.getCamunda().getCluster().getNetwork().getCommandApi();
+  private static void populateFromCommandApi(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final CommandApi commandApi = camunda.getCluster().getNetwork().getCommandApi();
     final CommandApiCfg commandApiCfg = override.getNetwork().getCommandApi();
 
     commandApiCfg.setHost(commandApi.getHost());
@@ -608,7 +628,8 @@ public class BrokerBasedPropertiesOverride {
     Optional.ofNullable(commandApi.getAdvertisedPort()).ifPresent(commandApiCfg::setAdvertisedPort);
   }
 
-  private void populateFromRestFilters(final BrokerBasedProperties override) {
+  private static void populateFromRestFilters(
+      final BrokerBasedProperties override, final Camunda camunda) {
     // Order between legacy and new filters props is not guaranteed.
     // Log common filters warning instead of using UnifiedConfigurationHelper logging.
     if (!override.getGateway().getFilters().isEmpty()) {
@@ -619,78 +640,61 @@ public class BrokerBasedPropertiesOverride {
       LOGGER.warn(warningMessage);
     }
 
-    final List<Filter> filters = unifiedConfiguration.getCamunda().getApi().getRest().getFilters();
+    final List<Filter> filters = camunda.getApi().getRest().getFilters();
     if (!filters.isEmpty()) {
       final List<FilterCfg> filterCfgList = filters.stream().map(Filter::toFilterCfg).toList();
       override.getGateway().setFilters(filterCfgList);
     }
   }
 
-  private void populateFromSystem(final BrokerBasedProperties override) {
-    final var system = unifiedConfiguration.getCamunda().getSystem();
+  private static void populateFromSystem(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var system = camunda.getSystem();
 
     final var threadsCfg = new ThreadsCfg();
     threadsCfg.setCpuThreadCount(system.getCpuThreadCount());
     threadsCfg.setIoThreadCount(system.getIoThreadCount());
     override.setThreads(threadsCfg);
 
-    final var enableVersionCheck =
-        unifiedConfiguration.getCamunda().getSystem().getUpgrade().getEnableVersionCheck();
+    final var enableVersionCheck = system.getUpgrade().getEnableVersionCheck();
     override.getExperimental().setVersionCheckRestrictionEnabled(enableVersionCheck);
   }
 
-  private void populateFromData(final BrokerBasedProperties override) {
-    final Data data = unifiedConfiguration.getCamunda().getData();
+  private static void populateFromData(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Data data = camunda.getData();
     override.getData().setSnapshotPeriod(data.getSnapshotPeriod());
 
-    populateFromExport(override);
-    populateFromBackup(override);
+    populateFromExport(override, camunda);
+    populateFromBackup(override, camunda);
   }
 
-  private void populateFromExport(final BrokerBasedProperties override) {
-    final Export export = unifiedConfiguration.getCamunda().getData().getExport();
+  private static void populateFromExport(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Export export = camunda.getData().getExport();
     final var exportingCfg =
         new ExportingCfg(export.getSkipRecords(), export.getDistributionInterval());
     override.setExporting(exportingCfg);
   }
 
-  private void populateFromBackup(final BrokerBasedProperties override) {
+  private static void populateFromBackup(
+      final BrokerBasedProperties override, final Camunda camunda) {
     final PrimaryStorageBackup primaryStorageBackup =
-        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup();
+        camunda.getData().getPrimaryStorage().getBackup();
     final BackupCfg backupCfg = override.getData().getBackup();
     backupCfg.setStore(BackupStoreType.valueOf(primaryStorageBackup.getStore().name()));
 
-    populateFromS3(override);
-    populateFromGcs(override);
-    populateFromAzure(override);
-    populateFromFilesystem(override);
+    populateFromS3(override, camunda);
+    populateFromGcs(override, camunda);
+    populateFromAzure(override, camunda);
+    populateFromFilesystem(override, camunda);
 
     override.getData().setBackup(backupCfg);
   }
 
-  private void populateFromS3(final BrokerBasedProperties override) {
-    final S3 s3 =
-        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getS3();
-    final S3BackupStoreConfig s3BackupStoreConfig = override.getData().getBackup().getS3();
-    s3BackupStoreConfig.setBucketName(s3.getBucketName());
-    s3BackupStoreConfig.setEndpoint(s3.getEndpoint());
-    s3BackupStoreConfig.setRegion(s3.getRegion());
-    s3BackupStoreConfig.setAccessKey(s3.getAccessKey());
-    s3BackupStoreConfig.setSecretKey(s3.getSecretKey());
-    s3BackupStoreConfig.setApiCallTimeout(s3.getApiCallTimeout());
-    s3BackupStoreConfig.setForcePathStyleAccess(s3.isForcePathStyleAccess());
-    s3BackupStoreConfig.setCompression(s3.getCompression());
-    s3BackupStoreConfig.setMaxConcurrentConnections(s3.getMaxConcurrentConnections());
-    s3BackupStoreConfig.setConnectionAcquisitionTimeout(s3.getConnectionAcquisitionTimeout());
-    s3BackupStoreConfig.setBasePath(s3.getBasePath());
-    s3BackupStoreConfig.setSupportLegacyMd5(s3.isSupportLegacyMd5());
-    s3BackupStoreConfig.setSsecKey(s3.getSsecKey());
-
-    override.getData().getBackup().setS3(s3BackupStoreConfig);
-  }
-
-  private void populateFromPrimaryStorage(final BrokerBasedProperties override) {
-    final var primaryStorage = unifiedConfiguration.getCamunda().getData().getPrimaryStorage();
+  private static void populateFromPrimaryStorage(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var primaryStorage = camunda.getData().getPrimaryStorage();
     final var data = override.getData();
     data.setDirectory(primaryStorage.getDirectory());
     data.setRuntimeDirectory(primaryStorage.getRuntimeDirectory());
@@ -709,10 +713,10 @@ public class BrokerBasedPropertiesOverride {
     // Migrate RocksDB configuration from new unified config to old broker config structure
     populateFromRocksDb(override, primaryStorage);
 
-    populateBackupScheduler(override, primaryStorage.getBackup());
+    populateBackupScheduler(override, primaryStorage.getBackup(), camunda);
   }
 
-  private void populateFromRocksDb(
+  private static void populateFromRocksDb(
       final BrokerBasedProperties override, final PrimaryStorage primaryStorage) {
     final var unifiedRocksDb = primaryStorage.getRocksDb();
     final var brokerRocksDb = override.getExperimental().getRocksdb();
@@ -742,9 +746,28 @@ public class BrokerBasedPropertiesOverride {
     brokerRocksDb.setEnableSstPartitioning(unifiedRocksDb.isSstPartitioningEnabled());
   }
 
-  private void populateFromGcs(final BrokerBasedProperties override) {
-    final Gcs gcs =
-        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getGcs();
+  private static void populateFromS3(final BrokerBasedProperties override, final Camunda camunda) {
+    final S3 s3 = camunda.getData().getPrimaryStorage().getBackup().getS3();
+    final S3BackupStoreConfig s3BackupStoreConfig = override.getData().getBackup().getS3();
+    s3BackupStoreConfig.setBucketName(s3.getBucketName());
+    s3BackupStoreConfig.setEndpoint(s3.getEndpoint());
+    s3BackupStoreConfig.setRegion(s3.getRegion());
+    s3BackupStoreConfig.setAccessKey(s3.getAccessKey());
+    s3BackupStoreConfig.setSecretKey(s3.getSecretKey());
+    s3BackupStoreConfig.setApiCallTimeout(s3.getApiCallTimeout());
+    s3BackupStoreConfig.setForcePathStyleAccess(s3.isForcePathStyleAccess());
+    s3BackupStoreConfig.setCompression(s3.getCompression());
+    s3BackupStoreConfig.setMaxConcurrentConnections(s3.getMaxConcurrentConnections());
+    s3BackupStoreConfig.setConnectionAcquisitionTimeout(s3.getConnectionAcquisitionTimeout());
+    s3BackupStoreConfig.setBasePath(s3.getBasePath());
+    s3BackupStoreConfig.setSupportLegacyMd5(s3.isSupportLegacyMd5());
+    s3BackupStoreConfig.setSsecKey(s3.getSsecKey());
+
+    override.getData().getBackup().setS3(s3BackupStoreConfig);
+  }
+
+  private static void populateFromGcs(final BrokerBasedProperties override, final Camunda camunda) {
+    final Gcs gcs = camunda.getData().getPrimaryStorage().getBackup().getGcs();
     final GcsBackupStoreConfig gcsBackupStoreConfig = override.getData().getBackup().getGcs();
     gcsBackupStoreConfig.setBucketName(gcs.getBucketName());
     gcsBackupStoreConfig.setBasePath(gcs.getBasePath());
@@ -756,9 +779,9 @@ public class BrokerBasedPropertiesOverride {
     override.getData().getBackup().setGcs(gcsBackupStoreConfig);
   }
 
-  private void populateFromAzure(final BrokerBasedProperties override) {
-    final Azure azure =
-        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getAzure();
+  private static void populateFromAzure(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Azure azure = camunda.getData().getPrimaryStorage().getBackup().getAzure();
     final AzureBackupStoreConfig azureBackupStoreConfig = override.getData().getBackup().getAzure();
     azureBackupStoreConfig.setEndpoint(azure.getEndpoint());
     azureBackupStoreConfig.setAccountName(azure.getAccountName());
@@ -766,20 +789,15 @@ public class BrokerBasedPropertiesOverride {
     azureBackupStoreConfig.setConnectionString(azure.getConnectionString());
     azureBackupStoreConfig.setBasePath(azure.getBasePath());
     azureBackupStoreConfig.setCreateContainer(azure.isCreateContainer());
-    populateFromSasToken(override);
+    populateFromSasToken(override, camunda);
 
     override.getData().getBackup().setAzure(azureBackupStoreConfig);
   }
 
-  private void populateFromSasToken(final BrokerBasedProperties override) {
+  private static void populateFromSasToken(
+      final BrokerBasedProperties override, final Camunda camunda) {
     final SasToken sasToken =
-        unifiedConfiguration
-            .getCamunda()
-            .getData()
-            .getPrimaryStorage()
-            .getBackup()
-            .getAzure()
-            .getSasToken();
+        camunda.getData().getPrimaryStorage().getBackup().getAzure().getSasToken();
     final SasTokenConfig sasTokenConfig = override.getData().getBackup().getAzure().getSasToken();
 
     if (sasToken != null) {
@@ -793,9 +811,9 @@ public class BrokerBasedPropertiesOverride {
     }
   }
 
-  private void populateFromFilesystem(final BrokerBasedProperties override) {
-    final Filesystem filesystem =
-        unifiedConfiguration.getCamunda().getData().getPrimaryStorage().getBackup().getFilesystem();
+  private static void populateFromFilesystem(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Filesystem filesystem = camunda.getData().getPrimaryStorage().getBackup().getFilesystem();
     final FilesystemBackupStoreConfig filesystemBackupStoreConfig =
         override.getData().getBackup().getFilesystem();
     filesystemBackupStoreConfig.setBasePath(filesystem.getBasePath());
@@ -803,10 +821,11 @@ public class BrokerBasedPropertiesOverride {
     override.getData().getBackup().setFilesystem(filesystemBackupStoreConfig);
   }
 
-  private void populateBackupScheduler(
-      final BrokerBasedProperties override, final PrimaryStorageBackup primaryStorageBackup) {
-
-    validateSchedulerConfiguration(primaryStorageBackup);
+  private static void populateBackupScheduler(
+      final BrokerBasedProperties override,
+      final PrimaryStorageBackup primaryStorageBackup,
+      final Camunda camunda) {
+    validateSchedulerConfiguration(primaryStorageBackup, camunda);
 
     final BackupCfg backupCfg = override.getData().getBackup();
     backupCfg.setRequired(primaryStorageBackup.isRequired());
@@ -817,8 +836,9 @@ public class BrokerBasedPropertiesOverride {
     backupCfg.setRetention(primaryStorageBackup.getRetention());
   }
 
-  private void validateSchedulerConfiguration(final PrimaryStorageBackup primaryStorageBackup) {
-    final var dbType = unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getType();
+  private static void validateSchedulerConfiguration(
+      final PrimaryStorageBackup primaryStorageBackup, final Camunda camunda) {
+    final var dbType = camunda.getData().getSecondaryStorage().getType();
 
     final var continuousBackupsEnabledOnDocumentBasedStore =
         (dbType.isElasticSearch() || dbType.isOpenSearch())
@@ -831,14 +851,15 @@ public class BrokerBasedPropertiesOverride {
     }
   }
 
-  private boolean hasScheduleConfig(final PrimaryStorageBackup primaryStorageBackup) {
+  private static boolean hasScheduleConfig(final PrimaryStorageBackup primaryStorageBackup) {
     return primaryStorageBackup.getSchedule() != null
         && !primaryStorageBackup.getSchedule().isBlank()
         && !primaryStorageBackup.getSchedule().equalsIgnoreCase("none");
   }
 
-  private void populateCamundaExporter(final BrokerBasedProperties override) {
-    final Data data = unifiedConfiguration.getCamunda().getData();
+  private static void populateCamundaExporter(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Data data = camunda.getData();
     final SecondaryStorage secondaryStorage = data.getSecondaryStorage();
 
     if (!secondaryStorage.getAutoconfigureCamundaExporter()) {
@@ -874,24 +895,22 @@ public class BrokerBasedPropertiesOverride {
         ExporterConfiguration.of(io.camunda.exporter.config.ExporterConfiguration.class, args)
             .apply(
                 config -> {
-                  CamundaExporterConfigurationApplier.applyRetention(config, unifiedConfiguration);
-                  CamundaExporterConfigurationApplier.applyConnect(config, unifiedConfiguration);
-                  CamundaExporterConfigurationApplier.applyIndex(config, unifiedConfiguration);
-                  CamundaExporterConfigurationApplier.applyHistory(config, unifiedConfiguration);
-                  CamundaExporterConfigurationApplier.applyPostExportConfiguration(
-                      config, unifiedConfiguration);
-                  CamundaExporterConfigurationApplier.applyBulk(config, unifiedConfiguration);
-                  CamundaExporterConfigurationApplier.applyIncidentNotifier(
-                      config, unifiedConfiguration);
-                  CamundaExporterConfigurationApplier.applyMisc(config, unifiedConfiguration);
-                  CamundaExporterConfigurationApplier.applyExtensionProperties(
-                      config, unifiedConfiguration);
+                  CamundaExporterConfigurationApplier.applyRetention(config, camunda);
+                  CamundaExporterConfigurationApplier.applyConnect(config, camunda);
+                  CamundaExporterConfigurationApplier.applyIndex(config, camunda);
+                  CamundaExporterConfigurationApplier.applyHistory(config, camunda);
+                  CamundaExporterConfigurationApplier.applyPostExportConfiguration(config, camunda);
+                  CamundaExporterConfigurationApplier.applyBulk(config, camunda);
+                  CamundaExporterConfigurationApplier.applyIncidentNotifier(config, camunda);
+                  CamundaExporterConfigurationApplier.applyMisc(config, camunda);
+                  CamundaExporterConfigurationApplier.applyExtensionProperties(config, camunda);
                 })
             .toArgs());
   }
 
-  private void populateRdbmsExporter(final BrokerBasedProperties override) {
-    final Data data = unifiedConfiguration.getCamunda().getData();
+  private static void populateRdbmsExporter(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Data data = camunda.getData();
     final SecondaryStorage secondaryStorage = data.getSecondaryStorage();
 
     final Rdbms database = secondaryStorage.getRdbms();
@@ -941,20 +960,10 @@ public class BrokerBasedPropertiesOverride {
                       database.isExportBatchOperationItemsOnCreation());
                   config.setBatchOperationItemInsertBlockSize(
                       database.getBatchOperationItemInsertBlockSize());
-                  config.setAuditLog(
-                      unifiedConfiguration.getCamunda().getData().getAuditLog().toConfiguration());
-                  config.setWaitState(
-                      unifiedConfiguration
-                          .getCamunda()
-                          .getData()
-                          .getWaitStates()
-                          .toConfiguration());
+                  config.setAuditLog(camunda.getData().getAuditLog().toConfiguration());
+                  config.setWaitState(camunda.getData().getWaitStates().toConfiguration());
                   config.setHistoryDeletion(
-                      unifiedConfiguration
-                          .getCamunda()
-                          .getData()
-                          .getHistoryDeletion()
-                          .toConfiguration());
+                      camunda.getData().getHistoryDeletion().toConfiguration());
 
                   applyRdbmsHistoryExporterConfiguration(config.getHistory(), database);
 
@@ -1003,13 +1012,12 @@ public class BrokerBasedPropertiesOverride {
                   }
 
                   applyRdbmsExtensionPropertyConfiguration(
-                      config.getExtensionProperties(),
-                      unifiedConfiguration.getCamunda().getData().getExtensionProperties());
+                      config.getExtensionProperties(), camunda.getData().getExtensionProperties());
                 })
             .toArgs());
   }
 
-  private void applyRdbmsExtensionPropertyConfiguration(
+  private static void applyRdbmsExtensionPropertyConfiguration(
       final io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration
           extensionProperties,
       final io.camunda.configuration.ExtensionProperties source) {
@@ -1018,7 +1026,7 @@ public class BrokerBasedPropertiesOverride {
     extensionProperties.setToolPropertiesPrefix(source.getToolPropertiesPrefix());
   }
 
-  private void applyRdbmsHistoryExporterConfiguration(
+  private static void applyRdbmsHistoryExporterConfiguration(
       final io.camunda.exporter.rdbms.ExporterConfiguration.HistoryConfiguration history,
       final Rdbms database) {
     if (database.getHistory() == null) {
@@ -1046,12 +1054,14 @@ public class BrokerBasedPropertiesOverride {
     history.setMaxHistoryCleanupUsage(database.getHistory().getMaxHistoryCleanupUsage());
   }
 
-  private void populateFromMonitoring(final BrokerBasedProperties override) {
-    populateFromMetrics(override);
+  private static void populateFromMonitoring(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    populateFromMetrics(override, camunda);
   }
 
-  private void populateFromMetrics(final BrokerBasedProperties override) {
-    final Metrics metrics = unifiedConfiguration.getCamunda().getMonitoring().getMetrics();
+  private static void populateFromMetrics(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Metrics metrics = camunda.getMonitoring().getMetrics();
     override.getExperimental().getFeatures().setEnableActorMetrics(metrics.isActor());
     override.setExecutionMetricsExporterEnabled(metrics.isEnableExporterExecutionMetrics());
 
@@ -1082,9 +1092,9 @@ public class BrokerBasedPropertiesOverride {
     cursor.put(keys[keys.length - 1], value);
   }
 
-  private void populateFromExporters(final BrokerBasedProperties override) {
-    final Map<String, Exporter> exporters =
-        unifiedConfiguration.getCamunda().getData().getExporters();
+  private static void populateFromExporters(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final Map<String, Exporter> exporters = camunda.getData().getExporters();
 
     // Log common legacy exporters warning instead of using UnifiedConfigurationHelper logging.
     if (!override.getExporters().isEmpty()) {
@@ -1099,16 +1109,17 @@ public class BrokerBasedPropertiesOverride {
         (name, exporter) -> override.getExporters().put(name, exporter.toExporterCfg()));
   }
 
-  private void populateFromGlobalListeners(final BrokerBasedProperties override) {
+  private static void populateFromGlobalListeners(
+      final BrokerBasedProperties override, final Camunda camunda) {
     override
         .getExperimental()
         .getEngine()
-        .setGlobalListeners(unifiedConfiguration.getCamunda().getCluster().getGlobalListeners());
+        .setGlobalListeners(camunda.getCluster().getGlobalListeners());
   }
 
-  private void populateFromProcessInstanceCreation(final BrokerBasedProperties override) {
-    final var processInstanceCreation =
-        unifiedConfiguration.getCamunda().getProcessInstanceCreation();
+  private static void populateFromProcessInstanceCreation(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var processInstanceCreation = camunda.getProcessInstanceCreation();
     final var processInstanceCreationCfg =
         override.getExperimental().getEngine().getProcessInstanceCreation();
     processInstanceCreationCfg.setBusinessIdUniquenessEnabled(
@@ -1127,17 +1138,13 @@ public class BrokerBasedPropertiesOverride {
         processInstanceCreation.getMessageStartLockReleasePollBatchLimit());
   }
 
-  private void populateFromJobs(final BrokerBasedProperties override) {
+  private static void populateFromJobs(
+      final BrokerBasedProperties override, final Camunda camunda) {
     override
         .getExperimental()
         .getEngine()
         .getJobs()
         .setIncludeVariablesInJobCompletedEvent(
-            unifiedConfiguration
-                .getCamunda()
-                .getProcessing()
-                .getEngine()
-                .getJob()
-                .isIncludeVariablesInJobCompletedEvent());
+            camunda.getProcessing().getEngine().getJob().isIncludeVariablesInJobCompletedEvent());
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.configuration.beanoverrides;
 
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.DocumentBasedSecondaryStorageDatabase;
 import io.camunda.configuration.ExtensionProperties;
 import io.camunda.configuration.InterceptorPlugin;
 import io.camunda.configuration.Opensearch;
 import io.camunda.configuration.Retention;
 import io.camunda.configuration.SecondaryStorage;
-import io.camunda.configuration.UnifiedConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.BulkConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.HistoryConfiguration;
@@ -34,29 +34,25 @@ public final class CamundaExporterConfigurationApplier {
   private CamundaExporterConfigurationApplier() {}
 
   public static void applyRetention(
-      final ExporterConfiguration exporterConfiguration,
-      final UnifiedConfiguration unifiedConfiguration) {
+      final ExporterConfiguration exporterConfiguration, final Camunda camunda) {
 
     final RetentionConfiguration target = exporterConfiguration.getHistory().getRetention();
 
-    final Retention source =
-        unifiedConfiguration.getCamunda().getData().getSecondaryStorage().getRetention();
+    final Retention source = camunda.getData().getSecondaryStorage().getRetention();
 
     target.setEnabled(source.isEnabled());
     target.setMinimumAge(source.getMinimumAge());
   }
 
   public static void applyConnect(
-      final ExporterConfiguration exporterConfiguration,
-      final UnifiedConfiguration unifiedConfiguration) {
+      final ExporterConfiguration exporterConfiguration, final Camunda camunda) {
 
     final ConnectConfiguration target = exporterConfiguration.getConnect();
-    final SecondaryStorage secondaryStorage =
-        unifiedConfiguration.getCamunda().getData().getSecondaryStorage();
+    final SecondaryStorage secondaryStorage = camunda.getData().getSecondaryStorage();
 
     target.setType(secondaryStorage.getType().name());
 
-    final var source = getDocumentBasedDatabase(unifiedConfiguration);
+    final var source = getDocumentBasedDatabase(camunda);
     if (source == null) {
       return;
     }
@@ -114,10 +110,9 @@ public final class CamundaExporterConfigurationApplier {
   }
 
   public static void applyIndex(
-      final ExporterConfiguration exporterConfiguration,
-      final UnifiedConfiguration unifiedConfiguration) {
+      final ExporterConfiguration exporterConfiguration, final Camunda camunda) {
 
-    final var source = getDocumentBasedDatabase(unifiedConfiguration);
+    final var source = getDocumentBasedDatabase(camunda);
     if (source == null) {
       return;
     }
@@ -142,10 +137,9 @@ public final class CamundaExporterConfigurationApplier {
   }
 
   public static void applyHistory(
-      final ExporterConfiguration exporterConfiguration,
-      final UnifiedConfiguration unifiedConfiguration) {
+      final ExporterConfiguration exporterConfiguration, final Camunda camunda) {
 
-    final var source = getDocumentBasedDatabase(unifiedConfiguration);
+    final var source = getDocumentBasedDatabase(camunda);
     if (source == null) {
       return;
     }
@@ -169,10 +163,9 @@ public final class CamundaExporterConfigurationApplier {
   }
 
   public static void applyPostExportConfiguration(
-      final ExporterConfiguration exporterConfiguration,
-      final UnifiedConfiguration unifiedConfiguration) {
+      final ExporterConfiguration exporterConfiguration, final Camunda camunda) {
 
-    final var source = getDocumentBasedDatabase(unifiedConfiguration);
+    final var source = getDocumentBasedDatabase(camunda);
     if (source == null) {
       return;
     }
@@ -187,10 +180,9 @@ public final class CamundaExporterConfigurationApplier {
   }
 
   public static void applyBulk(
-      final ExporterConfiguration exporterConfiguration,
-      final UnifiedConfiguration unifiedConfiguration) {
+      final ExporterConfiguration exporterConfiguration, final Camunda camunda) {
 
-    final var source = getDocumentBasedDatabase(unifiedConfiguration);
+    final var source = getDocumentBasedDatabase(camunda);
     if (source == null) {
       return;
     }
@@ -202,10 +194,9 @@ public final class CamundaExporterConfigurationApplier {
   }
 
   public static void applyIncidentNotifier(
-      final ExporterConfiguration exporterConfiguration,
-      final UnifiedConfiguration unifiedConfiguration) {
+      final ExporterConfiguration exporterConfiguration, final Camunda camunda) {
 
-    final var source = getDocumentBasedDatabase(unifiedConfiguration);
+    final var source = getDocumentBasedDatabase(camunda);
     if (source == null) {
       return;
     }
@@ -220,17 +211,14 @@ public final class CamundaExporterConfigurationApplier {
   }
 
   public static void applyMisc(
-      final ExporterConfiguration exporterConfiguration,
-      final UnifiedConfiguration unifiedConfiguration) {
+      final ExporterConfiguration exporterConfiguration, final Camunda camunda) {
 
-    exporterConfiguration.setAuditLog(
-        unifiedConfiguration.getCamunda().getData().getAuditLog().toConfiguration());
-    exporterConfiguration.setWaitState(
-        unifiedConfiguration.getCamunda().getData().getWaitStates().toConfiguration());
+    exporterConfiguration.setAuditLog(camunda.getData().getAuditLog().toConfiguration());
+    exporterConfiguration.setWaitState(camunda.getData().getWaitStates().toConfiguration());
     exporterConfiguration.setHistoryDeletion(
-        unifiedConfiguration.getCamunda().getData().getHistoryDeletion().toConfiguration());
+        camunda.getData().getHistoryDeletion().toConfiguration());
 
-    final var source = getDocumentBasedDatabase(unifiedConfiguration);
+    final var source = getDocumentBasedDatabase(camunda);
     if (source == null) {
       return;
     }
@@ -250,11 +238,9 @@ public final class CamundaExporterConfigurationApplier {
   }
 
   public static void applyExtensionProperties(
-      final ExporterConfiguration exporterConfiguration,
-      final UnifiedConfiguration unifiedConfiguration) {
+      final ExporterConfiguration exporterConfiguration, final Camunda camunda) {
 
-    final ExtensionProperties source =
-        unifiedConfiguration.getCamunda().getData().getExtensionProperties();
+    final ExtensionProperties source = camunda.getData().getExtensionProperties();
     final ExtensionPropertyConfiguration target = exporterConfiguration.getExtensionProperties();
 
     target.setToolNameProperty(source.getToolNameProperty());
@@ -263,11 +249,7 @@ public final class CamundaExporterConfigurationApplier {
   }
 
   private static DocumentBasedSecondaryStorageDatabase getDocumentBasedDatabase(
-      final UnifiedConfiguration unifiedConfiguration) {
-    return unifiedConfiguration
-        .getCamunda()
-        .getData()
-        .getSecondaryStorage()
-        .getDocumentBasedDatabase();
+      final Camunda camunda) {
+    return camunda.getData().getSecondaryStorage().getDocumentBasedDatabase();
   }
 }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -401,11 +401,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>identity-sdk</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>identity-spring-boot-autoconfigure</artifactId>
     </dependency>
 

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -11,31 +11,22 @@ import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.cluster.PhysicalTenantIds;
-import io.camunda.configuration.Camunda;
 import io.camunda.configuration.UnifiedConfiguration;
-import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
-import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
-import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.security.spring.oidc.ScopedJwtDecoderFactory;
 import io.camunda.security.spring.oidc.ScopedOidcClaimsProviderFactory;
 import io.camunda.service.UserServices;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
-import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
-import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
-import io.camunda.zeebe.broker.system.PhysicalTenantContext;
 import io.camunda.zeebe.broker.system.SystemContext;
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.FileUtil;
-import io.camunda.zeebe.util.jar.ExternalJarLoadException;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.util.Collections;
@@ -127,16 +118,6 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.workingDirectory = workingDirectory;
   }
 
-  private ExporterRepository exporterRepository(
-      final List<ExporterDescriptor> exporterDescriptors) {
-    if (exporterDescriptors != null && !exporterDescriptors.isEmpty()) {
-      LOGGER.info("Create ExporterRepository with predefined exporter descriptors.");
-      return new ExporterRepository(exporterDescriptors);
-    } else {
-      return new ExporterRepository();
-    }
-  }
-
   @Bean(destroyMethod = "close")
   public Broker broker(
       @Autowired(required = false) final List<ExporterDescriptor> exporterDescriptors) {
@@ -147,26 +128,26 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     final Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory =
         authentication -> scopedOidcClaimsProviderFactory.buildClaimsProvider(authentication);
 
-    final var physicalTenantEngineContexts =
-        physicalTenantResolver.mapValues(
-            camunda -> buildPhysicalTenantEngineContext(camunda, exporterDescriptors));
-
     final SystemContext systemContext =
-        new SystemContext(
-            configuration.shutdownTimeout(),
-            configuration.config(),
-            actorScheduler,
-            cluster,
-            brokerClient,
-            meterRegistry,
-            physicalTenantEngineContexts,
-            userServicesForTenant,
-            passwordEncoder,
-            jwtDecoderFactory,
-            oidcClaimsProviderFactory,
-            searchClientsProxy,
-            nodeIdProvider,
-            physicalTenantIds);
+        new SystemContextLoader()
+            .withShutdownTimeout(configuration.shutdownTimeout())
+            .withRootBrokerCfg(configuration.config())
+            .withRootCamunda(unifiedConfiguration.getCamunda())
+            .withActorScheduler(actorScheduler)
+            .withCluster(cluster)
+            .withBrokerClient(brokerClient)
+            .withMeterRegistry(meterRegistry)
+            .withPhysicalTenants(physicalTenantResolver.getAll())
+            .withUserServicesForTenant(userServicesForTenant)
+            .withPasswordEncoder(passwordEncoder)
+            .withJwtDecoderFactory(jwtDecoderFactory)
+            .withOidcClaimsProviderFactory(oidcClaimsProviderFactory)
+            .withSearchClientsProxy(searchClientsProxy)
+            .withNodeIdProvider(nodeIdProvider)
+            .withPhysicalTenantIds(physicalTenantIds)
+            .withWorkingDirectory(workingDirectory.path())
+            .withExporterDescriptors(exporterDescriptors)
+            .createSystemContext();
     springBrokerBridge.registerShutdownHelper(shutdownHelper::initiateShutdown);
     broker = new Broker(systemContext, springBrokerBridge, Collections.emptyList());
 
@@ -191,63 +172,6 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     } finally {
       cleanupWorkingDirectory();
     }
-  }
-
-  private PhysicalTenantContext buildPhysicalTenantEngineContext(
-      final Camunda camunda, final List<ExporterDescriptor> exporterDescriptors) {
-    final var s = camunda.getSecurity();
-    final var securityConfig =
-        new EngineSecurityConfig(
-            s.getAuthentication(),
-            s.getAuthorizations().isEnabled(),
-            s.getMultiTenancy().isChecksEnabled(),
-            s.getInitialization(),
-            s.getCompiledIdValidationPattern(),
-            s.getCompiledGroupIdValidationPattern());
-    final var authorizationConverter = new BrokerRequestAuthorizationConverter(securityConfig);
-
-    final BrokerCfg brokerConfig;
-    if (camunda == unifiedConfiguration.getCamunda()) {
-      // this is for default tenant, with no override
-      // This special handling is required so that legacy properties defined via `zeebe.broker.*`
-      // are still applied to the default tenant.
-      brokerConfig = configuration.config();
-    } else {
-      brokerConfig = BrokerBasedPropertiesOverride.convert(camunda);
-
-      // repeat the initialization done for the root broker config.
-      final var cluster = brokerConfig.getCluster();
-      final var currentInstance = nodeIdProvider.currentNodeInstance();
-      cluster.setNodeId(currentInstance.id());
-      cluster.setNodeVersion(currentInstance.version().version());
-      brokerConfig.init(workingDirectory.path().toAbsolutePath().toString());
-    }
-
-    final var featureFlags = brokerConfig.getExperimental().getFeatures().toFeatureFlags();
-
-    final var preDefinedExporters = exporterRepository(exporterDescriptors);
-    final var exporterRepository = buildExporterRepository(preDefinedExporters, brokerConfig);
-
-    return new PhysicalTenantContext(
-        securityConfig, authorizationConverter, featureFlags, brokerConfig, exporterRepository);
-  }
-
-  private ExporterRepository buildExporterRepository(
-      final ExporterRepository exporterRepository, final BrokerCfg cfg) {
-    exporterRepository.setLicenseKey(cfg.getLicenseKey());
-    final var exporterEntries = cfg.getExporters().entrySet();
-    for (final var exporterEntry : exporterEntries) {
-      final var id = exporterEntry.getKey();
-      final var exporterCfg = exporterEntry.getValue();
-      try {
-        exporterRepository.load(id, exporterCfg);
-      } catch (final ExporterLoadException | ExternalJarLoadException e) {
-        throw new IllegalStateException(
-            "Failed to load exporter with configuration: " + exporterCfg, e);
-      }
-    }
-
-    return exporterRepository;
   }
 
   private void cleanupWorkingDirectory() {

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -10,9 +10,9 @@ package io.camunda.zeebe.broker;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Processing;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
-import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
@@ -25,7 +25,7 @@ import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
-import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
+import io.camunda.zeebe.broker.system.PhysicalTenantContext;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -65,14 +65,13 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private static final Logger LOGGER = Loggers.SYSTEM_LOGGER;
 
   private final BrokerBasedConfiguration configuration;
-  private final IdentityConfiguration identityConfiguration;
   private final SpringBrokerBridge springBrokerBridge;
   private final ActorScheduler actorScheduler;
   private final AtomixCluster cluster;
   private final BrokerClient brokerClient;
   private final BrokerShutdownHelper shutdownHelper;
   private final MeterRegistry meterRegistry;
-  private final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts;
+  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts;
   private final ServiceRegistry serviceRegistry;
   private final PasswordEncoder passwordEncoder;
   private final ScopedJwtDecoderFactory scopedJwtDecoderFactory;
@@ -86,7 +85,6 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   @Autowired
   public BrokerModuleConfiguration(
       final BrokerBasedConfiguration configuration,
-      final IdentityConfiguration identityConfiguration,
       final SpringBrokerBridge springBrokerBridge,
       final ActorScheduler actorScheduler,
       final AtomixCluster cluster,
@@ -104,7 +102,6 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       final NodeIdProvider nodeIdProvider,
       final PhysicalTenantIds physicalTenantIds) {
     this.configuration = configuration;
-    this.identityConfiguration = identityConfiguration;
     this.springBrokerBridge = springBrokerBridge;
     this.actorScheduler = actorScheduler;
     this.cluster = cluster;
@@ -186,8 +183,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     }
   }
 
-  private PhysicalTenantEngineContext buildPhysicalTenantEngineContext(
-      final io.camunda.configuration.Camunda camunda) {
+  private PhysicalTenantContext buildPhysicalTenantEngineContext(final Camunda camunda) {
     final var s = camunda.getSecurity();
     final var securityConfig =
         new EngineSecurityConfig(
@@ -199,7 +195,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             s.getCompiledGroupIdValidationPattern());
     final var authorizationConverter = new BrokerRequestAuthorizationConverter(securityConfig);
     final var featureFlags = buildFeatureFlags(camunda.getProcessing());
-    return new PhysicalTenantEngineContext(securityConfig, authorizationConverter, featureFlags);
+    return new PhysicalTenantContext(securityConfig, authorizationConverter, featureFlags);
   }
 
   private FeatureFlags buildFeatureFlags(final Processing p) {

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -111,7 +111,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.brokerClient = brokerClient;
     this.shutdownHelper = shutdownHelper;
     this.meterRegistry = meterRegistry;
-    this.physicalTenantEngineContexts =
+    physicalTenantEngineContexts =
         physicalTenantResolver.mapValues(this::buildPhysicalTenantEngineContext);
     this.serviceRegistry = serviceRegistry;
     this.passwordEncoder = passwordEncoder;
@@ -146,7 +146,6 @@ public class BrokerModuleConfiguration implements CloseableSilently {
         new SystemContext(
             configuration.shutdownTimeout(),
             configuration.config(),
-            identityConfiguration,
             actorScheduler,
             cluster,
             brokerClient,

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.broker;
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
+import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.configuration.Camunda;
-import io.camunda.configuration.Processing;
+import io.camunda.configuration.UnifiedConfiguration;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
@@ -24,19 +26,20 @@ import io.camunda.service.UserServices;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.PhysicalTenantContext;
 import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
-import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.jar.ExternalJarLoadException;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -71,7 +74,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final BrokerClient brokerClient;
   private final BrokerShutdownHelper shutdownHelper;
   private final MeterRegistry meterRegistry;
-  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts;
+  private final UnifiedConfiguration unifiedConfiguration;
+  private final PhysicalTenantResolver physicalTenantResolver;
   private final ServiceRegistry serviceRegistry;
   private final PasswordEncoder passwordEncoder;
   private final ScopedJwtDecoderFactory scopedJwtDecoderFactory;
@@ -79,6 +83,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final SearchClientsProxy searchClientsProxy;
   private final NodeIdProvider nodeIdProvider;
   private final PhysicalTenantIds physicalTenantIds;
+  private final WorkingDirectory workingDirectory;
 
   private Broker broker;
 
@@ -91,6 +96,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       final BrokerClient brokerClient,
       final BrokerShutdownHelper shutdownHelper,
       final MeterRegistry meterRegistry,
+      final UnifiedConfiguration unifiedConfiguration,
       final PhysicalTenantResolver physicalTenantResolver,
       // The ServiceRegistry is not available if you want to start-up the Standalone Broker
       @Autowired(required = false) final ServiceRegistry serviceRegistry,
@@ -100,7 +106,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
           final ScopedOidcClaimsProviderFactory scopedOidcClaimsProviderFactory,
       @Autowired(required = false) final SearchClientsProxy searchClientsProxy,
       final NodeIdProvider nodeIdProvider,
-      final PhysicalTenantIds physicalTenantIds) {
+      final PhysicalTenantIds physicalTenantIds,
+      final WorkingDirectory workingDirectory) {
     this.configuration = configuration;
     this.springBrokerBridge = springBrokerBridge;
     this.actorScheduler = actorScheduler;
@@ -108,8 +115,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.brokerClient = brokerClient;
     this.shutdownHelper = shutdownHelper;
     this.meterRegistry = meterRegistry;
-    physicalTenantEngineContexts =
-        physicalTenantResolver.mapValues(this::buildPhysicalTenantEngineContext);
+    this.unifiedConfiguration = unifiedConfiguration;
+    this.physicalTenantResolver = physicalTenantResolver;
     this.serviceRegistry = serviceRegistry;
     this.passwordEncoder = passwordEncoder;
     this.scopedJwtDecoderFactory = scopedJwtDecoderFactory;
@@ -117,11 +124,11 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.searchClientsProxy = searchClientsProxy;
     this.nodeIdProvider = nodeIdProvider;
     this.physicalTenantIds = physicalTenantIds;
+    this.workingDirectory = workingDirectory;
   }
 
-  @Bean
-  public ExporterRepository exporterRepository(
-      @Autowired(required = false) final List<ExporterDescriptor> exporterDescriptors) {
+  private ExporterRepository exporterRepository(
+      final List<ExporterDescriptor> exporterDescriptors) {
     if (exporterDescriptors != null && !exporterDescriptors.isEmpty()) {
       LOGGER.info("Create ExporterRepository with predefined exporter descriptors.");
       return new ExporterRepository(exporterDescriptors);
@@ -131,13 +138,18 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   }
 
   @Bean(destroyMethod = "close")
-  public Broker broker(final ExporterRepository exporterRepository) {
+  public Broker broker(
+      @Autowired(required = false) final List<ExporterDescriptor> exporterDescriptors) {
     final Function<String, UserServices> userServicesForTenant =
-        tenantId -> serviceRegistry.userServices(tenantId);
+        physicalTenantId -> serviceRegistry.userServices(physicalTenantId);
     final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory =
-        authConfig -> scopedJwtDecoderFactory.buildIssuerAwareDecoder(authConfig);
+        authentication -> scopedJwtDecoderFactory.buildIssuerAwareDecoder(authentication);
     final Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory =
-        authConfig -> scopedOidcClaimsProviderFactory.buildClaimsProvider(authConfig);
+        authentication -> scopedOidcClaimsProviderFactory.buildClaimsProvider(authentication);
+
+    final var physicalTenantEngineContexts =
+        physicalTenantResolver.mapValues(
+            camunda -> buildPhysicalTenantEngineContext(camunda, exporterDescriptors));
 
     final SystemContext systemContext =
         new SystemContext(
@@ -155,10 +167,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             searchClientsProxy,
             nodeIdProvider,
             physicalTenantIds);
-    springBrokerBridge.registerShutdownHelper(
-        (errorCode, reason) -> shutdownHelper.initiateShutdown(errorCode, reason));
-    broker =
-        new Broker(systemContext, springBrokerBridge, Collections.emptyList(), exporterRepository);
+    springBrokerBridge.registerShutdownHelper(shutdownHelper::initiateShutdown);
+    broker = new Broker(systemContext, springBrokerBridge, Collections.emptyList());
 
     // already initiate starting the broker
     // to ensure that the necessary ports
@@ -183,7 +193,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     }
   }
 
-  private PhysicalTenantContext buildPhysicalTenantEngineContext(final Camunda camunda) {
+  private PhysicalTenantContext buildPhysicalTenantEngineContext(
+      final Camunda camunda, final List<ExporterDescriptor> exporterDescriptors) {
     final var s = camunda.getSecurity();
     final var securityConfig =
         new EngineSecurityConfig(
@@ -194,19 +205,49 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             s.getCompiledIdValidationPattern(),
             s.getCompiledGroupIdValidationPattern());
     final var authorizationConverter = new BrokerRequestAuthorizationConverter(securityConfig);
-    final var featureFlags = buildFeatureFlags(camunda.getProcessing());
-    return new PhysicalTenantContext(securityConfig, authorizationConverter, featureFlags);
+
+    final BrokerCfg brokerConfig;
+    if (camunda == unifiedConfiguration.getCamunda()) {
+      // this is for default tenant, with no override
+      // This special handling is required so that legacy properties defined via `zeebe.broker.*`
+      // are still applied to the default tenant.
+      brokerConfig = configuration.config();
+    } else {
+      brokerConfig = BrokerBasedPropertiesOverride.convert(camunda);
+
+      // repeat the initialization done for the root broker config.
+      final var cluster = brokerConfig.getCluster();
+      final var currentInstance = nodeIdProvider.currentNodeInstance();
+      cluster.setNodeId(currentInstance.id());
+      cluster.setNodeVersion(currentInstance.version().version());
+      brokerConfig.init(workingDirectory.path().toAbsolutePath().toString());
+    }
+
+    final var featureFlags = brokerConfig.getExperimental().getFeatures().toFeatureFlags();
+
+    final var preDefinedExporters = exporterRepository(exporterDescriptors);
+    final var exporterRepository = buildExporterRepository(preDefinedExporters, brokerConfig);
+
+    return new PhysicalTenantContext(
+        securityConfig, authorizationConverter, featureFlags, brokerConfig, exporterRepository);
   }
 
-  private FeatureFlags buildFeatureFlags(final Processing p) {
-    final var flags = configuration.config().getExperimental().getFeatures().toFeatureFlags();
-    flags.setYieldingDueDateChecker(p.isEnableYieldingDueDateChecker());
-    flags.setEnableMessageTTLCheckerAsync(p.isEnableAsyncMessageTtlChecker());
-    flags.setEnableTimerDueDateCheckerAsync(p.isEnableAsyncTimerDuedateChecker());
-    flags.setEnableStraightThroughProcessingLoopDetector(
-        p.isEnableStraightthroughProcessingLoopDetector());
-    flags.setEnableMessageBodyOnExpired(p.isEnableMessageBodyOnExpired());
-    return flags;
+  private ExporterRepository buildExporterRepository(
+      final ExporterRepository exporterRepository, final BrokerCfg cfg) {
+    exporterRepository.setLicenseKey(cfg.getLicenseKey());
+    final var exporterEntries = cfg.getExporters().entrySet();
+    for (final var exporterEntry : exporterEntries) {
+      final var id = exporterEntry.getKey();
+      final var exporterCfg = exporterEntry.getValue();
+      try {
+        exporterRepository.load(id, exporterCfg);
+      } catch (final ExporterLoadException | ExternalJarLoadException e) {
+        throw new IllegalStateException(
+            "Failed to load exporter with configuration: " + exporterCfg, e);
+      }
+    }
+
+    return exporterRepository;
   }
 
   private void cleanupWorkingDirectory() {

--- a/dist/src/main/java/io/camunda/zeebe/broker/SystemContextLoader.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/SystemContextLoader.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker;
+
+import io.atomix.cluster.AtomixCluster;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.api.context.OidcClaimsProvider;
+import io.camunda.security.api.model.config.AuthenticationConfiguration;
+import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
+import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.service.UserServices;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.broker.system.PhysicalTenantContext;
+import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.util.jar.ExternalJarLoadException;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+/**
+ * Builds a {@link SystemContext} from raw broker collaborators, translating the per-physical-tenant
+ * {@link Camunda} configuration into a {@link PhysicalTenantContext} for every tenant.
+ *
+ * <p>This logic used to live inline in {@link BrokerModuleConfiguration}, which — being a Spring
+ * {@code @Configuration} with a large constructor — was impractical to unit test. Extracting it
+ * into a plain builder lets the per-tenant configuration translation (security config, broker
+ * config selection, exporter loading and validation) be exercised directly. {@link
+ * BrokerModuleConfiguration} now only wires its injected beans into the {@code withXxx} setters and
+ * calls {@link #createSystemContext()}.
+ */
+public final class SystemContextLoader {
+
+  private static final Logger LOGGER = Loggers.SYSTEM_LOGGER;
+
+  private Duration shutdownTimeout;
+  private BrokerCfg rootBrokerCfg;
+  private Camunda rootCamunda;
+  private ActorScheduler actorScheduler;
+  private AtomixCluster cluster;
+  private BrokerClient brokerClient;
+  private MeterRegistry meterRegistry;
+  private Map<String, Camunda> physicalTenants;
+  private Function<String, UserServices> userServicesForTenant;
+  private PasswordEncoder passwordEncoder;
+  private Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
+  private Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory;
+  private SearchClientsProxy searchClientsProxy;
+  private NodeIdProvider nodeIdProvider;
+  private PhysicalTenantIds physicalTenantIds;
+  private Path workingDirectory;
+  private List<ExporterDescriptor> exporterDescriptors;
+
+  public SystemContextLoader withShutdownTimeout(final Duration shutdownTimeout) {
+    this.shutdownTimeout = shutdownTimeout;
+    return this;
+  }
+
+  /**
+   * The broker configuration for the default tenant. Also carries the broker-wide configuration
+   * consumed by {@link SystemContext} directly. This is the fully-initialized root {@code
+   * BrokerCfg} (node id stamped, {@code init()} already applied), which preserves legacy {@code
+   * zeebe.broker.*} property support for the default tenant.
+   */
+  public SystemContextLoader withRootBrokerCfg(final BrokerCfg rootBrokerCfg) {
+    this.rootBrokerCfg = rootBrokerCfg;
+    return this;
+  }
+
+  /**
+   * The root {@link Camunda} configuration. Used to detect, by identity, which resolved tenant is
+   * the default tenant so that it reuses {@link #rootBrokerCfg} instead of being converted again.
+   */
+  public SystemContextLoader withRootCamunda(final Camunda rootCamunda) {
+    this.rootCamunda = rootCamunda;
+    return this;
+  }
+
+  public SystemContextLoader withActorScheduler(final ActorScheduler actorScheduler) {
+    this.actorScheduler = actorScheduler;
+    return this;
+  }
+
+  public SystemContextLoader withCluster(final AtomixCluster cluster) {
+    this.cluster = cluster;
+    return this;
+  }
+
+  public SystemContextLoader withBrokerClient(final BrokerClient brokerClient) {
+    this.brokerClient = brokerClient;
+    return this;
+  }
+
+  public SystemContextLoader withMeterRegistry(final MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+    return this;
+  }
+
+  /** The resolved per-tenant configuration, keyed by physical tenant id. */
+  public SystemContextLoader withPhysicalTenants(final Map<String, Camunda> physicalTenants) {
+    this.physicalTenants = physicalTenants;
+    return this;
+  }
+
+  public SystemContextLoader withUserServicesForTenant(
+      final Function<String, UserServices> userServicesForTenant) {
+    this.userServicesForTenant = userServicesForTenant;
+    return this;
+  }
+
+  public SystemContextLoader withPasswordEncoder(final PasswordEncoder passwordEncoder) {
+    this.passwordEncoder = passwordEncoder;
+    return this;
+  }
+
+  public SystemContextLoader withJwtDecoderFactory(
+      final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory) {
+    this.jwtDecoderFactory = jwtDecoderFactory;
+    return this;
+  }
+
+  public SystemContextLoader withOidcClaimsProviderFactory(
+      final Function<AuthenticationConfiguration, OidcClaimsProvider> oidcClaimsProviderFactory) {
+    this.oidcClaimsProviderFactory = oidcClaimsProviderFactory;
+    return this;
+  }
+
+  public SystemContextLoader withSearchClientsProxy(final SearchClientsProxy searchClientsProxy) {
+    this.searchClientsProxy = searchClientsProxy;
+    return this;
+  }
+
+  public SystemContextLoader withNodeIdProvider(final NodeIdProvider nodeIdProvider) {
+    this.nodeIdProvider = nodeIdProvider;
+    return this;
+  }
+
+  public SystemContextLoader withPhysicalTenantIds(final PhysicalTenantIds physicalTenantIds) {
+    this.physicalTenantIds = physicalTenantIds;
+    return this;
+  }
+
+  /** The broker working directory, used to resolve relative paths in overridden tenant configs. */
+  public SystemContextLoader withWorkingDirectory(final Path workingDirectory) {
+    this.workingDirectory = workingDirectory;
+    return this;
+  }
+
+  public SystemContextLoader withExporterDescriptors(
+      final List<ExporterDescriptor> exporterDescriptors) {
+    this.exporterDescriptors = exporterDescriptors;
+    return this;
+  }
+
+  public SystemContext createSystemContext() {
+    final Map<String, PhysicalTenantContext> physicalTenantContexts = new LinkedHashMap<>();
+    physicalTenants.forEach(
+        (physicalTenantId, camunda) ->
+            physicalTenantContexts.put(physicalTenantId, buildPhysicalTenantContext(camunda)));
+
+    return new SystemContext(
+        shutdownTimeout,
+        rootBrokerCfg,
+        actorScheduler,
+        cluster,
+        brokerClient,
+        meterRegistry,
+        physicalTenantContexts,
+        userServicesForTenant,
+        passwordEncoder,
+        jwtDecoderFactory,
+        oidcClaimsProviderFactory,
+        searchClientsProxy,
+        nodeIdProvider,
+        physicalTenantIds);
+  }
+
+  private PhysicalTenantContext buildPhysicalTenantContext(final Camunda camunda) {
+    final var s = camunda.getSecurity();
+    final var securityConfig =
+        new EngineSecurityConfig(
+            s.getAuthentication(),
+            s.getAuthorizations().isEnabled(),
+            s.getMultiTenancy().isChecksEnabled(),
+            s.getInitialization(),
+            s.getCompiledIdValidationPattern(),
+            s.getCompiledGroupIdValidationPattern());
+    final var authorizationConverter = new BrokerRequestAuthorizationConverter(securityConfig);
+
+    final BrokerCfg brokerConfig;
+    if (camunda == rootCamunda) {
+      // this is for default tenant, with no override
+      // This special handling is required so that legacy properties defined via `zeebe.broker.*`
+      // are still applied to the default tenant.
+      brokerConfig = rootBrokerCfg;
+    } else {
+      brokerConfig = BrokerBasedPropertiesOverride.convert(camunda);
+
+      // repeat the initialization done for the root broker config.
+      final var clusterCfg = brokerConfig.getCluster();
+      final var currentInstance = nodeIdProvider.currentNodeInstance();
+      clusterCfg.setNodeId(currentInstance.id());
+      clusterCfg.setNodeVersion(currentInstance.version().version());
+      brokerConfig.init(workingDirectory.toAbsolutePath().toString());
+    }
+
+    final var featureFlags = brokerConfig.getExperimental().getFeatures().toFeatureFlags();
+
+    final var exporterRepository =
+        buildExporterRepository(predefinedExporterRepository(), brokerConfig);
+
+    return new PhysicalTenantContext(
+        securityConfig, authorizationConverter, featureFlags, brokerConfig, exporterRepository);
+  }
+
+  private ExporterRepository predefinedExporterRepository() {
+    if (exporterDescriptors != null && !exporterDescriptors.isEmpty()) {
+      LOGGER.info("Create ExporterRepository with predefined exporter descriptors.");
+      return new ExporterRepository(exporterDescriptors);
+    } else {
+      return new ExporterRepository();
+    }
+  }
+
+  private ExporterRepository buildExporterRepository(
+      final ExporterRepository exporterRepository, final BrokerCfg cfg) {
+    validateExporters(cfg.getExporters());
+    exporterRepository.setLicenseKey(cfg.getLicenseKey());
+    final var exporterEntries = cfg.getExporters().entrySet();
+    for (final var exporterEntry : exporterEntries) {
+      final var id = exporterEntry.getKey();
+      final var exporterCfg = exporterEntry.getValue();
+      try {
+        exporterRepository.load(id, exporterCfg);
+      } catch (final ExporterLoadException | ExternalJarLoadException e) {
+        throw new IllegalStateException(
+            "Failed to load exporter with configuration: " + exporterCfg, e);
+      }
+    }
+
+    return exporterRepository;
+  }
+
+  private static void validateExporters(final Map<String, ExporterCfg> exporters) {
+    final Set<Entry<String, ExporterCfg>> entries = exporters.entrySet();
+    final var badExportersNames =
+        entries.stream()
+            .filter(entry -> entry.getValue().getClassName() == null)
+            .map(Entry::getKey)
+            .toList();
+
+    if (!badExportersNames.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected to find a 'className' configured for the exporter. Couldn't find a valid one for the following exporters "
+              + badExportersNames);
+    }
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/broker/SystemContextLoaderTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/broker/SystemContextLoaderTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.AtomixCluster;
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.security.api.context.OidcClaimsProvider;
+import io.camunda.service.UserServices;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.system.SystemContext;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
+import io.camunda.zeebe.dynamic.nodeid.NodeInstance;
+import io.camunda.zeebe.dynamic.nodeid.Version;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+
+/**
+ * Unit tests for {@link SystemContextLoader}, the per-physical-tenant assembly logic extracted from
+ * {@link BrokerModuleConfiguration}. Exercised directly with plain objects and mocks — no Spring
+ * context — so the per-tenant configuration translation (default-tenant reuse, override conversion,
+ * exporter validation) can be verified in isolation.
+ */
+final class SystemContextLoaderTest {
+
+  @TempDir private Path workingDirectory;
+
+  @Test
+  void shouldThrowWhenExporterHasNoClassName() {
+    // given - a broker config with an exporter that is missing its className
+    final var rootCamunda = new Camunda();
+    final var rootBrokerCfg = new BrokerCfg();
+    final var invalidExporter = new ExporterCfg();
+    invalidExporter.setClassName(null);
+    rootBrokerCfg.setExporters(Map.of("oops", invalidExporter));
+
+    final var loader =
+        newLoader(
+            rootCamunda,
+            rootBrokerCfg,
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rootCamunda));
+
+    // when - then
+    assertThatCode(loader::createSystemContext)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "Expected to find a 'className' configured for the exporter. Couldn't find a valid one for the following exporters ");
+  }
+
+  @Test
+  void shouldReuseRootBrokerConfigForDefaultTenant() {
+    // given
+    final var rootCamunda = new Camunda();
+    final var rootBrokerCfg = new BrokerCfg();
+    final var loader =
+        newLoader(
+            rootCamunda,
+            rootBrokerCfg,
+            Map.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, rootCamunda));
+
+    // when
+    final SystemContext systemContext = loader.createSystemContext();
+
+    // then - the default tenant reuses the fully-initialized root broker config as-is
+    assertThat(
+            systemContext
+                .getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .config())
+        .isSameAs(rootBrokerCfg);
+  }
+
+  @Test
+  void shouldConvertConfigForNonDefaultTenant() {
+    // given - a non-default tenant with its own Camunda instance (not identical to the root)
+    final var rootCamunda = new Camunda();
+    final var rootBrokerCfg = new BrokerCfg();
+    final var tenantCamunda = new Camunda();
+    final var loader =
+        newLoader(
+            rootCamunda,
+            rootBrokerCfg,
+            Map.of(
+                PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID,
+                rootCamunda,
+                "tenanta",
+                tenantCamunda),
+            () -> Set.of(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID, "tenanta"));
+
+    // when
+    final SystemContext systemContext = loader.createSystemContext();
+
+    // then - the non-default tenant gets its own converted config, distinct from the root
+    final var tenantConfig = systemContext.getPhysicalTenantEngineContext("tenanta").config();
+    assertThat(tenantConfig).isNotSameAs(rootBrokerCfg);
+    assertThat(
+            systemContext
+                .getPhysicalTenantEngineContext(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .config())
+        .isSameAs(rootBrokerCfg);
+  }
+
+  private SystemContextLoader newLoader(
+      final Camunda rootCamunda,
+      final BrokerCfg rootBrokerCfg,
+      final Map<String, Camunda> physicalTenants) {
+    return newLoader(rootCamunda, rootBrokerCfg, physicalTenants, PhysicalTenantIds.DEFAULT);
+  }
+
+  private SystemContextLoader newLoader(
+      final Camunda rootCamunda,
+      final BrokerCfg rootBrokerCfg,
+      final Map<String, Camunda> physicalTenants,
+      final PhysicalTenantIds physicalTenantIds) {
+    final var nodeIdProvider = mock(NodeIdProvider.class);
+    when(nodeIdProvider.currentNodeInstance()).thenReturn(new NodeInstance(0, Version.zero()));
+
+    return new SystemContextLoader()
+        .withShutdownTimeout(SystemContext.DEFAULT_SHUTDOWN_TIMEOUT)
+        .withRootBrokerCfg(rootBrokerCfg)
+        .withRootCamunda(rootCamunda)
+        .withActorScheduler(mock(ActorScheduler.class))
+        .withCluster(mock(AtomixCluster.class))
+        .withBrokerClient(mock(BrokerClient.class))
+        .withMeterRegistry(new SimpleMeterRegistry())
+        .withPhysicalTenants(physicalTenants)
+        .withUserServicesForTenant(tenantId -> mock(UserServices.class))
+        .withPasswordEncoder(mock(PasswordEncoder.class))
+        .withJwtDecoderFactory(authentication -> mock(JwtDecoder.class))
+        .withOidcClaimsProviderFactory(
+            authentication -> (OidcClaimsProvider) (jwtClaims, tokenValue) -> jwtClaims)
+        .withSearchClientsProxy(mock(SearchClientsProxy.class))
+        .withNodeIdProvider(nodeIdProvider)
+        .withPhysicalTenantIds(physicalTenantIds)
+        .withWorkingDirectory(workingDirectory)
+        .withExporterDescriptors(null);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsageMetricsIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/UsageMetricsIT.java
@@ -21,9 +21,12 @@ import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator.AddTimeRequest;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -53,8 +56,13 @@ public class UsageMetricsIT {
           .withMultiTenancyEnabled()
           .withAuthenticatedAccess()
           // set exportInterval via properties because it is not yet supported in unified config
+          // (https://github.com/camunda/camunda/issues/56077). Legacy zeebe.broker.* properties
+          // are not applied to per-physical-tenant configuration, so under physical-tenant mode
+          // the export is triggered by advancing the broker clock instead — see
+          // advanceClockPastExportInterval().
           .withProperty(
-              "zeebe.broker.experimental.engine.usageMetrics.exportInterval", EXPORT_INTERVAL);
+              "zeebe.broker.experimental.engine.usageMetrics.exportInterval", EXPORT_INTERVAL)
+          .withProperty("zeebe.clock.controlled", "true");
 
   private static final String ADMIN = "admin";
   private static final String ASSIGNEE = "bar2";
@@ -69,6 +77,45 @@ public class UsageMetricsIT {
   private static final TestUser ADMIN_USER = new TestUser(ADMIN, "password", List.of());
 
   private static OffsetDateTime exportedTime;
+
+  /**
+   * Advances the broker clock past the default usage-metrics export interval (5 minutes) so the
+   * engine's {@code UsageMetricsCheckScheduler} fires on every partition group.
+   *
+   * <p>Needed because the export interval is only configurable via legacy {@code zeebe.broker.*}
+   * properties, which are not applied to per-physical-tenant configuration — under physical-tenant
+   * mode the tenant's partition group runs with the 5-minute default. Once <a
+   * href="https://github.com/camunda/camunda/issues/56077">#56077</a> adds the property to the
+   * unified configuration, the interval can be set there (inherited by all physical tenants) and
+   * this clock manipulation can be removed.
+   *
+   * <p>No-op when the broker actuator is not reachable (e.g. compatibility-mode runs against a
+   * containerized broker), where the short export interval is configured via environment variable
+   * instead.
+   */
+  private static void advanceClockPastExportInterval() {
+    try {
+      ActorClockActuator.of(BROKER)
+          .addTime(new AddTimeRequest(Duration.ofMinutes(5).plusSeconds(1).toMillis()));
+    } catch (final Exception e) {
+      // broker actuator not available (compatibility mode); rely on the configured interval
+    }
+  }
+
+  /**
+   * Returns the broker's current (possibly clock-advanced) time, falling back to wall-clock time
+   * when the actuator is not reachable. Metric record timestamps follow the broker clock, so
+   * interval assertions must use it as well.
+   */
+  private static OffsetDateTime currentBrokerTime() {
+    try {
+      return OffsetDateTime.ofInstant(
+          ActorClockActuator.of(BROKER.actuatorUri("clock").toString()).getCurrentClock().instant(),
+          ZoneOffset.UTC);
+    } catch (final Exception e) {
+      return OffsetDateTime.now();
+    }
+  }
 
   private static void waitForUsageMetrics(
       final CamundaClient camundaClient,
@@ -99,6 +146,7 @@ public class UsageMetricsIT {
     deployResource(adminClient, "process/process_with_assigned_user_task.bpmn", TENANT_A);
     startProcessInstance(adminClient, PROCESS_ID, TENANT_A);
     startProcessInstance(adminClient, PROCESS_ID_2, TENANT_A);
+    advanceClockPastExportInterval();
     waitForUsageMetrics(
         adminClient,
         NOW.minusDays(1),
@@ -110,7 +158,7 @@ public class UsageMetricsIT {
         });
 
     // Store first export time & wait 2 export intervals
-    exportedTime = OffsetDateTime.now();
+    exportedTime = currentBrokerTime();
     Thread.sleep(2 * EXPORT_INTERVAL.toMillis());
 
     // Create second batch of metrics
@@ -144,6 +192,7 @@ public class UsageMetricsIT {
     assertDecisionsInstantiated(adminClient);
 
     // Wait for all metrics to be exported
+    advanceClockPastExportInterval();
     waitForUsageMetrics(
         adminClient,
         NOW.minusDays(1),

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -198,6 +198,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>identity-sdk</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -79,7 +79,6 @@ public final class Broker implements AutoCloseable {
         new BrokerStartupContextImpl(
             localBroker,
             systemContext.getBrokerConfiguration(),
-            systemContext.getIdentityConfiguration(),
             springBrokerBridge,
             scheduler,
             healthCheckService,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -12,8 +12,6 @@ import io.camunda.zeebe.broker.bootstrap.BrokerContext;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContextImpl;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupProcess;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
-import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
-import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
@@ -25,7 +23,6 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.LogUtil;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
-import io.camunda.zeebe.util.jar.ExternalJarLoadException;
 import io.camunda.zeebe.util.micrometer.PartitionKeyNames;
 import io.netty.util.NetUtil;
 import java.util.List;
@@ -37,7 +34,6 @@ public final class Broker implements AutoCloseable {
   public static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
   private final SystemContext systemContext;
-  private final ExporterRepository exporterRepository;
   private boolean isClosed = false;
 
   private CompletableFuture<Broker> startFuture;
@@ -47,21 +43,11 @@ public final class Broker implements AutoCloseable {
   private final BrokerStartupActor brokerStartupActor;
   private BrokerContext brokerContext;
 
-  // TODO just used by tests ...
   public Broker(
       final SystemContext systemContext,
       final SpringBrokerBridge springBrokerBridge,
       final List<PartitionListener> additionalPartitionListeners) {
-    this(systemContext, springBrokerBridge, additionalPartitionListeners, new ExporterRepository());
-  }
-
-  public Broker(
-      final SystemContext systemContext,
-      final SpringBrokerBridge springBrokerBridge,
-      final List<PartitionListener> additionalPartitionListeners,
-      final ExporterRepository exporterRepository) {
     this.systemContext = systemContext;
-    this.exporterRepository = exporterRepository;
 
     final ActorScheduler scheduler = this.systemContext.getScheduler();
     final BrokerInfo localBroker = createBrokerInfo(getConfig());
@@ -82,7 +68,6 @@ public final class Broker implements AutoCloseable {
             springBrokerBridge,
             scheduler,
             healthCheckService,
-            buildExporterRepository(getConfig()),
             new ClusterServicesImpl(systemContext.getCluster()),
             systemContext.getBrokerClient(),
             additionalPartitionListeners,
@@ -166,23 +151,6 @@ public final class Broker implements AutoCloseable {
     }
 
     return result;
-  }
-
-  private ExporterRepository buildExporterRepository(final BrokerCfg cfg) {
-    exporterRepository.setLicenseKey(cfg.getLicenseKey());
-    final var exporterEntries = cfg.getExporters().entrySet();
-    for (final var exporterEntry : exporterEntries) {
-      final var id = exporterEntry.getKey();
-      final var exporterCfg = exporterEntry.getValue();
-      try {
-        exporterRepository.load(id, exporterCfg);
-      } catch (final ExporterLoadException | ExternalJarLoadException e) {
-        throw new IllegalStateException(
-            "Failed to load exporter with configuration: " + exporterCfg, e);
-      }
-    }
-
-    return exporterRepository;
   }
 
   public BrokerCfg getConfig() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -9,11 +9,9 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.cluster.PhysicalTenantIds;
-import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
-import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -58,8 +56,6 @@ public interface BrokerStartupContext {
   BrokerInfo getBrokerInfo();
 
   BrokerCfg getBrokerConfiguration();
-
-  IdentityConfiguration getIdentityConfiguration();
 
   SpringBrokerBridge getSpringBrokerBridge();
 
@@ -145,9 +141,6 @@ public interface BrokerStartupContext {
   void setRequestIdGenerator(SnowflakeIdGenerator requestIdGenerator);
 
   MeterRegistry getMeterRegistry();
-
-  /** Returns the security configuration for the {@code default} physical tenant. */
-  EngineSecurityConfig getSecurityConfiguration();
 
   /**
    * Returns the engine context for the given physical tenant.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
-import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
+import io.camunda.zeebe.broker.system.PhysicalTenantContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.management.CheckpointSchedulingService;
@@ -147,7 +147,7 @@ public interface BrokerStartupContext {
    *
    * @throws IllegalArgumentException if the physical tenant id is unknown
    */
-  PhysicalTenantEngineContext getPhysicalTenantEngineContext(String physicalTenantId);
+  PhysicalTenantContext getPhysicalTenantEngineContext(String physicalTenantId);
 
   Function<String, UserServices> getUserServicesForTenant();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
-import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
@@ -55,6 +54,13 @@ public interface BrokerStartupContext {
 
   BrokerInfo getBrokerInfo();
 
+  /**
+   * Return the broker configuration shared across all physical tenants. This should be used only
+   * for broker-wide configuration. The components that run per physical tenant must use the
+   * configuration from #getPhysicalTenantEngineContext(String physicalTenantId) instead.
+   *
+   * @return
+   */
   BrokerCfg getBrokerConfiguration();
 
   SpringBrokerBridge getSpringBrokerBridge();
@@ -100,8 +106,6 @@ public interface BrokerStartupContext {
   DiskSpaceUsageMonitor getDiskSpaceUsageMonitor();
 
   void setDiskSpaceUsageMonitor(DiskSpaceUsageMonitor diskSpaceUsageMonitor);
-
-  ExporterRepository getExporterRepository();
 
   /** Returns all currently registered partition managers, keyed by physical tenant ID. */
   Map<String, PartitionManager> getPartitionManagers();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -59,7 +59,7 @@ public interface BrokerStartupContext {
    * for broker-wide configuration. The components that run per physical tenant must use the
    * configuration from #getPhysicalTenantEngineContext(String physicalTenantId) instead.
    *
-   * @return
+   * @return the broker-wide configuration shared across all physical tenants
    */
   BrokerCfg getBrokerConfiguration();
 
@@ -147,7 +147,7 @@ public interface BrokerStartupContext {
   MeterRegistry getMeterRegistry();
 
   /**
-   * Returns the engine context for the given physical tenant.
+   * Returns the context for the given physical tenant.
    *
    * @throws IllegalArgumentException if the physical tenant id is unknown
    */

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
-import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
+import io.camunda.zeebe.broker.system.PhysicalTenantContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.management.CheckpointSchedulingService;
@@ -67,7 +67,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final List<PartitionRaftListener> partitionRaftListeners = new ArrayList<>();
   private final Duration shutdownTimeout;
   private final MeterRegistry meterRegistry;
-  private final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts;
+  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts;
   private final Function<String, UserServices> userServicesForTenant;
   private final PasswordEncoder passwordEncoder;
   private final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
@@ -103,7 +103,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final List<PartitionListener> additionalPartitionListeners,
       final Duration shutdownTimeout,
       final MeterRegistry meterRegistry,
-      final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts,
+      final Map<String, PhysicalTenantContext> physicalTenantEngineContexts,
       final Function<String, UserServices> userServicesForTenant,
       final PasswordEncoder passwordEncoder,
       final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory,
@@ -350,7 +350,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   }
 
   @Override
-  public PhysicalTenantEngineContext getPhysicalTenantEngineContext(final String physicalTenantId) {
+  public PhysicalTenantContext getPhysicalTenantEngineContext(final String physicalTenantId) {
     if (!physicalTenantEngineContexts.containsKey(physicalTenantId)) {
       throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -12,11 +12,9 @@ import static java.util.Objects.requireNonNull;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.cluster.PhysicalTenantIds;
-import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
-import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -59,7 +57,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
 
   private final BrokerInfo brokerInfo;
   private final BrokerCfg configuration;
-  private final IdentityConfiguration identityConfiguration;
   private final SpringBrokerBridge springBrokerBridge;
   private final ActorSchedulingService actorScheduler;
   private final BrokerHealthCheckService healthCheckService;
@@ -97,7 +94,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   public BrokerStartupContextImpl(
       final BrokerInfo brokerInfo,
       final BrokerCfg configuration,
-      final IdentityConfiguration identityConfiguration,
       final SpringBrokerBridge springBrokerBridge,
       final ActorSchedulingService actorScheduler,
       final BrokerHealthCheckService healthCheckService,
@@ -123,7 +119,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.healthCheckService = requireNonNull(healthCheckService);
     this.exporterRepository = requireNonNull(exporterRepository);
     this.clusterServices = requireNonNull(clusterServices);
-    this.identityConfiguration = identityConfiguration;
     this.brokerClient = brokerClient;
     this.shutdownTimeout = shutdownTimeout;
     this.meterRegistry = requireNonNull(meterRegistry);
@@ -151,11 +146,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public BrokerCfg getBrokerConfiguration() {
     return configuration;
-  }
-
-  @Override
-  public IdentityConfiguration getIdentityConfiguration() {
-    return identityConfiguration;
   }
 
   @Override
@@ -357,16 +347,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public MeterRegistry getMeterRegistry() {
     return meterRegistry;
-  }
-
-  @Override
-  public EngineSecurityConfig getSecurityConfiguration() {
-    final var ctx = physicalTenantEngineContexts.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
-    if (ctx == null) {
-      throw new IllegalStateException(
-          "No security configuration registered for the default physical tenant");
-    }
-    return ctx.securityConfig();
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.clustering.ClusterServicesImpl;
-import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
@@ -60,7 +59,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final SpringBrokerBridge springBrokerBridge;
   private final ActorSchedulingService actorScheduler;
   private final BrokerHealthCheckService healthCheckService;
-  private final ExporterRepository exporterRepository;
   private final ClusterServicesImpl clusterServices;
   private final BrokerClient brokerClient;
   private final List<PartitionListener> partitionListeners = new ArrayList<>();
@@ -97,7 +95,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final SpringBrokerBridge springBrokerBridge,
       final ActorSchedulingService actorScheduler,
       final BrokerHealthCheckService healthCheckService,
-      final ExporterRepository exporterRepository,
       final ClusterServicesImpl clusterServices,
       final BrokerClient brokerClient,
       final List<PartitionListener> additionalPartitionListeners,
@@ -117,7 +114,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.springBrokerBridge = requireNonNull(springBrokerBridge);
     this.actorScheduler = requireNonNull(actorScheduler);
     this.healthCheckService = requireNonNull(healthCheckService);
-    this.exporterRepository = requireNonNull(exporterRepository);
     this.clusterServices = requireNonNull(clusterServices);
     this.brokerClient = brokerClient;
     this.shutdownTimeout = shutdownTimeout;
@@ -260,11 +256,6 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public void setDiskSpaceUsageMonitor(final DiskSpaceUsageMonitor diskSpaceUsageMonitor) {
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
-  }
-
-  @Override
-  public ExporterRepository getExporterRepository() {
-    return exporterRepository;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+
 import io.camunda.zeebe.broker.partitioning.topology.ClusterChangeExecutorImpl;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.DynamicClusterConfigurationService;
@@ -34,7 +36,12 @@ public class ClusterConfigurationManagerStep
     final ClusterChangeExecutor clusterChangeExecutor =
         new ClusterChangeExecutorImpl(
             brokerStartupContext.getConcurrencyControl(),
-            brokerStartupContext.getExporterRepository(),
+            // Temp: use the default physical tenant engine context to get the exporter repository.
+            // This is a temporary solution until we support multiple physical tenants in dynamic
+            // cluster config module.
+            brokerStartupContext
+                .getPhysicalTenantEngineContext(DEFAULT_PHYSICAL_TENANT_ID)
+                .exporterRepository(),
             brokerStartupContext.getNodeIdProvider(),
             brokerStartupContext.getMeterRegistry(),
             Optional.ofNullable(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManager.java
@@ -67,12 +67,16 @@ public interface PartitionManager {
       final BrokerStartupContext brokerStartupContext,
       final String physicalTenantId,
       final TopologyManagerImpl topologyManager) {
-    final var engineContext = brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
+    final var physicalTenantContext =
+        brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId);
+
     return new PartitionManagerImpl(
         physicalTenantId,
         brokerStartupContext.getConcurrencyControl(),
         brokerStartupContext.getActorSchedulingService(),
-        brokerStartupContext.getBrokerConfiguration(),
+        // Use the physicalTenantConfig which contains both the shared broker-wide properties and
+        // the properties overridden for the physical tenant.
+        physicalTenantContext.config(),
         brokerStartupContext.getBrokerInfo(),
         brokerStartupContext.getClusterServices(),
         brokerStartupContext.getHealthCheckService(),
@@ -80,17 +84,17 @@ public interface PartitionManager {
         brokerStartupContext.getPartitionListeners(),
         brokerStartupContext.getPartitionRaftListeners(),
         brokerStartupContext.getSnapshotApiRequestHandler(),
-        brokerStartupContext.getExporterRepository(),
+        physicalTenantContext.exporterRepository(),
         brokerStartupContext.getGatewayBrokerTransport(),
         brokerStartupContext.getJobStreamService().jobStreamer(),
         brokerStartupContext.getClusterConfigurationService(),
         brokerStartupContext.getMeterRegistry(),
         brokerStartupContext.getBrokerClient(),
         brokerStartupContext.getRocksDbResources(),
-        engineContext.securityConfig(),
+        physicalTenantContext.securityConfig(),
         brokerStartupContext.getSearchClientsProxy(),
-        engineContext.authorizationConverter(),
-        engineContext.featureFlags(),
+        physicalTenantContext.authorizationConverter(),
+        physicalTenantContext.featureFlags(),
         topologyManager);
   }
 
@@ -101,7 +105,7 @@ public interface PartitionManager {
 
     return new RecoveryPartitionManager(
         physicalTenantId,
-        brokerStartupContext.getBrokerConfiguration(),
+        brokerStartupContext.getPhysicalTenantEngineContext(physicalTenantId).config(),
         brokerStartupContext.getBrokerInfo(),
         brokerStartupContext.getConcurrencyControl(),
         brokerStartupContext.getClusterConfigurationService(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/PhysicalTenantContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/PhysicalTenantContext.java
@@ -9,13 +9,23 @@ package io.camunda.zeebe.broker.system;
 
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfig;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.util.FeatureFlags;
 
 /**
- * Bundles all per-physical-tenant objects required to bootstrap the engine for a given physical
- * tenant. Passed as a single unit through the broker startup chain instead of three parallel maps.
+ * Bundles all per-physical-tenant objects required to bootstrap the services for a given physical
+ * tenant.
+ *
+ * <p>BrokerCfg present here contains the full effective configuration to be applied to the physical
+ * tenant.
+ *
+ * <p>exporterRepository contains all exporters that are configured for the physical tenant with the
+ * corresponding configuration.
  */
 public record PhysicalTenantContext(
     EngineSecurityConfig securityConfig,
     BrokerRequestAuthorizationConverter authorizationConverter,
-    FeatureFlags featureFlags) {}
+    FeatureFlags featureFlags,
+    BrokerCfg config,
+    ExporterRepository exporterRepository) {}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/PhysicalTenantContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/PhysicalTenantContext.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.util.FeatureFlags;
  * Bundles all per-physical-tenant objects required to bootstrap the engine for a given physical
  * tenant. Passed as a single unit through the broker startup chain instead of three parallel maps.
  */
-public record PhysicalTenantEngineContext(
+public record PhysicalTenantContext(
     EngineSecurityConfig securityConfig,
     BrokerRequestAuthorizationConverter authorizationConverter,
     FeatureFlags featureFlags) {}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -35,7 +35,6 @@ import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.DataCfg;
 import io.camunda.zeebe.broker.system.configuration.DiskCfg.FreeSpaceCfg;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
-import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.configuration.SecurityCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.AzureBackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg;
@@ -73,7 +72,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -197,7 +195,8 @@ public final class SystemContext {
     validClusterConfigs(cluster);
     validateExperimentalConfigs(cluster, brokerCfg.getExperimental());
 
-    validateExporters(brokerCfg.getExporters());
+    // Exporter configuration is validated by SystemContextLoader before the SystemContext is
+    // constructed, so that per-physical-tenant exporter configs are checked as they are loaded.
 
     final var security = brokerCfg.getNetwork().getSecurity();
     if (security.isEnabled()) {
@@ -240,21 +239,6 @@ public final class SystemContext {
     if (!errors.isEmpty()) {
       throw new InvalidConfigurationException(
           "Invalid ConfigManager configuration: " + String.join(", ", errors), null);
-    }
-  }
-
-  private void validateExporters(final Map<String, ExporterCfg> exporters) {
-    final Set<Entry<String, ExporterCfg>> entries = exporters.entrySet();
-    final var badExportersNames =
-        entries.stream()
-            .filter(entry -> entry.getValue().getClassName() == null)
-            .map(Entry::getKey)
-            .toList();
-
-    if (!badExportersNames.isEmpty()) {
-      throw new IllegalArgumentException(
-          "Expected to find a 'className' configured for the exporter. Couldn't find a valid one for the following exporters "
-              + badExportersNames);
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -131,7 +131,7 @@ public final class SystemContext {
   private final AtomixCluster cluster;
   private final BrokerClient brokerClient;
   private final MeterRegistry meterRegistry;
-  private final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts;
+  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts;
   private final Function<String, UserServices> userServicesForTenant;
   private final PasswordEncoder passwordEncoder;
   private final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory;
@@ -152,7 +152,7 @@ public final class SystemContext {
       final AtomixCluster cluster,
       final BrokerClient brokerClient,
       final MeterRegistry meterRegistry,
-      final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts,
+      final Map<String, PhysicalTenantContext> physicalTenantEngineContexts,
       final Function<String, UserServices> userServicesForTenant,
       final PasswordEncoder passwordEncoder,
       final Function<AuthenticationConfiguration, JwtDecoder> jwtDecoderFactory,
@@ -713,7 +713,7 @@ public final class SystemContext {
   }
 
   /** Returns the per-physical-tenant engine context map (unmodifiable). */
-  public Map<String, PhysicalTenantEngineContext> getPhysicalTenantEngineContexts() {
+  public Map<String, PhysicalTenantContext> getPhysicalTenantEngineContexts() {
     return physicalTenantEngineContexts;
   }
 
@@ -722,7 +722,7 @@ public final class SystemContext {
    *
    * @throws IllegalArgumentException if the physical tenant id is unknown
    */
-  public PhysicalTenantEngineContext getPhysicalTenantEngineContext(final String physicalTenantId) {
+  public PhysicalTenantContext getPhysicalTenantEngineContext(final String physicalTenantId) {
     if (!physicalTenantEngineContexts.containsKey(physicalTenantId)) {
       throw new IllegalArgumentException("Unknown physical tenant id '" + physicalTenantId + "'");
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirect
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.cluster.PhysicalTenantIds;
-import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
@@ -127,7 +126,6 @@ public final class SystemContext {
 
   private final Duration shutdownTimeout;
   private final BrokerCfg brokerCfg;
-  private final IdentityConfiguration identityConfiguration;
   private Map<String, String> diagnosticContext;
   private final ActorScheduler scheduler;
   private final AtomixCluster cluster;
@@ -150,7 +148,6 @@ public final class SystemContext {
   public SystemContext(
       final Duration shutdownTimeout,
       final BrokerCfg brokerCfg,
-      final IdentityConfiguration identityConfiguration,
       final ActorScheduler scheduler,
       final AtomixCluster cluster,
       final BrokerClient brokerClient,
@@ -165,7 +162,6 @@ public final class SystemContext {
       final PhysicalTenantIds physicalTenantIds) {
     this.shutdownTimeout = shutdownTimeout;
     this.brokerCfg = brokerCfg;
-    this.identityConfiguration = identityConfiguration;
     this.scheduler = scheduler;
     this.cluster = cluster;
     this.brokerClient = brokerClient;
@@ -694,10 +690,6 @@ public final class SystemContext {
 
   public BrokerCfg getBrokerConfiguration() {
     return brokerCfg;
-  }
-
-  public IdentityConfiguration getIdentityConfiguration() {
-    return identityConfiguration;
   }
 
   public AtomixCluster getCluster() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -109,6 +109,10 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   int getMaxFragmentSize();
 
+  /**
+   * Returns the configuration for the physical tenant of this partition. This configuration
+   * contains both the shared properties and the properties overridden for the physical tenant.
+   */
   BrokerCfg getBrokerCfg();
 
   EngineSecurityConfig getSecurityConfig();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -29,7 +29,7 @@ import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManager;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.EmbeddedGatewayService;
-import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
+import io.camunda.zeebe.broker.system.PhysicalTenantContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.system.management.CheckpointSchedulingService;
@@ -95,7 +95,7 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter =
       mock(BrokerRequestAuthorizationConverter.class);
   private FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
-  private final Map<String, PhysicalTenantEngineContext> physicalTenantEngineContexts =
+  private final Map<String, PhysicalTenantContext> physicalTenantEngineContexts =
       new LinkedHashMap<>();
   private CheckpointSchedulingService checkpointSchedulingService =
       mock(CheckpointSchedulingService.class);
@@ -358,11 +358,11 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   @Override
-  public PhysicalTenantEngineContext getPhysicalTenantEngineContext(final String physicalTenantId) {
+  public PhysicalTenantContext getPhysicalTenantEngineContext(final String physicalTenantId) {
     return physicalTenantEngineContexts.computeIfAbsent(
         physicalTenantId,
         id ->
-            new PhysicalTenantEngineContext(
+            new PhysicalTenantContext(
                 securityConfiguration, brokerRequestAuthorizationConverter, featureFlags));
   }
 
@@ -431,7 +431,7 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   public void setPhysicalTenantEngineContext(
-      final String physicalTenantId, final PhysicalTenantEngineContext context) {
+      final String physicalTenantId, final PhysicalTenantContext context) {
     physicalTenantEngineContexts.put(physicalTenantId, context);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.mock;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.cluster.PhysicalTenantIds;
-import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.api.context.OidcClaimsProvider;
 import io.camunda.security.api.model.config.AuthenticationConfiguration;
@@ -61,7 +60,6 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
 
   private BrokerInfo brokerInfo = mock(BrokerInfo.class);
   private BrokerCfg brokerConfiguration = mock(BrokerCfg.class);
-  private IdentityConfiguration identityConfiguration = mock(IdentityConfiguration.class);
   private SpringBrokerBridge springBrokerBridge = mock(SpringBrokerBridge.class);
   private ActorSchedulingService actorSchedulingService = mock(ActorSchedulingService.class);
   private ConcurrencyControl concurrencyControl = mock(ConcurrencyControl.class);
@@ -86,7 +84,8 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private Duration shutdownTimeout = Duration.ofSeconds(30);
   private SnowflakeIdGenerator requestIdGenerator = mock(SnowflakeIdGenerator.class);
   private MeterRegistry meterRegistry = new SimpleMeterRegistry();
-  private EngineSecurityConfig securityConfiguration = EngineSecurityConfigurations.defaultConfig();
+  private final EngineSecurityConfig securityConfiguration =
+      EngineSecurityConfigurations.defaultConfig();
   private UserServices userServices = mock(UserServices.class);
   private PasswordEncoder passwordEncoder = mock(PasswordEncoder.class);
   private JwtDecoder jwtDecoder = mock(JwtDecoder.class);
@@ -119,15 +118,6 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
 
   public void setBrokerConfiguration(final BrokerCfg brokerConfiguration) {
     this.brokerConfiguration = brokerConfiguration;
-  }
-
-  @Override
-  public IdentityConfiguration getIdentityConfiguration() {
-    return identityConfiguration;
-  }
-
-  public void setIdentityConfiguration(final IdentityConfiguration identityConfiguration) {
-    this.identityConfiguration = identityConfiguration;
   }
 
   @Override
@@ -368,11 +358,6 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   @Override
-  public EngineSecurityConfig getSecurityConfiguration() {
-    return securityConfiguration;
-  }
-
-  @Override
   public PhysicalTenantEngineContext getPhysicalTenantEngineContext(final String physicalTenantId) {
     return physicalTenantEngineContexts.computeIfAbsent(
         physicalTenantId,
@@ -381,22 +366,9 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
                 securityConfiguration, brokerRequestAuthorizationConverter, featureFlags));
   }
 
-  public void setPhysicalTenantEngineContext(
-      final String physicalTenantId, final PhysicalTenantEngineContext context) {
-    physicalTenantEngineContexts.put(physicalTenantId, context);
-  }
-
-  public void setSecurityConfiguration(final EngineSecurityConfig securityConfiguration) {
-    this.securityConfiguration = securityConfiguration;
-  }
-
   @Override
   public Function<String, UserServices> getUserServicesForTenant() {
     return tenantId -> userServices;
-  }
-
-  public void setUserServices(final UserServices userServices) {
-    this.userServices = userServices;
   }
 
   @Override
@@ -413,17 +385,9 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
     return authConfig -> jwtDecoder;
   }
 
-  public void setJwtDecoder(final JwtDecoder jwtDecoder) {
-    this.jwtDecoder = jwtDecoder;
-  }
-
   @Override
   public Function<AuthenticationConfiguration, OidcClaimsProvider> getOidcClaimsProviderFactory() {
     return authConfig -> oidcClaimsProvider;
-  }
-
-  public void setOidcClaimsProvider(final OidcClaimsProvider oidcClaimsProvider) {
-    this.oidcClaimsProvider = oidcClaimsProvider;
   }
 
   @Override
@@ -435,15 +399,6 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   public void setSnapshotApiRequestHandler(
       final SnapshotApiRequestHandler snapshotApiRequestHandler) {
     this.snapshotApiRequestHandler = snapshotApiRequestHandler;
-  }
-
-  public void setBrokerRequestAuthorizationConverter(
-      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
-    this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
-  }
-
-  public void setFeatureFlags(final FeatureFlags featureFlags) {
-    this.featureFlags = featureFlags;
   }
 
   @Override
@@ -473,5 +428,31 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
 
   public void setPhysicalTenantIds(final PhysicalTenantIds physicalTenantIds) {
     this.physicalTenantIds = physicalTenantIds;
+  }
+
+  public void setPhysicalTenantEngineContext(
+      final String physicalTenantId, final PhysicalTenantEngineContext context) {
+    physicalTenantEngineContexts.put(physicalTenantId, context);
+  }
+
+  public void setUserServices(final UserServices userServices) {
+    this.userServices = userServices;
+  }
+
+  public void setJwtDecoder(final JwtDecoder jwtDecoder) {
+    this.jwtDecoder = jwtDecoder;
+  }
+
+  public void setOidcClaimsProvider(final OidcClaimsProvider oidcClaimsProvider) {
+    this.oidcClaimsProvider = oidcClaimsProvider;
+  }
+
+  public void setBrokerRequestAuthorizationConverter(
+      final BrokerRequestAuthorizationConverter brokerRequestAuthorizationConverter) {
+    this.brokerRequestAuthorizationConverter = brokerRequestAuthorizationConverter;
+  }
+
+  public void setFeatureFlags(final FeatureFlags featureFlags) {
+    this.featureFlags = featureFlags;
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/MockBrokerStartupContext.java
@@ -73,7 +73,7 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   private ManagedMessagingService apiMessagingService = mock(ManagedMessagingService.class);
   private EmbeddedGatewayService embeddedGatewayService;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor = mock(DiskSpaceUsageMonitor.class);
-  private ExporterRepository exporterRepository = mock(ExporterRepository.class);
+  private final ExporterRepository exporterRepository = mock(ExporterRepository.class);
   private final Map<String, PartitionManager> partitionManagers = new LinkedHashMap<>();
   private RocksDbResources sharedRocksDbResources;
   private BrokerAdminServiceImpl brokerAdminService = mock(BrokerAdminServiceImpl.class);
@@ -255,15 +255,6 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
   }
 
   @Override
-  public ExporterRepository getExporterRepository() {
-    return exporterRepository;
-  }
-
-  public void setExporterRepository(final ExporterRepository exporterRepository) {
-    this.exporterRepository = exporterRepository;
-  }
-
-  @Override
   public Map<String, PartitionManager> getPartitionManagers() {
     return Collections.unmodifiableMap(partitionManagers);
   }
@@ -363,7 +354,11 @@ public class MockBrokerStartupContext implements BrokerStartupContext {
         physicalTenantId,
         id ->
             new PhysicalTenantContext(
-                securityConfiguration, brokerRequestAuthorizationConverter, featureFlags));
+                securityConfiguration,
+                brokerRequestAuthorizationConverter,
+                featureFlags,
+                brokerConfiguration,
+                exporterRepository));
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -20,6 +20,7 @@ import io.atomix.cluster.MemberConfig;
 import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.partitioning.RecoveryPartitionManager;
@@ -224,9 +225,21 @@ class PartitionManagerStepTest {
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
       final var conv = new BrokerRequestAuthorizationConverter(secCfg);
       testBrokerStartupContext.setPhysicalTenantEngineContext(
-          PHYSICAL_TENANT_ID, new PhysicalTenantContext(secCfg, conv, flagsA));
+          PHYSICAL_TENANT_ID,
+          new PhysicalTenantContext(
+              secCfg,
+              conv,
+              flagsA,
+              testBrokerStartupContext.getBrokerConfiguration(),
+              new ExporterRepository()));
       testBrokerStartupContext.setPhysicalTenantEngineContext(
-          secondTenantId, new PhysicalTenantContext(secCfg, conv, flagsB));
+          secondTenantId,
+          new PhysicalTenantContext(
+              secCfg,
+              conv,
+              flagsB,
+              testBrokerStartupContext.getBrokerConfiguration(),
+              new ExporterRepository()));
 
       final var secondFuture = CONCURRENCY_CONTROL.<BrokerStartupContext>createFuture();
       final var secondStep = new PartitionManagerStep(secondTenantId);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.broker.partitioning.RecoveryPartitionManager;
 import io.camunda.zeebe.broker.partitioning.startup.ZeebePartitionFactory;
 import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
-import io.camunda.zeebe.broker.system.PhysicalTenantEngineContext;
+import io.camunda.zeebe.broker.system.PhysicalTenantContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.management.BrokerAdminServiceImpl;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
@@ -224,9 +224,9 @@ class PartitionManagerStepTest {
       final var secCfg = EngineSecurityConfigurations.unauthenticatedAndUnauthorized();
       final var conv = new BrokerRequestAuthorizationConverter(secCfg);
       testBrokerStartupContext.setPhysicalTenantEngineContext(
-          PHYSICAL_TENANT_ID, new PhysicalTenantEngineContext(secCfg, conv, flagsA));
+          PHYSICAL_TENANT_ID, new PhysicalTenantContext(secCfg, conv, flagsA));
       testBrokerStartupContext.setPhysicalTenantEngineContext(
-          secondTenantId, new PhysicalTenantEngineContext(secCfg, conv, flagsB));
+          secondTenantId, new PhysicalTenantContext(secCfg, conv, flagsB));
 
       final var secondFuture = CONCURRENCY_CONTROL.<BrokerStartupContext>createFuture();
       final var secondStep = new PartitionManagerStep(secondTenantId);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -593,7 +593,6 @@ final class SystemContextTest {
         new SystemContext(
             SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
             new BrokerCfg(),
-            null,
             mock(ActorScheduler.class),
             mock(AtomixCluster.class),
             mock(BrokerClient.class),
@@ -676,7 +675,6 @@ final class SystemContextTest {
     return new SystemContext(
         SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
         brokerCfg,
-        null,
         mock(ActorScheduler.class),
         mock(AtomixCluster.class),
         mock(BrokerClient.class),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -29,6 +29,7 @@ import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.security.validation.IdentityInitializationException;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
@@ -602,7 +603,9 @@ final class SystemContextTest {
                 new PhysicalTenantContext(
                     EngineSecurityConfigurations.defaultConfig(),
                     mock(BrokerRequestAuthorizationConverter.class),
-                    flags)),
+                    flags,
+                    new BrokerCfg(),
+                    new ExporterRepository())),
             ignored -> mock(UserServices.class),
             mock(PasswordEncoder.class),
             authConfig -> mock(JwtDecoder.class),
@@ -671,7 +674,9 @@ final class SystemContextTest {
                     new PhysicalTenantContext(
                         configsByTenant.get(tenantId),
                         convertersByTenant.get(tenantId),
-                        FeatureFlags.createDefaultForTests())));
+                        FeatureFlags.createDefaultForTests(),
+                        brokerCfg,
+                        new ExporterRepository())));
     return new SystemContext(
         SystemContext.DEFAULT_SHUTDOWN_TIMEOUT,
         brokerCfg,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -599,7 +599,7 @@ final class SystemContextTest {
             new SimpleMeterRegistry(),
             Map.of(
                 tenantId,
-                new PhysicalTenantEngineContext(
+                new PhysicalTenantContext(
                     EngineSecurityConfigurations.defaultConfig(),
                     mock(BrokerRequestAuthorizationConverter.class),
                     flags)),
@@ -661,14 +661,14 @@ final class SystemContextTest {
       final BrokerCfg brokerCfg,
       final Map<String, EngineSecurityConfig> configsByTenant,
       final Map<String, BrokerRequestAuthorizationConverter> convertersByTenant) {
-    final Map<String, PhysicalTenantEngineContext> contextsByTenant = new HashMap<>();
+    final Map<String, PhysicalTenantContext> contextsByTenant = new HashMap<>();
     configsByTenant
         .keySet()
         .forEach(
             tenantId ->
                 contextsByTenant.put(
                     tenantId,
-                    new PhysicalTenantEngineContext(
+                    new PhysicalTenantContext(
                         configsByTenant.get(tenantId),
                         convertersByTenant.get(tenantId),
                         FeatureFlags.createDefaultForTests())));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -32,7 +32,6 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
-import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.engine.GlobalListenerCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
@@ -41,14 +40,12 @@ import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
-import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.FeatureFlags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
 import java.security.cert.CertificateException;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -360,31 +357,6 @@ final class SystemContextTest {
     assertThatCode(() -> initSystemContext(brokerCfg))
         .isInstanceOf(InvalidConfigurationException.class)
         .hasMessageContaining("Failed configuring backup store S3");
-  }
-
-  @RegressionTest("https://github.com/camunda/camunda/issues/12678")
-  void shouldThrowExceptionWithInvalidExporters() {
-    // given
-    final var brokerCfg = new BrokerCfg();
-    final List<String> exportersNames = Arrays.asList("unknown", "oops", "nope");
-    final Map<String, ExporterCfg> exporters = HashMap.newHashMap(exportersNames.size());
-
-    for (final String exporterName : exportersNames) {
-      final ExporterCfg exporterCfg = new ExporterCfg();
-      exporterCfg.setClassName(null);
-      exporterCfg.setJarPath("unknown".equals(exporterName) ? null : exporterName);
-      final Map<String, Object> args = HashMap.newHashMap(1);
-      args.put("any_arg", 1);
-      exporterCfg.setArgs(args);
-      exporters.put(exporterName, exporterCfg);
-    }
-    brokerCfg.setExporters(exporters);
-
-    // then
-    assertThatCode(() -> initSystemContext(brokerCfg))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageStartingWith(
-            "Expected to find a 'className' configured for the exporter. Couldn't find a valid one for the following exporters ");
   }
 
   // --- per-PT security config tests ---

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -100,7 +100,6 @@ public final class SystemContextTestFactory {
     return new SystemContext(
         shutdownTimeout,
         brokerCfg,
-        identityConfiguration,
         scheduler,
         cluster,
         brokerClient,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -16,6 +16,7 @@ import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.security.configuration.EngineSecurityConfig;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -107,7 +108,11 @@ public final class SystemContextTestFactory {
         singleValueMap(
             physicalTenantIds,
             new PhysicalTenantContext(
-                securityConfiguration, brokerRequestAuthorizationConverter, featureFlags)),
+                securityConfiguration,
+                brokerRequestAuthorizationConverter,
+                featureFlags,
+                brokerCfg,
+                new ExporterRepository())),
         tenantId -> userServices,
         passwordEncoder,
         authConfig -> jwtDecoder,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -18,6 +18,7 @@ import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.FeatureFlags;
@@ -25,6 +26,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
@@ -98,6 +100,16 @@ public final class SystemContextTestFactory {
       final FeatureFlags featureFlags,
       final NodeIdProvider nodeIdProvider,
       final PhysicalTenantIds physicalTenantIds) {
+    final var exporterRepository = new ExporterRepository();
+    for (final Entry<String, ExporterCfg> entry : brokerCfg.getExporters().entrySet()) {
+      final String key = entry.getKey();
+      final ExporterCfg value = entry.getValue();
+      try {
+        exporterRepository.load(key, value);
+      } catch (final Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
     return new SystemContext(
         shutdownTimeout,
         brokerCfg,
@@ -112,7 +124,7 @@ public final class SystemContextTestFactory {
                 brokerRequestAuthorizationConverter,
                 featureFlags,
                 brokerCfg,
-                new ExporterRepository())),
+                exporterRepository)),
         tenantId -> userServices,
         passwordEncoder,
         authConfig -> jwtDecoder,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -106,7 +106,7 @@ public final class SystemContextTestFactory {
         meterRegistry,
         singleValueMap(
             physicalTenantIds,
-            new PhysicalTenantEngineContext(
+            new PhysicalTenantContext(
                 securityConfiguration, brokerRequestAuthorizationConverter, featureFlags)),
         tenantId -> userServices,
         passwordEncoder,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTestFactory.java
@@ -18,7 +18,6 @@ import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.dynamic.nodeid.NodeIdProvider;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.FeatureFlags;
@@ -26,7 +25,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 
@@ -101,15 +99,17 @@ public final class SystemContextTestFactory {
       final NodeIdProvider nodeIdProvider,
       final PhysicalTenantIds physicalTenantIds) {
     final var exporterRepository = new ExporterRepository();
-    for (final Entry<String, ExporterCfg> entry : brokerCfg.getExporters().entrySet()) {
-      final String key = entry.getKey();
-      final ExporterCfg value = entry.getValue();
-      try {
-        exporterRepository.load(key, value);
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
+    brokerCfg
+        .getExporters()
+        .forEach(
+            (id, cfg) -> {
+              try {
+                exporterRepository.load(id, cfg);
+              } catch (final Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+
     return new SystemContext(
         shutdownTimeout,
         brokerCfg,

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Verifies that per-physical-tenant exporter configuration is applied at the exporter level.
+ *
+ * <p>Supported today: an exporter declared in the <b>root</b> configuration can be redeclared per
+ * physical tenant under {@code camunda.physical-tenants.<tenantId>.data.exporters.<id>.*} with
+ * different properties. The per-tenant declaration must be complete (class-name and all args):
+ * partial overrides do not inherit the root entry's remaining fields (Spring's MapBinder replaces
+ * the whole map entry; a merge strategy is discussed in a separate issue). Each tenant's partition
+ * group then runs the exporter with that tenant's configuration.
+ *
+ * <p>Not yet supported: declaring an exporter <b>only</b> for a physical tenant (absent from the
+ * root config). The initial cluster configuration — which decides which exporter ids are enabled on
+ * a partition — is still generated from the root {@code BrokerCfg} only, so a tenant-only exporter
+ * is never enabled. See the disabled test below; this will be addressed once the
+ * cluster-configuration layer supports per-physical-tenant exporters.
+ */
+@Timeout(120)
+@ZeebeIntegration
+final class PhysicalTenantExporterConfigIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String LOCATION_EXPORTER_ID = "location-exporter";
+  private static final String TARGET_ARG = "target";
+  private static final String ROOT_TARGET = "root-location";
+  private static final String TENANT_A_TARGET = "tenanta-location";
+
+  private static final String TENANT_A_ONLY_EXPORTER_ID = "tenanta-exporter";
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
+          .withTenant(TENANT_A, Storage.none())
+          .build();
+
+  // The exporter is declared in the ROOT config (so it is enabled on every partition group), and
+  // tenantA redeclares it fully with a different "target" arg. The tenantA-only exporter
+  // exercises the not-yet-supported case and is used by the disabled test only.
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS
+          .configure(new TestStandaloneBroker().withUnauthenticatedAccess())
+          .withExporter(
+              LOCATION_EXPORTER_ID,
+              cfg -> {
+                cfg.setClassName(LocationRecordingExporter.class.getName());
+                cfg.setArgs(Map.of(TARGET_ARG, ROOT_TARGET));
+              })
+          .withPtConfig(
+              TENANT_A,
+              camunda -> {
+                final var exporter = new io.camunda.configuration.Exporter();
+                exporter.setClassName(LocationRecordingExporter.class.getName());
+                exporter.setArgs(Map.of(TARGET_ARG, TENANT_A_TARGET));
+                camunda.getData().getExporters().put(LOCATION_EXPORTER_ID, exporter);
+
+                final var tenantOnlyExporter = new io.camunda.configuration.Exporter();
+                tenantOnlyExporter.setClassName(TenantAExporter.class.getName());
+                camunda.getData().getExporters().put(TENANT_A_ONLY_EXPORTER_ID, tenantOnlyExporter);
+              });
+
+  @AutoClose private CamundaClient tenantAClient;
+  @AutoClose private CamundaClient defaultClient;
+
+  @BeforeEach
+  void setUp() {
+    LocationRecordingExporter.reset();
+    TenantAExporter.reset();
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+  }
+
+  /**
+   * Asserts that a root-declared exporter runs on both tenants' partition groups, and that each
+   * partition group sees the exporter args of its own tenant: the default tenant exports to the
+   * root-configured target, while tenantA exports to the target redeclared under {@code
+   * camunda.physical-tenants.tenanta.data.exporters.*}.
+   */
+  @Test
+  void shouldApplyPerTenantExporterArgsOverride() {
+    // given — deploy a process to each tenant so records flow through both partition groups
+    deployAndCreateInstance(defaultClient, "default-process");
+    deployAndCreateInstance(tenantAClient, "tenanta-process");
+
+    // then — the exporter instance on the default partition group was configured with the root
+    // target and received records, and the instance on tenantA's partition group was configured
+    // with tenantA's overridden target and received records.
+    await("exporter receives records under both the root and the tenantA target")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              assertThat(LocationRecordingExporter.RECORDS_BY_TARGET)
+                  .containsKey(ROOT_TARGET)
+                  .containsKey(TENANT_A_TARGET);
+              assertThat(LocationRecordingExporter.RECORDS_BY_TARGET.get(ROOT_TARGET)).isNotEmpty();
+              assertThat(LocationRecordingExporter.RECORDS_BY_TARGET.get(TENANT_A_TARGET))
+                  .isNotEmpty();
+            });
+
+    // and no exporter instance was configured with anything but the two expected targets
+    assertThat(LocationRecordingExporter.RECORDS_BY_TARGET.keySet())
+        .containsOnly(ROOT_TARGET, TENANT_A_TARGET);
+  }
+
+  /**
+   * Asserts that an exporter declared only in {@code tenantA}'s config (absent from the root
+   * config) is opened and receives records from {@code tenantA}'s partition group.
+   *
+   * <p>Disabled: the initial cluster configuration that decides which exporter ids are enabled per
+   * partition is still generated from the root {@code BrokerCfg} only
+   * (StaticConfigurationGenerator), so a tenant-only exporter is never enabled even though it is
+   * present in the tenant's ExporterRepository. To be re-enabled once the cluster-configuration
+   * layer supports per-physical-tenant exporters.
+   */
+  @Disabled(
+      "Tenant-only exporters require per-physical-tenant exporter support in the"
+          + " cluster-configuration layer (initial DynamicPartitionConfig is generated from the"
+          + " root BrokerCfg only); tracked in"
+          + " https://github.com/camunda/camunda/issues/56652")
+  @Test
+  void shouldApplyExporterConfiguredOnlyForPhysicalTenant() {
+    // given — records flow through tenantA's partition group
+    deployAndCreateInstance(tenantAClient, "tenanta-only-process");
+
+    // then — the exporter configured only for tenantA should be opened on tenantA's partition and
+    // should receive exported records
+    await("tenant-only exporter is opened and receives records from tenantA's partition")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(() -> assertThat(TenantAExporter.RECORDS).isNotEmpty());
+  }
+
+  private static void deployAndCreateInstance(final CamundaClient client, final String processId) {
+    final var process = Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+
+    // the tenant's Raft group may need a moment to elect a leader after startup
+    await("deployment succeeds for " + processId)
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, processId + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+
+    client.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send().join();
+  }
+
+  /**
+   * A minimal {@link Exporter} that records exported record positions keyed by the {@code target}
+   * arg it was configured with. Static state so assertions can observe it from outside the exporter
+   * lifecycle; call {@link #reset()} in {@code @BeforeEach} to isolate test runs.
+   */
+  public static final class LocationRecordingExporter implements Exporter {
+
+    static final Map<String, CopyOnWriteArrayList<Long>> RECORDS_BY_TARGET =
+        new ConcurrentHashMap<>();
+
+    private String target;
+    private Controller controller;
+
+    static void reset() {
+      RECORDS_BY_TARGET.clear();
+    }
+
+    @Override
+    public void configure(final Context context) {
+      target = String.valueOf(context.getConfiguration().getArguments().get(TARGET_ARG));
+    }
+
+    @Override
+    public void open(final Controller controller) {
+      this.controller = controller;
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      RECORDS_BY_TARGET
+          .computeIfAbsent(target, ignored -> new CopyOnWriteArrayList<>())
+          .add(record.getPosition());
+      controller.updateLastExportedRecordPosition(record.getPosition());
+    }
+  }
+
+  /**
+   * A minimal {@link Exporter} used by the disabled tenant-only test. Records whether it was opened
+   * and collects exported record positions.
+   */
+  public static final class TenantAExporter implements Exporter {
+
+    static final AtomicBoolean OPENED = new AtomicBoolean(false);
+    static final CopyOnWriteArrayList<Long> RECORDS = new CopyOnWriteArrayList<>();
+
+    private Controller controller;
+
+    static void reset() {
+      OPENED.set(false);
+      RECORDS.clear();
+    }
+
+    @Override
+    public void configure(final Context context) {}
+
+    @Override
+    public void open(final Controller controller) {
+      this.controller = controller;
+      OPENED.set(true);
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      RECORDS.add(record.getPosition());
+      controller.updateLastExportedRecordPosition(record.getPosition());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes per-physical-tenant broker configuration being silently ignored in the broker.

- `BrokerBasedPropertiesOverride.convert(Camunda)` — new static factory that produces a `BrokerBasedProperties` from a per-tenant `Camunda` object, reusing the same `populate*` logic as the root Spring bean so the two cannot drift
- `PhysicalTenantContext` — extended to carry both a per-tenant `BrokerCfg` and a per-tenant `ExporterRepository` (renamed from `PhysicalTenantEngineContext`)
- `BrokerModuleConfiguration` — builds a distinct `PhysicalTenantContext` per tenant; the default tenant reuses the root Spring bean (preserving legacy `zeebe.broker.*` property support), non-default tenants go through `convert()`
- `PartitionManager` — now receives the per-tenant `BrokerCfg` and `ExporterRepository` from `PhysicalTenantContext` instead of the broker-wide instances
- Removed redundant security-config accessors from `BrokerStartupContext` (already available via `PhysicalTenantContext`)
- `UsageMetricsIT` — advances the JVM-wide broker clock past the 5-minute default export interval so the test passes under physical-tenant mode (linked to #56077)
- `PhysicalTenantExporterConfigIT` — new IT verifying per-tenant exporter args are applied; one scenario disabled pending #56652

**Known gap**: per-tenant RDBMS exporter args are correctly computed into `BrokerCfg` but the `ExporterRepository.load()` short-circuits on the predefined RDBMS descriptor — tracked separately.

related to #56517
