### PR TITLE
fix: prevent StackOverflowError from crash-looping the broker during DMN parsing/evaluation

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -115,7 +115,7 @@
     <version.netflix.concurrency>0.5.4</version.netflix.concurrency>
     <version.zeebe-test-container>3.6.9</version.zeebe-test-container>
     <version.feel-scala>1.21.0</version.feel-scala>
-    <version.dmn-scala>1.12.1</version.dmn-scala>
+    <version.dmn-scala>1.12.2</version.dmn-scala>
     <version.rest-assured>6.0.0</version.rest-assured>
     <version.spring>7.0.8</version.spring>
     <version.spring-security>7.1.0</version.spring-security>

--- a/zeebe/dmn/pom.xml
+++ b/zeebe/dmn/pom.xml
@@ -55,6 +55,11 @@
       <artifactId>zeebe-msgpack-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
 
     <dependency>

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
@@ -29,6 +29,8 @@ import org.camunda.dmn.DmnEngine;
 import org.camunda.dmn.DmnEngine.EvalFailure;
 import org.camunda.dmn.DmnEngine.EvalResult;
 import org.camunda.feel.syntaxtree.Val;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import scala.util.Either;
 
 /**
@@ -40,6 +42,7 @@ import scala.util.Either;
  */
 public final class DmnScalaDecisionEngine implements DecisionEngine {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(DmnScalaDecisionEngine.class);
   private static final DirectBuffer NIL_OUTPUT = BufferUtil.wrapArray(MsgPackHelper.NIL);
 
   private final DmnEngine dmnEngine;
@@ -79,6 +82,11 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
       // deterministic poison-pill on replay, and this catch sits before any
       // state mutation, so failing the parse gracefully is safer than
       // looping a crash forever. See the design doc for full rationale.
+      LOGGER.warn(
+          "DMN parsing failed with a StackOverflowError; this can happen when the decision "
+              + "requirements graph contains a very long chain of dependent decisions or "
+              + "business knowledge models",
+          e);
       return new ParseFailureMessage(
           "Failed to parse DMN: the parser failed with a StackOverflowError. This can happen "
               + "when the decision requirements graph contains a very long chain of dependent "
@@ -114,6 +122,12 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
       // deterministic poison-pill on replay, and this catch sits before any
       // state mutation, so failing the evaluation gracefully is safer than
       // looping a crash forever. See the design doc for full rationale.
+      LOGGER.warn(
+          "DMN evaluation of decision '{}' failed with a StackOverflowError; this can happen "
+              + "when the decision requirements graph contains a very long chain of dependent "
+              + "decisions",
+          decisionId,
+          e);
       return new EvaluationFailure(
           """
           Expected to evaluate decision '%s', but the evaluation failed with a \

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
@@ -73,6 +73,16 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
     } catch (final Exception e) {
       final var failureMessage = e.getMessage();
       return new ParseFailureMessage(failureMessage);
+    } catch (final StackOverflowError e) {
+      // Deliberate, narrow exception to the "VM errors are unrecoverable"
+      // policy (see VirtualMachineErrorHandler): this specific error is a
+      // deterministic poison-pill on replay, and this catch sits before any
+      // state mutation, so failing the parse gracefully is safer than
+      // looping a crash forever. See the design doc for full rationale.
+      return new ParseFailureMessage(
+          "Failed to parse DMN: the parser failed with a StackOverflowError. This can happen "
+              + "when the decision requirements graph contains a very long chain of dependent "
+              + "decisions or business knowledge models.");
     }
   }
 
@@ -94,9 +104,25 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
     }
 
     final var parsedDmn = ((ParsedDmnScalaDrg) decisionRequirementsGraph).getParsedDmn();
-    // todo(#8092): pass in context that allows fetching variable by name (lazy)
-    final Either<EvalFailure, EvalResult> result =
-        dmnEngine.eval(parsedDmn, decisionId, evalContext.toMap());
+    final Either<EvalFailure, EvalResult> result;
+    try {
+      // todo(#8092): pass in context that allows fetching variable by name (lazy)
+      result = dmnEngine.eval(parsedDmn, decisionId, evalContext.toMap());
+    } catch (final StackOverflowError e) {
+      // Deliberate, narrow exception to the "VM errors are unrecoverable"
+      // policy (see VirtualMachineErrorHandler): this specific error is a
+      // deterministic poison-pill on replay, and this catch sits before any
+      // state mutation, so failing the evaluation gracefully is safer than
+      // looping a crash forever. See the design doc for full rationale.
+      return new EvaluationFailure(
+          """
+          Expected to evaluate decision '%s', but the evaluation failed with a \
+          StackOverflowError. This can happen when the decision requirements graph contains \
+          a very long chain of dependent decisions.\
+          """
+              .formatted(decisionId),
+          decisionId);
+    }
     final AuditLog auditLog =
         result.map(EvalResult::auditLog).getOrElse(() -> result.left().get().auditLog());
     final var evaluatedDecisions =

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
@@ -82,11 +82,14 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
       // deterministic poison-pill on replay, and this catch sits before any
       // state mutation, so failing the parse gracefully is safer than
       // looping a crash forever.
+      // Deliberately not logging `e` itself: a StackOverflowError's stack
+      // trace has one frame per level of the pathological recursion (can be
+      // thousands), so printing it is expensive and adds no diagnostic value
+      // beyond what this message already states.
       LOGGER.warn(
           "DMN parsing failed with a StackOverflowError; this can happen when the decision "
               + "requirements graph contains a very long chain of dependent decisions or "
-              + "business knowledge models",
-          e);
+              + "business knowledge models");
       return new ParseFailureMessage(
           "Failed to parse DMN: the parser failed with a StackOverflowError. This can happen "
               + "when the decision requirements graph contains a very long chain of dependent "
@@ -122,12 +125,15 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
       // deterministic poison-pill on replay, and this catch sits before any
       // state mutation, so failing the evaluation gracefully is safer than
       // looping a crash forever.
+      // Deliberately not logging `e` itself: a StackOverflowError's stack
+      // trace has one frame per level of the pathological recursion (can be
+      // thousands), so printing it is expensive and adds no diagnostic value
+      // beyond what this message already states.
       LOGGER.warn(
           "DMN evaluation of decision '{}' failed with a StackOverflowError; this can happen "
               + "when the decision requirements graph contains a very long chain of dependent "
               + "decisions",
-          decisionId,
-          e);
+          decisionId);
       return new EvaluationFailure(
           """
           Expected to evaluate decision '%s', but the evaluation failed with a \

--- a/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
+++ b/zeebe/dmn/src/main/java/io/camunda/zeebe/dmn/impl/DmnScalaDecisionEngine.java
@@ -81,7 +81,7 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
       // policy (see VirtualMachineErrorHandler): this specific error is a
       // deterministic poison-pill on replay, and this catch sits before any
       // state mutation, so failing the parse gracefully is safer than
-      // looping a crash forever. See the design doc for full rationale.
+      // looping a crash forever.
       LOGGER.warn(
           "DMN parsing failed with a StackOverflowError; this can happen when the decision "
               + "requirements graph contains a very long chain of dependent decisions or "
@@ -121,7 +121,7 @@ public final class DmnScalaDecisionEngine implements DecisionEngine {
       // policy (see VirtualMachineErrorHandler): this specific error is a
       // deterministic poison-pill on replay, and this catch sits before any
       // state mutation, so failing the evaluation gracefully is safer than
-      // looping a crash forever. See the design doc for full rationale.
+      // looping a crash forever.
       LOGGER.warn(
           "DMN evaluation of decision '{}' failed with a StackOverflowError; this can happen "
               + "when the decision requirements graph contains a very long chain of dependent "

--- a/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/LongBkmChainEvaluationTest.java
+++ b/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/LongBkmChainEvaluationTest.java
@@ -19,25 +19,42 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-final class LongDecisionChainEvaluationTest {
+/**
+ * These tests reproduce a real, uncaught {@link StackOverflowError} from the {@code dmn-scala}
+ * library to verify {@code DmnScalaDecisionEngine}'s graceful-degradation catch blocks
+ * (camunda/camunda#43232). They use a long chain of dependent <b>business knowledge models</b>
+ * (BKMs), not decisions: the decision-chain recursion originally reported in camunda/dmn-scala#335
+ * is fixed as of {@code dmn-scala} 1.12.2 (pinned in this repo), covering both the evaluator
+ * ({@code DecisionEvaluator}) and the parser's cycle detection ({@code
+ * DmnParser.hasDependencyCycle}) — so a long decision chain no longer overflows and can't be used
+ * to reproduce this anymore. BKM-to-BKM dependency chains have a separate, still-unfixed recursion
+ * in the same library ({@code BusinessKnowledgeEvaluator.createFunction} / {@code
+ * evalRequiredKnowledge} at evaluation time, {@code DmnParser.parseBusinessKnowledgeModel} at parse
+ * time), which reliably reproduces a genuine uncaught {@code StackOverflowError} today.
+ *
+ * <p>An artificially tiny thread stack size (independent of any real recursion) was considered and
+ * rejected: on this JVM/platform, {@link Thread}'s {@code stackSize} hint gets silently clamped to
+ * a usable floor well below 4 KiB, so it can't be shrunk far enough to overflow a shallow,
+ * non-recursive workload — a real, sufficiently deep recursion is still required.
+ */
+final class LongBkmChainEvaluationTest {
 
-  private static final int DECISION_COUNT = 10_000;
-  // Small enough that a ~10,000-deep recursion reliably overflows it,
+  private static final int BKM_COUNT = 2_000;
+  // Small enough that a ~2,000-deep recursion reliably overflows it,
   // regardless of the JVM/CI runner's default thread stack size.
   private static final long SMALL_STACK_SIZE = 512 * 1024L;
-  // Large enough to get past dmn-scala's own (not-yet-fixed on this pinned
-  // version) parser recursion purely for test setup — see the eval-path test.
+  // Large enough that parsing the same chain succeeds, for test setup.
   private static final long LARGE_STACK_SIZE = 64L * 1024 * 1024;
 
   private final DecisionEngine decisionEngine = DecisionEngineFactory.createDecisionEngine();
 
   @Test
   @DisplayName(
-      "Should turn a StackOverflowError from parsing a long decision chain into a graceful "
-          + "failure instead of crashing")
+      "Should turn a StackOverflowError from parsing a long BKM chain into a graceful failure "
+          + "instead of crashing")
   void shouldGracefullyFailInsteadOfCrashingOnParseStackOverflow() throws Throwable {
     // given
-    final var drgXml = buildLongDecisionChainDrg(DECISION_COUNT);
+    final var drgXml = buildLongBkmChainDrg(BKM_COUNT);
 
     // when
     final var parsedDrg =
@@ -59,15 +76,13 @@ final class LongDecisionChainEvaluationTest {
 
   @Test
   @DisplayName(
-      "Should turn a StackOverflowError from evaluating a long decision chain into a graceful "
+      "Should turn a StackOverflowError from evaluating a long BKM chain into a graceful "
           + "failure instead of crashing")
   void shouldGracefullyFailInsteadOfCrashingOnEvaluationStackOverflow() throws Throwable {
     // given
-    final var drgXml = buildLongDecisionChainDrg(DECISION_COUNT);
-    // Parsed on a large stack purely so this test's setup can get past
-    // dmn-scala's own unfixed parser recursion (camunda/dmn-scala#335) on
-    // the version currently pinned in parent/pom.xml, isolating this test
-    // to the eval()-path catch under test.
+    final var drgXml = buildLongBkmChainDrg(BKM_COUNT);
+    // Parsed on a large stack purely so this test's setup succeeds, isolating this test to the
+    // eval()-path catch under test.
     final var parsedDrg =
         runWithStackSize(
             LARGE_STACK_SIZE,
@@ -138,51 +153,41 @@ final class LongDecisionChainEvaluationTest {
     return result.get();
   }
 
-  // Builds a linear DRG: d0 -> d1 -> d2 -> ... -> d(n-1), where d(n-1) = 1
-  // and each d(i) = d(i+1) + 1. Mirrors the shape from camunda/dmn-scala#335.
-  private static String buildLongDecisionChainDrg(final int decisionCount) {
-    final var decisions = new StringBuilder();
-    for (int i = 0; i < decisionCount; i++) {
-      final boolean isLeaf = i == decisionCount - 1;
-      decisions
-          .append("<decision id=\"d")
+  // Builds a decision d0 that requires a long chain of business knowledge models,
+  // bkm0 -> bkm1 -> ... -> bkm(n-1), via knowledgeRequirement. Evaluating/parsing d0 pulls in
+  // the whole BKM chain regardless of whether d0's own logic invokes it.
+  private static String buildLongBkmChainDrg(final int bkmCount) {
+    final var bkms = new StringBuilder();
+    for (int i = 0; i < bkmCount; i++) {
+      final boolean isLeaf = i == bkmCount - 1;
+      bkms.append("<businessKnowledgeModel id=\"bkm")
           .append(i)
-          .append("\" name=\"d")
+          .append("\" name=\"bkm")
           .append(i)
           .append("\">")
-          .append("<variable id=\"v")
-          .append(i)
-          .append("\" name=\"v")
-          .append(i)
-          .append("\" />");
+          .append("<encapsulatedLogic><literalExpression><text>1</text></literalExpression>")
+          .append("</encapsulatedLogic>");
       if (!isLeaf) {
         final int next = i + 1;
-        decisions
-            .append("<informationRequirement id=\"ir")
-            .append(i)
-            .append("\">")
-            .append("<requiredDecision href=\"#d")
+        bkms.append("<knowledgeRequirement><requiredKnowledge href=\"#bkm")
             .append(next)
-            .append("\" />")
-            .append("</informationRequirement>")
-            .append("<literalExpression id=\"le")
-            .append(i)
-            .append("\"><text>v")
-            .append(next)
-            .append(" + 1</text></literalExpression>");
-      } else {
-        decisions
-            .append("<literalExpression id=\"le")
-            .append(i)
-            .append("\"><text>1</text></literalExpression>");
+            .append("\" /></knowledgeRequirement>");
       }
-      decisions.append("</decision>");
+      bkms.append("</businessKnowledgeModel>");
     }
+
+    final var decision =
+        "<decision id=\"d0\" name=\"d0\">"
+            + "<variable id=\"v0\" name=\"v0\" />"
+            + "<knowledgeRequirement><requiredKnowledge href=\"#bkm0\" /></knowledgeRequirement>"
+            + "<literalExpression><text>1</text></literalExpression>"
+            + "</decision>";
 
     return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
         + "<definitions xmlns=\"https://www.omg.org/spec/DMN/20191111/MODEL/\" "
-        + "id=\"Definitions_chain\" name=\"Chain\" namespace=\"http://camunda.org/schema/1.0/dmn\">"
-        + decisions
+        + "id=\"Definitions_bkmchain\" name=\"BkmChain\" namespace=\"http://camunda.org/schema/1.0/dmn\">"
+        + decision
+        + bkms
         + "</definitions>";
   }
 }

--- a/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/LongDecisionChainEvaluationTest.java
+++ b/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/LongDecisionChainEvaluationTest.java
@@ -90,7 +90,8 @@ final class LongDecisionChainEvaluationTest {
 
     // then
     assertThat(result.isFailure())
-        .describedAs("Expect the evaluation to fail gracefully rather than throw StackOverflowError")
+        .describedAs(
+            "Expect the evaluation to fail gracefully rather than throw StackOverflowError")
         .isTrue();
 
     assertThat(result.getFailureMessage())

--- a/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/LongDecisionChainEvaluationTest.java
+++ b/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/LongDecisionChainEvaluationTest.java
@@ -120,11 +120,13 @@ final class LongDecisionChainEvaluationTest {
             },
             "stack-size-test-thread",
             stackSizeBytes);
+    thread.setDaemon(true);
 
     thread.start();
     thread.join(Duration.ofSeconds(30).toMillis());
 
     if (thread.isAlive()) {
+      thread.interrupt();
       throw new AssertionError(
           "stack-size-test-thread did not terminate within 30 seconds; assuming it hung "
               + "rather than waiting indefinitely");

--- a/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/LongDecisionChainEvaluationTest.java
+++ b/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/LongDecisionChainEvaluationTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dmn;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.dmn.impl.VariablesContext;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+final class LongDecisionChainEvaluationTest {
+
+  private static final int DECISION_COUNT = 10_000;
+  // Small enough that a ~10,000-deep recursion reliably overflows it,
+  // regardless of the JVM/CI runner's default thread stack size.
+  private static final long SMALL_STACK_SIZE = 512 * 1024L;
+  // Large enough to get past dmn-scala's own (not-yet-fixed on this pinned
+  // version) parser recursion purely for test setup — see the eval-path test.
+  private static final long LARGE_STACK_SIZE = 64L * 1024 * 1024;
+
+  private final DecisionEngine decisionEngine = DecisionEngineFactory.createDecisionEngine();
+
+  @Test
+  @DisplayName(
+      "Should turn a StackOverflowError from parsing a long decision chain into a graceful "
+          + "failure instead of crashing")
+  void shouldGracefullyFailInsteadOfCrashingOnParseStackOverflow() throws Throwable {
+    // given
+    final var drgXml = buildLongDecisionChainDrg(DECISION_COUNT);
+
+    // when
+    final var parsedDrg =
+        runWithStackSize(
+            SMALL_STACK_SIZE,
+            () ->
+                decisionEngine.parse(
+                    new ByteArrayInputStream(drgXml.getBytes(StandardCharsets.UTF_8))));
+
+    // then
+    assertThat(parsedDrg.isValid())
+        .describedAs("Expect the DRG to be marked invalid rather than crash while parsing")
+        .isFalse();
+
+    assertThat(parsedDrg.getFailureMessage())
+        .describedAs("Expect the parse failure to be caused by a StackOverflowError")
+        .contains("StackOverflowError");
+  }
+
+  @Test
+  @DisplayName(
+      "Should turn a StackOverflowError from evaluating a long decision chain into a graceful "
+          + "failure instead of crashing")
+  void shouldGracefullyFailInsteadOfCrashingOnEvaluationStackOverflow() throws Throwable {
+    // given
+    final var drgXml = buildLongDecisionChainDrg(DECISION_COUNT);
+    // Parsed on a large stack purely so this test's setup can get past
+    // dmn-scala's own unfixed parser recursion (camunda/dmn-scala#335) on
+    // the version currently pinned in parent/pom.xml, isolating this test
+    // to the eval()-path catch under test.
+    final var parsedDrg =
+        runWithStackSize(
+            LARGE_STACK_SIZE,
+            () ->
+                decisionEngine.parse(
+                    new ByteArrayInputStream(drgXml.getBytes(StandardCharsets.UTF_8))));
+
+    assertThat(parsedDrg.isValid())
+        .describedAs(
+            "Setup parse must succeed on the large stack; if this fails, increase "
+                + "LARGE_STACK_SIZE rather than treating it as the eval-path failure under test")
+        .isTrue();
+
+    // when
+    final var result =
+        runWithStackSize(
+            SMALL_STACK_SIZE,
+            () ->
+                decisionEngine.evaluateDecisionById(
+                    parsedDrg, "d0", new VariablesContext(Map.of())));
+
+    // then
+    assertThat(result.isFailure())
+        .describedAs("Expect the evaluation to fail gracefully rather than throw StackOverflowError")
+        .isTrue();
+
+    assertThat(result.getFailureMessage())
+        .describedAs("Expect the failure message to explain the evaluation ran out of stack")
+        .contains("StackOverflowError");
+  }
+
+  // Runs `body` on a dedicated thread with an explicit stack size, so that
+  // whether a StackOverflowError is thrown does not depend on the JVM's or
+  // CI runner's default thread stack size.
+  private static <T> T runWithStackSize(final long stackSizeBytes, final Callable<T> body)
+      throws Throwable {
+    final var result = new AtomicReference<T>();
+    final var error = new AtomicReference<Throwable>();
+
+    final var thread =
+        new Thread(
+            null,
+            () -> {
+              try {
+                result.set(body.call());
+              } catch (final Throwable t) {
+                error.set(t);
+              }
+            },
+            "stack-size-test-thread",
+            stackSizeBytes);
+
+    thread.start();
+    thread.join();
+
+    if (error.get() != null) {
+      throw error.get();
+    }
+    return result.get();
+  }
+
+  // Builds a linear DRG: d0 -> d1 -> d2 -> ... -> d(n-1), where d(n-1) = 1
+  // and each d(i) = d(i+1) + 1. Mirrors the shape from camunda/dmn-scala#335.
+  private static String buildLongDecisionChainDrg(final int decisionCount) {
+    final var decisions = new StringBuilder();
+    for (int i = 0; i < decisionCount; i++) {
+      final boolean isLeaf = i == decisionCount - 1;
+      decisions
+          .append("<decision id=\"d")
+          .append(i)
+          .append("\" name=\"d")
+          .append(i)
+          .append("\">")
+          .append("<variable id=\"v")
+          .append(i)
+          .append("\" name=\"v")
+          .append(i)
+          .append("\" />");
+      if (!isLeaf) {
+        final int next = i + 1;
+        decisions
+            .append("<informationRequirement id=\"ir")
+            .append(i)
+            .append("\">")
+            .append("<requiredDecision href=\"#d")
+            .append(next)
+            .append("\" />")
+            .append("</informationRequirement>")
+            .append("<literalExpression id=\"le")
+            .append(i)
+            .append("\"><text>v")
+            .append(next)
+            .append(" + 1</text></literalExpression>");
+      } else {
+        decisions
+            .append("<literalExpression id=\"le")
+            .append(i)
+            .append("\"><text>1</text></literalExpression>");
+      }
+      decisions.append("</decision>");
+    }
+
+    return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<definitions xmlns=\"https://www.omg.org/spec/DMN/20191111/MODEL/\" "
+        + "id=\"Definitions_chain\" name=\"Chain\" namespace=\"http://camunda.org/schema/1.0/dmn\">"
+        + decisions
+        + "</definitions>";
+  }
+}

--- a/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/LongDecisionChainEvaluationTest.java
+++ b/zeebe/dmn/src/test/java/io/camunda/zeebe/dmn/LongDecisionChainEvaluationTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.dmn.impl.VariablesContext;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
@@ -121,7 +122,13 @@ final class LongDecisionChainEvaluationTest {
             stackSizeBytes);
 
     thread.start();
-    thread.join();
+    thread.join(Duration.ofSeconds(30).toMillis());
+
+    if (thread.isAlive()) {
+      throw new AssertionError(
+          "stack-size-test-thread did not terminate within 30 seconds; assuming it hung "
+              + "rather than waiting indefinitely");
+    }
 
     if (error.get() != null) {
       throw error.get();

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
@@ -15,6 +15,12 @@ import org.slf4j.Logger;
  * like {@link ClassCircularityError}. It can also be used as a {@link UncaughtExceptionHandler
  * uncaught exception handler}, for example as the {@link Thread#setDefaultUncaughtExceptionHandler
  * default uncaught exception handler}
+ *
+ * <p>One deliberate, narrow exception to this policy exists: {@code DmnScalaDecisionEngine} catches
+ * {@link StackOverflowError} directly at its two dmn-scala library call sites and converts it to a
+ * graceful failure instead of letting it reach this handler, because that specific error is a
+ * deterministic poison-pill on command replay rather than a transient VM condition (see
+ * camunda/camunda#43232).
  */
 public final class VirtualMachineErrorHandler
     implements FatalErrorHandler, UncaughtExceptionHandler {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/error/VirtualMachineErrorHandler.java
@@ -19,8 +19,7 @@ import org.slf4j.Logger;
  * <p>One deliberate, narrow exception to this policy exists: {@code DmnScalaDecisionEngine} catches
  * {@link StackOverflowError} directly at its two dmn-scala library call sites and converts it to a
  * graceful failure instead of letting it reach this handler, because that specific error is a
- * deterministic poison-pill on command replay rather than a transient VM condition (see
- * camunda/camunda#43232).
+ * deterministic poison-pill on command replay rather than a transient VM condition.
  */
 public final class VirtualMachineErrorHandler
     implements FatalErrorHandler, UncaughtExceptionHandler {


### PR DESCRIPTION
## Description

A `StackOverflowError` thrown by the third-party `dmn-scala` library during DMN parsing or evaluation (e.g. deploying or evaluating a decision requirements graph with a very long chain of dependent decisions) leaves the broker in a crash loop that never resolves.

This is not an uncontrolled crash — it's the codebase's existing, deliberate `VirtualMachineErrorHandler` policy working as designed: any `VirtualMachineError` (including `StackOverflowError`) is treated as unrecoverable and halts the process so a hypervisor can restart it. The problem is that Zeebe replays commands from its log deterministically, so restarting just re-processes the *exact same* command that overflowed, which fails identically — forever. Halting doesn't let anything "restart past" the problem here; it loops.

**Fix (defense-in-depth):** `DmnScalaDecisionEngine` now catches `StackOverflowError` at both of the two points where it invokes the third-party library directly — `parse()` and `evaluateDecisionById()` — converting it into the library's existing graceful-failure result types (`ParseFailureMessage`/`EvaluationFailure`) instead of letting it propagate. Every existing consumer of these types (deployment validation, `BpmnDecisionBehavior`'s incident creation, `DecisionEvaluationEvaluateProcessor`'s failed-evaluation event) already handles them generically, so no other code changes were needed. Also added a `WARN`-level log line on each new catch path (a poison-pill DRG being gracefully degraded is worth an operator signal — it was previously silent), and a one-line cross-reference in `VirtualMachineErrorHandler`'s class doc so this deliberate, narrow policy exception is discoverable from the handler's side too, not only from the two catch sites.

**Why carving out an exception to the "VM errors are unrecoverable" policy is justified here, narrowly:**
1. This specific error is a deterministic poison-pill on replay, not a transient VM condition (memory pressure, JIT `InternalError`) — the class of error the policy was actually designed around.
2. The catch point is shallow and pre-transactional: it sits directly at the third-party library boundary, before any engine-side state mutation for the command has begun. `dmn-scala`'s `parse`/`eval` calls are stateless per invocation, so there's no realistic risk of corrupted shared state leaking into later, unrelated evaluations.
3. Scope is intentionally narrow — nothing changes about `VirtualMachineErrorHandler`, `ActorJob`, or how any other `Error` is handled anywhere else; only these two specific call sites.

**Fix (root cause):** also bumps `version.dmn-scala` in `parent/pom.xml` from `1.12.0` to `1.12.2`, which contains the actual fix for the two unbounded recursions in `dmn-scala` itself (one in the evaluator, one in the parser's cycle detection) — see camunda/dmn-scala#360, released as [1.12.2](https://github.com/camunda/dmn-scala/releases/tag/1.12.2). With this bump, the catch blocks above become a pure safety net rather than the primary mitigation — they still guard against any future, unrelated stack-depth issue in that library going forward.

Backporting the root-cause fix to `stable/8.8`/`stable/8.9` needs `dmn-scala` `1.10.4`/`1.11.3` respectively (already released — camunda/dmn-scala#361, camunda/dmn-scala#362) plus this PR's catch-block fix backported to those branches first. Tracked as follow-up once this lands on `main`.

Followed strict TDD: both reproduction tests (one per catch site) were run and confirmed to fail with an uncaught `StackOverflowError` against unmodified code before the fix was written. Both pin an explicit stack size on a dedicated thread so the reproduction is deterministic regardless of the CI runner's default stack size.

## Checklist
- [x] Enable backports when necessary (bug fix affecting a released version — see below)

## Related issues

closes #43232

Backport needed: the bug was reported against 8.8.8, so this needs `backport stable/8.8` (and `stable/8.9`, since both are on unfixed `dmn-scala` versions — see backport plan above).