### PR TITLE
test: stabilize Operate retry/cancel operations e2e (stable/8.7)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateOperationPanelPage.ts
@@ -141,7 +141,8 @@ export class OperateOperationPanelPage {
   getCancelOperationEntry(successCount: number): Locator {
     return this.getAllOperationEntries()
       .filter({hasText: 'Cancel'})
-      .filter({hasText: `${successCount} success`});
+      .filter({hasText: `${successCount} success`})
+      .first();
   }
 
   async clickOperationLink(operationEntry: Locator): Promise<void> {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/operations.spec.ts
@@ -201,7 +201,7 @@ test.describe('Operations', () => {
         onFailure: async () => {
           await page.reload();
         },
-        maxRetries: 8,
+        maxRetries: 15,
       });
 
       await operateOperationPanelPage.collapseOperationIdField();
@@ -260,7 +260,7 @@ test.describe('Operations', () => {
         onFailure: async () => {
           await page.reload();
         },
-        maxRetries: 10,
+        maxRetries: 15,
       });
 
       await operateOperationPanelPage.clickOperationLink(operationEntry);
@@ -309,7 +309,7 @@ test.describe('Operations', () => {
         onFailure: async () => {
           await page.reload();
         },
-        maxRetries: 10,
+        maxRetries: 15,
       });
 
       await Promise.all(


### PR DESCRIPTION
## Description

The [C8 Orchestration Cluster Nightly 8.7 E2E run 29014743978](https://github.com/camunda/camunda/actions/runs/29014743978) flaked on `tests/operate/operations.spec.ts` with **3 distinct failure instances** across the two tests. This PR addresses each; both files are scoped to stable/8.7 only.

### 1. Strict-mode violation — *Retry and cancel single instance* (real bug)
```
strict mode violation: …operations-entry.filter({hasText:'Cancel'}).filter({hasText:'1 success'}) resolved to 2 elements
```
`OperateOperationPanelPage.getCancelOperationEntry()` filters the **shared** Operations panel by `Cancel` + `N success`. The panel accumulates entries (50 demo operations + prior cancels), so more than one `Cancel … 1 success` entry can be present and the `toBeVisible()` assertion fails strict mode. Its sibling `getRetryOperationEntry()` already guards this with `.first()` — this PR makes `getCancelOperationEntry()` consistent by appending `.first()`.

### 2 & 3. Eventual-consistency timeouts — CANCELED-icon (single) and `Retry/Cancel N success` (multiple)
Investigated via the run's screenshots + aria snapshots. These are **not** selector or logic bugs:
- Clicking the operation entry already navigates with `active=true&incidents=true&completed=true&canceled=true&operationId=…`, so the canceled state filter is enabled, and the canceled instance *does* eventually render (confirmed in the afterEach snapshot).
- The lag traces to the **50 `RESOLVE_INCIDENT` demo operations** created in `beforeAll` (for the infinite-scroll test), which saturate Operate's **global** operation-executor + importer. The existing per-instance isolation in `beforeAll` doesn't reduce this because the executor is shared, so the operations these steps assert on are delayed past the reload-retry budget.

Since the assertions are correct and the outcomes are eventually consistent, the proper (non-masking) fix is more retry patience: the three lagged `waitForAssertion` waits are aligned to `maxRetries: 15` (already used by the operations-list wait above). The 30s inner timeout only re-fires on genuine failure, so this stays well within the 12-minute test timeout.

> **Follow-up (out of scope):** reduce the demo-operation contention at the source — e.g. drain the demo operations before the retry/cancel tests run — rather than relying on retry patience. Filed for a separate change to keep this PR minimal.

### Validation performed locally
- `npx tsc --noEmit` → clean
- `npx eslint` on changed files → 0 errors
- `npx prettier --check` (repo-pinned 3.5.3) → clean
- Live-cluster / nightly re-run still required to confirm green (the failing run's cluster is torn down).

## Checklist

- [ ] not a CI change

## Related issues

Nightly run: https://github.com/camunda/camunda/actions/runs/29014743978
