### PR TITLE
feat: reject new instances of a draining process definition

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -238,7 +237,7 @@ public final class ProcessInstanceStateTransitionGuard {
     }
     return stateBehavior
         .getProcess(context.getProcessDefinitionKey(), context.getTenantId())
-        .filter(process -> process.getState() == PersistedProcessState.DRAINING)
+        .filter(DeployedProcess::isDraining)
         .<Either<String, ?>>map(
             process ->
                 Either.left(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -12,7 +12,9 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -59,7 +61,8 @@ public final class ProcessInstanceStateTransitionGuard {
 
     return switch (context.getIntent()) {
       case ACTIVATE_ELEMENT ->
-          hasActiveFlowScopeInstance(context)
+          canActivateDrainingDefinition(context)
+              .flatMap(ok -> hasActiveFlowScopeInstance(context))
               .flatMap(ok -> hasActiveProcessInstance(context))
               .flatMap(ok -> canActivateParallelGateway(context, element))
               .flatMap(ok -> canActivateInclusiveGateway(context, element));
@@ -227,6 +230,24 @@ public final class ProcessInstanceStateTransitionGuard {
     } else {
       return Either.right(context);
     }
+  }
+
+  private Either<String, ?> canActivateDrainingDefinition(final BpmnElementContext context) {
+    if (context.getBpmnElementType() != BpmnElementType.PROCESS) {
+      return Either.right(null);
+    }
+    return stateBehavior
+        .getProcess(context.getProcessDefinitionKey(), context.getTenantId())
+        .filter(process -> process.getState() == PersistedProcessState.DRAINING)
+        .<Either<String, ?>>map(
+            process ->
+                Either.left(
+                    String.format(
+                        ProcessInstanceCreationHelper.ERROR_MESSAGE_PROCESS_IS_DRAINING,
+                        BufferUtil.bufferAsString(process.getBpmnProcessId()),
+                        process.getVersion(),
+                        process.getKey())))
+        .orElseGet(() -> Either.right(null));
   }
 
   private Either<String, ?> canActivateParallelGateway(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
 import io.camunda.zeebe.engine.processing.processinstance.BusinessIdValidator;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -93,6 +94,7 @@ public final class CallActivityProcessor
             processId ->
                 getCalledProcess(
                     processId, element.getBindingType(), element.getVersionTag(), context))
+        .flatMap(this::rejectIfDraining)
         .flatMap(this::checkProcessHasNoneStartEvent)
         .flatMap(p -> eventSubscriptionBehavior.subscribeToEvents(element, context).map(ok -> p))
         .flatMap(
@@ -433,6 +435,18 @@ public final class CallActivityProcessor
                             """,
                             BufferUtil.bufferAsString(processId), versionTag),
                         ErrorType.CALLED_ELEMENT_ERROR)));
+  }
+
+  private Either<Failure, DeployedProcess> rejectIfDraining(final DeployedProcess process) {
+    if (process.getState() == PersistedProcessState.DRAINING) {
+      return Either.left(
+          new Failure(
+              String.format(
+                  "Expected to call process with BPMN process id '%s', but it is being deleted.",
+                  BufferUtil.bufferAsString(process.getBpmnProcessId())),
+              ErrorType.CALLED_ELEMENT_ERROR));
+    }
+    return Either.right(process);
   }
 
   private Either<Failure, DeployedProcess> checkProcessHasNoneStartEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -438,7 +438,7 @@ public final class CallActivityProcessor
   }
 
   private Either<Failure, DeployedProcess> rejectIfDraining(final DeployedProcess process) {
-    if (process.getState() == PersistedProcessState.DRAINING) {
+    if (process.isDraining()) {
       return Either.left(
           new Failure(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
 import io.camunda.zeebe.engine.processing.processinstance.BusinessIdValidator;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
@@ -442,8 +441,10 @@ public final class CallActivityProcessor
       return Either.left(
           new Failure(
               String.format(
-                  "Expected to call process with BPMN process id '%s', but it is being deleted.",
-                  BufferUtil.bufferAsString(process.getBpmnProcessId())),
+                  "Expected to call process with BPMN process id '%s' and version %d (key %d), but it is being deleted.",
+                  BufferUtil.bufferAsString(process.getBpmnProcessId()),
+                  process.getVersion(),
+                  process.getKey()),
               ErrorType.CALLED_ELEMENT_ERROR));
     }
     return Either.right(process);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSta
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
@@ -243,6 +244,12 @@ public final class EventHandle {
       final String tenantId,
       final DirectBuffer businessId) {
 
+    final var process = processState.getProcessByKeyAndTenant(processDefinitionKey, tenantId);
+    if (process == null || process.getState() == PersistedProcessState.DRAINING) {
+      // Never spawn a new instance on a draining (or already removed) definition
+      return;
+    }
+
     triggeringProcessEvent(
         processDefinitionKey,
         processInstanceKey,
@@ -250,8 +257,6 @@ public final class EventHandle {
         processDefinitionKey /* The eventScope for the start event is the process definition key */,
         targetElementId,
         variablesBuffer);
-
-    final var process = processState.getProcessByKeyAndTenant(processDefinitionKey, tenantId);
 
     recordForPICreation
         .setBpmnProcessId(process.getBpmnProcessId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSta
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
+import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
@@ -29,11 +29,15 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class EventHandle {
 
+  private static final Logger LOG = LoggerFactory.getLogger(EventHandle.class);
   private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
 
   private final ProcessInstanceRecord recordForPICreation = new ProcessInstanceRecord();
@@ -197,6 +201,13 @@ public final class EventHandle {
       final DirectBuffer variables,
       final DirectBuffer businessId) {
 
+    // Validate before generating a key so we neither waste a key nor emit a CORRELATED event when
+    // no instance will be created (definition draining or already removed).
+    if (!canCreateInstanceForStartEvent(
+        subscription.getProcessDefinitionKey(), subscription.getTenantId())) {
+      return -1L;
+    }
+
     final var newProcessInstanceKey = keyGenerator.nextKey();
     startEventSubscriptionRecord
         .setProcessDefinitionKey(subscription.getProcessDefinitionKey())
@@ -210,24 +221,18 @@ public final class EventHandle {
         .setVariables(variables)
         .setTenantId(subscription.getTenantId());
 
-    // Activate first so a draining (or removed) definition short-circuits
-    final var activated =
-        activateProcessInstanceForStartEvent(
-            subscription.getProcessDefinitionKey(),
-            newProcessInstanceKey,
-            startEventSubscriptionRecord.getStartEventIdBuffer(),
-            variables,
-            subscription.getTenantId(),
-            businessId);
-
-    if (!activated) {
-      return -1L;
-    }
-
     stateWriter.appendFollowUpEvent(
         subscriptionKey,
         MessageStartEventSubscriptionIntent.CORRELATED,
         startEventSubscriptionRecord);
+
+    activateProcessInstanceForStartEvent(
+        subscription.getProcessDefinitionKey(),
+        newProcessInstanceKey,
+        startEventSubscriptionRecord.getStartEventIdBuffer(),
+        variables,
+        subscription.getTenantId(),
+        businessId);
 
     return newProcessInstanceKey;
   }
@@ -250,11 +255,11 @@ public final class EventHandle {
       final String tenantId,
       final DirectBuffer businessId) {
 
-    final var process = processState.getProcessByKeyAndTenant(processDefinitionKey, tenantId);
-    if (process == null || process.getState() == PersistedProcessState.DRAINING) {
-      // Never spawn a new instance on a draining (or already removed) definition
+    if (!canCreateInstanceForStartEvent(processDefinitionKey, tenantId)) {
       return false;
     }
+
+    final var process = processState.getProcessByKeyAndTenant(processDefinitionKey, tenantId);
 
     triggeringProcessEvent(
         processDefinitionKey,
@@ -309,6 +314,29 @@ public final class EventHandle {
 
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceCreationIntent.CREATED, recordForPICreationEvent);
+    return true;
+  }
+
+  private boolean canCreateInstanceForStartEvent(
+      final long processDefinitionKey, final String tenantId) {
+    final DeployedProcess process =
+        processState.getProcessByKeyAndTenant(processDefinitionKey, tenantId);
+    if (process == null) {
+      LOG.debug(
+          "Skipping start-event instance creation: process definition with key {} (tenant '{}') no longer exists.",
+          processDefinitionKey,
+          tenantId);
+      return false;
+    }
+    if (process.isDraining() && LOG.isDebugEnabled()) {
+      LOG.debug(
+          "Skipping start-event instance creation: process '{}' version {} (key {}, tenant '{}') is draining and no longer accepts new instances.",
+          BufferUtil.bufferAsString(process.getBpmnProcessId()),
+          process.getVersion(),
+          process.getKey(),
+          tenantId);
+      return false;
+    }
     return true;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -210,33 +210,39 @@ public final class EventHandle {
         .setVariables(variables)
         .setTenantId(subscription.getTenantId());
 
+    // Activate first so a draining (or removed) definition short-circuits
+    final var activated =
+        activateProcessInstanceForStartEvent(
+            subscription.getProcessDefinitionKey(),
+            newProcessInstanceKey,
+            startEventSubscriptionRecord.getStartEventIdBuffer(),
+            variables,
+            subscription.getTenantId(),
+            businessId);
+
+    if (!activated) {
+      return -1L;
+    }
+
     stateWriter.appendFollowUpEvent(
         subscriptionKey,
         MessageStartEventSubscriptionIntent.CORRELATED,
         startEventSubscriptionRecord);
 
-    activateProcessInstanceForStartEvent(
-        subscription.getProcessDefinitionKey(),
-        newProcessInstanceKey,
-        startEventSubscriptionRecord.getStartEventIdBuffer(),
-        variables,
-        subscription.getTenantId(),
-        businessId);
-
     return newProcessInstanceKey;
   }
 
-  public void activateProcessInstanceForStartEvent(
+  public boolean activateProcessInstanceForStartEvent(
       final long processDefinitionKey,
       final long processInstanceKey,
       final DirectBuffer targetElementId,
       final DirectBuffer variablesBuffer,
       final String tenantId) {
-    activateProcessInstanceForStartEvent(
+    return activateProcessInstanceForStartEvent(
         processDefinitionKey, processInstanceKey, targetElementId, variablesBuffer, tenantId, null);
   }
 
-  public void activateProcessInstanceForStartEvent(
+  public boolean activateProcessInstanceForStartEvent(
       final long processDefinitionKey,
       final long processInstanceKey,
       final DirectBuffer targetElementId,
@@ -247,7 +253,7 @@ public final class EventHandle {
     final var process = processState.getProcessByKeyAndTenant(processDefinitionKey, tenantId);
     if (process == null || process.getState() == PersistedProcessState.DRAINING) {
       // Never spawn a new instance on a draining (or already removed) definition
-      return;
+      return false;
     }
 
     triggeringProcessEvent(
@@ -303,5 +309,6 @@ public final class EventHandle {
 
     stateWriter.appendFollowUpEvent(
         processInstanceKey, ProcessInstanceCreationIntent.CREATED, recordForPICreationEvent);
+    return true;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/conditional/ConditionalEvaluationEvaluateProcessor.java
@@ -116,14 +116,19 @@ public class ConditionalEvaluationEvaluateProcessor
     for (final var match : matchedStartEvents) {
       final long processInstanceKey = keyGenerator.nextKey();
 
-      eventHandle.activateProcessInstanceForStartEvent(
-          match.processDefinitionKey(),
-          processInstanceKey,
-          match.startEventId(),
-          record.getVariablesBuffer(),
-          record.getTenantId());
+      final var activated =
+          eventHandle.activateProcessInstanceForStartEvent(
+              match.processDefinitionKey(),
+              processInstanceKey,
+              match.startEventId(),
+              record.getVariablesBuffer(),
+              record.getTenantId());
 
-      record.addStartedProcessInstance(match.processDefinitionKey(), processInstanceKey);
+      if (activated) {
+        // Only report instances that were actually started; a draining definition is skipped and
+        // must not appear in the EVALUATED event or the response.
+        record.addStartedProcessInstance(match.processDefinitionKey(), processInstanceKey);
+      }
     }
 
     final long eventKey = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessor.java
@@ -173,13 +173,20 @@ public final class MessageStartProcessInstanceRequestRequestProcessor
     // applier dereferences the buffered message in local MessageState — but on P_B the message
     // has never been published locally. The CORRELATED event against the originating
     // subscription is written on P_K when it applies the STARTED reply.
-    eventHandle.activateProcessInstanceForStartEvent(
-        request.getProcessDefinitionKey(),
-        processInstanceKey,
-        request.getStartEventIdBuffer(),
-        request.getVariablesBuffer(),
-        request.getTenantId(),
-        request.getBusinessIdBuffer());
+    final var activated =
+        eventHandle.activateProcessInstanceForStartEvent(
+            request.getProcessDefinitionKey(),
+            processInstanceKey,
+            request.getStartEventIdBuffer(),
+            request.getVariablesBuffer(),
+            request.getTenantId(),
+            request.getBusinessIdBuffer());
+
+    if (!activated) {
+      // Activation failed because the definition is draining/deleted on this partition.
+      commandSender.sendStartProcessInstanceNoSubscriptionRejected(request);
+      return;
+    }
 
     // Write a local STARTED follow-up event so the dedup applier records
     // (processDefinitionKey, messageKey) → processInstanceKey. The cross-partition reply

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.processing.identity.authorization.request.Authori
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.processing.variable.VariableValidationException;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
@@ -54,6 +55,8 @@ public class ProcessInstanceCreationHelper {
       "Expected to find process definition with key '%d', but none found";
   private static final String ERROR_MESSAGE_NO_NONE_START_EVENT =
       "Expected to create instance of process with none start event, but there is no such event";
+  private static final String ERROR_MESSAGE_PROCESS_IS_DRAINING =
+      "Expected to create instance of process '%s', but it is being deleted";
   private static final String ERROR_MESSAGE_BUSINESS_ID_ALREADY_EXISTS =
       "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'";
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
@@ -92,18 +95,36 @@ public class ProcessInstanceCreationHelper {
       final ProcessInstanceCreationRecord record) {
     final DirectBuffer bpmnProcessId = record.getBpmnProcessIdBuffer();
 
+    final Either<Rejection, DeployedProcess> process;
     if (bpmnProcessId.capacity() > 0) {
       if (record.getVersion() >= 0) {
-        return getProcess(bpmnProcessId, record.getVersion(), record.getTenantId());
+        process = getProcess(bpmnProcessId, record.getVersion(), record.getTenantId());
       } else {
-        return getProcess(bpmnProcessId, record.getTenantId());
+        process = getProcess(bpmnProcessId, record.getTenantId());
       }
     } else if (record.getProcessDefinitionKey() >= 0) {
-      return getProcess(record.getProcessDefinitionKey(), record.getTenantId());
+      process = getProcess(record.getProcessDefinitionKey(), record.getTenantId());
     } else {
       return Either.left(
           new Rejection(RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_NO_IDENTIFIER_SPECIFIED));
     }
+    return process.flatMap(this::rejectIfDraining);
+  }
+
+  /**
+   * A process definition that is being deleted is kept in state (as {@link
+   * PersistedProcessState#DRAINING}) so its already-running instances can finish, but no new
+   * instances may be created for it.
+   */
+  private Either<Rejection, DeployedProcess> rejectIfDraining(final DeployedProcess process) {
+    if (process.getState() == PersistedProcessState.DRAINING) {
+      return Either.left(
+          new Rejection(
+              RejectionType.INVALID_STATE,
+              String.format(
+                  ERROR_MESSAGE_PROCESS_IS_DRAINING, bufferAsString(process.getBpmnProcessId()))));
+    }
+    return Either.right(process);
   }
 
   public ProcessInstanceRecord initProcessInstanceRecord(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -56,7 +56,7 @@ public class ProcessInstanceCreationHelper {
   private static final String ERROR_MESSAGE_NO_NONE_START_EVENT =
       "Expected to create instance of process with none start event, but there is no such event";
   private static final String ERROR_MESSAGE_PROCESS_IS_DRAINING =
-      "Expected to create instance of process '%s', but it is being deleted";
+      "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted";
   private static final String ERROR_MESSAGE_BUSINESS_ID_ALREADY_EXISTS =
       "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'";
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
@@ -122,7 +122,10 @@ public class ProcessInstanceCreationHelper {
           new Rejection(
               RejectionType.INVALID_STATE,
               String.format(
-                  ERROR_MESSAGE_PROCESS_IS_DRAINING, bufferAsString(process.getBpmnProcessId()))));
+                  ERROR_MESSAGE_PROCESS_IS_DRAINING,
+                  bufferAsString(process.getBpmnProcessId()),
+                  process.getVersion(),
+                  process.getKey())));
     }
     return Either.right(process);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -45,6 +45,8 @@ import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 public class ProcessInstanceCreationHelper {
+  public static final String ERROR_MESSAGE_PROCESS_IS_DRAINING =
+      "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted";
   private static final String ERROR_MESSAGE_NO_IDENTIFIER_SPECIFIED =
       "Expected at least a bpmnProcessId or a key greater than -1, but none given";
   private static final String ERROR_MESSAGE_NOT_FOUND_BY_PROCESS =
@@ -55,8 +57,6 @@ public class ProcessInstanceCreationHelper {
       "Expected to find process definition with key '%d', but none found";
   private static final String ERROR_MESSAGE_NO_NONE_START_EVENT =
       "Expected to create instance of process with none start event, but there is no such event";
-  private static final String ERROR_MESSAGE_PROCESS_IS_DRAINING =
-      "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted";
   private static final String ERROR_MESSAGE_BUSINESS_ID_ALREADY_EXISTS =
       "Expected to create instance of process with business id '%s', but an instance with this business id already exists for process definition '%s'";
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationHelper.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.engine.processing.identity.authorization.request.Authori
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.processing.variable.VariableValidationException;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.BannedInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
@@ -112,12 +111,11 @@ public class ProcessInstanceCreationHelper {
   }
 
   /**
-   * A process definition that is being deleted is kept in state (as {@link
-   * PersistedProcessState#DRAINING}) so its already-running instances can finish, but no new
-   * instances may be created for it.
+   * A process definition that is being deleted is kept in state so its already-running instances
+   * can finish, but no new instances may be created for it.
    */
   private Either<Rejection, DeployedProcess> rejectIfDraining(final DeployedProcess process) {
-    if (process.getState() == PersistedProcessState.DRAINING) {
+    if (process.isDraining()) {
       return Either.left(
           new Rejection(
               RejectionType.INVALID_STATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -174,6 +174,7 @@ public class ProcessInstanceMigrationMigrateProcessor
             processInstanceRecord.getProcessDefinitionKey(), processInstanceRecord.getTenantId());
 
     requireNonNullTargetProcessDefinition(targetProcessDefinition, targetProcessDefinitionKey);
+    requireTargetProcessDefinitionNotDraining(targetProcessDefinition, targetProcessDefinitionKey);
     requireNoStartEventInstanceForTargetProcess(
         processInstance, targetProcessDefinition, messageState);
     requireReferredElementsExist(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSeq
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
@@ -268,7 +267,7 @@ public final class ProcessInstanceMigrationPreconditions {
    */
   public static void requireTargetProcessDefinitionNotDraining(
       final DeployedProcess targetProcessDefinition, final long targetProcessDefinitionKey) {
-    if (targetProcessDefinition.getState() == PersistedProcessState.DRAINING) {
+    if (targetProcessDefinition.isDraining()) {
       throw new ProcessInstanceMigrationPreconditionFailedException(
           String.format(
               ERROR_MESSAGE_TARGET_PROCESS_DEFINITION_DRAINING, targetProcessDefinitionKey),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSeq
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
@@ -80,6 +81,10 @@ public final class ProcessInstanceMigrationPreconditions {
       """
       Expected to migrate process instance to process definition \
       but no process definition found with key '%d'""";
+  private static final String ERROR_MESSAGE_TARGET_PROCESS_DEFINITION_DRAINING =
+      """
+      Expected to migrate process instance to process definition with key '%d' \
+      but it is being deleted""";
   private static final String ERROR_MESSAGE_PROCESS_DEFINITION_HAS_START_EVENT_INSTANCE =
       """
       Expected to migrate process instance '%d' \
@@ -250,6 +255,24 @@ public final class ProcessInstanceMigrationPreconditions {
           String.format(ERROR_MESSAGE_PROCESS_DEFINITION_NOT_FOUND, targetProcessDefinitionKey);
       throw new ProcessInstanceMigrationPreconditionFailedException(
           reason, RejectionType.NOT_FOUND);
+    }
+  }
+
+  /**
+   * Checks that the target process definition is not being deleted. A definition that is draining
+   * is kept in state so its running instances can finish, but no new instances may be migrated onto
+   * it.
+   *
+   * @param targetProcessDefinition target process definition to check (must be non-null)
+   * @param targetProcessDefinitionKey target process definition key, for the error message
+   */
+  public static void requireTargetProcessDefinitionNotDraining(
+      final DeployedProcess targetProcessDefinition, final long targetProcessDefinitionKey) {
+    if (targetProcessDefinition.getState() == PersistedProcessState.DRAINING) {
+      throw new ProcessInstanceMigrationPreconditionFailedException(
+          String.format(
+              ERROR_MESSAGE_TARGET_PROCESS_DEFINITION_DRAINING, targetProcessDefinitionKey),
+          RejectionType.INVALID_STATE);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -113,15 +114,21 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
             timer.getTargetElementIdBuffer(),
             ExecutableCatchEvent.class);
     if (isStartEvent(elementInstanceKey)) {
-      final long processInstanceKey = keyGenerator.nextKey();
-      timer.setProcessInstanceKey(processInstanceKey);
-      stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);
-      eventHandle.activateProcessInstanceForStartEvent(
-          processDefinitionKey,
-          processInstanceKey,
-          timer.getTargetElementIdBuffer(),
-          NO_VARIABLES,
-          tenantId);
+      if (deployedProcess.getState() == PersistedProcessState.DRAINING) {
+        // The definition is draining: never spawn a new instance. Still mark the timer as
+        // triggered so the command is consumed
+        stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);
+      } else {
+        final long processInstanceKey = keyGenerator.nextKey();
+        timer.setProcessInstanceKey(processInstanceKey);
+        stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);
+        eventHandle.activateProcessInstanceForStartEvent(
+            processDefinitionKey,
+            processInstanceKey,
+            timer.getTargetElementIdBuffer(),
+            NO_VARIABLES,
+            tenantId);
+      }
     } else {
       final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
       if (!eventHandle.canTriggerElement(elementInstance, timer.getTargetElementIdBuffer())) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -118,17 +117,18 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
         // The definition is draining: never spawn a new instance. Still mark the timer as
         // triggered so the command is consumed
         stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);
-      } else {
-        final long processInstanceKey = keyGenerator.nextKey();
-        timer.setProcessInstanceKey(processInstanceKey);
-        stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);
-        eventHandle.activateProcessInstanceForStartEvent(
-            processDefinitionKey,
-            processInstanceKey,
-            timer.getTargetElementIdBuffer(),
-            NO_VARIABLES,
-            tenantId);
+        // skip rescheduling since instances can't be created anymore
+        return;
       }
+      final long processInstanceKey = keyGenerator.nextKey();
+      timer.setProcessInstanceKey(processInstanceKey);
+      stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);
+      eventHandle.activateProcessInstanceForStartEvent(
+          processDefinitionKey,
+          processInstanceKey,
+          timer.getTargetElementIdBuffer(),
+          NO_VARIABLES,
+          tenantId);
     } else {
       final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
       if (!eventHandle.canTriggerElement(elementInstance, timer.getTargetElementIdBuffer())) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
@@ -114,7 +114,7 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
             timer.getTargetElementIdBuffer(),
             ExecutableCatchEvent.class);
     if (isStartEvent(elementInstanceKey)) {
-      if (deployedProcess.getState() == PersistedProcessState.DRAINING) {
+      if (deployedProcess.isDraining()) {
         // The definition is draining: never spawn a new instance. Still mark the timer as
         // triggered so the command is consumed
         stateWriter.appendFollowUpEvent(record.getKey(), TimerIntent.TRIGGERED, timer);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedProcess.java
@@ -52,6 +52,10 @@ public final class DeployedProcess {
     return persistedProcess.getState();
   }
 
+  public boolean isDraining() {
+    return persistedProcess.getState() == PersistedProcessState.DRAINING;
+  }
+
   public String getTenantId() {
     return persistedProcess.getTenantId();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStartProcessInstanceRequestRequestProcessorTest.java
@@ -14,14 +14,17 @@ import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartProcessInstanceRequestRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.MessageStartProcessInstanceRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -295,6 +298,92 @@ public final class MessageStartProcessInstanceRequestRequestProcessorTest {
     assertThat(startedPis)
         .as("messageDeadline == now must be treated as expired (inclusive <=)")
         .isZero();
+  }
+
+  @Test
+  public void shouldReplyNoSubscriptionRejectedWhenTargetDefinitionIsDraining() {
+    // given - a deployed process whose definition is then marked DRAINING
+    final var metadata =
+        engine
+            .deployment()
+            .withXmlResource(MESSAGE_START_PROCESS)
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0);
+    final long subscriptionKey = waitForStartEventSubscriptionKey();
+    drain(metadata);
+
+    // when - a REQUEST arrives for the draining definition
+    engine.writeRecords(
+        RecordToWrite.command()
+            .key(subscriptionKey)
+            .messageStartProcessInstanceRequest(
+                MessageStartProcessInstanceRequestIntent.REQUEST,
+                requestWith(BUSINESS_ID, subscriptionKey, metadata.getProcessDefinitionKey())));
+
+    // then - it is rejected as "no subscription" and no PI is activated
+    final var reply =
+        firstReplyCommand(MessageStartProcessInstanceRequestIntent.REJECT_NO_SUBSCRIPTION);
+    assertThat(reply.getProcessDefinitionKey()).isEqualTo(metadata.getProcessDefinitionKey());
+    assertThat(reply.getProcessInstanceKey()).isEqualTo(-1L);
+
+    // no STARTED event is written for a phantom instance and no PROCESS is activated
+    final long startedEvents =
+        RecordingExporter.records()
+            .limit(
+                r ->
+                    r.getRecordType() == RecordType.COMMAND
+                        && r.getIntent()
+                            == MessageStartProcessInstanceRequestIntent.REJECT_NO_SUBSCRIPTION)
+            .filter(
+                r ->
+                    r.getRecordType() == RecordType.EVENT
+                        && r.getIntent() == MessageStartProcessInstanceRequestIntent.STARTED)
+            .count();
+    assertThat(startedEvents).as("no dedup/STARTED entry for a draining definition").isZero();
+
+    final long activatedProcesses =
+        RecordingExporter.records()
+            .limit(
+                r ->
+                    r.getRecordType() == RecordType.COMMAND
+                        && r.getIntent()
+                            == MessageStartProcessInstanceRequestIntent.REJECT_NO_SUBSCRIPTION)
+            .processInstanceRecords()
+            .withElementType(BpmnElementType.PROCESS)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .count();
+    assertThat(activatedProcesses).as("no PI is activated for a draining definition").isZero();
+
+    assertNoOtherReply(MessageStartProcessInstanceRequestIntent.REJECT_NO_SUBSCRIPTION);
+  }
+
+  /**
+   * Puts the given process definition into the {@code DRAINING} state. Since no processor writes
+   * the {@code DRAINING} event yet, the event is injected onto the log while the engine is stopped
+   * so it is applied to state on the next start (replay). TODO(#56978): drive draining via a real
+   * {@code RESOURCE_DELETION.DELETE} once that change lands, and remove this injection helper.
+   */
+  private void drain(final ProcessMetadataValue metadata) {
+    engine.stop();
+    engine.writeRecords(
+        RecordToWrite.event()
+            .key(metadata.getProcessDefinitionKey())
+            .process(
+                ProcessIntent.DRAINING,
+                new ProcessRecord()
+                    .setKey(metadata.getProcessDefinitionKey())
+                    .setBpmnProcessId(metadata.getBpmnProcessId())
+                    .setVersion(metadata.getVersion())
+                    .setResourceName(metadata.getResourceName())
+                    .setTenantId(metadata.getTenantId())));
+    engine.start();
+
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
+        .await();
   }
 
   private MessageStartProcessInstanceRequestRecord request(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -297,19 +297,24 @@ public class DrainingProcessDefinitionTest {
 
   @Test
   public void shouldNotSpawnInstanceForDrainingDefinitionOnTimerStartEvent() {
-    // given
+    // given - a repeating timer start event so the trigger also reschedules
     final var processId = helper.getBpmnProcessId();
-    final var metadata = deployWithStartEvent(processId, start -> start.timerWithCycle("R1/PT1S"));
+    final var metadata = deployWithStartEvent(processId, start -> start.timerWithCycle("R2/PT1S"));
     drain(metadata);
 
     // when - the timer start event fires
     engine.increaseTime(Duration.ofHours(1));
-    RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
-        .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
-        .await();
+    final var triggered =
+        RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+            .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
+            .getFirst();
 
-    // then
+    // then - no instance is spawned and no phantom process instance key leaks into the TRIGGERED
+    // event
     assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
+    Assertions.assertThat(triggered.getValue().getProcessInstanceKey())
+        .describedAs("TRIGGERED timer of a draining definition carries no phantom instance key")
+        .isEqualTo(-1L);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -12,12 +12,12 @@ import static io.camunda.zeebe.protocol.record.RecordAssert.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -78,7 +78,7 @@ public class DrainingProcessDefinitionTest {
   }
 
   @Test
-  public void shouldRaiseIncidentWhenCallActivityCallsDrainingProcess() {
+  public void shouldRaiseIncidentWhenCallActivityCallsDrainingProcessWithLatestBinding() {
     // given
     final var childId = helper.getBpmnProcessId() + "-child";
     final var parentId = helper.getBpmnProcessId() + "-parent";
@@ -88,7 +88,9 @@ public class DrainingProcessDefinitionTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(parentId)
                 .startEvent()
-                .callActivity("call", c -> c.zeebeProcessId(childId))
+                .callActivity(
+                    "call",
+                    c -> c.zeebeProcessId(childId).zeebeBindingType(ZeebeBindingType.latest))
                 .endEvent()
                 .done())
         .deploy();
@@ -98,6 +100,87 @@ public class DrainingProcessDefinitionTest {
     final long parentInstanceKey = engine.processInstance().ofBpmnProcessId(parentId).create();
 
     // then
+    assertCalledElementIncident(parentInstanceKey, childId);
+  }
+
+  @Test
+  public void shouldRaiseIncidentWhenCallActivityCallsDrainingProcessWithDeploymentBinding() {
+    // given
+    final var childId = helper.getBpmnProcessId() + "-child";
+    final var parentId = helper.getBpmnProcessId() + "-parent";
+    // deployment binding resolves the called process within the same deployment
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                "child.bpmn", Bpmn.createExecutableProcess(childId).startEvent().endEvent().done())
+            .withXmlResource(
+                "parent.bpmn",
+                Bpmn.createExecutableProcess(parentId)
+                    .startEvent()
+                    .callActivity(
+                        "call",
+                        c ->
+                            c.zeebeProcessId(childId).zeebeBindingType(ZeebeBindingType.deployment))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final var child =
+        deployment.getValue().getProcessesMetadata().stream()
+            .filter(p -> p.getBpmnProcessId().equals(childId))
+            .findFirst()
+            .orElseThrow();
+    drain(child);
+
+    // when
+    final long parentInstanceKey = engine.processInstance().ofBpmnProcessId(parentId).create();
+
+    // then
+    assertCalledElementIncident(parentInstanceKey, childId);
+  }
+
+  @Test
+  public void shouldRaiseIncidentWhenCallActivityCallsDrainingProcessWithVersionTagBinding() {
+    // given
+    final var childId = helper.getBpmnProcessId() + "-child";
+    final var parentId = helper.getBpmnProcessId() + "-parent";
+    final var child =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(childId)
+                    .versionTag("v1")
+                    .startEvent()
+                    .endEvent()
+                    .done())
+            .deploy()
+            .getValue()
+            .getProcessesMetadata()
+            .get(0);
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(parentId)
+                .startEvent()
+                .callActivity(
+                    "call",
+                    c ->
+                        c.zeebeProcessId(childId)
+                            .zeebeBindingType(ZeebeBindingType.versionTag)
+                            .zeebeVersionTag("v1"))
+                .endEvent()
+                .done())
+        .deploy();
+    drain(child);
+
+    // when
+    final long parentInstanceKey = engine.processInstance().ofBpmnProcessId(parentId).create();
+
+    // then
+    assertCalledElementIncident(parentInstanceKey, childId);
+  }
+
+  private void assertCalledElementIncident(final long parentInstanceKey, final String childId) {
     final var incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(parentInstanceKey)
@@ -187,7 +270,7 @@ public class DrainingProcessDefinitionTest {
                     .setBpmnProcessId(metadata.getBpmnProcessId())
                     .setVersion(metadata.getVersion())
                     .setResourceName(metadata.getResourceName())
-                    .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)));
+                    .setTenantId(metadata.getTenantId())));
     engine.start();
 
     RecordingExporter.processRecords()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import static io.camunda.zeebe.protocol.record.RecordAssert.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies that no new process instances can be created for a process definition that is in the
+ * {@link io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState#DRAINING}
+ * state.
+ */
+public class DrainingProcessDefinitionTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectCreateInstanceByProcessIdWhenDraining() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    drain(deploy(processId));
+
+    // when
+    engine.processInstance().ofBpmnProcessId(processId).expectRejection().create();
+
+    // then
+    final var rejection =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+    io.camunda.zeebe.protocol.record.Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to create instance of process '%s', but it is being deleted"
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldRejectCreateInstanceByVersionWhenDraining() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    drain(deploy(processId));
+
+    // when
+    engine.processInstance().ofBpmnProcessId(processId).withVersion(1).expectRejection().create();
+
+    // then
+    final var rejection =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+    io.camunda.zeebe.protocol.record.Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to create instance of process '%s', but it is being deleted"
+                .formatted(processId));
+  }
+
+  @Test
+  public void shouldRaiseIncidentWhenCallActivityCallsDrainingProcess() {
+    // given
+    final var childId = helper.getBpmnProcessId() + "-child";
+    final var parentId = helper.getBpmnProcessId() + "-parent";
+    final var child = deploy(childId);
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(parentId)
+                .startEvent()
+                .callActivity("call", c -> c.zeebeProcessId(childId))
+                .endEvent()
+                .done())
+        .deploy();
+    drain(child);
+
+    // when
+    final long parentInstanceKey = engine.processInstance().ofBpmnProcessId(parentId).create();
+
+    // then
+    final var incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(parentInstanceKey)
+            .getFirst();
+    org.assertj.core.api.Assertions.assertThat(incident.getValue().getErrorType())
+        .isEqualTo(ErrorType.CALLED_ELEMENT_ERROR);
+    org.assertj.core.api.Assertions.assertThat(incident.getValue().getErrorMessage())
+        .isEqualTo(
+            "Expected to call process with BPMN process id '%s', but it is being deleted."
+                .formatted(childId));
+  }
+
+  @Test
+  public void shouldRejectMigrationToDrainingTargetProcess() {
+    // given
+    final var sourceId = helper.getBpmnProcessId() + "-source";
+    final var targetId = helper.getBpmnProcessId() + "-target";
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(sourceId).startEvent().userTask("A").endEvent().done())
+        .deploy();
+    final var target = deploy(targetId, "B");
+
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(sourceId).create();
+    RecordingExporter.processInstanceRecords(
+            io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(io.camunda.zeebe.protocol.record.value.BpmnElementType.USER_TASK)
+        .await();
+    drain(target);
+    final long targetProcessDefinitionKey = target.getProcessDefinitionKey();
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "B")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to migrate process instance to process definition with key '%d' but it is being deleted"
+                .formatted(targetProcessDefinitionKey));
+  }
+
+  private ProcessMetadataValue deploy(final String processId) {
+    return deploy(processId, null);
+  }
+
+  private ProcessMetadataValue deploy(final String processId, final String userTaskId) {
+    final var builder = Bpmn.createExecutableProcess(processId).startEvent();
+    if (userTaskId != null) {
+      builder.userTask(userTaskId);
+    }
+    return engine
+        .deployment()
+        .withXmlResource(builder.endEvent().done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0);
+  }
+
+  /**
+   * Puts the given process definition into the {@code DRAINING} state. Since no processor writes
+   * the {@code DRAINING} event yet, the event is injected onto the log while the engine is stopped
+   * so it is applied to state on the next start (replay), rather than being ignored during live
+   * processing. TODO(#56978): drive draining via a real {@code RESOURCE_DELETION.DELETE} once that
+   * change lands, and remove this injection helper.
+   */
+  private void drain(final ProcessMetadataValue metadata) {
+    engine.stop();
+    engine.writeRecords(
+        RecordToWrite.event()
+            .key(metadata.getProcessDefinitionKey())
+            .process(
+                ProcessIntent.DRAINING,
+                new ProcessRecord()
+                    .setKey(metadata.getProcessDefinitionKey())
+                    .setBpmnProcessId(metadata.getBpmnProcessId())
+                    .setVersion(metadata.getVersion())
+                    .setResourceName(metadata.getResourceName())
+                    .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)));
+    engine.start();
+
+    RecordingExporter.processRecords()
+        .withIntent(ProcessIntent.DRAINING)
+        .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
+        .await();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -12,16 +12,26 @@ import static io.camunda.zeebe.protocol.record.RecordAssert.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.assertj.core.api.Assertions;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -43,7 +53,8 @@ public class DrainingProcessDefinitionTest {
   public void shouldRejectCreateInstanceByProcessIdWhenDraining() {
     // given
     final var processId = helper.getBpmnProcessId();
-    drain(deploy(processId));
+    final var metadata = deploy(processId);
+    drain(metadata);
 
     // when
     engine.processInstance().ofBpmnProcessId(processId).expectRejection().create();
@@ -51,18 +62,19 @@ public class DrainingProcessDefinitionTest {
     // then
     final var rejection =
         RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
-    io.camunda.zeebe.protocol.record.Assertions.assertThat(rejection)
+    assertThat(rejection)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to create instance of process '%s', but it is being deleted"
-                .formatted(processId));
+            "Expected to create instance of process '%s' (version %d, process definition key %d), but it is being deleted"
+                .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
   }
 
   @Test
   public void shouldRejectCreateInstanceByVersionWhenDraining() {
     // given
     final var processId = helper.getBpmnProcessId();
-    drain(deploy(processId));
+    final var metadata = deploy(processId);
+    drain(metadata);
 
     // when
     engine.processInstance().ofBpmnProcessId(processId).withVersion(1).expectRejection().create();
@@ -70,11 +82,11 @@ public class DrainingProcessDefinitionTest {
     // then
     final var rejection =
         RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
-    io.camunda.zeebe.protocol.record.Assertions.assertThat(rejection)
+    assertThat(rejection)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to create instance of process '%s', but it is being deleted"
-                .formatted(processId));
+            "Expected to create instance of process '%s' (version %d, process definition key %d), but it is being deleted"
+                .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
   }
 
   @Test
@@ -185,9 +197,9 @@ public class DrainingProcessDefinitionTest {
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(parentInstanceKey)
             .getFirst();
-    org.assertj.core.api.Assertions.assertThat(incident.getValue().getErrorType())
+    Assertions.assertThat(incident.getValue().getErrorType())
         .isEqualTo(ErrorType.CALLED_ELEMENT_ERROR);
-    org.assertj.core.api.Assertions.assertThat(incident.getValue().getErrorMessage())
+    Assertions.assertThat(incident.getValue().getErrorMessage())
         .isEqualTo(
             "Expected to call process with BPMN process id '%s', but it is being deleted."
                 .formatted(childId));
@@ -206,10 +218,9 @@ public class DrainingProcessDefinitionTest {
     final var target = deploy(targetId, "B");
 
     final long processInstanceKey = engine.processInstance().ofBpmnProcessId(sourceId).create();
-    RecordingExporter.processInstanceRecords(
-            io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATED)
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
         .withProcessInstanceKey(processInstanceKey)
-        .withElementType(io.camunda.zeebe.protocol.record.value.BpmnElementType.USER_TASK)
+        .withElementType(BpmnElementType.USER_TASK)
         .await();
     drain(target);
     final long targetProcessDefinitionKey = target.getProcessDefinitionKey();
@@ -231,6 +242,99 @@ public class DrainingProcessDefinitionTest {
         .hasRejectionReason(
             "Expected to migrate process instance to process definition with key '%d' but it is being deleted"
                 .formatted(targetProcessDefinitionKey));
+  }
+
+  @Test
+  public void shouldNotSpawnInstanceForDrainingDefinitionOnTimerStartEvent() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deployWithStartEvent(processId, start -> start.timerWithCycle("R1/PT1S"));
+    drain(metadata);
+
+    // when - the timer start event fires
+    engine.increaseTime(Duration.ofHours(1));
+    RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+        .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
+        .await();
+
+    // then
+    assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
+  }
+
+  @Test
+  public void shouldNotSpawnInstanceForDrainingDefinitionOnMessageStartEvent() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deployWithStartEvent(processId, start -> start.message("start-message"));
+    drain(metadata);
+
+    // when - a message correlates to the (still-subscribed) message start event
+    engine.message().withName("start-message").withCorrelationKey("key").publish();
+    RecordingExporter.messageStartEventSubscriptionRecords(
+            MessageStartEventSubscriptionIntent.CORRELATED)
+        .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
+        .await();
+
+    // then
+    assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
+  }
+
+  @Test
+  public void shouldNotSpawnInstanceForDrainingDefinitionOnSignalStartEvent() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deployWithStartEvent(processId, start -> start.signal("start-signal"));
+    drain(metadata);
+
+    // when - a signal is broadcast to the (still-subscribed) signal start event
+    engine.signal().withSignalName("start-signal").broadcast();
+    RecordingExporter.signalRecords(SignalIntent.BROADCASTED)
+        .withSignalName("start-signal")
+        .await();
+
+    // then
+    assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
+  }
+
+  @Test
+  public void shouldNotSpawnInstanceForDrainingDefinitionOnConditionalStartEvent() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var metadata =
+        deployWithStartEvent(processId, start -> start.condition(c -> c.condition("=x > y")));
+    drain(metadata);
+
+    // when - the conditional start event's condition is evaluated to true
+    engine.conditionalEvaluation().withVariables(Map.of("x", 100, "y", 1)).evaluate();
+
+    // then - the guard blocks the activation
+    assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
+  }
+
+  private ProcessMetadataValue deployWithStartEvent(
+      final String processId, final Consumer<StartEventBuilder> startEventConfigurer) {
+    final var start = Bpmn.createExecutableProcess(processId).startEvent("start");
+    startEventConfigurer.accept(start);
+    return engine
+        .deployment()
+        .withXmlResource(start.endEvent().done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0);
+  }
+
+  private void assertNoInstanceSpawned(final long processDefinitionKey) {
+    Assertions.assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.processInstanceRecords(
+                            ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                        .withProcessDefinitionKey(processDefinitionKey)
+                        .withElementType(BpmnElementType.PROCESS)
+                        .exists()))
+        .describedAs("no new instance is spawned on a draining definition via a start event")
+        .isFalse();
   }
 
   private ProcessMetadataValue deploy(final String processId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.resource;
 
 import static io.camunda.zeebe.protocol.record.RecordAssert.assertThat;
 
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationHelper;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -68,8 +69,8 @@ public class DrainingProcessDefinitionTest {
     assertThat(rejection)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted"
-                .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
+            ProcessInstanceCreationHelper.ERROR_MESSAGE_PROCESS_IS_DRAINING.formatted(
+                processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
   }
 
   @Test
@@ -88,8 +89,8 @@ public class DrainingProcessDefinitionTest {
     assertThat(rejection)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted"
-                .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
+            ProcessInstanceCreationHelper.ERROR_MESSAGE_PROCESS_IS_DRAINING.formatted(
+                processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
   }
 
   @Test
@@ -111,8 +112,8 @@ public class DrainingProcessDefinitionTest {
     assertThat(rejection)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted"
-                .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
+            ProcessInstanceCreationHelper.ERROR_MESSAGE_PROCESS_IS_DRAINING.formatted(
+                processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
   }
 
   @Test
@@ -136,8 +137,8 @@ public class DrainingProcessDefinitionTest {
     assertThat(rejection)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted"
-                .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
+            ProcessInstanceCreationHelper.ERROR_MESSAGE_PROCESS_IS_DRAINING.formatted(
+                processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
   }
 
   @Test
@@ -163,7 +164,7 @@ public class DrainingProcessDefinitionTest {
     final long parentInstanceKey = engine.processInstance().ofBpmnProcessId(parentId).create();
 
     // then
-    assertCalledElementIncident(parentInstanceKey, childId);
+    assertCalledElementIncident(parentInstanceKey, child);
   }
 
   @Test
@@ -199,7 +200,7 @@ public class DrainingProcessDefinitionTest {
     final long parentInstanceKey = engine.processInstance().ofBpmnProcessId(parentId).create();
 
     // then
-    assertCalledElementIncident(parentInstanceKey, childId);
+    assertCalledElementIncident(parentInstanceKey, child);
   }
 
   @Test
@@ -240,10 +241,11 @@ public class DrainingProcessDefinitionTest {
     final long parentInstanceKey = engine.processInstance().ofBpmnProcessId(parentId).create();
 
     // then
-    assertCalledElementIncident(parentInstanceKey, childId);
+    assertCalledElementIncident(parentInstanceKey, child);
   }
 
-  private void assertCalledElementIncident(final long parentInstanceKey, final String childId) {
+  private void assertCalledElementIncident(
+      final long parentInstanceKey, final ProcessMetadataValue child) {
     final var incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(parentInstanceKey)
@@ -252,8 +254,9 @@ public class DrainingProcessDefinitionTest {
         .isEqualTo(ErrorType.CALLED_ELEMENT_ERROR);
     Assertions.assertThat(incident.getValue().getErrorMessage())
         .isEqualTo(
-            "Expected to call process with BPMN process id '%s', but it is being deleted."
-                .formatted(childId));
+            "Expected to call process with BPMN process id '%s' and version %d (key %d), but it is being deleted."
+                .formatted(
+                    child.getBpmnProcessId(), child.getVersion(), child.getProcessDefinitionKey()));
   }
 
   @Test
@@ -440,8 +443,8 @@ public class DrainingProcessDefinitionTest {
     assertThat(rejection)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted"
-                .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
+            ProcessInstanceCreationHelper.ERROR_MESSAGE_PROCESS_IS_DRAINING.formatted(
+                processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
     assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
@@ -79,6 +80,54 @@ public class DrainingProcessDefinitionTest {
 
     // when
     engine.processInstance().ofBpmnProcessId(processId).withVersion(1).expectRejection().create();
+
+    // then
+    final var rejection =
+        RecordingExporter.processInstanceCreationRecords().onlyCommandRejections().getFirst();
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted"
+                .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
+  }
+
+  @Test
+  public void shouldRejectCreateInstanceWithResultWhenDraining() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deploy(processId);
+    drain(metadata);
+
+    // when
+    engine.processInstance().ofBpmnProcessId(processId).withResult().asyncCreate();
+
+    // then
+    final var rejection =
+        RecordingExporter.processInstanceCreationRecords()
+            .withIntent(ProcessInstanceCreationIntent.CREATE_WITH_AWAITING_RESULT)
+            .onlyCommandRejections()
+            .getFirst();
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted"
+                .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
+  }
+
+  @Test
+  public void shouldRejectCreateInstanceWithStartInstructionsWhenDraining() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deploy(processId);
+    drain(metadata);
+
+    // when - bogus element id: proves the draining guard runs before start-instruction validation
+    engine
+        .processInstance()
+        .ofBpmnProcessId(processId)
+        .withStartInstruction("nonExistentElement")
+        .expectRejection()
+        .create();
 
     // then
     final var rejection =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
@@ -65,7 +66,7 @@ public class DrainingProcessDefinitionTest {
     assertThat(rejection)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to create instance of process '%s' (version %d, process definition key %d), but it is being deleted"
+            "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted"
                 .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
   }
 
@@ -85,7 +86,7 @@ public class DrainingProcessDefinitionTest {
     assertThat(rejection)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
-            "Expected to create instance of process '%s' (version %d, process definition key %d), but it is being deleted"
+            "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted"
                 .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
   }
 
@@ -335,6 +336,47 @@ public class DrainingProcessDefinitionTest {
                         .exists()))
         .describedAs("no new instance is spawned on a draining definition via a start event")
         .isFalse();
+  }
+
+  @Test
+  public void shouldRejectActivateElementCommandForDrainingDefinition() {
+    // given - a draining definition and a raw ACTIVATE_ELEMENT command for a fresh root process
+    // instance, mimicking a follow-up command that outlived the DRAINING mark. This bypasses the
+    // EventHandle guard to exercise the defensive ProcessInstanceStateTransitionGuard directly.
+    final var processId = helper.getBpmnProcessId();
+    final var metadata = deploy(processId);
+    drain(metadata);
+
+    final long processInstanceKey = 123L;
+    final var record =
+        new ProcessInstanceRecord()
+            .setBpmnProcessId(processId)
+            .setProcessDefinitionKey(metadata.getProcessDefinitionKey())
+            .setVersion(metadata.getVersion())
+            .setProcessInstanceKey(processInstanceKey)
+            .setElementId(processId)
+            .setBpmnElementType(BpmnElementType.PROCESS)
+            .setTenantId(metadata.getTenantId());
+
+    // when
+    engine.writeRecords(
+        RecordToWrite.command()
+            .key(processInstanceKey)
+            .processInstance(ProcessInstanceIntent.ACTIVATE_ELEMENT, record));
+
+    // then - the command is rejected and no instance is activated
+    final var rejection =
+        RecordingExporter.processInstanceRecords()
+            .withIntent(ProcessInstanceIntent.ACTIVATE_ELEMENT)
+            .onlyCommandRejections()
+            .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
+            .getFirst();
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to create instance of process with ID '%s' and version %d (key %d), but it is being deleted"
+                .formatted(processId, metadata.getVersion(), metadata.getProcessDefinitionKey()));
+    assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
   }
 
   private ProcessMetadataValue deploy(final String processId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/DrainingProcessDefinitionTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ConditionalEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
@@ -318,14 +319,19 @@ public class DrainingProcessDefinitionTest {
     final var metadata = deployWithStartEvent(processId, start -> start.message("start-message"));
     drain(metadata);
 
-    // when - a message correlates to the (still-subscribed) message start event
+    // when - a message is published against the (still-subscribed) message start event
     engine.message().withName("start-message").withCorrelationKey("key").publish();
-    RecordingExporter.messageStartEventSubscriptionRecords(
-            MessageStartEventSubscriptionIntent.CORRELATED)
-        .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
-        .await();
 
-    // then
+    // then - the message is not correlated to a phantom instance and no instance is spawned
+    Assertions.assertThat(
+            RecordingExporter.<Boolean>expectNoMatchingRecords(
+                records ->
+                    RecordingExporter.messageStartEventSubscriptionRecords(
+                            MessageStartEventSubscriptionIntent.CORRELATED)
+                        .withProcessDefinitionKey(metadata.getProcessDefinitionKey())
+                        .exists()))
+        .describedAs("message is not correlated to a draining definition's start subscription")
+        .isFalse();
     assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
   }
 
@@ -357,7 +363,13 @@ public class DrainingProcessDefinitionTest {
     // when - the conditional start event's condition is evaluated to true
     engine.conditionalEvaluation().withVariables(Map.of("x", 100, "y", 1)).evaluate();
 
-    // then - the guard blocks the activation
+    // then - the guard blocks the activation and the draining definition is not reported as started
+    final var evaluated =
+        RecordingExporter.conditionalEvaluationRecords(ConditionalEvaluationIntent.EVALUATED)
+            .getFirst();
+    Assertions.assertThat(evaluated.getValue().getStartedProcessInstances())
+        .describedAs("a draining definition is not reported as a started instance")
+        .isEmpty();
     assertNoInstanceSpawned(metadata.getProcessDefinitionKey());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProce
 import io.camunda.zeebe.protocol.impl.record.value.agenthistory.AgentHistoryRecord;
 import io.camunda.zeebe.protocol.impl.record.value.agentinstance.AgentInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.conditional.ConditionalSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.impl.record.value.globallistener.GlobalListenerBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
@@ -52,6 +53,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
@@ -77,6 +79,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordVa
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
 
 public final class RecordToWrite implements LogAppendEntry {
 
@@ -188,6 +191,12 @@ public final class RecordToWrite implements LogAppendEntry {
       final ProcessInstanceCreationIntent intent, final ProcessInstanceCreationRecordValue value) {
     recordMetadata.valueType(ValueType.PROCESS_INSTANCE_CREATION).intent(intent);
     unifiedRecordValue = (ProcessInstanceCreationRecord) value;
+    return this;
+  }
+
+  public RecordToWrite process(final ProcessIntent intent, final Process value) {
+    recordMetadata.valueType(ValueType.PROCESS).intent(intent);
+    unifiedRecordValue = (ProcessRecord) value;
     return this;
   }
 


### PR DESCRIPTION
## Description

A process definition in the DRAINING state stays retrievable so its already-running instances can finish, but it must not accept any new instances. This blocks every new-instance entry point:

- **Direct create** / create-with-result / start instructions (`ProcessInstanceCreationHelper#findRelevantProcess`) → `INVALID_STATE` rejection.
- **Call activity**, all binding types — deployment, latest, versionTag (`CallActivityProcessor`) → incident with `CALLED_ELEMENT_ERROR`.
- **Migration** whose target definition is draining (`ProcessInstanceMigrationPreconditions`) → `INVALID_STATE` rejection.
- **Start-event triggers** — timer, message, signal, conditional — at the single activation choke point (`EventHandle`) → activation skipped, no instance spawned.
- **Defensive `ACTIVATE_ELEMENT` guard** (`ProcessInstanceStateTransitionGuard`), scoped to the PROCESS element type, in case a follow-up command ever outlives the DRAINING mark; reuses the shared `ERROR_MESSAGE_PROCESS_IS_DRAINING` reason.
- Execution never reads the definition state, so in-flight instances of a draining definition run to completion; guards are inert until a definition is marked DRAINING (resource-deletion change). Adds a `RecordToWrite#process` test helper to inject DRAINING.

## Related issues

closes #56976
