### PR TITLE
test: verify per-physical-tenant exporter storage isolation and background tasks

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantCamundaExporterBackgroundTaskIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantCamundaExporterBackgroundTaskIT.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+/**
+ * Verifies that the {@code camundaexporter}'s <em>background tasks</em> run against each physical
+ * tenant's own storage. The incident-update task is the observable proxy: incident records are
+ * written by an export handler, but the {@code incident} flag on the process-instance document is
+ * only set afterwards by the background {@code IncidentUpdateTask} through the tenant's {@code
+ * IncidentUpdateRepository}. Two tenants share one Elasticsearch cluster under distinct index
+ * prefixes; each tenant's process instance must become incident-flagged in that tenant's indices
+ * only — proving the background task ran with the tenant-scoped configuration.
+ */
+@Timeout(240)
+@ZeebeIntegration
+final class PhysicalTenantCamundaExporterBackgroundTaskIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String JOB_TYPE = "fail-me";
+
+  @SuppressWarnings("resource")
+  private static final ElasticsearchContainer ES =
+      TestSearchContainers.createDefaultElasticsearchContainer();
+
+  private static final String ES_URL;
+
+  static {
+    ES.start();
+    ES_URL = "http://" + ES.getHttpHostAddress();
+  }
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(
+              PhysicalTenantsITHelper.DEFAULT_TENANT_ID,
+              Storage.elasticsearch(ES_URL, "defaultprefix"))
+          .withTenant(TENANT_A, Storage.elasticsearch(ES_URL, "tenantaprefix"))
+          .build();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker().withUnauthenticatedAccess().withCreateSchema(true));
+
+  @AutoClose private CamundaClient tenantAClient;
+  @AutoClose private CamundaClient defaultClient;
+
+  @BeforeEach
+  void setUp() {
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+  }
+
+  @Test
+  void shouldRunIncidentUpdateTaskAgainstEachTenantsOwnStorage() {
+    // given an incident in each tenant
+    createIncident(defaultClient, "default-process");
+    createIncident(tenantAClient, "tenanta-process");
+
+    // then each tenant's background incident-update task flags that tenant's process instance ...
+    Awaitility.await("each tenant's process instance is incident-flagged in its own storage")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              assertThat(incidentFlaggedInstances(defaultClient, "default-process")).isNotEmpty();
+              assertThat(incidentFlaggedInstances(tenantAClient, "tenanta-process")).isNotEmpty();
+            });
+
+    // ... and never the other tenant's
+    assertThat(incidentFlaggedInstances(defaultClient, "tenanta-process")).isEmpty();
+    assertThat(incidentFlaggedInstances(tenantAClient, "default-process")).isEmpty();
+  }
+
+  private static List<ProcessInstance> incidentFlaggedInstances(
+      final CamundaClient client, final String processId) {
+    return client
+        .newProcessInstanceSearchRequest()
+        .filter(f -> f.processDefinitionId(processId).hasIncident(true))
+        .send()
+        .join()
+        .items();
+  }
+
+  private static void createIncident(final CamundaClient client, final String processId) {
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    Awaitility.await("process is deployed for " + processId)
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, processId + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+    client.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send().join();
+
+    Awaitility.await("a job is activated and failed for " + processId)
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var jobs =
+                  client
+                      .newActivateJobsCommand()
+                      .jobType(JOB_TYPE)
+                      .maxJobsToActivate(1)
+                      .send()
+                      .join()
+                      .getJobs();
+              assertThat(jobs).isNotEmpty();
+              client
+                  .newFailCommand(jobs.getFirst().getKey())
+                  .retries(0)
+                  .errorMessage("expected failure to raise an incident")
+                  .send()
+                  .join();
+            });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantSeparateSecondaryStorageIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantSeparateSecondaryStorageIT.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.physicaltenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper;
+import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.lifecycle.Startables;
+
+/**
+ * Verifies that each physical tenant's {@code camundaexporter} — foreground writes and background
+ * tasks — runs against that tenant's own Elasticsearch <em>cluster</em>: one broker, two tenants,
+ * two clusters, mapped 1:1. Per tenant, a failed job raises an incident; the {@code incident} flag
+ * on the process-instance document is only set by the background {@code IncidentUpdateTask}, so the
+ * flag appearing through the tenant's own client proves both the writer path and the
+ * background-task repositories targeted that tenant's cluster. The other tenant's cluster is
+ * additionally checked directly for the absence of the documents, so leakage cannot be masked by
+ * tenant-scoped readers. The shared-cluster index-prefix mode is covered by {@link
+ * PhysicalTenantCamundaExporterBackgroundTaskIT}.
+ */
+@Timeout(240)
+@ZeebeIntegration
+final class PhysicalTenantSeparateSecondaryStorageIT {
+
+  private static final String TENANT_A = "tenanta";
+  private static final String JOB_TYPE = "fail-me";
+
+  @SuppressWarnings("resource")
+  private static final ElasticsearchContainer DEFAULT_ES =
+      TestSearchContainers.createDefaultElasticsearchContainer();
+
+  @SuppressWarnings("resource")
+  private static final ElasticsearchContainer TENANT_A_ES =
+      TestSearchContainers.createDefaultElasticsearchContainer();
+
+  private static final String DEFAULT_ES_URL;
+  private static final String TENANT_A_ES_URL;
+
+  static {
+    Startables.deepStart(DEFAULT_ES, TENANT_A_ES).join();
+    DEFAULT_ES_URL = "http://" + DEFAULT_ES.getHttpHostAddress();
+    TENANT_A_ES_URL = "http://" + TENANT_A_ES.getHttpHostAddress();
+  }
+
+  private static final PhysicalTenantsITHelper TENANTS =
+      PhysicalTenantsITHelper.builder()
+          .withTenant(
+              PhysicalTenantsITHelper.DEFAULT_TENANT_ID,
+              Storage.elasticsearch(DEFAULT_ES_URL, "defaultprefix"))
+          .withTenant(TENANT_A, Storage.elasticsearch(TENANT_A_ES_URL, "tenantaprefix"))
+          .build();
+
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      TENANTS.configure(
+          new TestStandaloneBroker().withUnauthenticatedAccess().withCreateSchema(true));
+
+  @AutoClose private CamundaClient tenantAClient;
+  @AutoClose private CamundaClient defaultClient;
+
+  @BeforeEach
+  void setUp() {
+    tenantAClient = TENANTS.newClientBuilder(broker, TENANT_A).build();
+    defaultClient =
+        TENANTS.newClientBuilder(broker, PhysicalTenantsITHelper.DEFAULT_TENANT_ID).build();
+  }
+
+  @Test
+  void shouldRouteWritesAndBackgroundTasksToEachTenantsOwnCluster() throws Exception {
+    // given an incident in each tenant
+    createIncident(defaultClient, "default-process");
+    createIncident(tenantAClient, "tenanta-process");
+
+    // then each tenant's instance is written to and incident-flagged in its own cluster ...
+    Awaitility.await("each tenant's process instance is incident-flagged in its own cluster")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              assertThat(incidentFlaggedInstances(defaultClient, "default-process")).isNotEmpty();
+              assertThat(incidentFlaggedInstances(tenantAClient, "tenanta-process")).isNotEmpty();
+            });
+
+    // ... and the other tenant's cluster never received its documents
+    assertThat(countDocuments(DEFAULT_ES_URL, "tenanta-process")).isZero();
+    assertThat(countDocuments(TENANT_A_ES_URL, "default-process")).isZero();
+  }
+
+  private static List<ProcessInstance> incidentFlaggedInstances(
+      final CamundaClient client, final String processId) {
+    return client
+        .newProcessInstanceSearchRequest()
+        .filter(f -> f.processDefinitionId(processId).hasIncident(true))
+        .send()
+        .join()
+        .items();
+  }
+
+  /** Counts documents matching the process id across all indices of the given cluster. */
+  private static long countDocuments(final String clusterUrl, final String processId)
+      throws IOException, InterruptedException {
+    final var query =
+        URLEncoder.encode("bpmnProcessId:\"" + processId + "\"", StandardCharsets.UTF_8);
+    final var request =
+        HttpRequest.newBuilder(URI.create(clusterUrl + "/_all/_count?q=" + query)).GET().build();
+    final var response = HTTP.send(request, BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+    return MAPPER.readTree(response.body()).path("count").asLong();
+  }
+
+  private static void createIncident(final CamundaClient client, final String processId) {
+    final var process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(JOB_TYPE))
+            .endEvent()
+            .done();
+    Awaitility.await("process is deployed for " + processId)
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        client
+                            .newDeployResourceCommand()
+                            .addProcessModel(process, processId + ".bpmn")
+                            .send()
+                            .join()
+                            .getProcesses())
+                    .isNotEmpty());
+    client.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send().join();
+
+    Awaitility.await("a job is activated and failed for " + processId)
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              final var jobs =
+                  client
+                      .newActivateJobsCommand()
+                      .jobType(JOB_TYPE)
+                      .maxJobsToActivate(1)
+                      .send()
+                      .join()
+                      .getJobs();
+              assertThat(jobs).isNotEmpty();
+              client
+                  .newFailCommand(jobs.getFirst().getKey())
+                  .retries(0)
+                  .errorMessage("expected failure to raise an incident")
+                  .send()
+                  .join();
+            });
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/PhysicalTenantsITHelper.java
@@ -273,12 +273,37 @@ public final class PhysicalTenantsITHelper {
     }
   }
 
+  private record ElasticsearchStorage(String url, String indexPrefix) implements Storage {
+
+    @Override
+    public void applyTo(final TestStandaloneBroker broker, final String tenantId) {
+      if (DEFAULT_TENANT_ID.equals(tenantId)) {
+        broker.withSecondaryStorageType(SecondaryStorageType.elasticsearch);
+        broker.withDataConfig(data -> applyElasticsearch(data.getSecondaryStorage()));
+      } else {
+        broker.withPtConfig(
+            tenantId, camunda -> applyElasticsearch(camunda.getData().getSecondaryStorage()));
+      }
+    }
+
+    private void applyElasticsearch(final SecondaryStorage secondaryStorage) {
+      secondaryStorage.setType(SecondaryStorageType.elasticsearch);
+      final var elasticsearch = secondaryStorage.getElasticsearch();
+      elasticsearch.setUrl(url);
+      elasticsearch.setIndexPrefix(indexPrefix);
+    }
+  }
+
   public interface Storage {
 
     void applyTo(TestStandaloneBroker broker, String tenantId);
 
     static Storage none() {
       return new NoneStorage();
+    }
+
+    static Storage elasticsearch(final String url, final String indexPrefix) {
+      return new ElasticsearchStorage(url, indexPrefix);
     }
 
     static Storage rdbms(final String url, final String username, final String password) {


### PR DESCRIPTION
## Summary

Two ITs proving each physical tenant's exporter — foreground writes and background tasks — targets that tenant's own storage, together demonstrating the goals of #51736 / #51922 / #51923 are achieved by per-tenant configuration alone (#56517, merged in #57202), with no exporter-side tenant awareness:

- **`PhysicalTenantSeparateSecondaryStorageIT`** — two tenants, two Elasticsearch clusters mapped 1:1 (the acceptance scenario of #51736). Per tenant, a failed job raises an incident: the `incident` flag appearing through the tenant's own client proves both the writer path (#51922) and the background incident-update task (#51923) targeted that tenant's cluster; the other cluster is checked directly for absence of the documents, so leakage cannot be masked by tenant-scoped readers.
- **`PhysicalTenantCamundaExporterBackgroundTaskIT`** — the same incident scenario on one shared Elasticsearch cluster with distinct index prefixes, covering the shared-cluster prefix-isolation deployment mode.
- New `Storage.elasticsearch(url, indexPrefix)` in `PhysicalTenantsITHelper`, mirroring the existing rdbms variant.

Verified as true regression tests: with #57202's per-tenant `BrokerCfg` conversion temporarily reverted, this isolation style of assertion fails (the second tenant's exporter inherits the root connect config); with it, both tests pass.

relates to #51736

🤖 Generated with [Claude Code](https://claude.com/claude-code)