### PR TITLE
fix: avoid archiver top_hits window limit for batch operations and standalone decisions

### DIFF
--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.operate.archiver;
 
-import static io.camunda.operate.archiver.AbstractArchiverJob.DATES_AGG;
-import static io.camunda.operate.archiver.AbstractArchiverJob.INSTANCES_AGG;
 import static io.camunda.operate.schema.SchemaManager.INDEX_LIFECYCLE_NAME;
 import static io.camunda.operate.schema.SchemaManager.OPERATE_DELETE_ARCHIVED_INDICES;
 import static java.lang.String.format;
@@ -20,9 +18,6 @@ import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
 import static org.elasticsearch.index.reindex.AbstractBulkByScrollRequest.AUTO_SLICES;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
-import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.bucketSort;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -40,7 +35,6 @@ import io.camunda.operate.util.Either;
 import io.camunda.operate.util.ElasticsearchUtil;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.Timer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -72,17 +66,12 @@ import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.index.reindex.DeleteByQueryRequest;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
-import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongTerms;
-import org.elasticsearch.search.aggregations.metrics.TopHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,29 +121,6 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     this.decisionInstanceTemplate = decisionInstanceTemplate;
   }
 
-  private ArchiveBatch createArchiveBatch(
-      final SearchResponse searchResponse,
-      final String datesAggName,
-      final String instancesAggName) {
-    final List<? extends Histogram.Bucket> buckets =
-        ((Histogram) searchResponse.getAggregations().get(datesAggName)).getBuckets();
-
-    if (buckets.size() > 0) {
-      final Histogram.Bucket bucket = buckets.get(0);
-      final String finishDate = bucket.getKeyAsString();
-      final SearchHits hits = ((TopHits) bucket.getAggregations().get(instancesAggName)).getHits();
-      final ArrayList<Object> ids =
-          Arrays.stream(hits.getHits())
-              .collect(
-                  ArrayList::new,
-                  (list, hit) -> list.add(hit.getId()),
-                  (list1, list2) -> list1.addAll(list2));
-      return new ArchiveBatch(finishDate, ids);
-    } else {
-      return null;
-    }
-  }
-
   private ArchiveBatch createArchiveBatchFromHits(
       final SearchResponse searchResponse,
       final String dateField,
@@ -202,16 +168,12 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
   }
 
   private CompletableFuture<ArchiveBatch> searchAsync(
-      final SearchRequest searchRequest, final Function<Throwable, String> errorMessage) {
-    return searchAsync(
-        searchRequest, errorMessage, r -> createArchiveBatch(r, DATES_AGG, INSTANCES_AGG));
-  }
-
-  private CompletableFuture<ArchiveBatch> searchAsync(
       final SearchRequest searchRequest,
       final Function<Throwable, String> errorMessage,
-      final Function<SearchResponse, ArchiveBatch> batchExtractor) {
+      final String dateField) {
     final var batchFuture = new CompletableFuture<ArchiveBatch>();
+    final var interval = operateProperties.getArchiver().getRolloverInterval();
+    final var dateFormat = operateProperties.getArchiver().getElsRolloverDateFormat();
 
     final var startTimer = Timer.start();
     sendSearchRequest(searchRequest)
@@ -220,7 +182,12 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
               try {
                 final var timer = getArchiverQueryTimer();
                 startTimer.stop(timer);
-                final var result = handleSearchResponse(response, e, errorMessage, batchExtractor);
+                final var result =
+                    handleSearchResponse(
+                        response,
+                        e,
+                        errorMessage,
+                        r -> createArchiveBatchFromHits(r, dateField, interval, dateFormat));
                 result.ifRightOrLeft(batchFuture::complete, batchFuture::completeExceptionally);
               } catch (final Exception ex) {
                 // Ensure the future is always completed; an uncaught exception in whenComplete
@@ -234,14 +201,13 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
 
   @Override
   public CompletableFuture<ArchiveBatch> getBatchOperationNextBatch() {
-    final var aggregation = createFinishedBatchOperationsAggregation(DATES_AGG, INSTANCES_AGG);
-    final var searchRequest = createFinishedBatchOperationsSearchRequest(aggregation);
+    final var searchRequest = createFinishedBatchOperationsSearchRequest();
     final Function<Throwable, String> errorMessage =
         t ->
             format(
                 "Exception occurred, while obtaining finished batch operations: %s",
                 t.getMessage());
-    return searchAsync(searchRequest, errorMessage);
+    return searchAsync(searchRequest, errorMessage, BatchOperationTemplate.END_DATE);
   }
 
   @Override
@@ -253,27 +219,19 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
             format(
                 "Exception occurred, while obtaining finished process instances: %s",
                 t.getMessage());
-    final var interval = operateProperties.getArchiver().getRolloverInterval();
-    final var dateFormat = operateProperties.getArchiver().getElsRolloverDateFormat();
-    return searchAsync(
-        searchRequest,
-        errorMessage,
-        response ->
-            createArchiveBatchFromHits(response, ListViewTemplate.END_DATE, interval, dateFormat));
+    return searchAsync(searchRequest, errorMessage, ListViewTemplate.END_DATE);
   }
 
   @Override
   public CompletableFuture<ArchiveBatch> getStandaloneDecisionNextBatch(
       final List<Integer> partitionIds) {
-    final var aggregation = createStandaloneDecisionInstancesAggregation(DATES_AGG, INSTANCES_AGG);
-    final var searchRequest =
-        createStandaloneDecisionInstancesSearchRequest(aggregation, partitionIds);
+    final var searchRequest = createStandaloneDecisionInstancesSearchRequest(partitionIds);
     final Function<Throwable, String> errorMessage =
         t ->
             format(
                 "Exception occurred, while obtaining finished standalone decision evaluations: %s",
                 t.getMessage());
-    return searchAsync(searchRequest, errorMessage);
+    return searchAsync(searchRequest, errorMessage, DecisionInstanceTemplate.EVALUATION_DATE);
   }
 
   @Override
@@ -586,7 +544,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
         .count();
   }
 
-  private SearchRequest createFinishedBatchOperationsSearchRequest(final AggregationBuilder agg) {
+  private SearchRequest createFinishedBatchOperationsSearchRequest() {
     final QueryBuilder endDateQ =
         rangeQuery(BatchOperationTemplate.END_DATE)
             .lte(operateProperties.getArchiver().getArchivingTimepoint());
@@ -597,36 +555,16 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
             .source(
                 new SearchSourceBuilder()
                     .query(q)
-                    .aggregation(agg)
                     .fetchSource(false)
-                    .size(0)
+                    .docValueField(
+                        BatchOperationTemplate.END_DATE,
+                        operateProperties.getArchiver().getElsRolloverDateFormat())
+                    .size(operateProperties.getArchiver().getRolloverBatchSize())
                     .sort(BatchOperationTemplate.END_DATE, SortOrder.ASC))
             .requestCache(false); // we don't need to cache this, as each time we need new data
 
-    LOGGER.debug(
-        "Finished batch operations for archiving request: \n{}\n and aggregation: \n{}",
-        q.toString(),
-        agg.toString());
+    LOGGER.debug("Finished batch operations for archiving request: \n{}", q.toString());
     return searchRequest;
-  }
-
-  private AggregationBuilder createFinishedBatchOperationsAggregation(
-      final String datesAggName, final String instancesAggName) {
-    return dateHistogram(datesAggName)
-        .field(BatchOperationTemplate.END_DATE)
-        .calendarInterval(
-            new DateHistogramInterval(operateProperties.getArchiver().getRolloverInterval()))
-        .format(operateProperties.getArchiver().getElsRolloverDateFormat())
-        .keyed(true) // get result as a map (not an array)
-        // we want to get only one bucket at a time
-        .subAggregation(
-            bucketSort("datesSortedAgg", Arrays.asList(new FieldSortBuilder("_key"))).size(1))
-        // we need process instance ids, also taking into account batch size
-        .subAggregation(
-            topHits(instancesAggName)
-                .size(operateProperties.getArchiver().getRolloverBatchSize())
-                .sort(BatchOperationTemplate.ID, SortOrder.ASC)
-                .fetchSource(BatchOperationTemplate.ID, null));
   }
 
   private Either<Throwable, ArchiveBatch> handleSearchResponse(
@@ -672,27 +610,8 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     return searchRequest;
   }
 
-  private AggregationBuilder createStandaloneDecisionInstancesAggregation(
-      final String datesAggName, final String instancesAggName) {
-    return dateHistogram(datesAggName)
-        .field(DecisionInstanceTemplate.EVALUATION_DATE)
-        .calendarInterval(
-            new DateHistogramInterval(operateProperties.getArchiver().getRolloverInterval()))
-        .format(operateProperties.getArchiver().getElsRolloverDateFormat())
-        .keyed(true) // get result as a map (not an array)
-        // we want to get only one bucket at a time
-        .subAggregation(
-            bucketSort("datesSortedAgg", Arrays.asList(new FieldSortBuilder("_key"))).size(1))
-        // we need process instance ids, also taking into account batch size
-        .subAggregation(
-            topHits(instancesAggName)
-                .size(operateProperties.getArchiver().getRolloverBatchSize())
-                .sort(DecisionInstanceTemplate.ID, SortOrder.ASC)
-                .fetchSource(DecisionInstanceTemplate.ID, null));
-  }
-
   private SearchRequest createStandaloneDecisionInstancesSearchRequest(
-      final AggregationBuilder agg, final List<Integer> partitionIds) {
+      final List<Integer> partitionIds) {
     final QueryBuilder endDateQ =
         rangeQuery(DecisionInstanceTemplate.EVALUATION_DATE)
             .lte(operateProperties.getArchiver().getArchivingTimepoint());
@@ -711,16 +630,16 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
             .source(
                 new SearchSourceBuilder()
                     .query(q)
-                    .aggregation(agg)
                     .fetchSource(false)
-                    .size(0)
+                    .docValueField(
+                        DecisionInstanceTemplate.EVALUATION_DATE,
+                        operateProperties.getArchiver().getElsRolloverDateFormat())
+                    .size(operateProperties.getArchiver().getRolloverBatchSize())
                     .sort(DecisionInstanceTemplate.EVALUATION_DATE, SortOrder.ASC))
             .requestCache(false); // we don't need to cache this, as each time we need new data
 
     LOGGER.debug(
-        "Finished standalone decision evaluations for archiving request: \n{}\n and aggregation: \n{}",
-        q,
-        agg.toString());
+        "Finished standalone decision evaluations for archiving request: \n{}", q.toString());
     return searchRequest;
   }
 

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -7,15 +7,8 @@
  */
 package io.camunda.operate.archiver;
 
-import static io.camunda.operate.archiver.AbstractArchiverJob.DATES_AGG;
-import static io.camunda.operate.archiver.AbstractArchiverJob.INSTANCES_AGG;
 import static io.camunda.operate.schema.SchemaManager.OPERATE_DELETE_ARCHIVED_INDICES;
-import static io.camunda.operate.schema.templates.BatchOperationTemplate.END_DATE;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.bucketSortAggregation;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.dateHistogramAggregation;
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.termAggregation;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.topHitsAggregation;
-import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.withSubaggregations;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.and;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.constantScore;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.ids;
@@ -118,35 +111,13 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     this.archiverExecutor = archiverExecutor;
   }
 
-  private <R> ArchiveBatch createArchiveBatch(
-      final SearchResponse<R> searchResponse,
-      final String datesAggName,
-      final String instancesAggName) {
-    final var buckets =
-        searchResponse.aggregations().get(datesAggName).dateHistogram().buckets().keyed();
-    if (!buckets.isEmpty()) {
-      final var entry = buckets.entrySet().iterator().next();
-      final var hits =
-          entry.getValue().aggregations().get(instancesAggName).topHits().hits().hits();
-      final var ids = hits.stream().map(hit -> (Object) hit.id()).toList();
-      return new ArchiveBatch(entry.getKey(), ids);
-    } else {
-      return null;
-    }
-  }
-
-  private CompletableFuture<ArchiveBatch> search(
-      final SearchRequest.Builder searchRequestBuilder,
-      final Function<Throwable, String> errorMessage) {
-    return search(
-        searchRequestBuilder, errorMessage, r -> createArchiveBatch(r, DATES_AGG, INSTANCES_AGG));
-  }
-
   private CompletableFuture<ArchiveBatch> search(
       final SearchRequest.Builder searchRequestBuilder,
       final Function<Throwable, String> errorMessage,
-      final Function<SearchResponse, ArchiveBatch> batchExtractor) {
+      final String dateField) {
     final var batchFuture = new CompletableFuture<ArchiveBatch>();
+    final var interval = operateProperties.getArchiver().getRolloverInterval();
+    final var dateFormat = operateProperties.getArchiver().getElsRolloverDateFormat();
 
     final var startTimer = Timer.start();
     OpensearchUtil.searchAsync(searchRequestBuilder.build(), Object.class, osAsyncClient)
@@ -156,7 +127,12 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
                 final var timer = metrics.getTimer(Metrics.TIMER_NAME_ARCHIVER_QUERY);
                 startTimer.stop(timer);
 
-                final var result = handleSearchResponse(response, e, errorMessage, batchExtractor);
+                final var result =
+                    handleSearchResponse(
+                        response,
+                        e,
+                        errorMessage,
+                        r -> createArchiveBatchFromHits(r, dateField, interval, dateFormat));
                 result.ifRightOrLeft(batchFuture::complete, batchFuture::completeExceptionally);
               } catch (final Exception ex) {
                 batchFuture.completeExceptionally(ex);
@@ -167,28 +143,15 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
   }
 
   private SearchRequest.Builder nextBatchSearchRequestBuilder(
-      final String index, final String idColumn, final String endDateField, final Query query) {
+      final String index, final String endDateField, final Query query) {
     final var format = operateProperties.getArchiver().getElsRolloverDateFormat();
-    final var interval = operateProperties.getArchiver().getRolloverInterval();
-    final var rollOverBatchSize = operateProperties.getArchiver().getRolloverBatchSize();
-
-    final Aggregation agg =
-        withSubaggregations(
-            dateHistogramAggregation(END_DATE, interval, format, true),
-            Map.of(
-                // we want to get only one bucket at a time
-                "datesSortedAgg",
-                bucketSortAggregation(1, sortOptions("_key", Asc))._toAggregation(),
-                // we need process instance ids, also taking into account batch size
-                INSTANCES_AGG,
-                topHitsAggregation(List.of(idColumn), rollOverBatchSize, sortOptions(idColumn, Asc))
-                    ._toAggregation()));
+    final var batchSize = operateProperties.getArchiver().getRolloverBatchSize();
 
     return searchRequestBuilder(index)
         .query(query)
-        .aggregations(DATES_AGG, agg)
         .source(SourceConfig.of(b -> b.fetch(false)))
-        .size(0)
+        .fields(f -> f.field(endDateField).format(format))
+        .size(batchSize)
         .sort(sortOptions(endDateField, Asc))
         .requestCache(false); // we don't need to cache this, as each time we need new data
   }
@@ -202,13 +165,11 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
                 operateProperties.getArchiver().getArchivingTimepoint()));
     final var searchRequestBuilder =
         nextBatchSearchRequestBuilder(
-            batchOperationTemplate.getFullQualifiedName(),
-            BatchOperationTemplate.ID,
-            BatchOperationTemplate.END_DATE,
-            query);
+            batchOperationTemplate.getFullQualifiedName(), BatchOperationTemplate.END_DATE, query);
     return search(
         searchRequestBuilder,
-        e -> "Failed to search in " + batchOperationTemplate.getFullQualifiedName());
+        e -> "Failed to search in " + batchOperationTemplate.getFullQualifiedName(),
+        BatchOperationTemplate.END_DATE);
   }
 
   @Override
@@ -232,13 +193,10 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
             query,
             partitionIds);
 
-    final var interval = operateProperties.getArchiver().getRolloverInterval();
-    final var dateFormat = operateProperties.getArchiver().getElsRolloverDateFormat();
     return search(
         searchRequestBuilder,
         e -> "Failed to search in " + processInstanceTemplate.getFullQualifiedName(),
-        response ->
-            createArchiveBatchFromHits(response, ListViewTemplate.END_DATE, interval, dateFormat));
+        ListViewTemplate.END_DATE);
   }
 
   @Override
@@ -256,13 +214,12 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     final var searchRequestBuilder =
         nextBatchSearchRequestBuilder(
             decisionInstanceTemplate.getFullQualifiedName(),
-            DecisionInstanceTemplate.ID,
             DecisionInstanceTemplate.EVALUATION_DATE,
             query);
-
     return search(
         searchRequestBuilder,
-        e -> "Failed to search in " + decisionInstanceTemplate.getFullQualifiedName());
+        e -> "Failed to search in " + decisionInstanceTemplate.getFullQualifiedName(),
+        DecisionInstanceTemplate.EVALUATION_DATE);
   }
 
   @Override

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
@@ -356,6 +356,70 @@ public class ElasticsearchArchiveRepositoryTest {
   }
 
   @Test
+  public void testGetStandaloneDecisionInstancesNextBatchPacksEarliestBucketOnly() {
+    setDecisionInstanceMocks();
+
+    try (final MockedStatic<ElasticsearchUtil> elasticsearchUtilMockedStatic =
+        mockStatic(ElasticsearchUtil.class)) {
+      elasticsearchUtilMockedStatic
+          .when(
+              () ->
+                  ElasticsearchUtil.joinWithAnd(
+                      any(),
+                      eq(
+                          QueryBuilders.termsQuery(
+                              DecisionInstanceTemplate.PARTITION_ID, PARTITION_IDS)),
+                      eq(
+                          QueryBuilders.termQuery(
+                              DecisionInstanceTemplate.PROCESS_INSTANCE_KEY, -1))))
+          .thenCallRealMethod();
+
+      final SearchResponse searchResponse = mock(SearchResponse.class);
+      final SearchHits searchHits = mock(SearchHits.class);
+      when(searchResponse.getHits()).thenReturn(searchHits);
+
+      final SearchHit hitA = mock(SearchHit.class);
+      final SearchHit hitB = mock(SearchHit.class);
+      final SearchHit hitC = mock(SearchHit.class);
+      when(hitA.getId()).thenReturn("a");
+      when(hitB.getId()).thenReturn("b");
+      // hitC.getId() is NOT stubbed — takeWhile stops before hitC so getId() is never called
+      final DocumentField fieldA = mock(DocumentField.class);
+      final DocumentField fieldB = mock(DocumentField.class);
+      final DocumentField fieldC = mock(DocumentField.class);
+      when(fieldA.getValue()).thenReturn("2024-01-01");
+      when(fieldB.getValue()).thenReturn("2024-01-01");
+      when(fieldC.getValue()).thenReturn("2024-01-02");
+      when(hitA.field(DecisionInstanceTemplate.EVALUATION_DATE)).thenReturn(fieldA);
+      when(hitB.field(DecisionInstanceTemplate.EVALUATION_DATE)).thenReturn(fieldB);
+      when(hitC.field(DecisionInstanceTemplate.EVALUATION_DATE)).thenReturn(fieldC);
+      when(searchHits.getHits()).thenReturn(new SearchHit[] {hitA, hitB, hitC});
+
+      try (final MockedConstruction<SearchRequest> mockedConstruction =
+          mockConstruction(
+              SearchRequest.class,
+              (mock, context) -> {
+                when(mock.source(any())).thenReturn(mock);
+                when(mock.requestCache(false)).thenReturn(mock);
+              })) {
+        try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+          final Timer.Sample timer = mock(Timer.Sample.class);
+          when(timer.stop(any())).thenReturn(1000L);
+          mockedTimer.when(Timer::start).thenReturn(timer);
+          elasticsearchUtilMockedStatic
+              .when(() -> ElasticsearchUtil.searchAsync(any(), any(), any()))
+              .thenReturn(CompletableFuture.completedFuture(searchResponse));
+
+          final ArchiveBatch batch = underTest.getStandaloneDecisionNextBatch(PARTITION_IDS).join();
+          assertThat(batch).isNotNull();
+          assertThat(batch.getFinishDate()).isEqualTo("2024-01-01");
+          assertThat(batch.getIds()).isEqualTo(List.of("a", "b"));
+        }
+      }
+    }
+  }
+
+  @Test
   void shouldPassRoutingToBulkDeleteRequest() {
     // given
     final var docs =

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/ElasticsearchArchiveRepositoryTest.java
@@ -9,8 +9,6 @@ package io.camunda.operate.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -31,11 +29,9 @@ import io.camunda.operate.schema.templates.ListViewTemplate;
 import io.camunda.operate.util.ElasticsearchUtil;
 import io.micrometer.core.instrument.Timer;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -50,15 +46,6 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.reindex.BulkByScrollResponse;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.AggregationBuilders;
-import org.elasticsearch.search.aggregations.Aggregations;
-import org.elasticsearch.search.aggregations.PipelineAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
-import org.elasticsearch.search.aggregations.metrics.TopHitsAggregationBuilder;
-import org.elasticsearch.search.sort.SortOrder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -236,18 +223,41 @@ public class ElasticsearchArchiveRepositoryTest {
   }
 
   @Test
-  public void testGetBatchOperationsNextBatchEmptyBucket() {
+  public void testGetBatchOperationsNextBatchEmptyHits() {
     setBatchOperationMocks();
 
     try (final MockedStatic<ElasticsearchUtil> elasticsearchUtilMockedStatic =
         mockStatic(ElasticsearchUtil.class)) {
-      testGetNextBatchEmptyBucket(
-          underTest::getBatchOperationNextBatch, "endDate", elasticsearchUtilMockedStatic);
+      final SearchResponse searchResponse = mock(SearchResponse.class);
+      final SearchHits searchHits = mock(SearchHits.class);
+      when(searchResponse.getHits()).thenReturn(searchHits);
+      when(searchHits.getHits()).thenReturn(new SearchHit[0]);
+
+      try (final MockedConstruction<SearchRequest> mockedConstruction =
+          mockConstruction(
+              SearchRequest.class,
+              (mock, context) -> {
+                when(mock.source(any())).thenReturn(mock);
+                when(mock.requestCache(false)).thenReturn(mock);
+              })) {
+        try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+          final Timer.Sample timer = mock(Timer.Sample.class);
+          when(timer.stop(any())).thenReturn(1000L);
+          mockedTimer.when(Timer::start).thenReturn(timer);
+          elasticsearchUtilMockedStatic
+              .when(() -> ElasticsearchUtil.searchAsync(any(), any(), any()))
+              .thenReturn(CompletableFuture.completedFuture(searchResponse));
+
+          final CompletableFuture<ArchiveBatch> res = underTest.getBatchOperationNextBatch();
+          assertThat(res).isCompleted();
+          assertThat(res.join()).isNull();
+        }
+      }
     }
   }
 
   @Test
-  public void testGetStandaloneDecisionInstancesNextBatchEmptyBucket() {
+  public void testGetStandaloneDecisionInstancesNextBatchEmptyHits() {
     setDecisionInstanceMocks();
 
     try (final MockedStatic<ElasticsearchUtil> elasticsearchUtilMockedStatic =
@@ -265,10 +275,83 @@ public class ElasticsearchArchiveRepositoryTest {
                               DecisionInstanceTemplate.PROCESS_INSTANCE_KEY, -1))))
           .thenCallRealMethod();
 
-      testGetNextBatchEmptyBucket(
-          () -> underTest.getStandaloneDecisionNextBatch(PARTITION_IDS),
-          "evaluationDate",
-          elasticsearchUtilMockedStatic);
+      final SearchResponse searchResponse = mock(SearchResponse.class);
+      final SearchHits searchHits = mock(SearchHits.class);
+      when(searchResponse.getHits()).thenReturn(searchHits);
+      when(searchHits.getHits()).thenReturn(new SearchHit[0]);
+
+      try (final MockedConstruction<SearchRequest> mockedConstruction =
+          mockConstruction(
+              SearchRequest.class,
+              (mock, context) -> {
+                when(mock.source(any())).thenReturn(mock);
+                when(mock.requestCache(false)).thenReturn(mock);
+              })) {
+        try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+          final Timer.Sample timer = mock(Timer.Sample.class);
+          when(timer.stop(any())).thenReturn(1000L);
+          mockedTimer.when(Timer::start).thenReturn(timer);
+          elasticsearchUtilMockedStatic
+              .when(() -> ElasticsearchUtil.searchAsync(any(), any(), any()))
+              .thenReturn(CompletableFuture.completedFuture(searchResponse));
+
+          final CompletableFuture<ArchiveBatch> res =
+              underTest.getStandaloneDecisionNextBatch(PARTITION_IDS);
+          assertThat(res).isCompleted();
+          assertThat(res.join()).isNull();
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testGetBatchOperationsNextBatchPacksEarliestBucketOnly() {
+    setBatchOperationMocks();
+
+    try (final MockedStatic<ElasticsearchUtil> elasticsearchUtilMockedStatic =
+        mockStatic(ElasticsearchUtil.class)) {
+      final SearchResponse searchResponse = mock(SearchResponse.class);
+      final SearchHits searchHits = mock(SearchHits.class);
+      when(searchResponse.getHits()).thenReturn(searchHits);
+
+      final SearchHit hitA = mock(SearchHit.class);
+      final SearchHit hitB = mock(SearchHit.class);
+      final SearchHit hitC = mock(SearchHit.class);
+      when(hitA.getId()).thenReturn("a");
+      when(hitB.getId()).thenReturn("b");
+      // hitC.getId() is NOT stubbed — takeWhile stops before hitC so getId() is never called
+      final DocumentField fieldA = mock(DocumentField.class);
+      final DocumentField fieldB = mock(DocumentField.class);
+      final DocumentField fieldC = mock(DocumentField.class);
+      when(fieldA.getValue()).thenReturn("2024-01-01");
+      when(fieldB.getValue()).thenReturn("2024-01-01");
+      when(fieldC.getValue()).thenReturn("2024-01-02");
+      when(hitA.field(BatchOperationTemplate.END_DATE)).thenReturn(fieldA);
+      when(hitB.field(BatchOperationTemplate.END_DATE)).thenReturn(fieldB);
+      when(hitC.field(BatchOperationTemplate.END_DATE)).thenReturn(fieldC);
+      when(searchHits.getHits()).thenReturn(new SearchHit[] {hitA, hitB, hitC});
+
+      try (final MockedConstruction<SearchRequest> mockedConstruction =
+          mockConstruction(
+              SearchRequest.class,
+              (mock, context) -> {
+                when(mock.source(any())).thenReturn(mock);
+                when(mock.requestCache(false)).thenReturn(mock);
+              })) {
+        try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
+          final Timer.Sample timer = mock(Timer.Sample.class);
+          when(timer.stop(any())).thenReturn(1000L);
+          mockedTimer.when(Timer::start).thenReturn(timer);
+          elasticsearchUtilMockedStatic
+              .when(() -> ElasticsearchUtil.searchAsync(any(), any(), any()))
+              .thenReturn(CompletableFuture.completedFuture(searchResponse));
+
+          final ArchiveBatch batch = underTest.getBatchOperationNextBatch().join();
+          assertThat(batch).isNotNull();
+          assertThat(batch.getFinishDate()).isEqualTo("2024-01-01");
+          assertThat(batch.getIds()).isEqualTo(List.of("a", "b"));
+        }
+      }
     }
   }
 
@@ -309,81 +392,6 @@ public class ElasticsearchArchiveRepositoryTest {
     assertThat(requests.get(0).routing()).isEqualTo("99");
     assertThat(requests.get(1).id()).isEqualTo("pi-doc");
     assertThat(requests.get(1).routing()).isNull();
-  }
-
-  public void testGetNextBatchEmptyBucket(
-      final Supplier<CompletableFuture<ArchiveBatch>> testMethod,
-      final String aggFieldName,
-      final MockedStatic<ElasticsearchUtil> elasticsearchUtilMockedStatic) {
-    final SearchRequest searchRequest = mock(SearchRequest.class);
-    final SearchResponse searchResponse = mock(SearchResponse.class);
-    try (final MockedStatic<AggregationBuilders> mockedStatic =
-        mockStatic(AggregationBuilders.class)) {
-      try (final MockedConstruction<SearchRequest> mockedConstruction =
-          mockConstruction(
-              SearchRequest.class,
-              (mock, context) -> {
-                when(mock.source(any())).thenReturn(searchRequest);
-                when(mock.requestCache(false)).thenReturn(searchRequest);
-              })) {
-        try (final MockedStatic<Timer> mockedTimer = mockStatic(Timer.class)) {
-          testGetNextBatchEmptyBucketHelper(
-              testMethod,
-              searchResponse,
-              mockedStatic,
-              mockedTimer,
-              elasticsearchUtilMockedStatic,
-              aggFieldName);
-          verify(searchRequest).requestCache(false);
-        }
-      }
-    }
-  }
-
-  public void testGetNextBatchEmptyBucketHelper(
-      final Supplier<CompletableFuture<ArchiveBatch>> testMethod,
-      final SearchResponse searchResponse,
-      final MockedStatic<AggregationBuilders> mockedStatic,
-      final MockedStatic<Timer> mockedTimer,
-      final MockedStatic<ElasticsearchUtil> elasticsearchUtilMockedStatic,
-      final String aggFieldName) {
-
-    final DateHistogramAggregationBuilder dateHistogramAggregationBuilder =
-        setHistogramMockForBatchOperations(mockedStatic);
-    final TopHitsAggregationBuilder topHitsAggregationBuilder =
-        setTopHitsAggregationBuilder(mockedStatic);
-    mockedStatic
-        .when(() -> AggregationBuilders.topHits(anyString()))
-        .thenReturn(topHitsAggregationBuilder);
-    final Timer.Sample timer = mock(Timer.Sample.class);
-    when(timer.stop(any())).thenReturn(1000L);
-    mockedTimer.when(Timer::start).thenReturn(timer);
-    elasticsearchUtilMockedStatic
-        .when(() -> ElasticsearchUtil.searchAsync(any(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(searchResponse));
-    final Aggregations aggregations = mock(Aggregations.class);
-    final Histogram histogram = mock(Histogram.class);
-    final CompletableFuture<SearchResponse> completableFuture = new CompletableFuture<>();
-    when(searchResponse.getAggregations()).thenReturn(aggregations);
-    when(aggregations.get(anyString())).thenReturn(histogram);
-    when(histogram.getBuckets()).thenReturn(new ArrayList<>());
-    completableFuture.complete(searchResponse);
-    final CompletableFuture<ArchiveBatch> res = testMethod.get();
-    assertThat(res).isCompleted();
-
-    verify(dateHistogramAggregationBuilder).field(aggFieldName);
-    verify(dateHistogramAggregationBuilder).calendarInterval(new DateHistogramInterval("1m"));
-    verify(dateHistogramAggregationBuilder).format("format");
-    verify(dateHistogramAggregationBuilder).keyed(true);
-    verify(dateHistogramAggregationBuilder).subAggregation((AggregationBuilder) any());
-    verify(dateHistogramAggregationBuilder).subAggregation((PipelineAggregationBuilder) any());
-    verify(topHitsAggregationBuilder).size(0);
-    verify(topHitsAggregationBuilder).sort("id", SortOrder.ASC);
-    verify(topHitsAggregationBuilder).fetchSource("id", null);
-    verify(searchResponse).getAggregations();
-    verify(timer).stop(any());
-    verify(aggregations).get("datesAgg");
-    verify(histogram).getBuckets();
   }
 
   @Test
@@ -499,62 +507,26 @@ public class ElasticsearchArchiveRepositoryTest {
     }
   }
 
-  private void setProcessInstancesMocks() {
+  private void setupMocks() {
     when(operateProperties.getArchiver()).thenReturn(archiverProperties);
     when(archiverProperties.getRolloverInterval()).thenReturn("1d");
     when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
     when(archiverProperties.getRolloverBatchSize()).thenReturn(100);
     when(archiverProperties.getArchivingTimepoint()).thenReturn("now-1s");
+  }
+
+  private void setProcessInstancesMocks() {
+    setupMocks();
     when(listViewTemplate.getFullQualifiedName()).thenReturn("qualifiedName");
   }
 
   private void setBatchOperationMocks() {
-    when(operateProperties.getArchiver()).thenReturn(archiverProperties);
-    when(archiverProperties.getRolloverInterval()).thenReturn("1m");
-    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("format");
+    setupMocks();
     when(batchOperationTemplate.getFullQualifiedName()).thenReturn("qualifiedName");
   }
 
   private void setDecisionInstanceMocks() {
-    when(operateProperties.getArchiver()).thenReturn(archiverProperties);
-    when(archiverProperties.getRolloverInterval()).thenReturn("1m");
-    when(archiverProperties.getArchivingTimepoint()).thenReturn("now-1s");
-    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("format");
+    setupMocks();
     when(decisionInstanceTemplate.getFullQualifiedName()).thenReturn("decisionsQualifiedName");
-  }
-
-  private DateHistogramAggregationBuilder setHistogramMockForBatchOperations(
-      final MockedStatic<AggregationBuilders> mockedStatic) {
-    final DateHistogramAggregationBuilder dateHistogramAggregationBuilder =
-        mock(DateHistogramAggregationBuilder.class);
-    mockedStatic
-        .when(() -> AggregationBuilders.dateHistogram(anyString()))
-        .thenReturn(dateHistogramAggregationBuilder);
-    when(dateHistogramAggregationBuilder.field(anyString()))
-        .thenReturn(dateHistogramAggregationBuilder);
-    when(dateHistogramAggregationBuilder.calendarInterval(any()))
-        .thenReturn(dateHistogramAggregationBuilder);
-    when(dateHistogramAggregationBuilder.format(anyString()))
-        .thenReturn(dateHistogramAggregationBuilder);
-    when(dateHistogramAggregationBuilder.keyed(true)).thenReturn(dateHistogramAggregationBuilder);
-    when(dateHistogramAggregationBuilder.subAggregation((PipelineAggregationBuilder) any()))
-        .thenReturn(dateHistogramAggregationBuilder);
-    when(dateHistogramAggregationBuilder.subAggregation((TopHitsAggregationBuilder) any()))
-        .thenReturn(dateHistogramAggregationBuilder);
-    return dateHistogramAggregationBuilder;
-  }
-
-  private TopHitsAggregationBuilder setTopHitsAggregationBuilder(
-      final MockedStatic<AggregationBuilders> mockedStatic) {
-    final TopHitsAggregationBuilder topHitsAggregationBuilder =
-        mock(TopHitsAggregationBuilder.class);
-    mockedStatic
-        .when(() -> AggregationBuilders.topHits(anyString()))
-        .thenReturn(topHitsAggregationBuilder);
-    when(topHitsAggregationBuilder.size(anyInt())).thenReturn(topHitsAggregationBuilder);
-    when(topHitsAggregationBuilder.sort(anyString(), any())).thenReturn(topHitsAggregationBuilder);
-    when(topHitsAggregationBuilder.fetchSource(anyString(), eq(null)))
-        .thenReturn(topHitsAggregationBuilder);
-    return topHitsAggregationBuilder;
   }
 }

--- a/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
+++ b/operate/archiver/src/test/java/io/camunda/operate/archiver/OpensearchArchiverRepositoryTest.java
@@ -7,19 +7,15 @@
  */
 package io.camunda.operate.archiver;
 
-import static io.camunda.operate.archiver.AbstractArchiverJob.DATES_AGG;
 import static io.camunda.operate.schema.SchemaManager.OPERATE_DELETE_ARCHIVED_INDICES;
-import static io.camunda.operate.store.opensearch.dsl.QueryDSL.sortOptions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.opensearch.client.opensearch._types.SortOrder.Asc;
 
 import io.camunda.operate.Metrics;
 import io.camunda.operate.archiver.ArchiveByIdTaskSupplier.IdWithRouting;
@@ -33,7 +29,6 @@ import io.camunda.operate.schema.templates.ListViewTemplate;
 import io.camunda.operate.store.opensearch.client.sync.OpenSearchISMOperations;
 import io.camunda.operate.store.opensearch.client.sync.OpenSearchIndexOperations;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
-import io.camunda.operate.store.opensearch.dsl.AggregationDSL;
 import io.camunda.operate.store.opensearch.dsl.QueryDSL;
 import io.camunda.operate.store.opensearch.dsl.RequestDSL;
 import io.camunda.operate.util.Either;
@@ -45,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -59,13 +53,9 @@ import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
-import org.opensearch.client.opensearch._types.aggregations.BucketSortAggregation;
 import org.opensearch.client.opensearch._types.aggregations.Buckets;
-import org.opensearch.client.opensearch._types.aggregations.DateHistogramAggregate;
-import org.opensearch.client.opensearch._types.aggregations.DateHistogramAggregation;
 import org.opensearch.client.opensearch._types.aggregations.LongTermsAggregate;
 import org.opensearch.client.opensearch._types.aggregations.LongTermsBucket;
-import org.opensearch.client.opensearch._types.aggregations.TopHitsAggregation;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.BulkRequest;
 import org.opensearch.client.opensearch.core.BulkResponse;
@@ -240,7 +230,7 @@ public class OpensearchArchiverRepositoryTest {
         final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class);
         final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class);
         final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
-      setupPISearchRequestBuilderMock(requestDSLMockedStatic, queryDSLMockedStatic);
+      setupPISearchRequestBuilderMock(requestDSLMockedStatic);
 
       final Timer.Sample timerSample = mock(Timer.Sample.class);
       timerMockedStatic.when(Timer::start).thenReturn(timerSample);
@@ -270,7 +260,7 @@ public class OpensearchArchiverRepositoryTest {
         final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class);
         final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class);
         final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
-      setupPISearchRequestBuilderMock(requestDSLMockedStatic, queryDSLMockedStatic);
+      setupPISearchRequestBuilderMock(requestDSLMockedStatic);
 
       final Timer.Sample timerSample = mock(Timer.Sample.class);
       timerMockedStatic.when(Timer::start).thenReturn(timerSample);
@@ -278,9 +268,9 @@ public class OpensearchArchiverRepositoryTest {
 
       // hits: "a" and "b" on 2024-01-01 (same bucket); "c" on 2024-01-02 (next bucket)
       // hit "c" fields() IS read by takeWhile predicate, but id() is NOT mapped
-      final Hit<Object> hitA = hitWithEndDate("a", "2024-01-01");
-      final Hit<Object> hitB = hitWithEndDate("b", "2024-01-01");
-      final Hit<Object> hitC = hitWithEndDateNoId("2024-01-02");
+      final Hit<Object> hitA = hitWithEndDate("a", ListViewTemplate.END_DATE, "2024-01-01");
+      final Hit<Object> hitB = hitWithEndDate("b", ListViewTemplate.END_DATE, "2024-01-01");
+      final Hit<Object> hitC = hitWithEndDateNoId(ListViewTemplate.END_DATE, "2024-01-02");
 
       final HitsMetadata<Object> hitsMeta = mock(HitsMetadata.class);
       final SearchResponse<Object> resp = mock(SearchResponse.class);
@@ -340,32 +330,128 @@ public class OpensearchArchiverRepositoryTest {
   }
 
   @Test
-  public void testGetBatchOperationsNextBatch() {
+  public void testGetBatchOperationsNextBatchEmptyHitsReturnsNull() {
     setBatchOperationMocks();
-    try (final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class)) {
-      try (final MockedStatic<AggregationDSL> aggregationDSLMockedStatic =
-          mockStatic(AggregationDSL.class)) {
-        testGetNextBatchHelper(
-            underTest::getBatchOperationNextBatch,
-            queryDSLMockedStatic,
-            aggregationDSLMockedStatic,
-            "endDate");
-      }
+    try (final MockedStatic<RequestDSL> requestDSLMockedStatic = mockStatic(RequestDSL.class);
+        final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class);
+        final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class);
+        final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
+      setupPlainSearchRequestBuilderMock(requestDSLMockedStatic);
+
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      timerMockedStatic.when(Timer::start).thenReturn(timerSample);
+      when(metrics.getTimer(any())).thenReturn(mock(Timer.class));
+
+      final HitsMetadata<Object> hitsMeta = mock(HitsMetadata.class);
+      final SearchResponse<Object> resp = mock(SearchResponse.class);
+      when(resp.hits()).thenReturn(hitsMeta);
+      when(hitsMeta.hits()).thenReturn(List.of());
+
+      opensearchUtil
+          .when(() -> OpensearchUtil.searchAsync(any(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(resp));
+
+      final CompletableFuture<ArchiveBatch> result = underTest.getBatchOperationNextBatch();
+      assertThat(result).isCompleted();
+      assertThat(result.join()).isNull();
     }
   }
 
   @Test
-  public void testGetStandaloneDecisionInstancesNextBatch() {
+  public void testGetBatchOperationsNextBatchPacksEarliestBucketOnly() {
+    setBatchOperationMocks();
+    try (final MockedStatic<RequestDSL> requestDSLMockedStatic = mockStatic(RequestDSL.class);
+        final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class);
+        final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class);
+        final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
+      setupPlainSearchRequestBuilderMock(requestDSLMockedStatic);
+
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      timerMockedStatic.when(Timer::start).thenReturn(timerSample);
+      when(metrics.getTimer(any())).thenReturn(mock(Timer.class));
+
+      final Hit<Object> hitA = hitWithEndDate("a", BatchOperationTemplate.END_DATE, "2024-01-01");
+      final Hit<Object> hitB = hitWithEndDate("b", BatchOperationTemplate.END_DATE, "2024-01-01");
+      final Hit<Object> hitC = hitWithEndDateNoId(BatchOperationTemplate.END_DATE, "2024-01-02");
+
+      final HitsMetadata<Object> hitsMeta = mock(HitsMetadata.class);
+      final SearchResponse<Object> resp = mock(SearchResponse.class);
+      when(resp.hits()).thenReturn(hitsMeta);
+      when(hitsMeta.hits()).thenReturn(List.of(hitA, hitB, hitC));
+
+      opensearchUtil
+          .when(() -> OpensearchUtil.searchAsync(any(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(resp));
+
+      final ArchiveBatch batch = underTest.getBatchOperationNextBatch().join();
+      assertThat(batch).isNotNull();
+      assertThat(batch.getFinishDate()).isEqualTo("2024-01-01");
+      assertThat(batch.getIds()).isEqualTo(List.of("a", "b"));
+    }
+  }
+
+  @Test
+  public void testGetStandaloneDecisionInstancesNextBatchEmptyHitsReturnsNull() {
     setDecisionInstanceMocks();
-    try (final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class)) {
-      try (final MockedStatic<AggregationDSL> aggregationDSLMockedStatic =
-          mockStatic(AggregationDSL.class)) {
-        testGetNextBatchHelper(
-            () -> underTest.getStandaloneDecisionNextBatch(PARTITION_IDS),
-            queryDSLMockedStatic,
-            aggregationDSLMockedStatic,
-            "evaluationDate");
-      }
+    try (final MockedStatic<RequestDSL> requestDSLMockedStatic = mockStatic(RequestDSL.class);
+        final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class);
+        final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class);
+        final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
+      setupPlainSearchRequestBuilderMock(requestDSLMockedStatic);
+
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      timerMockedStatic.when(Timer::start).thenReturn(timerSample);
+      when(metrics.getTimer(any())).thenReturn(mock(Timer.class));
+
+      final HitsMetadata<Object> hitsMeta = mock(HitsMetadata.class);
+      final SearchResponse<Object> resp = mock(SearchResponse.class);
+      when(resp.hits()).thenReturn(hitsMeta);
+      when(hitsMeta.hits()).thenReturn(List.of());
+
+      opensearchUtil
+          .when(() -> OpensearchUtil.searchAsync(any(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(resp));
+
+      final CompletableFuture<ArchiveBatch> result =
+          underTest.getStandaloneDecisionNextBatch(PARTITION_IDS);
+      assertThat(result).isCompleted();
+      assertThat(result.join()).isNull();
+    }
+  }
+
+  @Test
+  public void testGetStandaloneDecisionInstancesNextBatchPacksEarliestBucketOnly() {
+    setDecisionInstanceMocks();
+    try (final MockedStatic<RequestDSL> requestDSLMockedStatic = mockStatic(RequestDSL.class);
+        final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class);
+        final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class);
+        final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
+      setupPlainSearchRequestBuilderMock(requestDSLMockedStatic);
+
+      final Timer.Sample timerSample = mock(Timer.Sample.class);
+      timerMockedStatic.when(Timer::start).thenReturn(timerSample);
+      when(metrics.getTimer(any())).thenReturn(mock(Timer.class));
+
+      final Hit<Object> hitA =
+          hitWithEndDate("a", DecisionInstanceTemplate.EVALUATION_DATE, "2024-01-01");
+      final Hit<Object> hitB =
+          hitWithEndDate("b", DecisionInstanceTemplate.EVALUATION_DATE, "2024-01-01");
+      final Hit<Object> hitC =
+          hitWithEndDateNoId(DecisionInstanceTemplate.EVALUATION_DATE, "2024-01-02");
+
+      final HitsMetadata<Object> hitsMeta = mock(HitsMetadata.class);
+      final SearchResponse<Object> resp = mock(SearchResponse.class);
+      when(resp.hits()).thenReturn(hitsMeta);
+      when(hitsMeta.hits()).thenReturn(List.of(hitA, hitB, hitC));
+
+      opensearchUtil
+          .when(() -> OpensearchUtil.searchAsync(any(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(resp));
+
+      final ArchiveBatch batch = underTest.getStandaloneDecisionNextBatch(PARTITION_IDS).join();
+      assertThat(batch).isNotNull();
+      assertThat(batch.getFinishDate()).isEqualTo("2024-01-01");
+      assertThat(batch.getIds()).isEqualTo(List.of("a", "b"));
     }
   }
 
@@ -400,110 +486,9 @@ public class OpensearchArchiverRepositoryTest {
     assertThat(ops.get(1).delete().routing()).isNull();
   }
 
-  public void testGetNextBatchHelper(
-      final Supplier<CompletableFuture<ArchiveBatch>> testMethod,
-      final MockedStatic<QueryDSL> queryDSLMockedStatic,
-      final MockedStatic<AggregationDSL> aggregationDSLMockedStatic,
-      final String sortFieldName) {
-
-    try (final MockedStatic<RequestDSL> requestDSLMockedStatic = mockStatic(RequestDSL.class)) {
-      try (final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class)) {
-        final Query query = mock(Query.class);
-        queryDSLMockedStatic.when(() -> QueryDSL.constantScore(any())).thenReturn(query);
-        queryDSLMockedStatic
-            .when(() -> QueryDSL.sortOptions(sortFieldName, Asc))
-            .thenReturn(mock(SortOptions.class));
-        final SearchRequest.Builder searchRequestBuilder = mock(SearchRequest.Builder.class);
-        final Aggregation aggregation = mock(Aggregation.class);
-        final DateHistogramAggregation dateHistogramAggregation =
-            mock(DateHistogramAggregation.class);
-        final Aggregation bucketAggregation = mock(Aggregation.class);
-        final Aggregation topHitAggregation = mock(Aggregation.class);
-        final BucketSortAggregation bucketSortAggregation = mock(BucketSortAggregation.class);
-        final TopHitsAggregation topHitsAggregation = mock(TopHitsAggregation.class);
-        when(topHitsAggregation._toAggregation()).thenReturn(topHitAggregation);
-        aggregationDSLMockedStatic
-            .when(() -> AggregationDSL.bucketSortAggregation(any(), any()))
-            .thenReturn(bucketSortAggregation);
-        when(bucketSortAggregation._toAggregation()).thenReturn(bucketAggregation);
-        aggregationDSLMockedStatic
-            .when(
-                () ->
-                    AggregationDSL.dateHistogramAggregation(
-                        any(), any(), anyString(), anyBoolean()))
-            .thenReturn(dateHistogramAggregation);
-        aggregationDSLMockedStatic
-            .when(() -> AggregationDSL.withSubaggregations((DateHistogramAggregation) any(), any()))
-            .thenReturn(aggregation);
-        aggregationDSLMockedStatic
-            .when(() -> AggregationDSL.topHitsAggregation(any(), anyInt(), any()))
-            .thenReturn(topHitsAggregation);
-        requestDSLMockedStatic
-            .when(() -> RequestDSL.searchRequestBuilder(anyString()))
-            .thenReturn(searchRequestBuilder);
-        when(searchRequestBuilder.query(query)).thenReturn(searchRequestBuilder);
-        when(searchRequestBuilder.aggregations(anyString(), (Aggregation) any()))
-            .thenReturn(searchRequestBuilder);
-        when(searchRequestBuilder.source((SourceConfig) any())).thenReturn(searchRequestBuilder);
-        when(searchRequestBuilder.size(0)).thenReturn(searchRequestBuilder);
-        when(searchRequestBuilder.sort((SortOptions) any())).thenReturn(searchRequestBuilder);
-        when(searchRequestBuilder.requestCache(false)).thenReturn(searchRequestBuilder);
-
-        final SearchResponse searchResponse = mock(SearchResponse.class);
-        final CompletableFuture<SearchResponse<Object>> completableFuture =
-            new CompletableFuture<>();
-        completableFuture.complete(searchResponse);
-        try (final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
-          opensearchUtil
-              .when(() -> OpensearchUtil.searchAsync(any(), any(), any()))
-              .thenReturn(completableFuture);
-          final Map<String, Aggregate> aggregations = new HashMap<>();
-          when(searchResponse.aggregations()).thenReturn(aggregations);
-          final Aggregate aggregate = mock(Aggregate.class);
-          aggregations.put(DATES_AGG, aggregate);
-          final DateHistogramAggregate dateHistogramAggregate = mock(DateHistogramAggregate.class);
-          when(aggregate.dateHistogram()).thenReturn(dateHistogramAggregate);
-          final Buckets buckets = mock(Buckets.class);
-          when(dateHistogramAggregate.buckets()).thenReturn(buckets);
-          final Map<String, String> bucketsMap = new HashMap<>();
-          when(buckets.keyed()).thenReturn(bucketsMap);
-          final Timer timer = mock(Timer.class);
-          final Timer.Sample timerSample = mock(Timer.Sample.class);
-          when(metrics.getTimer(any())).thenReturn(timer);
-          timerMockedStatic.when(Timer::start).thenReturn(timerSample);
-          when(timerSample.stop(any())).thenReturn(5L);
-          final CompletableFuture<ArchiveBatch> res = testMethod.get();
-          assertThat(res).isCompleted();
-          verify(searchRequestBuilder).query(query);
-          verify(searchRequestBuilder).aggregations(DATES_AGG, aggregation);
-          verify(searchRequestBuilder).source((SourceConfig) any());
-          verify(searchRequestBuilder).size(0);
-          verify(searchRequestBuilder).sort(any(SortOptions.class));
-          queryDSLMockedStatic.verify(() -> sortOptions(sortFieldName, Asc));
-          verify(searchRequestBuilder).requestCache(false);
-          verify(bucketSortAggregation)._toAggregation();
-          verify(topHitsAggregation)._toAggregation();
-          verify(searchResponse).aggregations();
-          verify(aggregate).dateHistogram();
-          verify(dateHistogramAggregate).buckets();
-        }
-      }
-    }
-  }
-
-  private void setProcessInstancesMocks() {
-    when(operateProperties.getArchiver()).thenReturn(archiverProperties);
-    when(archiverProperties.getRolloverInterval()).thenReturn("1d");
-    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
-    when(archiverProperties.getRolloverBatchSize()).thenReturn(100);
-    when(archiverProperties.getArchivingTimepoint()).thenReturn("now-1s");
-    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("qualifiedName");
-  }
-
   @SuppressWarnings("unchecked")
   private void setupPISearchRequestBuilderMock(
-      final MockedStatic<RequestDSL> requestDSLMockedStatic,
-      final MockedStatic<QueryDSL> queryDSLMockedStatic) {
+      final MockedStatic<RequestDSL> requestDSLMockedStatic) {
     final SearchRequest.Builder searchRequestBuilder = mock(SearchRequest.Builder.class);
     requestDSLMockedStatic
         .when(() -> RequestDSL.searchRequestBuilder(anyString()))
@@ -520,13 +505,30 @@ public class OpensearchArchiverRepositoryTest {
   }
 
   @SuppressWarnings("unchecked")
-  private Hit<Object> hitWithEndDate(final String id, final String endDate) {
+  private void setupPlainSearchRequestBuilderMock(
+      final MockedStatic<RequestDSL> requestDSLMockedStatic) {
+    final SearchRequest.Builder searchRequestBuilder = mock(SearchRequest.Builder.class);
+    requestDSLMockedStatic
+        .when(() -> RequestDSL.searchRequestBuilder(anyString()))
+        .thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.query((Query) any())).thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.source((SourceConfig) any())).thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.fields(any(java.util.function.Function.class)))
+        .thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.size(anyInt())).thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.sort((SortOptions) any())).thenReturn(searchRequestBuilder);
+    when(searchRequestBuilder.requestCache(false)).thenReturn(searchRequestBuilder);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Hit<Object> hitWithEndDate(
+      final String id, final String fieldName, final String endDate) {
     final Hit<Object> hit = mock(Hit.class);
     when(hit.id()).thenReturn(id);
     final JsonValue jsonValue = mock(JsonValue.class);
     final JsonArray jsonArray = mock(JsonArray.class);
     final JsonData jsonData = mock(JsonData.class);
-    when(hit.fields()).thenReturn(java.util.Map.of("endDate", jsonData));
+    when(hit.fields()).thenReturn(java.util.Map.of(fieldName, jsonData));
     when(jsonData.toJson()).thenReturn(jsonValue);
     when(jsonValue.asJsonArray()).thenReturn(jsonArray);
     when(jsonArray.getString(0)).thenReturn(endDate);
@@ -534,31 +536,38 @@ public class OpensearchArchiverRepositoryTest {
   }
 
   @SuppressWarnings("unchecked")
-  private Hit<Object> hitWithEndDateNoId(final String endDate) {
+  private Hit<Object> hitWithEndDateNoId(final String fieldName, final String endDate) {
     final Hit<Object> hit = mock(Hit.class);
     final JsonValue jsonValue = mock(JsonValue.class);
     final JsonArray jsonArray = mock(JsonArray.class);
     final JsonData jsonData = mock(JsonData.class);
-    when(hit.fields()).thenReturn(java.util.Map.of("endDate", jsonData));
+    when(hit.fields()).thenReturn(java.util.Map.of(fieldName, jsonData));
     when(jsonData.toJson()).thenReturn(jsonValue);
     when(jsonValue.asJsonArray()).thenReturn(jsonArray);
     when(jsonArray.getString(0)).thenReturn(endDate);
     return hit;
   }
 
-  private void setBatchOperationMocks() {
+  private void setupMocks() {
     when(operateProperties.getArchiver()).thenReturn(archiverProperties);
-    when(archiverProperties.getRolloverInterval()).thenReturn("1m");
-    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("format");
-    when(archiverProperties.getRolloverBatchSize()).thenReturn(12);
+    when(archiverProperties.getRolloverInterval()).thenReturn("1d");
+    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
+    when(archiverProperties.getRolloverBatchSize()).thenReturn(100);
+    when(archiverProperties.getArchivingTimepoint()).thenReturn("now-1s");
+  }
+
+  private void setProcessInstancesMocks() {
+    setupMocks();
+    when(processInstanceTemplate.getFullQualifiedName()).thenReturn("qualifiedName");
+  }
+
+  private void setBatchOperationMocks() {
+    setupMocks();
     when(batchOperationTemplate.getFullQualifiedName()).thenReturn("qualifiedName");
   }
 
   private void setDecisionInstanceMocks() {
-    when(operateProperties.getArchiver()).thenReturn(archiverProperties);
-    when(archiverProperties.getRolloverInterval()).thenReturn("1m");
-    when(archiverProperties.getArchivingTimepoint()).thenReturn("now-1s");
-    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("format");
+    setupMocks();
     when(decisionInstanceTemplate.getFullQualifiedName()).thenReturn("decisionsQualifiedName");
   }
 
@@ -569,14 +578,14 @@ public class OpensearchArchiverRepositoryTest {
         final MockedStatic<QueryDSL> queryDSLMockedStatic = mockStatic(QueryDSL.class);
         final MockedStatic<Timer> timerMockedStatic = mockStatic(Timer.class);
         final MockedStatic<OpensearchUtil> opensearchUtil = mockStatic(OpensearchUtil.class)) {
-      setupPISearchRequestBuilderMock(requestDSLMockedStatic, queryDSLMockedStatic);
+      setupPISearchRequestBuilderMock(requestDSLMockedStatic);
 
       final Timer.Sample timerSample = mock(Timer.Sample.class);
       timerMockedStatic.when(Timer::start).thenReturn(timerSample);
       when(metrics.getTimer(any())).thenReturn(mock(Timer.class));
 
       // one hit so the batch is non-null and we reach getTotalPendingCount
-      final Hit<Object> hitA = hitWithEndDate("a", "2024-01-01");
+      final Hit<Object> hitA = hitWithEndDate("a", ListViewTemplate.END_DATE, "2024-01-01");
       final HitsMetadata<Object> hitsMeta = mock(HitsMetadata.class);
       final SearchResponse<Object> resp = mock(SearchResponse.class);
       when(resp.hits()).thenReturn(hitsMeta);

--- a/operate/common/src/main/java/io/camunda/operate/property/ArchiverProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ArchiverProperties.java
@@ -10,6 +10,8 @@ package io.camunda.operate.property;
 public class ArchiverProperties {
 
   private static final int DEFAULT_ARCHIVER_THREADS_COUNT = 1;
+  private static final int DEFAULT_ROLLOVER_BATCH_SIZE = 100;
+  private static final int DEFAULT_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE = 500;
 
   private boolean rolloverEnabled = true;
 
@@ -33,7 +35,7 @@ public class ArchiverProperties {
    */
   private String rolloverInterval = "1d";
 
-  private int rolloverBatchSize = 100;
+  private Integer rolloverBatchSize;
 
   private String waitPeriodBeforeArchiving = "1h";
 
@@ -138,6 +140,11 @@ public class ArchiverProperties {
   }
 
   public int getRolloverBatchSize() {
+    if (rolloverBatchSize == null) {
+      return archiveByIdEnabled
+          ? DEFAULT_ARCHIVE_BY_ID_ROLLOVER_BATCH_SIZE
+          : DEFAULT_ROLLOVER_BATCH_SIZE;
+    }
     return rolloverBatchSize;
   }
 

--- a/operate/common/src/test/java/io/camunda/operate/property/ArchiverPropertiesTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/property/ArchiverPropertiesTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.property;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class ArchiverPropertiesTest {
+
+  @Test
+  void shouldDefaultRolloverBatchSizeWhenArchiveByIdDisabled() {
+    final var properties = new ArchiverProperties();
+    properties.setArchiveByIdEnabled(false);
+
+    assertThat(properties.getRolloverBatchSize()).isEqualTo(100);
+  }
+
+  @Test
+  void shouldDefaultToLargerRolloverBatchSizeWhenArchiveByIdEnabled() {
+    final var properties = new ArchiverProperties();
+    properties.setArchiveByIdEnabled(true);
+
+    assertThat(properties.getRolloverBatchSize()).isEqualTo(500);
+  }
+
+  @Test
+  void shouldUseExplicitRolloverBatchSizeOverDefault() {
+    final var properties = new ArchiverProperties();
+    properties.setArchiveByIdEnabled(true);
+    properties.setRolloverBatchSize(42);
+
+    assertThat(properties.getRolloverBatchSize()).isEqualTo(42);
+  }
+}


### PR DESCRIPTION
## Summary
- Operate archiver's `getBatchOperationNextBatch` and `getStandaloneDecisionNextBatch` built a date-histogram + top_hits aggregation whose top_hits size was the rollover batch size. When that size exceeded Elasticsearch's `index.max_inner_result_window` (default 100), the search failed with a 400 and the archiver threw an NPE on the null aggregations, hiding the real error and stalling archiving.
- Replaced both with a plain query + sort (mirroring the existing `getProcessInstancesNextBatch` implementation), removing the top_hits sub-aggregation entirely — no size cap needed, no failure mode to hide. Applied to both ES and OS repositories.
- Since the batch size is no longer constrained by `max_inner_result_window`, raised the default rollover batch size to 500 when archive-by-id is enabled (mirrors `DocumentBasedHistory#getRolloverBatchSize()` on main).

## Test plan
- [x] `ElasticsearchArchiveRepositoryTest` / `OpensearchArchiverRepositoryTest` updated to cover empty-hits and pack-earliest-bucket-only cases for both entity types
- [x] `ArchiverPropertiesTest` added for the new default logic
- [x] All 31 tests pass under JDK 21 (`./mvnw verify -pl operate/archiver,operate/common -Dtest=... -DskipTests=false -DskipITs -Dquickly`)

Closes #56958