### PR TITLE
deps: optimize update parsson version to 1.1.9

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -68,6 +68,7 @@
     <slf4j.version>2.0.16</slf4j.version>
     <commons.io.version>2.17.0</commons.io.version>
     <commons.lang3.version>3.18.0</commons.lang3.version>
+    <version.parsson>1.1.9</version.parsson>
 
     <version.node>v20.9.0</version.node>
     <version.yarn>v1.22.19</version.yarn>
@@ -366,6 +367,13 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons.lang3.version}</version>
+      </dependency>
+
+      <!-- Override parsson pulled by elasticsearch-java and opensearch-java -->
+      <dependency>
+        <groupId>org.eclipse.parsson</groupId>
+        <artifactId>parsson</artifactId>
+        <version>${version.parsson}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Description

Override `parsson` pulled by `elasticsearch-java` and `opensearch-java`

Follow-up of https://github.com/camunda/camunda/pull/57151

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

[#cve-2026-9563-high-core-features-4vs](https://camunda.slack.com/archives/C0BG3H0L3DK)
