### PR TITLE
fix: point StandaloneCamunda run configs at camunda-zeebe.main module

### DIFF
--- a/.idea/runConfigurations/StandaloneCamunda_AIO.xml
+++ b/.idea/runConfigurations/StandaloneCamunda_AIO.xml
@@ -13,7 +13,7 @@
       <env name="CAMUNDA_MCP_ENABLED" value="true" />
     </envs>
     <option name="VM_PARAMETERS" value="--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED" />
-    <module name="camunda-zeebe" />
+    <module name="camunda-zeebe.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="io.camunda.application.StandaloneCamunda" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />

--- a/.idea/runConfigurations/StandaloneCamunda_DEV.xml
+++ b/.idea/runConfigurations/StandaloneCamunda_DEV.xml
@@ -14,7 +14,7 @@
       <env name="CAMUNDA_MCP_ENABLED" value="true" />
     </envs>
     <option name="VM_PARAMETERS" value="--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED" />
-    <module name="camunda-zeebe" />
+    <module name="camunda-zeebe.main" />
     <option name="SPRING_BOOT_MAIN_CLASS" value="io.camunda.application.StandaloneCamunda" />
     <extension name="net.ashald.envfile">
       <option name="IS_ENABLED" value="false" />


### PR DESCRIPTION
## Description

IntelliJ IDEA 2026.1 enables the Maven importer's conditional main/test module split (maven.import.separate.main.and.test.modules.when.compiler.args). Since commit e6944c0 ("build: configure log4j annotation processor for plugin discovery") the dist module's default-compile execution carries an extra annotation processor that default-testCompile does not, so main and test compiler args diverge. That divergence trips the split condition, and the flat 'camunda-zeebe' module no longer exists as a runnable target -- only 'camunda-zeebe.main' (production classpath) and 'camunda-zeebe.test'.

Update the DEV and AIO run configs to reference camunda-zeebe.main so startup resolves the correct classpath again.

Without the fix running failed with:
```
/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED -XX:TieredStopAtLevel=1 -Dspring.profiles.active=identity,tasklist,operate,broker,consolidated-auth,dev,insecure -Dspring.output.ansi.enabled=always -javaagent:/Users/sebastian.bathke/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=62812 -Dfile.encoding=UTF-8 -Dsun.stdout.encoding=UTF-8 -Dsun.stderr.encoding=UTF-8 io.camunda.application.StandaloneCamunda
Error: Could not find or load main class io.camunda.application.StandaloneCamunda
Caused by: java.lang.ClassNotFoundException: io.camunda.application.StandaloneCamunda
```

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.