### PR TITLE
Register PT-prefixed sibling for /v3/api-docs

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
@@ -29,7 +29,8 @@ public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHa
   // Controllers on other paths are therefore never auto-enrolled in PT routing.
   private static final Set<String> PREFIXABLE_ROOTS =
       Stream.concat(
-              Stream.of("/v2", "/webapp"), WebAppProviderAdapter.WEB_APPS.stream().map("/"::concat))
+              Stream.of("/v2", "/v3/api-docs", "/webapp"),
+              WebAppProviderAdapter.WEB_APPS.stream().map("/"::concat))
           .collect(Collectors.toUnmodifiableSet());
 
   @Override

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMappingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMappingTest.java
@@ -67,6 +67,8 @@ class PhysicalTenantRequestMappingHandlerMappingTest {
         Arguments.of("/v2", EXPECTED_PREFIX + "/v2"),
         Arguments.of("/v2/widgets", EXPECTED_PREFIX + "/v2/widgets"),
         Arguments.of("/v2/widgets/{id}", EXPECTED_PREFIX + "/v2/widgets/{id}"),
+        // OpenAPI docs: springdoc's /v3/api-docs spec endpoint gets a PT-prefixed sibling
+        Arguments.of("/v3/api-docs", EXPECTED_PREFIX + "/v3/api-docs"),
         // webapp routes
         Arguments.of("/operate", EXPECTED_PREFIX + "/operate"),
         Arguments.of("/operate/processes", EXPECTED_PREFIX + "/operate/processes"),


### PR DESCRIPTION
The OpenAPI spec endpoint (springdoc's `/v3/api-docs`) had no per-physical-tenant route, so requesting it under a tenant prefix (`/physical-tenants/{id}/v3/api-docs`) returned 404 even though the security layer already permits it. Add `/v3/api-docs` to `PREFIXABLE_ROOTS` so `PhysicalTenantRequestMappingHandlerMapping` registers the tenant-prefixed sibling

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
