### PR TITLE
Skip leased jobs when activating without a lease

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -4129,6 +4129,43 @@
                     "id": "custom.align"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "action"
+                },
+                "properties": [
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-background",
+                      "mode": "basic",
+                      "applyToRow": true
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "fixed",
+                      "fixedColor": "transparent"
+                    }
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "skipped": {
+                            "color": "orange",
+                            "index": 0
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
               }
             ]
           },

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -529,6 +529,7 @@ public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
   public enum JobAction {
     CREATED("created"),
     ACTIVATED("activated"),
+    SKIPPED("skipped"),
     TIMED_OUT("timed out"),
     COMPLETED("completed"),
     FAILED("failed"),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -74,7 +74,8 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     responseWriter = writers.response();
     authorizationCheckBehavior = authCheckBehavior;
     jobBatchCollector =
-        new JobBatchCollector(state, stateWriter::canWriteEventOfLength, authCheckBehavior, clock);
+        new JobBatchCollector(
+            state, stateWriter::canWriteEventOfLength, authCheckBehavior, clock, jobMetrics);
 
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.JobAction;
+import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.state.immutable.JobState;
@@ -51,6 +53,7 @@ final class JobBatchCollector {
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final Predicate<Integer> canWriteEventOfLength;
   private final InstantSource clock;
+  private final JobProcessingMetrics jobMetrics;
 
   /**
    * @param canWriteEventOfLength a predicate which should return whether the resulting {@link
@@ -62,12 +65,14 @@ final class JobBatchCollector {
       final ProcessingState state,
       final Predicate<Integer> canWriteEventOfLength,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final JobProcessingMetrics jobMetrics) {
     jobState = state.getJobState();
     this.canWriteEventOfLength = canWriteEventOfLength;
     jobVariablesCollector = new JobVariablesCollector(state);
     this.authCheckBehavior = authCheckBehavior;
     this.clock = clock;
+    this.jobMetrics = jobMetrics;
   }
 
   /**
@@ -110,6 +115,12 @@ final class JobBatchCollector {
         (key, jobRecord) -> {
           if (!isAuthorizedForJob(jobRecord, authorizedProcessIds)) {
             // Skip Jobs the user is not authorized for
+            return true;
+          }
+
+          if (!value.isWithLease() && !jobRecord.getLeaseToken().isEmpty()) {
+            // Skip leased jobs so an unleased activation cannot break the lease's exclusivity
+            jobMetrics.countJobEvent(JobAction.SKIPPED, jobRecord.getJobKind(), value.getType());
             return true;
           }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobProcessingMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobProcessingMetricsTest.java
@@ -78,6 +78,7 @@ public class JobProcessingMetricsTest {
   public void allCountsStartAtNull() {
     assertThat(findJobCounter("created", JOB_TYPE, scenario.jobKind)).isEmpty();
     assertThat(findJobCounter("activated", JOB_TYPE, scenario.jobKind)).isEmpty();
+    assertThat(findJobCounter("skipped", JOB_TYPE, scenario.jobKind)).isEmpty();
     assertThat(findJobCounter("timed out", JOB_TYPE, scenario.jobKind)).isEmpty();
     assertThat(findJobCounter("completed", JOB_TYPE, scenario.jobKind)).isEmpty();
     assertThat(findJobCounter("failed", JOB_TYPE, scenario.jobKind)).isEmpty();
@@ -110,6 +111,29 @@ public class JobProcessingMetricsTest {
 
     // then
     assertThat(jobMetric("activated", jobType, scenario.jobKind)).isOne();
+  }
+
+  @Test
+  public void shouldCountSkipped() {
+    // given
+    engine.deployment().withXmlResource(scenario.process).deploy();
+
+    // use a unique job type so the skip counter is isolated from other tests
+    final String jobType = String.format("%s_%s_skipped", JOB_TYPE, scenario.jobKind);
+    final long processInstanceKey = createProcessInstanceWithJob(jobType);
+
+    // lease the job, then fail it back to activatable so it stays leased but activatable
+    engine.jobs().withType(jobType).withLease().activate();
+    engine.job().ofInstance(processInstanceKey).withType(jobType).withRetries(1).fail();
+    RecordingExporter.jobRecords(JobIntent.FAILED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when activating without a lease, the leased job is skipped
+    engine.jobs().withType(jobType).activate();
+
+    // then
+    assertThat(jobMetric("skipped", jobType, scenario.jobKind)).isOne();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
@@ -198,4 +198,46 @@ public final class ActivateJobsWithLeaseTest {
         .describedAs("the lease token survives an engine restart and log replay")
         .isEqualTo(leaseToken);
   }
+
+  @Test
+  public void shouldSkipLeasedJobWhenActivatingWithoutLease() {
+    // given a leased job that failed back to activatable, alongside two unleased jobs
+    final long leasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    ENGINE.jobs().withType(jobType).withLease().activate();
+    ENGINE.job().withKey(leasedJobKey).withRetries(1).fail();
+    jobRecords(JobIntent.FAILED).withRecordKey(leasedJobKey).await();
+    final long unleasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    final long otherUnleasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+
+    // when activating without a lease, with room for all three jobs
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withMaxJobsToActivate(3).activate();
+
+    // then the leased job is skipped, the rest activate (no batch rejection)
+    assertThat(batch.getValue().getJobKeys())
+        .describedAs("activating without a lease skips the leased job and activates the rest")
+        .containsExactlyInAnyOrder(unleasedJobKey, otherUnleasedJobKey)
+        .doesNotContain(leasedJobKey);
+  }
+
+  @Test
+  public void shouldNotConsumeActivationSlotForSkippedLeasedJob() {
+    // given a leased job that failed back to activatable, alongside two unleased jobs.
+    // The leased job is created first (lowest key) so it is visited before the batch fills.
+    final long leasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    ENGINE.jobs().withType(jobType).withLease().activate();
+    ENGINE.job().withKey(leasedJobKey).withRetries(1).fail();
+    jobRecords(JobIntent.FAILED).withRecordKey(leasedJobKey).await();
+    final long unleasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+    final long otherUnleasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
+
+    // when activating without a lease, limited to two jobs
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withMaxJobsToActivate(2).activate();
+
+    // then the skipped leased job does not consume an activation slot: both unleased jobs activate
+    assertThat(batch.getValue().getJobKeys())
+        .describedAs("the skipped leased job does not consume an activation slot")
+        .containsExactlyInAnyOrder(unleasedJobKey, otherUnleasedJobKey);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.security.configuration.EngineSecurityConfigurations;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.AuthorizationCheckMetrics;
+import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.processing.identity.AuthenticatedAuthorizedTenants;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
@@ -75,7 +76,13 @@ final class JobBatchCollectorTest {
             EngineSecurityConfigurations.unauthenticatedAndUnauthorized(),
             new EngineConfiguration(),
             new AuthorizationCheckMetrics(new SimpleMeterRegistry()));
-    collector = new JobBatchCollector(state, lengthEvaluator, authorizationCheckBehavior, clock);
+    collector =
+        new JobBatchCollector(
+            state,
+            lengthEvaluator,
+            authorizationCheckBehavior,
+            clock,
+            new JobProcessingMetrics(new SimpleMeterRegistry()));
   }
 
   @Test


### PR DESCRIPTION
## Description

Completes the `withLease` activation work. This PR is the **read side**: when a job batch is activated with `withLease=false` (the default), any activatable job that still carries a lease token is skipped instead of being handed out, so an unleased activation can never break a lease's exclusivity. A job that returned to activatable while leased (after a fail or timeout) is only re-activated by a caller that also requests a lease.

The filter lives in `JobBatchCollector`, beside the token generation added in the previous PR: the skipped job is passed over before it is sized or appended, so it neither joins the batch nor consumes an activation slot — the batch fills from the remaining unleased jobs up to `maxJobsToActivate`.

Skips are otherwise invisible (the job simply never appears in a batch, indistinguishable from a missing or stuck job), so each skip increments a new `skipped` job-event counter tagged by job type and kind.

To surface that counter, the Zeebe Grafana dashboard's "Job events per second" table now highlights the `skipped` row in orange, so a rise in skips (a hint that unleased workers are colliding with leased jobs) stands out at a glance rather than blending into the list of job actions:

<img width="1000" height="378" alt="skipped-highlight" src="https://github.com/user-attachments/assets/d7a290e9-2037-4aef-95ae-c07030d4b885" />

## Out of scope (stacked)

- Response `leaseToken` mapping (#54844) and gRPC/REST exposure (#54846).

## Checklist

- [ ] Enable backports when necessary — not a bug fix, no backport needed.

## Related issues

closes #54845
