### PR TITLE
test: use default rollover batch size for archiver in benchmarks

### DIFF
--- a/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
+++ b/load-tests/setup/main/values/camunda-platform-values-defaults.yaml
@@ -307,7 +307,7 @@ orchestration:
         zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
 
         # Camunda Exporter configuration
-        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 300
+        zeebe.broker.exporters.camundaexporter.args.history.rolloverBatchSize: 1000
         zeebe.broker.exporters.camundaexporter.args.history.waitPeriodBeforeArchiving: "1m"
 
         # Configure a rate limit for all writes, so that we can visualize flow control metrics.


### PR DESCRIPTION
the default is higher when archive by ID is enabled, so this should help the archiver keep up when benchmarking.

## Related issues

refs #43121
