### PR TITLE
feat: add prefix-scoped index refresh to SearchClientAdapter

### DIFF
--- a/search/search-test-utils/pom.xml
+++ b/search/search-test-utils/pom.xml
@@ -85,11 +85,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
+++ b/search/search-test-utils/src/main/java/io/camunda/search/test/utils/SearchClientAdapter.java
@@ -32,6 +32,9 @@ import org.opensearch.client.opensearch.indices.IndexState;
 
 public class SearchClientAdapter {
 
+  private static final String REFRESH_NULL_SHARDS_ERROR_MESSAGE = "No shards stats returned";
+  private static final String REFRESH_ERROR_MESSAGE = "Index refresh failed with shard failures: ";
+
   private final ElasticsearchClient elsClient;
   private final OpenSearchClient osClient;
   private final SchemaResourceSerializer schemaResourceSerializer;
@@ -372,10 +375,34 @@ public class SearchClientAdapter {
   }
 
   public void refresh() throws IOException {
+    refresh(null);
+  }
+
+  public void refresh(final String prefix) throws IOException {
+    final boolean usePrefix = prefix != null && !prefix.isEmpty();
+
     if (elsClient != null) {
-      elsClient.indices().refresh();
+      final var response =
+          usePrefix
+              ? elsClient.indices().refresh(r -> r.index(prefix + "*"))
+              : elsClient.indices().refresh();
+      if (response.shards() == null) {
+        throw new RuntimeException(REFRESH_NULL_SHARDS_ERROR_MESSAGE);
+      }
+
+      final var failures = response.shards().failures();
+      if (failures != null && !failures.isEmpty()) {
+        throw new RuntimeException(REFRESH_ERROR_MESSAGE + failures);
+      }
     } else if (osClient != null) {
-      osClient.indices().refresh();
+      final var response =
+          usePrefix
+              ? osClient.indices().refresh(r -> r.index(prefix + "*"))
+              : osClient.indices().refresh();
+      final var failures = response.shards().failures();
+      if (!failures.isEmpty()) {
+        throw new RuntimeException(REFRESH_ERROR_MESSAGE + failures);
+      }
     }
   }
 

--- a/search/search-test-utils/src/test/java/io/camunda/search/test/utils/SearchClientAdapterTest.java
+++ b/search/search-test-utils/src/test/java/io/camunda/search/test/utils/SearchClientAdapterTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.test.utils;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ShardFailure;
+import co.elastic.clients.elasticsearch.indices.ElasticsearchIndicesClient;
+import co.elastic.clients.elasticsearch.indices.RefreshResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ShardSearchFailure;
+import org.opensearch.client.opensearch.indices.OpenSearchIndicesClient;
+
+class SearchClientAdapterTest {
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Elasticsearch tests
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Nested
+  class WithElasticsearchClient {
+
+    @Mock private ElasticsearchClient elsClient;
+    @Mock private ElasticsearchIndicesClient elsIndicesClient;
+    @Mock private RefreshResponse elsRefreshResponse;
+    @Mock private co.elastic.clients.elasticsearch._types.ShardStatistics elsShards;
+
+    private SearchClientAdapter adapter;
+
+    @BeforeEach
+    void setUp() {
+      MockitoAnnotations.openMocks(this);
+      when(elsClient.indices()).thenReturn(elsIndicesClient);
+      final var objectMapper = mock(ObjectMapper.class);
+      adapter = new SearchClientAdapter(elsClient, objectMapper);
+    }
+
+    // ── refresh() ────────────────────────────────────────────────────────
+
+    @Test
+    void refreshNoPrefixCallsRefreshWithoutIndex() throws IOException {
+      when(elsIndicesClient.refresh()).thenReturn(elsRefreshResponse);
+      when(elsRefreshResponse.shards()).thenReturn(elsShards);
+      when(elsShards.failures()).thenReturn(List.of());
+
+      adapter.refresh();
+
+      verify(elsIndicesClient).refresh();
+    }
+
+    // ── refresh(String prefix) ────────────────────────────────────────────
+
+    @Test
+    void refreshWithPrefixCallsRefreshWithWildcard() throws IOException {
+      when(elsIndicesClient.refresh(any(Function.class))).thenReturn(elsRefreshResponse);
+      when(elsRefreshResponse.shards()).thenReturn(elsShards);
+      when(elsShards.failures()).thenReturn(List.of());
+
+      adapter.refresh("my-prefix");
+
+      verify(elsIndicesClient).refresh(any(Function.class));
+    }
+
+    @Test
+    void refreshWithNullPrefixDelegatesToNoArgRefresh() throws IOException {
+      when(elsIndicesClient.refresh()).thenReturn(elsRefreshResponse);
+      when(elsRefreshResponse.shards()).thenReturn(elsShards);
+      when(elsShards.failures()).thenReturn(List.of());
+
+      adapter.refresh((String) null);
+
+      verify(elsIndicesClient).refresh();
+    }
+
+    @Test
+    void refreshWithEmptyPrefixDelegatesToNoArgRefresh() throws IOException {
+      when(elsIndicesClient.refresh()).thenReturn(elsRefreshResponse);
+      when(elsRefreshResponse.shards()).thenReturn(elsShards);
+      when(elsShards.failures()).thenReturn(List.of());
+
+      adapter.refresh("");
+
+      verify(elsIndicesClient).refresh();
+    }
+
+    @Test
+    void refreshNullShardsThrowsRuntimeException() throws IOException {
+      when(elsIndicesClient.refresh()).thenReturn(elsRefreshResponse);
+      when(elsRefreshResponse.shards()).thenReturn(null);
+
+      assertThatThrownBy(() -> adapter.refresh())
+          .isInstanceOf(RuntimeException.class)
+          .hasMessage("No shards stats returned");
+    }
+
+    @Test
+    void refreshWithShardFailuresThrowsRuntimeException() throws IOException {
+      final var failure = mock(co.elastic.clients.elasticsearch._types.ShardFailure.class);
+
+      when(elsIndicesClient.refresh()).thenReturn(elsRefreshResponse);
+      when(elsRefreshResponse.shards()).thenReturn(elsShards);
+      when(elsShards.failures()).thenReturn(List.of(failure));
+
+      assertThatThrownBy(() -> adapter.refresh())
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageStartingWith("Index refresh failed with shard failures: ");
+    }
+
+    @Test
+    void refreshWithPrefixNullShardsThrowsRuntimeException() throws IOException {
+      when(elsIndicesClient.refresh(any(Function.class))).thenReturn(elsRefreshResponse);
+      when(elsRefreshResponse.shards()).thenReturn(null);
+
+      assertThatThrownBy(() -> adapter.refresh("my-prefix"))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessage("No shards stats returned");
+    }
+
+    @Test
+    void refreshWithPrefixWithShardFailuresThrowsRuntimeException() throws IOException {
+      final var failure = mock(ShardFailure.class);
+
+      when(elsIndicesClient.refresh(any(Function.class))).thenReturn(elsRefreshResponse);
+      when(elsRefreshResponse.shards()).thenReturn(elsShards);
+      when(elsShards.failures()).thenReturn(List.of(failure));
+
+      assertThatThrownBy(() -> adapter.refresh("my-prefix"))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageStartingWith("Index refresh failed with shard failures: ");
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // OpenSearch tests
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Nested
+  class WithOpenSearchClient {
+
+    @Mock private OpenSearchClient osClient;
+    @Mock private OpenSearchIndicesClient osIndicesClient;
+    @Mock private org.opensearch.client.opensearch.indices.RefreshResponse osRefreshResponse;
+    @Mock private org.opensearch.client.opensearch._types.ShardStatistics osShards;
+
+    private SearchClientAdapter adapter;
+
+    @BeforeEach
+    void setUp() throws IOException {
+      MockitoAnnotations.openMocks(this);
+      when(osClient.indices()).thenReturn(osIndicesClient);
+      final var objectMapper = mock(ObjectMapper.class);
+      adapter = new SearchClientAdapter(osClient, objectMapper);
+    }
+
+    // ── refresh() ────────────────────────────────────────────────────────
+
+    @Test
+    void refreshNoPrefixCallsRefreshWithoutIndex() throws IOException {
+      when(osIndicesClient.refresh()).thenReturn(osRefreshResponse);
+      when(osRefreshResponse.shards()).thenReturn(osShards);
+      when(osShards.failures()).thenReturn(List.of());
+
+      adapter.refresh();
+
+      verify(osIndicesClient).refresh();
+    }
+
+    // ── refresh(String prefix) ────────────────────────────────────────────
+
+    @Test
+    void refreshWithPrefixCallsRefreshWithWildcard() throws IOException {
+      when(osIndicesClient.refresh(any(Function.class))).thenReturn(osRefreshResponse);
+      when(osRefreshResponse.shards()).thenReturn(osShards);
+      when(osShards.failures()).thenReturn(List.of());
+
+      adapter.refresh("my-prefix");
+
+      verify(osIndicesClient).refresh(any(Function.class));
+    }
+
+    @Test
+    void refreshWithNullPrefixDelegatesToNoArgRefresh() throws IOException {
+      when(osIndicesClient.refresh()).thenReturn(osRefreshResponse);
+      when(osRefreshResponse.shards()).thenReturn(osShards);
+      when(osShards.failures()).thenReturn(List.of());
+
+      adapter.refresh((String) null);
+
+      verify(osIndicesClient).refresh();
+    }
+
+    @Test
+    void refreshWithEmptyPrefixDelegatesToNoArgRefresh() throws IOException {
+      when(osIndicesClient.refresh()).thenReturn(osRefreshResponse);
+      when(osRefreshResponse.shards()).thenReturn(osShards);
+      when(osShards.failures()).thenReturn(List.of());
+
+      adapter.refresh("");
+
+      verify(osIndicesClient).refresh();
+    }
+
+    @Test
+    void refreshWithShardFailuresThrowsRuntimeException() throws IOException {
+      final var failure = mock(ShardSearchFailure.class);
+
+      when(osIndicesClient.refresh()).thenReturn(osRefreshResponse);
+      when(osRefreshResponse.shards()).thenReturn(osShards);
+      when(osShards.failures()).thenReturn(List.of(failure));
+
+      assertThatThrownBy(() -> adapter.refresh())
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageStartingWith("Index refresh failed with shard failures: ");
+    }
+
+    @Test
+    void refreshWithPrefixWithShardFailuresThrowsRuntimeException() throws IOException {
+      final var failure = mock(ShardSearchFailure.class);
+
+      when(osIndicesClient.refresh(any(Function.class))).thenReturn(osRefreshResponse);
+      when(osRefreshResponse.shards()).thenReturn(osShards);
+      when(osShards.failures()).thenReturn(List.of(failure));
+
+      assertThatThrownBy(() -> adapter.refresh("my-prefix"))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageStartingWith("Index refresh failed with shard failures: ");
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds a new `refresh(String prefix)` overload to `SearchClientAdapter` that scopes the refresh to indices matching `prefix*`, and refactors the existing `refresh()` to delegate to it.

Also adds unit tests for both methods.

The existing `refresh()` always refreshed all indices. Some callers need to refresh only a subset of indices by prefix, for example to avoid unnecessary load during tests that operate on a specific index namespace.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
