### PR TITLE
feat: gateway group aware stream registration and routing

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerJobStreamService.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerJobStreamService.java
@@ -7,14 +7,12 @@
  */
 package io.camunda.zeebe.broker;
 
-import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.shared.management.JobStreamEndpoint;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamInfo;
-import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import java.util.Collection;
 import java.util.Collections;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,9 +30,12 @@ final class BrokerJobStreamService implements JobStreamEndpoint.Service {
   @Override
   public Collection<RemoteStreamInfo<JobActivationProperties>> remoteJobStreams() {
     return bridge
-        .getJobStreamService()
-        .map(JobStreamService::remoteStreamService)
-        .map(RemoteStreamService::streams)
+        .getJobStreamServices()
+        .map(
+            services ->
+                services.stream()
+                    .flatMap(svc -> svc.remoteStreamService().streams().stream())
+                    .toList())
         .orElse(Collections.emptyList());
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
@@ -15,9 +15,7 @@ import io.atomix.cluster.BrokerMemberId;
  */
 public interface BrokerTopologyListener {
 
-  default void brokerAdded(final BrokerMemberId memberId) {}
-
-  default void brokerAddedToGroup(final BrokerMemberId memberId, final String physicalTenantId) {}
+  default void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {}
 
   default void brokerRemoved(final BrokerMemberId memberId) {}
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
@@ -17,6 +17,8 @@ public interface BrokerTopologyListener {
 
   default void brokerAdded(final BrokerMemberId memberId) {}
 
+  default void brokerAddedToGroup(final BrokerMemberId memberId, final String physicalTenantId) {}
+
   default void brokerRemoved(final BrokerMemberId memberId) {}
 
   default void completedClusterChange() {}

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
@@ -17,7 +17,7 @@ public interface BrokerTopologyListener {
 
   default void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {}
 
-  default void brokerRemoved(final BrokerMemberId memberId) {}
+  default void brokerRemoved(final BrokerMemberId memberId, final String physicalTenantId) {}
 
   default void completedClusterChange() {}
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -37,9 +37,9 @@ public interface BrokerTopologyManager extends ClusterConfigurationUpdateListene
   ClusterConfiguration getClusterConfiguration();
 
   /**
-   * Adds the topology listener. For each existing brokers, the listener will be notified via {@link
-   * BrokerTopologyListener#brokerAdded(BrokerMemberId)}. After that, the listener gets notified of
-   * every new broker added or removed events.
+   * Adds the topology listener. For each existing broker-group pair, the listener will be notified
+   * via {@link BrokerTopologyListener#brokerAdded(BrokerMemberId, String)}. After that, the
+   * listener gets notified of every new broker added or removed events.
    *
    * @param listener the topology listener
    */

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -78,17 +78,9 @@ public final class BrokerTopologyManagerImpl extends Actor
     actor.run(
         () -> {
           topologyListeners.add(listener);
-          // Backfill listener with all known broker IDs across all groups
-          memberPropertiesPerGroup.values().stream()
-              .flatMap(m -> m.keySet().stream())
-              .distinct()
-              .forEach(listener::brokerAdded);
-          // Backfill group-aware listener per physicalTenantId
           memberPropertiesPerGroup.forEach(
               (physicalTenantId, groupMap) ->
-                  groupMap
-                      .keySet()
-                      .forEach(id -> listener.brokerAddedToGroup(id, physicalTenantId)));
+                  groupMap.keySet().forEach(id -> listener.brokerAdded(id, physicalTenantId)));
         });
   }
 
@@ -123,22 +115,11 @@ public final class BrokerTopologyManagerImpl extends Actor
     final var physicalTenantId = brokerInfo.getPartitionGroup();
     actor.run(
         () -> {
-          // Notify listeners only on the first appearance of this broker across all groups.
-          final boolean isNew =
-              memberPropertiesPerGroup.values().stream()
-                  .noneMatch(m -> m.containsKey(brokerMemberId));
-          if (isNew) {
-            topologyListeners.forEach(l -> l.brokerAdded(brokerMemberId));
-          }
-
           memberPropertiesPerGroup
               .computeIfAbsent(physicalTenantId, id -> new HashMap<>())
               .put(brokerMemberId, brokerInfo);
           rebuildGroupTopology(physicalTenantId);
-
-          // Notify group-aware listeners every time (per physicalTenantId, not just on first
-          // appearance).
-          topologyListeners.forEach(l -> l.brokerAddedToGroup(brokerMemberId, physicalTenantId));
+          topologyListeners.forEach(l -> l.brokerAdded(brokerMemberId, physicalTenantId));
         });
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -145,8 +145,11 @@ public final class BrokerTopologyManagerImpl extends Actor
               });
 
           if (!groupsToRebuild.isEmpty()) {
-            topologyListeners.forEach(l -> l.brokerRemoved(brokerMemberId));
-            groupsToRebuild.forEach(this::rebuildGroupTopology);
+            groupsToRebuild.forEach(
+                physicalTenantId -> {
+                  rebuildGroupTopology(physicalTenantId);
+                  topologyListeners.forEach(l -> l.brokerRemoved(brokerMemberId, physicalTenantId));
+                });
           }
         });
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -83,6 +83,12 @@ public final class BrokerTopologyManagerImpl extends Actor
               .flatMap(m -> m.keySet().stream())
               .distinct()
               .forEach(listener::brokerAdded);
+          // Backfill group-aware listener per physicalTenantId
+          memberPropertiesPerGroup.forEach(
+              (physicalTenantId, groupMap) ->
+                  groupMap
+                      .keySet()
+                      .forEach(id -> listener.brokerAddedToGroup(id, physicalTenantId)));
         });
   }
 
@@ -114,7 +120,7 @@ public final class BrokerTopologyManagerImpl extends Actor
 
   private void addBroker(final BrokerInfo brokerInfo) {
     final var brokerMemberId = BrokerMemberId.from(brokerInfo.getZone(), brokerInfo.getNodeId());
-    final var group = brokerInfo.getPartitionGroup();
+    final var physicalTenantId = brokerInfo.getPartitionGroup();
     actor.run(
         () -> {
           // Notify listeners only on the first appearance of this broker across all groups.
@@ -126,9 +132,13 @@ public final class BrokerTopologyManagerImpl extends Actor
           }
 
           memberPropertiesPerGroup
-              .computeIfAbsent(group, g -> new HashMap<>())
+              .computeIfAbsent(physicalTenantId, id -> new HashMap<>())
               .put(brokerMemberId, brokerInfo);
-          rebuildGroupTopology(group);
+          rebuildGroupTopology(physicalTenantId);
+
+          // Notify group-aware listeners every time (per physicalTenantId, not just on first
+          // appearance).
+          topologyListeners.forEach(l -> l.brokerAddedToGroup(brokerMemberId, physicalTenantId));
         });
   }
 
@@ -147,9 +157,9 @@ public final class BrokerTopologyManagerImpl extends Actor
         () -> {
           final Set<String> groupsToRebuild = new HashSet<>();
           memberPropertiesPerGroup.forEach(
-              (group, groupMap) -> {
+              (physicalTenantId, groupMap) -> {
                 if (groupMap.remove(brokerMemberId) != null) {
-                  groupsToRebuild.add(group);
+                  groupsToRebuild.add(physicalTenantId);
                 }
               });
 
@@ -160,18 +170,19 @@ public final class BrokerTopologyManagerImpl extends Actor
         });
   }
 
-  private void rebuildGroupTopology(final String group) {
-    final var groupMembers = memberPropertiesPerGroup.getOrDefault(group, Map.of()).values();
+  private void rebuildGroupTopology(final String physicalTenantId) {
+    final var groupMembers =
+        memberPropertiesPerGroup.getOrDefault(physicalTenantId, Map.of()).values();
     final var configuredState = currentConfiguredState();
     final var newGroupTopology =
         BrokerClientTopologyImpl.fromMemberProperties(groupMembers, configuredState);
 
     final Map<String, BrokerClientTopologyImpl> updated = new HashMap<>(topologyPerGroup);
-    updated.put(group, newGroupTopology);
+    updated.put(physicalTenantId, newGroupTopology);
     topologyPerGroup = Map.copyOf(updated);
 
     // temp: only update metrics for default group until we support group-specific metrics
-    if (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(group)) {
+    if (PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID.equals(physicalTenantId)) {
       updateMetrics(newGroupTopology);
     }
   }
@@ -261,13 +272,16 @@ public final class BrokerTopologyManagerImpl extends Actor
     // temp: apply the same configured state to all other known groups. This must be revisited when
     // we add support for group-specific cluster configurations.
     memberPropertiesPerGroup.keySet().stream()
-        .filter(group -> !group.equals(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
+        .filter(
+            physicalTenantId ->
+                !physicalTenantId.equals(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
         .forEach(
-            group -> {
+            physicalTenantId -> {
               final var oldGroup =
-                  topologyPerGroup.getOrDefault(group, BrokerClientTopologyImpl.uninitialized());
+                  topologyPerGroup.getOrDefault(
+                      physicalTenantId, BrokerClientTopologyImpl.uninitialized());
               allGroups.put(
-                  group,
+                  physicalTenantId,
                   new BrokerClientTopologyImpl(oldGroup.liveClusterState(), newConfiguredState));
             });
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -563,7 +563,7 @@ final class BrokerTopologyManagerTest {
     topologyManager.addTopologyListener(
         new BrokerTopologyListener() {
           @Override
-          public void brokerAdded(final BrokerMemberId memberId) {
+          public void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {
             capturedIds.add(memberId);
           }
         });
@@ -581,8 +581,7 @@ final class BrokerTopologyManagerTest {
     addTopologyListener(
         new BrokerTopologyListener() {
           @Override
-          public void brokerAddedToGroup(
-              final BrokerMemberId memberId, final String physicalTenantId) {
+          public void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {
             capturedMembers.add(memberId);
             capturedGroups.add(physicalTenantId);
           }
@@ -612,14 +611,13 @@ final class BrokerTopologyManagerTest {
     addTopologyListener(
         new BrokerTopologyListener() {
           @Override
-          public void brokerAddedToGroup(
-              final BrokerMemberId memberId, final String physicalTenantId) {
+          public void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {
             capturedMembers.add(memberId);
             capturedGroups.add(physicalTenantId);
           }
         });
 
-    // then — backfill fires brokerAddedToGroup with the known group
+    // then — backfill fires brokerAdded with the known group
     assertThat(capturedMembers).containsExactly(brokerId);
     assertThat(capturedGroups).containsExactly("tenant1");
   }
@@ -744,7 +742,7 @@ final class BrokerTopologyManagerTest {
     private final Set<BrokerMemberId> brokers = new CopyOnWriteArraySet<>();
 
     @Override
-    public void brokerAdded(final BrokerMemberId memberId) {
+    public void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {
       brokers.add(memberId);
     }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.BrokerMemberId;
@@ -620,6 +621,62 @@ final class BrokerTopologyManagerTest {
     // then — backfill fires brokerAdded with the known group
     assertThat(capturedMembers).containsExactly(brokerId);
     assertThat(capturedGroups).containsExactly("tenant1");
+  }
+
+  @Test
+  void shouldNotifyListenerWithGroupWhenBrokerRemoved() {
+    // given
+    final var brokerId = BrokerMemberId.from(0);
+    final BrokerInfo broker = createBrokerWithGroup(brokerId, "tenant1");
+    notifyEvent(createMemberAddedEvent(broker));
+
+    final var capturedRemovedGroups = new CopyOnWriteArrayList<String>();
+    final var capturedRemovedMembers = new CopyOnWriteArrayList<BrokerMemberId>();
+    addTopologyListener(
+        new BrokerTopologyListener() {
+          @Override
+          public void brokerRemoved(final BrokerMemberId memberId, final String physicalTenantId) {
+            capturedRemovedMembers.add(memberId);
+            capturedRemovedGroups.add(physicalTenantId);
+          }
+        });
+
+    // when
+    notifyEvent(createMemberRemoveEvent(broker));
+
+    // then
+    assertThat(capturedRemovedMembers).containsExactly(brokerId);
+    assertThat(capturedRemovedGroups).containsExactly("tenant1");
+  }
+
+  @Test
+  void shouldNotifyListenerForEachGroupOnBrokerRemoved() {
+    // given — broker 0 serves both default and tenant1 groups
+    final var brokerId = BrokerMemberId.from(0);
+    final BrokerInfo defaultInfo = createBroker(brokerId);
+    final BrokerInfo tenant1Info = createBrokerWithGroup(brokerId, "tenant1");
+
+    final Member member = new Member(new MemberConfig().setId(defaultInfo.brokerIdStr()));
+    defaultInfo.writeIntoProperties(member.properties());
+    tenant1Info.writeIntoProperties(member.properties());
+    members.add(member);
+    notifyEvent(new ClusterMembershipEvent(Type.MEMBER_ADDED, member));
+
+    final var capturedRemovedGroups = new CopyOnWriteArrayList<String>();
+    addTopologyListener(
+        new BrokerTopologyListener() {
+          @Override
+          public void brokerRemoved(final BrokerMemberId memberId, final String physicalTenantId) {
+            capturedRemovedGroups.add(physicalTenantId);
+          }
+        });
+
+    // when
+    notifyEvent(new ClusterMembershipEvent(Type.MEMBER_REMOVED, member));
+
+    // then — one notification per group
+    assertThat(capturedRemovedGroups)
+        .containsExactlyInAnyOrder(DEFAULT_PHYSICAL_TENANT_ID, "tenant1");
   }
 
   @Test

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -747,7 +747,7 @@ final class BrokerTopologyManagerTest {
     }
 
     @Override
-    public void brokerRemoved(final BrokerMemberId memberId) {
+    public void brokerRemoved(final BrokerMemberId memberId, final String physicalTenantId) {
       brokers.remove(memberId);
     }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -574,6 +574,57 @@ final class BrokerTopologyManagerTest {
   }
 
   @Test
+  void shouldNotifyListenerWithGroupWhenBrokerJoins() {
+    // given
+    final var capturedGroups = new CopyOnWriteArrayList<String>();
+    final var capturedMembers = new CopyOnWriteArrayList<BrokerMemberId>();
+    addTopologyListener(
+        new BrokerTopologyListener() {
+          @Override
+          public void brokerAddedToGroup(
+              final BrokerMemberId memberId, final String physicalTenantId) {
+            capturedMembers.add(memberId);
+            capturedGroups.add(physicalTenantId);
+          }
+        });
+
+    final var brokerId = BrokerMemberId.from(0);
+    final BrokerInfo broker = createBrokerWithGroup(brokerId, "tenant1");
+
+    // when
+    notifyEvent(createMemberAddedEvent(broker));
+
+    // then
+    assertThat(capturedMembers).containsExactly(brokerId);
+    assertThat(capturedGroups).containsExactly("tenant1");
+  }
+
+  @Test
+  void shouldBackfillNewListenerWithGroupInfo() {
+    // given — broker 0 already joined with group "tenant1"
+    final var brokerId = BrokerMemberId.from(0);
+    final BrokerInfo broker = createBrokerWithGroup(brokerId, "tenant1");
+    notifyEvent(createMemberAddedEvent(broker));
+
+    // when — a new listener is registered after the broker is already known
+    final var capturedGroups = new CopyOnWriteArrayList<String>();
+    final var capturedMembers = new CopyOnWriteArrayList<BrokerMemberId>();
+    addTopologyListener(
+        new BrokerTopologyListener() {
+          @Override
+          public void brokerAddedToGroup(
+              final BrokerMemberId memberId, final String physicalTenantId) {
+            capturedMembers.add(memberId);
+            capturedGroups.add(physicalTenantId);
+          }
+        });
+
+    // then — backfill fires brokerAddedToGroup with the known group
+    assertThat(capturedMembers).containsExactly(brokerId);
+    assertThat(capturedGroups).containsExactly("tenant1");
+  }
+
+  @Test
   void shouldAggregateTopologyPerPartitionGroup() {
     // given — broker 0 publishes both a default-group and a tenant1-group BrokerInfo
     final var brokerId = BrokerMemberId.from(0);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/SpringBrokerBridge.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.system.management.BrokerAdminService;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -29,7 +30,7 @@ public class SpringBrokerBridge {
 
   private Supplier<BrokerHealthCheckService> healthCheckServiceSupplier;
   private Supplier<BrokerAdminService> adminServiceSupplier;
-  private Supplier<JobStreamService> jobStreamServiceSupplier;
+  private Supplier<Collection<JobStreamService>> jobStreamServicesSupplier;
   private Supplier<JobStreamClient> jobStreamClientSupplier;
 
   private BiConsumer<Integer, String> shutdownHelper;
@@ -61,13 +62,13 @@ public class SpringBrokerBridge {
     return Optional.ofNullable(jobStreamClientSupplier).map(Supplier::get);
   }
 
-  public void registerJobStreamServiceSupplier(
-      final Supplier<JobStreamService> jobStreamServiceSupplier) {
-    this.jobStreamServiceSupplier = jobStreamServiceSupplier;
+  public void registerJobStreamServicesSupplier(
+      final Supplier<Collection<JobStreamService>> jobStreamServicesSupplier) {
+    this.jobStreamServicesSupplier = jobStreamServicesSupplier;
   }
 
-  public Optional<JobStreamService> getJobStreamService() {
-    return Optional.ofNullable(jobStreamServiceSupplier).map(Supplier::get);
+  public Optional<Collection<JobStreamService>> getJobStreamServices() {
+    return Optional.ofNullable(jobStreamServicesSupplier).map(Supplier::get);
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStep.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-
 import io.camunda.zeebe.broker.jobstream.JobStreamMetrics;
 import io.camunda.zeebe.broker.jobstream.JobStreamService;
 import io.camunda.zeebe.broker.jobstream.RemoteJobStreamErrorHandlerService;
@@ -28,6 +26,7 @@ import io.camunda.zeebe.transport.stream.api.RemoteStreamService;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
 
@@ -71,8 +70,12 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
           }
           brokerStartupContext
               .getSpringBrokerBridge()
-              .registerJobStreamServiceSupplier(
-                  () -> brokerStartupContext.getJobStreamService(DEFAULT_PHYSICAL_TENANT_ID));
+              .registerJobStreamServicesSupplier(
+                  () ->
+                      tenantIds.stream()
+                          .map(brokerStartupContext::getJobStreamService)
+                          .filter(Objects::nonNull)
+                          .toList());
           startupFuture.complete(brokerStartupContext);
         });
   }
@@ -95,7 +98,7 @@ public final class JobStreamServiceStep extends AbstractBrokerStartupStep {
     concurrencyControl.runOnCompletion(
         futures,
         (ok, err) -> {
-          brokerShutdownContext.getSpringBrokerBridge().registerJobStreamServiceSupplier(null);
+          brokerShutdownContext.getSpringBrokerBridge().registerJobStreamServicesSupplier(null);
           if (err != null) {
             shutdownFuture.completeExceptionally(err);
           } else {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/JobStreamServiceStepTest.java
@@ -96,15 +96,15 @@ final class JobStreamServiceStepTest {
     }
 
     @Test
-    void shouldRegisterDefaultTenantServiceSupplierWithSpringBrokerBridge() {
+    void shouldRegisterAllTenantServicesSupplierWithSpringBrokerBridge() {
       // when
       sut.startupInternal(ctx, CONCURRENCY_CONTROL, startupFuture);
       completeAllScheduledActors();
 
-      // then — the bridge supplier is wired to the default physical tenant's service
+      // then — the bridge supplier exposes all physical tenant services for the actuator
       assertThat(startupFuture.isDone()).as("startup completed").isTrue();
       assertThat(startupFuture.isCompletedExceptionally()).as("no startup error").isFalse();
-      verify(ctx.getSpringBrokerBridge()).registerJobStreamServiceSupplier(notNull());
+      verify(ctx.getSpringBrokerBridge()).registerJobStreamServicesSupplier(notNull());
     }
 
     @Test

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -46,15 +46,8 @@ public final class JobStreamClientImpl implements JobStreamClient {
                 clusterCommunicationService, new JobClientStreamMetrics(meterRegistry));
   }
 
-  /**
-   * No-op: group information is required for correct stream routing. Handled by {@link
-   * #brokerAddedToGroup(BrokerMemberId, String)}.
-   */
   @Override
-  public synchronized void brokerAdded(final BrokerMemberId memberId) {}
-
-  @Override
-  public synchronized void brokerAddedToGroup(
+  public synchronized void brokerAdded(
       final BrokerMemberId memberId, final String physicalTenantId) {
     if (!started) {
       return;

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.gateway.impl.stream;
 
-import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
-
 import io.atomix.cluster.BrokerMemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
@@ -45,18 +43,24 @@ public final class JobStreamClientImpl implements JobStreamClient {
     streamService =
         new TransportFactory(schedulingService)
             .createRemoteStreamClient(
-                clusterCommunicationService,
-                new JobClientStreamMetrics(meterRegistry),
-                DEFAULT_PHYSICAL_TENANT_ID);
+                clusterCommunicationService, new JobClientStreamMetrics(meterRegistry));
   }
 
+  /**
+   * No-op: group information is required for correct stream routing. Handled by {@link
+   * #brokerAddedToGroup(BrokerMemberId, String)}.
+   */
   @Override
-  public synchronized void brokerAdded(final BrokerMemberId memberId) {
+  public synchronized void brokerAdded(final BrokerMemberId memberId) {}
+
+  @Override
+  public synchronized void brokerAddedToGroup(
+      final BrokerMemberId memberId, final String physicalTenantId) {
     if (!started) {
       return;
     }
 
-    streamService.onServerJoined(memberId.memberId());
+    streamService.onServerJoinedToGroup(memberId.memberId(), physicalTenantId);
   }
 
   @Override

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -57,7 +57,8 @@ public final class JobStreamClientImpl implements JobStreamClient {
   }
 
   @Override
-  public synchronized void brokerRemoved(final BrokerMemberId memberId) {
+  public synchronized void brokerRemoved(
+      final BrokerMemberId memberId, final String physicalTenantId) {
     if (!started) {
       return;
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -53,7 +53,7 @@ public final class JobStreamClientImpl implements JobStreamClient {
       return;
     }
 
-    streamService.onServerJoinedToGroup(memberId.memberId(), physicalTenantId);
+    streamService.onServerJoined(memberId.memberId(), physicalTenantId);
   }
 
   @Override

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -71,8 +71,7 @@ public final class TransportFactory {
 
   public <M extends BufferWriter> ClientStreamService<M> createRemoteStreamClient(
       final ClusterCommunicationService clusterCommunicationService,
-      final ClientStreamMetrics metrics,
-      final String physicalTenantId) {
-    return new ClientStreamServiceImpl<>(clusterCommunicationService, metrics, physicalTenantId);
+      final ClientStreamMetrics metrics) {
+    return new ClientStreamServiceImpl<>(clusterCommunicationService, metrics);
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
@@ -38,7 +38,7 @@ public interface ClientStreamService<M extends BufferWriter> extends AsyncClosab
    * {@code physicalTenantId} are registered with {@code memberId}. Implementations should be
    * idempotent.
    */
-  void onServerJoinedToGroup(final MemberId memberId, final String physicalTenantId);
+  void onServerJoined(final MemberId memberId, final String physicalTenantId);
 
   /**
    * A callback to be invoked when a new streaming server is removed. Implementations should be

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  * Manages an instance of {@link ClientStreamer}. Intended to be the main entry point when setting
  * up the client side for remote streams, primarily via {@link
  * io.camunda.zeebe.transport.TransportFactory#createRemoteStreamClient(ClusterCommunicationService,
- * ClientStreamMetrics, String)}.
+ * ClientStreamMetrics)}.
  *
  * @param <M> the type of the streaming metadata
  */
@@ -33,10 +33,12 @@ public interface ClientStreamService<M extends BufferWriter> extends AsyncClosab
   ActorFuture<Void> start(final ActorSchedulingService schedulingService);
 
   /**
-   * A callback to be invoked when a new streaming server is added. Implementations should be
+   * A callback to be invoked when a streaming server is confirmed to serve a specific partition
+   * group. Drives group-aware stream registration: only streams whose physical tenant matches
+   * {@code physicalTenantId} are registered with {@code memberId}. Implementations should be
    * idempotent.
    */
-  void onServerJoined(final MemberId memberId);
+  void onServerJoinedToGroup(final MemberId memberId, final String physicalTenantId);
 
   /**
    * A callback to be invoked when a new streaming server is removed. Implementations should be

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
@@ -41,8 +41,7 @@ final class ClientStreamApiHandler {
   }
 
   byte[] handleRestartRequest(final MemberId sender, final byte[] ignored) {
-    clientStreamManager.onServerRemoved(MemberId.from(sender.id()));
-    clientStreamManager.onServerJoined(MemberId.from(sender.id()));
+    clientStreamManager.onServerRestarted(MemberId.from(sender.id()));
     return ArrayUtil.EMPTY_BYTE_ARRAY;
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -55,7 +55,7 @@ final class ClientStreamManager<M extends BufferWriter> {
    * @param serverId the joining server
    * @param physicalTenantId the physical tenant served by this server
    */
-  void onServerJoinedToGroup(final MemberId serverId, final String physicalTenantId) {
+  void onServerJoined(final MemberId serverId, final String physicalTenantId) {
     serversByPhysicalTenantId
         .computeIfAbsent(physicalTenantId, id -> new HashSet<>())
         .add(serverId);

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -15,7 +15,10 @@ import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
@@ -23,7 +26,13 @@ import org.slf4j.LoggerFactory;
 
 final class ClientStreamManager<M extends BufferWriter> {
   private static final Logger LOG = LoggerFactory.getLogger(ClientStreamManager.class);
-  private final Set<MemberId> servers = new HashSet<>();
+
+  /** physicalTenantId → set of broker member IDs serving that physical tenant */
+  private final Map<String, Set<MemberId>> serversByPhysicalTenantId = new HashMap<>();
+
+  /** broker member ID → set of physicalTenantIds it serves (for RESTART lookup) */
+  private final Map<MemberId, Set<String>> physicalTenantsByServer = new HashMap<>();
+
   private final ClientStreamRegistry<M> registry;
   private final ClientStreamRequestManager<M> requestManager;
   private final ClientStreamMetrics metrics;
@@ -40,22 +49,56 @@ final class ClientStreamManager<M extends BufferWriter> {
   }
 
   /**
-   * When a new server is added to the cluster, or an existing server restarted, existing client
-   * streams must be registered (again) with the server.
+   * Called when a server joins the cluster for a specific partition group. Only streams whose
+   * physical tenant matches {@code physicalTenantId} are registered with this server.
    *
-   * @param serverId id of the server that is added or restarted
+   * @param serverId the joining server
+   * @param physicalTenantId the physical tenant served by this server
    */
-  void onServerJoined(final MemberId serverId) {
-    servers.add(serverId);
-    metrics.serverCount(servers.size());
+  void onServerJoinedToGroup(final MemberId serverId, final String physicalTenantId) {
+    serversByPhysicalTenantId
+        .computeIfAbsent(physicalTenantId, id -> new HashSet<>())
+        .add(serverId);
+    physicalTenantsByServer.computeIfAbsent(serverId, id -> new HashSet<>()).add(physicalTenantId);
+    metrics.serverCount(physicalTenantsByServer.size());
 
-    registry.list().forEach(c -> requestManager.add(c, serverId));
+    registry.list().stream()
+        .filter(c -> physicalTenantId.equals(c.physicalTenantId()))
+        .forEach(c -> requestManager.add(c, serverId));
   }
 
   void onServerRemoved(final MemberId serverId) {
-    servers.remove(serverId);
-    metrics.serverCount(servers.size());
+    final var physicalTenantIds = physicalTenantsByServer.remove(serverId);
+    if (physicalTenantIds != null) {
+      physicalTenantIds.forEach(
+          physicalTenantId -> {
+            final var servers = serversByPhysicalTenantId.get(physicalTenantId);
+            if (servers != null) {
+              servers.remove(serverId);
+              if (servers.isEmpty()) {
+                serversByPhysicalTenantId.remove(physicalTenantId);
+              }
+            }
+          });
+    }
+    metrics.serverCount(physicalTenantsByServer.size());
     requestManager.onServerRemoved(serverId);
+  }
+
+  /**
+   * Called when a server that was already in the topology sends a RESTART_STREAMS signal. Resets
+   * its registrations and re-registers all streams belonging to its known physical tenants —
+   * without touching the topology maps.
+   */
+  void onServerRestarted(final MemberId serverId) {
+    requestManager.onServerRemoved(serverId);
+    physicalTenantsByServer
+        .getOrDefault(serverId, Collections.emptySet())
+        .forEach(
+            physicalTenantId ->
+                registry.list().stream()
+                    .filter(c -> physicalTenantId.equals(c.physicalTenantId()))
+                    .forEach(c -> requestManager.add(c, serverId)));
   }
 
   ClientStreamId add(
@@ -67,6 +110,8 @@ final class ClientStreamManager<M extends BufferWriter> {
     final var clientStream =
         registry.addClient(streamType, metadata, clientStreamConsumer, physicalTenantId);
     LOG.debug("Added new client stream [{}]", clientStream.streamId());
+    final var servers =
+        serversByPhysicalTenantId.getOrDefault(physicalTenantId, Collections.emptySet());
     clientStream.serverStream().open(requestManager, servers);
 
     return clientStream.streamId();
@@ -79,13 +124,16 @@ final class ClientStreamManager<M extends BufferWriter> {
         stream -> {
           LOG.debug("Removing aggregated stream [{}]", stream.streamId());
           stream.close();
+          final var servers =
+              serversByPhysicalTenantId.getOrDefault(
+                  stream.physicalTenantId(), Collections.emptySet());
           requestManager.remove(stream, servers);
         });
   }
 
   void close() {
     registry.clear();
-    requestManager.removeAll(servers);
+    requestManager.removeAll(serversByPhysicalTenantId);
   }
 
   public void onPayloadReceived(
@@ -115,7 +163,7 @@ final class ClientStreamManager<M extends BufferWriter> {
           // Stream does not exist. We expect to have already sent remove request to all servers.
           // But just in case that request is lost, we send remove request again. To keep it simple,
           // we do not retry. Otherwise, it is possible that we send it multiple times unnecessary.
-          requestManager.removeUnreliable(streamId, servers);
+          requestManager.removeUnreliable(streamId, serversByPhysicalTenantId);
           LOG.warn("Expected to push payload to stream {}, but no stream found.", streamId);
           responseFuture.completeExceptionally(
               new NoSuchStreamException(

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
@@ -43,6 +43,10 @@ final class ClientStreamRegistration<M extends BufferWriter> {
     return stream.streamId();
   }
 
+  String physicalTenantId() {
+    return stream.physicalTenantId();
+  }
+
   LogicalId<? extends BufferWriter> logicalId() {
     return stream.logicalId();
   }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import org.jspecify.annotations.Nullable;
@@ -39,6 +40,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Coordinates registering/de-registering {@link AggregatedClientStream} with arbitrary set of
  * servers.
+ *
+ * <p>Each stream carries its own {@code physicalTenantId}; this manager uses that value to form the
+ * correct physicalTenantId-scoped topic for every ADD/REMOVE/REMOVE_ALL message, so that streams
+ * are only registered with brokers that serve their physical tenant.
  *
  * <p>NOTE: all operations are potentially asynchronous as network I/O is involved. To avoid race
  * conditions w.r.t to the stream lifecycle, the manager keeps track of the registration state per
@@ -62,15 +67,11 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
   private final ClusterCommunicationService communicationService;
   private final ConcurrencyControl executor;
-  private final String physicalTenantId;
 
   ClientStreamRequestManager(
-      final ClusterCommunicationService communicationService,
-      final ConcurrencyControl executor,
-      final String physicalTenantId) {
+      final ClusterCommunicationService communicationService, final ConcurrencyControl executor) {
     this.communicationService = communicationService;
     this.executor = executor;
-    this.physicalTenantId = physicalTenantId;
   }
 
   /**
@@ -144,38 +145,45 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   }
 
   /**
-   * Sends a single remove all request to each given server, and closes all pending registrations.
+   * Sends REMOVE_ALL to each broker on its physicalTenantId-scoped topic, and closes all pending
+   * registrations.
    *
-   * @param servers the list of servers to notify
+   * @param serversByPhysicalTenantId physicalTenantId → set of broker member IDs
    */
-  void removeAll(final Collection<MemberId> servers) {
+  void removeAll(final Map<String, Set<MemberId>> serversByPhysicalTenantId) {
     registrations.values().stream()
         .flatMap(m -> m.values().stream())
         .forEach(ClientStreamRegistration::transitionToClosed);
     registrations.clear();
 
-    servers.forEach(this::doRemoveAll);
+    serversByPhysicalTenantId.forEach(
+        (physicalTenantId, servers) ->
+            servers.forEach(brokerId -> doRemoveAll(brokerId, physicalTenantId)));
   }
 
   /**
    * Send remove stream request to servers without waiting for ack and without retry. As this is
    * used to send even when no stream was originally registered, we ignore any existing
-   * registrations.
+   * registrations. Iterates all known physical tenants since the stream's tenant is unknown at this
+   * point.
    */
-  void removeUnreliable(final UUID streamId, final Collection<MemberId> servers) {
+  void removeUnreliable(
+      final UUID streamId, final Map<String, Set<MemberId>> serversByPhysicalTenantId) {
     final var request = new RemoveStreamRequest().streamId(streamId);
     final var payload = BufferUtil.bufferAsArray(request);
 
-    servers.forEach(
-        serverId -> {
-          communicationService.unicast(
-              StreamTopics.REMOVE.topic(physicalTenantId),
-              payload,
-              Function.identity(),
-              serverId,
-              true);
-          purgeRegistration(streamId, serverId);
-        });
+    serversByPhysicalTenantId.forEach(
+        (physicalTenantId, servers) ->
+            servers.forEach(
+                serverId -> {
+                  communicationService.unicast(
+                      StreamTopics.REMOVE.topic(physicalTenantId),
+                      payload,
+                      Function.identity(),
+                      serverId,
+                      true);
+                  purgeRegistration(streamId, serverId);
+                }));
   }
 
   private void add(final ClientStreamRegistration<M> registration) {
@@ -256,7 +264,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
     final var pendingRequest =
         communicationService.send(
-            StreamTopics.ADD.topic(physicalTenantId),
+            StreamTopics.ADD.topic(registration.physicalTenantId()),
             request,
             Function.identity(),
             Function.identity(),
@@ -315,7 +323,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
 
     final var pendingRequest =
         communicationService.send(
-            StreamTopics.REMOVE.topic(physicalTenantId),
+            StreamTopics.REMOVE.topic(registration.physicalTenantId()),
             request,
             Function.identity(),
             Function.identity(),
@@ -408,8 +416,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
     }
   }
 
-  private void doRemoveAll(final MemberId brokerId) {
-    // Do not wait for response, as this is expected to be called while shutting down.
+  private void doRemoveAll(final MemberId brokerId, final String physicalTenantId) {
     communicationService.unicast(
         StreamTopics.REMOVE_ALL.topic(physicalTenantId),
         REMOVE_ALL_REQUEST,

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -25,7 +25,9 @@ import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
 
@@ -41,23 +43,20 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   private final ClusterCommunicationService communicationService;
   private final ClientStreamRegistry<M> registry;
   private final ClientStreamApiHandler apiHandler;
-  private final String physicalTenantId;
+
+  /** Tracks which physicalTenantId topics already have a RESTART_STREAMS listener registered. */
+  private final Set<String> registeredRestartPhysicalTenants = new HashSet<>();
 
   public ClientStreamServiceImpl(
-      final ClusterCommunicationService communicationService,
-      final ClientStreamMetrics metrics,
-      final String physicalTenantId) {
+      final ClusterCommunicationService communicationService, final ClientStreamMetrics metrics) {
     this.communicationService = communicationService;
-    this.physicalTenantId = physicalTenantId;
     registry = new ClientStreamRegistry<>(metrics);
 
     // ClientStreamRequestManager must use same actor as this because it is mutating shared
     // ClientStream objects.
     clientStreamManager =
         new ClientStreamManager<>(
-            registry,
-            new ClientStreamRequestManager<>(communicationService, actor, physicalTenantId),
-            metrics);
+            registry, new ClientStreamRequestManager<>(communicationService, actor), metrics);
     apiHandler = new ClientStreamApiHandler(clientStreamManager, actor);
   }
 
@@ -70,12 +69,9 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
         BufferUtil::bufferAsArray,
         actor::run);
 
-    communicationService.replyTo(
-        StreamTopics.RESTART_STREAMS.topic(physicalTenantId),
-        Function.identity(),
-        apiHandler::handleRestartRequest,
-        Function.identity(),
-        actor::run);
+    // Pre-register the default group's RESTART topic so restarted legacy brokers are handled
+    // even before the first brokerAddedToGroup callback fires.
+    registerRestartHandler(DEFAULT_PHYSICAL_TENANT_ID);
   }
 
   @Override
@@ -105,8 +101,12 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   }
 
   @Override
-  public void onServerJoined(final MemberId memberId) {
-    actor.run(() -> clientStreamManager.onServerJoined(memberId));
+  public void onServerJoinedToGroup(final MemberId memberId, final String physicalTenantId) {
+    actor.run(
+        () -> {
+          registerRestartHandler(physicalTenantId);
+          clientStreamManager.onServerJoinedToGroup(memberId, physicalTenantId);
+        });
   }
 
   @Override
@@ -133,5 +133,16 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
                 .flatMap(agg -> agg.list().stream())
                 .map(s -> (ClientStream<M>) s)
                 .toList());
+  }
+
+  private void registerRestartHandler(final String physicalTenantId) {
+    if (registeredRestartPhysicalTenants.add(physicalTenantId)) {
+      communicationService.replyTo(
+          StreamTopics.RESTART_STREAMS.topic(physicalTenantId),
+          Function.identity(),
+          apiHandler::handleRestartRequest,
+          Function.identity(),
+          actor::run);
+    }
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -101,11 +101,11 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   }
 
   @Override
-  public void onServerJoinedToGroup(final MemberId memberId, final String physicalTenantId) {
+  public void onServerJoined(final MemberId memberId, final String physicalTenantId) {
     actor.run(
         () -> {
           registerRestartHandler(physicalTenantId);
-          clientStreamManager.onServerJoinedToGroup(memberId, physicalTenantId);
+          clientStreamManager.onServerJoined(memberId, physicalTenantId);
         });
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -70,7 +70,7 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
         actor::run);
 
     // Pre-register the default group's RESTART topic so restarted legacy brokers are handled
-    // even before the first brokerAddedToGroup callback fires.
+    // even before the first brokerAdded callback fires.
     registerRestartHandler(DEFAULT_PHYSICAL_TENANT_ID);
   }
 

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.Test;
 
 class ClientStreamManagerTest {
 
+  private static final String OTHER_PHYSICAL_TENANT_ID = "other-tenant";
   private static final ClientStreamConsumer NOOP_CONSUMER =
       p -> CompletableActorFuture.completed(null);
   private final DirectBuffer streamType = BufferUtil.wrapString("foo");
@@ -52,8 +53,7 @@ class ClientStreamManagerTest {
   private final ClientStreamManager<TestMetadata> clientStreamManager =
       new ClientStreamManager<>(
           registry,
-          new ClientStreamRequestManager<>(
-              mockTransport, new TestConcurrencyControl(), DEFAULT_PHYSICAL_TENANT_ID),
+          new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl()),
           metrics);
 
   @BeforeEach
@@ -95,13 +95,13 @@ class ClientStreamManagerTest {
   void shouldAddStreamAfterServerWasRemoved() {
     // given
     final var serverId = MemberId.anonymous();
-    clientStreamManager.onServerJoined(serverId);
+    clientStreamManager.onServerJoinedToGroup(serverId, DEFAULT_PHYSICAL_TENANT_ID);
     final var streamId =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     clientStreamManager.onServerRemoved(serverId);
 
     // when
-    clientStreamManager.onServerJoined(serverId);
+    clientStreamManager.onServerJoinedToGroup(serverId, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(registry.getClient(streamId))
@@ -167,9 +167,9 @@ class ClientStreamManagerTest {
   void shouldOpenStreamToExistingServers() {
     // given
     final MemberId server1 = MemberId.from("1");
-    clientStreamManager.onServerJoined(server1);
+    clientStreamManager.onServerJoinedToGroup(server1, DEFAULT_PHYSICAL_TENANT_ID);
     final MemberId server2 = MemberId.from("2");
-    clientStreamManager.onServerJoined(server2);
+    clientStreamManager.onServerJoinedToGroup(server2, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     final var uuid =
@@ -192,7 +192,7 @@ class ClientStreamManagerTest {
 
     // when
     final MemberId server = MemberId.from("3");
-    clientStreamManager.onServerJoined(server);
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(serverStream.isConnected(server)).isTrue();
@@ -209,9 +209,10 @@ class ClientStreamManagerTest {
             BufferUtil.wrapString("bar"), metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var serverStream1 = registry.get(getServerStreamId(stream1)).orElseThrow();
     final var serverStream2 = registry.get(getServerStreamId(stream2)).orElseThrow();
+
     // when
     final MemberId server = MemberId.from("3");
-    clientStreamManager.onServerJoined(server);
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(serverStream1.isConnected(server)).isTrue();
@@ -326,7 +327,7 @@ class ClientStreamManagerTest {
   void shouldRemoveServerFromClientStream() {
     // given
     final MemberId server = MemberId.from("1");
-    clientStreamManager.onServerJoined(server);
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
     final var uuid =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
@@ -345,7 +346,7 @@ class ClientStreamManagerTest {
     final MemberId server = MemberId.from("1");
 
     // when
-    clientStreamManager.onServerJoined(server);
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(metrics.getServerCount()).isOne();
@@ -355,13 +356,63 @@ class ClientStreamManagerTest {
   void shouldReportServerCountOnRemoved() {
     // given
     final MemberId server = MemberId.from("1");
-    clientStreamManager.onServerJoined(server);
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     clientStreamManager.onServerRemoved(server);
 
     // then
     assertThat(metrics.getServerCount()).isZero();
+  }
+
+  @Test
+  void shouldNotRegisterStreamWithServerFromDifferentGroup() {
+    // given
+    final MemberId defaultServer = MemberId.from("default-1");
+    final MemberId otherServer = MemberId.from("other-1");
+    clientStreamManager.onServerJoinedToGroup(defaultServer, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoinedToGroup(otherServer, OTHER_PHYSICAL_TENANT_ID);
+
+    // when - add a stream for the default group
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
+
+    // then - only registered with the default server, not the other-group server
+    assertThat(stream.isConnected(defaultServer)).isTrue();
+    assertThat(stream.isConnected(otherServer)).isFalse();
+  }
+
+  @Test
+  void shouldOnlyPropagateServerJoinToMatchingGroupStreams() {
+    // given - stream for default group already open
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
+
+    // when - a server from a different group joins
+    final MemberId otherServer = MemberId.from("other-1");
+    clientStreamManager.onServerJoinedToGroup(otherServer, OTHER_PHYSICAL_TENANT_ID);
+
+    // then - stream not registered with that server
+    assertThat(stream.isConnected(otherServer)).isFalse();
+  }
+
+  @Test
+  void shouldRestartOnlyStreamsForKnownGroups() {
+    // given
+    final MemberId server = MemberId.from("1");
+    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
+    assertThat(stream.isConnected(server)).isTrue();
+
+    // when - server restarts
+    clientStreamManager.onServerRestarted(server);
+
+    // then - stream re-registered with same server
+    assertThat(stream.isConnected(server)).isTrue();
   }
 
   private UUID getServerStreamId(final ClientStreamId clientStreamId) {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -95,13 +95,13 @@ class ClientStreamManagerTest {
   void shouldAddStreamAfterServerWasRemoved() {
     // given
     final var serverId = MemberId.anonymous();
-    clientStreamManager.onServerJoinedToGroup(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
     final var streamId =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     clientStreamManager.onServerRemoved(serverId);
 
     // when
-    clientStreamManager.onServerJoinedToGroup(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(registry.getClient(streamId))
@@ -167,9 +167,9 @@ class ClientStreamManagerTest {
   void shouldOpenStreamToExistingServers() {
     // given
     final MemberId server1 = MemberId.from("1");
-    clientStreamManager.onServerJoinedToGroup(server1, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server1, DEFAULT_PHYSICAL_TENANT_ID);
     final MemberId server2 = MemberId.from("2");
-    clientStreamManager.onServerJoinedToGroup(server2, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server2, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     final var uuid =
@@ -192,7 +192,7 @@ class ClientStreamManagerTest {
 
     // when
     final MemberId server = MemberId.from("3");
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(serverStream.isConnected(server)).isTrue();
@@ -212,7 +212,7 @@ class ClientStreamManagerTest {
 
     // when
     final MemberId server = MemberId.from("3");
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(serverStream1.isConnected(server)).isTrue();
@@ -327,7 +327,7 @@ class ClientStreamManagerTest {
   void shouldRemoveServerFromClientStream() {
     // given
     final MemberId server = MemberId.from("1");
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
     final var uuid =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
@@ -346,7 +346,7 @@ class ClientStreamManagerTest {
     final MemberId server = MemberId.from("1");
 
     // when
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(metrics.getServerCount()).isOne();
@@ -356,7 +356,7 @@ class ClientStreamManagerTest {
   void shouldReportServerCountOnRemoved() {
     // given
     final MemberId server = MemberId.from("1");
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     clientStreamManager.onServerRemoved(server);
@@ -370,8 +370,8 @@ class ClientStreamManagerTest {
     // given
     final MemberId defaultServer = MemberId.from("default-1");
     final MemberId otherServer = MemberId.from("other-1");
-    clientStreamManager.onServerJoinedToGroup(defaultServer, DEFAULT_PHYSICAL_TENANT_ID);
-    clientStreamManager.onServerJoinedToGroup(otherServer, OTHER_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(defaultServer, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(otherServer, OTHER_PHYSICAL_TENANT_ID);
 
     // when - add a stream for the default group
     final var uuid =
@@ -392,7 +392,7 @@ class ClientStreamManagerTest {
 
     // when - a server from a different group joins
     final MemberId otherServer = MemberId.from("other-1");
-    clientStreamManager.onServerJoinedToGroup(otherServer, OTHER_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(otherServer, OTHER_PHYSICAL_TENANT_ID);
 
     // then - stream not registered with that server
     assertThat(stream.isConnected(otherServer)).isFalse();
@@ -402,7 +402,7 @@ class ClientStreamManagerTest {
   void shouldRestartOnlyStreamsForKnownGroups() {
     // given
     final MemberId server = MemberId.from("1");
-    clientStreamManager.onServerJoinedToGroup(server, DEFAULT_PHYSICAL_TENANT_ID);
+    clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
     final var uuid =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
     final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -415,6 +415,18 @@ class ClientStreamManagerTest {
     assertThat(stream.isConnected(server)).isTrue();
   }
 
+  @Test
+  void shouldHandleRestartFromUnknownServerGracefully() {
+    // given — a stream exists but this server never joined any group
+    clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final MemberId unknownServer = MemberId.from("never-joined");
+
+    // when / then — no exception, stream stays unregistered with unknown server
+    clientStreamManager.onServerRestarted(unknownServer);
+    final var stream = registry.list().stream().findFirst().orElseThrow();
+    assertThat(stream.isConnected(unknownServer)).isFalse();
+  }
+
   private UUID getServerStreamId(final ClientStreamId clientStreamId) {
     return registry.getClient(clientStreamId).orElseThrow().serverStream().streamId();
   }

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -623,6 +623,71 @@ final class ClientStreamRequestManagerTest {
             anyBoolean());
   }
 
+  @Test
+  void shouldUseGroupScopedTopicForNonDefaultPhysicalTenant() {
+    // given — stream owned by a non-default partition group
+    final String physicalTenantId = "tenant1";
+    final var tenantStream =
+        new AggregatedClientStream<>(
+            UUID.randomUUID(),
+            new LogicalId<>(
+                new UnsafeBuffer(BufferUtil.wrapString("tenant-foo")), new TestMetadata()),
+            physicalTenantId);
+    tenantStream.open(requestManager, Collections.emptySet());
+
+    final var serverId = MemberId.anonymous();
+    when(mockTransport.send(
+            eq(StreamTopics.ADD.topic(physicalTenantId)), any(), any(), any(), eq(serverId), any()))
+        .thenReturn(CompletableFuture.completedFuture(addStreamSuccess));
+    when(mockTransport.send(
+            eq(StreamTopics.REMOVE.topic(physicalTenantId)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
+        .thenReturn(CompletableFuture.completedFuture(removeStreamSuccess));
+
+    // when
+    requestManager.add(tenantStream, serverId);
+
+    // then — ADD uses prefixed topic "tenant1-stream-add", not legacy "stream-add"
+    verify(mockTransport)
+        .send(
+            eq(StreamTopics.ADD.topic(physicalTenantId)), any(), any(), any(), eq(serverId), any());
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.ADD.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    assertThat(tenantStream.isConnected(serverId)).isTrue();
+
+    // when
+    requestManager.remove(tenantStream, serverId);
+
+    // then — REMOVE also uses prefixed topic
+    verify(mockTransport)
+        .send(
+            eq(StreamTopics.REMOVE.topic(physicalTenantId)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    verify(mockTransport, never())
+        .send(
+            eq(StreamTopics.REMOVE.topic(DEFAULT_PHYSICAL_TENANT_ID)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any());
+    assertThat(tenantStream.isConnected(serverId)).isFalse();
+  }
+
   private static Stream<MessagingException> provideMessagingFailures() {
     return Stream.of(
         new NoSuchMemberException("failed"),

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -53,8 +54,7 @@ final class ClientStreamRequestManagerTest {
   private final ClusterCommunicationService mockTransport = mock(ClusterCommunicationService.class);
   private final TestConcurrencyControl concurrencyControl = spy(new TestConcurrencyControl());
   private final ClientStreamRequestManager<TestMetadata> requestManager =
-      new ClientStreamRequestManager<>(
-          mockTransport, concurrencyControl, DEFAULT_PHYSICAL_TENANT_ID);
+      new ClientStreamRequestManager<>(mockTransport, concurrencyControl);
   private final AggregatedClientStream<TestMetadata> clientStream =
       new AggregatedClientStream<>(
           UUID.randomUUID(),
@@ -484,7 +484,7 @@ final class ClientStreamRequestManagerTest {
 
     // when - remove all, which will close all registrations
     requestManager.remove(clientStream, serverId);
-    requestManager.removeAll(Collections.singleton(serverId));
+    requestManager.removeAll(Map.of(DEFAULT_PHYSICAL_TENANT_ID, Collections.singleton(serverId)));
     pendingRequest.completeExceptionally(new RuntimeException("failed"));
 
     // then
@@ -580,7 +580,7 @@ final class ClientStreamRequestManagerTest {
 
     // when - remove all, which will close all registrations
     requestManager.add(clientStream, serverId);
-    requestManager.removeAll(Collections.singleton(serverId));
+    requestManager.removeAll(Map.of(DEFAULT_PHYSICAL_TENANT_ID, Collections.singleton(serverId)));
     pendingRequest.completeExceptionally(new RuntimeException("failed"));
 
     // then
@@ -600,10 +600,11 @@ final class ClientStreamRequestManagerTest {
     // given
     final MemberId server1 = MemberId.from("1");
     final MemberId server2 = MemberId.from("2");
-    final var servers = Set.of(server1, server2);
+    final var serversByPhysicalTenantId =
+        Map.of(DEFAULT_PHYSICAL_TENANT_ID, Set.of(server1, server2));
 
     // when
-    requestManager.removeAll(servers);
+    requestManager.removeAll(serversByPhysicalTenantId);
 
     // then
     verify(mockTransport)

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -86,9 +86,9 @@ final class StreamIntegrationTest {
     server2.start();
     client.start();
 
-    client.streamService.onServerJoinedToGroup(
+    client.streamService.onServerJoined(
         server1.cluster.getMembershipService().getLocalMember().id(), DEFAULT_PHYSICAL_TENANT_ID);
-    client.streamService.onServerJoinedToGroup(
+    client.streamService.onServerJoined(
         server2.cluster.getMembershipService().getLocalMember().id(), DEFAULT_PHYSICAL_TENANT_ID);
     clientStreamer = client.streamService.streamer();
   }
@@ -345,7 +345,7 @@ final class StreamIntegrationTest {
                   .hasValue(Set.of(server2.memberId())));
 
       // when
-      client.streamService.onServerJoinedToGroup(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
+      client.streamService.onServerJoined(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
 
       // then
       awaitStreamAdded(streamType, streamId, server1, server2);
@@ -414,8 +414,7 @@ final class StreamIntegrationTest {
       try (final var restartedServer =
           new TestServer(createClusterNode(clusterNodes.get(0), clusterNodes))) {
         restartedServer.start();
-        client.streamService.onServerJoinedToGroup(
-            restartedServer.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
+        client.streamService.onServerJoined(restartedServer.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
 
         // then
         awaitStreamAdded(streamType, streamId, restartedServer, server2);

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -86,10 +86,10 @@ final class StreamIntegrationTest {
     server2.start();
     client.start();
 
-    client.streamService.onServerJoined(
-        server1.cluster.getMembershipService().getLocalMember().id());
-    client.streamService.onServerJoined(
-        server2.cluster.getMembershipService().getLocalMember().id());
+    client.streamService.onServerJoinedToGroup(
+        server1.cluster.getMembershipService().getLocalMember().id(), DEFAULT_PHYSICAL_TENANT_ID);
+    client.streamService.onServerJoinedToGroup(
+        server2.cluster.getMembershipService().getLocalMember().id(), DEFAULT_PHYSICAL_TENANT_ID);
     clientStreamer = client.streamService.streamer();
   }
 
@@ -345,7 +345,7 @@ final class StreamIntegrationTest {
                   .hasValue(Set.of(server2.memberId())));
 
       // when
-      client.streamService.onServerJoined(server1.memberId());
+      client.streamService.onServerJoinedToGroup(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
 
       // then
       awaitStreamAdded(streamType, streamId, server1, server2);
@@ -414,7 +414,8 @@ final class StreamIntegrationTest {
       try (final var restartedServer =
           new TestServer(createClusterNode(clusterNodes.get(0), clusterNodes))) {
         restartedServer.start();
-        client.streamService.onServerJoined(restartedServer.memberId());
+        client.streamService.onServerJoinedToGroup(
+            restartedServer.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
 
         // then
         awaitStreamAdded(streamType, streamId, restartedServer, server2);
@@ -483,9 +484,7 @@ final class StreamIntegrationTest {
       final var factory = new TransportFactory(actorScheduler);
       streamService =
           factory.createRemoteStreamClient(
-              cluster.getCommunicationService(),
-              ClientStreamMetrics.noop(),
-              DEFAULT_PHYSICAL_TENANT_ID);
+              cluster.getCommunicationService(), ClientStreamMetrics.noop());
     }
 
     private void start() {


### PR DESCRIPTION
## Description

Implements sub-issue 4 of the physical-tenant-aware job streaming epic: the gateway now registers each stream only with brokers serving its partition group, on that group's scoped control topic.

  Closes #56223
  Part of #56219

  ## Changes

  **`zeebe/broker-client`**
  - `BrokerTopologyListener`: new `brokerAddedToGroup(memberId, physicalTenantId)` default method
  - `BrokerTopologyManagerImpl`: fires `brokerAddedToGroup` on broker add and backfills late-registering listeners with group info

  **`zeebe/transport`**
  - `ClientStreamService`: replaced no-op `onServerJoined` with required `onServerJoinedToGroup(memberId, physicalTenantId)` — group context is mandatory for correct routing
  - `ClientStreamManager`: tracks `serversByPhysicalTenantId` and `physicalTenantsByServer`; on server join, registers only streams whose `physicalTenantId` matches; on restart, re-registers only streams for the server's known groups
  - `ClientStreamRequestManager`: routes `ADD`/`REMOVE` to `StreamTopics.ADD.topic(physicalTenantId)` (e.g. `"tenant1-stream-add"`); `REMOVE_ALL` iterates per physicalTenantId
  - `ClientStreamServiceImpl`: pre-registers default group `RESTART` handler on start; lazily registers per-physicalTenantId `RESTART` handler on first server appearance for that group

  **`zeebe/gateway-grpc`**
  - `JobStreamClientImpl`: delegates `brokerAddedToGroup` to `streamService.onServerJoinedToGroup`; `brokerAdded` is now a no-op (group context required)

  ## ADR decisions followed

  | Decision | How |
  |----------|-----|
  | D3 — control topics group-scoped, PUSH global | `ADD`/`REMOVE`/`REMOVE_ALL`/`RESTART` use `physicalTenantId`-prefixed topics; `PUSH` unchanged |
  | D4 — default tenant keeps legacy prefix-less names | `StreamTopics.topic(DEFAULT_PHYSICAL_TENANT_ID)` returns the unprefixed name |
  | D7 — single group-aware `ClientStreamService` | One service handles all tenants; physicalTenantId lives on each stream, not the service |

---

### 💭 High level observation

- `createRemoteStreamServer` on broker side -- creates one instance per physical tenant
   - server metrics can be updated per physical tenant id
- `createRemoteStreamClient` on gateway side -- creates one instance for all physical tenants (D7)
   - client metrics are not updated per physical tenant id -- require refactoring adding `Map<String, ClientStreamMetrics>` on `ClientStreamManager`

| Metric | Call site | `physicalTenantId` available? | Per-tenant? |
  |--------|-----------|-------------------------------|-------------|
  | `serverCount` | `ClientStreamManager.onServerJoinedToGroup` | Yes — method param | ✓ |
  | `clientCount` | `ClientStreamRegistry.addClient` / `removeClient` | No — registry counts globally today | Needs refactor |
  | `aggregatedStreamCount` | `ClientStreamRegistry.addClient` / `removeClient` | No — same | Needs refactor |
  | `observeAggregatedClientCount` | `AggregatedClientStream.addClient` / `removeClient` | Yes — `this.physicalTenantId()` | ✓ |                                                                       
  | `pushSucceeded` / `pushFailed` | `ClientStreamManager` push handler | Yes — `AggregatedClientStream` passed in | ✓ |
  | `pushTryFailed` | `ClientStreamPusher` | Yes — `stream` param carries it | ✓ |

❓Should we refactor `JobClientStreamMetrics` per physical tenant id in the scope of this issue?