### PR TITLE
fix: resolve properly openapi version for a `Orchestration Cluster API` group

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -93,6 +93,7 @@ management.metrics.distribution.percentiles.http.server.requests=0.5,0.95,0.99
 springdoc.swagger-ui.csrf.enabled=true
 springdoc.swagger-ui.csrf.header-name=X-CSRF-TOKEN
 springdoc.swagger-ui.csrf.cookie-name=X-CSRF-TOKEN
+springdoc.api-docs.version=openapi_3_0
 
 # Spring AI MCP integration - disabled by default
 spring.ai.mcp.server.enabled=false

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/OpenApiYamlLoader.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/OpenApiYamlLoader.java
@@ -78,6 +78,10 @@ public final class OpenApiYamlLoader {
   public static void customizeOpenApiFromYaml(final OpenAPI targetOpenApi, final String yamlPath) {
     final OpenAPI yamlOpenApi = loadOpenApiFromYaml(yamlPath);
 
+    if (yamlOpenApi.getOpenapi() != null) {
+      targetOpenApi.setOpenapi(yamlOpenApi.getOpenapi());
+    }
+
     if (yamlOpenApi.getTags() != null) {
       targetOpenApi.setTags(yamlOpenApi.getTags());
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/config/OpenApiYamlLoaderTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/config/OpenApiYamlLoaderTest.java
@@ -247,6 +247,29 @@ class OpenApiYamlLoaderTest {
   }
 
   @Test
+  void shouldCopyOpenApiVersionToTargetSpec() throws IOException {
+    // given
+    final String yaml =
+        """
+        openapi: "3.0.3"
+        info:
+          title: Test API
+          version: "1.0"
+        paths: {}
+        """;
+    final Path yamlFile = tempDir.resolve("test-api.yaml");
+    Files.writeString(yamlFile, yaml);
+    final OpenAPI target = new OpenAPI();
+    target.setOpenapi("3.0.1");
+
+    // when
+    OpenApiYamlLoader.customizeOpenApiFromYaml(target, yamlFile.toString());
+
+    // then
+    assertThat(target.getOpenapi()).isEqualTo("3.0.3");
+  }
+
+  @Test
   void openApiLoadingExceptionShouldHaveCorrectMessageAndCause() {
     // given
     final String message = "Test error message";


### PR DESCRIPTION
## Description

Generate declared openapi version for a `Orchestration Cluster API` group

`nullable` present also in Swagger as expected

<img width="498" height="150" alt="image" src="https://github.com/user-attachments/assets/c680583b-c895-4842-a29b-36d3f9f79ace" />

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

relates #55416
