### PR TITLE
57181 fix statistics element instances slow

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientReadersFactory.java
@@ -150,7 +150,7 @@ public final class SearchClientReadersFactory {
             executor, descriptors.get(ListViewTemplate.class)) {};
     final var processInstanceStatisticsReader =
         new ProcessInstanceStatisticsDocumentReader(
-            executor, descriptors.get(ListViewTemplate.class));
+            executor, descriptors.get(FlowNodeInstanceTemplate.class));
     final var deployedResourceReader =
         new DeployedResourceDocumentReader(executor, descriptors.get(DeployedResourceIndex.class));
     final var sequenceFlowReader =

--- a/load-tests/load-tester/src/main/java/io/camunda/zeebe/read/DataReadMeterQueryProvider.java
+++ b/load-tests/load-tester/src/main/java/io/camunda/zeebe/read/DataReadMeterQueryProvider.java
@@ -74,6 +74,11 @@ public final class DataReadMeterQueryProvider {
                         context.benchmarkProcessDefinitionKey())
                     .filter(f -> f.state(s -> s.in(List.of(ProcessInstanceState.ACTIVE))))),
         new ReadQuery(
+            "process_instance_element_statistics",
+            Duration.ofSeconds(30),
+            (client, context) ->
+                client.newProcessInstanceElementStatisticsRequest(context.processInstanceKey())),
+        new ReadQuery(
             "incident_by_error_statistics",
             Duration.ofSeconds(30),
             (client, context) ->

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -693,7 +693,7 @@ public final class ServiceTransformers {
     mappers.put(
         ProcessInstanceStatisticsFilter.class,
         new ProcessInstanceStatisticsFilterTransformer(
-            indexDescriptors.get(ListViewTemplate.class)));
+            indexDescriptors.get(FlowNodeInstanceTemplate.class)));
     mappers.put(
         BatchOperationFilter.class,
         new BatchOperationFilterTransformer(indexDescriptors.get(BatchOperationTemplate.class)));

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessInstanceFlowNodeStatisticsAggregationTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/ProcessInstanceFlowNodeStatisticsAggregationTransformer.java
@@ -15,8 +15,6 @@ import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAgg
 import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_GROUP_FLOW_NODES;
 import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_INCIDENTS;
 import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_TERMS_SIZE;
-import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_TO_FLOW_NODES;
-import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.children;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.filter;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.filters;
 import static io.camunda.search.clients.aggregator.SearchAggregatorBuilders.terms;
@@ -24,14 +22,13 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.not;
 import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
-import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ACTIVITY_TYPE;
 
 import io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation;
 import io.camunda.search.clients.aggregator.SearchAggregator;
 import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
-import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.List;
 
@@ -49,50 +46,45 @@ public class ProcessInstanceFlowNodeStatisticsAggregationTransformer
             .namedQuery(
                 AGGREGATION_ACTIVE,
                 and(
-                    term(ListViewTemplate.INCIDENT, false),
-                    term(ListViewTemplate.ACTIVITY_STATE, FlowNodeState.ACTIVE.toString())))
+                    term(FlowNodeInstanceTemplate.INCIDENT, false),
+                    term(FlowNodeInstanceTemplate.STATE, FlowNodeState.ACTIVE.toString())))
             .namedQuery(
                 AGGREGATION_COMPLETED,
-                term(ListViewTemplate.ACTIVITY_STATE, FlowNodeState.COMPLETED.toString()))
+                term(FlowNodeInstanceTemplate.STATE, FlowNodeState.COMPLETED.toString()))
             .namedQuery(
                 AGGREGATION_CANCELED,
-                term(ListViewTemplate.ACTIVITY_STATE, FlowNodeState.TERMINATED.toString()))
+                term(FlowNodeInstanceTemplate.STATE, FlowNodeState.TERMINATED.toString()))
             .namedQuery(
                 AGGREGATION_INCIDENTS,
                 and(
-                    term(ListViewTemplate.INCIDENT, true),
-                    term(ListViewTemplate.ACTIVITY_STATE, FlowNodeState.ACTIVE.toString())))
+                    term(FlowNodeInstanceTemplate.INCIDENT, true),
+                    term(FlowNodeInstanceTemplate.STATE, FlowNodeState.ACTIVE.toString())))
             .build();
 
     // aggregate by flow node id
     final var groupFlowNodesAgg =
         terms()
             .name(AGGREGATION_GROUP_FLOW_NODES)
-            .field(ListViewTemplate.ACTIVITY_ID)
+            .field(FlowNodeInstanceTemplate.FLOW_NODE_ID)
             .size(AGGREGATION_TERMS_SIZE)
             .aggregations(filtersAgg)
             .build();
 
-    // aggregate filter flow nodes - exclude multi-instance bodies UNLESS they have incidents
+    // exclude multi-instance bodies UNLESS they have incidents
     // so that incidents on the multi-instance body itself are counted
     final var filterFlowNodesAgg =
         filter()
             .name(AGGREGATION_FILTER_FLOW_NODES)
             .query(
                 or(
-                    not(term(ACTIVITY_TYPE, FlowNodeType.MULTI_INSTANCE_BODY.toString())),
-                    term(ListViewTemplate.INCIDENT, true)))
+                    not(
+                        term(
+                            FlowNodeInstanceTemplate.TYPE,
+                            FlowNodeType.MULTI_INSTANCE_BODY.toString())),
+                    term(FlowNodeInstanceTemplate.INCIDENT, true)))
             .aggregations(groupFlowNodesAgg)
             .build();
 
-    // aggregate flow node children
-    final var toFlowNodesAgg =
-        children()
-            .name(AGGREGATION_TO_FLOW_NODES)
-            .type(ListViewTemplate.ACTIVITIES_JOIN_RELATION)
-            .aggregations(filterFlowNodesAgg)
-            .build();
-
-    return List.of(toFlowNodesAgg);
+    return List.of(filterFlowNodesAgg);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessInstanceFlowNodeStatisticsAggregationResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/aggregation/result/ProcessInstanceFlowNodeStatisticsAggregationResultTransformer.java
@@ -14,7 +14,6 @@ import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAgg
 import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_GROUP_FILTERS;
 import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_GROUP_FLOW_NODES;
 import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_INCIDENTS;
-import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_TO_FLOW_NODES;
 
 import io.camunda.search.aggregation.result.ProcessInstanceFlowNodeStatisticsAggregationResult;
 import io.camunda.search.clients.core.AggregationResult;
@@ -28,8 +27,7 @@ public class ProcessInstanceFlowNodeStatisticsAggregationResultTransformer
   @Override
   public ProcessInstanceFlowNodeStatisticsAggregationResult apply(
       final Map<String, AggregationResult> aggregations) {
-    final var children = aggregations.get(AGGREGATION_TO_FLOW_NODES);
-    final var filter = children.aggregations().get(AGGREGATION_FILTER_FLOW_NODES);
+    final var filter = aggregations.get(AGGREGATION_FILTER_FLOW_NODES);
     final var group = filter.aggregations().get(AGGREGATION_GROUP_FLOW_NODES);
     final var items = new ArrayList<ProcessFlowNodeStatisticsEntity>();
     group

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceStatisticsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceStatisticsFilterTransformer.java
@@ -7,13 +7,10 @@
  */
 package io.camunda.search.clients.transformers.filter;
 
-import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
-import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.BPMN_PROCESS_ID;
-import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.JOIN_RELATION;
-import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION;
-import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate.PROCESS_INSTANCE_KEY;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.ProcessInstanceStatisticsFilter;
@@ -29,9 +26,7 @@ public class ProcessInstanceStatisticsFilterTransformer
 
   @Override
   public SearchQuery toSearchQuery(final ProcessInstanceStatisticsFilter filter) {
-    return and(
-        term(JOIN_RELATION, PROCESS_INSTANCE_JOIN_RELATION),
-        term(PROCESS_INSTANCE_KEY, filter.processInstanceKey()));
+    return term(PROCESS_INSTANCE_KEY, filter.processInstanceKey());
   }
 
   @Override

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/ProcessInstanceFlowNodeStatisticsQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/ProcessInstanceFlowNodeStatisticsQueryTransformerTest.java
@@ -15,24 +15,23 @@ import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAgg
 import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_GROUP_FLOW_NODES;
 import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_INCIDENTS;
 import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_TERMS_SIZE;
-import static io.camunda.search.aggregation.ProcessInstanceFlowNodeStatisticsAggregation.AGGREGATION_TO_FLOW_NODES;
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.not;
 import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
-import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ACTIVITY_TYPE;
-import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.JOIN_RELATION;
-import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION;
-import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate.FLOW_NODE_ID;
+import static io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate.INCIDENT;
+import static io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate.STATE;
+import static io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate.TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-import io.camunda.search.clients.aggregator.SearchChildrenAggregator;
 import io.camunda.search.clients.aggregator.SearchFilterAggregator;
 import io.camunda.search.clients.aggregator.SearchFiltersAggregator;
 import io.camunda.search.clients.aggregator.SearchTermsAggregator;
 import io.camunda.search.clients.core.SearchQueryRequest;
-import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
@@ -40,7 +39,6 @@ import io.camunda.search.filter.ProcessInstanceStatisticsFilter;
 import io.camunda.search.query.ProcessInstanceFlowNodeStatisticsQuery;
 import io.camunda.search.query.TypedSearchAggregationQuery;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
-import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
 import org.junit.jupiter.api.Test;
 
 public class ProcessInstanceFlowNodeStatisticsQueryTransformerTest {
@@ -68,29 +66,28 @@ public class ProcessInstanceFlowNodeStatisticsQueryTransformerTest {
     assertThat(searchRequest.from()).isZero();
     assertThat(searchRequest.size()).isZero();
 
+    // query: flat term on flownode-instance — no join relation filter
+    final var queryVariant = searchRequest.query().queryOption();
+    assertThat(queryVariant).isInstanceOf(SearchTermQuery.class);
+    final var termQuery = (SearchTermQuery) queryVariant;
+    assertThat(termQuery).isEqualTo(term(PROCESS_INSTANCE_KEY, processInstanceKey).queryOption());
+
+    // aggregation: flat filter → terms → filters (no children wrapper)
     final var aggregations = searchRequest.aggregations();
     assertThat(aggregations).hasSize(1);
-    assertThat(aggregations.getFirst()).isInstanceOf(SearchChildrenAggregator.class);
+    assertThat(aggregations.getFirst()).isInstanceOf(SearchFilterAggregator.class);
 
-    final var childrenAgg = (SearchChildrenAggregator) aggregations.getFirst();
-    assertThat(childrenAgg.name()).isEqualTo(AGGREGATION_TO_FLOW_NODES);
-    assertThat(childrenAgg.type()).isEqualTo(ListViewTemplate.ACTIVITIES_JOIN_RELATION);
-    assertThat(childrenAgg.aggregations()).hasSize(1);
-    assertThat(childrenAgg.aggregations().getFirst()).isInstanceOf(SearchFilterAggregator.class);
-
-    final var filterAgg = (SearchFilterAggregator) childrenAgg.aggregations().getFirst();
+    final var filterAgg = (SearchFilterAggregator) aggregations.getFirst();
     assertThat(filterAgg.name()).isEqualTo(AGGREGATION_FILTER_FLOW_NODES);
     assertThat(filterAgg.query())
         .isEqualTo(
-            or(
-                not(term(ACTIVITY_TYPE, FlowNodeType.MULTI_INSTANCE_BODY.toString())),
-                term(ListViewTemplate.INCIDENT, true)));
+            or(not(term(TYPE, FlowNodeType.MULTI_INSTANCE_BODY.toString())), term(INCIDENT, true)));
     assertThat(filterAgg.aggregations()).hasSize(1);
     assertThat(filterAgg.aggregations().getFirst()).isInstanceOf(SearchTermsAggregator.class);
 
     final var termsAgg = (SearchTermsAggregator) filterAgg.aggregations().getFirst();
     assertThat(termsAgg.name()).isEqualTo(AGGREGATION_GROUP_FLOW_NODES);
-    assertThat(termsAgg.field()).isEqualTo(ListViewTemplate.ACTIVITY_ID);
+    assertThat(termsAgg.field()).isEqualTo(FLOW_NODE_ID);
     assertThat(termsAgg.size()).isEqualTo(AGGREGATION_TERMS_SIZE);
     assertThat(termsAgg.minDocCount()).isEqualTo(1);
     assertThat(termsAgg.aggregations()).hasSize(1);
@@ -104,30 +101,11 @@ public class ProcessInstanceFlowNodeStatisticsQueryTransformerTest {
         .containsOnly(
             entry(
                 AGGREGATION_ACTIVE,
-                and(
-                    term(ListViewTemplate.INCIDENT, false),
-                    term(ListViewTemplate.ACTIVITY_STATE, FlowNodeState.ACTIVE.toString()))),
-            entry(
-                AGGREGATION_COMPLETED,
-                term(ListViewTemplate.ACTIVITY_STATE, FlowNodeState.COMPLETED.toString())),
-            entry(
-                AGGREGATION_CANCELED,
-                term(ListViewTemplate.ACTIVITY_STATE, FlowNodeState.TERMINATED.toString())),
+                and(term(INCIDENT, false), term(STATE, FlowNodeState.ACTIVE.toString()))),
+            entry(AGGREGATION_COMPLETED, term(STATE, FlowNodeState.COMPLETED.toString())),
+            entry(AGGREGATION_CANCELED, term(STATE, FlowNodeState.TERMINATED.toString())),
             entry(
                 AGGREGATION_INCIDENTS,
-                and(
-                    term(ListViewTemplate.INCIDENT, true),
-                    term(ListViewTemplate.ACTIVITY_STATE, FlowNodeState.ACTIVE.toString()))));
-
-    final var queryVariant = searchRequest.query().queryOption();
-    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
-    final var boolQuery = (SearchBoolQuery) queryVariant;
-    assertThat(boolQuery.filter()).isEmpty();
-    assertThat(boolQuery.should()).isEmpty();
-    assertThat(boolQuery.mustNot()).isEmpty();
-    assertThat(boolQuery.must())
-        .containsExactly(
-            term(JOIN_RELATION, PROCESS_INSTANCE_JOIN_RELATION),
-            term(PROCESS_INSTANCE_KEY, filter.processInstanceKey()));
+                and(term(INCIDENT, true), term(STATE, FlowNodeState.ACTIVE.toString()))));
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessInstanceFlowNodeStatisticsAggregation.java
+++ b/search/search-domain/src/main/java/io/camunda/search/aggregation/ProcessInstanceFlowNodeStatisticsAggregation.java
@@ -10,7 +10,6 @@ package io.camunda.search.aggregation;
 public record ProcessInstanceFlowNodeStatisticsAggregation() implements AggregationBase {
 
   public static final int AGGREGATION_TERMS_SIZE = 10000;
-  public static final String AGGREGATION_TO_FLOW_NODES = "to-flow-nodes";
   public static final String AGGREGATION_GROUP_FLOW_NODES = "group-flow-nodes";
   public static final String AGGREGATION_FILTER_FLOW_NODES = "filter-flow-nodes";
   public static final String AGGREGATION_GROUP_FILTERS = "group-filters";


### PR DESCRIPTION
## Description

  GET /v2/process-instances/{key}/statistics/element-instances was slow on large production clusters.

  The query ran against operate-list-view, a mixed index containing process instance, activity, and variable documents. To isolate activity documents it used a children() aggregation (ES parent-join) with eager_global_ordinals: true. This setting pre-builds an in-memory map of all parent-child relationships across the entire index. The map grows linearly with total doc count, rebuilds on every segment merge, and at production scale (hundreds of millions of documents accumulated over months) becomes very expensive regardless of shard count.

  Additionally, the query was using joinRelation=processInstance as a top-level filter, which only matched process instance parent documents (not their activity children). The children() aggregation then resolved the activity children via global ordinals. This means even an empty result set required loading the full ordinal table.

## Performance

ES-level query times on load-test clusters (~3-4M docs in each index):

| Query | ES `took` |
|---|---|
| OLD: `children()` agg on list-view | 143ms |
| NEW: `term(processInstanceKey)` on flownode-instance | 98ms |

At load-test scale the improvement is modest. The fix's benefit is production-scale clusters where the global ordinals table for list-view is gigabytes in size.

On grafana we have the measurements for the endpoint call (not ES-level query comparison)

**c8-ajanoni-element-statistics-1** namespace is main branch without the fix
**c8-ajanoni-statistics-element-slow-1** namespace is the branch with the fix

```
histogram_quantile(0.99,
    sum by (le, namespace) (
      rate(starter_read_benchmark_seconds_bucket{
        query="process_instance_element_statistics"
      }[5m])
    )
  )
```

<img width="1162" height="432" alt="Screenshot 2026-07-09 at 4 05 54 PM" src="https://github.com/user-attachments/assets/65cce8ee-7111-4927-8fad-7333fc7181f8" />



## Related issues

closes https://github.com/camunda/camunda/issues/57181
