### PR TITLE
ci: Update Slack webhook secret in CI workflow

### DIFF
--- a/.github/workflows/camunda-process-test-compatibility.yml
+++ b/.github/workflows/camunda-process-test-compatibility.yml
@@ -150,12 +150,12 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false
           secrets: |
-            secret/data/products/camunda/ci/github-actions SLACK_CAMUNDA_EX_CI_WEBHOOK;
+            secret/data/products/camunda/ci/github-actions SLACK_CPT_ZPT_CI_WEBHOOK;
       - name: Notify failure
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        if: steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK != ''
+        if: steps.secrets.outputs.SLACK_CPT_ZPT_CI_WEBHOOK != ''
         with:
-          webhook: ${{ steps.secrets.outputs.SLACK_CAMUNDA_EX_CI_WEBHOOK }}
+          webhook: ${{ steps.secrets.outputs.SLACK_CPT_ZPT_CI_WEBHOOK }}
           webhook-type: incoming-webhook
           payload: |
             {


### PR DESCRIPTION
## Description

Change the Slack webhook from `SLACK_CAMUNDA_EX_CI_WEBHOOK` to `SLACK_CPT_ZPT_CI_WEBHOOK`.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related [Slack discussion](https://camunda.slack.com/archives/C08NZ7E9ZT2/p1783601445705269).