### PR TITLE
fix: harden c8run rc release against compose merge race and download flakes

### DIFF
--- a/.github/workflows/c8run-release-rc.yaml
+++ b/.github/workflows/c8run-release-rc.yaml
@@ -75,7 +75,7 @@ jobs:
   verify-compose:
     name: Verify or remediate Docker Compose
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
     permissions:
       contents: read
     steps:
@@ -251,15 +251,73 @@ jobs:
             --field "componentVersions=${component_versions}" \
             --field "reason=C8Run RC ${CAMUNDA_VERSION} preflight"
 
+          # Resolve the dispatched run: its run-name embeds the reason, which is unique per version.
+          # The run id names the bump PR branch (force-compose-bump/<minor>-<run_id>), letting the
+          # poll below track the PR itself instead of only the release body.
+          run_id=""
+          for _ in $(seq 1 12); do
+            run_id="$(gh run list --repo "${DISTRIBUTIONS_REPO}" --workflow docker-compose-force-bump.yaml \
+              --limit 10 --json databaseId,displayTitle \
+              --jq "[.[] | select(.displayTitle | contains(\"C8Run RC ${CAMUNDA_VERSION} preflight\"))][0].databaseId // empty")"
+            [ -n "${run_id}" ] && break
+            sleep 10
+          done
+          if [ -n "${run_id}" ]; then
+            echo "Force-bump run: https://github.com/${DISTRIBUTIONS_REPO}/actions/runs/${run_id}"
+          else
+            echo "::warning::Could not resolve the dispatched force-bump run; falling back to polling the release body only."
+          fi
+          pr_branch="force-compose-bump/${COMPOSE_TAG}-${run_id}"
+
           # Bounded wait for the autorelease to rebuild the rolling release at target across ALL checked
           # components. Poll the release body each round (no zip download); tolerate transient 404.
+          # Track the bump PR alongside: the force-bump's own merge can lose the race against the
+          # branch ruleset's required checks, so arm auto-merge on the PR as soon as it appears and
+          # fail fast only when the PR is closed unmerged. The PR, not the force-bump run's
+          # conclusion, is the source of truth for whether the bump is still in flight.
           echo "Waiting for docker-compose-${COMPOSE_TAG} to reach the target versions..."
+          pr_number=""; pr_url=""; automerge_armed=""
           attempt=1
-          max_attempts=40   # 40 x 30s = 20 min, within the job's 30 min timeout
+          max_attempts=52   # 52 x 30s = 26 min, within the job's 35 min timeout
           until ! compose_behind; do
             if [ "${attempt}" -ge "${max_attempts}" ]; then
-              echo "::error::Timed out after ${attempt} polls waiting for docker-compose-${COMPOSE_TAG} to reach target (still behind:${BEHIND_DETAIL}). The force-bump may have failed — check its run in ${DISTRIBUTIONS_REPO}."
+              echo "::error::Timed out after ${attempt} polls waiting for docker-compose-${COMPOSE_TAG} to reach target (still behind:${BEHIND_DETAIL}). Bump PR: ${pr_url:-not found}."
               exit 1
+            fi
+            if [ -n "${run_id}" ]; then
+              if [ -z "${pr_number}" ]; then
+                pr_json="$(gh pr list --repo "${DISTRIBUTIONS_REPO}" --head "${pr_branch}" --state all \
+                  --json number,url --jq '.[0] // empty' || true)"
+                if [ -n "${pr_json}" ]; then
+                  pr_number="$(jq -r '.number' <<<"${pr_json}")"
+                  pr_url="$(jq -r '.url' <<<"${pr_json}")"
+                  echo "Bump PR: ${pr_url}"
+                fi
+              fi
+              if [ -n "${pr_number}" ]; then
+                pr_state="$(gh pr view "${pr_number}" --repo "${DISTRIBUTIONS_REPO}" --json state --jq .state || true)"
+                case "${pr_state}" in
+                  CLOSED)
+                    echo "::error::Bump PR ${pr_url} was closed without merging; docker-compose-${COMPOSE_TAG} cannot reach target (still behind:${BEHIND_DETAIL}). Force-bump run: https://github.com/${DISTRIBUTIONS_REPO}/actions/runs/${run_id}"
+                    exit 1
+                    ;;
+                  OPEN)
+                    if [ -z "${automerge_armed}" ]; then
+                      # Same remediation an on-call would do by hand: the distro app already merges
+                      # these PRs, so arming auto-merge needs no extra permissions.
+                      if gh pr merge "${pr_number}" --repo "${DISTRIBUTIONS_REPO}" --auto --squash; then
+                        automerge_armed=1
+                        echo "Armed auto-merge on ${pr_url}; it merges as soon as required checks pass."
+                      else
+                        echo "::warning::Could not arm auto-merge on ${pr_url}; it may need a manual merge."
+                      fi
+                    fi
+                    if [ $((attempt % 10)) -eq 0 ]; then
+                      echo "::warning::Bump PR ${pr_url} is still open after ${attempt} polls; check its required checks."
+                    fi
+                    ;;
+                esac
+              fi
             fi
             echo "  attempt ${attempt}/${max_attempts}: still behind:${BEHIND_DETAIL}; waiting 30s..."
             attempt=$((attempt + 1))

--- a/c8run/internal/archive/archive.go
+++ b/c8run/internal/archive/archive.go
@@ -68,14 +68,14 @@ func DownloadFile(filepath string, url string, authToken string) error {
 
 // downloadToFile performs one download attempt into path (truncating it) and reports
 // whether a failure is transient (network error, 5xx) and worth retrying.
-func downloadToFile(path string, url string, authToken string) (bool, error) {
+func downloadToFile(path string, url string, authToken string) (retryable bool, err error) {
 	out, err := os.Create(path)
 	if err != nil {
 		return false, fmt.Errorf("DownloadFile: failed to open file: %s\n%w\n%s", path, err, debug.Stack())
 	}
 	defer func() {
-		if err := out.Close(); err != nil {
-			log.Error().Err(err).Msg("failed to close file")
+		if closeErr := out.Close(); closeErr != nil && err == nil {
+			retryable, err = true, fmt.Errorf("DownloadFile: failed to close partial file: %s\n%w\n%s", path, closeErr, debug.Stack())
 		}
 	}()
 

--- a/c8run/internal/archive/archive.go
+++ b/c8run/internal/archive/archive.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -20,6 +21,10 @@ const (
 	OpenFlagsForWriting = os.O_RDWR | os.O_CREATE | os.O_TRUNC
 	ReadWriteMode       = 0755
 )
+
+// downloadRetryDelays gates the wait before each retry of a transient download
+// failure; the attempt count is len(downloadRetryDelays)+1. Overridable in tests.
+var downloadRetryDelays = []time.Duration{5 * time.Second, 15 * time.Second}
 
 func DownloadFile(filepath string, url string, authToken string) error {
 	info, err := os.Stat(filepath)
@@ -35,9 +40,38 @@ func DownloadFile(filepath string, url string, authToken string) error {
 		return fmt.Errorf("DownloadFile: failed to stat file: %s\n%w\n%s", filepath, err, debug.Stack())
 	}
 
-	out, err := os.Create(filepath)
+	// Download to a .partial file and rename into place on success, so an interrupted
+	// attempt can never leave a truncated file that a later run mistakes for a complete one.
+	partialPath := filepath + ".partial"
+	var lastErr error
+	for attempt := 0; ; attempt++ {
+		retryable, err := downloadToFile(partialPath, url, authToken)
+		if err == nil {
+			if renameErr := os.Rename(partialPath, filepath); renameErr != nil {
+				return fmt.Errorf("DownloadFile: failed to move download into place: %s\n%w\n%s", filepath, renameErr, debug.Stack())
+			}
+			fmt.Println("File downloaded successfully to " + filepath)
+			return nil
+		}
+		lastErr = err
+		if !retryable || attempt >= len(downloadRetryDelays) {
+			break
+		}
+		log.Warn().Err(err).Str("url", url).Int("attempt", attempt+1).Msg("download failed; retrying")
+		time.Sleep(downloadRetryDelays[attempt])
+	}
+	if removeErr := os.Remove(partialPath); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+		log.Error().Err(removeErr).Str("path", partialPath).Msg("failed to remove partial download")
+	}
+	return lastErr
+}
+
+// downloadToFile performs one download attempt into path (truncating it) and reports
+// whether a failure is transient (network error, 5xx) and worth retrying.
+func downloadToFile(path string, url string, authToken string) (bool, error) {
+	out, err := os.Create(path)
 	if err != nil {
-		return fmt.Errorf("DownloadFile: failed to open file: %s\n%w\n%s", filepath, err, debug.Stack())
+		return false, fmt.Errorf("DownloadFile: failed to open file: %s\n%w\n%s", path, err, debug.Stack())
 	}
 	defer func() {
 		if err := out.Close(); err != nil {
@@ -48,7 +82,7 @@ func DownloadFile(filepath string, url string, authToken string) error {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return fmt.Errorf("DownloadFile: failed to create request for url: %s\n%w\n%s", url, err, debug.Stack())
+		return false, fmt.Errorf("DownloadFile: failed to create request for url: %s\n%w\n%s", url, err, debug.Stack())
 	}
 
 	if strings.HasPrefix(authToken, "Basic ") {
@@ -59,7 +93,7 @@ func DownloadFile(filepath string, url string, authToken string) error {
 
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("DownloadFile: failed to download from url: %s\n%w\n%s", url, err, debug.Stack())
+		return true, fmt.Errorf("DownloadFile: failed to download from url: %s\n%w\n%s", url, err, debug.Stack())
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -68,16 +102,13 @@ func DownloadFile(filepath string, url string, authToken string) error {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("DownloadFile: bad http status: %s", resp.Status)
+		return resp.StatusCode >= http.StatusInternalServerError, fmt.Errorf("DownloadFile: bad http status: %s", resp.Status)
 	}
 
-	_, err = io.Copy(out, resp.Body)
-	if err != nil {
-		return fmt.Errorf("DownloadFile: failed to write to file %s\n%w\n%s", filepath, err, debug.Stack())
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		return true, fmt.Errorf("DownloadFile: failed to write to file %s\n%w\n%s", path, err, debug.Stack())
 	}
-
-	fmt.Println("File downloaded successfully to " + filepath)
-	return nil
+	return false, nil
 }
 
 func CreateTarGzArchive(files []string, buf io.Writer, sourceRoot, targetRoot string) error {

--- a/c8run/internal/archive/archive_test.go
+++ b/c8run/internal/archive/archive_test.go
@@ -1,0 +1,186 @@
+package archive
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func shrinkRetryDelays(t *testing.T) {
+	t.Helper()
+	originalDelays := downloadRetryDelays
+	downloadRetryDelays = []time.Duration{time.Millisecond, time.Millisecond}
+	t.Cleanup(func() { downloadRetryDelays = originalDelays })
+}
+
+func TestDownloadFileWritesContentAtomically(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer server.Close()
+	target := filepath.Join(t.TempDir(), "artifact.tar.gz")
+
+	err := DownloadFile(target, server.URL, "")
+
+	require.NoError(t, err)
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(content))
+	assert.NoFileExists(t, target+".partial")
+}
+
+func TestDownloadFileRetriesTransientServerErrors(t *testing.T) {
+	shrinkRetryDelays(t)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer server.Close()
+	target := filepath.Join(t.TempDir(), "artifact.tar.gz")
+
+	err := DownloadFile(target, server.URL, "")
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 3, requests.Load())
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(content))
+	assert.NoFileExists(t, target+".partial")
+}
+
+func TestDownloadFileRetriesTruncatedBody(t *testing.T) {
+	shrinkRetryDelays(t)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			// Announce more bytes than are sent, then drop the connection mid-body —
+			// the client sees an error during io.Copy, like a broken stream.
+			w.Header().Set("Content-Length", "1024")
+			_, _ = w.Write([]byte("trunc"))
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+			hijacker, ok := w.(http.Hijacker)
+			require.True(t, ok)
+			conn, _, err := hijacker.Hijack()
+			require.NoError(t, err)
+			_ = conn.Close()
+			return
+		}
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer server.Close()
+	target := filepath.Join(t.TempDir(), "artifact.tar.gz")
+
+	err := DownloadFile(target, server.URL, "")
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, requests.Load())
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(content))
+	assert.NoFileExists(t, target+".partial")
+}
+
+func TestDownloadFileDoesNotRetryClientErrors(t *testing.T) {
+	shrinkRetryDelays(t)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+	target := filepath.Join(t.TempDir(), "artifact.tar.gz")
+
+	err := DownloadFile(target, server.URL, "")
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "bad http status")
+	assert.EqualValues(t, 1, requests.Load())
+	assert.NoFileExists(t, target)
+	assert.NoFileExists(t, target+".partial")
+}
+
+func TestDownloadFileGivesUpAfterRetryBudget(t *testing.T) {
+	shrinkRetryDelays(t)
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	target := filepath.Join(t.TempDir(), "artifact.tar.gz")
+
+	err := DownloadFile(target, server.URL, "")
+
+	require.Error(t, err)
+	assert.EqualValues(t, len(downloadRetryDelays)+1, requests.Load())
+	assert.NoFileExists(t, target)
+	assert.NoFileExists(t, target+".partial")
+}
+
+func TestDownloadFileSkipsExistingNonEmptyFile(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		requests.Add(1)
+		_, _ = w.Write([]byte("fresh"))
+	}))
+	defer server.Close()
+	target := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	require.NoError(t, os.WriteFile(target, []byte("existing"), 0o644))
+
+	err := DownloadFile(target, server.URL, "")
+
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, requests.Load())
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "existing", string(content))
+}
+
+func TestDownloadFileReplacesExistingEmptyFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer server.Close()
+	target := filepath.Join(t.TempDir(), "artifact.tar.gz")
+	require.NoError(t, os.WriteFile(target, nil, 0o644))
+
+	err := DownloadFile(target, server.URL, "")
+
+	require.NoError(t, err)
+	content, err := os.ReadFile(target)
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(content))
+}
+
+func TestDownloadFileSendsAuthorizationHeader(t *testing.T) {
+	var gotAuth atomic.Value
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth.Store(r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte("payload"))
+	}))
+	defer server.Close()
+
+	// Built at runtime so secret scanners do not mistake the literal for a real credential.
+	basicAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("test-user:test-pass"))
+	basicTarget := filepath.Join(t.TempDir(), "basic.tar.gz")
+	require.NoError(t, DownloadFile(basicTarget, server.URL, basicAuth))
+	assert.Equal(t, basicAuth, gotAuth.Load())
+
+	bearerTarget := filepath.Join(t.TempDir(), "bearer.tar.gz")
+	require.NoError(t, DownloadFile(bearerTarget, server.URL, "token123"))
+	assert.Equal(t, "Bearer token123", gotAuth.Load())
+}


### PR DESCRIPTION
## Description

Hardens the C8Run RC workflow against the two failure classes from run [28937270047](https://github.com/camunda/camunda/actions/runs/28937270047):

- The verify-compose gate now resolves the dispatched force-bump run, tracks its bump PR by branch name, arms auto-merge on it with the distro app token, fails fast when the PR is closed unmerged, and polls up to 26 min (job timeout 35 min) instead of 20 min of blind release-body polling.
- The packager's `DownloadFile` downloads to a `.partial` file renamed into place on success, and retries transient failures (network errors, mid-stream copy errors, 5xx) up to 3 attempts with backoff; 4xx is never retried. Covered by new unit tests.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #57213
