### PR TITLE
Remove 8.8 specific code form the AnalyticsExporter

### DIFF
--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -17,13 +17,6 @@ declaration to your broker configuration; to disable it again, remove the declar
 The configuration can be provided via YAML or as environment variables — both styles are
 shown below.
 
-The exact shape of the configuration depends on your Camunda version:
-
-- **8.10 and later:** the exporter ships with Zeebe; you only need to declare it.
-- **8.9 and earlier:** the exporter is not shipped, so you must install the
-  [standalone JAR](#install-on-older-clusters-standalone-jar) and reference it via
-  `jarPath`.
-
 ### Prerequisites
 
 The exporter requires a Camunda license key and a cluster ID.
@@ -67,8 +60,6 @@ camunda:
     exporters:
       analytics:
         class-name: io.camunda.exporter.analytics.AnalyticsExporter
-        # jar-path is required on 8.9 only; omit on 8.10+
-        jar-path: /usr/local/zeebe/exporters/camunda-analytics-exporter.jar
         args:
           endpoint: https://analytics.cloud.camunda.io
           push-interval: PT5M
@@ -102,8 +93,6 @@ The same settings can be provided via environment variables.
 
 ```sh
 CAMUNDA_DATA_EXPORTERS_ANALYTICS_CLASSNAME=io.camunda.exporter.analytics.AnalyticsExporter
-# JARPATH is required on 8.9 only; omit on 8.10+
-CAMUNDA_DATA_EXPORTERS_ANALYTICS_JARPATH=/usr/local/zeebe/exporters/camunda-analytics-exporter.jar
 CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=https://analytics.cloud.camunda.io
 CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT5M
 CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_MAXQUEUESIZE=2048
@@ -114,7 +103,6 @@ CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_MAXBATCHSIZE=512
 
 ```sh
 ZEEBE_BROKER_EXPORTERS_ANALYTICS_CLASSNAME=io.camunda.exporter.analytics.AnalyticsExporter
-ZEEBE_BROKER_EXPORTERS_ANALYTICS_JARPATH=/usr/local/zeebe/exporters/camunda-analytics-exporter.jar
 ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=https://analytics.cloud.camunda.io
 ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT5M
 ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_MAXQUEUESIZE=2048
@@ -221,17 +209,6 @@ of these attributes as a composite key.
   other potentially sensitive fields are never sent.
 - **Fixed event set.** The exporter emits a small, hardcoded set of event types. There is
   no runtime configuration to add, remove, or filter event types.
-
-## Install on older clusters (standalone JAR)
-
-For clusters that do not ship the exporter as part of their distribution, a standalone
-JAR will be provided. Drop the JAR onto the broker classpath (for example, into
-`/usr/local/zeebe/exporters/`), point the exporter configuration at it with `jarPath`,
-and provide the `CAMUNDA_LICENSE_KEY` and `ZEEBE_BROKER_CLUSTER_CLUSTERID` environment
-variables described in [Prerequisites](#prerequisites).
-
-For the general procedure for adding custom exporters to a broker, see
-[installing Zeebe exporters](https://docs.camunda.io/docs/next/self-managed/components/orchestration-cluster/zeebe/exporters/install-zeebe-exporters/).
 
 ## How it works
 

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -21,8 +21,6 @@ import org.slf4j.LoggerFactory;
 /** Exporter that ships Camunda process analytics to the Camunda Analytics backend. */
 public class AnalyticsExporter implements Exporter {
 
-  private static final String LICENSE_KEY_ENV_VAR = "CAMUNDA_LICENSE_KEY";
-  private static final String CLUSTER_ID_ENV_VAR = "ZEEBE_BROKER_CLUSTER_CLUSTERID";
   private static final Logger LOG =
       LoggerFactory.getLogger(AnalyticsExporter.class.getPackageName());
   private static final ThrottledLogger SAMPLED_WARN_LOG =
@@ -147,40 +145,17 @@ public class AnalyticsExporter implements Exporter {
     }
   }
 
-  /**
-   * Resolves and validates the license key from the broker context, falling back to the {@code
-   * CAMUNDA_LICENSE_KEY} environment variable for brokers that predate the {@code getLicenseKey()}
-   * API (8.8 and earlier).
-   */
   private static String resolveLicenseKey(final Context context) {
-    String licenseKey;
-    try {
-      licenseKey = context.getLicenseKey();
-    } catch (final NoSuchMethodError e) {
-      LOG.warn("Context.getLicenseKey() not available (pre-8.10 broker); falling back to env var");
-      licenseKey = System.getenv(LICENSE_KEY_ENV_VAR);
-    }
+    final String licenseKey = context.getLicenseKey();
     if (licenseKey == null || licenseKey.isBlank()) {
       throw new IllegalStateException(
-          "Analytics exporter requires a license key. Set camunda.license.key in configuration or the "
-              + LICENSE_KEY_ENV_VAR
-              + " environment variable.");
+          "Analytics exporter requires a license key. Set camunda.license.key in configuration.");
     }
     return licenseKey;
   }
 
-  /**
-   * Resolves the cluster ID from the broker context, falling back to the {@code
-   * ZEEBE_BROKER_CLUSTER_CLUSTERID} environment variable for brokers that predate the {@code
-   * getClusterId()} API (8.8 and earlier).
-   */
   private static String resolveClusterId(final Context context) {
-    try {
-      return context.getClusterId();
-    } catch (final NoSuchMethodError e) {
-      final var fromEnv = System.getenv(CLUSTER_ID_ENV_VAR);
-      return fromEnv != null ? fromEnv : "";
-    }
+    return context.getClusterId();
   }
 
   private String resolveDigest(

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
@@ -44,10 +44,9 @@ public final class ProcessInstanceCreationHandler
                 .setAttribute(VERSION, (long) value.getVersion())
                 .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
                 .setAttribute(INSTANCE_KEY, record.getKey())
-                // TODO: re-enable once 8.8 brokers are no longer supported —
-                //  getRootProcessInstanceKey() does not exist on 8.8
-                // .setAttribute(AnalyticsAttributes.Process.ROOT_INSTANCE_KEY,
-                // value.getRootProcessInstanceKey())
+                .setAttribute(
+                    AnalyticsAttributes.Process.ROOT_INSTANCE_KEY,
+                    value.getRootProcessInstanceKey())
                 .setAttribute(ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
 

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -57,7 +57,7 @@ class AnalyticsExporterTest {
     // when / then
     assertThatThrownBy(() -> new AnalyticsExporter().configure(context))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("CAMUNDA_LICENSE_KEY");
+        .hasMessageContaining("camunda.license.key");
   }
 
   @Test

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -85,10 +85,9 @@ class AnalyticsExporterTest {
                   .containsEntry(
                       AnalyticsAttributes.Process.DEFINITION_KEY, value.getProcessDefinitionKey())
                   .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, record.getKey())
-                  // Temporarily commented out as root process instance key doesn't exist on 8.8.
-                  //                  .containsEntry(
-                  //                      AnalyticsAttributes.Process.ROOT_INSTANCE_KEY,
-                  //                      value.getRootProcessInstanceKey())
+                  .containsEntry(
+                      AnalyticsAttributes.Process.ROOT_INSTANCE_KEY,
+                      value.getRootProcessInstanceKey())
                   .containsEntry(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                   .containsEntry(AnalyticsAttributes.Log.POSITION, record.getPosition())
                   .containsEntry(AnalyticsAttributes.Event.SEQUENCE_NUMBER, 1L);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Removes the catch for the NoSuchMethodException and uncomment the root PI attributes.


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to #55707 
