### PR TITLE
ci: auto-generate load-test golden files

### DIFF
--- a/.github/instructions/load-tests.instructions.md
+++ b/.github/instructions/load-tests.instructions.md
@@ -20,7 +20,9 @@ When reviewing changes to load tests, workflows, or load test infrastructure:
    cd load-tests/setup/test && make update-golden
    ```
    then review `git diff golden/`. See `load-tests/setup/test/README.md` for the
-   suite, layout, and how to add a stable version.
+   suite, layout, and how to add a stable version. Or apply the `generate-golden`
+   label to same-repository PRs. Renovate PRs touching `load-tests/setup/**`
+   are handled automatically by `.github/workflows/load-test-golden-update.yml`.
 
 3. **Versioned setup folders**: For changes to `load-tests/setup/`, do **not**
    propose backports to stable branches. Instead, update the relevant versioned

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,7 @@ jobs:
           echo "  make update-golden"
           echo "  git diff golden/    # review the change"
           echo "  git add golden/ && git commit -m 'test: update golden files'"
+          echo "Or apply the 'generate-golden' label. Renovate PRs touching load-tests/setup/** are handled automatically."
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/load-test-golden-update.yml
+++ b/.github/workflows/load-test-golden-update.yml
@@ -1,0 +1,89 @@
+# description: Regenerates load-tests/setup golden files (rendered Kubernetes manifests) for
+#              Renovate branches or PRs labeled "generate-golden", and commits the diff back to
+#              the PR branch. Companion to the load-test-golden-tests job in ci.yml, which only verifies.
+# test location: load-tests/setup/test
+# type: ci
+# owner: @camunda/reliability-testing
+---
+name: Load Test Setup - Golden File Update
+
+on:
+  push:
+    branches:
+      - "renovate/**"
+    paths:
+      - "load-tests/setup/**"
+  pull_request:
+    types: [labeled, synchronize]
+    paths:
+      - "load-tests/setup/**"
+
+# Limit workflow to 1 concurrent run per PR: new commit -> old runs are canceled to save costs.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref) }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  update-golden:
+    if: >-
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.state != 'closed' && github.event.pull_request.head.repo.full_name == github.repository &&
+      (github.event.label.name == 'generate-golden' || contains(github.event.pull_request.labels.*.name, 'generate-golden')))
+    name: Update Golden Files
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions: {} # Using GitHub App token instead of GITHUB_TOKEN
+
+    steps:
+      - name: Generate a GitHub token
+        id: github-token
+        uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@6c85c5de572dbc1790e5e7b4636c2ad9f5b614d8 # generate-github-app-token-from-vault-secrets: v1.1.0
+        with:
+          github-app-id-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_ID
+          github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+          github-app-private-key-vault-key: MONOREPO_DEVOPS_AUTOMATION_APP_PRIVATE_KEY
+          github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+          vault-auth-method: approle
+          vault-url: ${{ secrets.VAULT_ADDR }}
+          vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+          token: ${{ steps.github-token.outputs.token }}
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: load-tests/setup/test/go.mod
+          cache-dependency-path: load-tests/setup/test/go.sum
+
+      - name: Set up Helm
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47 # v4.0.1
+
+      - name: Regenerate golden files
+        run: make -C load-tests/setup/test update-golden
+
+      - name: Commit and push golden files
+        uses: camunda/action-git-commit@v1
+        with:
+          commit-message: "test: update load-test golden files"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/load-test-golden-update.yml` to regenerate `load-tests/setup/test/golden/` and commit the generated diff back to the PR branch.

The workflow supports both paths:

- automatic runs for pushes to `renovate/**` branches that touch `load-tests/setup/**`
- manual runs for same-repository PRs touching `load-tests/setup/**` when the `generate-golden` label is present, including subsequent `synchronize` events

It runs `make -C load-tests/setup/test update-golden`, then commits via the now-public `camunda/action-git-commit@v1`. The checkout/push token uses the existing `MONOREPO_DEVOPS_AUTOMATION_APP` pattern so the generated commit can be pushed and normal PR CI is triggered afterward.

Also updates the existing golden-test failure hint in `ci.yml` and the load-test review instructions.

## Validation

- `actionlint .github/workflows/load-test-golden-update.yml`
- `conftest test --rego-version v0 -o github --policy .github .github/workflows/*.yml`
- `./mvnw spotless:apply -T1C`
- End-to-end validation with draft PRs:
  - #57815 (`renovate/**`) generated commit `1962954a721534f7cb8cc32a4a04df3f36021057`
  - #57816 regular branch did not generate before labeling; after `generate-golden`, generated commit `38af774a278fa4a85a3cbfeb942243341ed4053a`
  - Follow-up golden-update runs succeeded on both generated heads, and `Load Test / Golden File Tests` is green on both validation PRs

## Notes

The label-based path is intentionally limited to same-repository PRs so fork PR code is not run with a write-capable token.
