### PR TITLE
ci: build docs preview only for PRs targeting main

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -6,6 +6,12 @@ name: Docs PR Preview
 
 on:
   pull_request:
+    # The docs site is only ever deployed from main (see docs-build-deploy.yml),
+    # so only build/preview docs for PRs targeting main. Stable branches carry a
+    # copy of this workflow but must not run it — their monorepo-docs content is a
+    # backport subset and would otherwise fail the Docusaurus build on every
+    # docs-touching PR.
+    branches: [main]
     types: [opened, synchronize, closed]
   workflow_dispatch: {}
 


### PR DESCRIPTION
## Problem

`docs-preview.yml` triggers on `pull_request` to **any** base branch and builds the Docusaurus site whenever a PR touches docs paths. But the site is only ever deployed from `main` (`docs-build-deploy.yml` triggers on `push` to `main` only).

Stable branches inherit a copy of this workflow. Their `monorepo-docs` content is a backport subset of `main`, so the build fails on docs-touching PRs to stable branches — e.g. pages referenced by the sidebar/docs that were never backported. This has been breaking PRs on `stable/8.9`: https://github.com/camunda/camunda/actions/runs/29002955256

## Change

Restrict the `pull_request` trigger to `branches: [main]`. Previews still run for PRs against `main` (the only branch the site deploys from); PRs against stable branches no longer run the docs build.

This is the canonical fix so future stable branches cut from `main` inherit the filter. The existing `stable/8.9` copy is fixed (plus content cleanup) in https://github.com/camunda/camunda/pull/57247. `stable/8.8` and `stable/8.7` predate the docs-site and don't carry this workflow, so no backport is needed there.

## Verification

No behavior change for `main` PRs — the preview still builds and deploys for docs changes. Confirmed the trigger filter matches base=main only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)