### PR TITLE
feat: introduce GlobalConfiguration and BrokerState records

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/BrokerState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/BrokerState.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import java.time.Instant;
+import java.util.Objects;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents the cluster-wide lifecycle state of a single broker.
+ *
+ * <p>Unlike the legacy {@code MemberState}, this record carries <em>only</em> broker lifecycle
+ * state and no partition assignment: which partitions a broker replicates within a group lives in
+ * {@code BrokerPartitionState}, and per-broker recovery lives there too (as its {@code Mode}).
+ * Accordingly the lifecycle {@link State} deliberately omits {@code RECOVERING} — recovery is
+ * per-group, not a cluster-wide broker state.
+ *
+ * <p>{@code version} is incremented every time the state is updated. It is used to resolve
+ * conflicts when members receive gossip updates out of order. Only a member updates its own state,
+ * which prevents conflicting concurrent updates. To keep this invariant self-contained, the state
+ * is only changed through {@link #setState(State)}, which returns a new instance with an
+ * incremented version — callers never manage the version themselves.
+ *
+ * @param version version of this broker's lifecycle state
+ * @param lastUpdated time this state was last updated
+ * @param state the lifecycle state of the broker
+ */
+@NullMarked
+public record BrokerState(long version, Instant lastUpdated, State state) {
+
+  public BrokerState {
+    Objects.requireNonNull(lastUpdated, "lastUpdated must not be null");
+    Objects.requireNonNull(state, "state must not be null");
+  }
+
+  /** Creates an initial state at version {@code 0} in {@link State#ACTIVE}. */
+  public static BrokerState initializeAsActive() {
+    return new BrokerState(0, Instant.MIN, State.ACTIVE);
+  }
+
+  /** Creates an initial state at version {@code 0} in {@link State#UNINITIALIZED}. */
+  public static BrokerState uninitialized() {
+    return new BrokerState(0, Instant.MIN, State.UNINITIALIZED);
+  }
+
+  /**
+   * Returns a new state with the given lifecycle state and an incremented version, or {@code this}
+   * if the state is unchanged.
+   */
+  public BrokerState setState(final State state) {
+    if (this.state == state) {
+      return this;
+    }
+    return new BrokerState(version + 1, Instant.now(), state);
+  }
+
+  /**
+   * Returns a new {@link BrokerState} after merging this and {@code other}. Does not mutate either
+   * operand.
+   *
+   * <p>The state is always updated by a member for itself, so the highest version is guaranteed to
+   * be the latest state and wins. Two states at the same version must be identical; otherwise the
+   * inputs are in conflict and cannot be reconciled.
+   *
+   * @param other the state to merge with, may be {@code null}
+   * @return the merged state
+   */
+  BrokerState merge(final @Nullable BrokerState other) {
+    if (other == null) {
+      return this;
+    }
+
+    if (version == other.version && !equals(other)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to find same BrokerState at same version, but found %s and %s",
+              this, other));
+    }
+
+    return version >= other.version ? this : other;
+  }
+
+  /**
+   * The lifecycle state of a broker within the cluster. Recovery is tracked per group, not here.
+   */
+  public enum State {
+    UNINITIALIZED,
+    JOINING,
+    ACTIVE,
+    LEAVING,
+    LEFT
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/GlobalConfiguration.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import com.google.common.collect.ImmutableSortedMap;
+import io.atomix.cluster.MemberId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.SortedMap;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Represents the cluster-wide configuration that is not specific to any partition group: the
+ * lifecycle state of every broker in the cluster and cluster-level settings.
+ *
+ * <p>{@code GlobalConfiguration} is the single authority for cluster membership. Every broker is
+ * always visible here regardless of which partition groups it is assigned to. Per-group partition
+ * assignment lives in {@code PartitionGroupConfiguration}; this record holds no partition state.
+ *
+ * <p>{@code version} is incremented only at plan boundaries (see {@link
+ * #startConfigurationChange(List)}) and when cluster-level config changes ({@link
+ * #setClusterId(String)}, {@link #setPartitionDistributorConfig(PartitionDistributorConfig)}).
+ * Merge uses a two-level scheme: if two copies have different versions, the higher version wins
+ * wholesale; if equal, members are merged field-by-field using their per-member versions.
+ *
+ * <p>This class is immutable; every mutating method returns a new instance.
+ *
+ * @param version version of this global configuration
+ * @param clusterId the cluster id, if assigned
+ * @param members lifecycle state of every broker in the cluster
+ * @param partitionDistributorConfig the partition distributor configuration, if set
+ * @param pendingChanges the ongoing cluster-level change plan, if any
+ * @param lastChange the last completed cluster-level change plan, if any
+ */
+@NullMarked
+public record GlobalConfiguration(
+    long version,
+    Optional<String> clusterId,
+    SortedMap<MemberId, BrokerState> members,
+    Optional<PartitionDistributorConfig> partitionDistributorConfig,
+    Optional<ClusterChangePlan> pendingChanges,
+    Optional<CompletedChange> lastChange) {
+
+  public static final long INITIAL_VERSION = 1;
+
+  public GlobalConfiguration {
+    Objects.requireNonNull(clusterId, "clusterId must not be null");
+    Objects.requireNonNull(members, "members must not be null");
+    Objects.requireNonNull(
+        partitionDistributorConfig, "partitionDistributorConfig must not be null");
+    Objects.requireNonNull(pendingChanges, "pendingChanges must not be null");
+    Objects.requireNonNull(lastChange, "lastChange must not be null");
+    members = ImmutableSortedMap.copyOf(members);
+  }
+
+  @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+  public GlobalConfiguration(
+      final long version,
+      final Optional<String> clusterId,
+      final Map<MemberId, BrokerState> members,
+      final Optional<PartitionDistributorConfig> partitionDistributorConfig,
+      final Optional<ClusterChangePlan> pendingChanges,
+      final Optional<CompletedChange> lastChange) {
+    this(
+        version,
+        clusterId,
+        ImmutableSortedMap.copyOf(members),
+        partitionDistributorConfig,
+        pendingChanges,
+        lastChange);
+  }
+
+  /** Creates an empty global configuration at {@link #INITIAL_VERSION} with no members. */
+  public static GlobalConfiguration init() {
+    return new GlobalConfiguration(
+        INITIAL_VERSION,
+        Optional.empty(),
+        Map.of(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  /**
+   * Adds a new broker to the cluster. Does not change the config version — the broker carries its
+   * own per-member version; the config version only moves at plan boundaries and on cluster-level
+   * config changes.
+   *
+   * @throws IllegalStateException if the broker is already part of the cluster
+   */
+  public GlobalConfiguration addMember(final MemberId memberId, final BrokerState state) {
+    if (members.containsKey(memberId)) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to add a new member, but member %s already exists with state %s",
+              memberId.id(), members.get(memberId)));
+    }
+    final var updatedMembers = new HashMap<>(members);
+    updatedMembers.put(memberId, state);
+    return withMembers(updatedMembers);
+  }
+
+  /**
+   * Transforms an existing broker's state via {@code memberStateUpdater} (e.g. {@code bs ->
+   * bs.setState(ACTIVE)}). The per-member version is bumped by {@link BrokerState}'s own update
+   * methods. Does not change the config version. Returns {@code this} if the state is unchanged.
+   *
+   * @throws IllegalStateException if the broker is not part of the cluster
+   */
+  public GlobalConfiguration updateMember(
+      final MemberId memberId, final UnaryOperator<BrokerState> memberStateUpdater) {
+    final BrokerState current = members.get(memberId);
+    if (current == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to update member %s, but it is not part of the cluster", memberId.id()));
+    }
+    final var updated = memberStateUpdater.apply(current);
+    if (updated.equals(current)) {
+      return this;
+    }
+    final var updatedMembers = new HashMap<>(members);
+    updatedMembers.put(memberId, updated);
+    return withMembers(updatedMembers);
+  }
+
+  /**
+   * Sets the cluster id and bumps the config version. This is a cluster-level configuration change.
+   * Returns {@code this} if the id is unchanged.
+   */
+  public GlobalConfiguration setClusterId(final String clusterId) {
+    if (this.clusterId.map(id -> id.equals(clusterId)).orElse(false)) {
+      return this;
+    }
+    return new GlobalConfiguration(
+        version + 1,
+        Optional.of(clusterId),
+        members,
+        partitionDistributorConfig,
+        pendingChanges,
+        lastChange);
+  }
+
+  /**
+   * Sets the partition distributor configuration and bumps the config version. This is a
+   * cluster-level configuration change. Returns {@code this} if the config is unchanged.
+   */
+  public GlobalConfiguration setPartitionDistributorConfig(
+      final PartitionDistributorConfig config) {
+    if (partitionDistributorConfig.map(cfg -> cfg.equals(config)).orElse(false)) {
+      return this;
+    }
+    return new GlobalConfiguration(
+        version + 1, clusterId, members, Optional.of(config), pendingChanges, lastChange);
+  }
+
+  /**
+   * Starts a new configuration change by setting {@code pendingChanges} to a new {@link
+   * ClusterChangePlan} and bumping the config version.
+   *
+   * @param operations the operations to execute, must be non-empty
+   * @return the updated global configuration
+   * @throws IllegalArgumentException if a change is already in progress, or {@code operations} is
+   *     empty
+   */
+  public GlobalConfiguration startConfigurationChange(
+      final List<ClusterConfigurationChangeOperation> operations) {
+    if (hasPendingChanges()) {
+      throw new IllegalArgumentException(
+          "Expected to start new configuration change, but there is a configuration change in progress "
+              + pendingChanges);
+    }
+    if (operations.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected to start new configuration change, but there is no operation");
+    }
+    final long newVersion = version + 1;
+    return new GlobalConfiguration(
+        newVersion,
+        clusterId,
+        members,
+        partitionDistributorConfig,
+        Optional.of(ClusterChangePlan.init(newVersion, operations)),
+        lastChange);
+  }
+
+  /**
+   * Returns a new {@link GlobalConfiguration} after merging this and {@code other}. Does not mutate
+   * either operand.
+   *
+   * <p>If the versions differ, the higher version wins wholesale. If equal, the result merges:
+   * {@code members} field-by-field by per-member version; {@code pendingChanges} by plan-internal
+   * version; {@code clusterId} first non-empty wins; {@code partitionDistributorConfig} the present
+   * value wins over absent (and if both are present they must agree).
+   *
+   * @param other the configuration to merge with
+   * @return the merged configuration
+   */
+  public GlobalConfiguration merge(final GlobalConfiguration other) {
+    if (version > other.version) {
+      return this;
+    } else if (other.version > version) {
+      return other;
+    }
+
+    final var mergedMembers =
+        Stream.concat(members.entrySet().stream(), other.members().entrySet().stream())
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue, BrokerState::merge));
+
+    final Optional<String> mergedClusterId = clusterId.or(() -> other.clusterId);
+
+    final Optional<PartitionDistributorConfig> mergedDistributorConfig =
+        Stream.of(partitionDistributorConfig, other.partitionDistributorConfig)
+            .flatMap(Optional::stream)
+            .reduce(PartitionDistributorConfig::merge);
+
+    final Optional<ClusterChangePlan> mergedChanges =
+        Stream.of(pendingChanges, other.pendingChanges)
+            .flatMap(Optional::stream)
+            .reduce(ClusterChangePlan::merge);
+
+    return new GlobalConfiguration(
+        version,
+        mergedClusterId,
+        mergedMembers,
+        mergedDistributorConfig,
+        mergedChanges,
+        lastChange);
+  }
+
+  public boolean hasPendingChanges() {
+    return pendingChanges.isPresent() && pendingChanges.orElseThrow().hasPendingChanges();
+  }
+
+  public boolean hasMember(final MemberId memberId) {
+    return members.containsKey(memberId);
+  }
+
+  public @Nullable BrokerState getMember(final MemberId memberId) {
+    return members.get(memberId);
+  }
+
+  private GlobalConfiguration withMembers(final Map<MemberId, BrokerState> updatedMembers) {
+    return new GlobalConfiguration(
+        version, clusterId, updatedMembers, partitionDistributorConfig, pendingChanges, lastChange);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/BrokerStateTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/BrokerStateTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import java.time.Instant;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class BrokerStateTest {
+
+  @Nested
+  class Factories {
+
+    @Test
+    void shouldInitializeAsActive() {
+      // when
+      final var state = BrokerState.initializeAsActive();
+
+      // then
+      assertThat(state.version()).isZero();
+      assertThat(state.state()).isEqualTo(State.ACTIVE);
+    }
+
+    @Test
+    void shouldInitializeAsUninitialized() {
+      // when
+      final var state = BrokerState.uninitialized();
+
+      // then
+      assertThat(state.version()).isZero();
+      assertThat(state.state()).isEqualTo(State.UNINITIALIZED);
+    }
+  }
+
+  @Nested
+  class Updates {
+
+    @Test
+    void shouldSetStateAndIncrementVersion() {
+      // given
+      final var initial = BrokerState.uninitialized();
+
+      // when
+      final var updated = initial.setState(State.JOINING);
+
+      // then
+      assertThat(updated.state()).isEqualTo(State.JOINING);
+      assertThat(updated.version()).isEqualTo(initial.version() + 1);
+      assertThat(updated.lastUpdated()).isAfter(initial.lastUpdated());
+    }
+
+    @Test
+    void shouldReturnSameInstanceWhenStateUnchanged() {
+      // given
+      final var initial = BrokerState.initializeAsActive();
+
+      // when / then
+      assertThat(initial.setState(State.ACTIVE)).isSameAs(initial);
+    }
+  }
+
+  @Nested
+  class Merge {
+
+    @Test
+    void shouldReturnThisWhenOtherIsNull() {
+      // given
+      final var state = BrokerState.initializeAsActive();
+
+      // when
+      final var merged = state.merge(null);
+
+      // then
+      assertThat(merged).isSameAs(state);
+    }
+
+    @Test
+    void shouldPickHigherVersion() {
+      // given
+      final var lower = new BrokerState(1, Instant.EPOCH, State.JOINING);
+      final var higher = new BrokerState(2, Instant.EPOCH, State.ACTIVE);
+
+      // when / then — higher version wins regardless of merge direction
+      assertThat(lower.merge(higher)).isEqualTo(higher);
+      assertThat(higher.merge(lower)).isEqualTo(higher);
+    }
+
+    @Test
+    void shouldReturnEqualStateWhenSameVersionAndIdenticalContent() {
+      // given
+      final var a = new BrokerState(3, Instant.EPOCH, State.ACTIVE);
+      final var b = new BrokerState(3, Instant.EPOCH, State.ACTIVE);
+
+      // when / then
+      assertThat(a.merge(b)).isEqualTo(a);
+    }
+
+    @Test
+    void shouldThrowWhenSameVersionButDifferentContent() {
+      // given
+      final var a = new BrokerState(3, Instant.EPOCH, State.ACTIVE);
+      final var b = new BrokerState(3, Instant.EPOCH, State.LEAVING);
+
+      // when / then
+      assertThatThrownBy(() -> a.merge(b)).isInstanceOf(IllegalStateException.class);
+    }
+  }
+
+  @Nested
+  class Validation {
+
+    @Test
+    void shouldThrowWhenStateIsNull() {
+      // when / then
+      assertThatThrownBy(() -> new BrokerState(0, Instant.EPOCH, null))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowWhenLastUpdatedIsNull() {
+      // when / then
+      assertThatThrownBy(() -> new BrokerState(0, null, State.ACTIVE))
+          .isInstanceOf(NullPointerException.class);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/GlobalConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/GlobalConfigurationTest.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.FixedConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class GlobalConfigurationTest {
+
+  private static final MemberId MEMBER_0 = MemberId.from("0");
+  private static final MemberId MEMBER_1 = MemberId.from("1");
+
+  private static BrokerState broker(final long version, final State state) {
+    return new BrokerState(version, Instant.EPOCH, state);
+  }
+
+  private static GlobalConfiguration config(
+      final long version, final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        version, Optional.empty(), members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  @Nested
+  class Merge {
+
+    @Test
+    void shouldTakeHigherConfigVersionWholesale() {
+      // given — same member id, but the higher-version config has a different broker state
+      final var lower = config(1, Map.of(MEMBER_0, broker(5, State.ACTIVE)));
+      final var higher = config(2, Map.of(MEMBER_0, broker(1, State.LEAVING)));
+
+      // when / then — the whole higher-version config wins regardless of member versions
+      assertThat(lower.merge(higher)).isEqualTo(higher);
+      assertThat(higher.merge(lower)).isEqualTo(higher);
+    }
+
+    @Test
+    void shouldMergeMembersByMemberVersionWhenConfigVersionsEqual() {
+      // given — same config version; MEMBER_0 newer on the left, MEMBER_1 only on the right
+      final var left = config(3, Map.of(MEMBER_0, broker(9, State.ACTIVE)));
+      final var right =
+          config(3, Map.of(MEMBER_0, broker(2, State.JOINING), MEMBER_1, broker(1, State.ACTIVE)));
+
+      // when
+      final var merged = left.merge(right);
+
+      // then — higher per-member version wins, union of members is kept
+      assertThat(merged.members().get(MEMBER_0)).isEqualTo(broker(9, State.ACTIVE));
+      assertThat(merged.members().get(MEMBER_1)).isEqualTo(broker(1, State.ACTIVE));
+    }
+
+    @Test
+    void shouldMergePendingChangesByPlanVersion() {
+      // given — same config version, two versions of the same plan
+      final var plan = ClusterChangePlan.init(1, List.of(new DeleteHistoryOperation(MEMBER_0)));
+      final var advancedPlan = plan.advance();
+      final var left =
+          new GlobalConfiguration(
+              1, Optional.empty(), Map.of(), Optional.empty(), Optional.of(plan), Optional.empty());
+      final var right =
+          new GlobalConfiguration(
+              1,
+              Optional.empty(),
+              Map.of(),
+              Optional.empty(),
+              Optional.of(advancedPlan),
+              Optional.empty());
+
+      // when
+      final var merged = left.merge(right);
+
+      // then — the higher plan version wins
+      assertThat(merged.pendingChanges()).contains(advancedPlan);
+    }
+
+    @Test
+    void shouldKeepFirstNonEmptyClusterId() {
+      // given — this has a cluster id, other has a different one
+      final var withId =
+          new GlobalConfiguration(
+              1,
+              Optional.of("cluster-a"),
+              Map.of(),
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty());
+      final var withOtherId =
+          new GlobalConfiguration(
+              1,
+              Optional.of("cluster-b"),
+              Map.of(),
+              Optional.empty(),
+              Optional.empty(),
+              Optional.empty());
+
+      // when / then — this wins when present; other's id is adopted only when this is empty
+      assertThat(withId.merge(withOtherId).clusterId()).contains("cluster-a");
+      assertThat(config(1, Map.of()).merge(withId).clusterId()).contains("cluster-a");
+    }
+
+    @Test
+    void shouldTakePresentPartitionDistributorConfigOverAbsent() {
+      // given
+      final var withConfig =
+          new GlobalConfiguration(
+              1,
+              Optional.empty(),
+              Map.of(),
+              Optional.of(new RoundRobinConfig()),
+              Optional.empty(),
+              Optional.empty());
+      final var withoutConfig = config(1, Map.of());
+
+      // when / then — present wins over absent, both directions
+      assertThat(withConfig.merge(withoutConfig).partitionDistributorConfig())
+          .contains(new RoundRobinConfig());
+      assertThat(withoutConfig.merge(withConfig).partitionDistributorConfig())
+          .contains(new RoundRobinConfig());
+    }
+
+    @Test
+    void shouldThrowWhenMergingConflictingDistributorConfigsAtSameVersion() {
+      // given — both present but different, at the same config version
+      final var withRoundRobin =
+          new GlobalConfiguration(
+              1,
+              Optional.empty(),
+              Map.of(),
+              Optional.of(new RoundRobinConfig()),
+              Optional.empty(),
+              Optional.empty());
+      final var withFixed =
+          new GlobalConfiguration(
+              1,
+              Optional.empty(),
+              Map.of(),
+              Optional.of(new FixedConfig()),
+              Optional.empty(),
+              Optional.empty());
+
+      // when / then
+      assertThatThrownBy(() -> withRoundRobin.merge(withFixed))
+          .isInstanceOf(IllegalStateException.class);
+    }
+  }
+
+  @Nested
+  class StartConfigurationChange {
+
+    @Test
+    void shouldSetPendingChangesAndIncrementVersion() {
+      // given
+      final var config = config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE)));
+
+      // when
+      final var updated =
+          config.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0)));
+
+      // then
+      assertThat(updated.version()).isEqualTo(5);
+      assertThat(updated.hasPendingChanges()).isTrue();
+      assertThat(updated.pendingChanges().get().pendingOperations())
+          .containsExactly(new DeleteHistoryOperation(MEMBER_0));
+    }
+
+    @Test
+    void shouldUseNewVersionAsPlanId() {
+      // given
+      final var config = config(4, Map.of());
+
+      // when
+      final var updated =
+          config.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0)));
+
+      // then
+      assertThat(updated.pendingChanges().get().id()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldThrowWhenChangeAlreadyInProgress() {
+      // given
+      final var config =
+          config(4, Map.of())
+              .startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0)));
+
+      // when / then
+      assertThatThrownBy(
+              () -> config.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0))))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowWhenNoOperations() {
+      // given
+      final var config = config(4, Map.of());
+
+      // when / then
+      assertThatThrownBy(() -> config.startConfigurationChange(List.of()))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+  }
+
+  @Nested
+  class MemberUpdates {
+
+    @Test
+    void shouldAddMemberWithoutChangingConfigVersion() {
+      // given
+      final var config = config(4, Map.of());
+
+      // when
+      final var updated = config.addMember(MEMBER_0, broker(0, State.JOINING));
+
+      // then
+      assertThat(updated.hasMember(MEMBER_0)).isTrue();
+      assertThat(updated.version()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldThrowWhenAddingExistingMember() {
+      // given
+      final var config = config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE)));
+
+      // when / then
+      assertThatThrownBy(() -> config.addMember(MEMBER_0, broker(0, State.JOINING)))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldUpdateMemberBumpingOnlyTheMemberVersion() {
+      // given
+      final var config = config(4, Map.of(MEMBER_0, BrokerState.uninitialized()));
+
+      // when
+      final var updated = config.updateMember(MEMBER_0, b -> b.setState(State.ACTIVE));
+
+      // then — the member's own version is bumped, the config version is not
+      assertThat(updated.getMember(MEMBER_0).state()).isEqualTo(State.ACTIVE);
+      assertThat(updated.getMember(MEMBER_0).version()).isEqualTo(1);
+      assertThat(updated.version()).isEqualTo(4);
+    }
+
+    @Test
+    void shouldThrowWhenUpdatingUnknownMember() {
+      // given
+      final var config = config(4, Map.of());
+
+      // when / then
+      assertThatThrownBy(() -> config.updateMember(MEMBER_0, b -> b.setState(State.ACTIVE)))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldReturnSameConfigWhenMemberUpdateIsNoOp() {
+      // given
+      final var config = config(4, Map.of(MEMBER_0, broker(0, State.ACTIVE)));
+
+      // when / then — setState to the current state is a no-op, so the config is unchanged
+      assertThat(config.updateMember(MEMBER_0, b -> b.setState(State.ACTIVE))).isSameAs(config);
+    }
+
+    @Test
+    void shouldReturnNullForUnknownMember() {
+      // given
+      final var config = config(4, Map.of());
+
+      // when / then
+      assertThat(config.getMember(MEMBER_0)).isNull();
+    }
+  }
+
+  @Nested
+  class ClusterLevelUpdates {
+
+    @Test
+    void shouldSetClusterIdAndBumpVersion() {
+      // given
+      final var config = config(4, Map.of());
+
+      // when
+      final var updated = config.setClusterId("cluster-a");
+
+      // then
+      assertThat(updated.clusterId()).contains("cluster-a");
+      assertThat(updated.version()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldReturnSameWhenClusterIdUnchanged() {
+      // given
+      final var config = config(4, Map.of()).setClusterId("cluster-a");
+
+      // when / then
+      assertThat(config.setClusterId("cluster-a")).isSameAs(config);
+    }
+
+    @Test
+    void shouldSetPartitionDistributorConfigAndBumpVersion() {
+      // given
+      final var config = config(4, Map.of());
+
+      // when
+      final var updated = config.setPartitionDistributorConfig(new RoundRobinConfig());
+
+      // then
+      assertThat(updated.partitionDistributorConfig()).contains(new RoundRobinConfig());
+      assertThat(updated.version()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldReturnSameWhenPartitionDistributorConfigUnchanged() {
+      // given
+      final var config = config(4, Map.of()).setPartitionDistributorConfig(new RoundRobinConfig());
+
+      // when / then
+      assertThat(config.setPartitionDistributorConfig(new RoundRobinConfig())).isSameAs(config);
+    }
+  }
+
+  @Nested
+  class Factory {
+
+    @Test
+    void shouldCreateInitConfig() {
+      // when
+      final var config = GlobalConfiguration.init();
+
+      // then
+      assertThat(config.version()).isEqualTo(GlobalConfiguration.INITIAL_VERSION);
+      assertThat(config.members()).isEmpty();
+      assertThat(config.clusterId()).isEmpty();
+      assertThat(config.partitionDistributorConfig()).isEmpty();
+      assertThat(config.pendingChanges()).isEmpty();
+      assertThat(config.lastChange()).isEmpty();
+    }
+  }
+
+  @Nested
+  class Validation {
+
+    @Test
+    void shouldThrowWhenClusterIdIsNull() {
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new GlobalConfiguration(
+                      1, null, Map.of(), Optional.empty(), Optional.empty(), Optional.empty()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowWhenMembersIsNull() {
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new GlobalConfiguration(
+                      1,
+                      Optional.empty(),
+                      null,
+                      Optional.empty(),
+                      Optional.empty(),
+                      Optional.empty()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowWhenPartitionDistributorConfigIsNull() {
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new GlobalConfiguration(
+                      1, Optional.empty(), Map.of(), null, Optional.empty(), Optional.empty()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowWhenPendingChangesIsNull() {
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new GlobalConfiguration(
+                      1, Optional.empty(), Map.of(), Optional.empty(), null, Optional.empty()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowWhenLastChangeIsNull() {
+      // when / then
+      assertThatThrownBy(
+              () ->
+                  new GlobalConfiguration(
+                      1, Optional.empty(), Map.of(), Optional.empty(), Optional.empty(), null))
+          .isInstanceOf(NullPointerException.class);
+    }
+  }
+}


### PR DESCRIPTION
## Description

Introduces the two cluster-level data-model records for multi-partition-group cluster configuration (physical tenants), as specified in #56212 (Phase 1 — Data layer of #56018).

- **`BrokerState`** — the cluster-wide lifecycle state of a single broker: `version`, `lastUpdated`, and a lifecycle `State`. It carries no partition assignment (that lives in `BrokerPartitionState`). Its `State` enum is `{UNINITIALIZED, JOINING, ACTIVE, LEAVING, LEFT}` and deliberately **omits `RECOVERING`** — recovery is per-group, tracked as the `Mode` of `BrokerPartitionState`, not a cluster-wide broker state. `merge()` picks the highest per-member version; equal versions must be identical or the states are in conflict.
- **`GlobalConfiguration`** — cluster-wide configuration not specific to any partition group: `version`, `Optional<String> clusterId`, `Map<MemberId, BrokerState> members`, `Optional<PartitionDistributorConfig> partitionDistributorConfig`, `Optional<ClusterChangePlan> pendingChanges`, `Optional<CompletedChange> lastChange`. It is the single authority for cluster membership and holds no partition state.
  - `merge()` uses the two-level scheme from ADR 0001: differing config versions win wholesale; equal versions merge members field-by-field by member version, `pendingChanges` by plan version, `clusterId` first-non-empty-wins, and `partitionDistributorConfig` present-wins-over-absent (if both present they must agree, else conflict).
  - `startConfigurationChange()` sets `pendingChanges` to a new plan and bumps the config version.

Both records are `@NullMarked` with defensively-copied immutable collections. **No proto change** (the `GlobalConfiguration`/`BrokerState` proto messages already exist on `main`); **no existing class is modified**.

### Self-contained version management (update methods)

Version invariants are enforced inside the objects — callers never set versions, consistent with `BrokerPartitionState`/`PartitionGroupConfiguration`:

- `BrokerState#setState` returns a new instance with an incremented version (no-op when unchanged).
- `GlobalConfiguration#addMember` / `#updateMember` change members **without** bumping the config version (per-member versions are owned by `BrokerState`), while `#setClusterId` / `#setPartitionDistributorConfig` are cluster-level changes that **do** bump the config version, and `#startConfigurationChange` bumps it at the plan boundary.

closes #56212
