### PR TITLE
Move swagger paths from UNPROTECTED_PATHS

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
@@ -45,9 +45,6 @@ public class SecurityPathAdapter implements SecurityPathPort {
           "/health",
           "/startup",
           "/post-logout",
-          "/swagger/**",
-          "/swagger-ui/**",
-          "/v3/api-docs/**",
           "/favicon.ico");
 
   private static final Set<String> WEBAPP_PATHS =
@@ -70,7 +67,10 @@ public class SecurityPathAdapter implements SecurityPathPort {
           "/decisions/*",
           "/instances",
           "/instances/*",
-          "/default-ui.css");
+          "/default-ui.css",
+          "/swagger/**",
+          "/swagger-ui/**",
+          "/v3/api-docs/**");
 
   private static final Set<String> UNAUTHENTICATED_WEBAPP_PATHS =
       Set.of(
@@ -81,7 +81,10 @@ public class SecurityPathAdapter implements SecurityPathPort {
           "/tasklist/favicon.ico",
           "/webapp/assets/**",
           "/webapp/custom.css",
-          "/webapp/favicon.ico");
+          "/webapp/favicon.ico",
+          "/swagger/**",
+          "/swagger-ui/**",
+          "/v3/api-docs/**");
 
   // Single source of truth for the web component names; see WebAppProviderAdapter#WEB_APPS.
   private static final Set<String> WEB_COMPONENT_NAMES = WebAppProviderAdapter.WEB_APPS;

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
@@ -45,9 +45,6 @@ class SecurityPathAdapterTest {
             "/health",
             "/startup",
             "/post-logout",
-            "/swagger/**",
-            "/swagger-ui/**",
-            "/v3/api-docs/**",
             "/favicon.ico");
   }
 
@@ -73,7 +70,10 @@ class SecurityPathAdapterTest {
             "/decisions/*",
             "/instances",
             "/instances/*",
-            "/default-ui.css");
+            "/default-ui.css",
+            "/swagger/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**");
   }
 
   @Test
@@ -92,7 +92,10 @@ class SecurityPathAdapterTest {
             "/tasklist/favicon.ico",
             "/webapp/assets/**",
             "/webapp/custom.css",
-            "/webapp/favicon.ico");
+            "/webapp/favicon.ico",
+            "/swagger/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**");
   }
 
   @Test


### PR DESCRIPTION
Move swagger paths from` UNPROTECTED_PATHS` to `WEBAPP_PATHS` and `UNAUTHENTICATED_WEBAPP_PATHS`

Swagger UI and OpenAPI doc paths (`/swagger/**`, `/swagger-ui/**`, `/v3/api-docs/**`) are webapp paths that should be served under the webapp security chain rather than the generic unprotected chain, aligning them with other unauthenticated webapp resources.

Refs #56119

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56119
