### PR TITLE
feat: backport AnalyticsExporter to 8.8

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -69,6 +69,7 @@
     <version.surefire>3.5.6</version.surefire>
     <version.jackson>2.21.4</version.jackson>
     <version.junit>5.13.4</version.junit>
+    <version.junit-pioneer>2.3.0</version.junit-pioneer>
     <version.junit4>4.13.2</version.junit4>
     <version.log4j>2.25.4</version.log4j>
     <version.minlog>1.3.1</version.minlog>
@@ -1008,6 +1009,12 @@
         <version>${version.junit}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.junit-pioneer</groupId>
+        <artifactId>junit-pioneer</artifactId>
+        <version>${version.junit-pioneer}</version>
       </dependency>
 
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -451,6 +451,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>analytics-exporter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>zeebe-elasticsearch-exporter</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/zeebe/exporters/analytics-exporter/AGENTS.md
+++ b/zeebe/exporters/analytics-exporter/AGENTS.md
@@ -1,0 +1,159 @@
+# Analytics Exporter — Agent Instructions
+
+> Full design context: [APOLLO Engineering Doc](https://docs.google.com/document/d/1QG3snL1Va_PeVuO4gU0YGwVpyEkvbxUtxTPCy2Ouulg)
+> Epic: camunda/product-hub#3247 | Phase 1: camunda/camunda#52362
+
+## Hard Invariants
+
+These are non-negotiable. Every change must preserve them.
+
+- **Never impact broker throughput.** The exporter is fire-and-forget. Position is updated
+  eagerly BEFORE analytics processing. No blocking, no backpressure, no disk I/O on the
+  actor thread. If the endpoint is slow or down, drop data.
+- **No silent double-counting.** Server must always detect overlaps via position ranges +
+  sequence numbers. Overcounting = overcharging customers. Every push carries enough
+  metadata for server-side dedup.
+- **No PII.** Process metadata only. Never export process variables, payloads, message
+  bodies, BPMN XML content, or any end-user data.
+- **Analytics-grade.** Some data loss is accepted. No exactly-once delivery. Loss on crash
+  = entire in-memory buffer. This is by design, not a bug.
+- **Default off.** Exporter only runs when explicitly declared in broker config.
+- **TLS mandatory.** http:// endpoints rejected in config validation (except localhost).
+
+## What NOT To Do
+
+- Don't add retry logic that could stall the actor thread
+- Don't write to disk from the export path
+- Don't add new fields that could contain customer/user data without legal/GDPR review
+- Don't change position acknowledgment to be conditional on analytics delivery
+- Don't introduce cross-thread synchronization that blocks the actor thread
+- Don't bypass the RecordFilter — it prevents unnecessary deserialization
+- Don't add dependencies without checking standalone JAR shading impact (~3MB OTel SDK already)
+
+## Confirmed Design Decisions
+
+| # |                   Decision                    |                                                         Key point                                                         |
+|---|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| 1 | Analytics-grade data                          | Loss-tolerant. Never block broker for analytics.                                                                          |
+| 2 | Solution 2b — in-JVM fire-and-forget          | No sidecar, no disk buffer, no secondary storage dependency.                                                              |
+| 3 | OTLP/HTTP wire protocol                       | OTel Logs for events (/v1/logs), OTel Metrics for counters (/v1/metrics). Protobuf preferred.                             |
+| 4 | License-derived HMAC auth                     | Zero-config for SM. Fingerprint (SHA256) + HMAC signature per request. License never leaves cluster.                      |
+| 5 | Gap detection via sequence numbers (Option C) | Contiguous `camunda.event.sequence_number` per partition. Missing seq = exact loss count. ~10 lines, no custom processor. |
+| 6 | Pre-aggregated delta counters                 | Ship OTel Metrics alongside raw events. Companion gauge `camunda.metric.export_window` carries dedup/timing metadata.     |
+
+## Technical Setup
+
+### Pipeline
+
+```
+Replicated log
+  → AnalyticsRecordFilter (4 layers: record type → value type → intent → partition ownership)
+  → HandlerRegistry routes (ValueType, Intent) → specific handler
+  → OTel SDK:
+      Logs:    BatchLogRecordProcessor (bounded queue) → OtlpHttpLogRecordExporter → /v1/logs
+      Metrics: ManualMetricReader (flushed on partition thread) → OtlpHttpMetricExporter → /v1/metrics
+```
+
+### Key Components
+
+- **AnalyticsExporter** — Lifecycle, handler wiring, metadata persistence
+- **AnalyticsRecordFilter** — Filters before deserialization (implements RecordFilter)
+- **HandlerRegistry** — EnumMap<ValueType> → HashMap<Intent, Handler> routing
+- **OtelSdkManager** — OTel SDK lifecycle, event emission, metric flush, auth headers
+- **ManualMetricReader** — Custom MetricReader; collection triggered from partition thread (no cross-thread races)
+- **AnalyticsExporterMetadata** — Persisted state: eventSequenceNumber, metricSequenceNumber
+
+### Current Event Handlers
+
+|         ValueType         |      Intent       |            Handler             |          event.name          |                       Extra filter                        |
+|---------------------------|-------------------|--------------------------------|------------------------------|-----------------------------------------------------------|
+| PROCESS_INSTANCE_CREATION | CREATED           | ProcessInstanceCreationHandler | `process_instance_created`   | —                                                         |
+| PROCESS_INSTANCE          | ELEMENT_ACTIVATED | AdHocSubProcessHandler         | `adhoc_subprocess_activated` | bpmnElementType == AD_HOC_SUB_PROCESS                     |
+| USAGE_METRIC              | EXPORTED          | UsageMetricHandler             | `usage_metric_exported`      | skips EventType.NONE resets                               |
+| —                         | —                 | (scheduled)                    | `heartbeat`                  | every heartbeatInterval, carries broker/exporter versions |
+
+### Adding a New Event Handler
+
+1. Create handler class implementing `AnalyticsHandler`
+2. Register in `AnalyticsExporter.configure()` with `handlerRegistry.register(valueType, intent, handler)`
+3. Filter is auto-updated — HandlerRegistry builds the RecordFilter from registered handlers
+4. If pre-aggregated metric needed: call `otelSdkManager.incrementMetric()` from handler
+5. Run existing tests + add handler-specific test cases
+
+### Attribute Naming
+
+All attributes use **snake_case, dot-separated** following OTel semantic conventions:
+- `camunda.process.id` (not `camunda.bpmnProcessId`)
+- `camunda.process.definition_key` (not `camunda.processDefinitionKey`)
+- `camunda.event.sequence_number`, `camunda.log.position`, `camunda.tenant.id`
+
+Namespace all custom attributes with `camunda.` prefix. Use `event.name` (OTel standard, no prefix).
+
+### Auth Headers (current implementation)
+
+Static (set once): `x-camunda-fingerprint`, `x-camunda-cluster-id`
+Dynamic (per request, when signing=true): `x-camunda-timestamp`, `x-camunda-signature`
+Signature: HMAC-SHA256(licenseKey, `fingerprint|clusterId|timestamp`)
+
+### Sequencing & Metadata
+
+- `eventSequenceNumber` — incremented per emitted log event, persisted in exporter state
+- `metricSequenceNumber` — incremented per metric flush, persisted in exporter state
+- Both survive restart. Enable server-side gap detection (missing seq = lost data) and dedup.
+
+### Pre-Aggregated Metrics
+
+- Counter `camunda.process_instance.created` with delta temporality (resets each flush)
+- Companion gauge `camunda.metric.export_window` per flush carries:
+  - `camunda.metric.sequence_number` — contiguous per flush, gap = lost push
+  - `camunda.log.position_start/end` — for replay/overlap detection
+  - `camunda.event.time_min/max` — real event timestamps (CRITICAL: ≠ export time after replay)
+- **Replay detection:** new push `position_start` ≤ any ingested `position_end` → overlap → discard
+
+### Event Time vs Export Time
+
+OTel metric timestamps = flush time, not event time. After broker restart/replay these diverge
+by hours. Pipeline MUST use `event.time_min/max` from export_window gauge for time bucketing.
+
+### Replay Constraint
+
+During broker replay, the exporter re-processes records from its last persisted position.
+Sequence numbers resume from persisted state (no reset). Any change to sequencing logic must
+guarantee deterministic replay — same records must produce same sequence numbers regardless
+of whether they arrive during normal operation or replay.
+
+### Sampling
+
+Hash-based deterministic sampling in `OtelSdkManager.logEvent()`. See `docs/sampling-explainer.md`.
+
+- `HashSampler.shouldSample(position, rate)` — pure function of log position, no state
+- `logEvent(name, pos, samplingRate, builder)` overload for handlers that want sub-100% rate
+- `logEvent(name, pos, builder)` defaults to MAX (no sampling) — existing handlers unchanged
+- OtelSdkManager computes `min(defaultRate, samplingRate)` where defaultRate comes from config
+- `camunda.event.sample_rate` attribute emitted only when rate < 1.0
+- Sequence numbers only increment for sampled events
+- Sampling does NOT apply to pre-aggregated metrics (incrementMetric)
+
+**Adding a sampled handler:** call `logEvent(name, pos, 0.01, builder)` instead of the
+3-arg overload. That's it — no config, no registry changes, no interface changes.
+
+### Config Defaults
+
+|     Property      |               Default                |
+|-------------------|--------------------------------------|
+| endpoint          | `https://analytics.cloud.camunda.io` |
+| maxQueueSize      | 2048                                 |
+| maxBatchSize      | 512 (must be ≤ maxQueueSize)         |
+| pushInterval      | PT5M                                 |
+| heartbeatInterval | PT10M                                |
+| signing           | true                                 |
+| samplingRate      | 1.0 (no sampling)                    |
+
+## Testing
+
+- **Unit tests** (`AnalyticsExporterTest`) — handler routing, attributes, config validation, error resilience
+- **SDK tests** (`OtelSdkManagerTest`) — OTel pipeline contract: non-blocking queue, failure recovery
+- **Integration tests** (`AnalyticsExporterOtelIT`) — real OTel Collector in Docker, end-to-end
+- **Benchmarks** (`AnalyticsExporterBenchmark`, `HashSamplerBenchmark`) — JMH, manual only, not in CI
+
+Always run unit + integration tests before submitting changes to this module.

--- a/zeebe/exporters/analytics-exporter/README.md
+++ b/zeebe/exporters/analytics-exporter/README.md
@@ -1,0 +1,307 @@
+# Camunda Analytics Exporter
+
+Zeebe exporter that ships product analytics events to a Camunda analytics endpoint over
+OTLP/HTTP. It is opt-in, default-off, and intended for Camunda 8 Self-Managed deployments.
+
+The exporter is **analytics-grade**, not billing- or audit-grade: it is designed so it
+cannot impact broker throughput, and it accepts data loss under failure. It runs only on
+the partition leader, so no extra high-availability setup is required.
+
+> **Data handling.** The exporter sends process metadata only. It does **not** export
+> process variables, payloads, message bodies, or any other potentially sensitive data.
+
+## Enable the exporter
+
+The analytics exporter is disabled by default. To enable it, add an `analytics` exporter
+declaration to your broker configuration; to disable it again, remove the declaration.
+The configuration can be provided via YAML or as environment variables — both styles are
+shown below.
+
+### Prerequisites
+
+The exporter requires a Camunda license key and a cluster ID.
+
+**License key.** The exporter authenticates to the Camunda analytics endpoint using your
+Camunda 8 Self-Managed license key. The raw key is never sent over the network — it is
+hashed into a fingerprint (sent as the `x-camunda-fingerprint` header) and used as the
+HMAC secret for signing each batch of events. This is the same license key you already
+use to run Camunda 8 Self-Managed; if you do not have it, contact your Camunda account
+team or open a support ticket.
+
+**Cluster ID.** The cluster ID identifies which cluster a given event came from. It is
+attached to every event as the `camunda.cluster.id` resource attribute and is part of the
+deduplication key used by the analytics backend (`camunda.cluster.id` +
+`camunda.partition.id` + `camunda.log.position`). The value should be stable per cluster —
+changing it makes existing events look like they come from a different cluster.
+
+How the exporter obtains these values depends on your Camunda version:
+
+- **Camunda 8.10 and later:** [cluster id](https://docs.camunda.io/docs/next/self-managed/components/orchestration-cluster/core-settings/configuration/properties/#cluster)
+  and [license key](https://docs.camunda.io/docs/next/self-managed/components/orchestration-cluster/core-settings/configuration/properties/#licensing)
+  values are resolved automatically from the broker context. No additional setup is needed.
+- **Camunda 8.9 and earlier:** the broker does not expose the license key or cluster ID
+  through the context API. Provide them via environment variables on every broker:
+  - `CAMUNDA_LICENSE_KEY` — the Camunda license key.
+  - `ZEEBE_BROKER_CLUSTER_CLUSTERID` — the cluster identifier. This is the broker's
+    standard cluster-ID setting (`zeebe.broker.cluster.clusterId`); if it is already
+    configured on the broker, the analytics exporter picks it up automatically.
+
+  Without these variables, the exporter fails to start on 8.9 and earlier.
+
+### YAML configuration
+
+Two configuration styles are supported.
+
+**Unified configuration (Camunda 8.9 and later, recommended):**
+
+```yaml
+camunda:
+  data:
+    exporters:
+      analytics:
+        class-name: io.camunda.exporter.analytics.AnalyticsExporter
+        args:
+          endpoint: https://analytics.cloud.camunda.io
+          push-interval: PT5M
+          max-queue-size: 2048
+          max-batch-size: 512
+          sampling-rate: 1.0
+```
+
+**Legacy configuration (Camunda 8.8 and earlier):**
+
+```yaml
+zeebe:
+  broker:
+    exporters:
+      analytics:
+        className: io.camunda.exporter.analytics.AnalyticsExporter
+        jarPath: /usr/local/zeebe/exporters/camunda-analytics-exporter.jar
+        args:
+          endpoint: https://analytics.cloud.camunda.io
+          pushInterval: PT5M
+          maxQueueSize: 2048
+          maxBatchSize: 512
+          samplingRate: 1.0
+```
+
+### Environment variables
+
+The same settings can be provided via environment variables.
+
+**Unified (8.9+):** `CAMUNDA_DATA_EXPORTERS_ANALYTICS_*`
+
+```sh
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_CLASSNAME=io.camunda.exporter.analytics.AnalyticsExporter
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=https://analytics.cloud.camunda.io
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT5M
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_MAXQUEUESIZE=2048
+CAMUNDA_DATA_EXPORTERS_ANALYTICS_ARGS_MAXBATCHSIZE=512
+```
+
+**Legacy (8.8 and earlier):** `ZEEBE_BROKER_EXPORTERS_ANALYTICS_*`
+
+```sh
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_CLASSNAME=io.camunda.exporter.analytics.AnalyticsExporter
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=https://analytics.cloud.camunda.io
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT5M
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_MAXQUEUESIZE=2048
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_MAXBATCHSIZE=512
+```
+
+### Verify the exporter is running
+
+On broker startup, look for the following log line — it confirms the exporter loaded with
+the expected endpoint, cluster ID, and partition ID:
+
+```
+Analytics exporter configured: endpoint=https://analytics.cloud.camunda.io, clusterId=<cluster-id>, partitionId=<partition-id>
+```
+
+## Configuration reference
+
+All options live under `args`. Defaults are tuned for typical Self-Managed deployments and
+rarely need to be changed.
+
+|        Option        |   Type   |                                                                           Description                                                                           |               Default                |
+|----------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| `endpoint`           | string   | OTLP/HTTP base URL for the analytics endpoint. The OTel SDK appends `/v1/logs` automatically.                                                                   | `https://analytics.cloud.camunda.io` |
+| `push-interval`      | duration | Maximum time between batch pushes, as an [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations).                                                 | `PT5M`                               |
+| `heartbeat-interval` | duration | Interval between periodic heartbeat events carrying static cluster metadata.                                                                                    | `PT10M`                              |
+| `max-queue-size`     | int      | Maximum number of log records buffered in memory before new records are dropped.                                                                                | `2048`                               |
+| `max-batch-size`     | int      | Maximum number of records sent in a single OTLP request. Must be less than or equal to `max-queue-size`.                                                        | `512`                                |
+| `sampling-rate`      | double   | Default sampling rate for log events, between 0.0 (none) and 1.0 (all). Handlers may declare a lower rate; the effective rate is always the minimum of the two. | `1.0`                                |
+
+## What data is exported
+
+Each supported record is emitted as an [OpenTelemetry log record](https://opentelemetry.io/docs/specs/semconv/general/events/),
+identified by the `event.name` attribute following the OTel Events semantic convention.
+
+The exporter does **not** include process variables, payloads, message contents, job
+variables, or any other end-user data.
+
+### Event types
+
+|        Source record        |       Intent        |          Event name          |                                       Notes                                       |
+|-----------------------------|---------------------|------------------------------|-----------------------------------------------------------------------------------|
+| `PROCESS_INSTANCE_CREATION` | `CREATED`           | `process_instance_created`   | Emitted for every new process instance.                                           |
+| `PROCESS_INSTANCE`          | `ELEMENT_ACTIVATED` | `adhoc_subprocess_activated` | Emitted only when the activated element is an ad-hoc sub-process.                 |
+| `USAGE_METRIC`              | `EXPORTED`          | `usage_metric_exported`      | Emitted once per usage metric export interval. Internal reset events are skipped. |
+| —                           | —                   | `heartbeat`                  | Emitted periodically by the partition leader (see `heartbeat-interval`).          |
+
+### Common log record attributes
+
+These attributes are set on every log record:
+
+|         Attribute         |  Type  |                                               Description                                                |
+|---------------------------|--------|----------------------------------------------------------------------------------------------------------|
+| `event.name`              | string | Event type identifier (one of the names in the table above).                                             |
+| `camunda.log.position`    | long   | Log stream position. Used as a deduplication key.                                                        |
+| `camunda.sequence_number` | long   | Monotonic per-partition counter incremented for each emitted event. Used for ordering and gap detection. |
+
+### Heartbeat attributes
+
+The `heartbeat` event carries static cluster metadata instead of the common log/sequence
+attributes (heartbeats are not tied to the log stream):
+
+|              Attribute               |  Type  |                               Description                                |
+|--------------------------------------|--------|--------------------------------------------------------------------------|
+| `event.name`                         | string | Always `heartbeat`.                                                      |
+| `camunda.heartbeat.broker_version`   | string | Broker version (matches `io.camunda.zeebe.util.VersionUtil#getVersion`). |
+| `camunda.heartbeat.exporter_version` | string | Analytics exporter version.                                              |
+
+The analytics schema URL (`https://camunda.io/schemas/analytics/v1`) is delivered automatically via
+the OTel instrumentation scope on every record, not as a per-record attribute.
+
+### Resource attributes
+
+Cluster-wide attributes attached to every log record:
+
+|       Attribute        |  Type  |       Description       |
+|------------------------|--------|-------------------------|
+| `camunda.cluster.id`   | string | Cluster identifier.     |
+| `camunda.partition.id` | long   | Partition ID.           |
+| `service.name`         | string | Always `camunda-zeebe`. |
+
+## Failure behavior
+
+The exporter is fire-and-forget: under any failure mode, broker throughput is unaffected
+and analytics records may be dropped silently. Specifically, events can be lost when:
+
+- **The in-memory queue is full.** When `max-queue-size` is reached — typically because
+  the endpoint is slow or unreachable — new records are dropped on the broker thread
+  without retry.
+- **The broker crashes or restarts.** The in-memory queue is not persisted, so any records
+  buffered at the time of the crash are lost.
+- **The OTLP endpoint returns an error.** The exporter does not retry persistently and
+  does not buffer to disk; the affected events are dropped.
+
+Because each event carries `camunda.cluster.id`, `camunda.partition.id`, and
+`camunda.log.position`, downstream consumers can deduplicate events using the combination
+of these attributes as a composite key.
+
+## Known limitations
+
+- **Analytics-grade only.** No exactly-once delivery, no reconciliation, no client-side
+  gap filling. Use the exporter for product analytics and trends, not for billing, audit,
+  or any workflow that requires complete data.
+- **No PII.** Only process metadata is exported. Process variables, message payloads, and
+  other potentially sensitive fields are never sent.
+- **Fixed event set.** The exporter emits a small, hardcoded set of event types. There is
+  no runtime configuration to add, remove, or filter event types.
+
+## How it works
+
+The exporter consumes records from the Zeebe log stream, filters for a small set of event
+types, converts each matching record into an OpenTelemetry log record, and pushes it to
+the configured OTLP/HTTP endpoint. Three design choices keep the broker fast and
+predictable:
+
+- **Fire-and-forget, non-blocking pipeline.** A background thread batches and pushes
+  records through the OTel SDK's `BatchLogRecordProcessor`; when the in-memory queue
+  fills, new records are silently dropped instead of back-pressuring the broker. After
+  invoking the handler, the broker unconditionally acknowledges the record's position —
+  handler exceptions are caught and swallowed — so neither a failing handler nor a
+  saturated queue can stall the broker.
+- **Partition-aware filtering.** Each event is emitted by exactly one partition — the one
+  that originally produced it — so events are not duplicated across a multi-partition
+  cluster. See `AnalyticsRecordFilter` for the filtering layers and the rationale behind
+  partition-based deduplication.
+- **Leader-only execution.** The exporter runs on the partition leader only, so no extra
+  high-availability setup or cross-replica coordination is needed.
+
+## Architecture
+
+See source Javadocs for component details. Key files:
+
+- **`AnalyticsExporter`** — Zeebe exporter lifecycle and handler wiring.
+- **`HandlerRegistry`** — Routes records by (ValueType, Intent) to handlers.
+- **`AnalyticsRecordFilter`** — Broker-level filtering (type, value, intent, partition).
+- **`OtelSdkManager`** — OTel SDK lifecycle (Resource, LoggerProvider, BatchProcessor).
+- **`handler/`** — Individual event handlers (one per analytics event type).
+
+## Building
+
+```bash
+# Build with dependencies
+./mvnw install -pl zeebe/exporters/analytics-exporter -am -Dquickly -T1C
+
+# Run unit tests
+./mvnw verify -pl zeebe/exporters/analytics-exporter -DskipTests=false -DskipITs -Dquickly
+
+# Run all tests (unit + integration, requires Docker)
+./mvnw verify -pl zeebe/exporters/analytics-exporter -DskipTests=false -Dquickly
+```
+
+## Local development
+
+Start a local OTel Collector with debug output:
+
+```bash
+docker run --rm -p 4318:4318 \
+  -v $(pwd)/src/test/resources/otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml \
+  otel/opentelemetry-collector-contrib:0.119.0
+```
+
+Then configure the exporter with `endpoint: "http://localhost:4318"`.
+
+## Testing
+
+### Unit tests (`AnalyticsExporterTest`)
+
+Tests handler routing, position tracking, attribute mapping, config validation, and error
+resilience. Uses `InMemoryLogRecordExporter` via an `OtelSdkManager` subclass that swaps
+the OTLP transport — same Resource and SDK construction as production.
+
+### SDK pipeline tests (`OtelSdkManagerTest`)
+
+Tests OTel pipeline contract: non-blocking when queue is full, unreachable endpoint
+handling, event delivery, flush-on-shutdown, failure recovery, and post-shutdown safety.
+
+### Integration tests (`AnalyticsExporterOtelIT`)
+
+End-to-end tests using a real OTel Collector in Docker (Testcontainers). No mocking, no
+overrides — uses the default `AnalyticsExporter` constructor with the production
+`BatchLogRecordProcessor` and real OTLP/HTTP transport. Tests event delivery with
+attribute verification and batching behavior.
+
+### Microbenchmarks (`AnalyticsExporterBenchmark`)
+
+JMH benchmarks measuring per-record overhead across the main hot paths. Run manually only — not
+wired into CI.
+
+```bash
+./mvnw verify -pl zeebe/exporters/analytics-exporter \
+    -Dtest=AnalyticsExporterBenchmark -DskipTests=false -Dbenchmark=true
+```
+
+To profile, add `-Dbenchmark.profiler=jfr+gc`:
+
+```bash
+./mvnw verify -pl zeebe/exporters/analytics-exporter \
+    -Dtest=AnalyticsExporterBenchmark -DskipTests=false \
+    -Dbenchmark=true -Dbenchmark.profiler=jfr+gc
+```
+
+JMH writes the `.jfr` file to `target/jmh-jfr/`. Open it in IntelliJ Ultimate
+("Open Profiler Results") or JDK Mission Control.

--- a/zeebe/exporters/analytics-exporter/docs/sampling-explainer.md
+++ b/zeebe/exporters/analytics-exporter/docs/sampling-explainer.md
@@ -1,0 +1,125 @@
+# Why Hash-Based Sampling Works With Sparse Events
+
+## The Setup
+
+The Zeebe partition log contains ALL records — commands, events, rejections — for all value
+types. Positions are sequential integers: 1, 2, 3, ..., 1,000,000, ...
+
+The analytics exporter only cares about a tiny subset. For example, `PI_CREATED` events
+might appear at positions like:
+
+```
+All log positions:  1  2  3  4  5  ... 1001 1002 ... 2001 ... 3001 ... 99001 ...
+PI_CREATED events:  1                   1001            2001     3001     99001
+```
+
+100 relevant events scattered among 100,000 total records. The rest are jobs, deployments,
+timers, variables, etc.
+
+## The Sampling Check
+
+Sampling happens AFTER the RecordFilter already selected only relevant events. The handler
+receives a matched record and asks: "should I sample this?"
+
+```java
+boolean shouldSample(long position, double rate) {
+    // rate = 0.01 means 1%
+    // hash distributes any input uniformly into [0, 9999]
+    return (hash(position) % 10000) < (rate * 10000);
+}
+```
+
+For rate = 0.01 (1%), this checks: `hash(position) % 10000 < 100`.
+
+## Why It Works — The Key Insight
+
+A good bit-mixing function (e.g., Stafford Mix13 or Murmur3) is designed so that
+**for any set of distinct inputs, the outputs are approximately uniformly distributed
+across the output range.** This is not a mathematical guarantee but holds well in
+practice for the sequential/sparse integer inputs we see in log positions.
+
+This means:
+- If you feed it {1, 2, 3, ..., 100}, roughly 1% will land in [0, 99] out of [0, 9999]
+- If you feed it {1, 1001, 2001, ..., 99001}, roughly 1% will land in [0, 99] out of [0, 9999]
+- If you feed it {7, 42, 99999, 123456789}, roughly 1% will land in [0, 99] out of [0, 9999]
+
+**It does not matter how sparse or clustered the input positions are.** The hash function
+scrambles any pattern in the inputs.
+
+## Concrete Example
+
+100 PI_CREATED events at positions 1, 1001, 2001, ..., 99001. Rate = 1%.
+
+```
+hash(1)     % 10000 = 4217  → 4217 >= 100 → skip
+hash(1001)  % 10000 = 0712  → 712  >= 100 → skip
+hash(2001)  % 10000 = 0043  → 43   <  100 → SAMPLED ✓
+hash(3001)  % 10000 = 8891  → 8891 >= 100 → skip
+hash(4001)  % 10000 = 3344  → 3344 >= 100 → skip
+...
+hash(55001) % 10000 = 0008  → 8    <  100 → SAMPLED ✓
+...
+hash(99001) % 10000 = 5567  → 5567 >= 100 → skip
+```
+
+Result: ~1 out of 100 relevant events sampled. The sparsity of positions (every 1000th)
+is irrelevant — the hash output is uniform regardless.
+
+## Why NOT Plain Modulo
+
+Plain modulo (`position % 100 < 1`) does NOT have this property. It depends on the actual
+distribution of positions:
+
+```
+Positions: 100, 200, 300, 400, 500, ...
+100 % 100 = 0  → SAMPLED
+200 % 100 = 0  → SAMPLED
+300 % 100 = 0  → SAMPLED   ← 100% sampled! All are multiples of 100.
+```
+
+```
+Positions: 1, 1001, 2001, 3001, ...
+1    % 100 = 1  → skip
+1001 % 100 = 1  → skip
+2001 % 100 = 1  → skip     ← 0% sampled! All have remainder 1.
+```
+
+Modulo preserves patterns in the input. Hash destroys them. For sampling, we need uniform
+output — hash is required.
+
+## Replay Safety
+
+`hash(position)` is a pure function of the record's log position. No external state needed.
+
+- Same record → same position → same hash → same sampling decision
+- Broker crash + restart → same records replayed → same sampling decisions
+- Snapshot restore → same records replayed → same sampling decisions
+- No metadata dependency for the sampling decision itself
+
+## Probabilistic vs Exact
+
+Hash-based sampling is probabilistic: 1% rate gives approximately 1% of events, not
+exactly. Over 100 events you might get 0 or 3. Over 10,000 events you'll get ~100 ± 10.
+
+For analytics-grade data this is fine. The `sample_rate` attribute on each event tells
+the server the configured rate, so it can extrapolate totals correctly in aggregate.
+
+## What Hash Function?
+
+Requirements: fast, deterministic, good distribution. No cryptographic strength needed.
+
+A simple bit-mixing function (like Java's `Long.hashCode()` with additional mixing, or
+a Murmur3-style finalizer) is sufficient. The input is already a unique 64-bit integer
+(log position), so we just need to break its sequential pattern.
+
+Example (Stafford Mix13 variant, used in SplittableRandom):
+
+```java
+static long mix(long x) {
+    x = (x ^ (x >>> 30)) * 0xbf58476d1ce4e5b9L;
+    x = (x ^ (x >>> 27)) * 0x94d049bb133111ebL;
+    x = x ^ (x >>> 31);
+    return x;
+}
+```
+

--- a/zeebe/exporters/analytics-exporter/pom.xml
+++ b/zeebe/exporters/analytics-exporter/pom.xml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../../../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>analytics-exporter</artifactId>
+  <packaging>jar</packaging>
+  <name>Camunda Analytics Exporter</name>
+
+  <dependencies>
+    <!-- Exporter API + Protocol -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+    <!-- Serialization -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <!-- Logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <!-- Micrometer (provided by Zeebe broker at runtime) -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- OTel SDK -->
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-logs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-metrics</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-otlp</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>io.opentelemetry</groupId>
+          <artifactId>opentelemetry-exporter-sender-okhttp</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-exporter-sender-jdk</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-test-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- JMH microbenchmarks (run manually, not by CI) -->
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>${version.jmh}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>${version.jmh}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredUnusedDeclaredDependencies>
+            <dep>io.opentelemetry:opentelemetry-exporter-sender-jdk</dep>
+            <dep>org.openjdk.jmh:jmh-generator-annprocess</dep>
+          </ignoredUnusedDeclaredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>standalone-jar</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <phase>package</phase>
+                <configuration>
+                  <!-- Produce an extra jar with classifier 'standalone'; leave the original jar intact -->
+                  <shadedArtifactAttached>true</shadedArtifactAttached>
+                  <shadedClassifierName>standalone</shadedClassifierName>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <artifactSet>
+                    <excludes>
+                      <!-- Provided by the Zeebe broker at runtime -->
+                      <exclude>io.camunda:zeebe-exporter-api</exclude>
+                      <exclude>io.camunda:zeebe-protocol</exclude>
+                      <exclude>io.camunda:zeebe-util</exclude>
+                      <exclude>org.slf4j:slf4j-api</exclude>
+                      <exclude>io.micrometer:micrometer-core</exclude>
+                    </excludes>
+                  </artifactSet>
+                  <relocations>
+                    <!--
+                      Relocate all OTel classes to avoid version conflicts when the exporter is
+                      deployed alongside a broker that ships its own OTel dependencies.
+                    -->
+                    <relocation>
+                      <pattern>io.opentelemetry</pattern>
+                      <shadedPattern>io.camunda.shaded.otel</shadedPattern>
+                    </relocation>
+                  </relocations>
+                  <transformers>
+                    <!--
+                      Rename META-INF/services file names to match relocated package names,
+                      so ServiceLoader can find the HttpSenderProvider after relocation.
+                    -->
+                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                  </transformers>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/zeebe/exporters/analytics-exporter/pom.xml
+++ b/zeebe/exporters/analytics-exporter/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.10.0-SNAPSHOT</version>
+    <version>8.9.13-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 
@@ -114,6 +114,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit-pioneer</groupId>
+      <artifactId>junit-pioneer</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
@@ -171,6 +176,21 @@
       </resource>
     </resources>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!--
+            junit-pioneer's @SetEnvironmentVariable mutates the JVM's environment map via
+            reflection, which requires opening java.lang and java.util. The java.io open is
+            inherited from the parent surefire configuration and repeated here since argLine is
+            overridden rather than appended.
+          -->
+          <argLine>--add-opens=java.base/java.io=ALL-UNNAMED
+            --add-opens=java.base/java.lang=ALL-UNNAMED
+            --add-opens=java.base/java.util=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/zeebe/exporters/analytics-exporter/pom.xml
+++ b/zeebe/exporters/analytics-exporter/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>io.camunda</groupId>
     <artifactId>zeebe-parent</artifactId>
-    <version>8.9.13-SNAPSHOT</version>
+    <version>8.8.32-SNAPSHOT</version>
     <relativePath>../../../parent/pom.xml</relativePath>
   </parent>
 

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -74,8 +74,6 @@ public final class AnalyticsAttributes {
         AttributeKey.longKey("camunda.process.definition_key");
     public static final AttributeKey<Long> INSTANCE_KEY =
         AttributeKey.longKey("camunda.process.instance_key");
-    public static final AttributeKey<Long> ROOT_INSTANCE_KEY =
-        AttributeKey.longKey("camunda.process.root_instance_key");
 
     private Process() {}
   }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsAttributes.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.opentelemetry.api.common.AttributeKey;
+
+/**
+ * OTel attribute keys and event name constants for analytics events, grouped by domain. Naming
+ * follows OTel semantic conventions: dot-delimited namespaces, snake_case for multi-word
+ * components.
+ *
+ * @see <a href="https://opentelemetry.io/docs/specs/semconv/general/naming/">OTel Naming</a>
+ */
+public final class AnalyticsAttributes {
+
+  public static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
+  public static final AttributeKey<String> CLUSTER_ID =
+      AttributeKey.stringKey("camunda.cluster.id");
+  public static final AttributeKey<Long> PARTITION_ID =
+      AttributeKey.longKey("camunda.partition.id");
+
+  private AnalyticsAttributes() {}
+
+  public static final class Event {
+    /** OTel semantic convention for events (until Event API is stable). */
+    public static final AttributeKey<String> NAME = AttributeKey.stringKey("event.name");
+
+    public static final AttributeKey<Long> SEQUENCE_NUMBER =
+        AttributeKey.longKey("camunda.event.sequence_number");
+    public static final AttributeKey<Double> SAMPLE_RATE =
+        AttributeKey.doubleKey("camunda.event.sample_rate");
+    public static final AttributeKey<Long> TIME_MIN =
+        AttributeKey.longKey("camunda.event.time_min");
+    public static final AttributeKey<Long> TIME_MAX =
+        AttributeKey.longKey("camunda.event.time_max");
+
+    // Event name values
+    public static final String PROCESS_INSTANCE_CREATED = "process_instance_created";
+    public static final String ADHOC_SUBPROCESS_ACTIVATED = "adhoc_subprocess_activated";
+    public static final String USAGE_METRIC_EXPORTED = "usage_metric_exported";
+    public static final String HEARTBEAT = "heartbeat";
+    public static final String USER_TASK_CREATED = "user_task_created";
+
+    private Event() {}
+  }
+
+  public static final class Log {
+    public static final AttributeKey<Long> POSITION = AttributeKey.longKey("camunda.log.position");
+    public static final AttributeKey<Long> POSITION_START =
+        AttributeKey.longKey("camunda.log.position_start");
+    public static final AttributeKey<Long> POSITION_END =
+        AttributeKey.longKey("camunda.log.position_end");
+
+    private Log() {}
+  }
+
+  public static final class Tenant {
+    public static final AttributeKey<String> ID = AttributeKey.stringKey("camunda.tenant.id");
+
+    private Tenant() {}
+  }
+
+  public static final class Process {
+    public static final AttributeKey<String> BPMN_PROCESS_ID =
+        AttributeKey.stringKey("camunda.process.id");
+    public static final AttributeKey<Long> VERSION =
+        AttributeKey.longKey("camunda.process.version");
+    public static final AttributeKey<Long> DEFINITION_KEY =
+        AttributeKey.longKey("camunda.process.definition_key");
+    public static final AttributeKey<Long> INSTANCE_KEY =
+        AttributeKey.longKey("camunda.process.instance_key");
+    public static final AttributeKey<Long> ROOT_INSTANCE_KEY =
+        AttributeKey.longKey("camunda.process.root_instance_key");
+
+    private Process() {}
+  }
+
+  public static final class Element {
+    public static final AttributeKey<String> ID = AttributeKey.stringKey("camunda.element.id");
+
+    private Element() {}
+  }
+
+  public static final class Metric {
+    public static final String PROCESS_INSTANCE_CREATED = "camunda.process_instance.created";
+    public static final String EXPORT_WINDOW = "camunda.metric.export_window";
+    public static final AttributeKey<Long> SEQUENCE_NUMBER =
+        AttributeKey.longKey("camunda.metric.sequence_number");
+
+    private Metric() {}
+  }
+
+  public static final class Heartbeat {
+    public static final AttributeKey<String> BROKER_VERSION =
+        AttributeKey.stringKey("camunda.heartbeat.broker_version");
+    public static final AttributeKey<String> EXPORTER_VERSION =
+        AttributeKey.stringKey("camunda.heartbeat.exporter_version");
+
+    private Heartbeat() {}
+  }
+
+  public static final class Exporter {
+    public static final AttributeKey<String> DIGEST =
+        AttributeKey.stringKey("camunda.exporter.digest");
+
+    private Exporter() {}
+  }
+
+  public static final class UsageMetric {
+    public static final AttributeKey<String> EVENT_TYPE =
+        AttributeKey.stringKey("camunda.usage_metric.event_type");
+    public static final AttributeKey<Long> COUNT =
+        AttributeKey.longKey("camunda.usage_metric.count");
+    public static final AttributeKey<Long> INTERVAL_START =
+        AttributeKey.longKey("camunda.usage_metric.interval_start");
+    public static final AttributeKey<Long> INTERVAL_END =
+        AttributeKey.longKey("camunda.usage_metric.interval_end");
+
+    private UsageMetric() {}
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.exporter.api.context.ScheduledTask;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Exporter that ships Camunda process analytics to the Camunda Analytics backend. */
+public class AnalyticsExporter implements Exporter {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(AnalyticsExporter.class.getPackageName());
+  private static final ThrottledLogger SAMPLED_WARN_LOG =
+      new ThrottledLogger(LOG, Duration.ofMinutes(1));
+  private final OtelSdkManager otelSdkManager;
+
+  private AnalyticsExporterConfig config;
+  private Controller controller;
+  private HandlerRegistry handlers;
+  private AnalyticsExporterContext analyticsContext;
+  private AnalyticsExporterMetadata metadata;
+  private MeterRegistry meterRegistry;
+  private ScheduledTask metricFlushTask;
+  private ScheduledTask heartbeatTask;
+
+  public AnalyticsExporter() {
+    this(new OtelSdkManager());
+  }
+
+  AnalyticsExporter(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = otelSdkManager;
+  }
+
+  @Override
+  public void configure(final Context context) {
+    config = context.getConfiguration().instantiate(AnalyticsExporterConfig.class).validate();
+
+    handlers = AnalyticsHandlerCatalog.build(otelSdkManager).apply(context);
+    meterRegistry = context.getMeterRegistry();
+
+    analyticsContext =
+        AnalyticsExporterContext.create(
+            resolveLicenseKey(context),
+            resolveClusterId(context),
+            context.getPartitionId(),
+            resolveDigest(handlers, config));
+
+    LOG.info(
+        "Analytics exporter configured: endpoint={}, clusterId={}, partitionId={}, exporterDigest={}",
+        config.getEndpoint(),
+        analyticsContext.clusterId(),
+        analyticsContext.partitionId(),
+        analyticsContext.exporterDigest());
+  }
+
+  @Override
+  public void open(final Controller controller) {
+    this.controller = controller;
+    metadata =
+        controller
+            .readMetadata()
+            .map(AnalyticsExporterMetadata::deserialize)
+            .orElse(new AnalyticsExporterMetadata());
+    otelSdkManager.initialize(config, analyticsContext, metadata, meterRegistry);
+    scheduleMetricFlush();
+    scheduleHeartbeat();
+    LOG.info("Analytics exporter opened");
+  }
+
+  @Override
+  public void close() {
+    if (metricFlushTask != null) {
+      metricFlushTask.cancel();
+      metricFlushTask = null;
+    }
+    if (heartbeatTask != null) {
+      heartbeatTask.cancel();
+      heartbeatTask = null;
+    }
+    otelSdkManager.close();
+    if (controller != null && metadata != null) {
+      controller.updateLastExportedRecordPosition(
+          controller.getLastExportedRecordPosition(), metadata.serialize());
+    }
+    LOG.info("Analytics exporter closed");
+  }
+
+  @Override
+  public void export(final Record<?> record) {
+    try {
+      handlers.handle(record);
+    } catch (final Exception e) {
+      SAMPLED_WARN_LOG.warn("Failed to handle record at position {}", record.getPosition(), e);
+    }
+    if (metadata.isDirty()) {
+      controller.updateLastExportedRecordPosition(record.getPosition(), metadata.serialize());
+    } else {
+      // No need to serialize the metadata if it didn't change.
+      controller.updateLastExportedRecordPosition(record.getPosition());
+    }
+  }
+
+  private void scheduleMetricFlush() {
+    metricFlushTask =
+        controller.scheduleCancellableTask(
+            config.getPushInterval(), this::flushMetricsAndReschedule);
+  }
+
+  private void flushMetricsAndReschedule() {
+    try {
+      otelSdkManager.flushMetrics();
+    } catch (final Exception e) {
+      SAMPLED_WARN_LOG.warn("Failed to flush metrics", e);
+    } finally {
+      scheduleMetricFlush();
+    }
+  }
+
+  private void scheduleHeartbeat() {
+    heartbeatTask =
+        controller.scheduleCancellableTask(
+            config.getHeartbeatInterval(), this::emitHeartbeatAndReschedule);
+  }
+
+  private void emitHeartbeatAndReschedule() {
+    try {
+      otelSdkManager.emitHeartbeat();
+    } catch (final Exception e) {
+      SAMPLED_WARN_LOG.warn("Failed to emit heartbeat", e);
+    } finally {
+      scheduleHeartbeat();
+    }
+  }
+
+  private static String resolveLicenseKey(final Context context) {
+    final String licenseKey = context.getLicenseKey();
+    if (licenseKey == null || licenseKey.isBlank()) {
+      throw new IllegalStateException(
+          "Analytics exporter requires a license key. Set camunda.license.key in configuration.");
+    }
+    return licenseKey;
+  }
+
+  private static String resolveClusterId(final Context context) {
+    return context.getClusterId();
+  }
+
+  private String resolveDigest(
+      final HandlerRegistry handlers, final AnalyticsExporterConfig config) {
+    try {
+      return AnalyticsExporterDigest.compute(handlers, config);
+    } catch (final Exception e) {
+      LOG.warn("Failed to compute exporter digest; resource attribute will be empty", e);
+      return "";
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -21,6 +21,8 @@ import org.slf4j.LoggerFactory;
 /** Exporter that ships Camunda process analytics to the Camunda Analytics backend. */
 public class AnalyticsExporter implements Exporter {
 
+  private static final String LICENSE_KEY_ENV_VAR = "CAMUNDA_LICENSE_KEY";
+  private static final String CLUSTER_ID_ENV_VAR = "ZEEBE_BROKER_CLUSTER_CLUSTERID";
   private static final Logger LOG =
       LoggerFactory.getLogger(AnalyticsExporter.class.getPackageName());
   private static final ThrottledLogger SAMPLED_WARN_LOG =
@@ -53,8 +55,8 @@ public class AnalyticsExporter implements Exporter {
 
     analyticsContext =
         AnalyticsExporterContext.create(
-            resolveLicenseKey(context),
-            resolveClusterId(context),
+            resolveLicenseKey(),
+            resolveClusterId(),
             context.getPartitionId(),
             resolveDigest(handlers, config));
 
@@ -145,17 +147,20 @@ public class AnalyticsExporter implements Exporter {
     }
   }
 
-  private static String resolveLicenseKey(final Context context) {
-    final String licenseKey = context.getLicenseKey();
+  private static String resolveLicenseKey() {
+    final String licenseKey = System.getenv(LICENSE_KEY_ENV_VAR);
     if (licenseKey == null || licenseKey.isBlank()) {
       throw new IllegalStateException(
-          "Analytics exporter requires a license key. Set camunda.license.key in configuration.");
+          "Analytics exporter requires a license key. Set the "
+              + LICENSE_KEY_ENV_VAR
+              + " environment variable.");
     }
     return licenseKey;
   }
 
-  private static String resolveClusterId(final Context context) {
-    return context.getClusterId();
+  private static String resolveClusterId() {
+    final var clusterId = System.getenv(CLUSTER_ID_ENV_VAR);
+    return clusterId != null ? clusterId : "";
   }
 
   private String resolveDigest(

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.exporter.api.context.ScheduledTask;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -37,6 +38,7 @@ public class AnalyticsExporter implements Exporter {
   private MeterRegistry meterRegistry;
   private ScheduledTask metricFlushTask;
   private ScheduledTask heartbeatTask;
+  private int partitionId;
 
   public AnalyticsExporter() {
     this(new OtelSdkManager());
@@ -52,6 +54,7 @@ public class AnalyticsExporter implements Exporter {
 
     handlers = AnalyticsHandlerCatalog.build(otelSdkManager).apply(context);
     meterRegistry = context.getMeterRegistry();
+    partitionId = context.getPartitionId();
 
     analyticsContext =
         AnalyticsExporterContext.create(
@@ -103,7 +106,9 @@ public class AnalyticsExporter implements Exporter {
   @Override
   public void export(final Record<?> record) {
     try {
-      handlers.handle(record);
+      if (Protocol.decodePartitionId(record.getKey()) == partitionId) {
+        handlers.handle(record);
+      }
     } catch (final Exception e) {
       SAMPLED_WARN_LOG.warn("Failed to handle record at position {}", record.getPosition(), e);
     }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporter.java
@@ -38,7 +38,6 @@ public class AnalyticsExporter implements Exporter {
   private MeterRegistry meterRegistry;
   private ScheduledTask metricFlushTask;
   private ScheduledTask heartbeatTask;
-  private int partitionId;
 
   public AnalyticsExporter() {
     this(new OtelSdkManager());
@@ -54,7 +53,6 @@ public class AnalyticsExporter implements Exporter {
 
     handlers = AnalyticsHandlerCatalog.build(otelSdkManager).apply(context);
     meterRegistry = context.getMeterRegistry();
-    partitionId = context.getPartitionId();
 
     analyticsContext =
         AnalyticsExporterContext.create(
@@ -106,7 +104,7 @@ public class AnalyticsExporter implements Exporter {
   @Override
   public void export(final Record<?> record) {
     try {
-      if (Protocol.decodePartitionId(record.getKey()) == partitionId) {
+      if (Protocol.decodePartitionId(record.getKey()) == analyticsContext.partitionId()) {
         handlers.handle(record);
       }
     } catch (final Exception e) {

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterConfig.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterConfig.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.exporter.analytics.sampling.HashSampler;
+import java.time.Duration;
+
+/** Configuration for the Analytics Exporter. Instantiated from the exporter's args map. */
+public class AnalyticsExporterConfig {
+
+  private String endpoint = "https://analytics.cloud.camunda.io";
+  private int maxQueueSize = 2048;
+  private int maxBatchSize = 512;
+  private String pushInterval = "PT5M";
+  private String heartbeatInterval = "PT10M";
+  private boolean signing = true;
+  private double samplingRate = HashSampler.MAX_SAMPLE_RATE;
+
+  public String getEndpoint() {
+    return endpoint;
+  }
+
+  public AnalyticsExporterConfig setEndpoint(final String endpoint) {
+    this.endpoint = endpoint;
+    return this;
+  }
+
+  public int getMaxQueueSize() {
+    return maxQueueSize;
+  }
+
+  public AnalyticsExporterConfig setMaxQueueSize(final int maxQueueSize) {
+    this.maxQueueSize = maxQueueSize;
+    return this;
+  }
+
+  public int getMaxBatchSize() {
+    return maxBatchSize;
+  }
+
+  public AnalyticsExporterConfig setMaxBatchSize(final int maxBatchSize) {
+    this.maxBatchSize = maxBatchSize;
+    return this;
+  }
+
+  public Duration getPushInterval() {
+    return Duration.parse(pushInterval);
+  }
+
+  public AnalyticsExporterConfig setPushInterval(final String pushInterval) {
+    this.pushInterval = pushInterval;
+    return this;
+  }
+
+  public Duration getHeartbeatInterval() {
+    return Duration.parse(heartbeatInterval);
+  }
+
+  public AnalyticsExporterConfig setHeartbeatInterval(final String heartbeatInterval) {
+    this.heartbeatInterval = heartbeatInterval;
+    return this;
+  }
+
+  public boolean isSigning() {
+    return signing;
+  }
+
+  public AnalyticsExporterConfig setSigning(final boolean signing) {
+    this.signing = signing;
+    return this;
+  }
+
+  public double getSamplingRate() {
+    return samplingRate;
+  }
+
+  public AnalyticsExporterConfig setSamplingRate(final double samplingRate) {
+    this.samplingRate = samplingRate;
+    return this;
+  }
+
+  public AnalyticsExporterConfig validate() {
+    if (endpoint == null || endpoint.isBlank()) {
+      throw new IllegalArgumentException("Analytics exporter endpoint is not configured");
+    }
+    try {
+      Duration.parse(pushInterval);
+    } catch (final Exception e) {
+      throw new IllegalArgumentException("Invalid pushInterval: " + pushInterval, e);
+    }
+    final Duration parsedHeartbeat;
+    try {
+      parsedHeartbeat = Duration.parse(heartbeatInterval);
+    } catch (final Exception e) {
+      throw new IllegalArgumentException("Invalid heartbeatInterval: " + heartbeatInterval, e);
+    }
+    if (parsedHeartbeat.isZero() || parsedHeartbeat.isNegative()) {
+      throw new IllegalArgumentException(
+          "heartbeatInterval must be positive, got: " + heartbeatInterval);
+    }
+    if (maxQueueSize <= 0) {
+      throw new IllegalArgumentException("maxQueueSize must be positive, got: " + maxQueueSize);
+    }
+    if (maxBatchSize <= 0) {
+      throw new IllegalArgumentException("maxBatchSize must be positive, got: " + maxBatchSize);
+    }
+    if (maxBatchSize > maxQueueSize) {
+      throw new IllegalArgumentException(
+          "maxBatchSize ("
+              + maxBatchSize
+              + ") must not exceed maxQueueSize ("
+              + maxQueueSize
+              + ")");
+    }
+    if (Double.isNaN(samplingRate)
+        || samplingRate < HashSampler.MIN_SAMPLE_RATE
+        || samplingRate > HashSampler.MAX_SAMPLE_RATE) {
+      throw new IllegalArgumentException(
+          "samplingRate must be between "
+              + HashSampler.MIN_SAMPLE_RATE
+              + " and "
+              + HashSampler.MAX_SAMPLE_RATE
+              + ", got: "
+              + samplingRate);
+    }
+    return this;
+  }
+
+  /**
+   * Returns a stable string encoding the config fields that affect which events are emitted and at
+   * what rate. Used as input to the exporter digest.
+   *
+   * <p><b>Included</b> (behavioral — affect which events are emitted or what they contain): {@code
+   * samplingRate}.
+   *
+   * <p><b>Excluded</b> (transport-only — affect delivery, not event semantics): {@code endpoint},
+   * {@code maxQueueSize}, {@code maxBatchSize}, {@code pushInterval}, {@code heartbeatInterval},
+   * {@code signing}.
+   *
+   * <p>When adding a new field to this class, decide explicitly: if it changes event selection or
+   * content, add it here; if it only affects delivery mechanics, leave it out and update the
+   * excluded list above.
+   */
+  String toExporterDigestString() {
+    return "samplingRate=" + samplingRate;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterContext.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterContext.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.util.HexFormat;
+import java.util.Map;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Context for an analytics exporter instance, derived from the broker context at configure time.
+ * Bundles auth credentials (fingerprint, HMAC signer) and partition identity (clusterId,
+ * partitionId).
+ */
+public final class AnalyticsExporterContext {
+
+  static final String HEADER_FINGERPRINT = "x-camunda-fingerprint";
+  static final String HEADER_CLUSTER_ID = "x-camunda-cluster-id";
+  static final String HEADER_TIMESTAMP = "x-camunda-timestamp";
+  static final String HEADER_SIGNATURE = "x-camunda-signature";
+
+  private static final String SHA_256 = "SHA-256";
+  private static final String HMAC_SHA_256 = "HmacSHA256";
+  private static final String CANONICAL_FORMAT = "%s|%s|%s";
+  private static final HexFormat HEX = HexFormat.of();
+
+  private final String fingerprint;
+  private final String clusterId;
+  private final int partitionId;
+  private final Mac signer;
+  private final String exporterDigest;
+
+  private AnalyticsExporterContext(
+      final String fingerprint,
+      final String clusterId,
+      final int partitionId,
+      final Mac signer,
+      final String exporterDigest) {
+    this.fingerprint = fingerprint;
+    this.clusterId = clusterId;
+    this.partitionId = partitionId;
+    this.signer = signer;
+    this.exporterDigest = exporterDigest;
+  }
+
+  static AnalyticsExporterContext create(
+      final String licenseKey,
+      final String clusterId,
+      final int partitionId,
+      final String exporterDigest) {
+    if (licenseKey == null || licenseKey.isBlank()) {
+      throw new IllegalArgumentException("licenseKey must not be null or blank");
+    }
+    try {
+      final var keyBytes = licenseKey.getBytes(StandardCharsets.UTF_8);
+      final var fingerprint = HEX.formatHex(MessageDigest.getInstance(SHA_256).digest(keyBytes));
+      final var signer = Mac.getInstance(HMAC_SHA_256);
+      signer.init(new SecretKeySpec(keyBytes, HMAC_SHA_256));
+      return new AnalyticsExporterContext(
+          fingerprint, clusterId, partitionId, signer, exporterDigest);
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException(
+          "JVM does not support required crypto algorithms (SHA-256 or HmacSHA256)", e);
+    } catch (final InvalidKeyException e) {
+      throw new IllegalStateException("License key is not valid for HMAC signing", e);
+    }
+  }
+
+  String fingerprint() {
+    return fingerprint;
+  }
+
+  String clusterId() {
+    return clusterId;
+  }
+
+  int partitionId() {
+    return partitionId;
+  }
+
+  String exporterDigest() {
+    return exporterDigest;
+  }
+
+  /**
+   * Computes per-request HMAC signature headers (timestamp + signature). Called by the OTel SDK's
+   * export thread via {@code setHeaders(Supplier)} — synchronized because {@link Mac#doFinal} is
+   * not thread-safe.
+   */
+  Map<String, String> computeSignatureHeaders() {
+    final var timestamp = String.valueOf(Instant.now().getEpochSecond());
+    final var canonical = CANONICAL_FORMAT.formatted(fingerprint, clusterId, timestamp);
+    final byte[] sig;
+    synchronized (signer) {
+      sig = signer.doFinal(canonical.getBytes(StandardCharsets.UTF_8));
+    }
+    return Map.of(HEADER_TIMESTAMP, timestamp, HEADER_SIGNATURE, HEX.formatHex(sig));
+  }
+
+  /** Redact fingerprint and signing key to prevent accidental logging. */
+  @Override
+  public String toString() {
+    return "AnalyticsExporterContext[clusterId=" + clusterId + ", partitionId=" + partitionId + "]";
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterDigest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Computes a deterministic SHA-256 hash over:
+ *
+ * <ol>
+ *   <li>The (ValueType, Intent, handler class name, handler bytecode) of every registered handler,
+ *       sorted by "valueType:intent" to eliminate registration-order variance. The bytecode is
+ *       obtained via {@link AnalyticsHandler#digestInput()}, which each handler supplies.
+ *   <li>The behavior-affecting configuration fields (see {@link
+ *       AnalyticsExporterConfig#toExporterDigestString()}).
+ *   <li>The bytecode of {@link AnalyticsAttributes} and all its nested classes — detects renames of
+ *       attribute key strings, which don't show up in handler bytecodes.
+ * </ol>
+ *
+ * <p><b>Constraint:</b> handler implementations must be named, top-level or static nested classes.
+ * Lambda rejection now lives in {@link AnalyticsHandler#digestInput()}.
+ */
+final class AnalyticsExporterDigest {
+
+  private static final byte[] SEPARATOR = "|".getBytes(StandardCharsets.UTF_8);
+
+  private AnalyticsExporterDigest() {}
+
+  /**
+   * Returns a 64-character lowercase hex SHA-256 string. Throws {@link IllegalStateException} if
+   * class bytes cannot be located, or {@link UncheckedIOException} if they cannot be read.
+   */
+  static String compute(final HandlerRegistry registry, final AnalyticsExporterConfig config) {
+    try {
+      final var digest = MessageDigest.getInstance("SHA-256");
+      hashHandlers(digest, registry);
+      hashConfig(digest, config);
+      hashAttributes(digest);
+      return HexFormat.of().formatHex(digest.digest());
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException("JVM does not support SHA-256", e);
+    }
+  }
+
+  /**
+   * Hashes every registered handler, sorted by "valueType:intent" so registration order does not
+   * affect the result.
+   */
+  private static void hashHandlers(final MessageDigest digest, final HandlerRegistry registry) {
+    registry.registeredHandlers().entrySet().stream()
+        .flatMap(
+            valueTypeEntry ->
+                valueTypeEntry.getValue().entrySet().stream()
+                    .map(
+                        intentEntry ->
+                            Map.entry(
+                                valueTypeEntry.getKey().name() + ":" + intentEntry.getKey().name(),
+                                intentEntry.getValue())))
+        .sorted(Map.Entry.comparingByKey())
+        .forEach(
+            handlerEntry -> {
+              digest.update((handlerEntry.getKey() + ":").getBytes(StandardCharsets.UTF_8));
+              digest.update(
+                  handlerEntry.getValue().getClass().getName().getBytes(StandardCharsets.UTF_8));
+              digest.update(SEPARATOR);
+              digest.update(handlerEntry.getValue().digestInput());
+              digest.update(SEPARATOR);
+            });
+  }
+
+  private static void hashConfig(final MessageDigest digest, final AnalyticsExporterConfig config) {
+    digest.update(config.toExporterDigestString().getBytes(StandardCharsets.UTF_8));
+    digest.update(SEPARATOR);
+  }
+
+  /**
+   * Hashes {@link AnalyticsAttributes} (outer class + all nested classes, sorted for stability).
+   * This detects renames of attribute key strings, which don't show up in handler bytecodes.
+   */
+  private static void hashAttributes(final MessageDigest digest) {
+    Stream.concat(
+            Stream.of(AnalyticsAttributes.class),
+            Arrays.stream(AnalyticsAttributes.class.getDeclaredClasses()))
+        .sorted(Comparator.comparing(Class::getName))
+        .forEach(
+            c -> {
+              digest.update(c.getName().getBytes(StandardCharsets.UTF_8));
+              digest.update(SEPARATOR);
+              digest.update(loadClassBytes(c));
+              digest.update(SEPARATOR);
+            });
+  }
+
+  /**
+   * Returns the compiled {@code .class} bytecode of {@code clazz} from the classpath. Throws {@link
+   * IllegalStateException} if the class bytes cannot be located, or {@link UncheckedIOException} if
+   * they cannot be read.
+   */
+  static byte[] loadClassBytes(final Class<?> clazz) {
+    final var resourcePath = "/" + clazz.getName().replace('.', '/') + ".class";
+    try (final var stream = clazz.getResourceAsStream(resourcePath)) {
+      if (stream == null) {
+        throw new IllegalStateException("Cannot load class bytes for: " + clazz.getName());
+      }
+      return stream.readAllBytes();
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to read class bytes for: " + clazz.getName(), e);
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterMetadata.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterMetadata.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+
+/** Persisted state for the analytics exporter, stored alongside the last exported position. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+final class AnalyticsExporterMetadata {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private long eventSequenceNumber;
+
+  private long metricSequenceNumber;
+
+  /**
+   * Transient flag: true when a mutating method has been called since the last {@link #serialize()}
+   * or construction. Never persisted — Jackson setters must NOT set this flag so that a freshly
+   * deserialized object starts clean.
+   */
+  @JsonIgnore private boolean dirty;
+
+  /** No-arg constructor required by Jackson. */
+  AnalyticsExporterMetadata() {}
+
+  AnalyticsExporterMetadata(final long eventSequenceNumber, final long metricSequenceNumber) {
+    this.eventSequenceNumber = eventSequenceNumber;
+    this.metricSequenceNumber = metricSequenceNumber;
+  }
+
+  public long getEventSequenceNumber() {
+    return eventSequenceNumber;
+  }
+
+  public void setEventSequenceNumber(final long eventSequenceNumber) {
+    this.eventSequenceNumber = eventSequenceNumber;
+  }
+
+  public long incrementAndGetEventSequenceNumber() {
+    dirty = true;
+    return ++eventSequenceNumber;
+  }
+
+  public long getMetricSequenceNumber() {
+    return metricSequenceNumber;
+  }
+
+  public void setMetricSequenceNumber(final long metricSequenceNumber) {
+    this.metricSequenceNumber = metricSequenceNumber;
+  }
+
+  public long incrementAndGetMetricSequenceNumber() {
+    dirty = true;
+    return ++metricSequenceNumber;
+  }
+
+  /** Returns true if a mutating method has been called since construction or last serialization. */
+  @JsonIgnore
+  boolean isDirty() {
+    return dirty;
+  }
+
+  byte[] serialize() {
+    try {
+      final var bytes = OBJECT_MAPPER.writeValueAsBytes(this);
+      dirty = false;
+      return bytes;
+    } catch (final JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize exporter metadata", e);
+    }
+  }
+
+  static AnalyticsExporterMetadata deserialize(final byte[] bytes) {
+    try {
+      return OBJECT_MAPPER.readValue(bytes, AnalyticsExporterMetadata.class);
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to deserialize exporter metadata", e);
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterVersion.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsExporterVersion.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.Properties;
+
+/**
+ * Resolves the analytics exporter's own version from {@code /analytics-exporter.properties}, which
+ * is filtered at build time to substitute the Maven {@code project.version}.
+ *
+ * <p>Kept distinct from {@link io.camunda.zeebe.util.VersionUtil} so the exporter can be versioned
+ * independently of the broker when it is published as a standalone artifact.
+ */
+final class AnalyticsExporterVersion {
+
+  private static final String PROPERTIES_PATH = "/analytics-exporter.properties";
+  private static final String VERSION_PROPERTY = "analytics-exporter.version";
+  private static final String VERSION = readVersion();
+
+  static String get() {
+    return VERSION;
+  }
+
+  private static String readVersion() {
+    try (final InputStream in =
+        AnalyticsExporterVersion.class.getResourceAsStream(PROPERTIES_PATH)) {
+      if (in == null) {
+        throw new IllegalStateException(
+            PROPERTIES_PATH + " missing from classpath — build artifact is incomplete");
+      }
+      final var props = new Properties();
+      props.load(in);
+      final var version = props.getProperty(VERSION_PROPERTY);
+      if (version == null || version.isBlank()) {
+        throw new IllegalStateException(VERSION_PROPERTY + " not set in " + PROPERTIES_PATH);
+      }
+      return version;
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to read " + PROPERTIES_PATH, e);
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+
+/**
+ * Handler for a single analytics event type. Implementations must be named classes (not lambdas or
+ * anonymous classes) so that {@link AnalyticsExporterDigest} can load and hash their bytecode
+ * deterministically.
+ */
+public interface AnalyticsHandler<T extends RecordValue> {
+
+  void handle(Record<T> record);
+
+  /**
+   * Returns the bytecode of this handler's class, used by {@link AnalyticsExporterDigest} to
+   * compute a digest that detects handler implementation changes. Override to include additional
+   * identity (e.g. constructor parameters) in the digest.
+   *
+   * <p>Lambdas, anonymous classes, and local classes are rejected because they have no stable
+   * {@code .class} resource on the classpath.
+   */
+  default byte[] digestInput() {
+    final var clazz = getClass();
+    if (clazz.isSynthetic() || clazz.isAnonymousClass() || clazz.isLocalClass()) {
+      throw new IllegalArgumentException(
+          "Handler class must be a named class — lambdas, anonymous classes, and local classes"
+              + " are not supported because their bytecode is not stable across JVM restarts: "
+              + clazz.getName());
+    }
+    return AnalyticsExporterDigest.loadClassBytes(clazz);
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalog.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalog.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.exporter.analytics.handler.AdHocSubProcessHandler;
+import io.camunda.exporter.analytics.handler.ProcessInstanceCreationHandler;
+import io.camunda.exporter.analytics.handler.UsageMetricHandler;
+import io.camunda.exporter.analytics.handler.UserTaskCreatedHandler;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+/**
+ * Registers all analytics event handlers. This is the only file to edit when adding a new event:
+ * create a handler class in {@code handler/}, add one {@code .register()} call here, and add the
+ * event name constant to {@link AnalyticsAttributes.Event}.
+ *
+ * <p>{@link AnalyticsExporter} never needs to change when new events are added.
+ */
+final class AnalyticsHandlerCatalog {
+
+  private AnalyticsHandlerCatalog() {}
+
+  static HandlerRegistry build(final OtelSdkManager otelSdkManager) {
+    return new HandlerRegistry()
+        .register(
+            ValueType.PROCESS_INSTANCE_CREATION,
+            ProcessInstanceCreationIntent.CREATED,
+            new ProcessInstanceCreationHandler(otelSdkManager))
+        .register(
+            ValueType.PROCESS_INSTANCE,
+            ProcessInstanceIntent.ELEMENT_ACTIVATED,
+            new AdHocSubProcessHandler(otelSdkManager))
+        .register(
+            ValueType.USAGE_METRIC,
+            UsageMetricIntent.EXPORTED,
+            new UsageMetricHandler(otelSdkManager))
+        .register(
+            ValueType.USER_TASK,
+            UserTaskIntent.CREATED,
+            new UserTaskCreatedHandler(otelSdkManager));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsRecordFilter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsRecordFilter.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.Set;
+
+/**
+ * Record filter for the analytics exporter with four filtering layers:
+ *
+ * <ol>
+ *   <li><b>Record type</b> — only {@link RecordType#EVENT} records pass; commands and rejections
+ *       are skipped.
+ *   <li><b>Value type</b> — only value types with registered handlers pass (e.g. {@link
+ *       ValueType#PROCESS_INSTANCE_CREATION}).
+ *   <li><b>Intent</b> — only intents with registered handlers pass. This is an intentional
+ *       over-approximation: the set is flat across all value types, so a record may pass intent
+ *       filtering even if its (ValueType, Intent) pair has no handler. Exact routing happens in
+ *       {@link HandlerRegistry#handle}.
+ *   <li><b>Partition ownership</b> — only events whose key encodes the local partition ID pass.
+ * </ol>
+ *
+ * <p>Layers 1-3 are metadata-based and evaluated in phase 1 of the broker's filter pipeline (before
+ * record deserialization). Layer 4 runs in phase 2 on the deserialized record, but only for the
+ * small subset that passed phase 1.
+ *
+ * <h3>Partition filtering rationale</h3>
+ *
+ * <p>Zeebe distributes certain commands (deployments, identity, tenants, etc.) to all partitions.
+ * Each partition writes follow-up events for the distributed command, but the event keys preserve
+ * the originating partition's ID — encoded in the upper 13 bits of the 64-bit key via {@link
+ * Protocol#encodePartitionId(int, long)}.
+ *
+ * <p>Without this filter, the analytics exporter on every partition would emit the same logical
+ * event, leading to N× duplication in a cluster with N partitions.
+ *
+ * <p>The key-based check works because all {@code DistributedTypedRecordProcessor} implementations
+ * in the engine preserve the originating partition ID in follow-up event keys — either via {@code
+ * command.getKey()} directly, or via keys embedded in the distributed command's value that were
+ * generated on the originating partition.
+ */
+record AnalyticsRecordFilter(
+    Set<ValueType> acceptedValueTypes, Set<Intent> acceptedIntents, int partitionId)
+    implements RecordFilter {
+
+  AnalyticsRecordFilter {
+    acceptedValueTypes = Set.copyOf(acceptedValueTypes);
+    acceptedIntents = Set.copyOf(acceptedIntents);
+  }
+
+  @Override
+  public boolean acceptType(final RecordType recordType) {
+    return recordType == RecordType.EVENT;
+  }
+
+  @Override
+  public boolean acceptValue(final ValueType valueType) {
+    return acceptedValueTypes.contains(valueType);
+  }
+
+  @Override
+  public boolean acceptIntent(final Intent intent) {
+    return acceptedIntents.contains(intent);
+  }
+
+  @Override
+  public boolean acceptRecord(final Record<?> record) {
+    return Protocol.decodePartitionId(record.getKey()) == partitionId;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsRecordFilter.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/AnalyticsRecordFilter.java
@@ -9,7 +9,6 @@ package io.camunda.exporter.analytics;
 
 import io.camunda.zeebe.exporter.api.context.Context.RecordFilter;
 import io.camunda.zeebe.protocol.Protocol;
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -71,10 +70,5 @@ record AnalyticsRecordFilter(
   @Override
   public boolean acceptIntent(final Intent intent) {
     return acceptedIntents.contains(intent);
-  }
-
-  @Override
-  public boolean acceptRecord(final Record<?> record) {
-    return Protocol.decodePartitionId(record.getKey()) == partitionId;
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/HandlerRegistry.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Routes records to handlers by (ValueType, Intent) pairs. Supports multiple handlers per
+ * ValueType, each keyed by a distinct Intent. Two-level lookup: EnumMap for ValueType, then HashMap
+ * for Intent.
+ *
+ * <p>On {@link #apply}, installs an {@link AnalyticsRecordFilter} derived from the registered types
+ * and intents.
+ */
+final class HandlerRegistry {
+
+  private final EnumMap<ValueType, Map<Intent, AnalyticsHandler<?>>> handlers =
+      new EnumMap<>(ValueType.class);
+
+  <T extends RecordValue> HandlerRegistry register(
+      final ValueType valueType, final Intent intent, final AnalyticsHandler<T> handler) {
+    final var intentMap = handlers.computeIfAbsent(valueType, k -> new HashMap<>());
+    if (intentMap.containsKey(intent)) {
+      throw new IllegalStateException("Duplicate handler for (" + valueType + ", " + intent + ")");
+    }
+    intentMap.put(intent, handler);
+    return this;
+  }
+
+  HandlerRegistry apply(final Context context) {
+    final var acceptedIntents =
+        handlers.values().stream()
+            .flatMap(m -> m.keySet().stream())
+            .collect(Collectors.toUnmodifiableSet());
+    context.setFilter(
+        new AnalyticsRecordFilter(handlers.keySet(), acceptedIntents, context.getPartitionId()));
+    return this;
+  }
+
+  @VisibleForTesting
+  Set<Map.Entry<ValueType, Intent>> registrations() {
+    return handlers.entrySet().stream()
+        .flatMap(e -> e.getValue().keySet().stream().map(intent -> Map.entry(e.getKey(), intent)))
+        .collect(Collectors.toUnmodifiableSet());
+  }
+
+  /** Package-private production seam consumed by {@link AnalyticsExporterDigest}. */
+  Map<ValueType, Map<Intent, AnalyticsHandler<?>>> registeredHandlers() {
+    return Collections.unmodifiableMap(handlers);
+  }
+
+  /** Routes the record to its handler. Does nothing if no handler is registered. */
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void handle(final Record<?> record) {
+    final var intentMap = handlers.get(record.getValueType());
+    if (intentMap == null) {
+      return;
+    }
+    final AnalyticsHandler handler = intentMap.get(record.getIntent());
+    if (handler == null) {
+      return;
+    }
+    handler.handle(record);
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/ManualMetricReader.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/ManualMetricReader.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
+import io.opentelemetry.sdk.metrics.export.CollectionRegistration;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import java.util.Collection;
+
+/**
+ * A {@link MetricReader} that exposes manual collection and export. Unlike {@link
+ * io.opentelemetry.sdk.metrics.export.PeriodicMetricReader}, collection timing is controlled by the
+ * caller — enabling single-threaded collection on the partition thread with zero cross-thread
+ * races.
+ */
+public final class ManualMetricReader implements MetricReader {
+
+  private final MetricExporter exporter;
+  private CollectionRegistration registration = CollectionRegistration.noop();
+
+  ManualMetricReader(final MetricExporter exporter) {
+    this.exporter = exporter;
+  }
+
+  @Override
+  public void register(final CollectionRegistration registration) {
+    this.registration = registration;
+  }
+
+  /** Collects all metrics and exports them. Returns the export result. */
+  CompletableResultCode collectAndExport() {
+    final Collection<MetricData> metrics = registration.collectAllMetrics();
+    if (metrics.isEmpty()) {
+      return CompletableResultCode.ofSuccess();
+    }
+    return exporter.export(metrics);
+  }
+
+  @Override
+  public AggregationTemporality getAggregationTemporality(final InstrumentType instrumentType) {
+    return AggregationTemporalitySelector.deltaPreferred()
+        .getAggregationTemporality(instrumentType);
+  }
+
+  /** No-op — final flush is driven by {@code OtelSdkManager.close()} before sdk.shutdown(). */
+  @Override
+  public CompletableResultCode forceFlush() {
+    return CompletableResultCode.ofSuccess();
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    return exporter.shutdown();
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/MetricWindow.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/MetricWindow.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MAX;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MIN;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_END;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_START;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.SEQUENCE_NUMBER;
+
+import io.opentelemetry.api.common.Attributes;
+
+/**
+ * Tracks the export window state between metric flushes. Accumulates event count, position range,
+ * and event time range. Reset after each gauge collection.
+ *
+ * <p><b>Thread safety:</b> All access happens on the partition thread via {@link
+ * ManualMetricReader} + {@code scheduleCancellableTask}. No synchronization required.
+ */
+final class MetricWindow {
+
+  private long eventCount;
+  private long positionStart = Long.MAX_VALUE;
+  private long positionEnd = Long.MIN_VALUE;
+  private long eventTimeMin = Long.MAX_VALUE;
+  private long eventTimeMax = Long.MIN_VALUE;
+
+  /** Records a metric event, updating the window bounds. */
+  void record(final long position, final long eventTimeMs) {
+    eventCount++;
+    positionStart = Math.min(positionStart, position);
+    positionEnd = Math.max(positionEnd, position);
+    eventTimeMin = Math.min(eventTimeMin, eventTimeMs);
+    eventTimeMax = Math.max(eventTimeMax, eventTimeMs);
+  }
+
+  /**
+   * Builds OTel attributes for the companion gauge. When no events have been recorded, only the
+   * sequence number is included — position and time sentinels are omitted to avoid leaking
+   * Long.MAX_VALUE/MIN_VALUE to consumers.
+   */
+  Attributes toGaugeAttributes(final long metricSequenceNumber) {
+    if (!hasEvents()) {
+      return Attributes.of(SEQUENCE_NUMBER, metricSequenceNumber);
+    }
+    return Attributes.of(
+        SEQUENCE_NUMBER, metricSequenceNumber,
+        POSITION_START, positionStart,
+        POSITION_END, positionEnd,
+        TIME_MIN, eventTimeMin,
+        TIME_MAX, eventTimeMax);
+  }
+
+  /** Resets all fields for the next window. */
+  void reset() {
+    eventCount = 0;
+    positionStart = Long.MAX_VALUE;
+    positionEnd = Long.MIN_VALUE;
+    eventTimeMin = Long.MAX_VALUE;
+    eventTimeMax = Long.MIN_VALUE;
+  }
+
+  boolean hasEvents() {
+    return eventCount > 0;
+  }
+
+  long eventCount() {
+    return eventCount;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/MicrometerMeterProvider.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/MicrometerMeterProvider.java
@@ -1,0 +1,499 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleCounterBuilder;
+import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
+import io.opentelemetry.api.metrics.LongHistogramBuilder;
+import io.opentelemetry.api.metrics.LongUpDownCounter;
+import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterBuilder;
+import io.opentelemetry.api.metrics.MeterProvider;
+import io.opentelemetry.api.metrics.ObservableLongCounter;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.opentelemetry.api.metrics.ObservableLongUpDownCounter;
+import io.opentelemetry.context.Context;
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A {@link MeterProvider} backed by Micrometer. OTel SDK components that accept a {@link
+ * MeterProvider} for internal telemetry (e.g. {@code BatchLogRecordProcessor}, {@code
+ * OtlpHttpLogRecordExporter}) can be given this bridge so their self-metrics appear at the broker's
+ * Prometheus endpoint without any extra collection cycle.
+ *
+ * <p>Supported instrument types:
+ *
+ * <ul>
+ *   <li>{@code counterBuilder().build()} — maps to Micrometer {@link Counter}; {@code add()}
+ *       increments.
+ *   <li>{@code upDownCounterBuilder().build()} — maps to Micrometer {@link Gauge} backed by {@link
+ *       AtomicLong}.
+ *   <li>{@code upDownCounterBuilder().buildWithCallback()} — registers a Micrometer {@link Gauge}
+ *       whose supplier invokes the OTel callback synchronously at scrape time.
+ *   <li>{@code histogramBuilder().build()} — maps to Micrometer {@link Timer}; {@code record()}
+ *       converts seconds (unit {@code "s"}) to nanoseconds before recording.
+ *   <li>Double gauge builders — delegated to noop.
+ * </ul>
+ *
+ * <p>All meters receive the fixed tag {@value COMPONENT_TAG_KEY}={@value COMPONENT_TAG_VALUE}.
+ */
+@NullMarked
+final class MicrometerMeterProvider implements MeterProvider {
+
+  static final String COMPONENT_TAG_KEY = "otel.component.origin";
+  static final String COMPONENT_TAG_VALUE = "analytics_exporter";
+
+  /** Pre-computed tags for the common empty-attributes case — avoids per-call allocation. */
+  static final Tags ORIGIN_ONLY_TAGS = Tags.of(COMPONENT_TAG_KEY, COMPONENT_TAG_VALUE);
+
+  private static final Logger LOG = LoggerFactory.getLogger(MicrometerMeterProvider.class);
+
+  /** Noop meter used for unimplemented instrument types (histogram, double gauge, etc.). */
+  private static final Meter NOOP_METER = OpenTelemetry.noop().getMeter("noop");
+
+  private final MeterRegistry registry;
+
+  MicrometerMeterProvider(final MeterRegistry registry) {
+    this.registry = registry;
+  }
+
+  @Override
+  public MeterBuilder meterBuilder(final String instrumentationScopeName) {
+    return new BridgeMeterBuilder(instrumentationScopeName);
+  }
+
+  /**
+   * Converts OTel {@link Attributes} to Micrometer {@link Tags}, appending the fixed component
+   * origin tag. Returns the pre-computed {@link #ORIGIN_ONLY_TAGS} singleton when attributes are
+   * empty to avoid per-call allocation on the hot path.
+   *
+   * <p>Hot path for {@code otel.sdk.log.created} (empty attrs): returns {@link #ORIGIN_ONLY_TAGS}
+   * singleton — zero allocation. Non-empty attrs (e.g. {@code error.type=queue_full}): rebuilds
+   * {@link Tags} on every call for the map key. The {@link
+   * io.micrometer.core.instrument.Counter}/{@link io.micrometer.core.instrument.Timer} itself is
+   * cached in the instrument's {@link ConcurrentHashMap} after first registration. Further caching
+   * of {@link Tags} objects by {@link io.opentelemetry.api.common.Attributes} would require a
+   * second CHM lookup and is not worth the added complexity given the low OTel SDK self-metric call
+   * rate.
+   */
+  static Tags toMicrometerTags(final Attributes attributes) {
+    if (attributes.isEmpty()) {
+      return ORIGIN_ONLY_TAGS;
+    }
+    final var pairs = new ArrayList<String>(attributes.size() * 2 + 2);
+    attributes.forEach(
+        (key, value) -> {
+          pairs.add(sanitizeKey(key.getKey()));
+          pairs.add(sanitizeValue(String.valueOf(value)));
+        });
+    pairs.add(COMPONENT_TAG_KEY);
+    pairs.add(COMPONENT_TAG_VALUE);
+    return Tags.of(pairs.toArray(new String[0]));
+  }
+
+  /** Sanitizes an OTel attribute key to a valid Prometheus label name. */
+  private static String sanitizeKey(final String key) {
+    // Replace any character that is not [a-zA-Z0-9_] with '_'
+    return key.replaceAll("[^a-zA-Z0-9_]", "_");
+  }
+
+  /** Strips control characters from a Prometheus label value. */
+  private static String sanitizeValue(final String value) {
+    return value.replaceAll("[\\r\\n]", "");
+  }
+
+  // -------------------------------------------------------------------------
+  // MeterBuilder
+  // -------------------------------------------------------------------------
+
+  private final class BridgeMeterBuilder implements MeterBuilder {
+    @SuppressWarnings("unused")
+    private final String scopeName;
+
+    BridgeMeterBuilder(final String scopeName) {
+      this.scopeName = scopeName;
+    }
+
+    @Override
+    public MeterBuilder setSchemaUrl(final String schemaUrl) {
+      return this;
+    }
+
+    @Override
+    public MeterBuilder setInstrumentationVersion(final String instrumentationScopeVersion) {
+      return this;
+    }
+
+    @Override
+    public Meter build() {
+      return new BridgeMeter(registry);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Meter
+  // -------------------------------------------------------------------------
+
+  private static final class BridgeMeter implements Meter {
+    private final MeterRegistry registry;
+
+    BridgeMeter(final MeterRegistry registry) {
+      this.registry = registry;
+    }
+
+    @Override
+    public LongCounterBuilder counterBuilder(final String name) {
+      return new BridgeLongCounterBuilder(registry, name);
+    }
+
+    @Override
+    public LongUpDownCounterBuilder upDownCounterBuilder(final String name) {
+      return new BridgeLongUpDownCounterBuilder(registry, name);
+    }
+
+    @Override
+    public DoubleHistogramBuilder histogramBuilder(final String name) {
+      return new BridgeDoubleHistogramBuilder(registry, name);
+    }
+
+    @Override
+    public DoubleGaugeBuilder gaugeBuilder(final String name) {
+      // Noop: OTel SDK self-metrics don't emit double gauge instruments; all observable gauges use
+      // upDownCounterBuilder().buildWithCallback() instead.
+      LOG.warn(
+          "MicrometerMeterProvider: gauge '{}' is not bridged to Micrometer; measurements will be lost",
+          name);
+      return NOOP_METER.gaugeBuilder(name);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // LongCounter builder + instrument
+  // -------------------------------------------------------------------------
+
+  private static final class BridgeLongCounterBuilder implements LongCounterBuilder {
+    private final MeterRegistry registry;
+    private final String name;
+    private String description = "";
+
+    BridgeLongCounterBuilder(final MeterRegistry registry, final String name) {
+      this.registry = registry;
+      this.name = name;
+    }
+
+    @Override
+    public LongCounterBuilder setDescription(final String description) {
+      this.description = description;
+      return this;
+    }
+
+    @Override
+    public LongCounterBuilder setUnit(final String unit) {
+      return this;
+    }
+
+    @Override
+    public DoubleCounterBuilder ofDoubles() {
+      // Noop: OTel SDK self-metrics use only the long (integer) counter variant.
+      LOG.warn(
+          "MicrometerMeterProvider: counter '{}' requested as double; not bridged to Micrometer",
+          name);
+      return NOOP_METER.counterBuilder(name).ofDoubles();
+    }
+
+    @Override
+    public LongCounter build() {
+      return new BridgeLongCounter(registry, name, description);
+    }
+
+    @Override
+    public ObservableLongCounter buildWithCallback(
+        final Consumer<ObservableLongMeasurement> callback) {
+      // Noop: no OTel SDK self-metric uses an observable (pull-model) long counter.
+      LOG.warn(
+          "MicrometerMeterProvider: observable counter '{}' is not bridged to Micrometer; measurements will be lost",
+          name);
+      return NOOP_METER.counterBuilder(name).buildWithCallback(callback);
+    }
+  }
+
+  private static final class BridgeLongCounter implements LongCounter {
+    private final MeterRegistry registry;
+    private final String name;
+    private final String description;
+    private final ConcurrentHashMap<Tags, Counter> counters = new ConcurrentHashMap<>();
+
+    BridgeLongCounter(final MeterRegistry registry, final String name, final String description) {
+      this.registry = registry;
+      this.name = name;
+      this.description = description;
+    }
+
+    @Override
+    public void add(final long value) {
+      add(value, Attributes.empty());
+    }
+
+    @Override
+    public void add(final long value, final Attributes attributes) {
+      try {
+        final Tags tags = toMicrometerTags(attributes);
+        counters
+            .computeIfAbsent(
+                tags,
+                t -> Counter.builder(name).description(description).tags(t).register(registry))
+            .increment(value);
+      } catch (final Exception e) {
+        LOG.warn("Failed to record metric {}: {}", name, e.getMessage());
+      }
+    }
+
+    @Override
+    public void add(final long value, final Attributes attributes, final Context context) {
+      add(value, attributes);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // LongUpDownCounter builder + instrument
+  // -------------------------------------------------------------------------
+
+  private static final class BridgeLongUpDownCounterBuilder implements LongUpDownCounterBuilder {
+    private final MeterRegistry registry;
+    private final String name;
+    private String description = "";
+
+    BridgeLongUpDownCounterBuilder(final MeterRegistry registry, final String name) {
+      this.registry = registry;
+      this.name = name;
+    }
+
+    @Override
+    public LongUpDownCounterBuilder setDescription(final String description) {
+      this.description = description;
+      return this;
+    }
+
+    @Override
+    public LongUpDownCounterBuilder setUnit(final String unit) {
+      return this;
+    }
+
+    @Override
+    public DoubleUpDownCounterBuilder ofDoubles() {
+      // Noop: OTel SDK self-metrics use only the long (integer) up-down counter variant.
+      LOG.warn(
+          "MicrometerMeterProvider: up-down counter '{}' requested as double; not bridged to Micrometer",
+          name);
+      return NOOP_METER.upDownCounterBuilder(name).ofDoubles();
+    }
+
+    @Override
+    public LongUpDownCounter build() {
+      return new BridgeLongUpDownCounter(registry, name, description);
+    }
+
+    @Override
+    public ObservableLongUpDownCounter buildWithCallback(
+        final Consumer<ObservableLongMeasurement> callback) {
+      // On each Prometheus scrape, the Gauge supplier fires the OTel callback to refresh all
+      // values. One Gauge is registered per distinct attribute set seen; new ones are added lazily.
+      final ConcurrentHashMap<Tags, AtomicLong> backings = new ConcurrentHashMap<>();
+      final AtomicLong defaultBacking = new AtomicLong();
+      backings.put(ORIGIN_ONLY_TAGS, defaultBacking);
+      Gauge.builder(
+              name,
+              () -> {
+                callback.accept(
+                    new ObservableLongMeasurement() {
+                      @Override
+                      public void record(final long value) {
+                        defaultBacking.set(value);
+                      }
+
+                      @Override
+                      public void record(final long value, final Attributes attributes) {
+                        final Tags tags = toMicrometerTags(attributes);
+                        if (tags.equals(ORIGIN_ONLY_TAGS)) {
+                          defaultBacking.set(value);
+                        } else {
+                          backings
+                              .computeIfAbsent(
+                                  tags,
+                                  t -> {
+                                    final AtomicLong b = new AtomicLong();
+                                    Gauge.builder(name, b, a -> (double) a.get())
+                                        .description(description)
+                                        .tags(t)
+                                        .register(registry);
+                                    return b;
+                                  })
+                              .set(value);
+                        }
+                      }
+                    });
+                return (double) defaultBacking.get();
+              })
+          .description(description)
+          .tags(ORIGIN_ONLY_TAGS)
+          .register(registry);
+      // Return a noop — the OTel caller only uses this for unregistration which we don't need.
+      return NOOP_METER.upDownCounterBuilder(name).buildWithCallback(callback);
+    }
+  }
+
+  private static final class BridgeLongUpDownCounter implements LongUpDownCounter {
+    private final MeterRegistry registry;
+    private final String name;
+    private final String description;
+    private final ConcurrentHashMap<Tags, AtomicLong> gauges = new ConcurrentHashMap<>();
+
+    BridgeLongUpDownCounter(
+        final MeterRegistry registry, final String name, final String description) {
+      this.registry = registry;
+      this.name = name;
+      this.description = description;
+    }
+
+    @Override
+    public void add(final long value) {
+      add(value, Attributes.empty());
+    }
+
+    @Override
+    public void add(final long value, final Attributes attributes) {
+      try {
+        final Tags tags = toMicrometerTags(attributes);
+        final var backing =
+            gauges.computeIfAbsent(
+                tags,
+                t -> {
+                  final var atomicLong = new AtomicLong();
+                  Gauge.builder(name, atomicLong, a -> (double) a.get())
+                      .description(description)
+                      .tags(t)
+                      .register(registry);
+                  return atomicLong;
+                });
+        backing.addAndGet(value);
+      } catch (final Exception e) {
+        LOG.warn("Failed to record metric {}: {}", name, e.getMessage());
+      }
+    }
+
+    @Override
+    public void add(final long value, final Attributes attributes, final Context context) {
+      add(value, attributes);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // DoubleHistogram builder + instrument
+  // -------------------------------------------------------------------------
+
+  // Note: DoubleHistogramBuilder has no buildWithCallback — observable histograms are not part of
+  // the OTel SDK LATEST internal-telemetry schema, so no noop override is needed here.
+  private static final class BridgeDoubleHistogramBuilder implements DoubleHistogramBuilder {
+    private final MeterRegistry registry;
+    private final String name;
+    private String description = "";
+
+    BridgeDoubleHistogramBuilder(final MeterRegistry registry, final String name) {
+      this.registry = registry;
+      this.name = name;
+    }
+
+    @Override
+    public DoubleHistogramBuilder setDescription(final String description) {
+      this.description = description;
+      return this;
+    }
+
+    @Override
+    public DoubleHistogramBuilder setUnit(final String unit) {
+      return this;
+    }
+
+    @Override
+    public DoubleHistogramBuilder setExplicitBucketBoundariesAdvice(
+        final java.util.List<Double> bucketBoundaries) {
+      return this;
+    }
+
+    @Override
+    public LongHistogramBuilder ofLongs() {
+      // Noop: OTel SDK self-metrics use only the double histogram variant (export duration in "s").
+      LOG.warn(
+          "MicrometerMeterProvider: histogram '{}' requested as long; not bridged to Micrometer",
+          name);
+      return NOOP_METER.histogramBuilder(name).ofLongs();
+    }
+
+    @Override
+    public DoubleHistogram build() {
+      return new BridgeDoubleHistogram(registry, name, description);
+    }
+  }
+
+  private static final class BridgeDoubleHistogram implements DoubleHistogram {
+    private final MeterRegistry registry;
+    private final String name;
+    private final String description;
+    private final ConcurrentHashMap<Tags, Timer> timers = new ConcurrentHashMap<>();
+
+    BridgeDoubleHistogram(
+        final MeterRegistry registry, final String name, final String description) {
+      this.registry = registry;
+      this.name = name;
+      this.description = description;
+    }
+
+    @Override
+    public void record(final double amount) {
+      record(amount, Attributes.empty());
+    }
+
+    @Override
+    public void record(final double amount, final Attributes attributes) {
+      try {
+        final Tags tags = toMicrometerTags(attributes);
+        timers
+            .computeIfAbsent(
+                tags, t -> Timer.builder(name).description(description).tags(t).register(registry))
+            .record((long) (amount * 1_000_000_000L), TimeUnit.NANOSECONDS);
+      } catch (final Exception e) {
+        LOG.warn("Failed to record metric {}: {}", name, e.getMessage());
+      }
+    }
+
+    @Override
+    public void record(final double amount, final Attributes attributes, final Context context) {
+      record(amount, attributes);
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/OtelSdkManager.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.CLUSTER_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.HEARTBEAT;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.NAME;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.SAMPLE_RATE;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.SEQUENCE_NUMBER;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Exporter.DIGEST;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Heartbeat.BROKER_VERSION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Heartbeat.EXPORTER_VERSION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.EXPORT_WINDOW;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.PARTITION_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.SERVICE_NAME;
+
+import io.camunda.exporter.analytics.sampling.HashSampler;
+import io.camunda.zeebe.util.VersionUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Logger;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
+import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.common.InternalTelemetryVersion;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+/**
+ * Manages the OTel SDK lifecycle for one partition. Provides log events via {@link #logEvent} and
+ * pre-aggregated metric counters via {@link #incrementMetric}. Metric collection is triggered
+ * manually via {@link #flushMetrics} from the partition thread — no background reader thread.
+ */
+public class OtelSdkManager implements AutoCloseable {
+
+  private static final String INSTRUMENTATION_SCOPE = "io.camunda.analytics";
+  private static final String SCHEMA_URL = "https://camunda.io/schemas/analytics/v1";
+  private static final String OTLP_LOGS_PATH = "/v1/logs";
+  private static final String OTLP_METRICS_PATH = "/v1/metrics";
+  private static final String SERVICE_NAME_VALUE = "camunda-zeebe";
+
+  private double defaultSamplingRate = HashSampler.MAX_SAMPLE_RATE;
+
+  private OpenTelemetrySdk sdk;
+  private Logger otelLogger;
+  private Meter otelMeter;
+  private ManualMetricReader metricReader;
+  private AnalyticsExporterMetadata metadata;
+  private final Map<String, LongCounter> counters = new HashMap<>();
+  private final MetricWindow metricWindow = new MetricWindow();
+
+  OtelSdkManager initialize(
+      final AnalyticsExporterConfig config,
+      final AnalyticsExporterContext context,
+      final AnalyticsExporterMetadata metadata) {
+    return initialize(config, context, metadata, new SimpleMeterRegistry());
+  }
+
+  OtelSdkManager initialize(
+      final AnalyticsExporterConfig config,
+      final AnalyticsExporterContext context,
+      final AnalyticsExporterMetadata metadata,
+      final MeterRegistry meterRegistry) {
+    this.metadata = metadata;
+    this.defaultSamplingRate = config.getSamplingRate();
+    counters.clear();
+    metricWindow.reset();
+
+    final var bridge = new MicrometerMeterProvider(meterRegistry);
+
+    metricReader = createMetricReader(config, context, bridge);
+    final var meterProvider = createMeterProvider(context, metricReader);
+    final var loggerProvider = createLoggerProvider(config, context, bridge);
+
+    sdk =
+        OpenTelemetrySdk.builder()
+            .setLoggerProvider(loggerProvider)
+            .setMeterProvider(meterProvider)
+            .build();
+    otelLogger =
+        sdk.getLogsBridge().loggerBuilder(INSTRUMENTATION_SCOPE).setSchemaUrl(SCHEMA_URL).build();
+    otelMeter =
+        sdk.getMeterProvider().meterBuilder(INSTRUMENTATION_SCOPE).setSchemaUrl(SCHEMA_URL).build();
+    registerExportWindowGauge();
+    return this;
+  }
+
+  public void logEvent(
+      final String eventName, final long logPosition, final Consumer<LogRecordBuilder> builder) {
+    logEvent(eventName, logPosition, HashSampler.MAX_SAMPLE_RATE, builder);
+  }
+
+  public void logEvent(
+      final String eventName,
+      final long logPosition,
+      final double samplingRate,
+      final Consumer<LogRecordBuilder> builder) {
+    final double appliedRate = Math.min(defaultSamplingRate, samplingRate);
+    if (!HashSampler.shouldSample(logPosition, appliedRate)) {
+      return;
+    }
+    final var record =
+        otelLogger
+            .logRecordBuilder()
+            .setSeverity(Severity.INFO)
+            .setSeverityText("INFO")
+            .setAttribute(NAME, eventName)
+            .setAttribute(POSITION, logPosition)
+            .setAttribute(SEQUENCE_NUMBER, metadata.incrementAndGetEventSequenceNumber());
+    if (appliedRate < HashSampler.MAX_SAMPLE_RATE) {
+      record.setAttribute(SAMPLE_RATE, appliedRate);
+    }
+    builder.accept(record);
+    record.emit();
+  }
+
+  public void emitHeartbeat() {
+    otelLogger
+        .logRecordBuilder()
+        .setSeverity(Severity.INFO)
+        .setSeverityText("INFO")
+        .setAttribute(NAME, HEARTBEAT)
+        .setAttribute(BROKER_VERSION, VersionUtil.getVersion())
+        .setAttribute(EXPORTER_VERSION, AnalyticsExporterVersion.get())
+        .emit();
+  }
+
+  /** Increments the named counter by 1 and updates the export window tracking fields. */
+  public void incrementMetric(
+      final String metricName,
+      final long position,
+      final long eventTimeMs,
+      final Attributes dimensions) {
+    counters
+        .computeIfAbsent(metricName, name -> otelMeter.counterBuilder(name).build())
+        .add(1, dimensions);
+    metricWindow.record(position, eventTimeMs);
+  }
+
+  // Performance: collectAndExport() runs on the partition thread. Benchmarked at ~0.2ms for 50
+  // metrics × 1999 dimensions, ~5ms for 1000 × 1999 (worst case). If collection time becomes
+  // a concern, offload to a background thread: create a fresh MeterProvider per flush ("seal &
+  // create"), swap atomically, and collect the old provider on a background ExecutorService.
+  void flushMetrics() {
+    if (metricReader != null) {
+      metricReader.collectAndExport();
+    }
+  }
+
+  @Override
+  public void close() {
+    flushMetrics();
+    if (sdk != null) {
+      sdk.shutdown().join(10, TimeUnit.SECONDS);
+    }
+  }
+
+  @SuppressWarnings("resource") // gauge lifecycle is managed by sdk.shutdown(), not by us
+  private void registerExportWindowGauge() {
+    otelMeter
+        .gaugeBuilder(EXPORT_WINDOW)
+        .ofLongs()
+        .buildWithCallback(
+            measurement -> {
+              if (!metricWindow.hasEvents()) {
+                return;
+              }
+              final long seq = metadata.incrementAndGetMetricSequenceNumber();
+              measurement.record(metricWindow.eventCount(), metricWindow.toGaugeAttributes(seq));
+              metricWindow.reset();
+            });
+  }
+
+  /**
+   * Override in tests that need full pipeline control (e.g. sync processor, custom queue sizes).
+   */
+  protected SdkLoggerProvider createLoggerProvider(
+      final AnalyticsExporterConfig config,
+      final AnalyticsExporterContext context,
+      final MicrometerMeterProvider bridge) {
+    return SdkLoggerProvider.builder()
+        .setResource(buildResource(context))
+        .setMeterProvider(() -> bridge)
+        .addLogRecordProcessor(
+            BatchLogRecordProcessor.builder(createLogExporter(config, context, bridge))
+                .setMaxQueueSize(config.getMaxQueueSize())
+                .setMaxExportBatchSize(config.getMaxBatchSize())
+                .setScheduleDelay(config.getPushInterval())
+                .setMeterProvider(bridge)
+                .setInternalTelemetryVersion(InternalTelemetryVersion.LATEST)
+                .build())
+        .build();
+  }
+
+  /** Override in tests to swap the OTLP transport for an in-memory exporter. */
+  protected LogRecordExporter createLogExporter(
+      final AnalyticsExporterConfig config,
+      final AnalyticsExporterContext context,
+      final MicrometerMeterProvider bridge) {
+    final var builder =
+        OtlpHttpLogRecordExporter.builder()
+            .setEndpoint(config.getEndpoint() + OTLP_LOGS_PATH)
+            .addHeader(AnalyticsExporterContext.HEADER_FINGERPRINT, context.fingerprint())
+            .addHeader(AnalyticsExporterContext.HEADER_CLUSTER_ID, context.clusterId())
+            .setMeterProvider(bridge)
+            .setInternalTelemetryVersion(InternalTelemetryVersion.LATEST);
+
+    if (config.isSigning()) {
+      builder.setHeaders(context::computeSignatureHeaders);
+    }
+
+    return builder.build();
+  }
+
+  /** Override in tests to use an in-memory metric reader instead of OTLP. */
+  protected ManualMetricReader createMetricReader(
+      final AnalyticsExporterConfig config,
+      final AnalyticsExporterContext context,
+      final MicrometerMeterProvider bridge) {
+    return new ManualMetricReader(createMetricExporter(config, context, bridge));
+  }
+
+  /** Override in tests to swap the OTLP metric transport for an in-memory exporter. */
+  protected MetricExporter createMetricExporter(
+      final AnalyticsExporterConfig config,
+      final AnalyticsExporterContext context,
+      final MicrometerMeterProvider bridge) {
+    final var builder =
+        OtlpHttpMetricExporter.builder()
+            .setEndpoint(config.getEndpoint() + OTLP_METRICS_PATH)
+            .setAggregationTemporalitySelector(AggregationTemporalitySelector.deltaPreferred())
+            .addHeader(AnalyticsExporterContext.HEADER_FINGERPRINT, context.fingerprint())
+            .addHeader(AnalyticsExporterContext.HEADER_CLUSTER_ID, context.clusterId())
+            .setMeterProvider(bridge)
+            .setInternalTelemetryVersion(InternalTelemetryVersion.LATEST);
+
+    if (config.isSigning()) {
+      builder.setHeaders(context::computeSignatureHeaders);
+    }
+
+    return builder.build();
+  }
+
+  /** Override in tests to use an in-memory metric reader instead of ManualMetricReader. */
+  protected SdkMeterProvider createMeterProvider(
+      final AnalyticsExporterContext context, final ManualMetricReader reader) {
+    return SdkMeterProvider.builder()
+        .setResource(buildResource(context))
+        .registerMetricReader(reader)
+        .build();
+  }
+
+  static Resource buildResource(final AnalyticsExporterContext context) {
+    return Resource.getDefault()
+        .merge(
+            Resource.builder()
+                .put(SERVICE_NAME, SERVICE_NAME_VALUE)
+                .put(CLUSTER_ID, context.clusterId())
+                .put(PARTITION_ID, context.partitionId())
+                .put(DIGEST, context.exporterDigest())
+                .build());
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.ADHOC_SUBPROCESS_ACTIVATED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits an {@code adhoc_subprocess_activated} OTel event when an ad-hoc subprocess element is
+ * activated. Skips non-ad-hoc element types silently.
+ */
+public final class AdHocSubProcessHandler implements AnalyticsHandler<ProcessInstanceRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public AdHocSubProcessHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<ProcessInstanceRecordValue> record) {
+    final var value = record.getValue();
+    if (value.getBpmnElementType() != BpmnElementType.AD_HOC_SUB_PROCESS) {
+      return;
+    }
+
+    otelSdkManager.logEvent(
+        ADHOC_SUBPROCESS_ACTIVATED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                // Element.ID and Tenant.ID share the unqualified name ID — use qualified form to
+                // disambiguate
+                .setAttribute(AnalyticsAttributes.Element.ID, value.getElementId())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
@@ -44,9 +44,6 @@ public final class ProcessInstanceCreationHandler
                 .setAttribute(VERSION, (long) value.getVersion())
                 .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
                 .setAttribute(INSTANCE_KEY, record.getKey())
-                .setAttribute(
-                    AnalyticsAttributes.Process.ROOT_INSTANCE_KEY,
-                    value.getRootProcessInstanceKey())
                 .setAttribute(ID, value.getTenantId())
                 .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
 

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.VERSION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Tenant.ID;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.opentelemetry.api.common.Attributes;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/** Emits a {@code process_instance_created} OTel event for each process instance creation. */
+public final class ProcessInstanceCreationHandler
+    implements AnalyticsHandler<ProcessInstanceCreationRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public ProcessInstanceCreationHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<ProcessInstanceCreationRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        AnalyticsAttributes.Event.PROCESS_INSTANCE_CREATED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(VERSION, (long) value.getVersion())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(INSTANCE_KEY, record.getKey())
+                .setAttribute(
+                    AnalyticsAttributes.Process.ROOT_INSTANCE_KEY,
+                    value.getRootProcessInstanceKey())
+                .setAttribute(ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+
+    otelSdkManager.incrementMetric(
+        AnalyticsAttributes.Metric.PROCESS_INSTANCE_CREATED,
+        record.getPosition(),
+        record.getTimestamp(),
+        Attributes.of(
+            BPMN_PROCESS_ID, value.getBpmnProcessId(),
+            VERSION, (long) value.getVersion(),
+            ID, value.getTenantId()));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UsageMetricHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UsageMetricHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.USAGE_METRIC_EXPORTED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.UsageMetric.COUNT;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.UsageMetric.EVENT_TYPE;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.UsageMetric.INTERVAL_END;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.UsageMetric.INTERVAL_START;
+
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code usage_metric_exported} OTel event for each usage metric export (RPI, EDI, TU).
+ * Skips internal {@link UsageMetricRecordValue.EventType#NONE NONE} reset events.
+ */
+public final class UsageMetricHandler implements AnalyticsHandler<UsageMetricRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public UsageMetricHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<UsageMetricRecordValue> record) {
+    final var value = record.getValue();
+
+    if (value.getEventType() == UsageMetricRecordValue.EventType.NONE) {
+      return;
+    }
+
+    final long count =
+        switch (value.getEventType()) {
+          case TU -> value.getSetValues().values().stream().mapToLong(set -> set.size()).sum();
+          default -> value.getCounterValues().values().stream().mapToLong(Long::longValue).sum();
+        };
+
+    otelSdkManager.logEvent(
+        USAGE_METRIC_EXPORTED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(EVENT_TYPE, value.getEventType().name())
+                .setAttribute(COUNT, count)
+                .setAttribute(INTERVAL_START, value.getStartTime())
+                .setAttribute(INTERVAL_END, value.getEndTime())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.USER_TASK_CREATED;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.DEFINITION_KEY;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.INSTANCE_KEY;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.AnalyticsHandler;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Emits a {@code user_task_created} OTel event for each user task creation. Emits only safe
+ * process-metadata attributes — never assignee, candidate users, candidate groups, or variables.
+ */
+public final class UserTaskCreatedHandler implements AnalyticsHandler<UserTaskRecordValue> {
+
+  private final OtelSdkManager otelSdkManager;
+
+  public UserTaskCreatedHandler(final OtelSdkManager otelSdkManager) {
+    this.otelSdkManager = Objects.requireNonNull(otelSdkManager);
+  }
+
+  @Override
+  public void handle(final Record<UserTaskRecordValue> record) {
+    final var value = record.getValue();
+
+    otelSdkManager.logEvent(
+        USER_TASK_CREATED,
+        record.getPosition(),
+        log ->
+            log.setAttribute(BPMN_PROCESS_ID, value.getBpmnProcessId())
+                .setAttribute(DEFINITION_KEY, value.getProcessDefinitionKey())
+                .setAttribute(INSTANCE_KEY, value.getProcessInstanceKey())
+                .setAttribute(AnalyticsAttributes.Element.ID, value.getElementId())
+                .setAttribute(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                .setTimestamp(record.getTimestamp(), TimeUnit.MILLISECONDS));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/sampling/HashSampler.java
+++ b/zeebe/exporters/analytics-exporter/src/main/java/io/camunda/exporter/analytics/sampling/HashSampler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.sampling;
+
+/**
+ * Deterministic, stateless sampler. Bit-mixing distributes log positions uniformly so sampling
+ * works regardless of how sparse or clustered the relevant events are. See {@code
+ * docs/sampling-explainer.md} for the full design rationale.
+ */
+public final class HashSampler {
+
+  /** Minimum sample rate: no records are sampled. */
+  public static final double MIN_SAMPLE_RATE = 0.0;
+
+  /** Maximum sample rate: all records are sampled. */
+  public static final double MAX_SAMPLE_RATE = 1.0;
+
+  /**
+   * Resolution of the sampling bucket. A value of 10_000 gives 0.01 % granularity (one part in ten
+   * thousand).
+   */
+  static final long SAMPLING_RESOLUTION = 10_000L;
+
+  private HashSampler() {}
+
+  public static boolean shouldSample(final long position, final double rate) {
+    if (rate >= MAX_SAMPLE_RATE) {
+      return true;
+    }
+    if (rate <= MIN_SAMPLE_RATE) {
+      return false;
+    }
+    return (mix(position) & Long.MAX_VALUE) % SAMPLING_RESOLUTION
+        < (long) (rate * SAMPLING_RESOLUTION);
+  }
+
+  // Stafford Mix13 — selected via JMH benchmark (HashSamplerBenchmark) over Murmur3,
+  // multiply-shift, and FNV-1a for best avalanche properties at competitive throughput.
+  private static long mix(long x) {
+    x = (x ^ (x >>> 30)) * 0xbf58476d1ce4e5b9L;
+    x = (x ^ (x >>> 27)) * 0x94d049bb133111ebL;
+    x = x ^ (x >>> 31);
+    return x;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/main/resources/analytics-exporter.properties
+++ b/zeebe/exporters/analytics-exporter/src/main/resources/analytics-exporter.properties
@@ -1,0 +1,1 @@
+analytics-exporter.version=${project.version}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -59,6 +60,8 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 10, time = 1)
 @Fork(1)
+@SetEnvironmentVariable(key = "CAMUNDA_LICENSE_KEY", value = "bench-license-key")
+@SetEnvironmentVariable(key = "ZEEBE_BROKER_CLUSTER_CLUSTERID", value = "bench-cluster")
 public class AnalyticsExporterBenchmark {
 
   /** No-op exporter that discards all records — safe for unbounded benchmark loops. */
@@ -153,9 +156,7 @@ public class AnalyticsExporterBenchmark {
     final var context =
         new ExporterTestContext()
             .setConfiguration(new ExporterTestConfiguration<>("analytics-bench", config))
-            .setClusterId("bench-cluster")
-            .setPartitionId(1)
-            .setLicenseKey("bench-license-key");
+            .setPartitionId(1);
     final var exporter = new AnalyticsExporter(noopManager);
     exporter.configure(context);
     exporter.open(controller);

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterBenchmark.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH microbenchmarks for the {@link AnalyticsExporter} hot paths.
+ *
+ * <p>Run via: {@code mvn verify -pl zeebe/exporters/analytics-exporter
+ * -Dtest=AnalyticsExporterBenchmark -DskipTests=false -Dbenchmark=true}
+ *
+ * <p>Pass {@code -Dbenchmark.profiler=jfr} to capture a Java Flight Recorder {@code .jfr} file
+ * (built into the JVM; no native dependency). JMH writes the output to {@code target/jmh-jfr/}. The
+ * {@code .jfr} file can be opened in IntelliJ Ultimate ("Open Profiler Results") or JDK Mission
+ * Control. Combine with {@code gc} via {@code -Dbenchmark.profiler=jfr+gc}.
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+public class AnalyticsExporterBenchmark {
+
+  /** No-op exporter that discards all records — safe for unbounded benchmark loops. */
+  private static final LogRecordExporter NOOP_EXPORTER =
+      new LogRecordExporter() {
+        @Override
+        public CompletableResultCode export(final Collection<LogRecordData> logs) {
+          return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+          return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+          return CompletableResultCode.ofSuccess();
+        }
+      };
+
+  private AnalyticsExporter exporterWithSigning;
+  private AnalyticsExporter exporterWithoutSigning;
+  private ExporterTestController controllerSigning;
+  private ExporterTestController controllerNoSigning;
+  private Record<?> piCreatedRecord;
+  private Record<?> jobRecord;
+
+  @Setup
+  public void setUp() {
+    final var factory = new ProtocolFactory();
+
+    // Pre-generate records once — avoids allocation noise inside benchmarks
+    piCreatedRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE_CREATION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceCreationIntent.CREATED));
+    jobRecord = factory.generateRecord(ValueType.JOB);
+
+    controllerSigning = new ExporterTestController();
+    controllerNoSigning = new ExporterTestController();
+
+    exporterWithSigning = createExporter(controllerSigning, true);
+    exporterWithoutSigning = createExporter(controllerNoSigning, false);
+  }
+
+  /**
+   * Hot path: record with no matching handler. Represents the vast majority (~99 %) of records seen
+   * by the exporter in production.
+   */
+  @Benchmark
+  public void exportUnmatchedRecord() {
+    exporterWithSigning.export(jobRecord);
+  }
+
+  /** Handler match with HMAC signing enabled (default). Measures crypto overhead per export. */
+  @Benchmark
+  public void exportPiCreatedWithSigning() {
+    exporterWithSigning.export(piCreatedRecord);
+  }
+
+  /** Handler match with signing disabled (fingerprint-only). Baseline for comparison. */
+  @Benchmark
+  public void exportPiCreatedWithoutSigning() {
+    exporterWithoutSigning.export(piCreatedRecord);
+  }
+
+  @TearDown
+  public void tearDown() {
+    exporterWithSigning.close();
+    exporterWithoutSigning.close();
+  }
+
+  private static AnalyticsExporter createExporter(
+      final ExporterTestController controller, final boolean signing) {
+    final var noopManager =
+        new OtelSdkManager() {
+          @Override
+          protected SdkLoggerProvider createLoggerProvider(
+              final AnalyticsExporterConfig cfg,
+              final AnalyticsExporterContext context,
+              final MicrometerMeterProvider bridge) {
+            return SdkLoggerProvider.builder()
+                .setResource(OtelSdkManager.buildResource(context))
+                .addLogRecordProcessor(SimpleLogRecordProcessor.create(NOOP_EXPORTER))
+                .build();
+          }
+        };
+    final var config = new AnalyticsExporterConfig().setSigning(signing);
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(new ExporterTestConfiguration<>("analytics-bench", config))
+            .setClusterId("bench-cluster")
+            .setPartitionId(1)
+            .setLicenseKey("bench-license-key");
+    final var exporter = new AnalyticsExporter(noopManager);
+    exporter.configure(context);
+    exporter.open(controller);
+    return exporter;
+  }
+
+  /**
+   * Run benchmarks from IntelliJ via the play button. Skipped in CI by the {@code
+   * EnabledIfSystemProperty} condition — pass {@code -Dbenchmark=true} to enable.
+   *
+   * <p>Note: passing {@code -Dbenchmark.profiler=jfr} forces {@code forks=1} so the JFR profiler
+   * can attach to the forked JVM — this breaks IntelliJ in-process debugging. Leave the flag unset
+   * to preserve the debug workflow.
+   */
+  @Test
+  @EnabledIfSystemProperty(named = "benchmark", matches = "true")
+  void runBenchmarks() throws Exception {
+    final var profilerProp = System.getProperty("benchmark.profiler", "none");
+    final var profilers =
+        Arrays.stream(profilerProp.split("\\+"))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .map(s -> s.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toUnmodifiableSet());
+
+    final var builder =
+        new OptionsBuilder()
+            .include(AnalyticsExporterBenchmark.class.getSimpleName())
+            .warmupIterations(5)
+            .measurementIterations(10)
+            .resultFormat(ResultFormatType.JSON)
+            .result("target/jmh-result.json");
+
+    final var needsFork = profilers.contains("jfr");
+
+    if (profilers.contains("jfr")) {
+      builder.addProfiler("jfr", "dir=target/jmh-jfr");
+    }
+    if (profilers.contains("gc")) {
+      builder.addProfiler("gc");
+    }
+
+    // JFR needs a forked JVM; in-process runs cannot attach the profiler
+    builder.forks(needsFork ? 1 : 0);
+
+    new Runner(builder.build()).run();
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class AnalyticsExporterConfigTest {
+
+  @Test
+  void shouldRejectBlankEndpoint() {
+    assertThatThrownBy(() -> new AnalyticsExporterConfig().setEndpoint("").validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("endpoint");
+  }
+
+  @Test
+  void shouldRejectInvalidHeartbeatInterval() {
+    assertThatThrownBy(
+            () -> new AnalyticsExporterConfig().setHeartbeatInterval("not-a-duration").validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("heartbeatInterval");
+  }
+
+  @Test
+  void shouldRejectNonPositiveHeartbeatInterval() {
+    assertThatThrownBy(() -> new AnalyticsExporterConfig().setHeartbeatInterval("PT0S").validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("must be positive");
+  }
+
+  @Test
+  void shouldRejectInvalidPushInterval() {
+    assertThatThrownBy(
+            () -> new AnalyticsExporterConfig().setPushInterval("not-a-duration").validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("pushInterval");
+  }
+
+  @Test
+  void shouldRejectNonPositiveMaxQueueSize() {
+    assertThatThrownBy(() -> new AnalyticsExporterConfig().setMaxQueueSize(0).validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxQueueSize");
+  }
+
+  @Test
+  void shouldRejectNonPositiveMaxBatchSize() {
+    assertThatThrownBy(() -> new AnalyticsExporterConfig().setMaxBatchSize(0).validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxBatchSize");
+  }
+
+  @Test
+  void shouldRejectMaxBatchSizeExceedingMaxQueueSize() {
+    assertThatThrownBy(
+            () ->
+                new AnalyticsExporterConfig().setMaxQueueSize(100).setMaxBatchSize(200).validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("maxBatchSize")
+        .hasMessageContaining("maxQueueSize");
+  }
+
+  @Test
+  void shouldRejectSamplingRateBelowZero() {
+    assertThatThrownBy(() -> new AnalyticsExporterConfig().setSamplingRate(-0.1).validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("samplingRate");
+  }
+
+  @Test
+  void shouldRejectSamplingRateNaN() {
+    assertThatThrownBy(() -> new AnalyticsExporterConfig().setSamplingRate(Double.NaN).validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("samplingRate");
+  }
+
+  @Test
+  void shouldRejectSamplingRateAboveOne() {
+    assertThatThrownBy(() -> new AnalyticsExporterConfig().setSamplingRate(1.1).validate())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("samplingRate");
+  }
+
+  @Test
+  void shouldAcceptSamplingRateBoundaries() {
+    assertThatCode(() -> new AnalyticsExporterConfig().setSamplingRate(0.0).validate())
+        .doesNotThrowAnyException();
+    assertThatCode(() -> new AnalyticsExporterConfig().setSamplingRate(1.0).validate())
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldReturnSameDigestStringForEqualConfigs() {
+    // given
+    final var config = new AnalyticsExporterConfig().setSamplingRate(0.5);
+
+    // when
+    final var first = config.toExporterDigestString();
+    final var second = config.toExporterDigestString();
+
+    // then
+    assertThat(first).isEqualTo(second);
+  }
+
+  @Test
+  void shouldReturnDifferentDigestStringWhenSamplingRateChanges() {
+    // given
+    final var configA = new AnalyticsExporterConfig().setSamplingRate(0.5);
+    final var configB = new AnalyticsExporterConfig().setSamplingRate(0.25);
+
+    // when / then
+    assertThat(configA.toExporterDigestString()).isNotEqualTo(configB.toExporterDigestString());
+  }
+
+  @Test
+  void shouldReturnSameDigestStringWhenNonBehaviorConfigChanges() {
+    // given
+    final var configA = new AnalyticsExporterConfig().setSamplingRate(1.0);
+    final var configB =
+        new AnalyticsExporterConfig().setSamplingRate(1.0).setEndpoint("https://other.example.com");
+
+    // when / then
+    assertThat(configA.toExporterDigestString()).isEqualTo(configB.toExporterDigestString());
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigureTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigureTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.ClearEnvironmentVariable;
+
+/**
+ * Configure-time validation tests that require the {@code CAMUNDA_LICENSE_KEY} environment variable
+ * to be absent. Kept in a dedicated class (without the shared {@code @BeforeEach} that builds a
+ * configured exporter) so clearing the variable does not break exporter set-up.
+ */
+class AnalyticsExporterConfigureTest {
+
+  @Test
+  @ClearEnvironmentVariable(key = "CAMUNDA_LICENSE_KEY")
+  void shouldRejectMissingLicenseKey() {
+    // given
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(
+                new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()));
+
+    // when / then
+    assertThatThrownBy(() -> new AnalyticsExporter().configure(context))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("CAMUNDA_LICENSE_KEY");
+  }
+}
+

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigureTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterConfigureTest.java
@@ -36,4 +36,3 @@ class AnalyticsExporterConfigureTest {
         .hasMessageContaining("CAMUNDA_LICENSE_KEY");
   }
 }
-

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterContextTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterContextTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsExporterContextTest {
+
+  @Test
+  void shouldComputeDeterministicFingerprint() {
+    // given / when
+    final var ctx1 = AnalyticsExporterContext.create("test-license", "cluster-1", 1, "");
+    final var ctx2 = AnalyticsExporterContext.create("test-license", "cluster-1", 1, "");
+
+    // then
+    assertThat(ctx1.fingerprint())
+        .isEqualTo(ctx2.fingerprint())
+        .hasSize(64)
+        .matches("[0-9a-f]{64}");
+  }
+
+  @Test
+  void shouldProduceDifferentFingerprintsForDifferentLicenses() {
+    // given / when
+    final var ctx1 = AnalyticsExporterContext.create("license-a", "cluster-1", 1, "");
+    final var ctx2 = AnalyticsExporterContext.create("license-b", "cluster-1", 1, "");
+
+    // then
+    assertThat(ctx1.fingerprint()).isNotEqualTo(ctx2.fingerprint());
+  }
+
+  @Test
+  void shouldProduceDifferentFingerprintsForDifferentClusters() {
+    // given / when
+    final var ctx1 = AnalyticsExporterContext.create("test-license", "cluster-a", 1, "");
+    final var ctx2 = AnalyticsExporterContext.create("test-license", "cluster-b", 1, "");
+
+    // then — fingerprint is derived from license only, not cluster
+    // but these are different contexts, verify they are independent
+    assertThat(ctx1.fingerprint()).isEqualTo(ctx2.fingerprint());
+    assertThat(ctx1.clusterId()).isNotEqualTo(ctx2.clusterId());
+  }
+
+  @Test
+  void shouldRejectMissingLicenseKey() {
+    // when / then
+    assertThatThrownBy(() -> AnalyticsExporterContext.create(null, "cluster-1", 1, ""))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldRejectBlankLicenseKey() {
+    // when / then
+    assertThatThrownBy(() -> AnalyticsExporterContext.create("  ", "cluster-1", 1, ""))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldComputeVerifiableSignature() {
+    // given
+    final var licenseKey = "test-license";
+    final var clusterId = "cluster-1";
+    final var ctx = AnalyticsExporterContext.create(licenseKey, clusterId, 1, "");
+
+    // when
+    final var headers = ctx.computeSignatureHeaders();
+
+    // then — independently recompute the HMAC to verify correctness
+    final var timestamp = headers.get(AnalyticsExporterContext.HEADER_TIMESTAMP);
+    final var signature = headers.get(AnalyticsExporterContext.HEADER_SIGNATURE);
+    assertThat(timestamp).matches("\\d+");
+    assertThat(signature).matches("[0-9a-f]{64}");
+
+    final var canonical = ctx.fingerprint() + "|" + clusterId + "|" + timestamp;
+    final var expected = hmacSha256(licenseKey, canonical);
+    assertThat(signature).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldProduceDifferentSignaturesForDifferentLicenses() {
+    // given — same cluster, same timestamp input via canonical string
+    final var licenseA = "license-a";
+    final var licenseB = "license-b";
+    final var clusterId = "cluster-1";
+    final var timestamp = "1234567890";
+
+    final var ctxA = AnalyticsExporterContext.create(licenseA, clusterId, 1, "");
+    final var ctxB = AnalyticsExporterContext.create(licenseB, clusterId, 1, "");
+
+    // when — compute HMAC with identical canonical structure but different keys
+    final var canonicalA = ctxA.fingerprint() + "|" + clusterId + "|" + timestamp;
+    final var canonicalB = ctxB.fingerprint() + "|" + clusterId + "|" + timestamp;
+
+    final var sigA = hmacSha256(licenseA, canonicalA);
+    final var sigB = hmacSha256(licenseB, canonicalB);
+
+    // then — different licenses produce different signatures even for the same timestamp
+    assertThat(sigA).isNotEqualTo(sigB);
+  }
+
+  @Test
+  void shouldRedactSensitiveFieldsInToString() {
+    // given
+    final var ctx = AnalyticsExporterContext.create("secret-license", "cluster-1", 1, "");
+
+    // then
+    assertThat(ctx.toString())
+        .contains("cluster-1")
+        .doesNotContain(ctx.fingerprint())
+        .doesNotContain("secret-license");
+  }
+
+  /** Independent HMAC computation for test verification — must match production algorithm. */
+  private static String hmacSha256(final String key, final String data) {
+    try {
+      final var mac = Mac.getInstance("HmacSHA256");
+      mac.init(new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+      return HexFormat.of().formatHex(mac.doFinal(data.getBytes(StandardCharsets.UTF_8)));
+    } catch (final Exception e) {
+      throw new AssertionError("HMAC computation failed", e);
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterDigestTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterDigestTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsExporterDigestTest {
+
+  @Test
+  void shouldProduceSameHashForIdenticalInput() {
+    // given
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new StubHandlerAlpha());
+    final var config = new AnalyticsExporterConfig().setSamplingRate(1.0);
+
+    // when
+    final var first = AnalyticsExporterDigest.compute(registry, config);
+    final var second = AnalyticsExporterDigest.compute(registry, config);
+
+    // then
+    assertThat(first).isEqualTo(second).hasSize(64);
+  }
+
+  @Test
+  void shouldProduceSameHashRegardlessOfRegistrationOrder() {
+    // given — same handlers registered in different orders
+    final var config = new AnalyticsExporterConfig();
+    final var registryA =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new StubHandlerAlpha())
+            .register(ValueType.USER_TASK, UserTaskIntent.CREATED, new StubHandlerBeta());
+    final var registryB =
+        new HandlerRegistry()
+            .register(ValueType.USER_TASK, UserTaskIntent.CREATED, new StubHandlerBeta())
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new StubHandlerAlpha());
+
+    // when / then
+    assertThat(AnalyticsExporterDigest.compute(registryA, config))
+        .isEqualTo(AnalyticsExporterDigest.compute(registryB, config));
+  }
+
+  @Test
+  void shouldProduceDifferentHashWhenHandlerIsAdded() {
+    // given
+    final var config = new AnalyticsExporterConfig();
+    final var registryA =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new StubHandlerAlpha());
+    final var registryB =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new StubHandlerAlpha())
+            .register(ValueType.USER_TASK, UserTaskIntent.CREATED, new StubHandlerBeta());
+
+    // when / then
+    assertThat(AnalyticsExporterDigest.compute(registryA, config))
+        .isNotEqualTo(AnalyticsExporterDigest.compute(registryB, config));
+  }
+
+  @Test
+  void shouldProduceDifferentHashWhenHandlerImplementationChanges() {
+    // given — two handlers registered at the same key but with different bytecodes
+    final var config = new AnalyticsExporterConfig();
+    final var registryA =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new StubHandlerAlpha());
+    final var registryB =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new StubHandlerBeta());
+
+    // when / then
+    assertThat(AnalyticsExporterDigest.compute(registryA, config))
+        .isNotEqualTo(AnalyticsExporterDigest.compute(registryB, config));
+  }
+
+  @Test
+  void shouldProduceDifferentHashWhenSamplingRateChanges() {
+    // given
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                new StubHandlerAlpha());
+    final var configA = new AnalyticsExporterConfig().setSamplingRate(1.0);
+    final var configB = new AnalyticsExporterConfig().setSamplingRate(0.5);
+
+    // when / then
+    assertThat(AnalyticsExporterDigest.compute(registry, configA))
+        .isNotEqualTo(AnalyticsExporterDigest.compute(registry, configB));
+  }
+
+  @Test
+  void shouldRejectLambdaHandler() {
+    // given — lambda handlers are synthetic and have no stable .class resource
+    final var config = new AnalyticsExporterConfig();
+    final AnalyticsHandler<RecordValue> lambdaHandler = record -> {};
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                lambdaHandler);
+
+    // when / then
+    assertThatThrownBy(() -> AnalyticsExporterDigest.compute(registry, config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("lambdas");
+  }
+
+  // Two concrete handler classes with different bytecodes to test implementation-change detection.
+  // They differ in their handle() body so the compiler produces distinct .class files.
+  private static final class StubHandlerAlpha implements AnalyticsHandler<RecordValue> {
+    @Override
+    public void handle(final Record<RecordValue> record) {}
+  }
+
+  private static final class StubHandlerBeta implements AnalyticsHandler<RecordValue> {
+    @Override
+    public void handle(final Record<RecordValue> record) {
+      // intentionally different body so javac produces different bytecode
+      final var unused = record.getPosition();
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterHeartbeatTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterHeartbeatTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.HEARTBEAT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.util.VersionUtil;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsExporterHeartbeatTest {
+
+  private InMemoryLogRecordExporter memoryExporter;
+  private ExporterTestController controller;
+  private AnalyticsExporter exporter;
+
+  @BeforeEach
+  void setUp() {
+    memoryExporter = InMemoryLogRecordExporter.create();
+    controller = new ExporterTestController();
+    exporter = openExporter(new AnalyticsExporterConfig(), memoryExporter, controller);
+  }
+
+  @Test
+  void shouldScheduleHeartbeatAtConfiguredInterval() {
+    final var heartbeatInterval = new AnalyticsExporterConfig().getHeartbeatInterval();
+    assertThat(controller.getScheduledTasks())
+        .anyMatch(task -> task.getDelay().equals(heartbeatInterval));
+  }
+
+  @Test
+  void shouldEmitHeartbeatWhenScheduledTaskFires() {
+    // when — advance time past the heartbeat interval
+    controller.runScheduledTasks(new AnalyticsExporterConfig().getHeartbeatInterval());
+
+    // then — the scheduled heartbeat fired with the expected attributes
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            log -> {
+              final var attrs = log.getAttributes().asMap();
+              assertThat(attrs)
+                  .containsEntry(AnalyticsAttributes.Event.NAME, HEARTBEAT)
+                  .containsEntry(
+                      AnalyticsAttributes.Heartbeat.BROKER_VERSION, VersionUtil.getVersion())
+                  .containsEntry(
+                      AnalyticsAttributes.Heartbeat.EXPORTER_VERSION,
+                      AnalyticsExporterVersion.get());
+            });
+  }
+
+  @Test
+  void shouldRescheduleHeartbeatRepeatedly() {
+    final var heartbeatInterval = new AnalyticsExporterConfig().getHeartbeatInterval();
+
+    // when — advance two interval ticks
+    controller.runScheduledTasks(heartbeatInterval);
+    controller.runScheduledTasks(heartbeatInterval);
+
+    // then — two scheduled fires
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .filteredOn(
+            log -> HEARTBEAT.equals(log.getAttributes().get(AnalyticsAttributes.Event.NAME)))
+        .hasSize(2);
+  }
+
+  @Test
+  void shouldCancelHeartbeatTaskOnClose() {
+    exporter.close();
+
+    assertThat(controller.getScheduledTasks()).allMatch(task -> task.isCanceled());
+  }
+
+  @Test
+  void shouldHonorCustomHeartbeatInterval() {
+    final var customController = new ExporterTestController();
+    openExporter(
+        new AnalyticsExporterConfig().setHeartbeatInterval("PT1M"),
+        InMemoryLogRecordExporter.create(),
+        customController);
+
+    assertThat(customController.getScheduledTasks())
+        .anyMatch(task -> task.getDelay().equals(Duration.ofMinutes(1)));
+  }
+
+  private static AnalyticsExporter openExporter(
+      final AnalyticsExporterConfig config,
+      final InMemoryLogRecordExporter memoryExporter,
+      final ExporterTestController controller) {
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(new ExporterTestConfiguration<>("analytics", config))
+            .setClusterId("test-cluster")
+            .setPartitionId(1)
+            .setLicenseKey("test-license-key");
+    final var exporter = new AnalyticsExporter(TestOtelSdkManager.inMemory(memoryExporter));
+    exporter.configure(context);
+    exporter.open(controller);
+    return exporter;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterHeartbeatTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterHeartbeatTest.java
@@ -18,7 +18,10 @@ import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
+@SetEnvironmentVariable(key = "CAMUNDA_LICENSE_KEY", value = "test-license-key")
+@SetEnvironmentVariable(key = "ZEEBE_BROKER_CLUSTER_CLUSTERID", value = "test-cluster")
 class AnalyticsExporterHeartbeatTest {
 
   private InMemoryLogRecordExporter memoryExporter;
@@ -101,9 +104,7 @@ class AnalyticsExporterHeartbeatTest {
     final var context =
         new ExporterTestContext()
             .setConfiguration(new ExporterTestConfiguration<>("analytics", config))
-            .setClusterId("test-cluster")
-            .setPartitionId(1)
-            .setLicenseKey("test-license-key");
+            .setPartitionId(1);
     final var exporter = new AnalyticsExporter(TestOtelSdkManager.inMemory(memoryExporter));
     exporter.configure(context);
     exporter.open(controller);

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterMetadataTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterMetadataTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AnalyticsExporterMetadataTest {
+
+  @Test
+  void shouldSerializeAndDeserializeAllFields() {
+    // given
+    final var metadata = new AnalyticsExporterMetadata(10, 42);
+
+    // when
+    final var restored = AnalyticsExporterMetadata.deserialize(metadata.serialize());
+
+    // then
+    assertThat(restored.getEventSequenceNumber()).isEqualTo(10);
+    assertThat(restored.getMetricSequenceNumber()).isEqualTo(42);
+  }
+
+  @Test
+  void shouldDeserializeMetadataWithoutMetricSequenceNumber() {
+    // given
+    final var oldMetadata = new AnalyticsExporterMetadata(5, 0);
+
+    // when
+    final var restored = AnalyticsExporterMetadata.deserialize(oldMetadata.serialize());
+
+    // then
+    assertThat(restored.getEventSequenceNumber()).isEqualTo(5);
+    assertThat(restored.getMetricSequenceNumber()).isZero();
+  }
+
+  @Test
+  void shouldIncrementMetricSequenceNumber() {
+    // given
+    final var metadata = new AnalyticsExporterMetadata(0, 10);
+
+    // when / then
+    assertThat(metadata.incrementAndGetMetricSequenceNumber()).isEqualTo(11);
+    assertThat(metadata.incrementAndGetMetricSequenceNumber()).isEqualTo(12);
+  }
+
+  @Test
+  void shouldNotBeDirtyOnConstruction() {
+    // given / when
+    final var metadata = new AnalyticsExporterMetadata();
+
+    // then
+    assertThat(metadata.isDirty()).isFalse();
+  }
+
+  @Test
+  void shouldBeDirtyAfterIncrementingEventSequenceNumber() {
+    // given
+    final var metadata = new AnalyticsExporterMetadata();
+
+    // when
+    metadata.incrementAndGetEventSequenceNumber();
+
+    // then
+    assertThat(metadata.isDirty()).isTrue();
+  }
+
+  @Test
+  void shouldBeDirtyAfterIncrementingMetricSequenceNumber() {
+    // given
+    final var metadata = new AnalyticsExporterMetadata();
+
+    // when
+    metadata.incrementAndGetMetricSequenceNumber();
+
+    // then
+    assertThat(metadata.isDirty()).isTrue();
+  }
+
+  @Test
+  void shouldNotBeDirtyAfterSerialize() {
+    // given
+    final var metadata = new AnalyticsExporterMetadata();
+    metadata.incrementAndGetEventSequenceNumber();
+    assertThat(metadata.isDirty()).isTrue();
+
+    // when
+    metadata.serialize();
+
+    // then
+    assertThat(metadata.isDirty()).isFalse();
+  }
+
+  @Test
+  void shouldNotBeDirtyAfterDeserialize() {
+    // given
+    final var original = new AnalyticsExporterMetadata(3, 7);
+    final var bytes = original.serialize();
+
+    // when
+    final var restored = AnalyticsExporterMetadata.deserialize(bytes);
+
+    // then — Jackson setters must not mark the restored object as dirty
+    assertThat(restored.isDirty()).isFalse();
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterOtelIT.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterOtelIT.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.HEARTBEAT;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_INSTANCE_CREATED;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * End-to-end tests: real exporter → real BatchLogRecordProcessor → real OTLP/HTTP → real OTel
+ * Collector. No mocks, no overrides — production code path.
+ */
+@Testcontainers
+class AnalyticsExporterOtelIT {
+
+  private static final int OTLP_PORT = 4318;
+  private static final List<String> COLLECTOR_LOGS = new CopyOnWriteArrayList<>();
+
+  @Container
+  private static final GenericContainer<?> OTEL_COLLECTOR =
+      new GenericContainer<>(
+              DockerImageName.parse("otel/opentelemetry-collector-contrib").withTag("latest"))
+          .withClasspathResourceMapping(
+              "otel-collector-config.yaml", "/etc/otelcol-contrib/config.yaml", BindMode.READ_ONLY)
+          .withLogConsumer(frame -> COLLECTOR_LOGS.add(frame.getUtf8String()))
+          .withExposedPorts(OTLP_PORT);
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  @BeforeEach
+  void clearLogs() {
+    COLLECTOR_LOGS.clear();
+  }
+
+  /**
+   * Heartbeat reaches the collector with the static cluster metadata attributes (broker / exporter
+   * version). The schema URL is delivered automatically via the instrumentation scope, so we don't
+   * attach it as a record attribute.
+   */
+  @Test
+  void shouldDeliverHeartbeatWithVersionAttributes() {
+    // given — short heartbeat interval so the scheduled task fires within the test
+    final var controller = new ExporterTestController();
+    final var exporter =
+        createExporter(
+            new AnalyticsExporterConfig()
+                .setEndpoint("http://localhost:" + OTEL_COLLECTOR.getMappedPort(OTLP_PORT))
+                .setHeartbeatInterval("PT1S"),
+            controller);
+
+    // when — fire the scheduled heartbeat task
+    controller.runScheduledTasks(Duration.ofSeconds(1));
+    exporter.close();
+
+    // then
+    awaitCollectorLogs(
+        HEARTBEAT,
+        AnalyticsAttributes.Heartbeat.BROKER_VERSION.getKey(),
+        AnalyticsAttributes.Heartbeat.EXPORTER_VERSION.getKey(),
+        // schema URL is part of the instrumentation scope, not a record attribute
+        "ScopeLogs SchemaURL: https://camunda.io/schemas/analytics/v1");
+  }
+
+  /** Events arrive at the collector with correct event name and attributes. */
+  @Test
+  void shouldDeliverEventsWithAttributes() {
+    // given
+    final var exporter = createExporter();
+
+    // when
+    exporter.export(piCreatedEvent());
+    exporter.close();
+
+    // then
+    awaitCollectorLogs(
+        PROCESS_INSTANCE_CREATED,
+        AnalyticsAttributes.CLUSTER_ID.getKey(),
+        "test-cluster",
+        AnalyticsAttributes.Process.BPMN_PROCESS_ID.getKey());
+  }
+
+  /**
+   * Events are delivered in batches, not individually. Sends 500 events with maxBatchSize=100, then
+   * asserts the collector received multiple batch exports containing multiple records each.
+   *
+   * <p>The collector's debug exporter logs each export as a "ResourceLog" block containing
+   * "LogRecord #N" entries. Multiple LogRecord entries in a single export prove batching.
+   */
+  @Test
+  void shouldBatchEventsBeforeExporting() {
+    // given — small batch size and fast push interval to force multiple batches
+    final var exporter =
+        createExporter(
+            new AnalyticsExporterConfig()
+                .setEndpoint("http://localhost:" + OTEL_COLLECTOR.getMappedPort(OTLP_PORT))
+                .setMaxBatchSize(100)
+                .setPushInterval("PT0.1S"));
+
+    // when — send 500 events (should produce ~5 batches of 100)
+    for (int i = 0; i < 500; i++) {
+      exporter.export(piCreatedEvent());
+    }
+    exporter.close();
+
+    // then — collector received multiple batch exports, each with multiple records
+    Awaitility.await("Collector should receive all events in batches")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              // Count the PI-created records specifically to avoid coupling to other event types.
+              final var piCreatedCount =
+                  COLLECTOR_LOGS.stream()
+                      .filter(l -> l.contains("Str(" + PROCESS_INSTANCE_CREATED + ")"))
+                      .count();
+              assertThat(piCreatedCount).isEqualTo(500);
+
+              // Count export calls (each starts a "ScopeLogs" block)
+              final var exportCount =
+                  COLLECTOR_LOGS.stream().filter(l -> l.contains("ScopeLogs #")).count();
+
+              // With batchSize=100 and 500 events, we expect ~5 exports (not 500)
+              assertThat(exportCount).isGreaterThan(1).isLessThanOrEqualTo(10);
+            });
+  }
+
+  // -- helpers --
+
+  private AnalyticsExporter createExporter() {
+    return createExporter(
+        new AnalyticsExporterConfig()
+            .setEndpoint("http://localhost:" + OTEL_COLLECTOR.getMappedPort(OTLP_PORT)));
+  }
+
+  private AnalyticsExporter createExporter(final AnalyticsExporterConfig config) {
+    return createExporter(config, new ExporterTestController());
+  }
+
+  private AnalyticsExporter createExporter(
+      final AnalyticsExporterConfig config, final ExporterTestController controller) {
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(new ExporterTestConfiguration<>("analytics-it", config))
+            .setClusterId("test-cluster")
+            .setPartitionId(1)
+            .setLicenseKey("it-test-license-key");
+    final var exporter = new AnalyticsExporter();
+    exporter.configure(context);
+    exporter.open(controller);
+    return exporter;
+  }
+
+  private void awaitCollectorLogs(final String... expectedSubstrings) {
+    Awaitility.await("OTel Collector should receive expected log content")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              for (final var expected : expectedSubstrings) {
+                assertThat(COLLECTOR_LOGS).anyMatch(line -> line.contains(expected));
+              }
+            });
+  }
+
+  private io.camunda.zeebe.protocol.record.Record<?> piCreatedEvent() {
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE_CREATION,
+        r -> r.withRecordType(RecordType.EVENT).withIntent(ProcessInstanceCreationIntent.CREATED));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterOtelIT.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterOtelIT.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -35,6 +36,8 @@ import org.testcontainers.utility.DockerImageName;
  * Collector. No mocks, no overrides — production code path.
  */
 @Testcontainers
+@SetEnvironmentVariable(key = "CAMUNDA_LICENSE_KEY", value = "it-test-license-key")
+@SetEnvironmentVariable(key = "ZEEBE_BROKER_CLUSTER_CLUSTERID", value = "test-cluster")
 class AnalyticsExporterOtelIT {
 
   private static final int OTLP_PORT = 4318;
@@ -164,9 +167,7 @@ class AnalyticsExporterOtelIT {
     final var context =
         new ExporterTestContext()
             .setConfiguration(new ExporterTestConfiguration<>("analytics-it", config))
-            .setClusterId("test-cluster")
-            .setPartitionId(1)
-            .setLicenseKey("it-test-license-key");
+            .setPartitionId(1);
     final var exporter = new AnalyticsExporter();
     exporter.configure(context);
     exporter.open(controller);

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -1,0 +1,430 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.ArrayList;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsExporterTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  private InMemoryLogRecordExporter memoryExporter;
+  private ExporterTestController controller;
+  private AnalyticsExporter exporter;
+
+  @BeforeEach
+  void setUp() {
+    memoryExporter = InMemoryLogRecordExporter.create();
+    controller = new ExporterTestController();
+    exporter = exporterWithInMemory(memoryExporter, controller);
+  }
+
+  @Test
+  void shouldRejectMissingLicenseKey() {
+    // given
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(
+                new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()));
+
+    // when / then
+    assertThatThrownBy(() -> new AnalyticsExporter().configure(context))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("CAMUNDA_LICENSE_KEY");
+  }
+
+  @Test
+  void shouldEmitLogRecordWithAllAttributes() {
+    // given
+    final var record = piCreatedEvent();
+
+    // when
+    exporter.export(record);
+
+    // then
+    final var value = (ProcessInstanceCreationRecordValue) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getSeverity()).isEqualTo(Severity.INFO);
+              assertThat(logRecord.getAttributes().asMap())
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME,
+                      AnalyticsAttributes.Event.PROCESS_INSTANCE_CREATED)
+                  .containsEntry(
+                      AnalyticsAttributes.Process.BPMN_PROCESS_ID, value.getBpmnProcessId())
+                  .containsEntry(AnalyticsAttributes.Process.VERSION, (long) value.getVersion())
+                  .containsEntry(
+                      AnalyticsAttributes.Process.DEFINITION_KEY, value.getProcessDefinitionKey())
+                  .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, record.getKey())
+                  .containsEntry(
+                      AnalyticsAttributes.Process.ROOT_INSTANCE_KEY,
+                      value.getRootProcessInstanceKey())
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, value.getTenantId())
+                  .containsEntry(AnalyticsAttributes.Log.POSITION, record.getPosition())
+                  .containsEntry(AnalyticsAttributes.Event.SEQUENCE_NUMBER, 1L);
+              assertThat(logRecord.getResource().getAttribute(AnalyticsAttributes.Exporter.DIGEST))
+                  .isNotNull()
+                  .isNotEmpty();
+            });
+  }
+
+  @Test
+  void shouldUpdatePositionForUnhandledEventType() {
+    // given
+    final var record =
+        FACTORY.generateRecord(ValueType.JOB, r -> r.withRecordType(RecordType.EVENT));
+
+    // when
+    exporter.export(record);
+
+    // then
+    assertThat(controller.getPosition()).isEqualTo(record.getPosition());
+    assertThat(memoryExporter.getFinishedLogRecordItems()).isEmpty();
+  }
+
+  @Test
+  void shouldEmitMultipleEventsInSequence() {
+    // given / when
+    final var positions = new ArrayList<Long>(10);
+    for (int i = 0; i < 10; i++) {
+      final var record = piCreatedEvent();
+      exporter.export(record);
+      positions.add(record.getPosition());
+    }
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems()).hasSize(10);
+    assertThat(controller.getPosition())
+        .isEqualTo(positions.stream().mapToLong(Long::longValue).max().orElseThrow());
+  }
+
+  @Test
+  void shouldContinueWhenHandlerThrows() {
+    // given
+    final var failController = new ExporterTestController();
+    final var failExporter = exporterWithThrowingOtel(failController);
+    final var record = piCreatedEvent();
+
+    // when / then — export must not propagate the exception
+    assertThatCode(() -> failExporter.export(record)).doesNotThrowAnyException();
+    assertThat(failController.getPosition()).isEqualTo(record.getPosition());
+  }
+
+  @Test
+  void shouldUpdatePositionForAllRecords() {
+    // given
+    final var record = FACTORY.generateRecord(ValueType.JOB);
+
+    // when
+    exporter.export(record);
+
+    // then
+    assertThat(controller.getPosition()).isEqualTo(record.getPosition());
+    assertThat(memoryExporter.getFinishedLogRecordItems()).isEmpty();
+  }
+
+  @Test
+  void shouldNotSerializeMetadataWhenHandlerNoOps() {
+    // given — a record that passes the AnalyticsRecordFilter but the handler skips because the
+    // element isn't an ad-hoc sub-process. This is the realistic hot-path no-op case.
+    final var value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .withBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                    .withValue(value));
+
+    // when
+    exporter.export(record);
+
+    // then — position advances but no metadata was written, because the handler didn't touch
+    // it so serializing again would be wasted work
+    assertThat(controller.getPosition()).isEqualTo(record.getPosition());
+    assertThat(controller.readMetadata()).isEmpty();
+  }
+
+  @Test
+  void shouldPersistMetadataWhenHandlerThrowsAfterMutation() {
+    // given — OtelSdkManager that increments the sequence number and then throws
+    final var throwingController = new ExporterTestController();
+    final var throwingExporter = exporterWithMutatingThrowingOtel(throwingController);
+    final var record = piCreatedEvent();
+
+    // when — export must not propagate the exception
+    assertThatCode(() -> throwingExporter.export(record)).doesNotThrowAnyException();
+
+    // then — metadata was persisted despite the exception, because the mutation happened before
+    // throw
+    assertThat(throwingController.readMetadata())
+        .isPresent()
+        .get()
+        .satisfies(
+            bytes -> {
+              final var persisted = AnalyticsExporterMetadata.deserialize(bytes);
+              assertThat(persisted.getEventSequenceNumber()).isEqualTo(1L);
+            });
+  }
+
+  @Test
+  void shouldPersistMetadataMutatedOutsideHandler() {
+    // given — a custom OtelSdkManager that exposes the metadata so the test can simulate a gauge
+    // flush callback (which bumps the metric sequence number outside the export path)
+    final var metricOnlyController = new ExporterTestController();
+    final var metadataHolder = new AnalyticsExporterMetadata[1];
+    final var metricOnlyExporter =
+        newExporter(
+            new OtelSdkManager() {
+              @Override
+              OtelSdkManager initialize(
+                  final AnalyticsExporterConfig cfg,
+                  final AnalyticsExporterContext ctx,
+                  final AnalyticsExporterMetadata meta,
+                  final io.micrometer.core.instrument.MeterRegistry registry) {
+                metadataHolder[0] = meta;
+                return this;
+              }
+
+              @Override
+              public void logEvent(
+                  final String eventName,
+                  final long logPosition,
+                  final Consumer<LogRecordBuilder> builder) {
+                // no-op — event logging is not under test here
+              }
+            },
+            metricOnlyController);
+
+    // Simulate the gauge flush callback bumping the metric sequence number outside the export path.
+    metadataHolder[0].incrementAndGetMetricSequenceNumber();
+
+    // when — export an unhandled record (no handler runs, but metadata is already dirty)
+    final var unhandledRecord = FACTORY.generateRecord(ValueType.JOB);
+    metricOnlyExporter.export(unhandledRecord);
+
+    // then — metadata was persisted because the metric seqnum was bumped outside the export path
+    assertThat(metricOnlyController.readMetadata())
+        .isPresent()
+        .get()
+        .satisfies(
+            bytes -> {
+              final var persisted = AnalyticsExporterMetadata.deserialize(bytes);
+              assertThat(persisted.getMetricSequenceNumber()).isEqualTo(1L);
+            });
+  }
+
+  @Test
+  void shouldInstallRecordFilterOnConfigure() {
+    // given
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(
+                new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()))
+            .setClusterId("test-cluster")
+            .setPartitionId(1)
+            .setLicenseKey("test-license-key");
+
+    // when
+    new AnalyticsExporter().configure(context);
+
+    // then
+    assertThat(context.getRecordFilter()).isNotNull().isInstanceOf(AnalyticsRecordFilter.class);
+  }
+
+  @Test
+  void shouldPersistSequenceNumberInMetadata() {
+    // given / when — use explicit increasing positions so the controller always persists metadata
+    exporter.export(piCreatedEvent(1L));
+    exporter.export(piCreatedEvent(2L));
+    exporter.export(piCreatedEvent(3L));
+
+    // then
+    assertThat(controller.readMetadata())
+        .isPresent()
+        .get()
+        .satisfies(
+            bytes -> {
+              final var metadata = AnalyticsExporterMetadata.deserialize(bytes);
+              assertThat(metadata.getEventSequenceNumber()).isEqualTo(3L);
+              // metricSequenceNumber is only incremented during metric flush (gauge callback),
+              // not during export(). Since no metric flush occurs here, it stays at 0.
+              assertThat(metadata.getMetricSequenceNumber()).isZero();
+            });
+  }
+
+  @Test
+  void shouldRestoreSequenceNumberFromMetadataOnOpen() {
+    // given — controller pre-seeded with persisted sequence number 5
+    final var seededController = new ExporterTestController();
+    seededController.updateLastExportedRecordPosition(
+        0L, new AnalyticsExporterMetadata(5L, 0).serialize());
+    final var freshMemoryExporter = InMemoryLogRecordExporter.create();
+    final var freshExporter = exporterWithInMemory(freshMemoryExporter, seededController);
+
+    // when
+    freshExporter.export(piCreatedEvent());
+
+    // then
+    assertThat(freshMemoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .extracting(log -> log.getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
+        .isEqualTo(6L);
+  }
+
+  @Test
+  void shouldEmitUserTaskCreatedEvent() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.USER_TASK,
+            r -> r.withRecordType(RecordType.EVENT).withIntent(UserTaskIntent.CREATED));
+
+    // when
+    exporter.export(record);
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Event.NAME))
+                  .isEqualTo(AnalyticsAttributes.Event.USER_TASK_CREATED);
+              assertThat(logRecord.getAttributes().get(AnalyticsAttributes.Log.POSITION))
+                  .isEqualTo(record.getPosition());
+            });
+  }
+
+  @Test
+  void shouldNotThrowOnCloseWhenNeverOpened() {
+    // given — exporter is configured but open() was never called, so controller is null
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(
+                new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()))
+            .setClusterId("test-cluster")
+            .setPartitionId(1)
+            .setLicenseKey("test-license-key");
+    final var unopenedExporter = new AnalyticsExporter();
+    unopenedExporter.configure(context);
+
+    // when / then — close must not throw even though controller is null
+    assertThatCode(unopenedExporter::close).doesNotThrowAnyException();
+  }
+
+  // -- helpers --
+
+  private static io.camunda.zeebe.protocol.record.Record<?> piCreatedEvent() {
+    return FACTORY.generateRecord(
+        ValueType.PROCESS_INSTANCE_CREATION,
+        r -> r.withRecordType(RecordType.EVENT).withIntent(ProcessInstanceCreationIntent.CREATED));
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record<?> piCreatedEvent(final long position) {
+    return FACTORY.generateRecord(
+        ValueType.PROCESS_INSTANCE_CREATION,
+        r ->
+            r.withRecordType(RecordType.EVENT)
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withPosition(position));
+  }
+
+  private static AnalyticsExporter exporterWithInMemory(
+      final InMemoryLogRecordExporter memoryExporter, final ExporterTestController controller) {
+    return newExporter(TestOtelSdkManager.inMemory(memoryExporter), controller);
+  }
+
+  private static AnalyticsExporter exporterWithThrowingOtel(
+      final ExporterTestController controller) {
+    return newExporter(
+        new OtelSdkManager() {
+          @Override
+          public void logEvent(
+              final String eventName,
+              final long logPosition,
+              final Consumer<LogRecordBuilder> builder) {
+            throw new RuntimeException("simulated failure");
+          }
+        },
+        controller);
+  }
+
+  /**
+   * Builds an exporter whose {@code OtelSdkManager.logEvent} increments the event sequence number
+   * (via the metadata reference captured during {@code initialize}) and then throws. This simulates
+   * a handler that mutates metadata and then fails mid-way.
+   */
+  private static AnalyticsExporter exporterWithMutatingThrowingOtel(
+      final ExporterTestController controller) {
+    final var metadataHolder = new AnalyticsExporterMetadata[1];
+    return newExporter(
+        new OtelSdkManager() {
+          @Override
+          OtelSdkManager initialize(
+              final AnalyticsExporterConfig cfg,
+              final AnalyticsExporterContext ctx,
+              final AnalyticsExporterMetadata meta,
+              final io.micrometer.core.instrument.MeterRegistry registry) {
+            metadataHolder[0] = meta;
+            return this;
+          }
+
+          @Override
+          public void logEvent(
+              final String eventName,
+              final long logPosition,
+              final Consumer<LogRecordBuilder> builder) {
+            metadataHolder[0].incrementAndGetEventSequenceNumber();
+            throw new RuntimeException("simulated failure after mutation");
+          }
+        },
+        controller);
+  }
+
+  private static AnalyticsExporter newExporter(
+      final OtelSdkManager otelSdkManager, final ExporterTestController controller) {
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(
+                new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()))
+            .setClusterId("test-cluster")
+            .setPartitionId(1)
+            .setLicenseKey("test-license-key");
+    final var exporter = new AnalyticsExporter(otelSdkManager);
+    exporter.configure(context);
+    exporter.open(controller);
+    return exporter;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
@@ -293,7 +294,10 @@ class AnalyticsExporterTest {
     final var record =
         FACTORY.generateRecord(
             ValueType.USER_TASK,
-            r -> r.withRecordType(RecordType.EVENT).withIntent(UserTaskIntent.CREATED));
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(UserTaskIntent.CREATED)
+                    .withKey(2251799813685248L));
 
     // when
     exporter.export(record);
@@ -325,12 +329,61 @@ class AnalyticsExporterTest {
     assertThatCode(unopenedExporter::close).doesNotThrowAnyException();
   }
 
+  @Test
+  void shouldHandleRecordFromLocalPartition() {
+    // given
+    final var record = piCreatedEvent();
+    final int partitionId = Protocol.decodePartitionId(record.getKey());
+
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(
+                new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()))
+            .setPartitionId(partitionId);
+    final var freshMemoryExporter = InMemoryLogRecordExporter.create();
+    final var freshExporter = exporterWithInMemory(freshMemoryExporter, controller);
+    freshExporter.configure(context);
+
+    // when
+    freshExporter.export(record);
+
+    // then
+    final var value = (ProcessInstanceCreationRecordValue) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems()).hasSize(0);
+  }
+
+  @Test
+  void shouldSkipRecordFromRemotePartition() {
+    // given
+    final var record = piCreatedEvent();
+    final int partitionId = Protocol.decodePartitionId(record.getKey());
+
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(
+                new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()))
+            .setPartitionId(partitionId + 1);
+    final var freshMemoryExporter = InMemoryLogRecordExporter.create();
+    final var freshExporter = exporterWithInMemory(freshMemoryExporter, controller);
+    freshExporter.configure(context);
+
+    // when
+    freshExporter.export(record);
+
+    // then
+    final var value = (ProcessInstanceCreationRecordValue) record.getValue();
+    assertThat(memoryExporter.getFinishedLogRecordItems()).hasSize(0);
+  }
+
   // -- helpers --
 
   private static io.camunda.zeebe.protocol.record.Record<?> piCreatedEvent() {
     return FACTORY.generateRecord(
         ValueType.PROCESS_INSTANCE_CREATION,
-        r -> r.withRecordType(RecordType.EVENT).withIntent(ProcessInstanceCreationIntent.CREATED));
+        r ->
+            r.withRecordType(RecordType.EVENT)
+                .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withKey(2251799813685248L)); // Must resolve to partition 1
   }
 
   private static io.camunda.zeebe.protocol.record.Record<?> piCreatedEvent(final long position) {
@@ -339,6 +392,7 @@ class AnalyticsExporterTest {
         r ->
             r.withRecordType(RecordType.EVENT)
                 .withIntent(ProcessInstanceCreationIntent.CREATED)
+                .withKey(2251799813685248L) // Must resolve to partition 1
                 .withPosition(position));
   }
 

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -9,7 +9,6 @@ package io.camunda.exporter.analytics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
@@ -30,7 +29,10 @@ import java.util.ArrayList;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
+@SetEnvironmentVariable(key = "CAMUNDA_LICENSE_KEY", value = "test-license-key")
+@SetEnvironmentVariable(key = "ZEEBE_BROKER_CLUSTER_CLUSTERID", value = "test-cluster")
 class AnalyticsExporterTest {
 
   private static final ProtocolFactory FACTORY = new ProtocolFactory();
@@ -44,20 +46,6 @@ class AnalyticsExporterTest {
     memoryExporter = InMemoryLogRecordExporter.create();
     controller = new ExporterTestController();
     exporter = exporterWithInMemory(memoryExporter, controller);
-  }
-
-  @Test
-  void shouldRejectMissingLicenseKey() {
-    // given
-    final var context =
-        new ExporterTestContext()
-            .setConfiguration(
-                new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()));
-
-    // when / then
-    assertThatThrownBy(() -> new AnalyticsExporter().configure(context))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("CAMUNDA_LICENSE_KEY");
   }
 
   @Test
@@ -253,9 +241,7 @@ class AnalyticsExporterTest {
         new ExporterTestContext()
             .setConfiguration(
                 new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()))
-            .setClusterId("test-cluster")
-            .setPartitionId(1)
-            .setLicenseKey("test-license-key");
+            .setPartitionId(1);
 
     // when
     new AnalyticsExporter().configure(context);
@@ -334,9 +320,7 @@ class AnalyticsExporterTest {
         new ExporterTestContext()
             .setConfiguration(
                 new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()))
-            .setClusterId("test-cluster")
-            .setPartitionId(1)
-            .setLicenseKey("test-license-key");
+            .setPartitionId(1);
     final var unopenedExporter = new AnalyticsExporter();
     unopenedExporter.configure(context);
 
@@ -419,9 +403,7 @@ class AnalyticsExporterTest {
         new ExporterTestContext()
             .setConfiguration(
                 new ExporterTestConfiguration<>("analytics", new AnalyticsExporterConfig()))
-            .setClusterId("test-cluster")
-            .setPartitionId(1)
-            .setLicenseKey("test-license-key");
+            .setPartitionId(1);
     final var exporter = new AnalyticsExporter(otelSdkManager);
     exporter.configure(context);
     exporter.open(controller);

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterTest.java
@@ -73,9 +73,6 @@ class AnalyticsExporterTest {
                   .containsEntry(
                       AnalyticsAttributes.Process.DEFINITION_KEY, value.getProcessDefinitionKey())
                   .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, record.getKey())
-                  .containsEntry(
-                      AnalyticsAttributes.Process.ROOT_INSTANCE_KEY,
-                      value.getRootProcessInstanceKey())
                   .containsEntry(AnalyticsAttributes.Tenant.ID, value.getTenantId())
                   .containsEntry(AnalyticsAttributes.Log.POSITION, record.getPosition())
                   .containsEntry(AnalyticsAttributes.Event.SEQUENCE_NUMBER, 1L);

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterVersionTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsExporterVersionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsExporterVersionTest {
+
+  @Test
+  void shouldResolveVersionFromFilteredProperties() throws IOException {
+    // given — read the same properties file the production code reads
+    final var props = new Properties();
+    try (final var in = getClass().getResourceAsStream("/analytics-exporter.properties")) {
+      assertThat(in).as("analytics-exporter.properties must be on the classpath").isNotNull();
+      props.load(in);
+    }
+    final var expected = props.getProperty("analytics-exporter.version");
+    assertThat(expected)
+        .as("Maven filtering should have substituted ${project.version}")
+        .isNotBlank()
+        .doesNotContain("${");
+
+    // then — production code returns the same value
+    assertThat(AnalyticsExporterVersion.get()).isEqualTo(expected);
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalogTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsHandlerCatalogTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AnalyticsHandlerCatalogTest {
+
+  @Test
+  void shouldRegisterAllExpectedHandlers() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var otelSdkManager = TestOtelSdkManager.inMemory(logExporter);
+
+    // when
+    final var registry = AnalyticsHandlerCatalog.build(otelSdkManager);
+
+    // then
+    assertThat(registry.registrations())
+        .containsExactlyInAnyOrder(
+            Map.entry(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.CREATED),
+            Map.entry(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            Map.entry(ValueType.USAGE_METRIC, UsageMetricIntent.EXPORTED),
+            Map.entry(ValueType.USER_TASK, UserTaskIntent.CREATED));
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class AnalyticsRecordFilterTest {
+
+  private static final int TEST_PARTITION_ID = 1;
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  private final AnalyticsRecordFilter filter =
+      new AnalyticsRecordFilter(
+          Set.of(
+              ValueType.PROCESS_INSTANCE_CREATION,
+              ValueType.PROCESS_INSTANCE,
+              ValueType.USAGE_METRIC),
+          Set.of(
+              ProcessInstanceCreationIntent.CREATED,
+              ProcessInstanceIntent.ELEMENT_ACTIVATED,
+              UsageMetricIntent.EXPORTED),
+          TEST_PARTITION_ID);
+
+  @Test
+  void shouldAcceptEventRecordType() {
+    assertThat(filter.acceptType(RecordType.EVENT)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = RecordType.class,
+      mode = EnumSource.Mode.EXCLUDE,
+      names = {"EVENT"})
+  void shouldRejectNonEventRecordType(final RecordType type) {
+    assertThat(filter.acceptType(type)).isFalse();
+  }
+
+  @Test
+  void shouldAcceptAllRegisteredValueTypes() {
+    assertThat(filter.acceptValue(ValueType.PROCESS_INSTANCE_CREATION)).isTrue();
+    assertThat(filter.acceptValue(ValueType.PROCESS_INSTANCE)).isTrue();
+    assertThat(filter.acceptValue(ValueType.USAGE_METRIC)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ValueType.class,
+      mode = EnumSource.Mode.EXCLUDE,
+      names = {"PROCESS_INSTANCE_CREATION", "PROCESS_INSTANCE", "USAGE_METRIC"})
+  void shouldRejectUnregisteredValueType(final ValueType type) {
+    assertThat(filter.acceptValue(type)).isFalse();
+  }
+
+  @Test
+  void shouldAcceptAllRegisteredIntents() {
+    assertThat(filter.acceptIntent(ProcessInstanceCreationIntent.CREATED)).isTrue();
+    assertThat(filter.acceptIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)).isTrue();
+    assertThat(filter.acceptIntent(UsageMetricIntent.EXPORTED)).isTrue();
+  }
+
+  @ParameterizedTest
+  @MethodSource("unregisteredIntents")
+  void shouldRejectUnregisteredIntent(final Intent intent) {
+    assertThat(filter.acceptIntent(intent)).isFalse();
+  }
+
+  private static Stream<Intent> unregisteredIntents() {
+    return Stream.of(
+        ProcessInstanceCreationIntent.CREATE,
+        ProcessInstanceIntent.ELEMENT_COMPLETING,
+        DeploymentIntent.CREATED);
+  }
+
+  @Test
+  void shouldAcceptRecordFromLocalPartition() {
+    // given
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE_CREATION,
+            r ->
+                r.withKey(Protocol.encodePartitionId(TEST_PARTITION_ID, 1))
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceCreationIntent.CREATED));
+
+    // when / then
+    assertThat(filter.acceptRecord(record)).isTrue();
+  }
+
+  @Test
+  void shouldRejectRecordFromRemotePartition() {
+    // given — key encodes partition 2, but exporter runs on partition 1
+    final int remotePartition = 2;
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE_CREATION,
+            r ->
+                r.withKey(Protocol.encodePartitionId(remotePartition, 1))
+                    .withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceCreationIntent.CREATED));
+
+    // when / then
+    assertThat(filter.acceptRecord(record)).isFalse();
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/AnalyticsRecordFilterTest.java
@@ -9,7 +9,6 @@ package io.camunda.exporter.analytics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
@@ -90,36 +89,5 @@ class AnalyticsRecordFilterTest {
         ProcessInstanceCreationIntent.CREATE,
         ProcessInstanceIntent.ELEMENT_COMPLETING,
         DeploymentIntent.CREATED);
-  }
-
-  @Test
-  void shouldAcceptRecordFromLocalPartition() {
-    // given
-    final var record =
-        FACTORY.generateRecord(
-            ValueType.PROCESS_INSTANCE_CREATION,
-            r ->
-                r.withKey(Protocol.encodePartitionId(TEST_PARTITION_ID, 1))
-                    .withRecordType(RecordType.EVENT)
-                    .withIntent(ProcessInstanceCreationIntent.CREATED));
-
-    // when / then
-    assertThat(filter.acceptRecord(record)).isTrue();
-  }
-
-  @Test
-  void shouldRejectRecordFromRemotePartition() {
-    // given — key encodes partition 2, but exporter runs on partition 1
-    final int remotePartition = 2;
-    final var record =
-        FACTORY.generateRecord(
-            ValueType.PROCESS_INSTANCE_CREATION,
-            r ->
-                r.withKey(Protocol.encodePartitionId(remotePartition, 1))
-                    .withRecordType(RecordType.EVENT)
-                    .withIntent(ProcessInstanceCreationIntent.CREATED));
-
-    // when / then
-    assertThat(filter.acceptRecord(record)).isFalse();
   }
 }

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerRegistryTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/HandlerRegistryTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class HandlerRegistryTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @Test
+  void shouldRouteToHandlerByValueTypeAndIntent() {
+    // given
+    final var handled = new AtomicBoolean(false);
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                record -> handled.set(true))
+            .apply(testContext());
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE_CREATION,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceCreationIntent.CREATED));
+
+    // when
+    registry.handle(record);
+
+    // then
+    assertThat(handled).isTrue();
+  }
+
+  @Test
+  void shouldNotRouteWhenIntentDoesNotMatch() {
+    // given
+    final var handled = new AtomicBoolean(false);
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                record -> handled.set(true))
+            .apply(testContext());
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    // when
+    registry.handle(record);
+
+    // then
+    assertThat(handled).isFalse();
+  }
+
+  @Test
+  void shouldSupportMultipleHandlersForSameValueType() {
+    // given
+    final var activatedHandled = new AtomicBoolean(false);
+    final var completedHandled = new AtomicBoolean(false);
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                record -> activatedHandled.set(true))
+            .register(
+                ValueType.PROCESS_INSTANCE,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                record -> completedHandled.set(true))
+            .apply(testContext());
+
+    final var activatedRecord =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED));
+    final var completedRecord =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    // when
+    registry.handle(activatedRecord);
+    registry.handle(completedRecord);
+
+    // then
+    assertThat(activatedHandled).isTrue();
+    assertThat(completedHandled).isTrue();
+  }
+
+  @Test
+  void shouldRejectDuplicateRegistration() {
+    // given
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED, record -> {});
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                registry.register(
+                    ValueType.PROCESS_INSTANCE,
+                    ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                    record -> {}))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Duplicate");
+  }
+
+  @Test
+  void shouldDoNothingForUnregisteredValueType() {
+    // given
+    final var registry = new HandlerRegistry().apply(testContext());
+
+    final var record = FACTORY.generateRecord(ValueType.JOB);
+
+    // when / then — no exception
+    registry.handle(record);
+  }
+
+  @Test
+  void shouldExposeRegisteredHandlers() {
+    // given
+    final var registry =
+        new HandlerRegistry()
+            .register(
+                ValueType.PROCESS_INSTANCE_CREATION,
+                ProcessInstanceCreationIntent.CREATED,
+                record -> {})
+            .register(ValueType.USER_TASK, UserTaskIntent.CREATED, record -> {});
+
+    // when
+    final var registered = registry.registeredHandlers();
+
+    // then
+    assertThat(registered).containsKey(ValueType.PROCESS_INSTANCE_CREATION);
+    assertThat(registered).containsKey(ValueType.USER_TASK);
+    assertThat(registered.get(ValueType.PROCESS_INSTANCE_CREATION))
+        .containsKey(ProcessInstanceCreationIntent.CREATED);
+    assertThat(registered.get(ValueType.USER_TASK)).containsKey(UserTaskIntent.CREATED);
+  }
+
+  private static ExporterTestContext testContext() {
+    return new ExporterTestContext()
+        .setConfiguration(new ExporterTestConfiguration<>("test", new AnalyticsExporterConfig()))
+        .setPartitionId(1);
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/ManualMetricReaderTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/ManualMetricReaderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ManualMetricReaderTest {
+
+  private final List<Collection<MetricData>> exported = new ArrayList<>();
+  private ManualMetricReader reader;
+  private LongCounter counter;
+
+  @BeforeEach
+  void setUp() {
+    final MetricExporter capturingExporter =
+        new MetricExporter() {
+          @Override
+          public CompletableResultCode export(final Collection<MetricData> metrics) {
+            exported.add(new ArrayList<>(metrics));
+            return CompletableResultCode.ofSuccess();
+          }
+
+          @Override
+          public CompletableResultCode flush() {
+            return CompletableResultCode.ofSuccess();
+          }
+
+          @Override
+          public CompletableResultCode shutdown() {
+            return CompletableResultCode.ofSuccess();
+          }
+
+          @Override
+          public AggregationTemporality getAggregationTemporality(
+              final InstrumentType instrumentType) {
+            return AggregationTemporalitySelector.deltaPreferred()
+                .getAggregationTemporality(instrumentType);
+          }
+        };
+
+    reader = new ManualMetricReader(capturingExporter);
+    final var provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+    counter = provider.get("test").counterBuilder("test.counter").build();
+  }
+
+  @Test
+  void shouldCollectAndExportMetrics() {
+    // given
+    counter.add(1, Attributes.empty());
+
+    // when
+    final var result = reader.collectAndExport();
+
+    // then
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(exported).hasSize(1);
+    assertThat(exported.get(0)).isNotEmpty();
+  }
+
+  @Test
+  void shouldSkipExportWhenNoMetrics() {
+    // when — no counter increments, but there may still be SDK-internal metrics
+    // collectAndExport returns success regardless
+    final var result = reader.collectAndExport();
+
+    // then
+    assertThat(result.isSuccess()).isTrue();
+  }
+
+  @Test
+  void shouldUseDeltaTemporality() {
+    assertThat(reader.getAggregationTemporality(InstrumentType.COUNTER))
+        .isEqualTo(AggregationTemporality.DELTA);
+    assertThat(reader.getAggregationTemporality(InstrumentType.HISTOGRAM))
+        .isEqualTo(AggregationTemporality.DELTA);
+  }
+
+  @Test
+  void shouldNotExportOnForceFlush() {
+    // given
+    counter.add(1, Attributes.empty());
+
+    // when
+    reader.forceFlush();
+
+    // then — no-op to prevent double-flush; final flush is driven by OtelSdkManager.close()
+    assertThat(exported).isEmpty();
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/MetricFlushBenchmark.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/MetricFlushBenchmark.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Worst-case benchmark for {@code collectAndExport()} with varying metric counts and high
+ * cardinality (1999 dimensions per metric — the SDK default limit).
+ *
+ * <p>Run: {@code mvn verify -pl zeebe/exporters/analytics-exporter -Dtest=MetricFlushBenchmark
+ * -DskipTests=false -Dbenchmark=true}
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(1)
+public class MetricFlushBenchmark {
+
+  private static final int DIMENSIONS_PER_METRIC = 1999;
+
+  private static final MetricExporter NOOP_EXPORTER =
+      new MetricExporter() {
+        @Override
+        public CompletableResultCode export(final Collection<MetricData> metrics) {
+          return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode flush() {
+          return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public CompletableResultCode shutdown() {
+          return CompletableResultCode.ofSuccess();
+        }
+
+        @Override
+        public AggregationTemporality getAggregationTemporality(
+            final InstrumentType instrumentType) {
+          return AggregationTemporalitySelector.deltaPreferred()
+              .getAggregationTemporality(instrumentType);
+        }
+      };
+
+  @Param({"1", "10", "50", "100", "1000"})
+  private int metricCount;
+
+  private ManualMetricReader reader;
+  private SdkMeterProvider provider;
+  private LongCounter[] counters;
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    reader = new ManualMetricReader(NOOP_EXPORTER);
+    provider = SdkMeterProvider.builder().registerMetricReader(reader).build();
+    final var meter = provider.get("bench");
+    counters = new LongCounter[metricCount];
+    for (int m = 0; m < metricCount; m++) {
+      counters[m] = meter.counterBuilder("metric." + m).build();
+    }
+    populateCounters();
+    reader.collectAndExport();
+  }
+
+  @Setup(Level.Iteration)
+  public void populateCounters() {
+    for (final LongCounter counter : counters) {
+      for (int d = 0; d < DIMENSIONS_PER_METRIC; d++) {
+        counter.add(
+            1,
+            Attributes.of(
+                AttributeKey.stringKey("process.id"), "process-" + d,
+                AttributeKey.longKey("version"), (long) (d % 10),
+                AttributeKey.stringKey("tenant"), "tenant-" + (d % 50)));
+      }
+    }
+  }
+
+  @Benchmark
+  public CompletableResultCode collectAndExport() {
+    return reader.collectAndExport();
+  }
+
+  @TearDown
+  public void tearDown() {
+    provider.shutdown();
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "benchmark", matches = "true")
+  void runBenchmarks() throws Exception {
+    final var options =
+        new org.openjdk.jmh.runner.options.OptionsBuilder()
+            .include(MetricFlushBenchmark.class.getSimpleName())
+            .warmupIterations(3)
+            .measurementIterations(5)
+            .forks(0)
+            .build();
+    new org.openjdk.jmh.runner.Runner(options).run();
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/MetricWindowTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/MetricWindowTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MAX;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MIN;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_END;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_START;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.SEQUENCE_NUMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MetricWindowTest {
+
+  @Test
+  void shouldTrackSingleEvent() {
+    // given
+    final var window = new MetricWindow();
+
+    // when
+    window.record(100L, 5000L);
+
+    // then
+    assertThat(window.hasEvents()).isTrue();
+    assertThat(window.eventCount()).isEqualTo(1);
+    final var attrs = window.toGaugeAttributes(42L);
+    assertThat(attrs.get(SEQUENCE_NUMBER)).isEqualTo(42L);
+    // event_count is the gauge value, not an attribute
+    assertThat(attrs.get(POSITION_START)).isEqualTo(100L);
+    assertThat(attrs.get(POSITION_END)).isEqualTo(100L);
+    assertThat(attrs.get(TIME_MIN)).isEqualTo(5000L);
+    assertThat(attrs.get(TIME_MAX)).isEqualTo(5000L);
+  }
+
+  @Test
+  void shouldTrackMinMaxAcrossMultipleEvents() {
+    // given
+    final var window = new MetricWindow();
+
+    // when
+    window.record(200L, 6000L);
+    window.record(100L, 5000L);
+    window.record(300L, 7000L);
+
+    // then
+    assertThat(window.eventCount()).isEqualTo(3);
+    final var attrs = window.toGaugeAttributes(1L);
+    assertThat(attrs.get(POSITION_START)).isEqualTo(100L);
+    assertThat(attrs.get(POSITION_END)).isEqualTo(300L);
+    assertThat(attrs.get(TIME_MIN)).isEqualTo(5000L);
+    assertThat(attrs.get(TIME_MAX)).isEqualTo(7000L);
+  }
+
+  @Test
+  void shouldResetToEmptyState() {
+    // given
+    final var window = new MetricWindow();
+    window.record(100L, 5000L);
+
+    // when
+    window.reset();
+
+    // then
+    assertThat(window.hasEvents()).isFalse();
+    assertThat(window.eventCount()).isZero();
+  }
+
+  @Test
+  void shouldTrackCorrectlyAfterReset() {
+    // given
+    final var window = new MetricWindow();
+    window.record(100L, 5000L);
+    window.reset();
+
+    // when
+    window.record(500L, 9000L);
+
+    // then
+    assertThat(window.eventCount()).isEqualTo(1);
+    final var attrs = window.toGaugeAttributes(2L);
+    assertThat(attrs.get(POSITION_START)).isEqualTo(500L);
+    assertThat(attrs.get(POSITION_END)).isEqualTo(500L);
+    assertThat(attrs.get(TIME_MIN)).isEqualTo(9000L);
+    assertThat(attrs.get(TIME_MAX)).isEqualTo(9000L);
+  }
+
+  @Test
+  void shouldReportEmptyBeforeAnyRecords() {
+    // given
+    final var window = new MetricWindow();
+
+    // then
+    assertThat(window.hasEvents()).isFalse();
+    assertThat(window.eventCount()).isZero();
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/MicrometerMeterProviderBenchmark.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/MicrometerMeterProviderBenchmark.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmarks the hot-path cost of {@link MicrometerMeterProvider} counter recording.
+ *
+ * <p>Two attribute scenarios expose qualitatively different code paths:
+ *
+ * <ul>
+ *   <li>Empty attributes — the real hot path ({@code otel.sdk.log.created} carries no attributes).
+ *       After the first call the Counter is cached; subsequent calls cost one ConcurrentHashMap.get
+ *       + DoubleAdder.add with no allocation.
+ *   <li>N attributes — worst-case allocation path: {@code toMicrometerTags()} builds an ArrayList +
+ *       Tags + String[] on every call before the ConcurrentHashMap lookup. The Counter itself is
+ *       still cached after the first call per unique tag set.
+ * </ul>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@State(Scope.Benchmark)
+public class MicrometerMeterProviderBenchmark {
+
+  @Param({"0", "5", "20"})
+  int attrCount;
+
+  private LongCounter noopCounter;
+  private LongCounter bridgeCounter;
+  private Attributes attrs;
+
+  @Setup
+  public void setup() {
+    noopCounter = OpenTelemetry.noop().getMeter("noop").counterBuilder("test").build();
+    bridgeCounter =
+        new MicrometerMeterProvider(new SimpleMeterRegistry())
+            .meterBuilder("test")
+            .build()
+            .counterBuilder("otel.sdk.log.created")
+            .build();
+    final AttributesBuilder b = Attributes.builder();
+    for (int i = 0; i < attrCount; i++) {
+      b.put("key." + i, "value" + i);
+    }
+    attrs = b.build();
+  }
+
+  @Benchmark
+  public void measureNoopCounter() {
+    noopCounter.add(1, attrs);
+  }
+
+  @Benchmark
+  public void measureBridgeCounter() {
+    bridgeCounter.add(1, attrs);
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/MicrometerMeterProviderTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/MicrometerMeterProviderTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static io.camunda.exporter.analytics.MicrometerMeterProvider.COMPONENT_TAG_KEY;
+import static io.camunda.exporter.analytics.MicrometerMeterProvider.COMPONENT_TAG_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.within;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MicrometerMeterProviderTest {
+
+  private SimpleMeterRegistry registry;
+  private MicrometerMeterProvider bridge;
+
+  @BeforeEach
+  void setUp() {
+    registry = new SimpleMeterRegistry();
+    bridge = new MicrometerMeterProvider(registry);
+  }
+
+  @Test
+  void shouldIncrementMicrometerCounterWhenOtelCounterAdds() {
+    // given
+    final var counter = bridge.get("test").counterBuilder("test.counter").build();
+
+    // when
+    counter.add(3, Attributes.empty());
+
+    // then
+    assertThat(registry.find("test.counter").counter()).isNotNull();
+    assertThat(registry.find("test.counter").counter().count()).isEqualTo(3.0);
+  }
+
+  @Test
+  void shouldIncludeOtelAttributesAsMicrometerTags() {
+    // given
+    final var counter = bridge.get("test").counterBuilder("test.counter").build();
+
+    // when
+    counter.add(1, Attributes.of(AttributeKey.stringKey("error.type"), "queue_full"));
+
+    // then — dot in key is sanitized to underscore for Prometheus compatibility
+    assertThat(registry.find("test.counter").tag("error_type", "queue_full").counter()).isNotNull();
+  }
+
+  @Test
+  void shouldTagAllMetersWithComponentOrigin() {
+    // given
+    final var counter = bridge.get("test").counterBuilder("test.counter").build();
+
+    // when
+    counter.add(1, Attributes.empty());
+
+    // then
+    assertThat(
+            registry
+                .find("test.counter")
+                .tag(
+                    MicrometerMeterProvider.COMPONENT_TAG_KEY,
+                    MicrometerMeterProvider.COMPONENT_TAG_VALUE)
+                .counter())
+        .isNotNull()
+        .extracting(io.micrometer.core.instrument.Counter::count)
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void shouldUpdateGaugeWhenUpDownCounterAdds() {
+    // given
+    final var upDown = bridge.get("test").upDownCounterBuilder("test.queue").build();
+
+    // when
+    upDown.add(10, Attributes.empty());
+
+    // then
+    assertThat(registry.find("test.queue").gauge()).isNotNull();
+    assertThat(registry.find("test.queue").gauge().value()).isEqualTo(10.0);
+  }
+
+  @Test
+  void shouldReuseCounterAcrossMultipleAdds() {
+    // given
+    final var counter = bridge.get("test").counterBuilder("calls.total").build();
+
+    // when
+    counter.add(1, Attributes.empty());
+    counter.add(1, Attributes.empty());
+    counter.add(1, Attributes.empty());
+
+    // then — one Counter registered (not three), count = 3
+    assertThat(registry.find("calls.total").counters()).hasSize(1);
+    assertThat(registry.find("calls.total").counter().count()).isEqualTo(3.0);
+  }
+
+  @Test
+  void shouldRegisterGaugeThatEvaluatesCallbackAtScrapeTime() {
+    // given
+    bridge
+        .get("test")
+        .upDownCounterBuilder("test.queue.size")
+        .buildWithCallback(measurement -> measurement.record(42L, Attributes.empty()));
+
+    // when — read the gauge value (simulates Prometheus scrape)
+    final var gauge = registry.find("test.queue.size").gauge();
+
+    // then
+    assertThat(gauge).isNotNull();
+    assertThat(gauge.value()).isEqualTo(42.0);
+  }
+
+  @Test
+  void shouldRecordHistogramAsTimerWithSecondsToNanosConversion() {
+    // given
+    final var histogram = bridge.get("test").histogramBuilder("export.duration").build();
+
+    // when — record 1 ms expressed as seconds
+    histogram.record(0.001, Attributes.empty());
+
+    // then — value stored as nanoseconds in the Timer
+    final var timer = registry.find("export.duration").timer();
+    assertThat(timer).isNotNull();
+    assertThat(timer.totalTime(TimeUnit.MILLISECONDS)).isCloseTo(1.0, within(0.01));
+  }
+
+  @Test
+  void shouldRegisterSeparateGaugesForEachAttributeSetInCallback() {
+    // given
+    final var key = AttributeKey.stringKey("host");
+    bridge
+        .get("test")
+        .upDownCounterBuilder("queue.size")
+        .buildWithCallback(
+            measurement -> {
+              measurement.record(10L);
+              measurement.record(20L, Attributes.of(key, "broker-1"));
+            });
+
+    // when — reading the default gauge fires the callback, lazily registering host gauge
+    final var defaultGauge =
+        registry.find("queue.size").tag(COMPONENT_TAG_KEY, COMPONENT_TAG_VALUE).gauge();
+    assertThat(defaultGauge).isNotNull();
+    defaultGauge.value(); // drives callback
+
+    // then — a second gauge for host=broker-1 must have been registered
+    final var hostGauge = registry.find("queue.size").tag("host", "broker-1").gauge();
+    assertThat(hostGauge).isNotNull();
+    assertThat(hostGauge.value()).isEqualTo(20.0);
+    assertThat(defaultGauge.value()).isEqualTo(10.0);
+  }
+
+  @Test
+  void shouldNotPropagateExceptionFromThrowingRegistry() {
+    // given — a registry whose counter increment always throws
+    final var throwingRegistry = new SimpleMeterRegistry();
+    final var provider = new MicrometerMeterProvider(throwingRegistry);
+    final var counter = provider.get("test").counterBuilder("x").build();
+    // Remove the underlying counter so the next computeIfAbsent triggers registration;
+    // verify that even if something fails internally the bridge swallows it gracefully.
+    // We exercise the try-catch by calling add on a fresh counter — no exception must escape.
+
+    // when / then — must not throw
+    assertThatCode(() -> counter.add(1, Attributes.empty())).doesNotThrowAnyException();
+  }
+
+  @Test
+  void shouldShareCounterBetweenNoArgAddAndEmptyAttrsAdd() {
+    // given
+    final var counter = bridge.get("test").counterBuilder("calls").build();
+
+    // when
+    counter.add(1);
+    counter.add(1, Attributes.empty());
+
+    // then — same counter, total = 2
+    assertThat(registry.find("calls").counters()).hasSize(1);
+    assertThat(registry.find("calls").tag(COMPONENT_TAG_KEY, COMPONENT_TAG_VALUE).counter().count())
+        .isEqualTo(2.0);
+  }
+
+  @Test
+  void shouldCreateSeparateCountersForDistinctAttributeSets() {
+    // given
+    final var counter = bridge.get("test").counterBuilder("calls").build();
+    final var key = AttributeKey.stringKey("result");
+
+    // when
+    counter.add(1, Attributes.of(key, "ok"));
+    counter.add(1, Attributes.of(key, "error"));
+
+    // then — two distinct counters
+    assertThat(registry.find("calls").counters()).hasSize(2);
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/OtelSdkManagerTest.java
@@ -1,0 +1,671 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.SAMPLE_RATE;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MAX;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Event.TIME_MIN;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_END;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Log.POSITION_START;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.EXPORT_WINDOW;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Metric.SEQUENCE_NUMBER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.exporter.analytics.sampling.HashSampler;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests the OtelSdkManager contract: logEvent() never blocks, events are delivered end-to-end,
+ * pipeline recovers from failures, and shutdown is safe.
+ *
+ * <p>Uses BatchLogRecordProcessor (the production pipeline) with a swapped transport. Tests that
+ * need deterministic failure semantics (no retry) are noted.
+ */
+class OtelSdkManagerTest {
+
+  /** logEvent() returns immediately even when the export pipeline is completely stalled. */
+  @Test
+  @Timeout(10)
+  void shouldNotBlockWhenQueueIsFullAndDropEvents() {
+    // given — tiny queue (4), exporter blocks until we release the latch
+    final var exportStarted = new CountDownLatch(1);
+    final var releaseLatch = new CountDownLatch(1);
+    final var received = new AtomicInteger(0);
+    final var manager =
+        initManager(
+            logs -> {
+              received.addAndGet(logs.size());
+              exportStarted.countDown();
+              try {
+                releaseLatch.await();
+              } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              return CompletableResultCode.ofSuccess();
+            },
+            4,
+            2);
+
+    // when — flood 100 events; @Timeout kills the test if logEvent ever blocks
+    for (int i = 0; i < 100; i++) {
+      manager.logEvent("test", 0L, log -> {});
+    }
+
+    // then — wait for the exporter to confirm it started, then verify drops
+    try {
+      exportStarted.await();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    assertThat(received.get()).isLessThan(100);
+
+    releaseLatch.countDown();
+    manager.close();
+  }
+
+  /** Real OTLP transport to a refused port doesn't block or throw. */
+  @Test
+  @Timeout(10)
+  void shouldHandleUnreachableEndpoint() {
+    // given — localhost:1 gives an immediate connection refused (fast, no TCP timeout)
+    final var manager =
+        new OtelSdkManager()
+            .initialize(
+                new AnalyticsExporterConfig().setEndpoint("http://localhost:1"),
+                AnalyticsExporterContext.create("test-license", "test-cluster", 1, ""),
+                new AnalyticsExporterMetadata());
+
+    // when — @Timeout is the assertion: if logEvent blocks, we die
+    for (int i = 0; i < 10; i++) {
+      manager.logEvent("test", 0L, log -> {});
+    }
+
+    manager.close();
+  }
+
+  /** Events sent via logEvent() arrive at the exporter. */
+  @Test
+  @Timeout(30)
+  void shouldDeliverEventsToExporter() {
+    // given
+    final var received = new AtomicInteger(0);
+    final var manager =
+        initManager(
+            logs -> {
+              received.addAndGet(logs.size());
+              return CompletableResultCode.ofSuccess();
+            },
+            2048,
+            512);
+
+    // when
+    for (int i = 0; i < 50; i++) {
+      manager.logEvent("test", 0L, log -> {});
+    }
+    manager.close();
+
+    // then — all 50 delivered
+    assertThat(received.get()).isEqualTo(50);
+  }
+
+  /** Shutdown flushes pending events that haven't been exported yet. */
+  @Test
+  @Timeout(30)
+  void shouldFlushOnShutdown() {
+    // given — slow exporter ensures events are still in-flight when shutdown is called
+    final var received = new AtomicInteger(0);
+    final var manager =
+        initManager(
+            logs -> {
+              received.addAndGet(logs.size());
+              try {
+                Thread.sleep(50);
+              } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+              return CompletableResultCode.ofSuccess();
+            },
+            2048,
+            512);
+
+    // when — send events, then immediately shutdown
+    for (int i = 0; i < 20; i++) {
+      manager.logEvent("test", 0L, log -> {});
+    }
+    manager.close();
+
+    // then — shutdown waited for the slow exporter to drain
+    assertThat(received.get()).isEqualTo(20);
+  }
+
+  /**
+   * Pipeline drops events during failure and delivers new events after recovery.
+   *
+   * <p>Note: this test uses a failing exporter where BatchLogRecordProcessor may retry failed
+   * batches. We assert that post-recovery events ARE delivered. We don't assert that failure-phase
+   * events are absent — with retry, some may eventually succeed. The key contract is: recovery
+   * works, new events flow.
+   */
+  @Test
+  @Timeout(30)
+  void shouldDeliverEventsAfterRecovery() {
+    // given — exporter that fails initially, then recovers
+    final var failing = new AtomicBoolean(true);
+    final var receivedEventNames = new CopyOnWriteArrayList<String>();
+    final var manager =
+        initManager(
+            logs -> {
+              if (failing.get()) {
+                return CompletableResultCode.ofFailure();
+              }
+              logs.forEach(
+                  l ->
+                      receivedEventNames.add(
+                          l.getAttributes().get(AnalyticsAttributes.Event.NAME)));
+              return CompletableResultCode.ofSuccess();
+            },
+            2048,
+            512);
+
+    // when — send events during failure
+    for (int i = 0; i < 10; i++) {
+      manager.logEvent("during_failure", 0L, log -> {});
+    }
+
+    // recover, then send more and flush
+    failing.set(false);
+    for (int i = 0; i < 5; i++) {
+      manager.logEvent("after_recovery", 0L, log -> {});
+    }
+    manager.close();
+
+    // then — post-recovery events arrived
+    assertThat(receivedEventNames).contains("after_recovery");
+  }
+
+  /** Each logEvent() call increments the sequence number by one. */
+  @Test
+  void shouldIncrementSequenceNumberWithEachLogEvent() {
+    // given
+    final var received = new CopyOnWriteArrayList<LogRecordData>();
+    final var manager =
+        initManager(
+            logs -> {
+              received.addAll(logs);
+              return CompletableResultCode.ofSuccess();
+            },
+            2048,
+            512);
+
+    // when
+    manager.logEvent("test", 0L, log -> {});
+    manager.logEvent("test", 0L, log -> {});
+    manager.logEvent("test", 0L, log -> {});
+    manager.close();
+
+    // then
+    assertThat(received).hasSize(3);
+    assertThat(received.get(0).getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
+        .isEqualTo(1L);
+    assertThat(received.get(1).getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
+        .isEqualTo(2L);
+    assertThat(received.get(2).getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
+        .isEqualTo(3L);
+  }
+
+  /** The sequence number continues from the initial value provided at initialization. */
+  @Test
+  void shouldInitializeSequenceNumberFromGivenValue() {
+    // given — manager initialized with sequence number 5
+    final var received = new CopyOnWriteArrayList<LogRecordData>();
+    final var manager =
+        new OtelSdkManager() {
+          @Override
+          protected LogRecordExporter createLogExporter(
+              final AnalyticsExporterConfig cfg,
+              final AnalyticsExporterContext context,
+              final MicrometerMeterProvider bridge) {
+            return exporterFrom(
+                logs -> {
+                  received.addAll(logs);
+                  return CompletableResultCode.ofSuccess();
+                });
+          }
+        }.initialize(
+            new AnalyticsExporterConfig().setPushInterval("PT0.1S"),
+            AnalyticsExporterContext.create("test-license", "test-cluster", 1, ""),
+            new AnalyticsExporterMetadata(5L, 0));
+
+    // when
+    manager.logEvent("test", 0L, log -> {});
+    manager.close();
+
+    // then — sequence continues from 5, so first event gets 6
+    assertThat(received)
+        .singleElement()
+        .extracting(log -> log.getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
+        .isEqualTo(6L);
+  }
+
+  /** logEvent() and shutdown() are safe to call after shutdown (idempotent, no NPE). */
+  @Test
+  void shouldHandlePostShutdownCallsGracefully() {
+    // given
+    final var manager = initManager(logs -> CompletableResultCode.ofSuccess(), 2048, 512);
+    manager.close();
+
+    // when / then
+    assertThatCode(() -> manager.logEvent("post_shutdown", 0L, log -> {}))
+        .doesNotThrowAnyException();
+    assertThatCode(manager::close).doesNotThrowAnyException();
+  }
+
+  // -- helpers --
+
+  private static OtelSdkManager initManager(
+      final Function<Collection<LogRecordData>, CompletableResultCode> exportFn,
+      final int maxQueueSize,
+      final int maxBatchSize) {
+    return new OtelSdkManager() {
+      @Override
+      protected LogRecordExporter createLogExporter(
+          final AnalyticsExporterConfig cfg,
+          final AnalyticsExporterContext context,
+          final MicrometerMeterProvider bridge) {
+        return exporterFrom(exportFn);
+      }
+    }.initialize(
+        new AnalyticsExporterConfig()
+            .setMaxQueueSize(maxQueueSize)
+            .setMaxBatchSize(maxBatchSize)
+            .setPushInterval("PT0.1S"),
+        AnalyticsExporterContext.create("test-license", "test-cluster", 1, ""),
+        new AnalyticsExporterMetadata());
+  }
+
+  private static LogRecordExporter exporterFrom(
+      final Function<Collection<LogRecordData>, CompletableResultCode> exportFn) {
+    return new LogRecordExporter() {
+      @Override
+      public CompletableResultCode export(final Collection<LogRecordData> logs) {
+        return exportFn.apply(logs);
+      }
+
+      @Override
+      public CompletableResultCode flush() {
+        return CompletableResultCode.ofSuccess();
+      }
+
+      @Override
+      public CompletableResultCode shutdown() {
+        return CompletableResultCode.ofSuccess();
+      }
+    };
+  }
+
+  @Test
+  void shouldExposeOtelSdkLogCreatedMetricInMicrometer() {
+    // given
+    final var micrometerRegistry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    final var logExporter =
+        io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter.create();
+    final var manager = TestOtelSdkManager.inMemoryWithRegistry(logExporter, micrometerRegistry);
+
+    try {
+      // when — otel.sdk.log.created increments synchronously on emit(), no flush needed
+      manager.logEvent(
+          io.camunda.exporter.analytics.AnalyticsAttributes.Event.PROCESS_INSTANCE_CREATED,
+          1L,
+          b -> {});
+
+      // then — SdkLoggerProvider emits otel.sdk.log.created on every emit()
+      assertThat(
+              micrometerRegistry
+                  .find("otel.sdk.log.created")
+                  .tag(
+                      MicrometerMeterProvider.COMPONENT_TAG_KEY,
+                      MicrometerMeterProvider.COMPONENT_TAG_VALUE)
+                  .counter())
+          .isNotNull()
+          .extracting(io.micrometer.core.instrument.Counter::count)
+          .isEqualTo(1.0);
+    } finally {
+      manager.close();
+    }
+  }
+
+  @Nested
+  class Sampling {
+
+    private InMemoryLogRecordExporter logExporter;
+    private OtelSdkManager manager;
+
+    @BeforeEach
+    void setUp() {
+      logExporter = InMemoryLogRecordExporter.create();
+      manager = TestOtelSdkManager.inMemory(logExporter);
+    }
+
+    @Test
+    void shouldSkipEventWhenSamplingDecisionRejects() {
+      // given — rate 0.0 rejects all positions
+      // when
+      manager.logEvent("test", 42L, 0.0, log -> {});
+
+      // then — no log record emitted, sequence number not incremented
+      assertThat(logExporter.getFinishedLogRecordItems()).isEmpty();
+    }
+
+    @Test
+    void shouldEmitEventWhenSamplingDecisionAccepts() {
+      // given — rate 1.0 accepts all positions
+      // when
+      manager.logEvent("test", 42L, HashSampler.MAX_SAMPLE_RATE, log -> {});
+
+      // then
+      assertThat(logExporter.getFinishedLogRecordItems()).hasSize(1);
+    }
+
+    @Test
+    void shouldNotIncrementSequenceNumberWhenEventIsDropped() {
+      // given — rate 0.0 drops everything
+      manager.logEvent("test", 1L, 0.0, log -> {});
+      manager.logEvent("test", 2L, 0.0, log -> {});
+
+      // when — emit one with full rate
+      manager.logEvent("test", 3L, HashSampler.MAX_SAMPLE_RATE, log -> {});
+
+      // then — sequence number is 1 (not 3), proving drops don't consume slots
+      assertThat(logExporter.getFinishedLogRecordItems())
+          .singleElement()
+          .extracting(log -> log.getAttributes().get(AnalyticsAttributes.Event.SEQUENCE_NUMBER))
+          .isEqualTo(1L);
+    }
+
+    @Test
+    void shouldEmitSampleRateAttributeWhenRateBelowMax() {
+      // given — find a position that passes at rate 0.5
+      long passingPosition = -1L;
+      for (long pos = 0; pos < 1000; pos++) {
+        if (HashSampler.shouldSample(pos, 0.5)) {
+          passingPosition = pos;
+          break;
+        }
+      }
+      assertThat(passingPosition).isGreaterThanOrEqualTo(0L);
+
+      // when
+      manager.logEvent("test", passingPosition, 0.5, log -> {});
+
+      // then — sample_rate attribute is set
+      assertThat(logExporter.getFinishedLogRecordItems())
+          .singleElement()
+          .extracting(log -> log.getAttributes().get(SAMPLE_RATE))
+          .isEqualTo(0.5);
+    }
+
+    @Test
+    void shouldNotEmitSampleRateAttributeWhenRateIsMax() {
+      // when — default logEvent (no rate param)
+      manager.logEvent("test", 42L, log -> {});
+
+      // then — sample_rate attribute is absent
+      assertThat(logExporter.getFinishedLogRecordItems())
+          .singleElement()
+          .satisfies(log -> assertThat(log.getAttributes().get(SAMPLE_RATE)).isNull());
+    }
+
+    @Test
+    void shouldApplyMinOfDefaultAndHandlerRate() {
+      // given — default rate 0.5 via config, handler rate 0.8 → effective is 0.5
+      final var customLogExporter = InMemoryLogRecordExporter.create();
+      final var customManager =
+          TestOtelSdkManager.inMemory(
+              customLogExporter, new AnalyticsExporterConfig().setSamplingRate(0.5));
+
+      // find a position that passes at 0.5
+      long passingPosition = -1L;
+      for (long pos = 0; pos < 1000; pos++) {
+        if (HashSampler.shouldSample(pos, 0.5)) {
+          passingPosition = pos;
+          break;
+        }
+      }
+      assertThat(passingPosition).isGreaterThanOrEqualTo(0L);
+
+      // when — handler requests 0.8, but default is 0.5
+      customManager.logEvent("test", passingPosition, 0.8, log -> {});
+
+      // then — effective rate 0.5 is used (attribute reflects the min)
+      assertThat(customLogExporter.getFinishedLogRecordItems())
+          .singleElement()
+          .extracting(log -> log.getAttributes().get(SAMPLE_RATE))
+          .isEqualTo(0.5);
+    }
+  }
+
+  @Nested
+  class MetricRecording {
+
+    private InMemoryMetricReader metricReader;
+    private OtelSdkManager manager;
+
+    @BeforeEach
+    void setUp() {
+      metricReader = InMemoryMetricReader.create();
+      manager =
+          TestOtelSdkManager.inMemoryWithMetrics(InMemoryLogRecordExporter.create(), metricReader);
+    }
+
+    @Test
+    void shouldRecordMetricByName() {
+      // when
+      manager.incrementMetric("test.counter", 100L, 1000L, Attributes.empty());
+
+      // then
+      assertThat(findMetric(metricReader.collectAllMetrics(), "test.counter")).isPresent();
+    }
+
+    @Test
+    void shouldReuseCounterForSameName() {
+      // when
+      manager.incrementMetric("test.counter", 100L, 1000L, Attributes.empty());
+      manager.incrementMetric("test.counter", 100L, 1000L, Attributes.empty());
+
+      // then
+      assertThat(findMetric(metricReader.collectAllMetrics(), "test.counter"))
+          .hasValueSatisfying(
+              metric -> {
+                final long total =
+                    metric.getLongSumData().getPoints().stream()
+                        .mapToLong(LongPointData::getValue)
+                        .sum();
+                assertThat(total).isEqualTo(2);
+              });
+    }
+
+    @Test
+    void shouldCreateSeparateCountersForDifferentNames() {
+      // when
+      manager.incrementMetric("counter.a", 100L, 1000L, Attributes.empty());
+      manager.incrementMetric("counter.b", 200L, 2000L, Attributes.empty());
+
+      // then
+      final var metrics = metricReader.collectAllMetrics();
+      assertThat(findMetric(metrics, "counter.a")).isPresent();
+      assertThat(findMetric(metrics, "counter.b")).isPresent();
+    }
+
+    @Test
+    void shouldPreserveDimensionAttributes() {
+      // given
+      final var attrs =
+          Attributes.of(
+              AttributeKey.stringKey("process.id"), "order", AttributeKey.longKey("version"), 3L);
+
+      // when
+      manager.incrementMetric("test.counter", 100L, 1000L, attrs);
+
+      // then
+      assertThat(findMetric(metricReader.collectAllMetrics(), "test.counter"))
+          .hasValueSatisfying(
+              metric ->
+                  assertThat(metric.getLongSumData().getPoints())
+                      .first()
+                      .satisfies(
+                          point -> {
+                            assertThat(
+                                    point.getAttributes().get(AttributeKey.stringKey("process.id")))
+                                .isEqualTo("order");
+                            assertThat(point.getAttributes().get(AttributeKey.longKey("version")))
+                                .isEqualTo(3L);
+                          }));
+    }
+
+    @Test
+    void shouldEmitExportWindowGaugeWithMetadata() {
+      // given
+      manager.incrementMetric("test.counter", 100L, 5000L, Attributes.empty());
+      manager.incrementMetric("test.counter", 200L, 6000L, Attributes.empty());
+
+      // when
+      final var metrics = metricReader.collectAllMetrics();
+
+      // then
+      assertThat(findMetric(metrics, EXPORT_WINDOW))
+          .isPresent()
+          .hasValueSatisfying(
+              metric ->
+                  assertThat(metric.getLongGaugeData().getPoints())
+                      .first()
+                      .satisfies(
+                          point -> {
+                            assertThat(point.getValue()).isEqualTo(2);
+                            final var pointAttrs = point.getAttributes();
+                            assertThat(pointAttrs.get(SEQUENCE_NUMBER)).isEqualTo(1L);
+                            assertThat(pointAttrs.get(POSITION_START)).isEqualTo(100L);
+                            assertThat(pointAttrs.get(POSITION_END)).isEqualTo(200L);
+                            assertThat(pointAttrs.get(TIME_MIN)).isEqualTo(5000L);
+                            assertThat(pointAttrs.get(TIME_MAX)).isEqualTo(6000L);
+                          }));
+    }
+
+    @Test
+    void shouldIncrementFlushSequenceAcrossCollections() {
+      // given — two collection cycles
+      manager.incrementMetric("test.counter", 100L, 1000L, Attributes.empty());
+      metricReader.collectAllMetrics(); // flush_sequence = 1
+
+      manager.incrementMetric("test.counter", 200L, 2000L, Attributes.empty());
+
+      // when
+      final var metrics = metricReader.collectAllMetrics();
+
+      // then
+      assertThat(findMetric(metrics, EXPORT_WINDOW))
+          .isPresent()
+          .hasValueSatisfying(
+              metric ->
+                  assertThat(metric.getLongGaugeData().getPoints())
+                      .first()
+                      .satisfies(
+                          point ->
+                              assertThat(point.getAttributes().get(SEQUENCE_NUMBER))
+                                  .isEqualTo(2L)));
+    }
+
+    @Test
+    void shouldResetWindowAfterCollection() {
+      // given
+      manager.incrementMetric("test.counter", 100L, 5000L, Attributes.empty());
+      metricReader.collectAllMetrics(); // resets window
+
+      manager.incrementMetric("test.counter", 300L, 8000L, Attributes.empty());
+
+      // when
+      final var metrics = metricReader.collectAllMetrics();
+
+      // then — should reflect only the second event
+      assertThat(findMetric(metrics, EXPORT_WINDOW))
+          .isPresent()
+          .hasValueSatisfying(
+              metric ->
+                  assertThat(metric.getLongGaugeData().getPoints())
+                      .first()
+                      .satisfies(
+                          point -> {
+                            assertThat(point.getValue()).isEqualTo(1);
+                            final var pointAttrs = point.getAttributes();
+                            assertThat(pointAttrs.get(POSITION_START)).isEqualTo(300L);
+                            assertThat(pointAttrs.get(POSITION_END)).isEqualTo(300L);
+                            assertThat(pointAttrs.get(TIME_MIN)).isEqualTo(8000L);
+                            assertThat(pointAttrs.get(TIME_MAX)).isEqualTo(8000L);
+                          }));
+    }
+
+    @Test
+    void shouldSkipExportWindowGaugeWhenNoEvents() {
+      // when — no incrementMetric calls
+      final var metrics = metricReader.collectAllMetrics();
+
+      // then — gauge has no data points
+      assertThat(findMetric(metrics, EXPORT_WINDOW))
+          .satisfiesAnyOf(
+              opt -> assertThat(opt).isEmpty(),
+              opt ->
+                  assertThat(opt)
+                      .hasValueSatisfying(
+                          metric -> assertThat(metric.getLongGaugeData().getPoints()).isEmpty()));
+    }
+
+    @Test
+    void shouldNotIncrementMetricSequenceWhenWindowIsEmpty() {
+      // when — first collection happens with no events, then a real increment, then collection
+      metricReader.collectAllMetrics(); // empty window — should not consume a sequence number
+      manager.incrementMetric("test.counter", 100L, 1000L, Attributes.empty());
+      final var metrics = metricReader.collectAllMetrics();
+
+      // then — sequence number is 1 (not 2), proving the empty window did not consume a slot
+      assertThat(findMetric(metrics, EXPORT_WINDOW))
+          .isPresent()
+          .hasValueSatisfying(
+              metric ->
+                  assertThat(metric.getLongGaugeData().getPoints())
+                      .first()
+                      .satisfies(
+                          point ->
+                              assertThat(point.getAttributes().get(SEQUENCE_NUMBER))
+                                  .isEqualTo(1L)));
+    }
+
+    private Optional<MetricData> findMetric(
+        final Collection<MetricData> metrics, final String name) {
+      return metrics.stream().filter(m -> m.getName().equals(name)).findFirst();
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/TestOtelSdkManager.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/TestOtelSdkManager.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.opentelemetry.sdk.logs.SdkLoggerProvider;
+import io.opentelemetry.sdk.logs.export.LogRecordExporter;
+import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+
+/** Test factory for {@link OtelSdkManager} with in-memory OTel transport. */
+public final class TestOtelSdkManager {
+
+  private TestOtelSdkManager() {}
+
+  /** Creates an initialized OtelSdkManager that captures events in the given exporter. */
+  public static OtelSdkManager inMemory(final InMemoryLogRecordExporter memoryExporter) {
+    return inMemory(memoryExporter, new AnalyticsExporterConfig());
+  }
+
+  public static OtelSdkManager inMemory(
+      final InMemoryLogRecordExporter memoryExporter, final AnalyticsExporterConfig config) {
+    return inMemoryWithMetrics(memoryExporter, InMemoryMetricReader.create(), config);
+  }
+
+  public static OtelSdkManager inMemoryWithMetrics(
+      final InMemoryLogRecordExporter logExporter, final InMemoryMetricReader metricReader) {
+    return inMemoryWithMetrics(logExporter, metricReader, new AnalyticsExporterConfig());
+  }
+
+  public static OtelSdkManager inMemoryWithMetrics(
+      final InMemoryLogRecordExporter logExporter,
+      final InMemoryMetricReader metricReader,
+      final AnalyticsExporterConfig config) {
+    return inMemoryWithMetrics(logExporter, metricReader, config, new SimpleMeterRegistry());
+  }
+
+  public static OtelSdkManager inMemoryWithMetrics(
+      final InMemoryLogRecordExporter logExporter,
+      final InMemoryMetricReader metricReader,
+      final AnalyticsExporterConfig config,
+      final MeterRegistry meterRegistry) {
+    final var manager =
+        new OtelSdkManager() {
+          @Override
+          protected SdkLoggerProvider createLoggerProvider(
+              final AnalyticsExporterConfig cfg,
+              final AnalyticsExporterContext context,
+              final MicrometerMeterProvider bridge) {
+            return SdkLoggerProvider.builder()
+                .setResource(OtelSdkManager.buildResource(context))
+                .addLogRecordProcessor(SimpleLogRecordProcessor.create(logExporter))
+                .build();
+          }
+
+          @Override
+          protected SdkMeterProvider createMeterProvider(
+              final AnalyticsExporterContext context, final ManualMetricReader reader) {
+            // Bypass ManualMetricReader — use InMemoryMetricReader for synchronous test collection
+            return SdkMeterProvider.builder()
+                .setResource(OtelSdkManager.buildResource(context))
+                .registerMetricReader(metricReader)
+                .build();
+          }
+        };
+    manager.initialize(
+        config,
+        AnalyticsExporterContext.create("test-license", "test-cluster", 1, ""),
+        new AnalyticsExporterMetadata(),
+        meterRegistry);
+    return manager;
+  }
+
+  /**
+   * Creates an initialized manager wired to both an in-memory OTel exporter and a Micrometer
+   * registry. Uses the production {@link OtelSdkManager#createLoggerProvider} so that {@code
+   * selfMetricsSdkMeterProvider} is wired in (needed to test OTel SDK self-metrics). Only {@link
+   * OtelSdkManager#createLogExporter} is overridden to avoid real HTTP connections.
+   */
+  public static OtelSdkManager inMemoryWithRegistry(
+      final InMemoryLogRecordExporter logExporter, final MeterRegistry meterRegistry) {
+    final var manager =
+        new OtelSdkManager() {
+          @Override
+          protected LogRecordExporter createLogExporter(
+              final AnalyticsExporterConfig cfg,
+              final AnalyticsExporterContext context,
+              final MicrometerMeterProvider bridge) {
+            return logExporter;
+          }
+
+          @Override
+          protected ManualMetricReader createMetricReader(
+              final AnalyticsExporterConfig config,
+              final AnalyticsExporterContext context,
+              final MicrometerMeterProvider bridge) {
+            // Use a noop exporter so the metrics pipeline never attempts HTTP connections.
+            return new ManualMetricReader(
+                new io.opentelemetry.sdk.metrics.export.MetricExporter() {
+                  @Override
+                  public io.opentelemetry.sdk.common.CompletableResultCode export(
+                      final java.util.Collection<io.opentelemetry.sdk.metrics.data.MetricData>
+                          metrics) {
+                    return io.opentelemetry.sdk.common.CompletableResultCode.ofSuccess();
+                  }
+
+                  @Override
+                  public io.opentelemetry.sdk.common.CompletableResultCode flush() {
+                    return io.opentelemetry.sdk.common.CompletableResultCode.ofSuccess();
+                  }
+
+                  @Override
+                  public io.opentelemetry.sdk.common.CompletableResultCode shutdown() {
+                    return io.opentelemetry.sdk.common.CompletableResultCode.ofSuccess();
+                  }
+
+                  @Override
+                  public io.opentelemetry.sdk.metrics.data.AggregationTemporality
+                      getAggregationTemporality(
+                          final io.opentelemetry.sdk.metrics.InstrumentType instrumentType) {
+                    return io.opentelemetry.sdk.metrics.data.AggregationTemporality.CUMULATIVE;
+                  }
+                });
+          }
+        };
+    manager.initialize(
+        new AnalyticsExporterConfig(),
+        AnalyticsExporterContext.create("test-license", "test-cluster", 1, ""),
+        new AnalyticsExporterMetadata(),
+        meterRegistry);
+    return manager;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/AdHocSubProcessHandlerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AdHocSubProcessHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  private InMemoryLogRecordExporter memoryExporter;
+  private AdHocSubProcessHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    memoryExporter = InMemoryLogRecordExporter.create();
+    handler = new AdHocSubProcessHandler(TestOtelSdkManager.inMemory(memoryExporter));
+  }
+
+  @Test
+  void shouldEmitEventForAdHocSubProcess() {
+    // given
+    final var value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .withBpmnElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+            .withBpmnProcessId("my-process")
+            .withProcessDefinitionKey(42L)
+            .withProcessInstanceKey(99L)
+            .withElementId("adhoc-1")
+            .withTenantId("tenant-a")
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(
+                        AnalyticsAttributes.Event.NAME,
+                        AnalyticsAttributes.Event.ADHOC_SUBPROCESS_ACTIVATED)
+                    .containsEntry(AnalyticsAttributes.Process.BPMN_PROCESS_ID, "my-process")
+                    .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 42L)
+                    .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, 99L)
+                    .containsEntry(AnalyticsAttributes.Element.ID, "adhoc-1")
+                    .containsEntry(AnalyticsAttributes.Tenant.ID, "tenant-a"));
+  }
+
+  @Test
+  void shouldSkipNonAdHocSubProcessElement() {
+    // given
+    final var value =
+        ImmutableProcessInstanceRecordValue.builder()
+            .withBpmnElementType(BpmnElementType.SERVICE_TASK)
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems()).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/ProcessInstanceCreationHandlerTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.BPMN_PROCESS_ID;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Process.VERSION;
+import static io.camunda.exporter.analytics.AnalyticsAttributes.Tenant.ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.OtelSdkManager;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import java.util.Collection;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ProcessInstanceCreationHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  private InMemoryLogRecordExporter logExporter;
+  private InMemoryMetricReader metricReader;
+  private ProcessInstanceCreationHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    logExporter = InMemoryLogRecordExporter.create();
+    metricReader = InMemoryMetricReader.create();
+    final OtelSdkManager manager =
+        TestOtelSdkManager.inMemoryWithMetrics(logExporter, metricReader);
+    handler = new ProcessInstanceCreationHandler(manager);
+  }
+
+  private static Record<?> piCreatedRecord() {
+    return FACTORY.generateRecord(
+        ValueType.PROCESS_INSTANCE_CREATION,
+        r -> r.withRecordType(RecordType.EVENT).withIntent(ProcessInstanceCreationIntent.CREATED));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  private static Optional<MetricData> findCounter(final Collection<MetricData> metrics) {
+    return metrics.stream()
+        .filter(m -> m.getName().equals(AnalyticsAttributes.Metric.PROCESS_INSTANCE_CREATED))
+        .findFirst();
+  }
+
+  @Nested
+  class LogEvent {
+
+    @Test
+    void shouldEmitLogEventWithCorrectName() {
+      // when
+      handler.handle(typed(piCreatedRecord()));
+
+      // then
+      assertThat(logExporter.getFinishedLogRecordItems())
+          .singleElement()
+          .satisfies(
+              log ->
+                  assertThat(log.getAttributes().asMap())
+                      .containsEntry(
+                          AnalyticsAttributes.Event.NAME,
+                          AnalyticsAttributes.Event.PROCESS_INSTANCE_CREATED));
+    }
+  }
+
+  @Nested
+  class MetricCounter {
+
+    @Test
+    void shouldAggregateCounterAcrossHandles() {
+      // when
+      handler.handle(typed(piCreatedRecord()));
+      handler.handle(typed(piCreatedRecord()));
+      handler.handle(typed(piCreatedRecord()));
+
+      // then
+      assertThat(findCounter(metricReader.collectAllMetrics()))
+          .isPresent()
+          .hasValueSatisfying(
+              metric -> {
+                final long total =
+                    metric.getLongSumData().getPoints().stream()
+                        .mapToLong(LongPointData::getValue)
+                        .sum();
+                assertThat(total).isEqualTo(3);
+              });
+    }
+
+    @Test
+    void shouldIncludeCorrectCounterAttributes() {
+      // when
+      handler.handle(typed(piCreatedRecord()));
+
+      // then
+      assertThat(findCounter(metricReader.collectAllMetrics()))
+          .isPresent()
+          .hasValueSatisfying(
+              metric ->
+                  assertThat(metric.getLongSumData().getPoints())
+                      .first()
+                      .satisfies(
+                          point -> {
+                            final var attrs = point.getAttributes();
+                            assertThat(attrs.get(BPMN_PROCESS_ID)).isNotNull();
+                            assertThat(attrs.get(VERSION)).isNotNull();
+                            assertThat(attrs.get(ID)).isNotNull();
+                          }));
+    }
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UsageMetricHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UsageMetricHandlerTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UsageMetricIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableUsageMetricRecordValue;
+import io.camunda.zeebe.protocol.record.value.UsageMetricRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class UsageMetricHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  private InMemoryLogRecordExporter memoryExporter;
+  private UsageMetricHandler handler;
+
+  @BeforeEach
+  void setUp() {
+    memoryExporter = InMemoryLogRecordExporter.create();
+    handler = new UsageMetricHandler(TestOtelSdkManager.inMemory(memoryExporter));
+  }
+
+  @Test
+  void shouldEmitRpiEventWithSummedCounterValues() {
+    // given
+    final var record = usageMetricRecord(UsageMetricRecordValue.EventType.RPI, 10L, 20L);
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(
+                        AnalyticsAttributes.Event.NAME,
+                        AnalyticsAttributes.Event.USAGE_METRIC_EXPORTED)
+                    .containsEntry(AnalyticsAttributes.UsageMetric.EVENT_TYPE, "RPI")
+                    .containsEntry(AnalyticsAttributes.UsageMetric.COUNT, 30L)
+                    .containsEntry(AnalyticsAttributes.UsageMetric.INTERVAL_START, 1000L)
+                    .containsEntry(AnalyticsAttributes.UsageMetric.INTERVAL_END, 2000L));
+  }
+
+  @Test
+  void shouldEmitEdiEventWithSummedCounterValues() {
+    // given
+    final var record = usageMetricRecord(UsageMetricRecordValue.EventType.EDI, 5L, 15L);
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(AnalyticsAttributes.UsageMetric.EVENT_TYPE, "EDI")
+                    .containsEntry(AnalyticsAttributes.UsageMetric.COUNT, 20L));
+  }
+
+  @Test
+  void shouldEmitTuEventWithSetSizes() {
+    // given
+    final var value =
+        ImmutableUsageMetricRecordValue.builder()
+            .withEventType(UsageMetricRecordValue.EventType.TU)
+            .withSetValues(Map.of("tenant-a", Set.of(1L, 2L), "tenant-b", Set.of(3L)))
+            .withStartTime(1000L)
+            .withEndTime(2000L)
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.USAGE_METRIC,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(UsageMetricIntent.EXPORTED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord ->
+                assertThat(logRecord.getAttributes().asMap())
+                    .containsEntry(AnalyticsAttributes.UsageMetric.COUNT, 3L));
+  }
+
+  @Test
+  void shouldSkipNoneEventType() {
+    // given
+    final var value =
+        ImmutableUsageMetricRecordValue.builder()
+            .withEventType(UsageMetricRecordValue.EventType.NONE)
+            .build();
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.USAGE_METRIC,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(UsageMetricIntent.EXPORTED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(memoryExporter.getFinishedLogRecordItems()).isEmpty();
+  }
+
+  // -- helpers --
+
+  private Record<?> usageMetricRecord(
+      final UsageMetricRecordValue.EventType eventType,
+      final long tenantACount,
+      final long tenantBCount) {
+    final var value =
+        ImmutableUsageMetricRecordValue.builder()
+            .withEventType(eventType)
+            .withCounterValues(Map.of("tenant-a", tenantACount, "tenant-b", tenantBCount))
+            .withStartTime(1000L)
+            .withEndTime(2000L)
+            .build();
+    return FACTORY.generateRecord(
+        ValueType.USAGE_METRIC,
+        r ->
+            r.withRecordType(RecordType.EVENT)
+                .withIntent(UsageMetricIntent.EXPORTED)
+                .withValue(value));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandlerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/handler/UserTaskCreatedHandlerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.analytics.AnalyticsAttributes;
+import io.camunda.exporter.analytics.TestOtelSdkManager;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class UserTaskCreatedHandlerTest {
+
+  private static final ProtocolFactory FACTORY = new ProtocolFactory();
+
+  @SuppressWarnings("unchecked")
+  private static <T extends RecordValue> Record<T> typed(final Record<?> record) {
+    return (Record<T>) record;
+  }
+
+  @Test
+  void shouldEmitUserTaskCreatedEventWithSafeAttributesOnly() {
+    // given
+    final var logExporter = InMemoryLogRecordExporter.create();
+    final var handler = new UserTaskCreatedHandler(TestOtelSdkManager.inMemory(logExporter));
+
+    final var value =
+        ImmutableUserTaskRecordValue.builder()
+            .withBpmnProcessId("test-process")
+            .withProcessDefinitionKey(42L)
+            .withProcessInstanceKey(100L)
+            .withElementId("user-task-1")
+            .withTenantId("<default>")
+            // PII fields — must NOT appear in the emitted event
+            .withAssignee("john.doe@example.com")
+            .withCandidateUsersList(List.of("alice@example.com"))
+            .withCandidateGroupsList(List.of("finance-team"))
+            .build();
+
+    final var record =
+        FACTORY.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withRecordType(RecordType.EVENT)
+                    .withIntent(UserTaskIntent.CREATED)
+                    .withValue(value));
+
+    // when
+    handler.handle(typed(record));
+
+    // then
+    assertThat(logExporter.getFinishedLogRecordItems())
+        .singleElement()
+        .satisfies(
+            logRecord -> {
+              final var attrs = logRecord.getAttributes().asMap();
+
+              assertThat(attrs)
+                  .containsEntry(
+                      AnalyticsAttributes.Event.NAME, AnalyticsAttributes.Event.USER_TASK_CREATED)
+                  .containsEntry(AnalyticsAttributes.Process.BPMN_PROCESS_ID, "test-process")
+                  .containsEntry(AnalyticsAttributes.Process.DEFINITION_KEY, 42L)
+                  .containsEntry(AnalyticsAttributes.Process.INSTANCE_KEY, 100L)
+                  .containsEntry(AnalyticsAttributes.Element.ID, "user-task-1")
+                  .containsEntry(AnalyticsAttributes.Tenant.ID, "<default>")
+                  .containsKey(AnalyticsAttributes.Log.POSITION)
+                  .containsKey(AnalyticsAttributes.Event.SEQUENCE_NUMBER);
+
+              assertThat(logRecord.getTimestampEpochNanos())
+                  .isEqualTo(TimeUnit.MILLISECONDS.toNanos(record.getTimestamp()));
+
+              // PII must not appear in any attribute value
+              final var allValues = attrs.values().stream().map(Object::toString).toList();
+              assertThat(allValues)
+                  .doesNotContain("john.doe@example.com")
+                  .doesNotContain("alice@example.com")
+                  .doesNotContain("finance-team");
+            });
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/sampling/HashSamplerBenchmark.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/sampling/HashSamplerBenchmark.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.sampling;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * JMH microbenchmarks for {@link HashSampler#shouldSample(long, double)}.
+ *
+ * <p>Run via: {@code mvn verify -pl zeebe/exporters/analytics-exporter -Dtest=HashSamplerBenchmark
+ * -DskipTests=false -Dbenchmark=true}
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(1)
+public class HashSamplerBenchmark {
+
+  private long position;
+
+  @Setup
+  public void setUp() {
+    // Pre-compute a representative position to avoid allocation noise inside benchmarks
+    position = 42_000_001L;
+  }
+
+  /** Measures the normal sampling path at a low rate (hash + modulo + compare). */
+  @Benchmark
+  public boolean shouldSampleWithRate() {
+    return HashSampler.shouldSample(position, 0.01);
+  }
+
+  /** Measures the fast-path short-circuit when rate == 1.0 (no hashing performed). */
+  @Benchmark
+  public boolean shouldSampleAlwaysPath() {
+    return HashSampler.shouldSample(position, 1.0);
+  }
+
+  /** No-op baseline — establishes the JMH call overhead floor. */
+  @Benchmark
+  public boolean baseline() {
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Test runner (skipped in CI; enable with -Dbenchmark=true)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Run benchmarks from IntelliJ via the play button. Skipped in CI by the {@code
+   * EnabledIfSystemProperty} condition — pass {@code -Dbenchmark=true} to enable.
+   */
+  @Test
+  @EnabledIfSystemProperty(named = "benchmark", matches = "true")
+  void runBenchmarks() throws Exception {
+    final var builder =
+        new OptionsBuilder()
+            .include(HashSamplerBenchmark.class.getSimpleName())
+            .warmupIterations(5)
+            .measurementIterations(10)
+            .resultFormat(ResultFormatType.JSON)
+            .result("target/jmh-result.json")
+            .forks(1);
+
+    new Runner(builder.build()).run();
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/sampling/HashSamplerTest.java
+++ b/zeebe/exporters/analytics-exporter/src/test/java/io/camunda/exporter/analytics/sampling/HashSamplerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.analytics.sampling;
+
+import static io.camunda.exporter.analytics.sampling.HashSampler.MAX_SAMPLE_RATE;
+import static io.camunda.exporter.analytics.sampling.HashSampler.MIN_SAMPLE_RATE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.within;
+
+import java.util.ArrayList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class HashSamplerTest {
+
+  @Test
+  void shouldSampleAllWhenRateIsMax() {
+    for (int i = 0; i < 100; i++) {
+      assertThat(HashSampler.shouldSample(i, MAX_SAMPLE_RATE)).isTrue();
+    }
+  }
+
+  @Test
+  void shouldSampleNoneWhenRateIsMin() {
+    for (int i = 0; i < 100; i++) {
+      assertThat(HashSampler.shouldSample(i, MIN_SAMPLE_RATE)).isFalse();
+    }
+  }
+
+  @Test
+  void shouldClampRateAboveOneToFullSampling() {
+    for (int i = 0; i < 100; i++) {
+      assertThat(HashSampler.shouldSample(i, 1.5)).isTrue();
+    }
+  }
+
+  @Test
+  void shouldClampRateBelowZeroToNoSampling() {
+    for (int i = 0; i < 100; i++) {
+      assertThat(HashSampler.shouldSample(i, -0.5)).isFalse();
+    }
+  }
+
+  @Test
+  void shouldDistributeUniformlyAtOnePercent() {
+    // given
+    final int total = 10_000;
+
+    // when
+    int count = 0;
+    for (int i = 0; i < total; i++) {
+      if (HashSampler.shouldSample(i, 0.01)) {
+        count++;
+      }
+    }
+
+    // then
+    assertThat(count).isCloseTo(100, within(20));
+  }
+
+  @Test
+  void shouldDistributeUniformlyAtFiftyPercent() {
+    // given
+    final int total = 10_000;
+
+    // when
+    int count = 0;
+    for (int i = 0; i < total; i++) {
+      if (HashSampler.shouldSample(i, 0.5)) {
+        count++;
+      }
+    }
+
+    // then
+    assertThat(count).isCloseTo(5000, within(500));
+  }
+
+  @Test
+  void shouldDistributeUniformlyForSparsePositions() {
+    // given — 100 events at every 1000th position
+    int count = 0;
+    for (int i = 0; i < 100; i++) {
+      if (HashSampler.shouldSample(1L + (long) i * 1000, 0.1)) {
+        count++;
+      }
+    }
+
+    // then
+    assertThat(count).isCloseTo(10, within(5));
+  }
+
+  @Test
+  void shouldProduceSameResultsOnReplay() {
+    // given
+    final int total = 1_000;
+    final var firstPass = new ArrayList<Boolean>(total);
+    final var secondPass = new ArrayList<Boolean>(total);
+
+    // when
+    for (int i = 1; i <= total; i++) {
+      firstPass.add(HashSampler.shouldSample(i, 0.1));
+    }
+    for (int i = 1; i <= total; i++) {
+      secondPass.add(HashSampler.shouldSample(i, 0.1));
+    }
+
+    // then
+    assertThat(secondPass).isEqualTo(firstPass);
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {0L, Long.MAX_VALUE, Long.MIN_VALUE})
+  void shouldHandleEdgePositions(final long position) {
+    assertThatCode(() -> HashSampler.shouldSample(position, 0.5)).doesNotThrowAnyException();
+  }
+}

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/README.md
@@ -1,0 +1,117 @@
+# Analytics Exporter Local Test
+
+Run the analytics exporter locally and see raw log events + pre-aggregated metrics in Grafana.
+
+## 1. Start the observability stack
+
+```bash
+docker compose -f zeebe/exporters/analytics-exporter/src/test/resources/local-test/docker-compose.yaml up -d
+```
+
+This starts:
+| Service | URL | Purpose |
+|---|---|---|
+| OTel Collector | localhost:4318 | Receives OTLP logs + metrics |
+| Prometheus | localhost:9090 | Metric storage |
+| Loki | localhost:3100 | Log storage |
+| Grafana | localhost:3333 | Dashboards (no login) |
+
+## 2. Configure the analytics exporter
+
+### Option A: Environment variables
+
+Add these to your Zeebe / Camunda run configuration:
+
+```
+CAMUNDA_LICENSE_KEY=local-test-license-key
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_CLASSNAME=io.camunda.exporter.analytics.AnalyticsExporter
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=http://localhost:4318
+ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT10S
+
+```
+
+### Option B: YAML configuration
+
+Add to your `application.yaml` or pass via `-Dspring.config.additional-location=`:
+
+```yaml
+zeebe:
+  broker:
+    exporters:
+      analytics:
+        className: io.camunda.exporter.analytics.AnalyticsExporter
+        args:
+          endpoint: http://localhost:4318
+          pushInterval: PT10S
+
+camunda:
+  license:
+    key: local-test-license-key
+```
+
+A reference file is provided at `application.yaml` in this directory.
+
+## 3. Generate load
+
+### Shell script (included)
+
+```bash
+# Default: 5 instances/sec for 120 seconds
+./zeebe/exporters/analytics-exporter/src/test/resources/local-test/generate-load.sh
+
+# Custom: 10 instances/sec for 60 seconds
+./zeebe/exporters/analytics-exporter/src/test/resources/local-test/generate-load.sh 10 60
+```
+
+### curl (one-off)
+
+```bash
+# Deploy a process
+curl -X POST http://localhost:8080/v2/deployments \
+  -F "resources=@-;filename=test.bpmn;type=application/xml" <<'BPMN'
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="http://camunda.org/test">
+  <bpmn:process id="analytics-test" isExecutable="true">
+    <bpmn:startEvent id="start"/><bpmn:endEvent id="end"/>
+    <bpmn:sequenceFlow id="flow" sourceRef="start" targetRef="end"/>
+  </bpmn:process>
+</bpmn:definitions>
+BPMN
+
+# Create instances
+for i in $(seq 1 50); do
+  curl -s -X POST http://localhost:8080/v2/process-instances \
+    -H "Content-Type: application/json" \
+    -d '{"bpmnProcessId":"analytics-test"}'
+done
+```
+
+### Camunda Modeler / Web UI
+
+Deploy any process via Modeler or the web UI at http://localhost:8080 and start instances manually.
+
+## 4. View in Grafana
+
+Open http://localhost:3333 → **Explore**
+
+### Metrics (Prometheus datasource)
+
+|                                 Query                                  |                      What it shows                       |
+|------------------------------------------------------------------------|----------------------------------------------------------|
+| `camunda_process_instance_created_total`                               | Pre-aggregated counter                                   |
+| `sum by (camunda_process_id) (camunda_process_instance_created_total)` | Breakdown by process                                     |
+| `camunda_metric_export_window`                                         | Companion gauge (flush sequence, positions, event times) |
+
+### Logs (Loki datasource)
+
+|                              Query                              |        What it shows         |
+|-----------------------------------------------------------------|------------------------------|
+| `{service_name="camunda-zeebe"}`                                | All raw analytics events     |
+| `{service_name="camunda-zeebe"} \|= "process_instance_created"` | Process instance events only |
+
+## 5. Tear down
+
+```bash
+docker compose -f zeebe/exporters/analytics-exporter/src/test/resources/local-test/docker-compose.yaml down
+```
+

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/application.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/application.yaml
@@ -1,0 +1,12 @@
+zeebe:
+  broker:
+    exporters:
+      analytics:
+        className: io.camunda.exporter.analytics.AnalyticsExporter
+        args:
+          endpoint: http://localhost:4318
+          pushInterval: PT10S
+
+camunda:
+  license:
+    key: local-test-license-key

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/docker-compose.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/docker-compose.yaml
@@ -1,0 +1,56 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    ports:
+      - "4318:4318"
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml
+    depends_on:
+      - prometheus
+      - loki
+
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yml
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=native-histograms
+
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3333:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    volumes:
+      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    depends_on:
+      - prometheus
+      - loki
+
+  # Optional: uncomment to run Camunda in Docker instead of from IntelliJ.
+  # Uses the docker network — endpoint is otel-collector:4318 (not localhost).
+  #
+  # camunda:
+  #   image: camunda/camunda:SNAPSHOT
+  #   ports:
+  #     - "8080:8080"
+  #     - "26500:26500"
+  #   environment:
+  #     - CAMUNDA_LICENSE_KEY=local-test-license-key
+  #     - ZEEBE_BROKER_EXPORTERS_ANALYTICS_CLASSNAME=io.camunda.exporter.analytics.AnalyticsExporter
+  #     - ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_ENDPOINT=http://otel-collector:4318
+  #     - ZEEBE_BROKER_EXPORTERS_ANALYTICS_ARGS_PUSHINTERVAL=PT10S
+  #   depends_on:
+  #     - otel-collector

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/generate-load.sh
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/generate-load.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Deploys 2 processes and creates instances in a loop.
+# Usage: ./generate-load.sh [instances-per-second] [duration-seconds]
+# Defaults: 5 instances/sec for 120 seconds
+
+set -euo pipefail
+
+API="http://localhost:8080/v2"
+RATE="${1:-5}"
+DURATION="${2:-120}"
+
+if [ "$RATE" -le 0 ] 2>/dev/null; then
+  echo "Error: rate must be a positive integer" >&2
+  exit 1
+fi
+
+SLEEP=$(awk "BEGIN {printf \"%.3f\", 1/$RATE}")
+
+echo "Waiting for Zeebe to be ready..."
+until curl -sf "$API/../v1/topology" > /dev/null 2>&1; do sleep 1; done
+
+echo "Deploying processes..."
+
+for PROCESS_ID in order-process payment-flow; do
+  curl -sf --retry 3 --retry-connrefused -X POST "$API/deployments" \
+    -F "resources=@-;filename=$PROCESS_ID.bpmn;type=application/xml" <<BPMN
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="http://camunda.org/test">
+  <bpmn:process id="$PROCESS_ID" isExecutable="true">
+    <bpmn:startEvent id="start"/><bpmn:endEvent id="end"/>
+    <bpmn:sequenceFlow id="flow" sourceRef="start" targetRef="end"/>
+  </bpmn:process>
+</bpmn:definitions>
+BPMN
+  echo "  Deployed $PROCESS_ID"
+done
+
+PROCESSES=("order-process" "payment-flow")
+COUNT=0
+START=$(date +%s)
+
+echo ""
+echo "Creating ~$RATE instances/sec for ${DURATION}s..."
+echo "Grafana: http://localhost:3333  Prometheus: http://localhost:9090"
+echo ""
+
+while true; do
+  ELAPSED=$(( $(date +%s) - START ))
+  if [ "$ELAPSED" -ge "$DURATION" ]; then break; fi
+
+  PROCESS="${PROCESSES[$((COUNT % ${#PROCESSES[@]}))]}"
+  curl -sf -X POST "$API/process-instances" \
+    -H "Content-Type: application/json" \
+    -d "{\"bpmnProcessId\":\"$PROCESS\"}" > /dev/null
+
+  COUNT=$((COUNT + 1))
+  if [ $((COUNT % 50)) -eq 0 ]; then
+    echo "  $COUNT instances (${ELAPSED}s)"
+  fi
+
+  sleep "$SLEEP"
+done
+
+echo ""
+echo "Done — created $COUNT instances in ${DURATION}s"
+echo "Wait ~10s for the next metric flush, then check Grafana."

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/grafana-datasources.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/grafana-datasources.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/otel-collector-config.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/otel-collector-config.yaml
@@ -1,0 +1,26 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  deltatocumulative:
+
+exporters:
+  debug:
+    verbosity: detailed
+  prometheusremotewrite:
+    endpoint: http://prometheus:9090/api/v1/write
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [debug, otlphttp/loki]
+    metrics:
+      receivers: [otlp]
+      processors: [deltatocumulative]
+      exporters: [debug, prometheusremotewrite]

--- a/zeebe/exporters/analytics-exporter/src/test/resources/local-test/prometheus.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/local-test/prometheus.yaml
@@ -1,0 +1,2 @@
+global:
+  scrape_interval: 5s

--- a/zeebe/exporters/analytics-exporter/src/test/resources/otel-collector-config.yaml
+++ b/zeebe/exporters/analytics-exporter/src/test/resources/otel-collector-config.yaml
@@ -1,0 +1,15 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [debug]

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
 
@@ -44,6 +46,7 @@
     <module>exporters/elasticsearch-exporter</module>
     <module>exporters/opensearch-exporter</module>
     <module>exporters/rdbms-exporter</module>
+    <module>exporters/analytics-exporter</module>
     <module>protocol-impl</module>
     <module>protocol-jackson</module>
     <module>zb-db</module>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

First 3 commits are simply cherry-picked from the 8.9 (https://github.com/camunda/camunda/pull/57274). I did alter the commit message to indicate it's going to 8.8. The last commit is 8.8 specific and only updates the version of the analytics-exporter to align with the 8.8 versioning.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #55707
