### PR TITLE
docs: point load-test-ops skill at the shared load-test knowledge base

### DIFF
--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -11,8 +11,8 @@ definitions, SLO targets, and Prometheus queries, see
 [`load-tests/docs/metrics.md`](https://github.com/camunda/camunda/blob/main/load-tests/docs/metrics.md). For the canonical schema of every
 available chart value (beyond what `load-tests/setup/main/values/camunda-platform-values-defaults.yaml` overrides), see
 the upstream chart at [`camunda/camunda-platform-helm`](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform).
-For known load-test tribal knowledge (recurring gotchas, prior incidents, tooling patterns), see
-[`knowledge/load-tests.md`](https://github.com/camunda/team-reliability-testing/blob/main/knowledge/load-tests.md)
+For known load-test and incident tribal knowledge (recurring gotchas, prior incidents, tooling patterns), see
+[`knowledge base`](https://github.com/camunda/team-reliability-testing/blob/main/knowledge/)
 in `camunda/team-reliability-testing` — check it before an investigation, and add durable findings
 back to it afterward.
 

--- a/load-tests/skills/load-test-ops/SKILL.md
+++ b/load-tests/skills/load-test-ops/SKILL.md
@@ -11,6 +11,10 @@ definitions, SLO targets, and Prometheus queries, see
 [`load-tests/docs/metrics.md`](https://github.com/camunda/camunda/blob/main/load-tests/docs/metrics.md). For the canonical schema of every
 available chart value (beyond what `load-tests/setup/main/values/camunda-platform-values-defaults.yaml` overrides), see
 the upstream chart at [`camunda/camunda-platform-helm`](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform).
+For known load-test tribal knowledge (recurring gotchas, prior incidents, tooling patterns), see
+[`knowledge/load-tests.md`](https://github.com/camunda/team-reliability-testing/blob/main/knowledge/load-tests.md)
+in `camunda/team-reliability-testing` — check it before an investigation, and add durable findings
+back to it afterward.
 
 ## Prerequisites check
 


### PR DESCRIPTION
## Summary
- Adds a pointer from the `load-test-ops` skill to `knowledge/` in [camunda/team-reliability-testing](https://github.com/camunda/team-reliability-testing), so sessions using the skill can discover and contribute to the shared knowledge base.

## Why

The Camunda component knowledge base moved to `camunda/team-reliability-testing`'s `knowledge/` directory on 2026-07-08. `knowledge/` already covers load-test tooling patterns, incidents, and gotchas, but `load-test-ops` had no reference to it, so a session running load tests had no way to discover it. 

This could be especially useful when investigating issues around load tests.

## Test plan
- [x] Docs-only change, no code/build impact.