### PR TITLE
feat: add variable name autocomplete endpoint

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/VariableNameDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/VariableNameDbQuery.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.filter.VariableFilter;
+import java.util.List;
+
+public record VariableNameDbQuery(
+    VariableFilter filter,
+    List<String> authorizedResourceIds,
+    List<String> authorizedTenantIds,
+    Integer limit) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.read.RdbmsReaderConfig;
 import io.camunda.db.rdbms.read.domain.VariableDbQuery;
+import io.camunda.db.rdbms.read.domain.VariableNameDbQuery;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.sql.columns.VariableSearchColumn;
 import io.camunda.search.clients.reader.VariableReader;
@@ -16,6 +17,7 @@ import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.VariableFilter.Builder;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.search.sort.VariableSort;
 import io.camunda.security.api.model.authz.AuthorizationResourceType;
@@ -87,5 +89,25 @@ public class VariableDbReader extends AbstractEntityReader<VariableEntity>
 
   public List<String> findLookupVariableNames(final long processDefinitionKey) {
     return variableMapper.findLookupVariableNames(processDefinitionKey);
+  }
+
+  @Override
+  public List<String> searchVariableNames(
+      final VariableNameQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    if (query.filter().processDefinitionKeyOperations().isEmpty()
+        || shouldReturnEmptyResult(resourceAccessChecks)) {
+      return List.of();
+    }
+
+    final var authorizedResourceIds =
+        resourceAccessChecks
+            .getAuthorizedResourceIdsByType()
+            .getOrDefault(AuthorizationResourceType.PROCESS_DEFINITION.name(), List.of());
+    return variableMapper.findVariableNamesByPrefix(
+        new VariableNameDbQuery(
+            query.filter(),
+            authorizedResourceIds,
+            resourceAccessChecks.getAuthorizedTenantIds(),
+            query.page().size()));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableDbReader.java
@@ -103,7 +103,7 @@ public class VariableDbReader extends AbstractEntityReader<VariableEntity>
         resourceAccessChecks
             .getAuthorizedResourceIdsByType()
             .getOrDefault(AuthorizationResourceType.PROCESS_DEFINITION.name(), List.of());
-    return variableMapper.findVariableNamesByPrefix(
+    return variableMapper.findVariableNames(
         new VariableNameDbQuery(
             query.filter(),
             authorizedResourceIds,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
@@ -41,10 +41,10 @@ public interface VariableMapper extends ProcessInstanceDependantMapper {
   List<String> findLookupVariableNames(@Param("processDefinitionKey") long processDefinitionKey);
 
   /**
-   * Returns distinct variable names for the given process definition, narrowed by the filter's name
-   * prefix, ordered alphabetically and capped at the query's limit.
+   * Returns distinct variable names for the given process definition, narrowed by the query's name
+   * filter, ordered alphabetically and capped at the query's limit.
    */
-  List<String> findVariableNamesByPrefix(VariableNameDbQuery query);
+  List<String> findVariableNames(VariableNameDbQuery query);
 
   /** Deletes all lookup entries for the given process definition keys. */
   void deleteLookupByProcessDefinitionKeys(List<Long> processDefinitionKeys, int limit);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.sql;
 
 import io.camunda.db.rdbms.read.domain.VariableDbQuery;
+import io.camunda.db.rdbms.read.domain.VariableNameDbQuery;
 import io.camunda.db.rdbms.write.domain.ProcessDefinitionVariableNameLookupDbModel;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.db.rdbms.write.queue.BatchInsertDto;
@@ -38,6 +39,12 @@ public interface VariableMapper extends ProcessInstanceDependantMapper {
 
   /** Returns all variable names recorded for the given process definition key. */
   List<String> findLookupVariableNames(@Param("processDefinitionKey") long processDefinitionKey);
+
+  /**
+   * Returns distinct variable names for the given process definition, narrowed by the filter's name
+   * prefix, ordered alphabetically and capped at the query's limit.
+   */
+  List<String> findVariableNamesByPrefix(VariableNameDbQuery query);
 
   /** Deletes all lookup entries for the given process definition keys. */
   void deleteLookupByProcessDefinitionKeys(List<Long> processDefinitionKeys, int limit);

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -270,6 +270,52 @@
     WHERE PROCESS_DEFINITION_KEY = #{processDefinitionKey}
   </select>
 
+  <!-- Returns distinct, prefix-narrowed, authorized variable names, ordered alphabetically and capped at the limit. -->
+  <select id="findVariableNamesByPrefix" parameterType="io.camunda.db.rdbms.read.domain.VariableNameDbQuery"
+    resultType="java.lang.String">
+    SELECT DISTINCT l.VAR_NAME
+    FROM ${prefix}PROCESS_DEF_VAR_NAME_LOOKUP l
+    JOIN ${prefix}PROCESS_DEFINITION pd ON pd.PROCESS_DEFINITION_KEY = l.PROCESS_DEFINITION_KEY
+    <where>
+      <if test="authorizedResourceIds != null and !authorizedResourceIds.isEmpty()">
+        AND pd.PROCESS_DEFINITION_ID IN
+        <foreach collection="authorizedResourceIds" item="resourceId" open="(" separator="," close=")">
+          #{resourceId}
+        </foreach>
+      </if>
+      <if test="authorizedTenantIds != null and !authorizedTenantIds.isEmpty()">
+        AND pd.TENANT_ID IN
+        <foreach collection="authorizedTenantIds" item="tenantId" open="(" separator="," close=")">
+          #{tenantId}
+        </foreach>
+      </if>
+      <if test="filter.processDefinitionKeyOperations != null and !filter.processDefinitionKeyOperations.isEmpty()">
+        <foreach collection="filter.processDefinitionKeyOperations" item="operation">
+          AND l.PROCESS_DEFINITION_KEY
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+      <if test="filter.nameOperations != null and !filter.nameOperations.isEmpty()">
+        <foreach collection="filter.nameOperations" item="operation">
+          AND l.VAR_NAME
+          <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        </foreach>
+      </if>
+    </where>
+    ORDER BY l.VAR_NAME
+    <choose>
+      <when test="_databaseId == 'mssql'">
+        OFFSET 0 ROWS FETCH NEXT #{limit} ROWS ONLY
+      </when>
+      <when test="_databaseId == 'oracle'">
+        FETCH FIRST #{limit} ROWS ONLY
+      </when>
+      <otherwise>
+        LIMIT #{limit}
+      </otherwise>
+    </choose>
+  </select>
+
   <!-- Removes all lookup entries for the given process definitions, used when a process definition is deleted. -->
   <delete id="deleteLookupByProcessDefinitionKeys">
     DELETE FROM ${prefix}PROCESS_DEF_VAR_NAME_LOOKUP

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -270,8 +270,8 @@
     WHERE PROCESS_DEFINITION_KEY = #{processDefinitionKey}
   </select>
 
-  <!-- Returns distinct, prefix-narrowed, authorized variable names, ordered alphabetically and capped at the limit. -->
-  <select id="findVariableNamesByPrefix" parameterType="io.camunda.db.rdbms.read.domain.VariableNameDbQuery"
+  <!-- Returns distinct, name-narrowed, authorized variable names, ordered alphabetically and capped at the limit. -->
+  <select id="findVariableNames" parameterType="io.camunda.db.rdbms.read.domain.VariableNameDbQuery"
     resultType="java.lang.String">
     SELECT DISTINCT l.VAR_NAME
     FROM ${prefix}PROCESS_DEF_VAR_NAME_LOOKUP l

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/VariableDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/VariableDbReaderTest.java
@@ -81,7 +81,7 @@ class VariableDbReaderTest {
     final var names = variableDbReader.searchVariableNames(query, resourceAccessChecks);
 
     assertThat(names).isEmpty();
-    verify(variableMapper, never()).findVariableNamesByPrefix(any());
+    verify(variableMapper, never()).findVariableNames(any());
   }
 
   @Test
@@ -97,13 +97,13 @@ class VariableDbReaderTest {
     final var names = variableDbReader.searchVariableNames(query, resourceAccessChecks);
 
     assertThat(names).isEmpty();
-    verify(variableMapper, never()).findVariableNamesByPrefix(any());
+    verify(variableMapper, never()).findVariableNames(any());
   }
 
   @Test
   void shouldInjectAuthorizedProcessDefinitionIdsIntoNameQuery() {
     final var authorizedIds = List.of("process-a", "process-b");
-    when(variableMapper.findVariableNamesByPrefix(any())).thenReturn(List.of("amount", "total"));
+    when(variableMapper.findVariableNames(any())).thenReturn(List.of("amount", "total"));
 
     final VariableNameQuery query =
         VariableNameQuery.of(b -> b.filter(f -> f.processDefinitionKeys(1L)).page(p -> p.size(5)));
@@ -118,7 +118,7 @@ class VariableDbReaderTest {
 
     assertThat(names).containsExactly("amount", "total");
     verify(variableMapper)
-        .findVariableNamesByPrefix(
+        .findVariableNames(
             argThat(
                 (VariableNameDbQuery q) ->
                     q.authorizedResourceIds().equals(authorizedIds) && q.limit() == 5));

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/VariableDbReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/VariableDbReaderTest.java
@@ -9,12 +9,16 @@ package io.camunda.db.rdbms.read.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.db.rdbms.read.domain.VariableNameDbQuery;
 import io.camunda.db.rdbms.sql.VariableMapper;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.security.core.authz.AuthorizationCheck;
@@ -64,5 +68,59 @@ class VariableDbReaderTest {
     assertThat(result.total()).isEqualTo(21L);
     assertThat(result.items()).isEmpty();
     verify(variableMapper, times(0)).search(any());
+  }
+
+  // ===== searchVariableNames =====
+
+  @Test
+  void shouldReturnEmptyListWhenNoProcessDefinitionKeyGiven() {
+    final VariableNameQuery query = VariableNameQuery.of(b -> b);
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(AuthorizationCheck.disabled(), TenantCheck.disabled());
+
+    final var names = variableDbReader.searchVariableNames(query, resourceAccessChecks);
+
+    assertThat(names).isEmpty();
+    verify(variableMapper, never()).findVariableNamesByPrefix(any());
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenAuthorizedResourceIdsIsNullForNameSearch() {
+    final VariableNameQuery query =
+        VariableNameQuery.of(b -> b.filter(f -> f.processDefinitionKeys(1L)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(
+                RequiredAuthorization.of(a -> a.processDefinition().readProcessInstance())),
+            TenantCheck.disabled());
+
+    final var names = variableDbReader.searchVariableNames(query, resourceAccessChecks);
+
+    assertThat(names).isEmpty();
+    verify(variableMapper, never()).findVariableNamesByPrefix(any());
+  }
+
+  @Test
+  void shouldInjectAuthorizedProcessDefinitionIdsIntoNameQuery() {
+    final var authorizedIds = List.of("process-a", "process-b");
+    when(variableMapper.findVariableNamesByPrefix(any())).thenReturn(List.of("amount", "total"));
+
+    final VariableNameQuery query =
+        VariableNameQuery.of(b -> b.filter(f -> f.processDefinitionKeys(1L)).page(p -> p.size(5)));
+    final ResourceAccessChecks resourceAccessChecks =
+        ResourceAccessChecks.of(
+            AuthorizationCheck.enabled(
+                RequiredAuthorization.of(
+                    a -> a.processDefinition().readProcessInstance().resourceIds(authorizedIds))),
+            TenantCheck.disabled());
+
+    final var names = variableDbReader.searchVariableNames(query, resourceAccessChecks);
+
+    assertThat(names).containsExactly("amount", "total");
+    verify(variableMapper)
+        .findVariableNamesByPrefix(
+            argThat(
+                (VariableNameDbQuery q) ->
+                    q.authorizedResourceIds().equals(authorizedIds) && q.limit() == 5));
   }
 }

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryFilterMapper.java
@@ -35,6 +35,7 @@ import io.camunda.gateway.protocol.model.ClusterVariableSearchQueryFilterRequest
 import io.camunda.gateway.protocol.model.ElementInstanceFilterFields;
 import io.camunda.gateway.protocol.model.GlobalTaskListenerSearchQueryFilterRequest;
 import io.camunda.gateway.protocol.model.IncidentProcessInstanceStatisticsByDefinitionFilter;
+import io.camunda.gateway.protocol.model.ProcessDefinitionVariableNameFilter;
 import io.camunda.gateway.protocol.model.ProcessInstanceFilterFields;
 import io.camunda.gateway.protocol.model.ResourceFilter;
 import io.camunda.gateway.protocol.model.StringFilterProperty;
@@ -357,6 +358,17 @@ public class SearchQueryFilterMapper {
     return validationErrors.isEmpty()
         ? Either.right(builder.build())
         : Either.left(validationErrors);
+  }
+
+  static Either<List<String>, VariableFilter> toVariableNameFilter(
+      final long processDefinitionKey, final @Nullable ProcessDefinitionVariableNameFilter filter) {
+    final var builder = FilterBuilders.variable().processDefinitionKeys(processDefinitionKey);
+
+    if (filter != null) {
+      ofNullable(filter.getName()).map(mapToStringOperations()).ifPresent(builder::nameOperations);
+    }
+
+    return Either.right(builder.build());
   }
 
   static ClusterVariableFilter toClusterVariableFilter(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryRequestMapper.java
@@ -57,6 +57,7 @@ import io.camunda.search.query.TypedSearchQueryBuilder;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.search.sort.SortOption;
 import io.camunda.search.sort.SortOptionBuilders;
@@ -665,6 +666,22 @@ public final class SearchQueryRequestMapper {
             SearchQuerySortRequestMapper::applyVariableSortField);
     final var filter = SearchQueryFilterMapper.toVariableFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::variableSearchQuery);
+  }
+
+  public static Either<ProblemDetail, VariableNameQuery> toVariableNameQuery(
+      final long processDefinitionKey,
+      final @Nullable ProcessDefinitionVariableNameSearchQuery request) {
+    if (request == null) {
+      return Either.right(
+          SearchQueryBuilders.variableNameSearchQuery()
+              .filter(FilterBuilders.variable().processDefinitionKeys(processDefinitionKey).build())
+              .build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var filter =
+        SearchQueryFilterMapper.toVariableNameFilter(processDefinitionKey, request.getFilter());
+    return buildSearchQuery(
+        filter, Either.right(null), page, SearchQueryBuilders::variableNameSearchQuery);
   }
 
   public static Either<ProblemDetail, ClusterVariableQuery> toClusterVariableQuery(

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -129,6 +129,8 @@ import io.camunda.gateway.protocol.model.ProcessDefinitionMessageSubscriptionSta
 import io.camunda.gateway.protocol.model.ProcessDefinitionMessageSubscriptionStatisticsResult;
 import io.camunda.gateway.protocol.model.ProcessDefinitionResult;
 import io.camunda.gateway.protocol.model.ProcessDefinitionSearchQueryResult;
+import io.camunda.gateway.protocol.model.ProcessDefinitionVariableNameSearchQueryResult;
+import io.camunda.gateway.protocol.model.ProcessDefinitionVariableNameSearchResult;
 import io.camunda.gateway.protocol.model.ProcessElementStatisticsResult;
 import io.camunda.gateway.protocol.model.ProcessInstanceCallHierarchyEntry;
 import io.camunda.gateway.protocol.model.ProcessInstanceElementStatisticsQueryResult;
@@ -1576,6 +1578,24 @@ public final class SearchQueryResponseMapper {
         .isTruncated(truncateValues && variableEntity.isPreview())
         .value(!truncateValues ? getFullValueIfPresent(variableEntity) : variableEntity.value())
         .build();
+  }
+
+  public static ProcessDefinitionVariableNameSearchQueryResult toVariableNameSearchResponse(
+      final List<String> names) {
+    return ProcessDefinitionVariableNameSearchQueryResult.Builder.create()
+        .page(
+            SearchQueryPageResponse.Builder.create()
+                .totalItems((long) names.size())
+                .hasMoreTotalItems(false)
+                .startCursor(null)
+                .endCursor(null)
+                .build())
+        .items(names.stream().map(SearchQueryResponseMapper::toVariableNameResult).toList())
+        .build();
+  }
+
+  private static ProcessDefinitionVariableNameSearchResult toVariableNameResult(final String name) {
+    return ProcessDefinitionVariableNameSearchResult.Builder.create().name(name).build();
   }
 
   public static VariableResult toVariableItem(final VariableEntity variableEntity) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -32,6 +32,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.List;
@@ -432,7 +433,9 @@ class ProcessInstanceAuthorizationIT {
   }
 
   private static String basicAuthentication(final String username) {
-    return "Basic " + Base64.getEncoder().encodeToString((username + ":password").getBytes());
+    return "Basic "
+        + Base64.getEncoder()
+            .encodeToString((username + ":password").getBytes(StandardCharsets.UTF_8));
   }
 
   private static URI createUri(final CamundaClient client, final String path)

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -13,6 +13,9 @@ import static io.camunda.client.api.search.enums.ResourceType.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.enums.BatchOperationType;
@@ -23,8 +26,16 @@ import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.List;
+import java.util.stream.StreamSupport;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
@@ -283,6 +294,21 @@ class ProcessInstanceAuthorizationIT {
   }
 
   @Test
+  void searchVariableNamesShouldReturnEmptyForUnauthorizedProcessDefinition(
+      @Authenticated(ADMIN) final CamundaClient adminClient,
+      @Authenticated(USER1) final CamundaClient camundaClient)
+      throws Exception {
+    // given: USER1 is only authorized to read process instances of PROCESS_ID_1
+    final var processDefinitionKey = getProcessDefinitionKey(adminClient, PROCESS_ID_2);
+
+    // when
+    final var names = searchVariableNames(camundaClient, USER1, processDefinitionKey);
+
+    // then: no names leaked for a process definition the caller is not authorized to read
+    assertThat(names).isEmpty();
+  }
+
+  @Test
   public void resolveIncidentsShouldReturnBatchOperation(
       @Authenticated(ADMIN) final CamundaClient adminClient,
       @Authenticated(USER3) final CamundaClient camundaClient) {
@@ -372,6 +398,48 @@ class ProcessInstanceAuthorizationIT {
         .items()
         .getFirst()
         .getProcessDefinitionKey();
+  }
+
+  /**
+   * Issues a raw HTTP call to {@code POST
+   * /v2/process-definitions/{processDefinitionKey}/variable-names/search}, authenticated as the
+   * given user. The endpoint has no fluent Java client method yet.
+   */
+  private List<String> searchVariableNames(
+      final CamundaClient camundaClient, final String username, final long processDefinitionKey)
+      throws Exception {
+    final var body = "{\"page\": {\"limit\": 100}}";
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(
+                createUri(
+                    camundaClient,
+                    "v2/process-definitions/%d/variable-names/search"
+                        .formatted(processDefinitionKey)))
+            .header("Content-Type", "application/json")
+            .header("Authorization", basicAuthentication(username))
+            .POST(BodyPublishers.ofString(body))
+            .build();
+    final var response = HttpClient.newHttpClient().send(request, BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+
+    final var objectMapper =
+        new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    final JsonNode root = objectMapper.readTree(response.body());
+    return StreamSupport.stream(root.get("items").spliterator(), false)
+        .map(item -> item.get("name").asText())
+        .toList();
+  }
+
+  private static String basicAuthentication(final String username) {
+    return "Basic " + Base64.getEncoder().encodeToString((username + ":password").getBytes());
+  }
+
+  private static URI createUri(final CamundaClient client, final String path)
+      throws URISyntaxException {
+    final String base = client.getConfiguration().getRestAddress().toString();
+    final String separator = base.endsWith("/") ? "" : "/";
+    return new URI(base + separator + path);
   }
 
   private static void deployResource(final CamundaClient camundaClient, final String resourceName) {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableNameSearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/VariableNameSearchIT.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployProcessAndWaitForIt;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.StreamSupport;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Cross-exporter parity coverage for {@code POST
+ * /v2/process-definitions/{processDefinitionKey}/variable-names/search}. The endpoint has no fluent
+ * Java client method yet, so requests are issued as raw HTTP calls against the default
+ * (unauthenticated) {@link CamundaClient} REST address.
+ */
+@MultiDbTest
+class VariableNameSearchIT {
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  private static CamundaClient camundaClient;
+  private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+  private static long processDefinitionKey;
+  private static long wildcardProcessDefinitionKey;
+
+  @BeforeAll
+  static void beforeAll() throws Exception {
+    final var process = deployProcessAndWaitForIt(camundaClient, "process/bpm_variable_test.bpmn");
+    processDefinitionKey = process.getProcessDefinitionKey();
+
+    startProcessInstance(
+        camundaClient,
+        "bpmProcessVariable",
+        Map.of("amount", 1, "amendment", 2, "total", 3, "unrelated", 4));
+
+    waitForVariableNames(
+        processDefinitionKey,
+        null,
+        100,
+        List.of("amendment", "amount", "process01", "task01", "task02", "total", "unrelated"));
+
+    final var wildcardProcess =
+        deployProcessAndWaitForIt(camundaClient, "process/bpm_variable_wildcard_test.bpmn");
+    wildcardProcessDefinitionKey = wildcardProcess.getProcessDefinitionKey();
+
+    startProcessInstance(
+        camundaClient, "bpmProcessVariableWildcard", Map.of("50*off", 1, "50xoff", 2));
+
+    waitForVariableNames(wildcardProcessDefinitionKey, null, 100, List.of("50*off", "50xoff"));
+  }
+
+  @Test
+  void shouldReturnNamesOrderedAlphabetically() throws Exception {
+    // when
+    final var names = searchVariableNames(processDefinitionKey, null, 100);
+
+    // then
+    assertThat(names)
+        .containsExactly(
+            "amendment", "amount", "process01", "task01", "task02", "total", "unrelated");
+  }
+
+  @Test
+  void shouldNarrowByNamePrefix() throws Exception {
+    // when
+    final var names = searchVariableNames(processDefinitionKey, "am*", 100);
+
+    // then
+    assertThat(names).containsExactly("amendment", "amount");
+  }
+
+  @Test
+  void shouldCapAtClientSuppliedLimit() throws Exception {
+    // when
+    final var names = searchVariableNames(processDefinitionKey, null, 2);
+
+    // then
+    assertThat(names).containsExactly("amendment", "amount");
+  }
+
+  @Test
+  void shouldEscapeLiteralWildcardCharactersInPrefix() throws Exception {
+    // when: the literal asterisk must be escaped, not treated as the wildcard character
+    final var names = searchVariableNames(wildcardProcessDefinitionKey, "50\\\\**", 100);
+
+    // then
+    assertThat(names).containsExactly("50*off");
+  }
+
+  @Test
+  void shouldReturnEmptyForUnknownProcessDefinitionKey() throws Exception {
+    // when
+    final var names = searchVariableNames(999999999L, null, 100);
+
+    // then
+    assertThat(names).isEmpty();
+  }
+
+  private static void waitForVariableNames(
+      final long processDefinitionKey,
+      final String namePrefix,
+      final int limit,
+      final List<String> expectedNames) {
+    Awaitility.await("should receive variable names from secondary storage")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .ignoreExceptions()
+        .untilAsserted(
+            () ->
+                assertThat(searchVariableNames(processDefinitionKey, namePrefix, limit))
+                    .containsExactlyElementsOf(expectedNames));
+  }
+
+  private static List<String> searchVariableNames(
+      final long processDefinitionKey, final String namePrefix, final int limit)
+      throws IOException, InterruptedException, URISyntaxException {
+    final var filter =
+        namePrefix == null ? "" : "\"filter\": {\"name\": {\"$like\": \"" + namePrefix + "\"}}, ";
+    final var body = "{%s\"page\": {\"limit\": %d}}".formatted(filter, limit);
+
+    final var response = sendSearchRequest(processDefinitionKey, body);
+    assertThat(response.statusCode()).isEqualTo(200);
+    return readNames(response);
+  }
+
+  private static HttpResponse<String> sendSearchRequest(
+      final long processDefinitionKey, final String jsonBody)
+      throws IOException, InterruptedException, URISyntaxException {
+    final var request =
+        HttpRequest.newBuilder()
+            .uri(
+                createUri(
+                    camundaClient,
+                    "v2/process-definitions/%d/variable-names/search"
+                        .formatted(processDefinitionKey)))
+            .header("Content-Type", "application/json")
+            .POST(BodyPublishers.ofString(jsonBody))
+            .build();
+    return HTTP_CLIENT.send(request, BodyHandlers.ofString());
+  }
+
+  private static List<String> readNames(final HttpResponse<String> response) throws IOException {
+    final JsonNode root = OBJECT_MAPPER.readTree(response.body());
+    return StreamSupport.stream(root.get("items").spliterator(), false)
+        .map(item -> item.get("name").asText())
+        .toList();
+  }
+
+  private static URI createUri(final CamundaClient client, final String path)
+      throws URISyntaxException {
+    final String base = client.getConfiguration().getRestAddress().toString();
+    final String separator = base.endsWith("/") ? "" : "/";
+    return new URI(base + separator + path);
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/ProcessDefinitionVariableNameLookupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/ProcessDefinitionVariableNameLookupIT.java
@@ -266,6 +266,30 @@ public class ProcessDefinitionVariableNameLookupIT {
   }
 
   @TestTemplate
+  public void shouldReturnEmptyListWhenCallerUnauthorizedOnTenant(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters writers = rdbmsService.createWriter(0L);
+    final var processDef =
+        ProcessDefinitionFixtures.createAndSaveRandomProcessDefinition(writers, b -> b);
+    final long procDefKey = processDef.processDefinitionKey();
+
+    createInstanceWithVariable(rdbmsService, procDefKey, "amount");
+
+    // when: caller is authorized on the correct process definition but a different tenant
+    final var names =
+        rdbmsService
+            .getVariableReader()
+            .searchVariableNames(
+                VariableNameQuery.of(b -> b.filter(f -> f.processDefinitionKeys(procDefKey))),
+                authorizedFor(processDef.processDefinitionId(), "some-other-tenant"));
+
+    // then: no names leaked across tenants
+    assertThat(names).isEmpty();
+  }
+
+  @TestTemplate
   public void shouldReturnEmptyListWhenNoProcessDefinitionKeyGiven(
       final CamundaRdbmsTestApplication testApplication) {
     // given

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/ProcessDefinitionVariableNameLookupIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/db/variables/ProcessDefinitionVariableNameLookupIT.java
@@ -18,6 +18,11 @@ import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.query.VariableNameQuery;
+import io.camunda.security.core.auth.RequiredAuthorization;
+import io.camunda.security.core.authz.AuthorizationCheck;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.security.core.authz.TenantCheck;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
@@ -142,6 +147,151 @@ public class ProcessDefinitionVariableNameLookupIT {
                 .getVariableReader()
                 .findLookupVariableNames(procDefKey))
         .isEmpty();
+  }
+
+  // ===== searchVariableNames =====
+
+  @TestTemplate
+  public void shouldSearchVariableNamesOrderedAlphabeticallyAndCappedAtLimit(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters writers = rdbmsService.createWriter(0L);
+    final var processDef =
+        ProcessDefinitionFixtures.createAndSaveRandomProcessDefinition(writers, b -> b);
+    final long procDefKey = processDef.processDefinitionKey();
+
+    createInstanceWithVariable(rdbmsService, procDefKey, "charlie");
+    createInstanceWithVariable(rdbmsService, procDefKey, "alpha");
+    createInstanceWithVariable(rdbmsService, procDefKey, "bravo");
+
+    // when
+    final var names =
+        rdbmsService
+            .getVariableReader()
+            .searchVariableNames(
+                VariableNameQuery.of(
+                    b -> b.filter(f -> f.processDefinitionKeys(procDefKey)).page(p -> p.size(2))),
+                authorizedFor(processDef.processDefinitionId(), processDef.tenantId()));
+
+    // then: alphabetical order, capped at limit
+    assertThat(names).containsExactly("alpha", "bravo");
+  }
+
+  @TestTemplate
+  public void shouldSearchVariableNamesNarrowedByPrefix(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters writers = rdbmsService.createWriter(0L);
+    final var processDef =
+        ProcessDefinitionFixtures.createAndSaveRandomProcessDefinition(writers, b -> b);
+    final long procDefKey = processDef.processDefinitionKey();
+
+    createInstanceWithVariable(rdbmsService, procDefKey, "amount");
+    createInstanceWithVariable(rdbmsService, procDefKey, "amendment");
+    createInstanceWithVariable(rdbmsService, procDefKey, "total");
+
+    // when
+    final var names =
+        rdbmsService
+            .getVariableReader()
+            .searchVariableNames(
+                VariableNameQuery.of(
+                    b ->
+                        b.filter(
+                            f ->
+                                f.processDefinitionKeys(procDefKey)
+                                    .nameOperations(
+                                        io.camunda.search.filter.Operation.like("am*")))),
+                authorizedFor(processDef.processDefinitionId(), processDef.tenantId()));
+
+    // then
+    assertThat(names).containsExactly("amendment", "amount");
+  }
+
+  @TestTemplate
+  public void shouldEscapeLiteralWildcardCharactersInPrefix(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters writers = rdbmsService.createWriter(0L);
+    final var processDef =
+        ProcessDefinitionFixtures.createAndSaveRandomProcessDefinition(writers, b -> b);
+    final long procDefKey = processDef.processDefinitionKey();
+
+    createInstanceWithVariable(rdbmsService, procDefKey, "50*off");
+    createInstanceWithVariable(rdbmsService, procDefKey, "50xoff");
+
+    // when: the literal asterisk must be escaped, not treated as the wildcard character
+    final var names =
+        rdbmsService
+            .getVariableReader()
+            .searchVariableNames(
+                VariableNameQuery.of(
+                    b ->
+                        b.filter(
+                            f ->
+                                f.processDefinitionKeys(procDefKey)
+                                    .nameOperations(
+                                        io.camunda.search.filter.Operation.like("50\\**")))),
+                authorizedFor(processDef.processDefinitionId(), processDef.tenantId()));
+
+    // then
+    assertThat(names).containsExactly("50*off");
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyListWhenCallerUnauthorizedOnProcessDefinition(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriters writers = rdbmsService.createWriter(0L);
+    final var processDef =
+        ProcessDefinitionFixtures.createAndSaveRandomProcessDefinition(writers, b -> b);
+    final long procDefKey = processDef.processDefinitionKey();
+
+    createInstanceWithVariable(rdbmsService, procDefKey, "amount");
+
+    // when: caller is authorized on a different process definition
+    final var names =
+        rdbmsService
+            .getVariableReader()
+            .searchVariableNames(
+                VariableNameQuery.of(b -> b.filter(f -> f.processDefinitionKeys(procDefKey))),
+                authorizedFor("some-other-process", processDef.tenantId()));
+
+    // then: no names leaked
+    assertThat(names).isEmpty();
+  }
+
+  @TestTemplate
+  public void shouldReturnEmptyListWhenNoProcessDefinitionKeyGiven(
+      final CamundaRdbmsTestApplication testApplication) {
+    // given
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    // when
+    final var names =
+        rdbmsService
+            .getVariableReader()
+            .searchVariableNames(
+                VariableNameQuery.of(b -> b), authorizedFor("any-process", "any-tenant"));
+
+    // then
+    assertThat(names).isEmpty();
+  }
+
+  private ResourceAccessChecks authorizedFor(
+      final String processDefinitionId, final String tenantId) {
+    return ResourceAccessChecks.of(
+        AuthorizationCheck.enabled(
+            RequiredAuthorization.of(
+                a ->
+                    a.processDefinition()
+                        .readProcessInstance()
+                        .resourceIds(List.of(processDefinitionId)))),
+        TenantCheck.enabled(List.of(tenantId)));
   }
 
   // ---------------------------------------------------------------------------

--- a/qa/acceptance-tests/src/test/resources/process/bpm_variable_wildcard_test.bpmn
+++ b/qa/acceptance-tests/src/test/resources/process/bpm_variable_wildcard_test.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_wildcard_var_test" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="bpmProcessVariableWildcard" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="StartEvent_1" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="bpmProcessVariableWildcard">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="252" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1_di" bpmnElement="Flow_1">
+        <di:waypoint x="188" y="170" />
+        <di:waypoint x="252" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/VariableDocumentReader.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/reader/VariableDocumentReader.java
@@ -7,18 +7,32 @@
  */
 package io.camunda.search.clients.reader;
 
+import io.camunda.search.aggregation.result.VariableNameAggregationResult;
 import io.camunda.search.clients.SearchClientBasedQueryExecutor;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.core.authz.ResourceAccessChecks;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.List;
 
 public class VariableDocumentReader extends DocumentBasedReader implements VariableReader {
 
   public VariableDocumentReader(
       final SearchClientBasedQueryExecutor executor, final IndexDescriptor indexDescriptor) {
     super(executor, indexDescriptor);
+  }
+
+  @Override
+  public List<String> searchVariableNames(
+      final VariableNameQuery query, final ResourceAccessChecks resourceAccessChecks) {
+    if (query.filter().processDefinitionKeyOperations().isEmpty()) {
+      return List.of();
+    }
+    return getSearchExecutor()
+        .aggregate(query, VariableNameAggregationResult.class, resourceAccessChecks)
+        .items();
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -24,6 +24,7 @@ import io.camunda.search.aggregation.ProcessDefinitionMessageSubscriptionStatist
 import io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation;
 import io.camunda.search.aggregation.UsageMetricsAggregation;
 import io.camunda.search.aggregation.UsageMetricsTUAggregation;
+import io.camunda.search.aggregation.VariableNameAggregation;
 import io.camunda.search.aggregation.WaitStateStatisticsAggregation;
 import io.camunda.search.aggregation.result.AggregationResultBase;
 import io.camunda.search.aggregation.result.DecisionDefinitionLatestVersionAggregationResult;
@@ -42,6 +43,7 @@ import io.camunda.search.aggregation.result.ProcessDefinitionMessageSubscription
 import io.camunda.search.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResult;
 import io.camunda.search.aggregation.result.UsageMetricsAggregationResult;
 import io.camunda.search.aggregation.result.UsageMetricsTUAggregationResult;
+import io.camunda.search.aggregation.result.VariableNameAggregationResult;
 import io.camunda.search.aggregation.result.WaitStateStatisticsAggregationResult;
 import io.camunda.search.clients.aggregator.SearchAggregator;
 import io.camunda.search.clients.core.AggregationResult;
@@ -64,6 +66,7 @@ import io.camunda.search.clients.transformers.aggregation.ProcessDefinitionMessa
 import io.camunda.search.clients.transformers.aggregation.ProcessInstanceFlowNodeStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.UsageMetricsTUAggregationTransformer;
+import io.camunda.search.clients.transformers.aggregation.VariableNameAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.WaitStateStatisticsAggregationTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.AggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.DecisionDefinitionLatestVersionAggregationResultTransformer;
@@ -82,6 +85,7 @@ import io.camunda.search.clients.transformers.aggregation.result.ProcessDefiniti
 import io.camunda.search.clients.transformers.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.UsageMetricsTUAggregationResultTransformer;
+import io.camunda.search.clients.transformers.aggregation.result.VariableNameAggregationResultTransformer;
 import io.camunda.search.clients.transformers.aggregation.result.WaitStateStatisticsAggregationResultTransformer;
 import io.camunda.search.clients.transformers.entity.AgentHistoryEntityTransformer;
 import io.camunda.search.clients.transformers.entity.AgentInstanceEntityTransformer;
@@ -292,6 +296,7 @@ import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.search.query.WaitStateStatisticsQuery;
 import io.camunda.search.result.DecisionInstanceQueryResultConfig;
@@ -497,6 +502,7 @@ public final class ServiceTransformers {
             UserTaskQuery.class,
             UserQuery.class,
             VariableQuery.class,
+            VariableNameQuery.class,
             ClusterVariableQuery.class,
             AuditLogQuery.class,
             IncidentProcessInstanceStatisticsByErrorQuery.class,
@@ -751,6 +757,7 @@ public final class ServiceTransformers {
     mappers.put(
         ProcessDefinitionFlowNodeStatisticsAggregation.class,
         new ProcessDefinitionFlowNodeStatisticsAggregationTransformer());
+    mappers.put(VariableNameAggregation.class, new VariableNameAggregationTransformer());
     mappers.put(
         ProcessInstanceFlowNodeStatisticsAggregation.class,
         new ProcessInstanceFlowNodeStatisticsAggregationTransformer());
@@ -794,6 +801,8 @@ public final class ServiceTransformers {
     mappers.put(
         ProcessDefinitionFlowNodeStatisticsAggregationResult.class,
         new ProcessDefinitionFlowNodeStatisticsAggregationResultTransformer());
+    mappers.put(
+        VariableNameAggregationResult.class, new VariableNameAggregationResultTransformer());
     mappers.put(
         ProcessInstanceFlowNodeStatisticsAggregationResult.class,
         new ProcessInstanceFlowNodeStatisticsAggregationResultTransformer());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/VariableNameAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/VariableNameAggregationTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.VariableNameAggregation.AGGREGATION_NAME_BY_NAME;
+import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
+import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.NAME;
+
+import io.camunda.search.aggregation.VariableNameAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+
+public class VariableNameAggregationTransformer
+    implements AggregationTransformer<VariableNameAggregation> {
+
+  private static final String AGGREGATION_FIELD_KEY = "_key";
+
+  @Override
+  public List<SearchAggregator> apply(
+      final Tuple<VariableNameAggregation, ServiceTransformers> value) {
+    final var aggregation = value.getLeft();
+    final var limit = aggregation.page() != null ? aggregation.page().size() : null;
+
+    final var byNameAgg =
+        terms()
+            .name(AGGREGATION_NAME_BY_NAME)
+            .field(NAME)
+            .size(limit)
+            .sorting(List.of(new FieldSorting(AGGREGATION_FIELD_KEY, SortOrder.ASC)))
+            .build();
+
+    return List.of(byNameAgg);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/VariableNameAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/VariableNameAggregationResultTransformer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.VariableNameAggregation.AGGREGATION_NAME_BY_NAME;
+
+import io.camunda.search.aggregation.result.VariableNameAggregationResult;
+import io.camunda.search.clients.core.AggregationResult;
+import java.util.List;
+import java.util.Map;
+
+public class VariableNameAggregationResultTransformer
+    implements AggregationResultTransformer<VariableNameAggregationResult> {
+
+  @Override
+  public VariableNameAggregationResult apply(final Map<String, AggregationResult> aggregations) {
+    final var byNameAgg = aggregations.get(AGGREGATION_NAME_BY_NAME);
+    if (byNameAgg == null || byNameAgg.aggregations() == null) {
+      return new VariableNameAggregationResult(List.of());
+    }
+    return new VariableNameAggregationResult(List.copyOf(byNameAgg.aggregations().keySet()));
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/reader/VariableDocumentReaderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/reader/VariableDocumentReaderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.search.clients.SearchClientBasedQueryExecutor;
+import io.camunda.search.query.VariableNameQuery;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import org.junit.jupiter.api.Test;
+
+class VariableDocumentReaderTest {
+
+  @Test
+  void shouldReturnEmptyListWithoutQueryingWhenNoProcessDefinitionKeyGiven() {
+    // given
+    final var executor = mock(SearchClientBasedQueryExecutor.class);
+    final var indexDescriptor = mock(IndexDescriptor.class);
+    final var reader = new VariableDocumentReader(executor, indexDescriptor);
+
+    // when
+    final var names =
+        reader.searchVariableNames(VariableNameQuery.of(b -> b), ResourceAccessChecks.disabled());
+
+    // then
+    assertThat(names).isEmpty();
+    verifyNoInteractions(executor);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/VariableNameAggregationTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/VariableNameAggregationTransformerTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation;
+
+import static io.camunda.search.aggregation.VariableNameAggregation.AGGREGATION_NAME_BY_NAME;
+import static io.camunda.webapps.schema.descriptors.template.VariableTemplate.NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.aggregation.VariableNameAggregation;
+import io.camunda.search.clients.aggregator.SearchAggregator;
+import io.camunda.search.clients.aggregator.SearchTermsAggregator;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class VariableNameAggregationTransformerTest {
+
+  private final VariableNameAggregationTransformer transformer =
+      new VariableNameAggregationTransformer();
+
+  private final ServiceTransformers transformers =
+      ServiceTransformers.newInstance(new IndexDescriptors("", true));
+
+  @Test
+  void shouldBuildTermsAggregationOnNameFieldOrderedByKeyAscending() {
+    // given
+    final var filter = FilterBuilders.variable().build();
+    final var page = SearchQueryPage.of(b -> b.size(25));
+    final var aggregation = new VariableNameAggregation(filter, page);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    assertThat(aggregations).hasSize(1);
+    assertThat(aggregations.get(0))
+        .isInstanceOfSatisfying(
+            SearchTermsAggregator.class,
+            termsAgg -> {
+              assertThat(termsAgg.name()).isEqualTo(AGGREGATION_NAME_BY_NAME);
+              assertThat(termsAgg.field()).isEqualTo(NAME);
+              assertThat(termsAgg.size()).isEqualTo(25);
+              assertThat(termsAgg.sorting()).hasSize(1);
+              assertThat(termsAgg.sorting().get(0).field()).isEqualTo("_key");
+              assertThat(termsAgg.sorting().get(0).order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  @Test
+  void shouldUseClientSuppliedLimitAsAggregationSize() {
+    // given
+    final var filter = FilterBuilders.variable().build();
+    final var page = SearchQueryPage.of(b -> b.size(3));
+    final var aggregation = new VariableNameAggregation(filter, page);
+
+    // when
+    final List<SearchAggregator> aggregations =
+        transformer.apply(Tuple.of(aggregation, transformers));
+
+    // then
+    final var termsAgg = (SearchTermsAggregator) aggregations.get(0);
+    assertThat(termsAgg.size()).isEqualTo(3);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/VariableNameAggregationResultTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/aggregation/result/VariableNameAggregationResultTransformerTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.aggregation.result;
+
+import static io.camunda.search.aggregation.VariableNameAggregation.AGGREGATION_NAME_BY_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.core.AggregationResult;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class VariableNameAggregationResultTransformerTest {
+
+  private final VariableNameAggregationResultTransformer transformer =
+      new VariableNameAggregationResultTransformer();
+
+  @Test
+  void shouldExtractBucketKeysInOrder() {
+    // given
+    final var buckets = new LinkedHashMap<String, AggregationResult>();
+    buckets.put("amount", new AggregationResult(2L, Map.of()));
+    buckets.put("total", new AggregationResult(1L, Map.of()));
+    final var byNameAgg = new AggregationResult(null, buckets);
+
+    // when
+    final var result = transformer.apply(Map.of(AGGREGATION_NAME_BY_NAME, byNameAgg));
+
+    // then
+    assertThat(result.items()).containsExactly("amount", "total");
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenAggregationMissing() {
+    // when
+    final var result = transformer.apply(Map.of());
+
+    // then
+    assertThat(result.items()).isEmpty();
+  }
+}

--- a/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/VariableReader.java
+++ b/search/search-client-reader/src/main/java/io/camunda/search/clients/reader/VariableReader.java
@@ -8,6 +8,13 @@
 package io.camunda.search.clients.reader;
 
 import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
+import io.camunda.security.core.authz.ResourceAccessChecks;
+import java.util.List;
 
-public interface VariableReader extends SearchEntityReader<VariableEntity, VariableQuery> {}
+public interface VariableReader extends SearchEntityReader<VariableEntity, VariableQuery> {
+
+  List<String> searchVariableNames(
+      VariableNameQuery query, ResourceAccessChecks resourceAccessChecks);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClients.java
@@ -117,6 +117,7 @@ import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.search.query.WaitStateStatisticsQuery;
 import io.camunda.security.core.auth.SecurityContext;
@@ -587,6 +588,12 @@ public class CamundaSearchClients implements SearchClientsProxy {
   @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery query) {
     return doSearchWithReader(requireScopedReaders().variableReader(), query);
+  }
+
+  @Override
+  public List<String> searchVariableNames(final VariableNameQuery query) {
+    return doReadWithResourceAccessController(
+        access -> requireScopedReaders().variableReader().searchVariableNames(query, access));
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/VariableSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/VariableSearchClient.java
@@ -9,14 +9,18 @@ package io.camunda.search.clients;
 
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.core.auth.SecurityContext;
+import java.util.List;
 
 public interface VariableSearchClient {
 
   VariableEntity getVariable(final long key);
 
   SearchQueryResult<VariableEntity> searchVariables(VariableQuery filter);
+
+  List<String> searchVariableNames(VariableNameQuery query);
 
   VariableSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoDBSearchClientsProxy.java
@@ -101,6 +101,7 @@ import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.core.auth.SecurityContext;
 import java.util.List;
@@ -368,6 +369,11 @@ public class NoDBSearchClientsProxy implements SearchClientsProxy {
 
   @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery filter) {
+    throw new NoSecondaryStorageException();
+  }
+
+  @Override
+  public List<String> searchVariableNames(final VariableNameQuery query) {
     throw new NoSecondaryStorageException();
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/impl/NoopSearchClientsProxy.java
@@ -102,6 +102,7 @@ import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.search.query.UsageMetricsTUQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.core.auth.SecurityContext;
 import java.util.List;
@@ -371,6 +372,11 @@ public class NoopSearchClientsProxy implements SearchClientsProxy {
   @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery filter) {
     return SearchQueryResult.empty();
+  }
+
+  @Override
+  public List<String> searchVariableNames(final VariableNameQuery query) {
+    return List.of();
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/VariableNameAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/VariableNameAggregation.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation;
+
+import io.camunda.search.filter.VariableFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.AggregationPaginated;
+
+public record VariableNameAggregation(VariableFilter filter, SearchQueryPage page)
+    implements AggregationBase, AggregationPaginated {
+
+  public static final String AGGREGATION_NAME_BY_NAME = "by-name";
+}

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/result/VariableNameAggregationResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/result/VariableNameAggregationResult.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.aggregation.result;
+
+import java.util.List;
+
+public record VariableNameAggregationResult(List<String> items) implements AggregationResultBase {}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -107,6 +107,15 @@ public final class SearchQueryBuilders {
     return fn.apply(variableSearchQuery()).build();
   }
 
+  public static VariableNameQuery.Builder variableNameSearchQuery() {
+    return new VariableNameQuery.Builder();
+  }
+
+  public static VariableNameQuery variableNameSearchQuery(
+      final Function<VariableNameQuery.Builder, ObjectBuilder<VariableNameQuery>> fn) {
+    return fn.apply(variableNameSearchQuery()).build();
+  }
+
   public static ClusterVariableQuery.Builder clusterVariableSearchQuery() {
     return new ClusterVariableQuery.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/query/VariableNameQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/VariableNameQuery.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.aggregation.VariableNameAggregation;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.VariableFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.NoSort;
+import io.camunda.search.sort.SortOption;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record VariableNameQuery(VariableFilter filter, SearchQueryPage page)
+    implements TypedSearchAggregationQuery<VariableFilter, SortOption, VariableNameAggregation> {
+
+  public static VariableNameQuery of(final Function<Builder, ObjectBuilder<VariableNameQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  @Override
+  public SortOption sort() {
+    return NoSort.NO_SORT;
+  }
+
+  @Override
+  public VariableNameAggregation aggregation() {
+    return new VariableNameAggregation(filter, page);
+  }
+
+  public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
+      implements TypedSearchQueryBuilder<VariableNameQuery, Builder, VariableFilter, SortOption> {
+
+    private static final VariableFilter EMPTY_FILTER = FilterBuilders.variable().build();
+
+    private VariableFilter filter;
+
+    @Override
+    public Builder filter(final VariableFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public Builder sort(final SortOption value) {
+      return this;
+    }
+
+    public Builder filter(
+        final Function<VariableFilter.Builder, ObjectBuilder<VariableFilter>> fn) {
+      return filter(FilterBuilders.variable(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public VariableNameQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      return new VariableNameQuery(filter, page());
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -13,12 +13,14 @@ import static io.camunda.service.authorization.Authorizations.VARIABLE_READ_AUTH
 import io.camunda.search.clients.VariableSearchClient;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.api.model.CamundaAuthentication;
 import io.camunda.security.auth.BrokerRequestAuthorizationConverter;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.List;
 
 public final class VariableServices
     extends SearchQueryService<VariableServices, VariableQuery, VariableEntity> {
@@ -51,6 +53,17 @@ public final class VariableServices
                     securityContextProvider.provideSecurityContext(
                         authentication, VARIABLE_READ_AUTHORIZATION))
                 .searchVariables(query));
+  }
+
+  public List<String> searchVariableNames(
+      final VariableNameQuery query, final CamundaAuthentication authentication) {
+    return executeSearchRequest(
+        () ->
+            variableSearchClient
+                .withSecurityContext(
+                    securityContextProvider.provideSecurityContext(
+                        authentication, VARIABLE_READ_AUTHORIZATION))
+                .searchVariableNames(query));
   }
 
   public VariableEntity getByKey(final Long key, final CamundaAuthentication authentication) {

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -241,9 +241,7 @@ paths:
         - bearerAuth: []
         - basicAuth: []
       summary: Search process definition variable names
-      description: |-
-        Search for distinct variable names defined on a process definition, optionally narrowed
-        by a name prefix.
+      description: Search for distinct variable names defined on a process definition, optionally narrowed by the name filter.
       parameters:
         - name: processDefinitionKey
           in: path

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -228,6 +228,52 @@ paths:
           $ref: 'common-responses.yaml#/components/responses/InternalServerError'
       x-added-in-version: "8.8"
 
+  /process-definitions/{processDefinitionKey}/variable-names/search:
+    post:
+      x-eventually-consistent: true
+      tags:
+        - Process definition
+      operationId: searchProcessDefinitionVariableNames
+      x-permission-enforcement: filter
+      x-required-permissions:
+        - { resourceType: PROCESS_DEFINITION, permissionType: READ_PROCESS_INSTANCE }
+      security:
+        - bearerAuth: []
+        - basicAuth: []
+      summary: Search process definition variable names
+      description: |-
+        Search for distinct variable names defined on a process definition, optionally narrowed
+        by a name prefix.
+      parameters:
+        - name: processDefinitionKey
+          in: path
+          required: true
+          description: The assigned key of the process definition, which acts as a unique identifier for this process definition.
+          schema:
+            $ref: 'keys.yaml#/components/schemas/ProcessDefinitionKey'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProcessDefinitionVariableNameSearchQuery'
+      responses:
+        "200":
+          description: The process definition variable name search result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProcessDefinitionVariableNameSearchQueryResult'
+        "400":
+          $ref: 'common-responses.yaml#/components/responses/InvalidData'
+        "401":
+          $ref: 'common-responses.yaml#/components/responses/Unauthorized'
+        "403":
+          $ref: 'common-responses.yaml#/components/responses/Forbidden'
+        "500":
+          $ref: 'common-responses.yaml#/components/responses/InternalServerError'
+      x-added-in-version: "8.10"
+
   /process-definitions/statistics/message-subscriptions:
     post:
       x-eventually-consistent: true
@@ -531,6 +577,54 @@ components:
           description: The total number of completed instances of the element.
           type: integer
           format: int64
+
+    ProcessDefinitionVariableNameSearchQuery:
+      description: Process definition variable name search query request.
+      additionalProperties: false
+      type: object
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryRequest'
+      properties:
+        filter:
+          description: The process definition variable name search filters.
+          allOf:
+            - $ref: '#/components/schemas/ProcessDefinitionVariableNameFilter'
+
+    ProcessDefinitionVariableNameFilter:
+      description: Process definition variable name filter request.
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          description: |
+            Prefix to narrow the returned variable names. Matching is case-sensitive and
+            left-anchored.
+          allOf:
+            - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
+
+    ProcessDefinitionVariableNameSearchQueryResult:
+      description: Process definition variable name search query response.
+      type: object
+      required:
+        - items
+      allOf:
+        - $ref: 'search-models.yaml#/components/schemas/SearchQueryResponse'
+      properties:
+        items:
+          description: The matching variable names.
+          type: array
+          items:
+            $ref: '#/components/schemas/ProcessDefinitionVariableNameSearchResult'
+
+    ProcessDefinitionVariableNameSearchResult:
+      description: Process definition variable name search response item.
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          description: The variable name.
+          type: string
 
     ProcessDefinitionMessageSubscriptionStatisticsQuery:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/process-definitions.yaml
@@ -596,9 +596,7 @@ components:
       additionalProperties: false
       properties:
         name:
-          description: |
-            Prefix to narrow the returned variable names. Matching is case-sensitive and
-            left-anchored.
+          description: The variable name search filter.
           allOf:
             - $ref: 'filters.yaml#/components/schemas/StringFilterProperty'
 

--- a/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml
@@ -318,6 +318,8 @@ paths:
     $ref: 'process-definitions.yaml#/paths/~1process-definitions~1{processDefinitionKey}~1form'
   /process-definitions/{processDefinitionKey}/statistics/element-instances:
     $ref: 'process-definitions.yaml#/paths/~1process-definitions~1{processDefinitionKey}~1statistics~1element-instances'
+  /process-definitions/{processDefinitionKey}/variable-names/search:
+    $ref: 'process-definitions.yaml#/paths/~1process-definitions~1{processDefinitionKey}~1variable-names~1search'
   /process-definitions/{processDefinitionKey}/xml:
     $ref: 'process-definitions.yaml#/paths/~1process-definitions~1{processDefinitionKey}~1xml'
   /process-definitions/statistics/process-instances-by-version:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
@@ -22,8 +22,11 @@ import io.camunda.gateway.protocol.model.ProcessDefinitionMessageSubscriptionSta
 import io.camunda.gateway.protocol.model.ProcessDefinitionMessageSubscriptionStatisticsQueryResult;
 import io.camunda.gateway.protocol.model.ProcessDefinitionSearchQuery;
 import io.camunda.gateway.protocol.model.ProcessDefinitionSearchQueryResult;
+import io.camunda.gateway.protocol.model.ProcessDefinitionVariableNameSearchQuery;
+import io.camunda.gateway.protocol.model.ProcessDefinitionVariableNameSearchQueryResult;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
@@ -149,6 +152,29 @@ public class ProcessDefinitionController {
         .fold(
             RestErrorMapper::mapProblemToResponse,
             filter -> elementStatistics(physicalTenantId, filter));
+  }
+
+  @RequiresSecondaryStorage
+  @CamundaPostMapping(path = "/{processDefinitionKey}/variable-names/search")
+  public ResponseEntity<ProcessDefinitionVariableNameSearchQueryResult> searchVariableNames(
+      @PhysicalTenantId final String physicalTenantId,
+      @PathVariable("processDefinitionKey") final long processDefinitionKey,
+      @RequestBody(required = false) final ProcessDefinitionVariableNameSearchQuery query) {
+    return SearchQueryRequestMapper.toVariableNameQuery(processDefinitionKey, query)
+        .fold(RestErrorMapper::mapProblemToResponse, q -> searchVariableNames(physicalTenantId, q));
+  }
+
+  private ResponseEntity<ProcessDefinitionVariableNameSearchQueryResult> searchVariableNames(
+      final String physicalTenantId, final VariableNameQuery query) {
+    final var variableServices = serviceRegistry.variableServices(physicalTenantId);
+    try {
+      final var result =
+          variableServices.searchVariableNames(
+              query, authenticationProvider.getCamundaAuthentication());
+      return ResponseEntity.ok(SearchQueryResponseMapper.toVariableNameSearchResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
   }
 
   @RequiresSecondaryStorage

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -23,16 +23,19 @@ import io.camunda.search.entities.ProcessDefinitionInstanceStatisticsEntity;
 import io.camunda.search.entities.ProcessDefinitionInstanceVersionStatisticsEntity;
 import io.camunda.search.entities.ProcessFlowNodeStatisticsEntity;
 import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.filter.ProcessDefinitionStatisticsFilter;
 import io.camunda.search.query.ProcessDefinitionInstanceVersionStatisticsQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
+import io.camunda.search.query.VariableNameQuery;
 import io.camunda.security.api.context.CamundaAuthenticationProvider;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.service.FormServices;
 import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.service.VariableServices;
 import io.camunda.service.exception.ErrorMapper;
 import io.camunda.service.registry.ServiceRegistry;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -140,6 +143,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
   @MockitoBean ProcessDefinitionServices processDefinitionServices;
 
   @MockitoBean FormServices formServices;
+  @MockitoBean VariableServices variableServices;
   @MockitoBean CamundaAuthenticationProvider authenticationProvider;
   @MockitoBean ServiceRegistry serviceRegistry;
 
@@ -156,6 +160,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
     lenient()
         .when(serviceRegistry.processDefinitionServices(any()))
         .thenReturn(processDefinitionServices);
+    lenient().when(serviceRegistry.variableServices(any())).thenReturn(variableServices);
     when(authenticationProvider.getCamundaAuthentication())
         .thenReturn(AUTHENTICATION_WITH_DEFAULT_TENANT);
   }
@@ -435,6 +440,94 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
         .json(expectedResponse, JsonCompareMode.STRICT);
 
     verify(processDefinitionServices, never()).elementStatistics(any(), any());
+  }
+
+  @Test
+  void shouldSearchVariableNamesWithPrefixAndLimit() {
+    // given
+    when(variableServices.searchVariableNames(any(VariableNameQuery.class), any()))
+        .thenReturn(List.of("amount", "total"));
+    final var request =
+        """
+            {
+                "filter": {
+                    "name": {"$like": "a*"}
+                },
+                "page": {
+                    "limit": 5
+                }
+            }""";
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_URL + "123/variable-names/search")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+                {
+                    "items": [
+                        {"name": "amount"},
+                        {"name": "total"}
+                    ],
+                    "page": {
+                        "totalItems": 2,
+                        "hasMoreTotalItems": false
+                    }
+                }""",
+            JsonCompareMode.LENIENT);
+
+    verify(variableServices)
+        .searchVariableNames(
+            eq(
+                VariableNameQuery.of(
+                    b ->
+                        b.filter(
+                                f ->
+                                    f.processDefinitionKeys(123L)
+                                        .nameOperations(Operation.like("a*")))
+                            .page(p -> p.size(5)))),
+            any());
+  }
+
+  @Test
+  void shouldSearchVariableNamesWithEmptyBody() {
+    // given
+    when(variableServices.searchVariableNames(any(VariableNameQuery.class), any()))
+        .thenReturn(List.of());
+
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_URL + "123/variable-names/search")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+                {
+                    "items": [],
+                    "page": {
+                        "totalItems": 0,
+                        "hasMoreTotalItems": false
+                    }
+                }""",
+            JsonCompareMode.LENIENT);
+
+    verify(variableServices)
+        .searchVariableNames(
+            eq(VariableNameQuery.of(b -> b.filter(f -> f.processDefinitionKeys(123L)))), any());
   }
 
   @Test


### PR DESCRIPTION
## Description

Implements the `POST /v2/process-definitions/{processDefinitionKey}/variable-names/search` endpoint for variable-name autocomplete, returning distinct variable names for a given process definition (identified by the path key), narrowed by the name filter (supports the standard string filter operators — `$eq`, `$like`, etc. — prefix matching is a client choice via `$like`, not an endpoint guarantee) and bounded by a client-supplied limit. The endpoint works identically on ES/OS (via terms aggregation) and RDBMS (via the `PROCESS_DEF_VAR_NAME_LOOKUP` table), with alphabetical ordering and proper authorization enforcement on both backends.

## Checklist

<!--- Please delete options that are not relevant. -->

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #54177