### PR TITLE
ci: grant observe-aborted-jobs actions:read to read raw job logs

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -163,6 +163,7 @@ jobs:
     - analyze
     if: failure()
     permissions:
+      actions: read # required to read raw job logs for runner-abort detection
       checks: read
     runs-on: ubuntu-latest
     timeout-minutes: 3


### PR DESCRIPTION
## What

Adds `actions: read` to the `observe-aborted-jobs` job in `check-licenses.yml`.

## Why

Companion to [camunda/infra-global-github-actions#744](https://github.com/camunda/infra-global-github-actions/pull/744), which changes `submit-aborted-gha-status` to detect runner aborts by scanning **raw job logs** instead of job **annotations**. GitHub moved the tell-tale `The runner has received a shutdown signal.` message out of annotations (which now only say `The operation was canceled.`) and into the raw logs, so the old annotation-based detection stopped recording preempted/aborted self-hosted runner jobs.

Reading raw job logs requires the token to have `actions: read`; the previous annotation approach only needed `checks: read`. This job scoped its permissions to `checks: read` only, so without this change the log fetch fails and aborted-job events go unrecorded.

`ci.yml`'s `check-results` job already grants `actions: read`, so no change is needed there.

## Note

Merge order: this is safe to merge independently, but the behavior only takes effect once #744 is live on `infra-global-github-actions` `main` (the action is pulled `@main`).

Related to https://github.com/camunda/camunda/issues/57701

🤖 Generated with [Claude Code](https://claude.com/claude-code)