### PR TITLE
feat: support migrating a bare cluster to a zone-aware topology

### DIFF
--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -26,6 +26,30 @@
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/cluster/src/main/java/io/camunda/cluster/ZoneLayout.java
+++ b/cluster/src/main/java/io/camunda/cluster/ZoneLayout.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.cluster;
+
+import java.util.List;
+import java.util.OptionalInt;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Slot-layout arithmetic that relates bare integer member IDs to zone-aware member positions.
+ *
+ * <p>The invariant: bare member {@code nodeIdx} maps to zone rank {@code nodeIdx % zoneCount} at
+ * local position {@code nodeIdx / zoneCount}. A zoned member with local index {@code n} at zone
+ * rank {@code r} occupies effective slot {@code n * zoneCount + r}, which equals the original bare
+ * {@code nodeIdx}. This coordinate system lets the round-robin distributor and the migration
+ * planner agree on member positions without coupling to each other.
+ */
+@NullMarked
+public final class ZoneLayout {
+
+  private ZoneLayout() {}
+
+  /**
+   * Returns the effective slot of a member. Bare members ({@code zone == null}) return {@code
+   * nodeIdx}. Zoned members return {@code nodeIdx * zoneOrder.size() + rank}. Returns {@link
+   * OptionalInt#empty()} when {@code zone} is not present in {@code zoneOrder}.
+   */
+  public static OptionalInt effectiveSlot(
+      final @Nullable String zone, final int nodeIdx, final List<String> zoneOrder) {
+    if (zone == null) {
+      return OptionalInt.of(nodeIdx);
+    }
+    final var rank = zoneOrder.indexOf(zone);
+    return rank < 0 ? OptionalInt.empty() : OptionalInt.of((nodeIdx * zoneOrder.size()) + rank);
+  }
+
+  /**
+   * Returns the zone rank (index in zone order) that a bare broker with the given {@code nodeIdx}
+   * belongs to. Equivalent to {@code nodeIdx % zoneCount}.
+   */
+  public static int zoneRankForBareNodeIdx(final int nodeIdx, final int zoneCount) {
+    return nodeIdx % zoneCount;
+  }
+
+  /**
+   * Returns the local node index within its zone for a bare broker with the given {@code nodeIdx}.
+   * Equivalent to {@code nodeIdx / zoneCount}.
+   */
+  public static int localNodeIdxForBareNodeIdx(final int nodeIdx, final int zoneCount) {
+    return nodeIdx / zoneCount;
+  }
+}

--- a/cluster/src/test/java/io/camunda/cluster/ZoneLayoutTest.java
+++ b/cluster/src/test/java/io/camunda/cluster/ZoneLayoutTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class ZoneLayoutTest {
+
+  // ── effectiveSlot ──────────────────────────────────────────────────────────
+  private static final List<String> DUAL_ZONES = List.of("zone-a", "zone-b");
+
+  @Test
+  void shouldReturnNodeIdxForBareMember() {
+    // given / when / then
+    assertThat(ZoneLayout.effectiveSlot(null, 3, DUAL_ZONES)).hasValue(3);
+  }
+
+  @Test
+  void shouldReturnEmptyForZonedMemberNotInZoneOrder() {
+    assertThat(ZoneLayout.effectiveSlot("zone-c", 0, DUAL_ZONES)).isEqualTo(OptionalInt.empty());
+  }
+
+  static Stream<List<String>> zoneOrders() {
+    return Stream.of(
+        List.of("zone-a"), List.of("zone-a", "zone-b"), List.of("zone-a", "zone-b", "zone-c"));
+  }
+
+  @ParameterizedTest(name = "zones={0}")
+  @MethodSource("zoneOrders")
+  void shouldPreserveRoundRobinSlotInvariant(final List<String> zoneOrder) {
+    // zoned member (zone=zones[r], localNodeIdx=n) must occupy the same slot as the bare member it
+    // replaced (nodeIdx = n * zoneCount + r).
+    final int zoneCount = zoneOrder.size();
+    for (int localNodeIdx = 0; localNodeIdx < 4; localNodeIdx++) {
+      for (int rank = 0; rank < zoneCount; rank++) {
+        final int bareNodeIdx = localNodeIdx * zoneCount + rank;
+        final var bareSlot = ZoneLayout.effectiveSlot(null, bareNodeIdx, zoneOrder);
+        final var zonedSlot =
+            ZoneLayout.effectiveSlot(zoneOrder.get(rank), localNodeIdx, zoneOrder);
+
+        assertThat(zonedSlot)
+            .describedAs(
+                "zoned (zone=%s, localIdx=%d) should map to same slot as bare nodeIdx=%d",
+                zoneOrder.get(rank), localNodeIdx, bareNodeIdx)
+            .isEqualTo(bareSlot);
+      }
+    }
+  }
+
+  // ── zoneRankForBareNodeIdx ─────────────────────────────────────────────────
+
+  @ParameterizedTest(name = "nodeIdx={0}, zoneCount={1} -> rank={2}")
+  @CsvSource(
+      textBlock =
+          """
+          0, 2, 0
+          1, 2, 1
+          2, 2, 0
+          3, 2, 1
+          0, 3, 0
+          1, 3, 1
+          2, 3, 2
+          3, 3, 0
+          4, 3, 1
+          """)
+  void shouldReturnZoneRankForBareNodeIdx(
+      final int nodeIdx, final int zoneCount, final int expectedRank) {
+    assertThat(ZoneLayout.zoneRankForBareNodeIdx(nodeIdx, zoneCount)).isEqualTo(expectedRank);
+  }
+
+  // ── localNodeIdxForBareNodeIdx ─────────────────────────────────────────────
+
+  @ParameterizedTest(name = "nodeIdx={0}, zoneCount={1} -> localIdx={2}")
+  @CsvSource(
+      textBlock =
+          """
+          0, 2, 0
+          1, 2, 0
+          2, 2, 1
+          3, 2, 1
+          0, 3, 0
+          1, 3, 0
+          2, 3, 0
+          3, 3, 1
+          4, 3, 1
+          5, 3, 1
+          """)
+  void shouldReturnLocalNodeIdxForBareNodeIdx(
+      final int nodeIdx, final int zoneCount, final int expectedLocalIdx) {
+    assertThat(ZoneLayout.localNodeIdxForBareNodeIdx(nodeIdx, zoneCount))
+        .isEqualTo(expectedLocalIdx);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -128,11 +128,9 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     final var allPartitions =
         Stream.of(oldPartitions, newPartitions).flatMap(List::stream).toList();
 
+    final var distributor = currentConfiguration.partitionDistributor();
     final var newDistribution =
-        currentConfiguration
-            .partitionDistributor()
-            .distributePartitions(brokers, allPartitions, replicationFactor)
-            .stream()
+        distributor.distributePartitions(brokers, allPartitions, replicationFactor).stream()
             .collect(Collectors.toMap(PartitionMetadata::id, p -> p));
 
     for (final PartitionId partition : oldPartitions) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -27,6 +27,9 @@ import java.util.Optional;
  * first and then redistributes partitions accordingly. When migrating from {@link RoundRobinConfig}
  * the same {@link ZoneAwareConfig} no partition reassignment is expected if the new configuration
  * is correct.
+ *
+ * <p>When migrating to {@link ZoneAwareConfig} the order of the zones is used to identify primary
+ * and secondary zone: the first zone is primary, the second is secondary.
  */
 public class UpdatePartitionDistributionTransformer implements ConfigurationChangeRequest {
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -54,8 +54,7 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
     final var zoneNames = zoneAwareConfig.zones().stream().map(z -> z.name()).toList();
     if (zoneNames.stream().distinct().count() != zoneNames.size()) {
       return Either.left(
-          new InvalidRequest(
-              "Expected zone names to be unique, but got duplicates: " + zoneNames));
+          new InvalidRequest("Expected zone names to be unique, but got duplicates: " + zoneNames));
     }
 
     final int targetReplicationFactor = zoneAwareConfig.replicationFactor();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -15,6 +15,8 @@ import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartiti
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.util.CollectionUtil;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,17 +46,19 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
               "Only ZONE_AWARE partition distribution config is supported. Received: "
                   + newConfig.getClass().getSimpleName()));
     }
+    final var zones = zoneAwareConfig.zones();
 
-    if (zoneAwareConfig.zones().isEmpty()) {
+    if (zones.isEmpty()) {
       return Either.left(
           new InvalidRequest(
               "Expected partition distribution config to contain at least one zone, but was empty"));
     }
 
-    final var zoneNames = zoneAwareConfig.zones().stream().map(z -> z.name()).toList();
-    if (zoneNames.stream().distinct().count() != zoneNames.size()) {
+    if (CollectionUtil.containsDuplicates(zones, ZoneSpec::name)) {
       return Either.left(
-          new InvalidRequest("Expected zone names to be unique, but got duplicates: " + zoneNames));
+          new InvalidRequest(
+              "Expected zone names to be unique, but got duplicates: "
+                  + zones.stream().map(ZoneSpec::name).toList()));
     }
 
     final int targetReplicationFactor = zoneAwareConfig.replicationFactor();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
@@ -20,18 +21,10 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Computes the operations needed to apply a new {@link ZoneAwareConfig} to a zone-aware cluster.
- *
- * <p>The transformer:
- *
- * <ol>
- *   <li>Validates that the cluster is currently zone-aware.
- *   <li>Validates that the requested config is a {@link ZoneAwareConfig} (no type switches).
- *   <li>Prepends an {@link UpdatePartitionDistributorConfigOperation} so the new config is
- *       persisted before redistribution begins.
- *   <li>Delegates to {@link PartitionReassignRequestTransformer} against a temporary configuration
- *       that already carries the new distributor, so the diff reflects the new placement strategy.
- * </ol>
+ * Computes the operations needed to apply a new {@link ZoneAwareConfig}. It persists the new config
+ * first and then redistributes partitions accordingly. When migrating from {@link RoundRobinConfig}
+ * the same {@link ZoneAwareConfig} no partition reassignment is expected if the new configuration
+ * is correct.
  */
 public class UpdatePartitionDistributionTransformer implements ConfigurationChangeRequest {
 
@@ -45,12 +38,6 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
 
-    if (!currentConfiguration.isFullyZoneAware()) {
-      return Either.left(
-          new InvalidRequest(
-              "Partition distribution changes are only supported on zone-aware clusters."));
-    }
-
     if (!(newConfig instanceof final ZoneAwareConfig zoneAwareConfig)) {
       return Either.left(
           new InvalidRequest(
@@ -61,12 +48,38 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
     if (zoneAwareConfig.zones().isEmpty()) {
       return Either.left(
           new InvalidRequest(
-              "Expected partition distribution config to be contain at least one zone, but was empty"));
+              "Expected partition distribution config to contain at least one zone, but was empty"));
+    }
+
+    final var zoneNames = zoneAwareConfig.zones().stream().map(z -> z.name()).toList();
+    if (zoneNames.stream().distinct().count() != zoneNames.size()) {
+      return Either.left(
+          new InvalidRequest(
+              "Expected zone names to be unique, but got duplicates: " + zoneNames));
+    }
+
+    final int targetReplicationFactor = zoneAwareConfig.replicationFactor();
+    final int currentReplicationFactor = currentConfiguration.minReplicationFactor();
+    if (!currentConfiguration.isFullyZoneAware()
+        && targetReplicationFactor != currentReplicationFactor) {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "Sum of zone replicas [%d] must equal the current replication factor [%d] "
+                      + "before zone migration starts.",
+                  targetReplicationFactor, currentReplicationFactor)));
     }
 
     final var coordinator =
         ClusterConfigurationCoordinatorSupplier.of(() -> currentConfiguration)
             .getDefaultCoordinator();
+
+    if (currentConfiguration.isPartiallyZoneAware()) {
+      return Either.left(
+          new InvalidRequest(
+              "Partition distribution changes are only supported on fully zone-aware clusters or "
+                  + "on fully bare clusters before zone migration starts."));
+    }
 
     // Apply the new config to produce a temporary configuration whose partitionDistributor()
     // returns the new ZoneAwarePartitionDistributor. This is only used for distribution
@@ -81,7 +94,9 @@ public class UpdatePartitionDistributionTransformer implements ConfigurationChan
         .map(
             ops -> {
               final var allOps = new ArrayList<ClusterConfigurationChangeOperation>(ops.size() + 1);
-              allOps.add(new UpdatePartitionDistributorConfigOperation(coordinator, newConfig));
+              final var updateConfigOperation =
+                  new UpdatePartitionDistributorConfigOperation(coordinator, newConfig);
+              allOps.add(updateConfigOperation);
               allOps.addAll(ops);
               return allOps;
             });

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.cluster.ZoneLayout;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -78,7 +79,10 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
     for (final var memberId :
         currentConfiguration.members().keySet().stream()
             .filter(candidate -> candidate.zone() == null)
-            .filter(candidate -> candidate.nodeIdx() % zones.size() == zoneIndex)
+            .filter(
+                candidate ->
+                    ZoneLayout.zoneRankForBareNodeIdx(candidate.nodeIdx(), zones.size())
+                        == zoneIndex)
             .sorted(Comparator.comparingInt(MemberId::nodeIdx))
             .toList()) {
       stageReplacements.put(memberId, MemberId.from(zoneName, localNodeIndex++));
@@ -221,60 +225,44 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
       final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
     final var brokerCount = currentConfiguration.members().size();
     final var effectiveSlots = new HashSet<Integer>(brokerCount);
+    final var zoneNames = zones.stream().map(ZoneSpec::name).toList();
 
     for (final var memberId : currentConfiguration.members().keySet()) {
-      final var effectiveSlot = effectiveSlot(memberId, zones);
-      if (effectiveSlot.isLeft()) {
-        return Either.left(effectiveSlot.getLeft());
+      final var slot = ZoneLayout.effectiveSlot(memberId.zone(), memberId.nodeIdx(), zoneNames);
+      if (slot.isEmpty()) {
+        return Either.left(
+            new InvalidRequest(
+                "Current topology is incompatible with the persisted zone migration plan: member '"
+                    + memberId
+                    + "' belongs to zone '"
+                    + memberId.zone()
+                    + "' which is not part of the persisted config."));
       }
 
-      final var slot = effectiveSlot.get();
-      if (slot >= brokerCount) {
+      final var slotValue = slot.getAsInt();
+      if (slotValue >= brokerCount) {
         return Either.left(
             new InvalidRequest(
                 "Current topology is incompatible with the persisted zone migration plan: member '"
                     + memberId
                     + "' maps to slot "
-                    + slot
+                    + slotValue
                     + " but the cluster has only "
                     + brokerCount
                     + " broker slots."));
       }
 
-      if (!effectiveSlots.add(slot)) {
+      if (!effectiveSlots.add(slotValue)) {
         return Either.left(
             new InvalidRequest(
                 "Current topology is incompatible with the persisted zone migration plan: multiple"
                     + " members map to slot "
-                    + slot
+                    + slotValue
                     + ". Check the persisted zone order."));
       }
     }
 
     return Either.right(null);
-  }
-
-  private Either<Exception, Integer> effectiveSlot(
-      final MemberId memberId, final List<ZoneSpec> zones) {
-    if (memberId.zone() == null) {
-      return Either.right(memberId.nodeIdx());
-    }
-
-    final var zoneRank =
-        IntStream.range(0, zones.size())
-            .filter(index -> zones.get(index).name().equals(memberId.zone()))
-            .findFirst();
-    if (zoneRank.isEmpty()) {
-      return Either.left(
-          new InvalidRequest(
-              "Current topology is incompatible with the persisted zone migration plan: member '"
-                  + memberId
-                  + "' belongs to zone '"
-                  + memberId.zone()
-                  + "' which is not part of the persisted config."));
-    }
-
-    return Either.right((memberId.nodeIdx() * zones.size()) + zoneRank.getAsInt());
   }
 
   private int expectedNextZoneIndex(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
@@ -45,19 +45,22 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
-    final var zoneAwareConfig =
-        currentConfiguration
-            .partitionDistributorConfig()
-            .filter(ZoneAwareConfig.class::isInstance)
-            .map(ZoneAwareConfig.class::cast);
-    if (zoneAwareConfig.isEmpty()) {
+    final var partitionDistribution = currentConfiguration.partitionDistributorConfig();
+    final ZoneAwareConfig zoneAwareConfig;
+    if (partitionDistribution.isPresent()
+        && partitionDistribution.get() instanceof final ZoneAwareConfig cfg) {
+      zoneAwareConfig = cfg;
+    } else {
       return Either.left(
           new InvalidRequest(
-              "Zone migration requires a persisted zone-aware partition distribution config. "
-                  + "Update the partition distribution before migrating brokers."));
+              "Zone migration requires a persisted zone-aware partition distribution config, but was %s. Update the partition distribution before migrating brokers."
+                  .formatted(
+                      partitionDistribution
+                          .map(c -> c.getClass().getSimpleName())
+                          .orElse("not set"))));
     }
 
-    final var zones = zoneAwareConfig.get().zones();
+    final var zones = zoneAwareConfig.zones();
     if (zones.stream().noneMatch(zone -> zone.name().equals(zoneName))) {
       return Either.left(
           new InvalidRequest(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.util.Either;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+/**
+ * Migrates a cluster from bare integer member ids like {@code 0}, {@code 1}, ... to zoned ids like
+ * {@code <zone>_<nodeId>} one zone at a time.
+ *
+ * <p>This transformer assumes the target {@link ZoneAwareConfig} has already been persisted via
+ * {@link UpdatePartitionDistributionTransformer}. It computes the stage-specific target members for
+ * the requested zone and delegates the actual add/reassign/remove planning to {@link
+ * ScaleRequestTransformer}.
+ */
+public final class ZoneMigrationRequestTransformer implements ConfigurationChangeRequest {
+
+  private final String zoneName;
+
+  public ZoneMigrationRequestTransformer(final String zoneName) {
+    this.zoneName = zoneName;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration currentConfiguration) {
+    final var validation = validate(currentConfiguration);
+    if (validation.isLeft()) {
+      return Either.left(validation.getLeft());
+    }
+
+    final var zones = zones(currentConfiguration);
+    return new ScaleRequestTransformer(
+            stageTargetMembers(currentConfiguration, zones),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(zoneName))
+        .operations(currentConfiguration);
+  }
+
+  /**
+   * Returns the bare brokers replaced in the current stage, keyed by the existing bare member id
+   * and valued by the zoned member id that will take over its slot.
+   *
+   * <p>Example for a dual-region plan persisted as {@code [zone-a, zone-b]} and request zone {@code
+   * zone-b}: on a current topology {@code [0, 1, 2, 3]} this returns {@code {1 -> zone-b_0, 3 ->
+   * zone-b_1}}.
+   */
+  private Map<MemberId, MemberId> stageReplacements(
+      final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
+    final int zoneIndex = zoneIndex(zones);
+
+    // Preserve the sorted bare-member order so replacements and the resulting operations are
+    // planned deterministically.
+    final var stageReplacements = new LinkedHashMap<MemberId, MemberId>();
+    int localNodeIndex = 0;
+    for (final var memberId :
+        currentConfiguration.members().keySet().stream()
+            .filter(candidate -> candidate.zone() == null)
+            .filter(candidate -> candidate.nodeIdx() % zones.size() == zoneIndex)
+            .sorted(Comparator.comparingInt(MemberId::nodeIdx))
+            .toList()) {
+      stageReplacements.put(memberId, MemberId.from(zoneName, localNodeIndex++));
+    }
+    return stageReplacements;
+  }
+
+  private Set<MemberId> stageTargetMembers(
+      final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
+    final var stageReplacements = stageReplacements(currentConfiguration, zones);
+
+    // Keep member iteration deterministic, e.g. for stable coordinator selection and test output.
+    final var stageTargetMembers = new LinkedHashSet<>(currentConfiguration.members().keySet());
+    stageTargetMembers.removeAll(stageReplacements.keySet());
+    stageTargetMembers.addAll(stageReplacements.values());
+    return stageTargetMembers;
+  }
+
+  private Either<Exception, Void> validate(final ClusterConfiguration currentConfiguration) {
+    final var zoneAwareConfig =
+        currentConfiguration
+            .partitionDistributorConfig()
+            .filter(ZoneAwareConfig.class::isInstance)
+            .map(ZoneAwareConfig.class::cast);
+    if (zoneAwareConfig.isEmpty()) {
+      return Either.left(
+          new InvalidRequest(
+              "Zone migration requires a persisted zone-aware partition distribution config. "
+                  + "Update the partition distribution before migrating brokers."));
+    }
+
+    if (currentConfiguration.isFullyZoneAware()) {
+      return Either.left(
+          new InvalidRequest(
+              "Zone migration is only supported while the cluster still contains bare brokers, but"
+                  + " the current cluster is already fully zone-aware."));
+    }
+
+    final var zones = zoneAwareConfig.get().zones();
+    if (zones.isEmpty()) {
+      return Either.left(new InvalidRequest("Zone migration requires at least one target zone."));
+    }
+
+    if (zones.stream().noneMatch(zone -> zone.name().equals(zoneName))) {
+      return Either.left(
+          new InvalidRequest(
+              "Zone migration request targets unknown zone '"
+                  + zoneName
+                  + "'. Configure it first via the persisted partition distribution."));
+    }
+
+    final int zoneIndex = zoneIndex(zones);
+
+    if (zones.stream().map(ZoneSpec::name).distinct().count() != zones.size()) {
+      return Either.left(
+          new InvalidRequest("Zone migration requires zone names to be unique: " + zones));
+    }
+
+    final int targetReplicationFactor = zones.stream().mapToInt(ZoneSpec::numberOfReplicas).sum();
+    final int currentReplicationFactor = currentConfiguration.minReplicationFactor();
+    if (targetReplicationFactor != currentReplicationFactor) {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "Sum of zone replicas [%d] must equal the current replication factor [%d];"
+                      + " zone migration must not change the replication factor.",
+                  targetReplicationFactor, currentReplicationFactor)));
+    }
+
+    final var topologyValidation = validateCurrentTopologyAgainstZones(currentConfiguration, zones);
+    if (topologyValidation.isLeft()) {
+      return Either.left(topologyValidation.getLeft());
+    }
+
+    final var capacityValidation = validateZoneBrokerCapacity(currentConfiguration, zones);
+    if (capacityValidation.isLeft()) {
+      return Either.left(capacityValidation.getLeft());
+    }
+
+    if (currentConfiguration.members().keySet().stream()
+        .anyMatch(member -> zoneName.equals(member.zone()))) {
+      return Either.left(
+          new InvalidRequest(
+              "Zone migration request targets zone '"
+                  + zoneName
+                  + "' which has already been migrated."));
+    }
+
+    final int expectedNextZoneIndex = expectedNextZoneIndex(currentConfiguration, zones);
+    if (zoneIndex != expectedNextZoneIndex) {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "Zone migration must proceed from the highest remaining zone index to the lowest."
+                      + " Expected next zoneIndex %d but got %d.",
+                  expectedNextZoneIndex, zoneIndex)));
+    }
+
+    if (stageReplacements(currentConfiguration, zones).isEmpty()) {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "No unzoned brokers map to zone '%s' under the persisted %d-zone migration plan.",
+                  zoneName, zones.size())));
+    }
+
+    return Either.right(null);
+  }
+
+  /**
+   * The migration assigns physical broker slots to zones purely by {@code slot % zones.size()}, so
+   * the number of brokers a zone ends up with is fixed by the total broker count and the zone's
+   * rank in the persisted config — independent of its {@link ZoneSpec#numberOfReplicas()}. This
+   * rejects plans where that fixed share is smaller than the declared replica count (which would
+   * otherwise fail late when the fully-zoned distribution is computed), e.g. when an
+   * asymmetric-replica config lists a high-replica zone in a rank that receives too few brokers.
+   */
+  private Either<Exception, Void> validateZoneBrokerCapacity(
+      final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
+    final int brokerCount = currentConfiguration.members().size();
+    final int zoneCount = zones.size();
+    for (int rank = 0; rank < zoneCount; rank++) {
+      final int brokerSlots = Math.max(0, Math.ceilDiv(brokerCount - rank, zoneCount));
+      final var zone = zones.get(rank);
+      if (brokerSlots < zone.numberOfReplicas()) {
+        return Either.left(
+            new InvalidRequest(
+                String.format(
+                    "Zone '%s' requires %d replicas but only %d broker slot(s) map to it under the"
+                        + " current %d-broker topology and %d-zone plan. Adjust the zone order or"
+                        + " replica counts so each zone receives at least as many brokers as"
+                        + " replicas.",
+                    zone.name(), zone.numberOfReplicas(), brokerSlots, brokerCount, zoneCount)));
+      }
+    }
+    return Either.right(null);
+  }
+
+  private Either<Exception, Void> validateCurrentTopologyAgainstZones(
+      final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
+    final var brokerCount = currentConfiguration.members().size();
+    final var effectiveSlots = new HashSet<Integer>(brokerCount);
+
+    for (final var memberId : currentConfiguration.members().keySet()) {
+      final var effectiveSlot = effectiveSlot(memberId, zones);
+      if (effectiveSlot.isLeft()) {
+        return Either.left(effectiveSlot.getLeft());
+      }
+
+      final var slot = effectiveSlot.get();
+      if (slot >= brokerCount) {
+        return Either.left(
+            new InvalidRequest(
+                "Current topology is incompatible with the persisted zone migration plan: member '"
+                    + memberId
+                    + "' maps to slot "
+                    + slot
+                    + " but the cluster has only "
+                    + brokerCount
+                    + " broker slots."));
+      }
+
+      if (!effectiveSlots.add(slot)) {
+        return Either.left(
+            new InvalidRequest(
+                "Current topology is incompatible with the persisted zone migration plan: multiple"
+                    + " members map to slot "
+                    + slot
+                    + ". Check the persisted zone order."));
+      }
+    }
+
+    return Either.right(null);
+  }
+
+  private Either<Exception, Integer> effectiveSlot(
+      final MemberId memberId, final List<ZoneSpec> zones) {
+    if (memberId.zone() == null) {
+      return Either.right(memberId.nodeIdx());
+    }
+
+    final var zoneRank =
+        IntStream.range(0, zones.size())
+            .filter(index -> zones.get(index).name().equals(memberId.zone()))
+            .findFirst();
+    if (zoneRank.isEmpty()) {
+      return Either.left(
+          new InvalidRequest(
+              "Current topology is incompatible with the persisted zone migration plan: member '"
+                  + memberId
+                  + "' belongs to zone '"
+                  + memberId.zone()
+                  + "' which is not part of the persisted config."));
+    }
+
+    return Either.right((memberId.nodeIdx() * zones.size()) + zoneRank.getAsInt());
+  }
+
+  private int expectedNextZoneIndex(
+      final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
+    return IntStream.range(0, zones.size())
+        .filter(
+            index ->
+                currentConfiguration.members().keySet().stream()
+                    .noneMatch(member -> zones.get(index).name().equals(member.zone())))
+        .max()
+        .orElseThrow();
+  }
+
+  private int zoneIndex(final List<ZoneSpec> zones) {
+    return IntStream.range(0, zones.size())
+        .filter(index -> zones.get(index).name().equals(zoneName))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private List<ZoneSpec> zones(final ClusterConfiguration currentConfiguration) {
+    return currentConfiguration
+        .partitionDistributorConfig()
+        .filter(ZoneAwareConfig.class::isInstance)
+        .map(ZoneAwareConfig.class::cast)
+        .orElseThrow()
+        .zones();
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformer.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwar
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.util.Either;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -46,14 +45,35 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration currentConfiguration) {
-    final var validation = validate(currentConfiguration);
+    final var zoneAwareConfig =
+        currentConfiguration
+            .partitionDistributorConfig()
+            .filter(ZoneAwareConfig.class::isInstance)
+            .map(ZoneAwareConfig.class::cast);
+    if (zoneAwareConfig.isEmpty()) {
+      return Either.left(
+          new InvalidRequest(
+              "Zone migration requires a persisted zone-aware partition distribution config. "
+                  + "Update the partition distribution before migrating brokers."));
+    }
+
+    final var zones = zoneAwareConfig.get().zones();
+    if (zones.stream().noneMatch(zone -> zone.name().equals(zoneName))) {
+      return Either.left(
+          new InvalidRequest(
+              "Zone migration request targets unknown zone '"
+                  + zoneName
+                  + "'. Configure it first via the persisted partition distribution."));
+    }
+
+    final var stageReplacements = stageReplacements(currentConfiguration, zones);
+    final var validation = validate(currentConfiguration, zones, stageReplacements);
     if (validation.isLeft()) {
       return Either.left(validation.getLeft());
     }
 
-    final var zones = zones(currentConfiguration);
     return new ScaleRequestTransformer(
-            stageTargetMembers(currentConfiguration, zones),
+            stageTargetMembers(currentConfiguration, stageReplacements),
             Optional.empty(),
             Optional.empty(),
             Optional.of(zoneName))
@@ -91,9 +111,8 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
   }
 
   private Set<MemberId> stageTargetMembers(
-      final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
-    final var stageReplacements = stageReplacements(currentConfiguration, zones);
-
+      final ClusterConfiguration currentConfiguration,
+      final Map<MemberId, MemberId> stageReplacements) {
     // Keep member iteration deterministic, e.g. for stable coordinator selection and test output.
     final var stageTargetMembers = new LinkedHashSet<>(currentConfiguration.members().keySet());
     stageTargetMembers.removeAll(stageReplacements.keySet());
@@ -101,67 +120,11 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
     return stageTargetMembers;
   }
 
-  private Either<Exception, Void> validate(final ClusterConfiguration currentConfiguration) {
-    final var zoneAwareConfig =
-        currentConfiguration
-            .partitionDistributorConfig()
-            .filter(ZoneAwareConfig.class::isInstance)
-            .map(ZoneAwareConfig.class::cast);
-    if (zoneAwareConfig.isEmpty()) {
-      return Either.left(
-          new InvalidRequest(
-              "Zone migration requires a persisted zone-aware partition distribution config. "
-                  + "Update the partition distribution before migrating brokers."));
-    }
-
-    if (currentConfiguration.isFullyZoneAware()) {
-      return Either.left(
-          new InvalidRequest(
-              "Zone migration is only supported while the cluster still contains bare brokers, but"
-                  + " the current cluster is already fully zone-aware."));
-    }
-
-    final var zones = zoneAwareConfig.get().zones();
-    if (zones.isEmpty()) {
-      return Either.left(new InvalidRequest("Zone migration requires at least one target zone."));
-    }
-
-    if (zones.stream().noneMatch(zone -> zone.name().equals(zoneName))) {
-      return Either.left(
-          new InvalidRequest(
-              "Zone migration request targets unknown zone '"
-                  + zoneName
-                  + "'. Configure it first via the persisted partition distribution."));
-    }
-
+  private Either<Exception, Void> validate(
+      final ClusterConfiguration currentConfiguration,
+      final List<ZoneSpec> zones,
+      final Map<MemberId, MemberId> stageReplacements) {
     final int zoneIndex = zoneIndex(zones);
-
-    if (zones.stream().map(ZoneSpec::name).distinct().count() != zones.size()) {
-      return Either.left(
-          new InvalidRequest("Zone migration requires zone names to be unique: " + zones));
-    }
-
-    final int targetReplicationFactor = zones.stream().mapToInt(ZoneSpec::numberOfReplicas).sum();
-    final int currentReplicationFactor = currentConfiguration.minReplicationFactor();
-    if (targetReplicationFactor != currentReplicationFactor) {
-      return Either.left(
-          new InvalidRequest(
-              String.format(
-                  "Sum of zone replicas [%d] must equal the current replication factor [%d];"
-                      + " zone migration must not change the replication factor.",
-                  targetReplicationFactor, currentReplicationFactor)));
-    }
-
-    final var topologyValidation = validateCurrentTopologyAgainstZones(currentConfiguration, zones);
-    if (topologyValidation.isLeft()) {
-      return Either.left(topologyValidation.getLeft());
-    }
-
-    final var capacityValidation = validateZoneBrokerCapacity(currentConfiguration, zones);
-    if (capacityValidation.isLeft()) {
-      return Either.left(capacityValidation.getLeft());
-    }
-
     if (currentConfiguration.members().keySet().stream()
         .anyMatch(member -> zoneName.equals(member.zone()))) {
       return Either.left(
@@ -181,7 +144,7 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
                   expectedNextZoneIndex, zoneIndex)));
     }
 
-    if (stageReplacements(currentConfiguration, zones).isEmpty()) {
+    if (stageReplacements.isEmpty()) {
       return Either.left(
           new InvalidRequest(
               String.format(
@@ -192,86 +155,15 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
     return Either.right(null);
   }
 
-  /**
-   * The migration assigns physical broker slots to zones purely by {@code slot % zones.size()}, so
-   * the number of brokers a zone ends up with is fixed by the total broker count and the zone's
-   * rank in the persisted config — independent of its {@link ZoneSpec#numberOfReplicas()}. This
-   * rejects plans where that fixed share is smaller than the declared replica count (which would
-   * otherwise fail late when the fully-zoned distribution is computed), e.g. when an
-   * asymmetric-replica config lists a high-replica zone in a rank that receives too few brokers.
-   */
-  private Either<Exception, Void> validateZoneBrokerCapacity(
-      final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
-    final int brokerCount = currentConfiguration.members().size();
-    final int zoneCount = zones.size();
-    for (int rank = 0; rank < zoneCount; rank++) {
-      final int brokerSlots = Math.max(0, Math.ceilDiv(brokerCount - rank, zoneCount));
-      final var zone = zones.get(rank);
-      if (brokerSlots < zone.numberOfReplicas()) {
-        return Either.left(
-            new InvalidRequest(
-                String.format(
-                    "Zone '%s' requires %d replicas but only %d broker slot(s) map to it under the"
-                        + " current %d-broker topology and %d-zone plan. Adjust the zone order or"
-                        + " replica counts so each zone receives at least as many brokers as"
-                        + " replicas.",
-                    zone.name(), zone.numberOfReplicas(), brokerSlots, brokerCount, zoneCount)));
-      }
-    }
-    return Either.right(null);
-  }
-
-  private Either<Exception, Void> validateCurrentTopologyAgainstZones(
-      final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
-    final var brokerCount = currentConfiguration.members().size();
-    final var effectiveSlots = new HashSet<Integer>(brokerCount);
-    final var zoneNames = zones.stream().map(ZoneSpec::name).toList();
-
-    for (final var memberId : currentConfiguration.members().keySet()) {
-      final var slot = ZoneLayout.effectiveSlot(memberId.zone(), memberId.nodeIdx(), zoneNames);
-      if (slot.isEmpty()) {
-        return Either.left(
-            new InvalidRequest(
-                "Current topology is incompatible with the persisted zone migration plan: member '"
-                    + memberId
-                    + "' belongs to zone '"
-                    + memberId.zone()
-                    + "' which is not part of the persisted config."));
-      }
-
-      final var slotValue = slot.getAsInt();
-      if (slotValue >= brokerCount) {
-        return Either.left(
-            new InvalidRequest(
-                "Current topology is incompatible with the persisted zone migration plan: member '"
-                    + memberId
-                    + "' maps to slot "
-                    + slotValue
-                    + " but the cluster has only "
-                    + brokerCount
-                    + " broker slots."));
-      }
-
-      if (!effectiveSlots.add(slotValue)) {
-        return Either.left(
-            new InvalidRequest(
-                "Current topology is incompatible with the persisted zone migration plan: multiple"
-                    + " members map to slot "
-                    + slotValue
-                    + ". Check the persisted zone order."));
-      }
-    }
-
-    return Either.right(null);
-  }
-
   private int expectedNextZoneIndex(
       final ClusterConfiguration currentConfiguration, final List<ZoneSpec> zones) {
+    // Bare members have no zone identity, so derive the next stage from the highest configured
+    // zone that does not yet have a zoned member.
     return IntStream.range(0, zones.size())
         .filter(
-            index ->
+            zoneIndex ->
                 currentConfiguration.members().keySet().stream()
-                    .noneMatch(member -> zones.get(index).name().equals(member.zone())))
+                    .noneMatch(member -> zones.get(zoneIndex).name().equals(member.zone())))
         .max()
         .orElseThrow();
   }
@@ -281,14 +173,5 @@ public final class ZoneMigrationRequestTransformer implements ConfigurationChang
         .filter(index -> zones.get(index).name().equals(zoneName))
         .findFirst()
         .orElseThrow();
-  }
-
-  private List<ZoneSpec> zones(final ClusterConfiguration currentConfiguration) {
-    return currentConfiguration
-        .partitionDistributorConfig()
-        .filter(ZoneAwareConfig.class::isInstance)
-        .map(ZoneAwareConfig.class::cast)
-        .orElseThrow()
-        .zones();
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Sets;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.ZoneLayout;
 import io.camunda.zeebe.dynamic.config.PartitionDistributor;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -103,12 +104,8 @@ public final class RoundRobinPartitionDistributor implements PartitionDistributo
 
   /** Translate zoned ids into "bare" ids so they can be sorted as before they were zoned. */
   private int effectiveSlot(final MemberId memberId) {
-    if (memberId.zone() == null) {
-      return memberId.nodeIdx();
-    }
-
-    final var rank = zoneOrder.indexOf(memberId.zone());
-    return rank < 0 ? Integer.MAX_VALUE : (memberId.nodeIdx() * zoneOrder.size()) + rank;
+    return ZoneLayout.effectiveSlot(memberId.zone(), memberId.nodeIdx(), zoneOrder)
+        .orElse(Integer.MAX_VALUE);
   }
 
   private Map<MemberId, Integer> getPriorities(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributor.java
@@ -39,17 +39,31 @@ import java.util.Set;
  */
 public final class RoundRobinPartitionDistributor implements PartitionDistributor {
 
+  /**
+   * Explicit zone tiebreak order (zone name -&gt; rank). When empty, members are ordered by zone
+   * name alphabetically (the default).
+   *
+   * <p>When set, zoned members are ordered by their effective global slot {@code localNodeIdx *
+   * zoneCount + zoneRank}. Bare members keep their global slot {@code nodeIdx}. This lets the
+   * distributor preserve the original round-robin slot layout for both fully zoned and mixed
+   * bare/zoned topologies during staged zone migration.
+   */
+  private final List<String> zoneOrder;
+
+  public RoundRobinPartitionDistributor() {
+    this(List.of());
+  }
+
+  public RoundRobinPartitionDistributor(final List<String> zoneOrder) {
+    this.zoneOrder = List.copyOf(zoneOrder);
+  }
+
   @Override
   public Set<PartitionMetadata> distributePartitions(
       final Set<MemberId> clusterMembers,
       final List<PartitionId> sortedPartitionIds,
       final int replicationFactor) {
-    final List<MemberId> sorted =
-        clusterMembers.stream()
-            .sorted(
-                Comparator.comparingInt(MemberId::nodeIdx)
-                    .thenComparing(id -> id.zone() != null ? id.zone() : ""))
-            .toList();
+    final List<MemberId> sorted = clusterMembers.stream().sorted(memberComparator()).toList();
 
     final int length = sorted.size();
     final int count = Math.min(replicationFactor, length);
@@ -74,6 +88,27 @@ public final class RoundRobinPartitionDistributor implements PartitionDistributo
               primary));
     }
     return metadata;
+  }
+
+  private Comparator<MemberId> memberComparator() {
+    if (zoneOrder.isEmpty()) {
+      return Comparator.comparingInt(MemberId::nodeIdx)
+          .thenComparing(id -> id.zone() != null ? id.zone() : "");
+    }
+
+    return Comparator.comparingInt(this::effectiveSlot)
+        .thenComparingInt(MemberId::nodeIdx)
+        .thenComparing(id -> id.zone() != null ? id.zone() : "");
+  }
+
+  /** Translate zoned ids into "bare" ids so they can be sorted as before they were zoned. */
+  private int effectiveSlot(final MemberId memberId) {
+    if (memberId.zone() == null) {
+      return memberId.nodeIdx();
+    }
+
+    final var rank = zoneOrder.indexOf(memberId.zone());
+    return rank < 0 ? Integer.MAX_VALUE : (memberId.nodeIdx() * zoneOrder.size()) + rank;
   }
 
   private Map<MemberId, Integer> getPriorities(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributor.java
@@ -34,7 +34,14 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The broker list for each zone is derived at distribution time from the {@code clusterMembers}
  * set by filtering members whose {@link MemberId#zone()} matches the zone name and sorting them by
- * {@link MemberId#nodeIdx()} ascending. All members in {@code clusterMembers} must have a zone set.
+ * {@link MemberId#nodeIdx()} ascending.
+ *
+ * <p>Whenever any bare (not-yet-migrated) member is present — a fully bare cluster whose zone-aware
+ * config has been persisted but whose migration has not started, or a cluster mid-migration with a
+ * mix of bare and zoned members — the distributor falls back to a zone-order-steered {@link
+ * RoundRobinPartitionDistributor} so the original slot layout is preserved until the migration is
+ * complete. On a fully bare cluster this reproduces plain round-robin, so recomputing the
+ * distribution before migration is a no-op.
  *
  * <p>Raft election priorities are assigned sequentially from {@code replicationFactor} down to
  * {@code 1}, iterating zones from highest to lowest priority and brokers within each zone in
@@ -47,8 +54,10 @@ import org.slf4j.LoggerFactory;
  *       naturally falls over to the next zone without any additional code.
  * </ul>
  *
- * <p>Zones with equal priority values are allowed; the ordering between them falls back to {@link
- * RoundRobinPartitionDistributor}, with brokers ordered by (nodeId, zone).
+ * <p>Zones with equal priority values are allowed; the distribution then also falls back to {@link
+ * RoundRobinPartitionDistributor}, with brokers ordered by the configured zone order rather than by
+ * zone name, so an equal-priority zone-aware config reproduces the exact placement a
+ * zone-order-steered migration materialised.
  *
  * <p>Example distribution with 3 zones (us-east1 prio=1000 × 2 replicas/2 brokers, us-west1
  * prio=500 × 2 replicas/2 brokers, euro-east1 prio=10 × 1 replica/1 broker), 5 partitions, RF=5:
@@ -72,8 +81,11 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
 
   private static final Logger LOG = LoggerFactory.getLogger(ZoneAwarePartitionDistributor.class);
 
-  /** Regions sorted by {@link ZoneSpec#priority()} descending (highest priority first). */
+  /** Zone specs in the configured request order, used for slot-preserving round-robin fallback. */
   private final List<ZoneSpec> zoneSpecs;
+
+  /** Regions sorted by {@link ZoneSpec#priority()} descending (highest priority first). */
+  private final List<ZoneSpec> zoneSpecsByPriority;
 
   /**
    * @param zoneSpecs the zone specifications. May be in any order; the constructor sorts them by
@@ -81,7 +93,8 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
    *     receive the highest Raft priorities.
    */
   public ZoneAwarePartitionDistributor(final List<ZoneSpec> zoneSpecs) {
-    this.zoneSpecs =
+    this.zoneSpecs = List.copyOf(zoneSpecs);
+    this.zoneSpecsByPriority =
         zoneSpecs.stream().sorted(Comparator.comparingInt(ZoneSpec::priority).reversed()).toList();
     if (this.zoneSpecs.size() == 1) {
       LOG.warn(
@@ -100,14 +113,24 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
       final List<PartitionId> sortedPartitionIds,
       final int replicationFactor) {
 
-    validateMemberZones(clusterMembers);
     validateReplicaSum(replicationFactor);
+
+    // As long as any bare (not-yet-migrated) member is present the cluster is either fully bare
+    // (config persisted but migration not started) or mid-migration. In both cases the zone-aware
+    // placement cannot be materialised yet, so fall back to a zone-order-steered round-robin that
+    // preserves the original slot layout. On a fully bare cluster this is identical to plain
+    // round-robin, so recomputing the distribution before migration is a no-op.
+    if (hasBareMembers(clusterMembers)) {
+      validateKnownZonedMembers(clusterMembers);
+      return new RoundRobinPartitionDistributor(zoneSpecs.stream().map(ZoneSpec::name).toList())
+          .distributePartitions(clusterMembers, sortedPartitionIds, replicationFactor);
+    }
+
     validateZoneHasSufficientBrokers(clusterMembers);
 
     // all zones have the same priority
-    if (zoneSpecs.stream().map(ZoneSpec::priority).distinct().count() == 1) {
-      // use RoundRobinDistributor instead
-      return new RoundRobinPartitionDistributor()
+    if (zoneSpecsByPriority.stream().map(ZoneSpec::priority).distinct().count() == 1) {
+      return new RoundRobinPartitionDistributor(zoneSpecs.stream().map(ZoneSpec::name).toList())
           .distributePartitions(clusterMembers, sortedPartitionIds, replicationFactor);
     }
 
@@ -123,7 +146,7 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
       final List<MemberId> orderedMembers = new ArrayList<>(replicationFactor);
       final Map<MemberId, Integer> priorityMap = new HashMap<>(replicationFactor);
 
-      for (final var spec : zoneSpecs) {
+      for (final var spec : zoneSpecsByPriority) {
         final var zoneBrokers =
             clusterMembers.stream()
                 .filter(m -> m.isInZone(spec.name()))
@@ -155,15 +178,20 @@ public final class ZoneAwarePartitionDistributor implements PartitionDistributor
   }
 
   public List<ZoneSpec> zoneSpecs() {
-    return zoneSpecs;
+    return zoneSpecsByPriority;
   }
 
-  private void validateMemberZones(final Set<MemberId> clusterMembers) {
+  private boolean hasBareMembers(final Set<MemberId> clusterMembers) {
+    return clusterMembers.stream().anyMatch(member -> member.zone() == null);
+  }
+
+  private void validateKnownZonedMembers(final Set<MemberId> clusterMembers) {
+    final var zoneNames = zoneSpecs.stream().map(ZoneSpec::name).collect(Collectors.toSet());
     for (final var member : clusterMembers) {
-      if (member.zone() == null) {
+      if (member.zone() != null && !zoneNames.contains(member.zone())) {
         throw new IllegalStateException(
-            "ZoneAwarePartitionDistributor: member '%s' has no zone configured; all cluster members must have a zone"
-                .formatted(member));
+            "ZoneAwarePartitionDistributor: member '%s' has zone '%s' which is not part of the configured zones"
+                .formatted(member, member.zone()));
       }
     }
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.api.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -36,12 +37,9 @@ class UpdatePartitionDistributionTransformerTest {
   // 3 partitions, 2 zones: zone-a (1 replica, priority 1000), zone-b (1 replica, priority 500)
   // Members: zone-a_0, zone-a_1, zone-b_0 — RF = 2
   private static final ZoneAwareConfig INITIAL_CONFIG =
-      new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1000), new ZoneSpec("zone-b", 1, 500)));
+      new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000), new ZoneSpec(ZONE_B, 1, 500)));
 
   // Coordinator = lexicographically smallest member ID = zone-a_0
-  private static final MemberId ZONE_A_0 = MemberId.from("zone-a", 0);
-  private static final MemberId ZONE_A_1 = MemberId.from("zone-a", 1);
-  private static final MemberId ZONE_B_0 = MemberId.from("zone-b", 0);
   private static final MemberId COORDINATOR = ZONE_A_0;
 
   private static final Set<MemberId> MEMBERS = Set.of(ZONE_A_0, ZONE_A_1, ZONE_B_0);
@@ -70,8 +68,7 @@ class UpdatePartitionDistributionTransformerTest {
     // new replica joins at priority 2.
     final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
     final var newConfig =
-        new ZoneAwareConfig(
-            List.of(new ZoneSpec("zone-a", 2, 1000), new ZoneSpec("zone-b", 1, 500)));
+        new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 2, 1000), new ZoneSpec(ZONE_B, 1, 500)));
 
     // when
     final var result =
@@ -96,7 +93,7 @@ class UpdatePartitionDistributionTransformerTest {
     // The single-zone distributor recomputes the placement after the config change. In the current
     // layout P2 stays on zone-a_1 and only the zone-b replica leaves.
     final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
-    final var newConfig = new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1000)));
+    final var newConfig = new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000)));
 
     // when
     final var result =
@@ -121,8 +118,7 @@ class UpdatePartitionDistributionTransformerTest {
     // zone-b replicas get promoted to priority 2, zone-a replicas demoted to priority 1.
     final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
     final var newConfig =
-        new ZoneAwareConfig(
-            List.of(new ZoneSpec("zone-a", 1, 500), new ZoneSpec("zone-b", 1, 1000)));
+        new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 500), new ZoneSpec(ZONE_B, 1, 1000)));
 
     // when
     final var result =
@@ -150,8 +146,7 @@ class UpdatePartitionDistributionTransformerTest {
     final var roundRobinTopology =
         ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
     final var newConfig =
-        new ZoneAwareConfig(
-            List.of(new ZoneSpec("zone-a", 1, 1000), new ZoneSpec("zone-b", 1, 500)));
+        new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000), new ZoneSpec(ZONE_B, 1, 500)));
     final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
 
     // when
@@ -167,16 +162,15 @@ class UpdatePartitionDistributionTransformerTest {
   @Test
   void shouldRejectPartiallyZoneAwareCluster() {
     // given
-    final var mixedMembers = Set.of(MemberId.from(0), MemberId.from(2), MemberId.from("zone-b", 0));
+    final var mixedMembers = Set.of(MemberId.from(0), MemberId.from(2), MemberId.from(ZONE_B, 0));
     final var mixedDistribution =
-        new RoundRobinPartitionDistributor(List.of("zone-a", "zone-b"))
+        new RoundRobinPartitionDistributor(List.of(ZONE_A, ZONE_B))
             .distributePartitions(mixedMembers, PARTITION_IDS, 2);
     final var mixedTopology =
         ConfigurationUtil.getClusterConfigFrom(mixedDistribution, PARTITION_CONFIG, "c")
             .setPartitionDistributorConfig(INITIAL_CONFIG);
     final var newConfig =
-        new ZoneAwareConfig(
-            List.of(new ZoneSpec("zone-a", 1, 500), new ZoneSpec("zone-b", 1, 1000)));
+        new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 500), new ZoneSpec(ZONE_B, 1, 1000)));
 
     // when
     final var result =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
-import static io.camunda.zeebe.dynamic.config.api.ZoneFixtures.*;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -89,11 +89,16 @@ class UpdatePartitionDistributionTransformerTest {
 
   @Test
   void shouldPrependConfigOpAndEmitLeaveOpsWhenRfDecreases() {
-    // given: initial RF=2, new RF=1 (remove zone-b, keep only zone-a)
-    // The single-zone distributor recomputes the placement after the config change. In the current
-    // layout P2 stays on zone-a_1 and only the zone-b replica leaves.
-    final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
-    final var newConfig = new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000)));
+    // given: initial RF=3 (zone-a x2, zone-b x1), new RF=2 (zone-a x1, zone-b x1)
+    // Each partition drops its second zone-a replica; the remaining zone-a and zone-b replicas
+    // stay in place with only their priority adjusted.
+    final var currentTopology =
+        buildTopology(
+            new ZoneAwareConfig(
+                List.of(new ZoneSpec(ZONE_A, 2, 1000), new ZoneSpec(ZONE_B, 1, 500))),
+            MEMBERS);
+    final var newConfig =
+        new ZoneAwareConfig(List.of(new ZoneSpec(ZONE_A, 1, 1000), new ZoneSpec(ZONE_B, 1, 500)));
 
     // when
     final var result =
@@ -104,12 +109,12 @@ class UpdatePartitionDistributionTransformerTest {
     assertThat(result.get())
         .containsExactly(
             new UpdatePartitionDistributorConfigOperation(COORDINATOR, newConfig),
-            new PartitionLeaveOperation(ZONE_B_0, 1, 1),
-            new PartitionReconfigurePriorityOperation(ZONE_A_0, 1, 1),
-            new PartitionLeaveOperation(ZONE_A_1, 2, 1),
-            new PartitionJoinOperation(ZONE_A_1, 3, 1),
-            new PartitionLeaveOperation(ZONE_A_0, 3, 1),
-            new PartitionLeaveOperation(ZONE_B_0, 3, 1));
+            new PartitionLeaveOperation(ZONE_A_1, 1, 1),
+            new PartitionReconfigurePriorityOperation(ZONE_A_0, 1, 2),
+            new PartitionLeaveOperation(ZONE_A_0, 2, 1),
+            new PartitionReconfigurePriorityOperation(ZONE_A_1, 2, 2),
+            new PartitionLeaveOperation(ZONE_A_1, 3, 1),
+            new PartitionReconfigurePriorityOperation(ZONE_A_0, 3, 2));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -93,8 +93,8 @@ class UpdatePartitionDistributionTransformerTest {
   @Test
   void shouldPrependConfigOpAndEmitLeaveOpsWhenRfDecreases() {
     // given: initial RF=2, new RF=1 (remove zone-b, keep only zone-a)
-    // The single-zone distributor reassigns zone-a replicas, causing some zone-a brokers to
-    // move partitions (P2: zone-a_1→leaves, P3: zone-a_1 joins, zone-a_0 and zone-b_0 leave).
+    // The single-zone distributor recomputes the placement after the config change. In the current
+    // layout P2 stays on zone-a_1 and only the zone-b replica leaves.
     final var currentTopology = buildTopology(INITIAL_CONFIG, MEMBERS);
     final var newConfig = new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1000)));
 
@@ -142,7 +142,7 @@ class UpdatePartitionDistributionTransformerTest {
   }
 
   @Test
-  void shouldRejectNonZoneAwareCluster() {
+  void shouldPersistConfigWithoutRedistributionOnBareCluster() {
     // given: a plain round-robin cluster with plain-integer member IDs (no zone)
     final var plainMembers = Set.of(MemberId.from("0"), MemberId.from("1"), MemberId.from("2"));
     final var distribution =
@@ -151,11 +151,36 @@ class UpdatePartitionDistributionTransformerTest {
         ConfigurationUtil.getClusterConfigFrom(distribution, PARTITION_CONFIG, "c");
     final var newConfig =
         new ZoneAwareConfig(
-            List.of(new ZoneSpec("zone-a", 2, 1000), new ZoneSpec("zone-b", 1, 500)));
+            List.of(new ZoneSpec("zone-a", 1, 1000), new ZoneSpec("zone-b", 1, 500)));
     final var transformer = new UpdatePartitionDistributionTransformer(newConfig);
 
     // when
     final var result = transformer.operations(roundRobinTopology);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactly(
+            new UpdatePartitionDistributorConfigOperation(MemberId.from("0"), newConfig));
+  }
+
+  @Test
+  void shouldRejectPartiallyZoneAwareCluster() {
+    // given
+    final var mixedMembers = Set.of(MemberId.from(0), MemberId.from(2), MemberId.from("zone-b", 0));
+    final var mixedDistribution =
+        new RoundRobinPartitionDistributor(List.of("zone-a", "zone-b"))
+            .distributePartitions(mixedMembers, PARTITION_IDS, 2);
+    final var mixedTopology =
+        ConfigurationUtil.getClusterConfigFrom(mixedDistribution, PARTITION_CONFIG, "c")
+            .setPartitionDistributorConfig(INITIAL_CONFIG);
+    final var newConfig =
+        new ZoneAwareConfig(
+            List.of(new ZoneSpec("zone-a", 1, 500), new ZoneSpec("zone-b", 1, 1000)));
+
+    // when
+    final var result =
+        new UpdatePartitionDistributionTransformer(newConfig).operations(mixedTopology);
 
     // then
     EitherAssert.assertThat(result)

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneFixtures.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneFixtures.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import java.util.List;
+
+public class ZoneFixtures {
+
+  // zones
+  public static final String ZONE_A = "us-east-1";
+  public static final String ZONE_B = "us-west-1";
+
+  // bare node ids
+  public static final MemberId BARE_0 = MemberId.from(0);
+  public static final MemberId BARE_1 = MemberId.from(1);
+  public static final MemberId BARE_2 = MemberId.from(2);
+  public static final MemberId BARE_3 = MemberId.from(3);
+
+  // zone A
+  public static final MemberId ZONE_A_0 = MemberId.from(ZONE_A, 0);
+  public static final MemberId ZONE_A_1 = MemberId.from(ZONE_A, 1);
+  public static final MemberId ZONE_A_2 = MemberId.from(ZONE_A, 2);
+
+  // zone B
+  public static final MemberId ZONE_B_0 = MemberId.from(ZONE_B, 0);
+  public static final MemberId ZONE_B_1 = MemberId.from(ZONE_B, 1);
+  public static final MemberId ZONE_B_2 = MemberId.from(ZONE_B, 2);
+
+  // Zone configs
+  public static final List<ZoneSpec> SINGLE_REGION = List.of(new ZoneSpec(ZONE_A, 3, 100));
+  public static final List<ZoneSpec> DUAL_REGION =
+      List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.cluster.PartitionId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+final class ZoneMigrationRequestTransformerTest {
+
+  private static final String ZONE_A = "us-east-1";
+  private static final String ZONE_B = "us-west-1";
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @Test
+  void shouldMigrateSingleRegionCluster() {
+    // given
+    final var zones = List.of(new ZoneSpec(ZONE_A, 3, 100));
+    final var initialTopology = unzonedTopology(3, 3, 3);
+    final var configUpdatedTopology = setZoneAwareConfig(initialTopology, zones);
+
+    // when
+    final var newTopology = migrate(configUpdatedTopology, 0);
+
+    // then
+    assertThat(newTopology.isFullyZoneAware()).isTrue();
+    assertThat(newTopology.partitionDistributorConfig()).hasValue(new ZoneAwareConfig(zones));
+    assertThat(newTopology.members().keySet())
+        .containsExactlyInAnyOrder(
+            MemberId.from(ZONE_A, 0), MemberId.from(ZONE_A, 1), MemberId.from(ZONE_A, 2));
+    assertSamePartitionDistribution(
+        initialTopology, newTopology, nodeMapping(IntStream.range(0, 3), ZONE_A));
+  }
+
+  @Test
+  void shouldMigrateOnlySelectedZoneUsingScaleRequestTransformer() {
+    // given
+    final var zones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
+    final var oldTopology = setZoneAwareConfig(unzonedTopology(4, 2, 4), zones);
+
+    // when
+    final var result = new ZoneMigrationRequestTransformer(ZONE_B).operations(oldTopology);
+
+    // then
+    assertThat(result).isRight();
+    final var operations = result.get();
+
+    final var secondaryLastLeaveIndex =
+        indexOf(operations, new MemberLeaveOperation(MemberId.from(3)));
+    assertThat(operations.subList(0, secondaryLastLeaveIndex + 1))
+        .extracting(ClusterConfigurationChangeOperation::memberId)
+        .contains(
+            MemberId.from(ZONE_B, 0), MemberId.from(ZONE_B, 1), MemberId.from(1), MemberId.from(3))
+        .doesNotContain(
+            MemberId.from(ZONE_A, 0), MemberId.from(ZONE_A, 1), MemberId.from(0), MemberId.from(2));
+    assertThat(operations)
+        .filteredOn(MemberJoinOperation.class::isInstance)
+        .extracting(ClusterConfigurationChangeOperation::memberId)
+        .doesNotContain(MemberId.from(ZONE_A, 0), MemberId.from(ZONE_A, 1));
+  }
+
+  @Test
+  void shouldMigrateDualRegionClusterInTwoSteps() {
+    // given
+    final var zones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
+    final var initialTopology = unzonedTopology(4, 2, 4);
+    final var configUpdatedTopology = setZoneAwareConfig(initialTopology, zones);
+
+    // when
+    final var afterSecondaryMigration = migrate(configUpdatedTopology, 1);
+    final var finalTopology = migrate(afterSecondaryMigration, 0);
+
+    // then
+    assertThat(afterSecondaryMigration.isPartiallyZoneAware()).isTrue();
+    assertThat(afterSecondaryMigration.partitionDistributorConfig())
+        .hasValue(new ZoneAwareConfig(zones));
+    assertThat(afterSecondaryMigration.members().keySet())
+        .containsExactlyInAnyOrder(
+            MemberId.from(0), MemberId.from(2), MemberId.from(ZONE_B, 0), MemberId.from(ZONE_B, 1));
+    assertSamePartitionDistribution(
+        initialTopology, afterSecondaryMigration, mixedDualRegionNodeMapping());
+
+    assertThat(finalTopology.isFullyZoneAware()).isTrue();
+    assertThat(finalTopology.partitionDistributorConfig()).hasValue(new ZoneAwareConfig(zones));
+    assertThat(finalTopology.members().keySet())
+        .containsExactlyInAnyOrder(
+            MemberId.from(ZONE_A, 0),
+            MemberId.from(ZONE_A, 1),
+            MemberId.from(ZONE_B, 0),
+            MemberId.from(ZONE_B, 1));
+    assertSamePartitionDistribution(
+        initialTopology, finalTopology, dualRegionNodeMapping(4, ZONE_A, ZONE_B));
+  }
+
+  @Test
+  void shouldPreserveDistributionWhenZoneNamesSortAgainstPhysicalLayout() {
+    // given
+    final var zones =
+        List.of(new ZoneSpec("zzz-region", 1, 100), new ZoneSpec("aaa-region", 1, 100));
+    final var initialTopology = unzonedTopology(6, 6, 2);
+    final var oldTopology = setZoneAwareConfig(initialTopology, zones);
+
+    // when
+    final var afterSecondaryMigration = migrate(oldTopology, 1);
+    final var newTopology = migrate(afterSecondaryMigration, 0);
+
+    // then
+    assertThat(newTopology.isFullyZoneAware()).isTrue();
+    final var expectedNodeMapping = dualRegionNodeMapping(6, "zzz-region", "aaa-region");
+    assertSamePartitionDistribution(initialTopology, newTopology, expectedNodeMapping);
+  }
+
+  @Test
+  void shouldRejectAlreadyZonedCluster() {
+    // given
+    final var zones = List.of(new ZoneSpec(ZONE_A, 3, 100));
+    final var alreadyZoned = migrate(setZoneAwareConfig(unzonedTopology(3, 3, 3), zones), 0);
+
+    // when
+    final var result = new ZoneMigrationRequestTransformer(ZONE_A).operations(alreadyZoned);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+        .satisfies(
+            e ->
+                assertThat(e)
+                    .hasMessageContaining(
+                        "Zone migration is only supported while the cluster still contains bare brokers, but the current cluster is already fully zone-aware."));
+  }
+
+  @Test
+  void shouldRejectMissingPersistedZoneAwareConfig() {
+    // given
+    final var oldTopology = unzonedTopology(3, 3, 3);
+
+    // when
+    final var result = new ZoneMigrationRequestTransformer(ZONE_A).operations(oldTopology);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+        .satisfies(
+            e ->
+                assertThat(e)
+                    .hasMessageContaining(
+                        "Zone migration requires a persisted zone-aware partition distribution config"));
+  }
+
+  @Test
+  void shouldRejectTargetingAnAlreadyMigratedZone() {
+    // given
+    final var zones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
+    final var afterSecondaryMigration =
+        migrate(setZoneAwareConfig(unzonedTopology(4, 2, 4), zones), 1);
+
+    // when
+    final var result =
+        new ZoneMigrationRequestTransformer(ZONE_B).operations(afterSecondaryMigration);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+        .satisfies(
+            e ->
+                assertThat(e)
+                    .hasMessageContaining(
+                        "Zone migration request targets zone 'us-west-1' which has already been migrated."));
+  }
+
+  @Test
+  void shouldRejectMigratingPrimaryZoneBeforeSecondaryZone() {
+    // given
+    final var zones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
+    final var topology = setZoneAwareConfig(unzonedTopology(4, 2, 4), zones);
+
+    // when
+    final var result = new ZoneMigrationRequestTransformer(ZONE_A).operations(topology);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+        .satisfies(
+            e ->
+                assertThat(e)
+                    .hasMessageContaining(
+                        "Zone migration must proceed from the highest remaining zone index to the lowest.")
+                    .hasMessageContaining("Expected next zoneIndex 1 but got 0"));
+  }
+
+  @Test
+  void shouldRejectUnknownZone() {
+    // given
+    final var zones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
+    final var topology = setZoneAwareConfig(unzonedTopology(4, 2, 4), zones);
+
+    // when
+    final var result = new ZoneMigrationRequestTransformer("unknown-zone").operations(topology);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+        .satisfies(
+            e ->
+                assertThat(e)
+                    .hasMessageContaining(
+                        "Zone migration request targets unknown zone 'unknown-zone'"));
+  }
+
+  @Test
+  void shouldRejectPersistedZoneOrderThatDoesNotMatchTheCurrentMixedTopology() {
+    // given
+    final var originalZones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
+    final var afterSecondaryMigration =
+        migrate(setZoneAwareConfig(unzonedTopology(4, 2, 4), originalZones), 1);
+    final var swappedZones = List.of(new ZoneSpec(ZONE_B, 2, 100), new ZoneSpec(ZONE_A, 2, 100));
+    final var mismatchedConfigTopology =
+        afterSecondaryMigration.setPartitionDistributorConfig(new ZoneAwareConfig(swappedZones));
+
+    // when
+    final var result =
+        new ZoneMigrationRequestTransformer(ZONE_A).operations(mismatchedConfigTopology);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+        .satisfies(
+            e ->
+                assertThat(e)
+                    .hasMessageContaining(
+                        "Current topology is incompatible with the persisted zone migration plan: multiple members map to slot 0. Check the persisted zone order."));
+  }
+
+  @Test
+  void shouldRejectWhenAZoneGetsFewerBrokerSlotsThanItsReplicas() {
+    // given — 3 bare brokers, RF=3. Under the nodeIdx % zoneCount assignment the first zone owns
+    // slots {0,2} (2 brokers) and the second owns slot {1} (1 broker). Declaring the second zone
+    // with 2 replicas is therefore impossible to realise, even though the replica sum equals RF.
+    final var zones = List.of(new ZoneSpec(ZONE_A, 1, 100), new ZoneSpec(ZONE_B, 2, 100));
+    final var topology = setZoneAwareConfig(unzonedTopology(3, 3, 3), zones);
+
+    // when
+    final var result = new ZoneMigrationRequestTransformer(ZONE_B).operations(topology);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+        .satisfies(
+            e ->
+                assertThat(e)
+                    .hasMessageContaining("us-west-1")
+                    .hasMessageContaining("2 replicas")
+                    .hasMessageContaining("1 broker slot"));
+  }
+
+  private ClusterConfiguration migrate(
+      final ClusterConfiguration oldTopology, final int zoneIndex) {
+    final var zoneName =
+        oldTopology
+            .partitionDistributorConfig()
+            .map(ZoneAwareConfig.class::cast)
+            .orElseThrow()
+            .zones()
+            .get(zoneIndex)
+            .name();
+    final var result = new ZoneMigrationRequestTransformer(zoneName).operations(oldTopology);
+    assertThat(result).isRight();
+    return TestTopologyChangeSimulator.apply(oldTopology, result.get());
+  }
+
+  private ClusterConfiguration setZoneAwareConfig(
+      final ClusterConfiguration topology, final List<ZoneSpec> zones) {
+    final var result =
+        new UpdatePartitionDistributionTransformer(new ZoneAwareConfig(zones)).operations(topology);
+    assertThat(result).isRight();
+    return TestTopologyChangeSimulator.apply(topology, result.get());
+  }
+
+  private void assertSamePartitionDistribution(
+      final ClusterConfiguration oldTopology,
+      final ClusterConfiguration newTopology,
+      final Map<MemberId, MemberId> nodeMapping) {
+    final Map<Integer, Set<MemberId>> expected =
+        partitionToMembers(oldTopology).entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> e.getValue().stream().map(nodeMapping::get).collect(Collectors.toSet())));
+    assertThat(partitionToMembers(newTopology))
+        .describedAs("partition distribution must be preserved (each partition keeps its slots)")
+        .isEqualTo(expected);
+  }
+
+  private int indexOf(
+      final List<ClusterConfigurationChangeOperation> operations,
+      final ClusterConfigurationChangeOperation expectedOperation) {
+    final var index = operations.indexOf(expectedOperation);
+    assertThat(index)
+        .describedAs("expected operation %s to be part of the migration plan", expectedOperation)
+        .isNotNegative();
+    return index;
+  }
+
+  private Map<Integer, Set<MemberId>> partitionToMembers(final ClusterConfiguration topology) {
+    return ConfigurationUtil.getPartitionDistributionFrom(topology, "temp").stream()
+        .collect(Collectors.toMap(p -> p.id().number(), p -> Set.copyOf(p.members())));
+  }
+
+  private ClusterConfiguration unzonedTopology(
+      final int clusterSize, final int partitionCount, final int replicationFactor) {
+    final Set<MemberId> members =
+        IntStream.range(0, clusterSize).mapToObj(MemberId::from).collect(Collectors.toSet());
+    final Set<PartitionMetadata> distribution =
+        new RoundRobinConfig()
+            .toDistributor()
+            .distributePartitions(members, sortedPartitionIds(partitionCount), replicationFactor);
+    var topology = ConfigurationUtil.getClusterConfigFrom(distribution, partitionConfig, "cid");
+    for (final MemberId member : members) {
+      if (!topology.hasMember(member)) {
+        topology = topology.addMember(member, MemberState.initializeAsActive(Map.of()));
+      }
+    }
+    return topology;
+  }
+
+  private List<PartitionId> sortedPartitionIds(final int partitionCount) {
+    return IntStream.rangeClosed(1, partitionCount)
+        .mapToObj(id -> new PartitionId("temp", id))
+        .collect(Collectors.toList());
+  }
+
+  private Map<MemberId, MemberId> nodeMapping(final IntStream sourceIndices, final String zone) {
+    return sourceIndices
+        .boxed()
+        .collect(Collectors.toMap(MemberId::from, i -> MemberId.from(zone, i)));
+  }
+
+  private Map<MemberId, MemberId> mixedDualRegionNodeMapping() {
+    final var nodeMapping = new HashMap<MemberId, MemberId>();
+    nodeMapping.put(MemberId.from(0), MemberId.from(0));
+    nodeMapping.put(MemberId.from(1), MemberId.from(ZONE_B, 0));
+    nodeMapping.put(MemberId.from(2), MemberId.from(2));
+    nodeMapping.put(MemberId.from(3), MemberId.from(ZONE_B, 1));
+    return nodeMapping;
+  }
+
+  private Map<MemberId, MemberId> dualRegionNodeMapping(
+      final int clusterSize, final String zoneA, final String zoneB) {
+    final var nodeMapping = new HashMap<MemberId, MemberId>();
+    int localA = 0;
+    int localB = 0;
+    for (int i = 0; i < clusterSize; i++) {
+      if (i % 2 == 0) {
+        nodeMapping.put(MemberId.from(i), MemberId.from(zoneA, localA++));
+      } else {
+        nodeMapping.put(MemberId.from(i), MemberId.from(zoneB, localB++));
+      }
+    }
+    return nodeMapping;
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -53,31 +53,31 @@ final class ZoneMigrationRequestTransformerTest {
     assertThat(result).isRight();
     assertThat(result.get())
         // check is unordered because member ordering between runs is not stable
-        .containsExactlyInAnyOrder(
+        .containsExactly(
             new MemberJoinOperation(ZONE_A_0),
             new MemberJoinOperation(ZONE_A_1),
             new MemberJoinOperation(ZONE_A_2),
             new PartitionJoinOperation(ZONE_A_0, 1, 3),
-            new PartitionJoinOperation(ZONE_A_2, 1, 1),
             new PartitionJoinOperation(ZONE_A_1, 1, 2),
+            new PartitionJoinOperation(ZONE_A_2, 1, 1),
+            new PartitionLeaveOperation(BARE_0, 1, 1),
             new PartitionLeaveOperation(BARE_1, 1, 1),
             new PartitionLeaveOperation(BARE_2, 1, 1),
-            new PartitionLeaveOperation(BARE_0, 1, 1),
             new PartitionJoinOperation(ZONE_A_0, 2, 1),
-            new PartitionJoinOperation(ZONE_A_2, 2, 2),
             new PartitionJoinOperation(ZONE_A_1, 2, 3),
+            new PartitionJoinOperation(ZONE_A_2, 2, 2),
+            new PartitionLeaveOperation(BARE_0, 2, 1),
             new PartitionLeaveOperation(BARE_1, 2, 1),
             new PartitionLeaveOperation(BARE_2, 2, 1),
-            new PartitionLeaveOperation(BARE_0, 2, 1),
             new PartitionJoinOperation(ZONE_A_0, 3, 2),
-            new PartitionJoinOperation(ZONE_A_2, 3, 3),
             new PartitionJoinOperation(ZONE_A_1, 3, 1),
+            new PartitionJoinOperation(ZONE_A_2, 3, 3),
+            new PartitionLeaveOperation(BARE_0, 3, 1),
             new PartitionLeaveOperation(BARE_1, 3, 1),
             new PartitionLeaveOperation(BARE_2, 3, 1),
-            new PartitionLeaveOperation(BARE_0, 3, 1),
+            new MemberLeaveOperation(BARE_0),
             new MemberLeaveOperation(BARE_1),
-            new MemberLeaveOperation(BARE_2),
-            new MemberLeaveOperation(BARE_0));
+            new MemberLeaveOperation(BARE_2));
     final var newTopology = TestTopologyChangeSimulator.apply(configUpdatedTopology, result.get());
 
     // then
@@ -103,7 +103,7 @@ final class ZoneMigrationRequestTransformerTest {
 
     assertThat(operations)
         // check is unordered because member ordering between runs is not stable
-        .containsExactlyInAnyOrder(
+        .containsExactly(
             new MemberJoinOperation(ZONE_B_0),
             new MemberJoinOperation(ZONE_B_1),
             new PartitionJoinOperation(ZONE_B_0, 1, 3),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -5,6 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
+
 package io.camunda.zeebe.dynamic.config.api;
 
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
@@ -13,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
+import io.camunda.cluster.ZoneLayout;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -22,6 +24,8 @@ import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +39,14 @@ final class ZoneMigrationRequestTransformerTest {
 
   private static final String ZONE_A = "us-east-1";
   private static final String ZONE_B = "us-west-1";
+  private static final MemberId bare0 = MemberId.from(0);
+  private static final MemberId bare1 = MemberId.from(1);
+  private static final MemberId bare2 = MemberId.from(2);
+  private static final MemberId zoneB0 = MemberId.from(ZONE_B, 0);
+  private static final MemberId zoneB1 = MemberId.from(ZONE_B, 1);
+  private static final MemberId zoneA0 = MemberId.from(ZONE_A, 0);
+  private static final MemberId zoneA1 = MemberId.from(ZONE_A, 1);
+  private static final MemberId zoneA2 = MemberId.from(ZONE_A, 2);
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
   @Test
@@ -45,7 +57,37 @@ final class ZoneMigrationRequestTransformerTest {
     final var configUpdatedTopology = setZoneAwareConfig(initialTopology, zones);
 
     // when
-    final var newTopology = migrate(configUpdatedTopology, 0);
+    final var result =
+        new ZoneMigrationRequestTransformer(ZONE_A).operations(configUpdatedTopology);
+    assertThat(result).isRight();
+    assertThat(result.get())
+        // check is unordered because member ordering between runs is not stable
+        .containsExactlyInAnyOrder(
+            new MemberJoinOperation(zoneA0),
+            new MemberJoinOperation(zoneA1),
+            new MemberJoinOperation(zoneA2),
+            new PartitionJoinOperation(zoneA0, 1, 3),
+            new PartitionJoinOperation(zoneA2, 1, 1),
+            new PartitionJoinOperation(zoneA1, 1, 2),
+            new PartitionLeaveOperation(bare1, 1, 1),
+            new PartitionLeaveOperation(bare2, 1, 1),
+            new PartitionLeaveOperation(bare0, 1, 1),
+            new PartitionJoinOperation(zoneA0, 2, 1),
+            new PartitionJoinOperation(zoneA2, 2, 2),
+            new PartitionJoinOperation(zoneA1, 2, 3),
+            new PartitionLeaveOperation(bare1, 2, 1),
+            new PartitionLeaveOperation(bare2, 2, 1),
+            new PartitionLeaveOperation(bare0, 2, 1),
+            new PartitionJoinOperation(zoneA0, 3, 2),
+            new PartitionJoinOperation(zoneA2, 3, 3),
+            new PartitionJoinOperation(zoneA1, 3, 1),
+            new PartitionLeaveOperation(bare1, 3, 1),
+            new PartitionLeaveOperation(bare2, 3, 1),
+            new PartitionLeaveOperation(bare0, 3, 1),
+            new MemberLeaveOperation(bare1),
+            new MemberLeaveOperation(bare2),
+            new MemberLeaveOperation(bare0));
+    final var newTopology = TestTopologyChangeSimulator.apply(configUpdatedTopology, result.get());
 
     // then
     assertThat(newTopology.isFullyZoneAware()).isTrue();
@@ -73,15 +115,24 @@ final class ZoneMigrationRequestTransformerTest {
     final var secondaryLastLeaveIndex =
         indexOf(operations, new MemberLeaveOperation(MemberId.from(3)));
     assertThat(operations.subList(0, secondaryLastLeaveIndex + 1))
-        .extracting(ClusterConfigurationChangeOperation::memberId)
-        .contains(
-            MemberId.from(ZONE_B, 0), MemberId.from(ZONE_B, 1), MemberId.from(1), MemberId.from(3))
-        .doesNotContain(
-            MemberId.from(ZONE_A, 0), MemberId.from(ZONE_A, 1), MemberId.from(0), MemberId.from(2));
+        // check is unordered because member ordering between runs is not stable
+        .containsExactlyInAnyOrder(
+            new MemberJoinOperation(zoneB0),
+            new MemberJoinOperation(zoneB1),
+            new PartitionJoinOperation(zoneB0, 1, 3),
+            new PartitionJoinOperation(zoneB1, 1, 1),
+            new PartitionLeaveOperation(MemberId.from(1), 1, 1),
+            new PartitionLeaveOperation(MemberId.from(3), 1, 1),
+            new PartitionJoinOperation(zoneB0, 2, 4),
+            new PartitionJoinOperation(zoneB1, 2, 2),
+            new PartitionLeaveOperation(MemberId.from(1), 2, 1),
+            new PartitionLeaveOperation(MemberId.from(3), 2, 1),
+            new MemberLeaveOperation(MemberId.from(1)),
+            new MemberLeaveOperation(MemberId.from(3)));
+
     assertThat(operations)
         .filteredOn(MemberJoinOperation.class::isInstance)
-        .extracting(ClusterConfigurationChangeOperation::memberId)
-        .doesNotContain(MemberId.from(ZONE_A, 0), MemberId.from(ZONE_A, 1));
+        .doesNotContain(new MemberJoinOperation(zoneA0), new MemberJoinOperation(zoneA1));
   }
 
   @Test
@@ -114,7 +165,7 @@ final class ZoneMigrationRequestTransformerTest {
             MemberId.from(ZONE_B, 0),
             MemberId.from(ZONE_B, 1));
     assertSamePartitionDistribution(
-        initialTopology, finalTopology, dualRegionNodeMapping(4, ZONE_A, ZONE_B));
+        initialTopology, finalTopology, dualRegionNodeMapping(4, List.of(ZONE_A, ZONE_B)));
   }
 
   @Test
@@ -131,7 +182,7 @@ final class ZoneMigrationRequestTransformerTest {
 
     // then
     assertThat(newTopology.isFullyZoneAware()).isTrue();
-    final var expectedNodeMapping = dualRegionNodeMapping(6, "zzz-region", "aaa-region");
+    final var expectedNodeMapping = dualRegionNodeMapping(6, List.of("zzz-region", "aaa-region"));
     assertSamePartitionDistribution(initialTopology, newTopology, expectedNodeMapping);
   }
 
@@ -194,7 +245,7 @@ final class ZoneMigrationRequestTransformerTest {
             e ->
                 assertThat(e)
                     .hasMessageContaining(
-                        "Zone migration requires a persisted zone-aware partition distribution config, but was Optional[RoundRobinConfig]. Update the partition distribution before migrating brokers"));
+                        "Zone migration requires a persisted zone-aware partition distribution config, but was RoundRobinConfig. Update the partition distribution before migrating brokers."));
   }
 
   @Test
@@ -318,6 +369,7 @@ final class ZoneMigrationRequestTransformerTest {
       final Map<MemberId, MemberId> nodeMapping) {
     final Map<Integer, Set<MemberId>> expected =
         partitionToMembers(oldTopology).entrySet().stream()
+            // remap bare ids to zoned ids to compare
             .collect(
                 Collectors.toMap(
                     Map.Entry::getKey,
@@ -381,16 +433,13 @@ final class ZoneMigrationRequestTransformerTest {
   }
 
   private Map<MemberId, MemberId> dualRegionNodeMapping(
-      final int clusterSize, final String zoneA, final String zoneB) {
+      final int clusterSize, final List<String> zones) {
     final var nodeMapping = new HashMap<MemberId, MemberId>();
-    int localA = 0;
-    int localB = 0;
     for (int i = 0; i < clusterSize; i++) {
-      if (i % 2 == 0) {
-        nodeMapping.put(MemberId.from(i), MemberId.from(zoneA, localA++));
-      } else {
-        nodeMapping.put(MemberId.from(i), MemberId.from(zoneB, localB++));
-      }
+      final var zoneIdx = ZoneLayout.zoneRankForBareNodeIdx(i, zones.size());
+      nodeMapping.put(
+          MemberId.from(i),
+          MemberId.from(zones.get(zoneIdx), ZoneLayout.localNodeIdxForBareNodeIdx(i, 2)));
     }
     return nodeMapping;
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -182,7 +182,7 @@ final class ZoneMigrationRequestTransformerTest {
             e ->
                 assertThat(e)
                     .hasMessageContaining(
-                        "Zone migration request targets zone 'us-east-1' which has already been migrated"));
+                        "Zone migration request targets zone 'zone-a' which has already been migrated"));
   }
 
   @Test
@@ -245,7 +245,7 @@ final class ZoneMigrationRequestTransformerTest {
             e ->
                 assertThat(e)
                     .hasMessageContaining(
-                        "Zone migration request targets zone 'us-west-1' which has already been migrated."));
+                        "Zone migration request targets zone 'zone-b' which has already been migrated."));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -8,7 +8,7 @@
 
 package io.camunda.zeebe.dynamic.config.api;
 
-import static io.camunda.zeebe.dynamic.config.api.ZoneFixtures.*;
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -153,7 +153,7 @@ final class ZoneMigrationRequestTransformerTest {
             e ->
                 assertThat(e)
                     .hasMessageContaining(
-                        "Zone migration is only supported while the cluster still contains bare brokers, but the current cluster is already fully zone-aware."));
+                        "Zone migration request targets zone 'us-east-1' which has already been migrated"));
   }
 
   @Test
@@ -246,8 +246,8 @@ final class ZoneMigrationRequestTransformerTest {
   void shouldRejectPersistedZoneOrderThatDoesNotMatchTheCurrentMixedTopology() {
     // given
     final var originalZones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
-    final var afterSecondaryMigration =
-        migrate(setZoneAwareConfig(unzonedTopology(4, 2, 4), originalZones), 1);
+    final var oldConfig = setZoneAwareConfig(unzonedTopology(4, 2, 4), originalZones);
+    final var afterSecondaryMigration = migrate(oldConfig, 1);
     final var swappedZones = List.of(new ZoneSpec(ZONE_B, 2, 100), new ZoneSpec(ZONE_A, 2, 100));
     final var mismatchedConfigTopology =
         afterSecondaryMigration.setPartitionDistributorConfig(new ZoneAwareConfig(swappedZones));
@@ -265,31 +265,7 @@ final class ZoneMigrationRequestTransformerTest {
             e ->
                 assertThat(e)
                     .hasMessageContaining(
-                        "Current topology is incompatible with the persisted zone migration plan: multiple members map to slot 0. Check the persisted zone order."));
-  }
-
-  @Test
-  void shouldRejectWhenAZoneGetsFewerBrokerSlotsThanItsReplicas() {
-    // given — 3 bare brokers, RF=3. Under the nodeIdx % zoneCount assignment the first zone owns
-    // slots {0,2} (2 brokers) and the second owns slot {1} (1 broker). Declaring the second zone
-    // with 2 replicas is therefore impossible to realise, even though the replica sum equals RF.
-    final var zones = List.of(new ZoneSpec(ZONE_A, 1, 100), new ZoneSpec(ZONE_B, 2, 100));
-    final var topology = setZoneAwareConfig(unzonedTopology(3, 3, 3), zones);
-
-    // when
-    final var result = new ZoneMigrationRequestTransformer(ZONE_B).operations(topology);
-
-    // then
-    assertThat(result)
-        .isLeft()
-        .left()
-        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
-        .satisfies(
-            e ->
-                assertThat(e)
-                    .hasMessageContaining("us-west-1")
-                    .hasMessageContaining("2 replicas")
-                    .hasMessageContaining("1 broker slot"));
+                        "No unzoned brokers map to zone 'us-east-1' under the persisted 2-zone migration plan."));
   }
 
   private ClusterConfiguration migrate(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -173,7 +173,28 @@ final class ZoneMigrationRequestTransformerTest {
             e ->
                 assertThat(e)
                     .hasMessageContaining(
-                        "Zone migration requires a persisted zone-aware partition distribution config"));
+                        "Zone migration requires a persisted zone-aware partition distribution config, but was not set. Update the partition distribution before migrating brokers."));
+  }
+
+  @Test
+  void shouldRejectInvalidPartitionDistribution() {
+    // given
+    final var oldTopology =
+        unzonedTopology(3, 3, 3).setPartitionDistributorConfig(new RoundRobinConfig());
+
+    // when
+    final var result = new ZoneMigrationRequestTransformer(ZONE_A).operations(oldTopology);
+
+    // then
+    assertThat(result)
+        .isLeft()
+        .left()
+        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
+        .satisfies(
+            e ->
+                assertThat(e)
+                    .hasMessageContaining(
+                        "Zone migration requires a persisted zone-aware partition distribution config, but was Optional[RoundRobinConfig]. Update the partition distribution before migrating brokers"));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ZoneMigrationRequestTransformerTest.java
@@ -8,6 +8,7 @@
 
 package io.camunda.zeebe.dynamic.config.api;
 
+import static io.camunda.zeebe.dynamic.config.api.ZoneFixtures.*;
 import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,22 +38,12 @@ import org.junit.jupiter.api.Test;
 
 final class ZoneMigrationRequestTransformerTest {
 
-  private static final String ZONE_A = "us-east-1";
-  private static final String ZONE_B = "us-west-1";
-  private static final MemberId bare0 = MemberId.from(0);
-  private static final MemberId bare1 = MemberId.from(1);
-  private static final MemberId bare2 = MemberId.from(2);
-  private static final MemberId zoneB0 = MemberId.from(ZONE_B, 0);
-  private static final MemberId zoneB1 = MemberId.from(ZONE_B, 1);
-  private static final MemberId zoneA0 = MemberId.from(ZONE_A, 0);
-  private static final MemberId zoneA1 = MemberId.from(ZONE_A, 1);
-  private static final MemberId zoneA2 = MemberId.from(ZONE_A, 2);
   private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
   @Test
   void shouldMigrateSingleRegionCluster() {
     // given
-    final var zones = List.of(new ZoneSpec(ZONE_A, 3, 100));
+    final var zones = SINGLE_REGION;
     final var initialTopology = unzonedTopology(3, 3, 3);
     final var configUpdatedTopology = setZoneAwareConfig(initialTopology, zones);
 
@@ -63,38 +54,37 @@ final class ZoneMigrationRequestTransformerTest {
     assertThat(result.get())
         // check is unordered because member ordering between runs is not stable
         .containsExactlyInAnyOrder(
-            new MemberJoinOperation(zoneA0),
-            new MemberJoinOperation(zoneA1),
-            new MemberJoinOperation(zoneA2),
-            new PartitionJoinOperation(zoneA0, 1, 3),
-            new PartitionJoinOperation(zoneA2, 1, 1),
-            new PartitionJoinOperation(zoneA1, 1, 2),
-            new PartitionLeaveOperation(bare1, 1, 1),
-            new PartitionLeaveOperation(bare2, 1, 1),
-            new PartitionLeaveOperation(bare0, 1, 1),
-            new PartitionJoinOperation(zoneA0, 2, 1),
-            new PartitionJoinOperation(zoneA2, 2, 2),
-            new PartitionJoinOperation(zoneA1, 2, 3),
-            new PartitionLeaveOperation(bare1, 2, 1),
-            new PartitionLeaveOperation(bare2, 2, 1),
-            new PartitionLeaveOperation(bare0, 2, 1),
-            new PartitionJoinOperation(zoneA0, 3, 2),
-            new PartitionJoinOperation(zoneA2, 3, 3),
-            new PartitionJoinOperation(zoneA1, 3, 1),
-            new PartitionLeaveOperation(bare1, 3, 1),
-            new PartitionLeaveOperation(bare2, 3, 1),
-            new PartitionLeaveOperation(bare0, 3, 1),
-            new MemberLeaveOperation(bare1),
-            new MemberLeaveOperation(bare2),
-            new MemberLeaveOperation(bare0));
+            new MemberJoinOperation(ZONE_A_0),
+            new MemberJoinOperation(ZONE_A_1),
+            new MemberJoinOperation(ZONE_A_2),
+            new PartitionJoinOperation(ZONE_A_0, 1, 3),
+            new PartitionJoinOperation(ZONE_A_2, 1, 1),
+            new PartitionJoinOperation(ZONE_A_1, 1, 2),
+            new PartitionLeaveOperation(BARE_1, 1, 1),
+            new PartitionLeaveOperation(BARE_2, 1, 1),
+            new PartitionLeaveOperation(BARE_0, 1, 1),
+            new PartitionJoinOperation(ZONE_A_0, 2, 1),
+            new PartitionJoinOperation(ZONE_A_2, 2, 2),
+            new PartitionJoinOperation(ZONE_A_1, 2, 3),
+            new PartitionLeaveOperation(BARE_1, 2, 1),
+            new PartitionLeaveOperation(BARE_2, 2, 1),
+            new PartitionLeaveOperation(BARE_0, 2, 1),
+            new PartitionJoinOperation(ZONE_A_0, 3, 2),
+            new PartitionJoinOperation(ZONE_A_2, 3, 3),
+            new PartitionJoinOperation(ZONE_A_1, 3, 1),
+            new PartitionLeaveOperation(BARE_1, 3, 1),
+            new PartitionLeaveOperation(BARE_2, 3, 1),
+            new PartitionLeaveOperation(BARE_0, 3, 1),
+            new MemberLeaveOperation(BARE_1),
+            new MemberLeaveOperation(BARE_2),
+            new MemberLeaveOperation(BARE_0));
     final var newTopology = TestTopologyChangeSimulator.apply(configUpdatedTopology, result.get());
 
     // then
     assertThat(newTopology.isFullyZoneAware()).isTrue();
     assertThat(newTopology.partitionDistributorConfig()).hasValue(new ZoneAwareConfig(zones));
     assertThat(newTopology.members().keySet())
-        .containsExactlyInAnyOrder(
-            MemberId.from(ZONE_A, 0), MemberId.from(ZONE_A, 1), MemberId.from(ZONE_A, 2));
+        .containsExactlyInAnyOrder(ZONE_A_0, ZONE_A_1, ZONE_A_2);
     assertSamePartitionDistribution(
         initialTopology, newTopology, nodeMapping(IntStream.range(0, 3), ZONE_A));
   }
@@ -102,8 +92,7 @@ final class ZoneMigrationRequestTransformerTest {
   @Test
   void shouldMigrateOnlySelectedZoneUsingScaleRequestTransformer() {
     // given
-    final var zones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
-    final var oldTopology = setZoneAwareConfig(unzonedTopology(4, 2, 4), zones);
+    final var oldTopology = setZoneAwareConfig(unzonedTopology(4, 2, 4), DUAL_REGION);
 
     // when
     final var result = new ZoneMigrationRequestTransformer(ZONE_B).operations(oldTopology);
@@ -112,58 +101,47 @@ final class ZoneMigrationRequestTransformerTest {
     assertThat(result).isRight();
     final var operations = result.get();
 
-    final var secondaryLastLeaveIndex =
-        indexOf(operations, new MemberLeaveOperation(MemberId.from(3)));
-    assertThat(operations.subList(0, secondaryLastLeaveIndex + 1))
+    assertThat(operations)
         // check is unordered because member ordering between runs is not stable
         .containsExactlyInAnyOrder(
-            new MemberJoinOperation(zoneB0),
-            new MemberJoinOperation(zoneB1),
-            new PartitionJoinOperation(zoneB0, 1, 3),
-            new PartitionJoinOperation(zoneB1, 1, 1),
-            new PartitionLeaveOperation(MemberId.from(1), 1, 1),
-            new PartitionLeaveOperation(MemberId.from(3), 1, 1),
-            new PartitionJoinOperation(zoneB0, 2, 4),
-            new PartitionJoinOperation(zoneB1, 2, 2),
-            new PartitionLeaveOperation(MemberId.from(1), 2, 1),
-            new PartitionLeaveOperation(MemberId.from(3), 2, 1),
-            new MemberLeaveOperation(MemberId.from(1)),
-            new MemberLeaveOperation(MemberId.from(3)));
-
-    assertThat(operations)
-        .filteredOn(MemberJoinOperation.class::isInstance)
-        .doesNotContain(new MemberJoinOperation(zoneA0), new MemberJoinOperation(zoneA1));
+            new MemberJoinOperation(ZONE_B_0),
+            new MemberJoinOperation(ZONE_B_1),
+            new PartitionJoinOperation(ZONE_B_0, 1, 3),
+            new PartitionJoinOperation(ZONE_B_1, 1, 1),
+            new PartitionLeaveOperation(BARE_1, 1, 1),
+            new PartitionLeaveOperation(BARE_3, 1, 1),
+            new PartitionJoinOperation(ZONE_B_0, 2, 4),
+            new PartitionJoinOperation(ZONE_B_1, 2, 2),
+            new PartitionLeaveOperation(BARE_1, 2, 1),
+            new PartitionLeaveOperation(BARE_3, 2, 1),
+            new MemberLeaveOperation(BARE_1),
+            new MemberLeaveOperation(BARE_3));
   }
 
   @Test
   void shouldMigrateDualRegionClusterInTwoSteps() {
     // given
-    final var zones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
+    final var zones = DUAL_REGION;
     final var initialTopology = unzonedTopology(4, 2, 4);
     final var configUpdatedTopology = setZoneAwareConfig(initialTopology, zones);
 
     // when
-    final var afterSecondaryMigration = migrate(configUpdatedTopology, 1);
-    final var finalTopology = migrate(afterSecondaryMigration, 0);
+    final var afterSecondaryMigration = migrate(configUpdatedTopology, ZONE_B);
+    final var finalTopology = migrate(afterSecondaryMigration, ZONE_A);
 
     // then
     assertThat(afterSecondaryMigration.isPartiallyZoneAware()).isTrue();
     assertThat(afterSecondaryMigration.partitionDistributorConfig())
         .hasValue(new ZoneAwareConfig(zones));
     assertThat(afterSecondaryMigration.members().keySet())
-        .containsExactlyInAnyOrder(
-            MemberId.from(0), MemberId.from(2), MemberId.from(ZONE_B, 0), MemberId.from(ZONE_B, 1));
+        .containsExactlyInAnyOrder(BARE_0, BARE_2, ZONE_B_0, ZONE_B_1);
     assertSamePartitionDistribution(
         initialTopology, afterSecondaryMigration, mixedDualRegionNodeMapping());
 
     assertThat(finalTopology.isFullyZoneAware()).isTrue();
     assertThat(finalTopology.partitionDistributorConfig()).hasValue(new ZoneAwareConfig(zones));
     assertThat(finalTopology.members().keySet())
-        .containsExactlyInAnyOrder(
-            MemberId.from(ZONE_A, 0),
-            MemberId.from(ZONE_A, 1),
-            MemberId.from(ZONE_B, 0),
-            MemberId.from(ZONE_B, 1));
+        .containsExactlyInAnyOrder(ZONE_A_0, ZONE_A_1, ZONE_B_0, ZONE_B_1);
     assertSamePartitionDistribution(
         initialTopology, finalTopology, dualRegionNodeMapping(4, List.of(ZONE_A, ZONE_B)));
   }
@@ -177,8 +155,8 @@ final class ZoneMigrationRequestTransformerTest {
     final var oldTopology = setZoneAwareConfig(initialTopology, zones);
 
     // when
-    final var afterSecondaryMigration = migrate(oldTopology, 1);
-    final var newTopology = migrate(afterSecondaryMigration, 0);
+    final var afterSecondaryMigration = migrate(oldTopology, "aaa-region");
+    final var newTopology = migrate(afterSecondaryMigration, "zzz-region");
 
     // then
     assertThat(newTopology.isFullyZoneAware()).isTrue();
@@ -189,8 +167,8 @@ final class ZoneMigrationRequestTransformerTest {
   @Test
   void shouldRejectAlreadyZonedCluster() {
     // given
-    final var zones = List.of(new ZoneSpec(ZONE_A, 3, 100));
-    final var alreadyZoned = migrate(setZoneAwareConfig(unzonedTopology(3, 3, 3), zones), 0);
+    final var zones = SINGLE_REGION;
+    final var alreadyZoned = migrate(setZoneAwareConfig(unzonedTopology(3, 3, 3), zones), ZONE_A);
 
     // when
     final var result = new ZoneMigrationRequestTransformer(ZONE_A).operations(alreadyZoned);
@@ -251,9 +229,8 @@ final class ZoneMigrationRequestTransformerTest {
   @Test
   void shouldRejectTargetingAnAlreadyMigratedZone() {
     // given
-    final var zones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
     final var afterSecondaryMigration =
-        migrate(setZoneAwareConfig(unzonedTopology(4, 2, 4), zones), 1);
+        migrate(setZoneAwareConfig(unzonedTopology(4, 2, 4), DUAL_REGION), ZONE_B);
 
     // when
     final var result =
@@ -274,8 +251,7 @@ final class ZoneMigrationRequestTransformerTest {
   @Test
   void shouldRejectMigratingPrimaryZoneBeforeSecondaryZone() {
     // given
-    final var zones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
-    final var topology = setZoneAwareConfig(unzonedTopology(4, 2, 4), zones);
+    final var topology = setZoneAwareConfig(unzonedTopology(4, 2, 4), DUAL_REGION);
 
     // when
     final var result = new ZoneMigrationRequestTransformer(ZONE_A).operations(topology);
@@ -296,8 +272,7 @@ final class ZoneMigrationRequestTransformerTest {
   @Test
   void shouldRejectUnknownZone() {
     // given
-    final var zones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
-    final var topology = setZoneAwareConfig(unzonedTopology(4, 2, 4), zones);
+    final var topology = setZoneAwareConfig(unzonedTopology(4, 2, 4), DUAL_REGION);
 
     // when
     final var result = new ZoneMigrationRequestTransformer("unknown-zone").operations(topology);
@@ -314,42 +289,8 @@ final class ZoneMigrationRequestTransformerTest {
                         "Zone migration request targets unknown zone 'unknown-zone'"));
   }
 
-  @Test
-  void shouldRejectPersistedZoneOrderThatDoesNotMatchTheCurrentMixedTopology() {
-    // given
-    final var originalZones = List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
-    final var oldConfig = setZoneAwareConfig(unzonedTopology(4, 2, 4), originalZones);
-    final var afterSecondaryMigration = migrate(oldConfig, 1);
-    final var swappedZones = List.of(new ZoneSpec(ZONE_B, 2, 100), new ZoneSpec(ZONE_A, 2, 100));
-    final var mismatchedConfigTopology =
-        afterSecondaryMigration.setPartitionDistributorConfig(new ZoneAwareConfig(swappedZones));
-
-    // when
-    final var result =
-        new ZoneMigrationRequestTransformer(ZONE_A).operations(mismatchedConfigTopology);
-
-    // then
-    assertThat(result)
-        .isLeft()
-        .left()
-        .isInstanceOf(ClusterConfigurationRequestFailedException.InvalidRequest.class)
-        .satisfies(
-            e ->
-                assertThat(e)
-                    .hasMessageContaining(
-                        "No unzoned brokers map to zone 'us-east-1' under the persisted 2-zone migration plan."));
-  }
-
   private ClusterConfiguration migrate(
-      final ClusterConfiguration oldTopology, final int zoneIndex) {
-    final var zoneName =
-        oldTopology
-            .partitionDistributorConfig()
-            .map(ZoneAwareConfig.class::cast)
-            .orElseThrow()
-            .zones()
-            .get(zoneIndex)
-            .name();
+      final ClusterConfiguration oldTopology, final String zoneName) {
     final var result = new ZoneMigrationRequestTransformer(zoneName).operations(oldTopology);
     assertThat(result).isRight();
     return TestTopologyChangeSimulator.apply(oldTopology, result.get());
@@ -425,10 +366,10 @@ final class ZoneMigrationRequestTransformerTest {
 
   private Map<MemberId, MemberId> mixedDualRegionNodeMapping() {
     final var nodeMapping = new HashMap<MemberId, MemberId>();
-    nodeMapping.put(MemberId.from(0), MemberId.from(0));
-    nodeMapping.put(MemberId.from(1), MemberId.from(ZONE_B, 0));
-    nodeMapping.put(MemberId.from(2), MemberId.from(2));
-    nodeMapping.put(MemberId.from(3), MemberId.from(ZONE_B, 1));
+    nodeMapping.put(BARE_0, BARE_0);
+    nodeMapping.put(BARE_1, ZONE_B_0);
+    nodeMapping.put(BARE_2, BARE_2);
+    nodeMapping.put(BARE_3, ZONE_B_1);
     return nodeMapping;
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributorTest.java
@@ -10,11 +10,15 @@ package io.camunda.zeebe.dynamic.config.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -128,6 +132,86 @@ final class RoundRobinPartitionDistributorTest {
                         .isPositive();
                   });
         });
+  }
+
+  @Test
+  void shouldPreserveRoundRobinSlotsForMixedBareAndZonedMembersWhenZoneOrderIsConfigured() {
+    // given
+    final var originalMembers =
+        Set.of(MemberId.from(0), MemberId.from(1), MemberId.from(2), MemberId.from(3));
+    final var mixedMembers =
+        Set.of(
+            MemberId.from(0),
+            MemberId.from(2),
+            MemberId.from("zone-b", 0),
+            MemberId.from("zone-b", 1));
+    final var expectedMapping =
+        Map.of(
+            MemberId.from(0), MemberId.from(0),
+            MemberId.from(1), MemberId.from("zone-b", 0),
+            MemberId.from(2), MemberId.from(2),
+            MemberId.from(3), MemberId.from("zone-b", 1));
+
+    // when
+    final var originalDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(originalMembers, getSortedPartitionIds(4), 4);
+    final var mixedDistribution =
+        new RoundRobinPartitionDistributor(List.of("zone-a", "zone-b"))
+            .distributePartitions(mixedMembers, getSortedPartitionIds(4), 4);
+
+    // then
+    assertThat(partitionMembers(mixedDistribution))
+        .isEqualTo(remapMembers(originalDistribution, expectedMapping));
+  }
+
+  @Test
+  void shouldPreserveRoundRobinSlotsForFullyZonedMembersWhenZoneOrderIsConfigured() {
+    // given
+    final var originalMembers =
+        Set.of(MemberId.from(0), MemberId.from(1), MemberId.from(2), MemberId.from(3));
+    final var zonedMembers =
+        Set.of(
+            MemberId.from("zone-a", 0),
+            MemberId.from("zone-b", 0),
+            MemberId.from("zone-a", 1),
+            MemberId.from("zone-b", 1));
+    final var expectedMapping =
+        Map.of(
+            MemberId.from(0), MemberId.from("zone-a", 0),
+            MemberId.from(1), MemberId.from("zone-b", 0),
+            MemberId.from(2), MemberId.from("zone-a", 1),
+            MemberId.from(3), MemberId.from("zone-b", 1));
+
+    // when
+    final var originalDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(originalMembers, getSortedPartitionIds(4), 4);
+    final var zonedDistribution =
+        new RoundRobinPartitionDistributor(List.of("zone-a", "zone-b"))
+            .distributePartitions(zonedMembers, getSortedPartitionIds(4), 4);
+
+    // then
+    assertThat(partitionMembers(zonedDistribution))
+        .isEqualTo(remapMembers(originalDistribution, expectedMapping));
+  }
+
+  private Map<Integer, Set<MemberId>> partitionMembers(final Set<PartitionMetadata> distribution) {
+    return distribution.stream()
+        .collect(
+            Collectors.toMap(
+                metadata -> metadata.id().number(), metadata -> Set.copyOf(metadata.members())));
+  }
+
+  private Map<Integer, Set<MemberId>> remapMembers(
+      final Set<PartitionMetadata> distribution, final Map<MemberId, MemberId> mapping) {
+    final var remapped = new HashMap<Integer, Set<MemberId>>();
+    distribution.forEach(
+        metadata ->
+            remapped.put(
+                metadata.id().number(),
+                metadata.members().stream().map(mapping::get).collect(Collectors.toSet())));
+    return remapped;
   }
 
   private Set<MemberId> getMembers(final int nodeCount) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/RoundRobinPartitionDistributorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
@@ -107,8 +108,7 @@ final class RoundRobinPartitionDistributorTest {
   @Test
   void shouldDistributePartitionsAcrossZoneAwareMembers() {
     // given
-    final var members =
-        Set.of(MemberId.from("eu-west_0"), MemberId.from("eu-west_1"), MemberId.from("eu-west_2"));
+    final var members = new HashSet<>(ZONE_A_NODES);
 
     // when
     final var distribution =
@@ -137,27 +137,21 @@ final class RoundRobinPartitionDistributorTest {
   @Test
   void shouldPreserveRoundRobinSlotsForMixedBareAndZonedMembersWhenZoneOrderIsConfigured() {
     // given
-    final var originalMembers =
-        Set.of(MemberId.from(0), MemberId.from(1), MemberId.from(2), MemberId.from(3));
-    final var mixedMembers =
-        Set.of(
-            MemberId.from(0),
-            MemberId.from(2),
-            MemberId.from("zone-b", 0),
-            MemberId.from("zone-b", 1));
+    final var originalMembers = bareNodes(4);
+    final var mixedMembers = Set.of(BARE_0, BARE_2, ZONE_B_0, ZONE_B_1);
     final var expectedMapping =
         Map.of(
-            MemberId.from(0), MemberId.from(0),
-            MemberId.from(1), MemberId.from("zone-b", 0),
-            MemberId.from(2), MemberId.from(2),
-            MemberId.from(3), MemberId.from("zone-b", 1));
+            BARE_0, BARE_0, // no change
+            BARE_1, ZONE_B_0, // to zoned
+            BARE_2, BARE_2, // no change
+            BARE_3, ZONE_B_1 // to zoned
+            );
 
-    // when
     final var originalDistribution =
         new RoundRobinPartitionDistributor()
             .distributePartitions(originalMembers, getSortedPartitionIds(4), 4);
     final var mixedDistribution =
-        new RoundRobinPartitionDistributor(List.of("zone-a", "zone-b"))
+        new RoundRobinPartitionDistributor(List.of(ZONE_A, ZONE_B))
             .distributePartitions(mixedMembers, getSortedPartitionIds(4), 4);
 
     // then
@@ -170,25 +164,21 @@ final class RoundRobinPartitionDistributorTest {
     // given
     final var originalMembers =
         Set.of(MemberId.from(0), MemberId.from(1), MemberId.from(2), MemberId.from(3));
-    final var zonedMembers =
-        Set.of(
-            MemberId.from("zone-a", 0),
-            MemberId.from("zone-b", 0),
-            MemberId.from("zone-a", 1),
-            MemberId.from("zone-b", 1));
+    final var zonedMembers = Set.of(ZONE_A_0, ZONE_B_0, ZONE_A_1, ZONE_B_1);
     final var expectedMapping =
         Map.of(
-            MemberId.from(0), MemberId.from("zone-a", 0),
-            MemberId.from(1), MemberId.from("zone-b", 0),
-            MemberId.from(2), MemberId.from("zone-a", 1),
-            MemberId.from(3), MemberId.from("zone-b", 1));
+            BARE_0, ZONE_A_0, // to primary
+            BARE_1, ZONE_B_0, // to secondary
+            BARE_2, ZONE_A_1, // to primary
+            BARE_3, ZONE_B_1 // to secondary
+            );
 
     // when
     final var originalDistribution =
         new RoundRobinPartitionDistributor()
             .distributePartitions(originalMembers, getSortedPartitionIds(4), 4);
     final var zonedDistribution =
-        new RoundRobinPartitionDistributor(List.of("zone-a", "zone-b"))
+        new RoundRobinPartitionDistributor(List.of(ZONE_A, ZONE_B))
             .distributePartitions(zonedMembers, getSortedPartitionIds(4), 4);
 
     // then
@@ -217,7 +207,7 @@ final class RoundRobinPartitionDistributorTest {
   private Set<MemberId> getMembers(final int nodeCount) {
     final Set<MemberId> members = new HashSet<>();
     for (int i = 0; i < nodeCount; i++) {
-      members.add(MemberId.from(String.valueOf(i)));
+      members.add(MemberId.from(i));
     }
     return members;
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributorTest.java
@@ -22,18 +22,17 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class ZoneAwarePartitionDistributorTest {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(ZoneAwarePartitionDistributorTest.class);
   private static final String GROUP = "raft";
   private static final TestConfig TWO_ZONES =
       new TestConfig(
@@ -265,16 +264,54 @@ final class ZoneAwarePartitionDistributorTest {
   }
 
   @Test
-  void shouldThrowWhenMemberHasNoZone() {
-    // given — bare member id (no zone)
-    final var specs = List.of(new ZoneSpec("us-east1", 1, 1000));
+  void shouldFallbackToRoundRobinWhenClusterIsFullyBare() {
+    // given — a not-yet-migrated cluster: the zone-aware config is already persisted but every
+    // member is still bare. Distributing must not throw; it must behave like plain round-robin so
+    // that recomputing the distribution before migration is a no-op.
+    final var specs = List.of(new ZoneSpec("us-east1", 2, 1000), new ZoneSpec("us-west1", 1, 500));
+    final var bareMembers =
+        Set.of(MemberId.from(0), MemberId.from(1), MemberId.from(2), MemberId.from(3));
     final var distributor = new ZoneAwarePartitionDistributor(specs);
-    final Set<MemberId> bareMembers = Set.of(MemberId.from("0"));
 
-    // when / then
-    assertThatThrownBy(() -> distributor.distributePartitions(bareMembers, partitions(1), 1))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("no zone");
+    // when
+    final var result = distributor.distributePartitions(bareMembers, partitions(4), 3);
+
+    // then — identical to plain round-robin over the same bare members
+    final var expected =
+        new RoundRobinPartitionDistributor().distributePartitions(bareMembers, partitions(4), 3);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Property(tries = 25)
+  void shouldEqualPlainRoundRobinForAnyFullyBareCluster(
+      @ForAll @IntRange(min = 2, max = 30) final int replicationFactor,
+      @ForAll @IntRange(min = 0, max = 30) final int extraBrokers,
+      @ForAll @IntRange(min = 1, max = 30) final int partitionCount) {
+    // given — two zones whose replicas sum to the replication factor, distinct priorities so the
+    // zone-aware path would normally engage, and a fully bare cluster with at least RF brokers.
+    final var zoneAReplicas = (replicationFactor + 1) / 2;
+    final var zoneBReplicas = replicationFactor - zoneAReplicas;
+    final var specs =
+        List.of(
+            new ZoneSpec("us-east1", zoneAReplicas, 1000),
+            new ZoneSpec("us-west1", zoneBReplicas, 500));
+    final var clusterSize = replicationFactor + extraBrokers;
+    final var bareMembers =
+        IntStream.range(0, clusterSize)
+            .mapToObj(MemberId::from)
+            .collect(Collectors.toUnmodifiableSet());
+    final var distributor = new ZoneAwarePartitionDistributor(specs);
+
+    // when
+    final var result =
+        distributor.distributePartitions(
+            bareMembers, partitions(partitionCount), replicationFactor);
+
+    // then — a bare cluster must be distributed exactly like plain round-robin (no changes)
+    final var expected =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(bareMembers, partitions(partitionCount), replicationFactor);
+    assertThat(result).isEqualTo(expected);
   }
 
   // -------------------------------------------------------------------------
@@ -368,6 +405,55 @@ Partition | us-east1_0 | us-east1_1 | us-west1_0
         2 |     1      |     2      |     3
         3 |     2      |     3      |     1
 """);
+  }
+
+  @Test
+  void shouldFallbackToZoneOrderedRoundRobinWhenClusterIsMixed() {
+    // given - the cluster is in the middle of a staged migration: one zone has zoned members,
+    // the other still has bare members.
+    final var specs = List.of(new ZoneSpec("zone-a", 2, 1000), new ZoneSpec("zone-b", 2, 500));
+    final var mixedMembers =
+        Set.of(
+            MemberId.from(0),
+            MemberId.from(2),
+            MemberId.from("zone-b", 0),
+            MemberId.from("zone-b", 1));
+    final var distributor = new ZoneAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(mixedMembers, partitions(4), 4);
+
+    // then - mixed topologies should preserve the slot layout via the zone-ordered round-robin
+    // fallback, regardless of the configured zone priorities.
+    final var expected =
+        new RoundRobinPartitionDistributor(specs.stream().map(ZoneSpec::name).toList())
+            .distributePartitions(mixedMembers, partitions(4), 4);
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldSteerRoundRobinByZoneOrderWhenPrioritiesAreIdentical() {
+    // given - two equal-priority zones whose names sort against the desired slot order:
+    // "zzz-region" must own the low slots but sorts after "aaa-region" alphabetically.
+    final var specs =
+        List.of(new ZoneSpec("zzz-region", 1, 100), new ZoneSpec("aaa-region", 1, 100));
+    final var members = union(membersOf("zzz-region", 3), membersOf("aaa-region", 3));
+    final var distributor = new ZoneAwarePartitionDistributor(specs);
+
+    // when
+    final var result = distributor.distributePartitions(members, partitions(6), 2);
+
+    // then - the equal-priority delegation must steer round-robin by the spec order, not by zone
+    // name, so it is identical to a round-robin explicitly steered by that same order.
+    final var steered =
+        new RoundRobinPartitionDistributor(specs.stream().map(ZoneSpec::name).toList())
+            .distributePartitions(members, partitions(6), 2);
+    assertThat(result).isEqualTo(steered);
+
+    // and - it differs from the name-ordered (default) round-robin, proving the steering matters.
+    final var nameOrdered =
+        new RoundRobinPartitionDistributor().distributePartitions(members, partitions(6), 2);
+    assertThat(result).isNotEqualTo(nameOrdered);
   }
 
   // -------------------------------------------------------------------------

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributorTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneAwarePartitionDistributorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.util;
 
+import static io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -14,6 +15,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.cluster.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import io.camunda.zeebe.dynamic.config.util.ZoneFixtures.*;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -36,17 +38,17 @@ final class ZoneAwarePartitionDistributorTest {
   private static final String GROUP = "raft";
   private static final TestConfig TWO_ZONES =
       new TestConfig(
-          List.of(new ZoneSpec("us-east1", 2, 1000), new ZoneSpec("us-west1", 1, 500)),
+          List.of(new ZoneSpec(ZONE_A, 2, 1000), new ZoneSpec(ZONE_B, 1, 500)),
           3,
-          union(membersOf("us-east1", 2), membersOf("us-west1", 1)));
+          union(membersOf(ZONE_A, 2), membersOf(ZONE_B, 1)));
   private static final TestConfig THREE_ZONES =
       new TestConfig(
           List.of(
-              new ZoneSpec("us-east1", 2, 1000),
-              new ZoneSpec("us-west1", 2, 500),
-              new ZoneSpec("eu-east1", 1, 10)),
+              new ZoneSpec(ZONE_A, 2, 1000),
+              new ZoneSpec(ZONE_B, 2, 500),
+              new ZoneSpec(ZONE_C, 1, 10)),
           5,
-          union(membersOf("us-east1", 2), membersOf("us-west1", 2), membersOf("eu-east1", 1)));
+          union(membersOf(ZONE_A, 2), membersOf(ZONE_B, 2), membersOf(ZONE_C, 1)));
 
   // -------------------------------------------------------------------------
   // Helpers
@@ -118,7 +120,7 @@ final class ZoneAwarePartitionDistributorTest {
   @ParameterizedTest
   @MethodSource("twoAndThreeZoneConfigs")
   void shouldPlaceLeaderInHighestPriorityRegion(final TestConfig config) {
-    // given — us-east1 is highest-priority in both configurations
+    // given — zone-a is highest-priority in both configurations
     final var distributor = new ZoneAwarePartitionDistributor(config.specs());
 
     // when
@@ -126,13 +128,13 @@ final class ZoneAwarePartitionDistributorTest {
         distributor.distributePartitions(
             config.clusterMembers(), partitions(3), config.replicationFactor());
 
-    // then — primary of every partition must be a broker from us-east1
+    // then — primary of every partition must be a broker from zone-a
     result.forEach(
         p ->
             assertThat(p.getPrimary())
                 .isPresent()
                 .get()
-                .matches(m -> m.isInZone("us-east1"), "primary should be in us-east1"));
+                .matches(m -> m.isInZone(ZONE_A), "primary should be in zone-a"));
   }
 
   @ParameterizedTest
@@ -160,36 +162,36 @@ final class ZoneAwarePartitionDistributorTest {
         distributor.distributePartitions(
             THREE_ZONES.clusterMembers(), partitions(1), THREE_ZONES.replicationFactor());
 
-    // then — us-east1 brokers must have the two highest priorities (5 and 4)
+    // then — zone-a brokers must have the two highest priorities (5 and 4)
     final var p1 = partitionById(result, 1);
-    final var eastBrokers = membersOf("us-east1", 2);
+    final var eastBrokers = membersOf(ZONE_A, 2);
     final var eastPriorities = eastBrokers.stream().mapToInt(p1::getPriority).boxed().toList();
     assertThat(eastPriorities)
         .containsExactlyInAnyOrder(
             THREE_ZONES.replicationFactor(), THREE_ZONES.replicationFactor() - 1);
 
-    // us-west1 brokers have the next two (3 and 2)
-    final var westBrokers = membersOf("us-west1", 2);
+    // zone-b brokers have the next two (3 and 2)
+    final var westBrokers = membersOf(ZONE_B, 2);
     final var westPriorities = westBrokers.stream().mapToInt(p1::getPriority).boxed().toList();
     assertThat(westPriorities)
         .containsExactlyInAnyOrder(
             THREE_ZONES.replicationFactor() - 2, THREE_ZONES.replicationFactor() - 3);
 
     // eu-east1 broker has the lowest priority (1)
-    assertThat(p1.getPriority(MemberId.from("eu-east1", 0))).isEqualTo(1);
+    assertThat(p1.getPriority(MemberId.from(ZONE_C, 0))).isEqualTo(1);
   }
 
   @Test
   void shouldBeEqualToRoundRobinForSingleRegion() {
     // given — one region, 2 brokers, 1 replica per partition
-    final var specs = List.of(new ZoneSpec("us-east1", 3, 1000));
-    final var clusterMembers = membersOf("us-east1", 3);
+    final var specs = List.of(new ZoneSpec(ZONE_A, 3, 1000));
+    final var clusterMembers = membersOf(ZONE_A, 3);
     final var distributor = new ZoneAwarePartitionDistributor(specs);
 
     // when
     final var result = distributor.distributePartitions(clusterMembers, partitions(3), 3);
 
-    // then — partitions 1,3 → us-east1_0; partitions 2,4 → us-east1_1 (or vice versa)
+    // then — partitions 1,3 → zone-a_0; partitions 2,4 → zone-a_1 (or vice versa)
     final var rrResult =
         new RoundRobinPartitionDistributor().distributePartitions(clusterMembers, partitions(3), 3);
 
@@ -203,7 +205,7 @@ final class ZoneAwarePartitionDistributorTest {
   @ParameterizedTest
   @MethodSource("twoAndThreeZoneConfigs")
   void shouldShiftStartingBrokerPerPartitionWithinRegion(final TestConfig config) {
-    // given — us-east1 has 2 brokers and 2 replicas per partition in both configs
+    // given — zone-a has 2 brokers and 2 replicas per partition in both configs
     final var distributor = new ZoneAwarePartitionDistributor(config.specs());
 
     // when
@@ -211,17 +213,17 @@ final class ZoneAwarePartitionDistributorTest {
         distributor.distributePartitions(
             config.clusterMembers(), partitions(2), config.replicationFactor());
 
-    // then — for partition 1 the highest-priority east broker is us-east1_0,
-    //        for partition 2 it is us-east1_1 (offset shifts by 1)
+    // then — for partition 1 the highest-priority east broker is zone-a_0,
+    //        for partition 2 it is zone-a_1 (offset shifts by 1)
     final var p1 = partitionById(result, 1);
     final var p2 = partitionById(result, 2);
 
-    assertThat(p1.getPrimary().orElseThrow()).isEqualTo(MemberId.from("us-east1", 0));
-    assertThat(p2.getPrimary().orElseThrow()).isEqualTo(MemberId.from("us-east1", 1));
+    assertThat(p1.getPrimary().orElseThrow()).isEqualTo(MemberId.from(ZONE_A, 0));
+    assertThat(p2.getPrimary().orElseThrow()).isEqualTo(MemberId.from(ZONE_A, 1));
 
-    // us-west1_0 is always assigned regardless of zone size or round-robin offset
-    assertThat(p1.members()).contains(MemberId.from("us-west1", 0));
-    assertThat(p2.members()).contains(MemberId.from("us-west1", 0));
+    // zone-b_0 is always assigned regardless of zone size or round-robin offset
+    assertThat(p1.members()).contains(MemberId.from(ZONE_B, 0));
+    assertThat(p2.members()).contains(MemberId.from(ZONE_B, 0));
   }
 
   // -------------------------------------------------------------------------
@@ -250,7 +252,7 @@ final class ZoneAwarePartitionDistributorTest {
   @ParameterizedTest
   @ValueSource(ints = {-100, -1, 0})
   void shouldThrowWhenNumberOfReplicasIsNotPositive(final int numberOfReplicas) {
-    assertThatThrownBy(() -> new ZoneSpec("us-east1", numberOfReplicas, 1000))
+    assertThatThrownBy(() -> new ZoneSpec(ZONE_A, numberOfReplicas, 1000))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("numberOfReplicas");
   }
@@ -258,7 +260,7 @@ final class ZoneAwarePartitionDistributorTest {
   @ParameterizedTest
   @ValueSource(ints = {-100, -1, 0})
   void shouldThrowWhenPriorityIsNotPositive(final int priority) {
-    assertThatThrownBy(() -> new ZoneSpec("us-east1", 1, priority))
+    assertThatThrownBy(() -> new ZoneSpec(ZONE_A, 1, priority))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("priority");
   }
@@ -268,7 +270,7 @@ final class ZoneAwarePartitionDistributorTest {
     // given — a not-yet-migrated cluster: the zone-aware config is already persisted but every
     // member is still bare. Distributing must not throw; it must behave like plain round-robin so
     // that recomputing the distribution before migration is a no-op.
-    final var specs = List.of(new ZoneSpec("us-east1", 2, 1000), new ZoneSpec("us-west1", 1, 500));
+    final var specs = List.of(new ZoneSpec(ZONE_A, 2, 1000), new ZoneSpec(ZONE_B, 1, 500));
     final var bareMembers =
         Set.of(MemberId.from(0), MemberId.from(1), MemberId.from(2), MemberId.from(3));
     final var distributor = new ZoneAwarePartitionDistributor(specs);
@@ -293,8 +295,7 @@ final class ZoneAwarePartitionDistributorTest {
     final var zoneBReplicas = replicationFactor - zoneAReplicas;
     final var specs =
         List.of(
-            new ZoneSpec("us-east1", zoneAReplicas, 1000),
-            new ZoneSpec("us-west1", zoneBReplicas, 500));
+            new ZoneSpec(ZONE_A, zoneAReplicas, 1000), new ZoneSpec(ZONE_B, zoneBReplicas, 500));
     final var clusterSize = replicationFactor + extraBrokers;
     final var bareMembers =
         IntStream.range(0, clusterSize)
@@ -336,14 +337,14 @@ final class ZoneAwarePartitionDistributorTest {
   @Test
   void shouldThrowWhenZoneHasFewerBrokersThanReplicas() {
     // given — zone declares 3 replicas but clusterMembers only has 2 in that zone
-    final var specs = List.of(new ZoneSpec("us-east1", 3, 1000));
+    final var specs = List.of(new ZoneSpec(ZONE_A, 3, 1000));
     final var distributor = new ZoneAwarePartitionDistributor(specs);
-    final var clusterMembers = membersOf("us-east1", 2);
+    final var clusterMembers = membersOf(ZONE_A, 2);
 
     // when / then
     assertThatThrownBy(() -> distributor.distributePartitions(clusterMembers, partitions(1), 3))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("us-east1");
+        .hasMessageContaining(ZONE_A);
   }
 
   @ParameterizedTest
@@ -363,23 +364,23 @@ final class ZoneAwarePartitionDistributorTest {
         Map.of(
             2,
 """
-Partition | us-east1_0 | us-east1_1 | us-west1_0
-----------|------------|------------|-----------
-        1 |     3      |     2      |     1    \s
-        2 |     2      |     3      |     1    \s
-        3 |     3      |     2      |     1    \s
-        4 |     2      |     3      |     1    \s
-        5 |     3      |     2      |     1    \s
+Partition | zone-a_0 | zone-a_1 | zone-b_0
+----------|----------|----------|---------
+        1 |     3    |     2    |     1
+        2 |     2    |     3    |     1
+        3 |     3    |     2    |     1
+        4 |     2    |     3    |     1
+        5 |     3    |     2    |     1
 """,
             3,
 """
-Partition | us-east1_0 | us-east1_1 | us-west1_0 | us-west1_1 | eu-east1_0
-----------|------------|------------|------------|------------|-----------
-        1 |     5      |     4      |     3      |     2      |     1
-        2 |     4      |     5      |     2      |     3      |     1
-        3 |     5      |     4      |     3      |     2      |     1
-        4 |     4      |     5      |     2      |     3      |     1
-        5 |     5      |     4      |     3      |     2      |     1
+Partition | zone-a_0 | zone-a_1 | zone-b_0 | zone-b_1 | zone-c_0
+----------|----------|----------|----------|----------|---------
+        1 |     5    |     4    |     3    |     2    |     1
+        2 |     4    |     5    |     2    |     3    |     1
+        3 |     5    |     4    |     3    |     2    |     1
+        4 |     4    |     5    |     2    |     3    |     1
+        5 |     5    |     4    |     3    |     2    |     1
 """);
     assertThat(table).isEqualToIgnoringWhitespace(expected.get(config.specs.size()));
   }
@@ -399,8 +400,8 @@ Partition | us-east1_0 | us-east1_1 | us-west1_0 | us-west1_1 | eu-east1_0
     assertThat(priorityTable)
         .isEqualToIgnoringWhitespace(
 """
-Partition | us-east1_0 | us-east1_1 | us-west1_0
-----------|------------|------------|-----------
+Partition | zone-a_0 | zone-a_1 | zone-b_0
+----------|----------|----------|---------
         1 |     3      |     1      |     2
         2 |     1      |     2      |     3
         3 |     2      |     3      |     1
@@ -412,12 +413,7 @@ Partition | us-east1_0 | us-east1_1 | us-west1_0
     // given - the cluster is in the middle of a staged migration: one zone has zoned members,
     // the other still has bare members.
     final var specs = List.of(new ZoneSpec("zone-a", 2, 1000), new ZoneSpec("zone-b", 2, 500));
-    final var mixedMembers =
-        Set.of(
-            MemberId.from(0),
-            MemberId.from(2),
-            MemberId.from("zone-b", 0),
-            MemberId.from("zone-b", 1));
+    final var mixedMembers = Set.of(BARE_0, BARE_2, ZONE_B_0, ZONE_B_1);
     final var distributor = new ZoneAwarePartitionDistributor(specs);
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneFixtures.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneFixtures.java
@@ -5,36 +5,41 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.dynamic.config.api;
+package io.camunda.zeebe.dynamic.config.util;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class ZoneFixtures {
 
   // zones
-  public static final String ZONE_A = "us-east-1";
-  public static final String ZONE_B = "us-west-1";
+  public static final String ZONE_A = "zone-a";
+  public static final String ZONE_B = "zone-b";
 
   // bare node ids
   public static final MemberId BARE_0 = MemberId.from(0);
   public static final MemberId BARE_1 = MemberId.from(1);
   public static final MemberId BARE_2 = MemberId.from(2);
   public static final MemberId BARE_3 = MemberId.from(3);
-
   // zone A
   public static final MemberId ZONE_A_0 = MemberId.from(ZONE_A, 0);
   public static final MemberId ZONE_A_1 = MemberId.from(ZONE_A, 1);
   public static final MemberId ZONE_A_2 = MemberId.from(ZONE_A, 2);
-
+  public static final List<MemberId> ZONE_A_NODES = List.of(ZONE_A_0, ZONE_A_1, ZONE_A_2);
   // zone B
   public static final MemberId ZONE_B_0 = MemberId.from(ZONE_B, 0);
   public static final MemberId ZONE_B_1 = MemberId.from(ZONE_B, 1);
   public static final MemberId ZONE_B_2 = MemberId.from(ZONE_B, 2);
-
   // Zone configs
   public static final List<ZoneSpec> SINGLE_REGION = List.of(new ZoneSpec(ZONE_A, 3, 100));
   public static final List<ZoneSpec> DUAL_REGION =
       List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
+
+  public static Set<MemberId> bareNodes(final int n) {
+    return IntStream.range(0, n).mapToObj(MemberId::from).collect(Collectors.toSet());
+  }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneFixtures.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ZoneFixtures.java
@@ -19,6 +19,7 @@ public class ZoneFixtures {
   // zones
   public static final String ZONE_A = "zone-a";
   public static final String ZONE_B = "zone-b";
+  public static final String ZONE_C = "zone-c";
 
   // bare node ids
   public static final MemberId BARE_0 = MemberId.from(0);

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -18,6 +18,11 @@
   <dependencies>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-cluster</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>configuration</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.qa.util.cluster;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.cluster.ZoneLayout;
 import io.camunda.configuration.Camunda;
 import io.camunda.configuration.Partitioning.Scheme;
 import io.camunda.configuration.Zone;
@@ -381,10 +382,10 @@ public final class TestClusterBuilder {
       return;
     }
 
-    final var zoneIndex = brokerIndex % zoneCount;
+    final var zoneIndex = ZoneLayout.zoneRankForBareNodeIdx(brokerIndex, zoneCount);
     final var cluster = config.getCluster();
     cluster.setZone(multiZoneConfigs.get(zoneIndex).name());
-    cluster.setNodeId(brokerIndex / zoneCount);
+    cluster.setNodeId(ZoneLayout.localNodeIdxForBareNodeIdx(brokerIndex, zoneCount));
     cluster.getPartitioning().setScheme(Scheme.ZONE_AWARE);
     cluster
         .getPartitioning()

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/CollectionUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/CollectionUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.function.Function;
+
+public class CollectionUtil {
+  public static <T, V> boolean containsDuplicates(
+      final Collection<T> collection, final Function<T, V> projection) {
+    final var set = new HashSet<V>();
+    for (final var t : collection) {
+      final var v = projection.apply(t);
+      if (set.contains(v)) {
+        return true;
+      }
+      set.add(v);
+    }
+    return false;
+  }
+
+  public static <T> boolean containsDuplicates(final Collection<T> collection) {
+    return containsDuplicates(collection, Function.identity());
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Either.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Either.java
@@ -61,6 +61,8 @@ import org.jspecify.annotations.Nullable;
  */
 public sealed interface Either<L extends @Nullable Object, R extends @Nullable Object> {
 
+  static final Either<Void, Void> RIGHT_VOID = Either.right(Unit.unit());
+
   /**
    * Returns a {@link Right} describing the given value.
    *
@@ -370,6 +372,11 @@ public sealed interface Either<L extends @Nullable Object, R extends @Nullable O
    */
   <T extends @Nullable Object> T fold(
       Function<? super L, ? extends T> leftFn, Function<? super R, ? extends T> rightFn);
+
+  @SuppressWarnings("unchecked")
+  static <A extends @Nullable Object> Either<A, Void> rightVoid() {
+    return (Either<A, Void>) Either.RIGHT_VOID;
+  }
 
   /**
    * A right for either a left or right. By convention, right is used for success and left for

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/CollectionUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/CollectionUtilTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CollectionUtilTest {
+
+  @Test
+  void shouldReturnFalseWhenElementsAreUnique() {
+    assertThat(CollectionUtil.containsDuplicates(List.of("a", "b", "c"))).isFalse();
+  }
+
+  @Test
+  void shouldReturnFalseForAnEmptyCollection() {
+    assertThat(CollectionUtil.containsDuplicates(List.of())).isFalse();
+  }
+
+  @Test
+  void shouldReturnTrueWhenElementsAreDuplicated() {
+    assertThat(CollectionUtil.containsDuplicates(List.of("a", "b", "a"))).isTrue();
+  }
+
+  @Test
+  void shouldReturnFalseWhenProjectedValuesAreUnique() {
+    assertThat(
+            CollectionUtil.containsDuplicates(
+                List.of(new Item("a", 1), new Item("b", 1)), Item::name))
+        .isFalse();
+  }
+
+  @Test
+  void shouldReturnTrueWhenProjectedValuesAreDuplicated() {
+    assertThat(
+            CollectionUtil.containsDuplicates(
+                List.of(new Item("a", 1), new Item("a", 2)), Item::name))
+        .isTrue();
+  }
+
+  private record Item(String name, int id) {}
+}


### PR DESCRIPTION


## Description

Add support for turning an existing non-zone-aware cluster into a zone-aware one in explicit stages.

The partition-distribution update can now persist a ZoneAwareConfig on a bare cluster delegating to RoundRobinDistributor until the cluster is fully zoned. This makes the target zone layout durable before any broker identities are changed.

Zone migration is then executed one zone at a time. The migration transformer reads the persisted ZoneAwareConfig, computes which bare brokers belong to the requested zoneIndex, and delegates the actual add/reassign/remove plan to the existing scaling machinery. This keeps the persisted config as the single source of truth for zone order, priorities, and replica counts.

To make staged migration work, partition placement now supports mixed bare/zoned topologies by preserving round-robin slot order until all brokers are zoned, after which normal zone-aware placement applies.

To recap, the order of operation for a dual region cluster with zones `zone-a`, `zone-b` is:

- update partition-distribution w/ zone aware config with both zones.
  - the order of the zones is used to decide which is primary and which is secondary
- migrate `zone-a`
- migrate `zone-b`

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #51986
