### PR TITLE
docs: add ADR for PT configuration resolution and validation

### DIFF
--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0007-physical-tenant-configuration-resolution-and-validation.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0007-physical-tenant-configuration-resolution-and-validation.md
@@ -1,0 +1,234 @@
+# ADR-0007: Physical-Tenant Configuration Resolution — Shared-Config-with-Override Model and the Per-PT / Cross-PT Validation Split
+
+## Status
+
+Accepted
+
+## Deciders
+
+- Proposed by: Houssain Barouni ([@houssain-barouni](https://github.com/houssain-barouni))
+- Deepthi Akkoorath ([@deepthidevaki](https://github.com/deepthidevaki))
+
+_Additional deciders may be recorded as more of the team reviews._
+
+## Context
+
+Issue [#52680](https://github.com/camunda/camunda/issues/52680) (epic
+[#52027](https://github.com/camunda/camunda/issues/52027), Physical Tenants) introduces
+per-physical-tenant (PT) configuration for the Orchestration Cluster. Operators declare global
+defaults once under `camunda.*` and override selected properties per tenant under
+`camunda.physical-tenants.<id>.*`. Each tenant must resolve to a *fully-resolved* `Camunda`
+configuration that consumers (secondary-storage clients, document services, per-tenant security
+chains) can read exactly as they read the root configuration today.
+
+This ADR records the decisions taken for the **configuration-resolution layer** — everything that
+lives in the `configuration/` module around `PhysicalTenantResolver`. It is the counterpart of the
+runtime/security decisions already captured in the sibling ADRs in this folder:
+[ADR-0003](0003-physical-tenant-request-scoping-via-pre-security-filter.md) (request scoping),
+[ADR-0004](0004-per-physical-tenant-provider-selection-via-assigned.md) (provider selection),
+[ADR-0005](0005-physical-tenant-routing-of-authorization-reads.md) (authorization-read routing) and
+ADR-0006 (gRPC authentication). Those consume the resolved per-tenant `Camunda`; this ADR is about
+how that `Camunda` is produced and validated.
+
+The problem breaks into three parts:
+
+1. **A resolution model** — how a per-tenant `Camunda` is built from the root config plus the tenant
+   overlay, and what "override" means (which properties inherit, which replace, which deep-merge).
+2. **A validation architecture** — the physical-tenant model is unsafe by default in specific ways
+   (two tenants silently writing into the same secondary storage or document store; a tenant
+   overriding a cluster-wide property that must be uniform; a tenant silently inheriting the root's
+   identity seed and so accepting foreign tokens). These must fail fast at boot.
+3. **A pitfall in Spring Boot's `MapBinder`** — for a `Map`-typed property, a partial per-tenant
+   override of a map *entry* silently drops the root entry's untouched fields.
+
+Two facts about the runtime shape the decisions. First, all validation runs *inside* `configuration/`
+where the resolved `Camunda` objects and all their getters are already available. Second, detection
+of storage collisions can only ever be **best-effort and static**: the config layer compares declared
+coordinates, not live connections, so DNS aliases and distinct URLs resolving to the same cluster are
+out of reach.
+
+Related work: PR [#52529](https://github.com/camunda/camunda/pull/52529) (resolver),
+PR [#54700](https://github.com/camunda/camunda/pull/54700) (cross-tenant validation),
+PR [#55132](https://github.com/camunda/camunda/pull/55132) (tenant-id length); sub-issues
+[#54366](https://github.com/camunda/camunda/issues/54366) (document-store isolation),
+[#54730](https://github.com/camunda/camunda/issues/54730) (OIDC `assigned`),
+[#55155](https://github.com/camunda/camunda/issues/55155) (per-tenant exporters).
+
+## Decision
+
+### 1. Resolution model: shared config + per-tenant override via a two-bind
+
+`PhysicalTenantResolver.of(Environment, Camunda)` eagerly resolves one `Camunda` per discovered
+physical tenant. Each tenant `Camunda` is produced by:
+
+1. creating a fresh `Camunda` instance;
+2. binding `camunda.*` into it (so every non-overridden value matches the root resolution, and the
+   legacy-property fallback in the getters — via `UnifiedConfigurationHelper` — keeps working
+   unchanged);
+3. binding `camunda.physical-tenants.<id>.*` on top (so tenant-specific keys override the seeded
+   values).
+
+This "shared defaults, override per tenant" model is the general rule for **every** property. Spring
+Binder's overlay semantics govern the merge for scalars and nested non-map beans (e.g. `cluster`,
+whose sibling fields survive a partial override). The resolver is the single place per-tenant config
+is computed; consumers only ever read an already-resolved `Camunda` through
+`PhysicalTenantResolver.mapValues(...)` / `forPhysicalTenant(...)` and never re-merge.
+
+**Default-tenant synthesis.** If no `default` tenant is declared under `camunda.physical-tenants.*`,
+the resolver synthesizes one whose value **is the root `Camunda`** — so consumers can always address
+the root configuration as a tenant, and the synthesized `default` participates in cross-PT validation
+like any other tenant. An explicit `default` declaration is honored as-is.
+
+**Tenant-id constraints.** Ids are discovered by pure key inspection and must be lowercase
+alphanumeric (`[a-z0-9]+`, no dashes) and at most 64 characters. Forbidding dashes keeps YAML
+(`tenant-a`) and environment-variable (`CAMUNDA_PHYSICALTENANTS_TENANTA_*`) forms from resolving to
+two different ids.
+
+### 2. The `MapBinder` defect and the generic overlay engine (typed-POJO maps)
+
+Spring Boot's `MapBinder` merges `Map`-typed properties at the **entry level** (disjoint keys
+survive), but for a key the tenant overlay *touches*, it constructs a **fresh** value POJO from only
+the tenant's sub-keys instead of seeding from the existing root entry. A tenant overriding one field
+of a shared map entry therefore silently loses every root field it did not restate.
+
+This bites named OIDC providers (`Map<String, OidcConfiguration>`) and document stores
+(`Map<String, AwsStore>` and its sibling provider maps). It is repaired by **one generic,
+registry-driven overlay engine** (`PhysicalTenantMapOverlay` + `MapOverlaySpec` +
+`PhysicalTenantMapOverlays`) that runs after the two-bind and recomputes each registered map with a
+**snapshot-then-rebind** algorithm: snapshot the original root entries, then for every id present on
+both root and tenant, re-bind the tenant overlay onto the original root POJO so omitted fields
+inherit root. Adding a per-tenant typed-POJO map means adding one `MapOverlaySpec` to the registry —
+not new merge code. The registry (currently: document stores, OIDC providers) is also the single
+source of truth the override golden test reads to guard the per-field surface.
+
+### 3. Exporter args (`Map<String, Object>`) — deferred to #55155
+
+Exporter `args` at `camunda.data.exporters.<id>.args` is a raw `Map<String, Object>` whose value
+type cannot be field-enumerated, so it stays **out** of the typed-POJO overlay engine. Per-tenant
+exporter handling is **deferred to [#55155](https://github.com/camunda/camunda/issues/55155) and not
+sorted out yet**. Current state: a partial tenant override **replaces** the whole `args` map (root
+`className` and sibling args are dropped), and no per-tenant exporter consumer exists, so per-tenant
+resolved exporter args are effectively not consumed.
+
+### 4. Validation architecture: per-PT vs cross-PT
+
+Validations are split by **what they read**, and run in a fixed order inside
+`PhysicalTenantResolver.of()`: first the per-PT key-inspection checks (before/independent of
+binding), then the per-tenant two-bind + overlay, then the cross-PT checks over the resolved map.
+
+**Per-PT validations** — operate on a single tenant's *declared* keys (pure key inspection over the
+`Environment`, with a targeted `Binder` read only where a value genuinely decides applicability).
+They fail fast before or independently of the full resolution:
+
+- **Override policy** (`PhysicalTenantOverridePolicyValidation`) — a **deny-list** of cluster-wide
+  and identity-security properties that may **not** be overridden per tenant (see §5).
+- **Required override** (`PhysicalTenantRequiredOverrideValidation`) — every explicitly-declared
+  non-`default` tenant **must** declare its own `security.initialization.*` block (unless
+  authorization is disabled for it). The identity seed must not be inherited from the root, or every
+  tenant would get the same admin user/authorizations, defeating isolation.
+- **OIDC provider selection** (`PhysicalTenantAssignedProvidersValidation`) — under the OIDC
+  method, every non-`default` tenant must declare a non-empty `security.authentication.providers.assigned`
+  of known provider ids; the `default` tenant may omit it (implicit full set). Configuration-layer
+  counterpart of the `authentication`-module narrowing (see
+  [ADR-0004](0004-per-physical-tenant-provider-selection-via-assigned.md), #54730).
+- **Document store selection** (`PhysicalTenantDocumentAssignedValidation`) — every non-`default`
+  tenant with a non-empty store catalog must declare a non-empty `document.assigned` of known store
+  ids; and `camunda.document.assigned` is rejected at the **root** level (it is meaningful only per
+  tenant).
+- **Tenant-id format/length** — as in §1.
+
+**Cross-PT validations** — operate on the *resolved* `Map<String, Camunda>` (the synthesized
+`default` included) after all tenants are bound. They express relational, uniqueness/group-by rules
+via a single SPI, `CrossTenantValidation.validate(Map<String, Camunda>)` (a collection signature,
+not pairwise, so it can group collisions into one message and name the tenants). There is
+**no opt-out toggle** — hard isolation is the point. The registered rules:
+
+- **Secondary-storage isolation** (`SecondaryStorageIsolationValidation`) — group tenants by
+  `StorageIdentity` `(type, normalized-connection, namespace)` and reject any group with more than
+  one tenant. This closes the headline risk: two tenants left at the shared default storage
+  (both with the default empty index prefix / null table prefix) resolve to the same identity and
+  fail at boot. The identity is deliberately **minimal and location-only** — adding cluster name or
+  credentials would let an incidental difference mask a real collision. Same URL + different
+  index/table prefix is the explicitly-allowed "shared cluster, distinct namespace" setup.
+- **Secondary-storage type homogeneity** (`SecondaryStorageTypeHomogeneityValidation`) — all tenants
+  must resolve to the same *category* of secondary storage. Elasticsearch and OpenSearch are one
+  category and may be mixed with each other; `rdbms` is its own category and `none` (no secondary
+  storage) is its own — neither may be combined with any other type. So a deployment cannot have one
+  tenant on Elasticsearch and another on RDBMS, or one tenant with `none` and another with a
+  configured store.
+- **Document-store isolation** (`DocumentStoreIsolationValidation`) — reject two tenants resolving to
+  the same `DocumentStoreLocation` (provider-dependent, location-only coordinates: AWS
+  `bucketName + bucketPath`; GCP `bucketName + prefix`; Azure `containerName + containerPath +
+  endpoint`; `local` `path`; in-memory excluded — ephemeral, cannot collide). Same philosophy as
+  `StorageIdentity`; per #54366, hard-fail with no opt-out.
+
+### 5. Override policy: deny-list, not allow-list
+
+The physical-tenant model is "override anything except cluster identity and uniform security policy",
+so an allow-list would be enormous and perpetually out of date. The policy is therefore a **deny-list**
+of non-overridable properties, enforced by pure key inspection (ancestor matching, no value
+comparison). It covers the cluster-topology/identity subtrees (`cluster.*` minus the carve-outs
+`partition-count` / `replication-factor`), process-wide `system.*` (minus `clock-controlled`), the
+single-per-installation `license.key`, and the **identity-security** subtrees of `security.*` that
+must apply uniformly (authentication method, unprotected-api, CSRF, HTTP headers, session,
+multi-tenancy, cluster TLS, and the forward-declared `cluster-admin` from #54898). Notably,
+identity-security *policy* is denied, but provider *content* (`security.authentication.oidc` /
+`providers.oidc`) and the per-tenant `security.initialization` block remain overridable — indeed the
+latter is *required* per tenant (§4).
+
+## Considered alternatives
+
+- **Generic declarative validation engine** — express cross-PT rules by annotating individual config
+  fields (e.g. `@CrossTenantUnique` on a field) and have a framework walk the config tree
+  reflectively to enforce them. Rejected: cross-PT rules are *relational* — they constrain a set of
+  tenants together ("these N tenants' storage locations must all be distinct"), not one field in
+  isolation. A per-field annotation cannot express "distinct across the whole set", and building the
+  framework is a large upfront cost for the handful of rules that exist. Hand-written validators over
+  the resolved map express the relational rules directly.
+- **Pairwise cross-PT SPI** — a validator signature `validate(Camunda a, Camunda b)` invoked on every
+  pair of tenants. Rejected: the rules are uniqueness / group-by, so a pairwise callback produces
+  O(n²) redundant collision reports (every pair in a colliding group reported separately) and cannot
+  name the whole colliding group in one message. The chosen collection signature
+  `validate(Map<String, Camunda>)` can still express pairwise checks internally, so it is the strict
+  superset.
+- **Storage identity that is connection-only, or broad (with credentials).** The storage identity
+  decides when two tenants "point at the same place". A connection-*only* identity (URL, ignoring the
+  index/table prefix) would reject the legitimate "shared cluster, distinct prefix per tenant" setup.
+  A *broad* identity (adding cluster name or credentials) makes real collisions *harder* to detect,
+  because an incidental difference in a non-location field would hide two tenants that actually write
+  to the same place. The chosen minimal location-only tuple `(type, connection, namespace)` is the
+  balance between the two.
+- **Allow-list of overridable properties.** Rejected — enormous and perpetually stale versus the
+  deny-list.
+- **Pluggable `MapBinder` / generic `BindHandler` to fix the map-override behavior.** The custom
+  `MapBinder` is impossible (package-private in Spring Boot 4.0.7). A `BindHandler` was spiked and
+  proven correct via `onStart`-replace, but rejected on cost/risk: ~20% more code, reliance on
+  undocumented per-entry bind semantics, and version-pinned characterization tests.
+  Snapshot-then-rebind is a verbatim extraction of shipping code using only the public `Binder` API.
+- **Raw `deepMerge` for typed-POJO maps as well** — convert each typed config (OIDC provider,
+  document store) to a `Map<String,Object>`, deep-merge root and tenant, then rebind via Spring
+  `Binder`. Rejected: the round-trip silently discards Spring's type-safe binding and
+  `@ConfigurationProperties` validation. Exporter args use raw `deepMerge` without this penalty
+  because their value type is *already* `Map<String,Object>` — there is no typed POJO to lose.
+
+## Consequences
+
+- The two headline isolation risks are closed at boot: two tenants sharing a secondary storage or a
+  document store fail fast with a message naming the tenants and the shared identity.
+- Every non-`default` tenant must **spell out** its storage namespace, its `document.assigned` (when a
+  catalog exists), its OIDC `providers.assigned` (under OIDC), and its own `security.initialization`
+  block. This raises the configuration bar for operators adopting physical tenants — intended, and to
+  be documented.
+- Collision detection is **best-effort static**: DNS aliases, distinct URLs resolving to one cluster,
+  partially-overlapping multi-URL lists, and (for Azure) same-container-different-account are **not**
+  flagged. Accepted limitations, not bugs.
+- Adding a per-tenant typed-POJO map is one registry entry; adding a cross-PT rule is one
+  `CrossTenantValidation` class — the SPI does not grow. Adding a document provider forces a
+  `DocumentStoreLocation` factory (a compile-time obligation).
+- Per-tenant **exporter** args are resolved but effectively unconsumed and still use native REPLACE;
+  the deep-merge and a per-tenant exporter consumer are deferred to
+  [#55155](https://github.com/camunda/camunda/issues/55155).
+- The merge itself never deletes: a tenant can override or add entries, not remove one the root
+  declares (the `assigned` lists narrow the *visible* set, but do not delete from the merge). Whether
+  per-tenant disable of an inherited entry is needed is **not decided yet**; it would be a separate
+  follow-up if it becomes a requirement.

--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0007-physical-tenant-configuration-resolution-and-validation.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0007-physical-tenant-configuration-resolution-and-validation.md
@@ -1,234 +1,56 @@
-# ADR-0007: Physical-Tenant Configuration Resolution — Shared-Config-with-Override Model and the Per-PT / Cross-PT Validation Split
+# Physical-Tenant Configuration: Shared-Config-with-Override Resolution and the Per-PT / Cross-PT Validation Split
 
-## Status
+**DRI**: Houssain Barouni ([@houssain-barouni](https://github.com/houssain-barouni))
 
-Accepted
+**Status**: Accepted (8.10)
 
-## Deciders
+**Purpose**: Defines how a fully-resolved per-physical-tenant `Camunda` configuration is produced from the root config plus a per-tenant overlay, and how it is validated at boot.
 
-- Proposed by: Houssain Barouni ([@houssain-barouni](https://github.com/houssain-barouni))
-- Deepthi Akkoorath ([@deepthidevaki](https://github.com/deepthidevaki))
-
-_Additional deciders may be recorded as more of the team reviews._
+**Audience**: Engineers working on physical-tenant configuration resolution, secondary-storage and document-store isolation, and the Orchestration Cluster `configuration/` layer.
 
 ## Context
 
-Issue [#52680](https://github.com/camunda/camunda/issues/52680) (epic
-[#52027](https://github.com/camunda/camunda/issues/52027), Physical Tenants) introduces
-per-physical-tenant (PT) configuration for the Orchestration Cluster. Operators declare global
-defaults once under `camunda.*` and override selected properties per tenant under
-`camunda.physical-tenants.<id>.*`. Each tenant must resolve to a *fully-resolved* `Camunda`
-configuration that consumers (secondary-storage clients, document services, per-tenant security
-chains) can read exactly as they read the root configuration today.
+Physical Tenants (epic [#52027](https://github.com/camunda/camunda/issues/52027), issue [#52680](https://github.com/camunda/camunda/issues/52680)) introduces per-physical-tenant (PT) configuration for the Orchestration Cluster. Operators declare global defaults once under `camunda.*` and override selected properties per tenant under `camunda.physical-tenants.<id>.*`. Each tenant must resolve to a *fully-resolved* `Camunda` configuration that consumers — secondary-storage clients, document services, per-tenant security chains — read exactly as they read the root configuration today.
 
-This ADR records the decisions taken for the **configuration-resolution layer** — everything that
-lives in the `configuration/` module around `PhysicalTenantResolver`. It is the counterpart of the
-runtime/security decisions already captured in the sibling ADRs in this folder:
-[ADR-0003](0003-physical-tenant-request-scoping-via-pre-security-filter.md) (request scoping),
-[ADR-0004](0004-per-physical-tenant-provider-selection-via-assigned.md) (provider selection),
-[ADR-0005](0005-physical-tenant-routing-of-authorization-reads.md) (authorization-read routing) and
-[ADR-0006](0006-physical-tenant-scoped-grpc-authentication.md) (gRPC authentication). Those consume the resolved per-tenant `Camunda`; this ADR is about
-how that `Camunda` is produced and validated.
+The model is unsafe by default in specific ways: two tenants can silently write into the same secondary storage or document store; a tenant can override a property that must be cluster-uniform; a tenant can inherit the root's identity seed and so accept foreign tokens. These must fail fast at boot. This ADR covers how a per-tenant `Camunda` is *produced and validated* in the `configuration/` layer; its runtime and security *consumers* are covered by the sibling ADRs [ADR-0003](0003-physical-tenant-request-scoping-via-pre-security-filter.md), [ADR-0004](0004-per-physical-tenant-provider-selection-via-assigned.md), [ADR-0005](0005-physical-tenant-routing-of-authorization-reads.md), and [ADR-0006](0006-physical-tenant-scoped-grpc-authentication.md).
 
-The problem breaks into three parts:
-
-1. **A resolution model** — how a per-tenant `Camunda` is built from the root config plus the tenant
-   overlay, and what "override" means (which properties inherit, which replace, which deep-merge).
-2. **A validation architecture** — the physical-tenant model is unsafe by default in specific ways
-   (two tenants silently writing into the same secondary storage or document store; a tenant
-   overriding a cluster-wide property that must be uniform; a tenant silently inheriting the root's
-   identity seed and so accepting foreign tokens). These must fail fast at boot.
-3. **A pitfall in Spring Boot's `MapBinder`** — for a `Map`-typed property, a partial per-tenant
-   override of a map *entry* silently drops the root entry's untouched fields.
-
-Two facts about the runtime shape the decisions. First, all validation runs *inside* `configuration/`
-where the resolved `Camunda` objects and all their getters are already available. Second, detection
-of storage collisions can only ever be **best-effort and static**: the config layer compares declared
-coordinates, not live connections, so DNS aliases and distinct URLs resolving to the same cluster are
-out of reach.
-
-Related work: PR [#52529](https://github.com/camunda/camunda/pull/52529) (resolver),
-PR [#54700](https://github.com/camunda/camunda/pull/54700) (cross-tenant validation),
-PR [#55132](https://github.com/camunda/camunda/pull/55132) (tenant-id length); sub-issues
-[#54366](https://github.com/camunda/camunda/issues/54366) (document-store isolation),
-[#54730](https://github.com/camunda/camunda/issues/54730) (OIDC `assigned`),
-[#55155](https://github.com/camunda/camunda/issues/55155) (per-tenant exporters).
+Two constraints bound the design. All validation runs inside `configuration/`, where the resolved `Camunda` objects are already available. And storage-collision detection can only ever be best-effort and static: the config layer compares declared coordinates, not live connections, so DNS aliases and distinct URLs resolving to the same cluster are out of reach.
 
 ## Decision
 
-### 1. Resolution model: shared config + per-tenant override via a two-bind
+**D1. Shared config plus per-tenant override.** Each tenant's `Camunda` is produced by binding the root `camunda.*` into a fresh instance, then binding the tenant's `camunda.physical-tenants.<id>.*` overlay on top. This "shared defaults, override per tenant" rule applies to every property; standard binder overlay semantics govern the merge for scalars and nested beans. Per-tenant config is computed once in a single resolver, and consumers only ever read an already-resolved `Camunda` — they never re-merge.
 
-`PhysicalTenantResolver.of(Environment, Camunda)` eagerly resolves one `Camunda` per discovered
-physical tenant. Each tenant `Camunda` is produced by:
+**D2. The `default` tenant is synthesized from the root config.** When no `default` tenant is declared, the resolver synthesizes one whose value *is* the root `Camunda`, so the root is always addressable as a tenant and participates in cross-PT validation like any other. An explicit `default` declaration is honored as-is.
 
-1. creating a fresh `Camunda` instance;
-2. binding `camunda.*` into it (so every non-overridden value matches the root resolution, and the
-   legacy-property fallback in the getters — via `UnifiedConfigurationHelper` — keeps working
-   unchanged);
-3. binding `camunda.physical-tenants.<id>.*` on top (so tenant-specific keys override the seeded
-   values).
+**D3. Tenant ids are lowercase-alphanumeric, at most 64 characters.** Ids are discovered by key inspection and constrained to `[a-z0-9]+` (no dashes). This avoids a mismatch where a YAML key containing punctuation and its environment-variable form (which typically drops punctuation) would resolve to different ids.
 
-This "shared defaults, override per tenant" model is the general rule for **every** property. Spring
-Binder's overlay semantics govern the merge for scalars and nested non-map beans (e.g. `cluster`,
-whose sibling fields survive a partial override). The resolver is the single place per-tenant config
-is computed; consumers only ever read an already-resolved `Camunda` through
-`PhysicalTenantResolver.mapValues(...)` / `forPhysicalTenant(...)` and never re-merge.
+**D4. Partial overrides of a typed map entry inherit the untouched root fields.** Spring's map binding replaces a touched entry with a fresh value built only from the tenant's sub-keys, silently dropping root fields the tenant did not restate (this affects named OIDC providers and document stores). The resolver instead re-applies each touched entry's overlay onto the original root entry, so omitted fields inherit. A registry of the maps that need this behavior is the single source of truth, so adding a per-tenant typed map is a registry entry, not new merge code.
 
-**Default-tenant synthesis.** If no `default` tenant is declared under `camunda.physical-tenants.*`,
-the resolver synthesizes one whose value **is the root `Camunda`** — so consumers can always address
-the root configuration as a tenant, and the synthesized `default` participates in cross-PT validation
-like any other tenant. An explicit `default` declaration is honored as-is.
+**D5. Raw `Map<String,Object>` exporter args are excluded from the typed overlay.** Exporter `args` have no enumerable field type, so they cannot participate in the field-level inheritance of D4. Per-tenant exporter handling is deferred to [#55155](https://github.com/camunda/camunda/issues/55155); until then a partial override replaces the whole `args` map and no per-tenant exporter consumer exists.
 
-**Tenant-id constraints.** Ids are discovered by pure key inspection and must be lowercase
-alphanumeric (`[a-z0-9]+`, no dashes) and at most 64 characters. This avoids a mismatch where a YAML
-key containing punctuation (e.g. `tenant-a`) and an environment-variable form that typically drops it
-(e.g. `CAMUNDA_PHYSICALTENANTS_TENANTA_*`) could otherwise resolve to different ids.
+**D6. Validation is split by what it reads: per-PT versus cross-PT.** Per-PT validations operate on a single tenant's declared keys (override policy, required per-tenant identity seed, OIDC provider selection, document-store selection, id format) and fail fast independently of full resolution. Cross-PT validations operate on the resolved set of all tenants (the synthesized `default` included) and express relational uniqueness rules through a single collection-signature SPI — so a colliding group is reported in one message naming its tenants. Cross-PT isolation has **no opt-out**: secondary-storage isolation (tenants grouped by a minimal, location-only storage identity), secondary-storage type homogeneity, and document-store isolation (provider-dependent, location-only coordinates) all hard-fail at boot.
 
-### 2. The `MapBinder` defect and the generic overlay engine (typed-POJO maps)
+**D7. Non-overridable properties are a deny-list, not an allow-list.** The model is "override anything except cluster identity and uniform security policy", so an allow-list would be enormous and perpetually stale. A deny-list, enforced by key inspection, covers the cluster-topology/identity subtrees, process-wide system settings, the single-per-installation license key, and the identity-security policy that must apply uniformly — while leaving provider *content* and the per-tenant identity-seed block overridable (the latter is in fact required per tenant, per D6).
 
-Spring Boot's `MapBinder` merges `Map`-typed properties at the **entry level** (disjoint keys
-survive), but for a key the tenant overlay *touches*, it constructs a **fresh** value POJO from only
-the tenant's sub-keys instead of seeding from the existing root entry. A tenant overriding one field
-of a shared map entry therefore silently loses every root field it did not restate.
+## Alternatives considered
 
-This bites named OIDC providers (`Map<String, OidcConfiguration>`) and document stores
-(`Map<String, AwsStore>` and its sibling provider maps). It is repaired by **one generic,
-registry-driven overlay engine** (`PhysicalTenantMapOverlay` + `MapOverlaySpec` +
-`PhysicalTenantMapOverlays`) that runs after the two-bind and recomputes each registered map with a
-**snapshot-then-rebind** algorithm: snapshot the original root entries, then for every id present on
-both root and tenant, re-bind the tenant overlay onto the original root POJO so omitted fields
-inherit root. Adding a per-tenant typed-POJO map means adding one `MapOverlaySpec` to the registry —
-not new merge code. The registry (currently: document stores, OIDC providers) is also the single
-source of truth the override golden test reads to guard the per-field surface.
-
-### 3. Exporter args (`Map<String, Object>`) — deferred to #55155
-
-Exporter `args` at `camunda.data.exporters.<id>.args` is a raw `Map<String, Object>` whose value
-type cannot be field-enumerated, so it stays **out** of the typed-POJO overlay engine. Per-tenant
-exporter handling is **deferred to [#55155](https://github.com/camunda/camunda/issues/55155) and not
-sorted out yet**. Current state: a partial tenant override **replaces** the whole `args` map (root
-`className` and sibling args are dropped), and no per-tenant exporter consumer exists, so per-tenant
-resolved exporter args are effectively not consumed.
-
-### 4. Validation architecture: per-PT vs cross-PT
-
-Validations are split by **what they read**, and run in a fixed order inside
-`PhysicalTenantResolver.of()`: first the per-PT key-inspection checks (before/independent of
-binding), then the per-tenant two-bind + overlay, then the cross-PT checks over the resolved map.
-
-**Per-PT validations** — operate on a single tenant's *declared* keys (pure key inspection over the
-`Environment`, with a targeted `Binder` read only where a value genuinely decides applicability).
-They fail fast before or independently of the full resolution:
-
-- **Override policy** (`PhysicalTenantOverridePolicyValidation`) — a **deny-list** of cluster-wide
-  and identity-security properties that may **not** be overridden per tenant (see §5).
-- **Required override** (`PhysicalTenantRequiredOverrideValidation`) — every explicitly-declared
-  non-`default` tenant **must** declare its own `security.initialization.*` block (unless
-  authorization is disabled for it). The identity seed must not be inherited from the root, or every
-  tenant would get the same admin user/authorizations, defeating isolation.
-- **OIDC provider selection** (`PhysicalTenantAssignedProvidersValidation`) — under the OIDC
-  method, every non-`default` tenant must declare a non-empty `security.authentication.providers.assigned`
-  of known provider ids; the `default` tenant may omit it (implicit full set). Configuration-layer
-  counterpart of the `authentication`-module narrowing (see
-  [ADR-0004](0004-per-physical-tenant-provider-selection-via-assigned.md), #54730).
-- **Document store selection** (`PhysicalTenantDocumentAssignedValidation`) — every non-`default`
-  tenant with a non-empty store catalog must declare a non-empty `document.assigned` of known store
-  ids; and `camunda.document.assigned` is rejected at the **root** level (it is meaningful only per
-  tenant).
-- **Tenant-id format/length** — as in §1.
-
-**Cross-PT validations** — operate on the *resolved* `Map<String, Camunda>` (the synthesized
-`default` included) after all tenants are bound. They express relational, uniqueness/group-by rules
-via a single SPI, `CrossTenantValidation.validate(Map<String, Camunda>)` (a collection signature,
-not pairwise, so it can group collisions into one message and name the tenants). There is
-**no opt-out toggle** — hard isolation is the point. The registered rules:
-
-- **Secondary-storage isolation** (`SecondaryStorageIsolationValidation`) — group tenants by
-  `StorageIdentity` `(type, normalized-connection, namespace)` and reject any group with more than
-  one tenant. This closes the headline risk: two tenants left at the shared default storage
-  (both with the default empty index prefix / null table prefix) resolve to the same identity and
-  fail at boot. The identity is deliberately **minimal and location-only** — adding cluster name or
-  credentials would let an incidental difference mask a real collision. Same URL + different
-  index/table prefix is the explicitly-allowed "shared cluster, distinct namespace" setup.
-- **Secondary-storage type homogeneity** (`SecondaryStorageTypeHomogeneityValidation`) — all tenants
-  must resolve to the same *category* of secondary storage. Elasticsearch and OpenSearch are one
-  category and may be mixed with each other; `rdbms` is its own category and `none` (no secondary
-  storage) is its own — neither may be combined with any other type. So a deployment cannot have one
-  tenant on Elasticsearch and another on RDBMS, or one tenant with `none` and another with a
-  configured store.
-- **Document-store isolation** (`DocumentStoreIsolationValidation`) — reject two tenants resolving to
-  the same `DocumentStoreLocation` (provider-dependent, location-only coordinates: AWS
-  `bucketName + bucketPath`; GCP `bucketName + prefix`; Azure `containerName + containerPath +
-  endpoint`; `local` `path`; in-memory excluded — ephemeral, cannot collide). Same philosophy as
-  `StorageIdentity`; per #54366, hard-fail with no opt-out.
-
-### 5. Override policy: deny-list, not allow-list
-
-The physical-tenant model is "override anything except cluster identity and uniform security policy",
-so an allow-list would be enormous and perpetually out of date. The policy is therefore a **deny-list**
-of non-overridable properties, enforced by pure key inspection (ancestor matching, no value
-comparison). It covers the cluster-topology/identity subtrees (`cluster.*` minus the carve-outs
-`partition-count` / `replication-factor`), process-wide `system.*` (minus `clock-controlled`), the
-single-per-installation `license.key`, and the **identity-security** subtrees of `security.*` that
-must apply uniformly (authentication method, unprotected-api, CSRF, HTTP headers, session,
-multi-tenancy, cluster TLS, and the forward-declared `cluster-admin` from #54898). Notably,
-identity-security *policy* is denied, but provider *content* (`security.authentication.oidc` /
-`providers.oidc`) and the per-tenant `security.initialization` block remain overridable — indeed the
-latter is *required* per tenant (§4).
-
-## Considered alternatives
-
-- **Generic declarative validation engine** — express cross-PT rules by annotating individual config
-  fields (e.g. `@CrossTenantUnique` on a field) and have a framework walk the config tree
-  reflectively to enforce them. Rejected: cross-PT rules are *relational* — they constrain a set of
-  tenants together ("these N tenants' storage locations must all be distinct"), not one field in
-  isolation. A per-field annotation cannot express "distinct across the whole set", and building the
-  framework is a large upfront cost for the handful of rules that exist. Hand-written validators over
-  the resolved map express the relational rules directly.
-- **Pairwise cross-PT SPI** — a validator signature `validate(Camunda a, Camunda b)` invoked on every
-  pair of tenants. Rejected: the rules are uniqueness / group-by, so a pairwise callback produces
-  O(n²) redundant collision reports (every pair in a colliding group reported separately) and cannot
-  name the whole colliding group in one message. The chosen collection signature
-  `validate(Map<String, Camunda>)` can still express pairwise checks internally, so it is the strict
-  superset.
-- **Storage identity that is connection-only, or broad (with credentials).** The storage identity
-  decides when two tenants "point at the same place". A connection-*only* identity (URL, ignoring the
-  index/table prefix) would reject the legitimate "shared cluster, distinct prefix per tenant" setup.
-  A *broad* identity (adding cluster name or credentials) makes real collisions *harder* to detect,
-  because an incidental difference in a non-location field would hide two tenants that actually write
-  to the same place. The chosen minimal location-only tuple `(type, connection, namespace)` is the
-  balance between the two.
-- **Allow-list of overridable properties.** Rejected — enormous and perpetually stale versus the
-  deny-list.
-- **Pluggable `MapBinder` / generic `BindHandler` to fix the map-override behavior.** The custom
-  `MapBinder` is impossible (package-private in Spring Boot 4.0.7). A `BindHandler` was spiked and
-  proven correct via `onStart`-replace, but rejected on cost/risk: ~20% more code, reliance on
-  undocumented per-entry bind semantics, and version-pinned characterization tests.
-  Snapshot-then-rebind is a verbatim extraction of shipping code using only the public `Binder` API.
-- **Raw `deepMerge` for typed-POJO maps as well** — convert each typed config (OIDC provider,
-  document store) to a `Map<String,Object>`, deep-merge root and tenant, then rebind via Spring
-  `Binder`. Rejected: the round-trip silently discards Spring's type-safe binding and
-  `@ConfigurationProperties` validation. Exporter args use raw `deepMerge` without this penalty
-  because their value type is *already* `Map<String,Object>` — there is no typed POJO to lose.
+- **Per-field declarative validation (annotate a field `@CrossTenantUnique` and walk the tree).** Rejected: cross-PT rules are relational — they constrain a *set* of tenants together ("these N storage locations must all be distinct"), which a per-field annotation cannot express, and the framework is a large cost for a handful of rules. Hand-written validators over the resolved set express the relational rules directly.
+- **Allow-list of overridable properties.** Rejected as the inverse of D7 — enormous and perpetually stale against a model whose default is "override almost anything".
 
 ## Consequences
 
-- The two headline isolation risks are closed at boot: two tenants sharing a secondary storage or a
-  document store fail fast with a message naming the tenants and the shared identity.
-- Every non-`default` tenant must **spell out** its storage namespace, its `document.assigned` (when a
-  catalog exists), its OIDC `providers.assigned` (under OIDC), and its own `security.initialization`
-  block. This raises the configuration bar for operators adopting physical tenants — intended, and to
-  be documented.
-- Collision detection is **best-effort static**: DNS aliases, distinct URLs resolving to one cluster,
-  partially-overlapping multi-URL lists, and (for Azure) same-container-different-account are **not**
-  flagged. Accepted limitations, not bugs.
-- Adding a per-tenant typed-POJO map is one registry entry; adding a cross-PT rule is one
-  `CrossTenantValidation` class — the SPI does not grow. Adding a document provider forces a
-  `DocumentStoreLocation` factory (a compile-time obligation).
-- Per-tenant **exporter** args are resolved but effectively unconsumed and still use native REPLACE;
-  the deep-merge and a per-tenant exporter consumer are deferred to
-  [#55155](https://github.com/camunda/camunda/issues/55155).
-- The merge itself never deletes: a tenant can override or add entries, not remove one the root
-  declares (the `assigned` lists narrow the *visible* set, but do not delete from the merge). Whether
-  per-tenant disable of an inherited entry is needed is **not decided yet**; it would be a separate
-  follow-up if it becomes a requirement.
+- The two headline isolation risks close at boot: two tenants sharing a secondary storage or a document store fail fast with a message naming the tenants and the shared identity.
+- Every non-`default` tenant must spell out its storage namespace, its assigned document stores and OIDC providers (where applicable), and its own identity-seed block. This raises the configuration bar for operators adopting physical tenants — intended, and to be documented.
+- Collision detection is best-effort static: DNS aliases, distinct URLs resolving to one cluster, partially-overlapping URL lists, and same-container-different-account are not flagged. Accepted limitations, not bugs.
+- Adding a per-tenant typed map is one registry entry; adding a cross-PT rule is one validator — the SPI does not grow.
+- Per-tenant exporter args are resolved but effectively unconsumed and still replace-on-override until [#55155](https://github.com/camunda/camunda/issues/55155).
+- The merge itself never deletes: a tenant can override or add entries, but not remove one the root declares. The exception is maps that carry an `assigned` selector (document stores, OIDC providers): a tenant narrows its effective set to the assigned keys, which drops the unassigned root entries from that tenant's resolved configuration. Outside those selector-backed maps, per-tenant disable of an inherited entry is not possible and would be a follow-up if it becomes a requirement.
+
+## Source
+
+- [Strong Isolation via Physical Tenants: Implementation planning — PT configuration resolution](https://docs.google.com/document/d/1hLdPXbKNZvijRxwFn-N1QUW8pAMXX4vZtrrnpAr9TGM/edit?tab=t.jread4etvuh3#heading=h.l89qqep6cx5i) (internal) — design doc.
+- [Strong Isolation via Physical Tenants: Implementation planning — per-PT override rules for multi-provider maps (document store, OIDC, secret store)](https://docs.google.com/document/d/1hLdPXbKNZvijRxwFn-N1QUW8pAMXX4vZtrrnpAr9TGM/edit?tab=t.tl54tsmcckua#heading=h.h42i1w443l5o) (internal) — design doc.
+- [Cross-tenant config validation #52680](https://github.com/camunda/camunda/issues/52680) (internal) — primary issue.
+- [Physical Tenants epic #52027](https://github.com/camunda/camunda/issues/52027) (internal).
+- Related sub-issues: [#54366](https://github.com/camunda/camunda/issues/54366) (document-store isolation), [#54730](https://github.com/camunda/camunda/issues/54730) (OIDC `assigned`), [#55155](https://github.com/camunda/camunda/issues/55155) (per-tenant exporters).
+- Sibling ADRs: [ADR-0003](0003-physical-tenant-request-scoping-via-pre-security-filter.md), [ADR-0004](0004-per-physical-tenant-provider-selection-via-assigned.md), [ADR-0005](0005-physical-tenant-routing-of-authorization-reads.md), [ADR-0006](0006-physical-tenant-scoped-grpc-authentication.md).

--- a/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0007-physical-tenant-configuration-resolution-and-validation.md
+++ b/docs/monorepo-docs/architecture/components/orchestration-cluster/adr/0007-physical-tenant-configuration-resolution-and-validation.md
@@ -27,7 +27,7 @@ runtime/security decisions already captured in the sibling ADRs in this folder:
 [ADR-0003](0003-physical-tenant-request-scoping-via-pre-security-filter.md) (request scoping),
 [ADR-0004](0004-per-physical-tenant-provider-selection-via-assigned.md) (provider selection),
 [ADR-0005](0005-physical-tenant-routing-of-authorization-reads.md) (authorization-read routing) and
-ADR-0006 (gRPC authentication). Those consume the resolved per-tenant `Camunda`; this ADR is about
+[ADR-0006](0006-physical-tenant-scoped-grpc-authentication.md) (gRPC authentication). Those consume the resolved per-tenant `Camunda`; this ADR is about
 how that `Camunda` is produced and validated.
 
 The problem breaks into three parts:
@@ -80,9 +80,9 @@ the root configuration as a tenant, and the synthesized `default` participates i
 like any other tenant. An explicit `default` declaration is honored as-is.
 
 **Tenant-id constraints.** Ids are discovered by pure key inspection and must be lowercase
-alphanumeric (`[a-z0-9]+`, no dashes) and at most 64 characters. Forbidding dashes keeps YAML
-(`tenant-a`) and environment-variable (`CAMUNDA_PHYSICALTENANTS_TENANTA_*`) forms from resolving to
-two different ids.
+alphanumeric (`[a-z0-9]+`, no dashes) and at most 64 characters. This avoids a mismatch where a YAML
+key containing punctuation (e.g. `tenant-a`) and an environment-variable form that typically drops it
+(e.g. `CAMUNDA_PHYSICALTENANTS_TENANTA_*`) could otherwise resolve to different ids.
 
 ### 2. The `MapBinder` defect and the generic overlay engine (typed-POJO maps)
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Document the architectural decisions taken in https://github.com/camunda/camunda/issues/52680

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates to https://github.com/camunda/camunda/issues/55155
