### PR TITLE
ci: run physical tenant acceptance tests against Elasticsearch

### DIFF
--- a/.github/actions/collect-flaky-tests/action.yml
+++ b/.github/actions/collect-flaky-tests/action.yml
@@ -58,6 +58,18 @@ inputs:
     physical-tenant-acceptance-matrix-output-result:
         description: 'Matrix output for physical-tenant acceptance tests'
         required: true
+    physical-tenant-identity-tests-result:
+        description: 'Result of the physical-tenant identity tests job'
+        required: true
+    physical-tenant-identity-matrix-output-result:
+        description: 'Matrix output for physical-tenant identity tests'
+        required: true
+    physical-tenant-history-tests-result:
+        description: 'Result of the physical-tenant history tests job'
+        required: true
+    physical-tenant-history-matrix-output-result:
+        description: 'Matrix output for physical-tenant history tests'
+        required: true
 
 
 outputs:
@@ -90,6 +102,10 @@ runs:
         INTEGRATION_MATRIX_OUTPUT_RESULT: ${{ inputs.integration-matrix-output-result }}
         PHYSICAL_TENANT_ACCEPTANCE_TESTS_RESULT: ${{ inputs.physical-tenant-acceptance-tests-result }}
         PHYSICAL_TENANT_ACCEPTANCE_MATRIX_OUTPUT_RESULT: ${{ inputs.physical-tenant-acceptance-matrix-output-result }}
+        PHYSICAL_TENANT_IDENTITY_TESTS_RESULT: ${{ inputs.physical-tenant-identity-tests-result }}
+        PHYSICAL_TENANT_IDENTITY_MATRIX_OUTPUT_RESULT: ${{ inputs.physical-tenant-identity-matrix-output-result }}
+        PHYSICAL_TENANT_HISTORY_TESTS_RESULT: ${{ inputs.physical-tenant-history-tests-result }}
+        PHYSICAL_TENANT_HISTORY_MATRIX_OUTPUT_RESULT: ${{ inputs.physical-tenant-history-matrix-output-result }}
       run: |
         set -euo pipefail
 
@@ -111,6 +127,8 @@ runs:
         collect_from_matrix_job "zeebe-unit-tests" "$ZEEBE_TESTS_RESULT" "$ZEEBE_MATRIX_OUTPUT_RESULT"
         collect_from_matrix_job "integration-tests" "$INTEGRATION_TESTS_RESULT" "$INTEGRATION_MATRIX_OUTPUT_RESULT"
         collect_from_matrix_job "physical-tenant-acceptance-tests" "$PHYSICAL_TENANT_ACCEPTANCE_TESTS_RESULT" "$PHYSICAL_TENANT_ACCEPTANCE_MATRIX_OUTPUT_RESULT"
+        collect_from_matrix_job "physical-tenant-identity-tests" "$PHYSICAL_TENANT_IDENTITY_TESTS_RESULT" "$PHYSICAL_TENANT_IDENTITY_MATRIX_OUTPUT_RESULT"
+        collect_from_matrix_job "physical-tenant-history-tests" "$PHYSICAL_TENANT_HISTORY_TESTS_RESULT" "$PHYSICAL_TENANT_HISTORY_MATRIX_OUTPUT_RESULT"
 
         # Output the collected data
         {

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -33,7 +33,16 @@ on:
         required: false
         type: string
         default: ""
-        description: When set, runs the acceptance suite under this physical tenant by passing -Dtest.integration.camunda.physical-tenant=<value>. Only supported with RDBMS database types.
+        description: When set, runs the acceptance suite under this physical tenant by passing -Dtest.integration.camunda.physical-tenant=<value>.
+      physical-tenant-elasticsearch-url:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          When set (together with physical-tenant), the PT's secondary storage is pointed at this
+          separate Elasticsearch instance instead of reusing the default tenant's connection, by
+          passing -Dtest.integration.camunda.physical-tenant.elasticsearch.url=<value>. Requires the
+          "elasticsearch-tenant" docker-compose service to be running.
       maven-profiles:
         required: false
         type: string
@@ -118,7 +127,7 @@ jobs:
       - name: Start Database service
         if: ${{ inputs.database-type != 'h2' }}
         run: |
-          docker compose -f db/docker-compose.yml up -d --wait ${{ env.DATABASE_CONTAINER }} || {
+          docker compose -f db/docker-compose.yml up -d --wait ${{ env.DATABASE_CONTAINER }} ${{ inputs.physical-tenant-elasticsearch-url != '' && 'elasticsearch-tenant' || '' }} || {
             docker compose -f db/docker-compose.yml logs
             exit 1
           }
@@ -155,6 +164,7 @@ jobs:
           -D test.integration.camunda.database.type=${{inputs.it-database-type}}
           -D test.integration.camunda.database.fast-init=true
           ${{ inputs.physical-tenant != '' && format('-D test.integration.camunda.physical-tenant={0}', inputs.physical-tenant) || '' }}
+          ${{ inputs.physical-tenant-elasticsearch-url != '' && format('-D test.integration.camunda.physical-tenant.elasticsearch.url={0}', inputs.physical-tenant-elasticsearch-url) || '' }}
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild,${{inputs.maven-profiles}}
           -pl 'qa/acceptance-tests'
           verify

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -93,7 +93,9 @@ env:
 
 jobs:
   integration-tests:
-    name: "${{ inputs.database-type }}"
+    # include the test-type label so matrix entries are distinguishable in the GHA sidebar, which
+    # only shows this leaf name (e.g. "Physical Tenant Acceptance History / elasticsearch")
+    name: "${{ inputs.test-type-label }} / ${{ inputs.database-type }}"
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token

--- a/.github/workflows/ci-database-integration-tests-reusable.yml
+++ b/.github/workflows/ci-database-integration-tests-reusable.yml
@@ -43,6 +43,15 @@ on:
           separate Elasticsearch instance instead of reusing the default tenant's connection, by
           passing -Dtest.integration.camunda.physical-tenant.elasticsearch.url=<value>. Requires the
           "elasticsearch-tenant" docker-compose service to be running.
+      test-suite-name:
+        required: false
+        type: string
+        default: ""
+        description: >-
+          Short suite name appended to the job's display name (e.g. "identity" renders the job as
+          "elasticsearch - identity"). Leave empty to display the database type alone. Joined with
+          a non-slash separator because the GHA sidebar only displays the last " / "-separated
+          segment of the check name.
       maven-profiles:
         required: false
         type: string
@@ -93,9 +102,10 @@ env:
 
 jobs:
   integration-tests:
-    # include the test-type label so matrix entries are distinguishable in the GHA sidebar, which
-    # only shows this leaf name (e.g. "Physical Tenant Acceptance History / elasticsearch")
-    name: "${{ inputs.test-type-label }} / ${{ inputs.database-type }}"
+    # the GHA sidebar only shows the last " / "-separated segment of the composed check name, so
+    # append the suite with a non-slash separator to keep matrix entries distinguishable
+    # (e.g. "elasticsearch - identity")
+    name: "${{ inputs.database-type }}${{ inputs.test-suite-name != '' && format(' - {0}', inputs.test-suite-name) || '' }}"
     permissions:
       contents: read
       id-token: write  # google-github-actions/auth (WIF) mints a GitHub OIDC token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1156,6 +1156,7 @@ jobs:
       maven-profiles: "physical-tenant"
       test-type: "physical-tenant-acceptance-tests"
       test-type-label: "Physical Tenant Acceptance"
+      test-suite-name: "acceptance"
       use-shared-distball: true
 
   physical-tenant-identity-tests:
@@ -1187,6 +1188,7 @@ jobs:
       maven-profiles: "physical-tenant-identity"
       test-type: "physical-tenant-identity-tests"
       test-type-label: "Physical Tenant Acceptance Identity"
+      test-suite-name: "identity"
       use-shared-distball: true
 
   physical-tenant-history-tests:
@@ -1218,6 +1220,7 @@ jobs:
       maven-profiles: "physical-tenant-history"
       test-type: "physical-tenant-history-tests"
       test-type-label: "Physical Tenant Acceptance History"
+      test-suite-name: "history"
       use-shared-distball: true
 
   rdbms-integration-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1124,7 +1124,7 @@ jobs:
   physical-tenant-acceptance-tests:
     name: "Physical Tenant Acceptance Tests / ${{ matrix.database-name }}"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes, generate-db-versions ]
+    needs: [ detect-changes, generate-db-versions, build-distball ]
     strategy:
       fail-fast: false
       matrix:
@@ -1156,11 +1156,12 @@ jobs:
       maven-profiles: "physical-tenant"
       test-type: "physical-tenant-acceptance-tests"
       test-type-label: "Physical Tenant Acceptance"
+      use-shared-distball: true
 
   physical-tenant-identity-tests:
     name: "Physical Tenant Acceptance Tests / Identity / ${{ matrix.database-name }}"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes, generate-db-versions ]
+    needs: [ detect-changes, generate-db-versions, build-distball ]
     strategy:
       fail-fast: false
       matrix:
@@ -1186,11 +1187,12 @@ jobs:
       maven-profiles: "physical-tenant-identity"
       test-type: "physical-tenant-identity-tests"
       test-type-label: "Physical Tenant Acceptance Identity"
+      use-shared-distball: true
 
   physical-tenant-history-tests:
     name: "Physical Tenant Acceptance Tests / History / ${{ matrix.database-name }}"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes, generate-db-versions ]
+    needs: [ detect-changes, generate-db-versions, build-distball ]
     strategy:
       fail-fast: false
       matrix:
@@ -1216,6 +1218,7 @@ jobs:
       maven-profiles: "physical-tenant-history"
       test-type: "physical-tenant-history-tests"
       test-type-label: "Physical Tenant Acceptance History"
+      use-shared-distball: true
 
   rdbms-integration-tests:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
@@ -1669,6 +1672,8 @@ jobs:
       - identity-tests
       - integration-tests
       - physical-tenant-acceptance-tests
+      - physical-tenant-identity-tests
+      - physical-tenant-history-tests
       - rdbms-integration-tests
       - zeebe-unit-tests
     runs-on: ubuntu-latest
@@ -1720,6 +1725,8 @@ jobs:
             "zeebe:zeebe-unit-tests" \
             "integration:integration-tests" \
             "physical-tenant-acceptance:physical-tenant-acceptance-tests" \
+            "physical-tenant-identity:physical-tenant-identity-tests" \
+            "physical-tenant-history:physical-tenant-history-tests" \
             "database-integration:database-integration-tests" \
             "history:history-tests" \
             "identity:identity-tests"; do
@@ -1752,6 +1759,10 @@ jobs:
           integration-matrix-output-result: ${{ steps.matrix-read.outputs.integration }}
           physical-tenant-acceptance-tests-result: ${{ needs.physical-tenant-acceptance-tests.result }}
           physical-tenant-acceptance-matrix-output-result: ${{ steps.matrix-read.outputs.physical-tenant-acceptance }}
+          physical-tenant-identity-tests-result: ${{ needs.physical-tenant-identity-tests.result }}
+          physical-tenant-identity-matrix-output-result: ${{ steps.matrix-read.outputs.physical-tenant-identity }}
+          physical-tenant-history-tests-result: ${{ needs.physical-tenant-history-tests.result }}
+          physical-tenant-history-matrix-output-result: ${{ steps.matrix-read.outputs.physical-tenant-history }}
 
       - name: Check if there are flaky tests to analyze
         if: steps.bypass.outputs.present != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1122,23 +1122,100 @@ jobs:
       use-shared-distball: true
 
   physical-tenant-acceptance-tests:
-    name: "Physical Tenant Acceptance Tests / H2"
+    name: "Physical Tenant Acceptance Tests / ${{ matrix.database-name }}"
     if: needs.detect-changes.outputs.java-code-changes == 'true'
-    needs: [ detect-changes ]
+    needs: [ detect-changes, generate-db-versions ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - database-type: "h2"
+            database-name: "H2"
+            # Lowercase to match the @DisabledIfSystemProperty(matches = "rdbms.*$") guards that
+            # skip RDBMS-incompatible tests.
+            it-database-type: "rdbms_h2"
+            database-image-version: ""
+          - database-type: "elasticsearch"
+            database-name: "ES 8.x"
+            it-database-type: "es"
+            database-image-version: "${{ needs.generate-db-versions.outputs.elasticsearch-8 }}"
+            # Points the PT at a genuinely separate ES instance (db/docker-compose.yml's
+            # elasticsearch-tenant service) instead of the default tenant's cluster.
+            physical-tenant-elasticsearch-url: "http://localhost:9201"
     uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
     secrets: inherit
     with:
-      database-type: "h2"
-      database-name: "H2"
-      # Lowercase to match the @DisabledIfSystemProperty(matches = "rdbms.*$") guards that skip
-      # RDBMS-incompatible tests.
-      it-database-type: "rdbms_h2"
+      database-type: "${{ matrix.database-type }}"
+      database-name: "${{ matrix.database-name }}"
+      database-image-version: "${{ matrix.database-image-version }}"
+      it-database-type: "${{ matrix.it-database-type }}"
       physical-tenant: "tenanta"
+      physical-tenant-elasticsearch-url: "${{ matrix.physical-tenant-elasticsearch-url }}"
       # Scope to the tests that pass under physical-tenant mode; known gaps are excluded in the
       # physical-tenant profile.
       maven-profiles: "physical-tenant"
       test-type: "physical-tenant-acceptance-tests"
       test-type-label: "Physical Tenant Acceptance"
+
+  physical-tenant-identity-tests:
+    name: "Physical Tenant Acceptance Tests / Identity / ${{ matrix.database-name }}"
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes, generate-db-versions ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - database-type: "h2"
+            database-name: "H2"
+            it-database-type: "rdbms_h2"
+            database-image-version: ""
+          - database-type: "elasticsearch"
+            database-name: "ES 8.x"
+            it-database-type: "es"
+            database-image-version: "${{ needs.generate-db-versions.outputs.elasticsearch-8 }}"
+            physical-tenant-elasticsearch-url: "http://localhost:9201"
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "${{ matrix.database-type }}"
+      database-name: "${{ matrix.database-name }}"
+      database-image-version: "${{ matrix.database-image-version }}"
+      it-database-type: "${{ matrix.it-database-type }}"
+      physical-tenant: "tenanta"
+      physical-tenant-elasticsearch-url: "${{ matrix.physical-tenant-elasticsearch-url }}"
+      maven-profiles: "physical-tenant-identity"
+      test-type: "physical-tenant-identity-tests"
+      test-type-label: "Physical Tenant Acceptance Identity"
+
+  physical-tenant-history-tests:
+    name: "Physical Tenant Acceptance Tests / History / ${{ matrix.database-name }}"
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes, generate-db-versions ]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - database-type: "h2"
+            database-name: "H2"
+            it-database-type: "rdbms_h2"
+            database-image-version: ""
+          - database-type: "elasticsearch"
+            database-name: "ES 8.x"
+            it-database-type: "es"
+            database-image-version: "${{ needs.generate-db-versions.outputs.elasticsearch-8 }}"
+            physical-tenant-elasticsearch-url: "http://localhost:9201"
+    uses: ./.github/workflows/ci-database-integration-tests-reusable.yml
+    secrets: inherit
+    with:
+      database-type: "${{ matrix.database-type }}"
+      database-name: "${{ matrix.database-name }}"
+      database-image-version: "${{ matrix.database-image-version }}"
+      it-database-type: "${{ matrix.it-database-type }}"
+      physical-tenant: "tenanta"
+      physical-tenant-elasticsearch-url: "${{ matrix.physical-tenant-elasticsearch-url }}"
+      maven-profiles: "physical-tenant-history"
+      test-type: "physical-tenant-history-tests"
+      test-type-label: "Physical Tenant Acceptance History"
 
   rdbms-integration-tests:
     if: needs.detect-changes.outputs.rdbms-integration-tests == 'true'
@@ -2367,6 +2444,8 @@ jobs:
       - operate-ci
       - optimize-ci
       - physical-tenant-acceptance-tests
+      - physical-tenant-identity-tests
+      - physical-tenant-history-tests
       - pin-check
       - pr-maven-snapshot
       - pr-vuln-check

--- a/db/docker-compose.yml
+++ b/db/docker-compose.yml
@@ -134,6 +134,26 @@ services:
     volumes:
       - ./els-snapshots:/usr/local/els-snapshots
 
+  elasticsearch-tenant:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${IMAGE_VERSION:-8.19.16}
+    container_name: elasticsearch-tenant
+    environment:
+      - discovery.type=single-node
+      - cluster.name=elasticsearch-tenant
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx1024m"
+      - action.destructive_requires_name=false
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+      - 9201:9200
+    networks:
+      - zeebe_network
+    restart: always
+
   opensearch:
     image: opensearchproject/opensearch:${IMAGE_VERSION:-2.19.5}
     container_name: opensearch

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -886,16 +886,89 @@
               <groups>multi-db-test</groups>
               <excludedGroups>rdbms, history, multi-db-physical-tenants</excludedGroups>
               <excludes>
+                <exclude>${identity-packages}</exclude>
                 <!-- Excluded under physical tenant pending follow-up; see #56134. -->
                 <exclude>**/auth/UsageMetricAuthorizationIT.java</exclude>
                 <exclude>**/*$*.java</exclude>
                 <!-- Cluster purge is not routed to the per-tenant secondary store, so purged
                      entities still surface in tenant-scoped search. -->
                 <exclude>**/ClusterPurgeMultiDbIT.java</exclude>
+                <!-- Recover drives the debug CLI against a single secondary-storage connection and
+                     deletes documents there directly; the tenant-scoped read path targets a
+                     different store, so the deletion never surfaces as missing. -->
+                <exclude>**/RecoverProcessDefinitionsMultiDbIT.java</exclude>
+                <!-- Instance banning is a broker-admin operation routed by partition id to the
+                     default partition group, not the tenant's; the ban never reaches the tenant
+                     partition where the instance lives, so the command is never rejected. -->
+                <exclude>**/CommandRejectionIT.java</exclude>
+                <!-- System endpoints (/v2/system/*) are global, not tenant-scoped; a
+                     physical-tenant client prefixes /physical-tenants/<id>/ and gets 401. -->
+                <exclude>**/GlobalErrorControllerWithAuthIT.java</exclude>
+                <exclude>**/system/SystemConfigurationIT.java</exclude>
                 <!-- MCP server search/audit not yet validated under physical-tenant mode. -->
                 <exclude>**/mcp/authentication/BasicAuthMcpServerIT.java</exclude>
                 <exclude>**/mcp/authentication/OidcMcpServerIT.java</exclude>
               </excludes>
+              <systemPropertyVariables>
+                <camunda.test.preferred.extension>multi-db</camunda.test.preferred.extension>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!--
+    This profile will run all tests annotated with @Tag("multiDbTest") for the identity related
+    packages, under a physical tenant. Mirrors identity-tests, but scoped to the physical-tenant
+    exclusions above.
+    -->
+    <profile>
+      <id>physical-tenant-identity</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <failIfNoTests>false</failIfNoTests>
+              <groups>multi-db-test</groups>
+              <excludedGroups>rdbms, history, multi-db-physical-tenants</excludedGroups>
+              <includes>
+                <include>${identity-packages}</include>
+              </includes>
+              <excludes>
+                <!-- Excluded under physical tenant pending follow-up; see #56134. -->
+                <exclude>**/auth/UsageMetricAuthorizationIT.java</exclude>
+                <exclude>**/*$*.java</exclude>
+                <!-- MCP server search/audit not yet validated under physical-tenant mode. -->
+                <exclude>**/mcp/authentication/BasicAuthMcpServerIT.java</exclude>
+                <exclude>**/mcp/authentication/OidcMcpServerIT.java</exclude>
+              </excludes>
+              <systemPropertyVariables>
+                <camunda.test.preferred.extension>multi-db</camunda.test.preferred.extension>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!--
+    This profile will run all tests annotated with @Tag("history"), under a physical tenant.
+    Mirrors the history profile, but scoped to run under a physical tenant.
+    -->
+    <profile>
+      <id>physical-tenant-history</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <failIfNoTests>false</failIfNoTests>
+              <groups>history</groups>
+              <excludedGroups>rdbms</excludedGroups>
               <systemPropertyVariables>
                 <camunda.test.preferred.extension>multi-db</camunda.test.preferred.extension>
               </systemPropertyVariables>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -929,9 +929,6 @@
                 <!-- Excluded under physical tenant pending follow-up; see #56134. -->
                 <exclude>**/auth/UsageMetricAuthorizationIT.java</exclude>
                 <exclude>**/*$*.java</exclude>
-                <!-- MCP server search/audit not yet validated under physical-tenant mode. -->
-                <exclude>**/mcp/authentication/BasicAuthMcpServerIT.java</exclude>
-                <exclude>**/mcp/authentication/OidcMcpServerIT.java</exclude>
               </excludes>
               <systemPropertyVariables>
                 <camunda.test.preferred.extension>multi-db</camunda.test.preferred.extension>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -893,18 +893,6 @@
                 <!-- Cluster purge is not routed to the per-tenant secondary store, so purged
                      entities still surface in tenant-scoped search. -->
                 <exclude>**/ClusterPurgeMultiDbIT.java</exclude>
-                <!-- Recover drives the debug CLI against a single secondary-storage connection and
-                     deletes documents there directly; the tenant-scoped read path targets a
-                     different store, so the deletion never surfaces as missing. -->
-                <exclude>**/RecoverProcessDefinitionsMultiDbIT.java</exclude>
-                <!-- Instance banning is a broker-admin operation routed by partition id to the
-                     default partition group, not the tenant's; the ban never reaches the tenant
-                     partition where the instance lives, so the command is never rejected. -->
-                <exclude>**/CommandRejectionIT.java</exclude>
-                <!-- System endpoints (/v2/system/*) are global, not tenant-scoped; a
-                     physical-tenant client prefixes /physical-tenants/<id>/ and gets 401. -->
-                <exclude>**/GlobalErrorControllerWithAuthIT.java</exclude>
-                <exclude>**/system/SystemConfigurationIT.java</exclude>
                 <!-- MCP server search/audit not yet validated under physical-tenant mode. -->
                 <exclude>**/mcp/authentication/BasicAuthMcpServerIT.java</exclude>
                 <exclude>**/mcp/authentication/OidcMcpServerIT.java</exclude>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/CommandRejectionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/CommandRejectionIT.java
@@ -27,6 +27,13 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms.*$")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.physical-tenant",
+    matches = ".+",
+    disabledReason =
+        "Instance banning is a broker-admin operation routed by partition id to the default"
+            + " partition group, not the tenant's; the ban never reaches the tenant partition"
+            + " where the instance lives, so the command is never rejected")
 public class CommandRejectionIT {
 
   @MultiDbTestApplication

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
@@ -207,6 +207,12 @@ class ApplicationAuthorizationIT {
   }
 
   @Test
+  @DisabledIfSystemProperty(
+      named = "test.integration.camunda.physical-tenant",
+      matches = ".+",
+      disabledReason =
+          "authorizedComponents is resolved against root storage under a physical tenant, "
+              + "see https://github.com/camunda/camunda/issues/58393")
   void meContainsComponentUserSpecificAuthorizations(
       @Authenticated(RESTRICTED) final CamundaClient restrictedClient)
       throws IOException, URISyntaxException, InterruptedException {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerWithAuthIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/GlobalErrorControllerWithAuthIT.java
@@ -31,8 +31,15 @@ import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.physical-tenant",
+    matches = ".+",
+    disabledReason =
+        "System endpoints (/v2/system/*) are global, not tenant-scoped; a physical-tenant client"
+            + " prefixes /physical-tenants/<id>/ and gets 401")
 public class GlobalErrorControllerWithAuthIT {
 
   private static final String ADMIN = "admin";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/recover/RecoverProcessDefinitionsMultiDbIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/recover/RecoverProcessDefinitionsMultiDbIT.java
@@ -61,6 +61,13 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
     named = "test.integration.camunda.database.type",
     matches = "AWS_OS",
     disabledReason = "AWS OpenSearch requires a dedicated client not built by this test")
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.physical-tenant",
+    matches = ".+",
+    disabledReason =
+        "Recover drives the debug CLI against a single secondary-storage connection and deletes"
+            + " documents there directly; the tenant-scoped read path targets a different store,"
+            + " so the deletion never surfaces as missing")
 public class RecoverProcessDefinitionsMultiDbIT {
 
   private static final int TIMEOUT = 60;

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/system/SystemConfigurationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/system/SystemConfigurationIT.java
@@ -29,6 +29,12 @@ import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.physical-tenant",
+    matches = ".+",
+    disabledReason =
+        "System endpoints (/v2/system/*) are global, not tenant-scoped; a physical-tenant client"
+            + " prefixes /physical-tenants/<id>/ and gets 401")
 public class SystemConfigurationIT {
 
   private static final String SYSTEM_CONFIGURATION_PATH = "v2/system/configuration";

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -660,7 +660,10 @@ public class CamundaMultiDBExtension
       return restAddress;
     }
     final String base = restAddress.toString().replaceAll("/+$", "");
-    return URI.create(base + "/physical-tenants/" + physicalTenantId);
+    // keep the trailing slash so the address matches the root REST address convention: raw-HTTP
+    // tests concatenate relative paths onto getRestAddress() (e.g. ApplicationAuthorizationIT's
+    // createUri), which 404s on ".../<tenant>v2/..." without it
+    return URI.create(base + "/physical-tenants/" + physicalTenantId + "/");
   }
 
   private void setupTestApplication(final Class<?> testClass) {

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -13,6 +13,7 @@ import dasniko.testcontainers.keycloak.KeycloakContainer;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.configuration.SecondaryStorage;
 import io.camunda.configuration.SecondaryStorage.SecondaryStorageType;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.multidb.TestEntityCollector.TestEntityCollection;
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.agrona.CloseHelper;
@@ -223,6 +225,8 @@ public class CamundaMultiDBExtension
       "test.integration.camunda.database.fast-init";
   public static final String TEST_INTEGRATION_PHYSICAL_TENANT =
       "test.integration.camunda.physical-tenant";
+  public static final String TEST_INTEGRATION_PHYSICAL_TENANT_ELASTICSEARCH_URL =
+      "test.integration.camunda.physical-tenant.elasticsearch.url";
   public static final Duration TIMEOUT_DATA_AVAILABILITY =
       Optional.ofNullable(System.getProperty(PROP_TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT))
           .map(val -> Duration.ofSeconds(Long.parseLong(val)))
@@ -269,6 +273,8 @@ public class CamundaMultiDBExtension
   private MultiPhysicalTenantClients multiPhysicalTenantClients;
   private MultiDbConfigurator multiDbConfigurator;
   private MultiDbSetupHelper setupHelper = new NoopDBSetupHelper();
+  // the physical tenant's own Elasticsearch cluster, when it runs on a separate one
+  private MultiDbSetupHelper ptSetupHelper = new NoopDBSetupHelper();
   private CamundaClientTestFactory authenticatedClientFactory;
   private KeycloakContainer keycloakContainer;
 
@@ -309,6 +315,18 @@ public class CamundaMultiDBExtension
   public static String getPhysicalTenant() {
     final String value = System.getProperty(TEST_INTEGRATION_PHYSICAL_TENANT);
     return value == null || value.isBlank() ? null : value;
+  }
+
+  public static String getPhysicalTenantElasticsearchUrl() {
+    final String value = System.getProperty(TEST_INTEGRATION_PHYSICAL_TENANT_ELASTICSEARCH_URL);
+    return value == null || value.isBlank() ? null : value;
+  }
+
+  private static MultiDbSetupHelper physicalTenantSetupHelper() {
+    final String ptElasticsearchUrl = getPhysicalTenantElasticsearchUrl();
+    return ptElasticsearchUrl != null
+        ? new ElasticsearchSetupHelper(ptElasticsearchUrl, List.of())
+        : new NoopDBSetupHelper();
   }
 
   private DatabaseType currentMultiDbDatabaseType(final ExtensionContext context) {
@@ -387,15 +405,17 @@ public class CamundaMultiDBExtension
   }
 
   /**
-   * Provisions a single physical tenant: configures isolated RDBMS secondary storage, and copies
-   * the root {@code security.initialization} into the PT — a PT must own its initialization and
-   * cannot inherit it from root (see {@code PhysicalTenantRequiredOverrideValidation}).
-   * Authentication method and {@code authorizations.enabled} DO inherit from root and are not
-   * copied.
+   * Provisions a single physical tenant: configures isolated secondary storage, and copies the root
+   * {@code security.initialization} into the PT — a PT must own its initialization and cannot
+   * inherit it from root (see {@code PhysicalTenantRequiredOverrideValidation}). Authentication
+   * method and {@code authorizations.enabled} DO inherit from root and are not copied.
    *
    * <p>Storage isolation strategy:
    *
    * <ul>
+   *   <li>{@code ES}/{@code LOCAL} (Elasticsearch): each PT gets a per-tenant index prefix ({@code
+   *       <testPrefix>-<tenantId>}) on the shared cluster. The prefix extends the base test prefix
+   *       so the delete-by-prefix cleanup in afterAll also removes the PT's indices.
    *   <li>{@code RDBMS_H2}: each PT gets a fresh dedicated in-memory H2 database (separate URL per
    *       PT, so no table-prefix separation is needed).
    *   <li>{@code RDBMS_POSTGRES}/{@code RDBMS_AURORA}, {@code RDBMS_MYSQL}/{@code RDBMS_MARIADB},
@@ -429,14 +449,29 @@ public class CamundaMultiDBExtension
     final String adminUsername = physicalTenantAdminUsername(tenantId);
 
     // Derive per-PT storage config based on the active database type.
-    final String ptUrl;
-    final String ptUsername;
-    final String ptPassword;
-    final String ptPrefix;
-    final String ptDatabaseVendorId;
-    if (databaseType == DatabaseType.RDBMS_H2) {
+    final Consumer<SecondaryStorage> configurePtStorage;
+    if (databaseType.storageType().isElasticSearch()) {
+      // Same cluster by default (per-PT index prefix); if
+      // test.integration.camunda.physical-tenant.elasticsearch.url is set, the PT points at that
+      // separate cluster instead. Extending testPrefix keeps the PT's indices covered by the
+      // delete-by-prefix cleanup in afterAll, and the distinct prefix/URL satisfies the
+      // storage-isolation validation (SecondaryStorageIsolationValidation).
+      final var baseElasticsearch =
+          springApplication.unifiedConfig().getData().getSecondaryStorage().getElasticsearch();
+      final String ptUrl =
+          Optional.ofNullable(getPhysicalTenantElasticsearchUrl())
+              .orElseGet(baseElasticsearch::getUrl);
+      final String ptIndexPrefix = baseElasticsearch.getIndexPrefix() + "-" + tenantId;
+      configurePtStorage =
+          secondaryStorage -> {
+            secondaryStorage.setType(SecondaryStorageType.elasticsearch);
+            final var elasticsearch = secondaryStorage.getElasticsearch();
+            elasticsearch.setUrl(ptUrl);
+            elasticsearch.setIndexPrefix(ptIndexPrefix);
+          };
+    } else if (databaseType == DatabaseType.RDBMS_H2) {
       // Fresh in-memory database per PT — DBs are already separate, so no prefix needed.
-      ptUrl =
+      final String ptUrl =
           "jdbc:h2:mem:"
               + testPrefix
               + "-"
@@ -444,10 +479,7 @@ public class CamundaMultiDBExtension
               + "-"
               + UUID.randomUUID()
               + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
-      ptUsername = "sa";
-      ptPassword = "";
-      ptPrefix = testPrefix;
-      ptDatabaseVendorId = null;
+      configurePtStorage = configureRdbmsStorage(ptUrl, "sa", "", testPrefix, null);
     } else {
       // Per-PT isolated storage derived from the database type: a dedicated schema/database whose
       // namespace lives in the PT URL (Postgres/MySQL/MariaDB/SQL Server), or — on Oracle — a
@@ -463,11 +495,13 @@ public class CamundaMultiDBExtension
               baseRdbms.getPassword(),
               baseRdbms.getPrefix(),
               tenantId);
-      ptUrl = ptConfig.url();
-      ptUsername = ptConfig.username();
-      ptPassword = ptConfig.password();
-      ptPrefix = ptConfig.prefix();
-      ptDatabaseVendorId = ptConfig.databaseVendorId();
+      configurePtStorage =
+          configureRdbmsStorage(
+              ptConfig.url(),
+              ptConfig.username(),
+              ptConfig.password(),
+              ptConfig.prefix(),
+              ptConfig.databaseVendorId());
 
       // Track the provisioned namespace so afterAll can drop it best-effort, preventing schemas /
       // databases from accumulating on persistent shared instances (e.g. Aurora) across CI runs.
@@ -488,18 +522,7 @@ public class CamundaMultiDBExtension
     springApplication.withPtConfig(
         tenantId,
         camunda -> {
-          final var secondaryStorage = camunda.getData().getSecondaryStorage();
-          secondaryStorage.setType(SecondaryStorageType.rdbms);
-          final var rdbms = secondaryStorage.getRdbms();
-          rdbms.setUrl(ptUrl);
-          rdbms.setUsername(ptUsername);
-          rdbms.setPassword(ptPassword);
-          rdbms.setPrefix(ptPrefix);
-          if (ptDatabaseVendorId != null) {
-            // Oracle: pin the vendor so the production isolation check keys on the connecting user
-            // (schema-per-user), instead of collapsing the two PTs to a single storage location.
-            rdbms.setDatabaseVendorId(ptDatabaseVendorId);
-          }
+          configurePtStorage.accept(camunda.getData().getSecondaryStorage());
 
           final var init = camunda.getSecurity().getInitialization();
           init.setUsers(rootInit.getUsers());
@@ -538,6 +561,27 @@ public class CamundaMultiDBExtension
         && springApplication.property(assignedProviderProperty, String.class, null) == null) {
       springApplication.withProperty(assignedProviderProperty, "oidc");
     }
+  }
+
+  private static Consumer<SecondaryStorage> configureRdbmsStorage(
+      final String url,
+      final String username,
+      final String password,
+      final String prefix,
+      final String databaseVendorId) {
+    return secondaryStorage -> {
+      secondaryStorage.setType(SecondaryStorageType.rdbms);
+      final var rdbms = secondaryStorage.getRdbms();
+      rdbms.setUrl(url);
+      rdbms.setUsername(username);
+      rdbms.setPassword(password);
+      rdbms.setPrefix(prefix);
+      if (databaseVendorId != null) {
+        // Oracle: pin the vendor so the production isolation check keys on the connecting user
+        // (schema-per-user), instead of collapsing the two PTs to a single storage location.
+        rdbms.setDatabaseVendorId(databaseVendorId);
+      }
+    };
   }
 
   private MultiPhysicalTenantClients buildMultiPhysicalTenantClients(final List<String> tenantIds) {
@@ -616,7 +660,9 @@ public class CamundaMultiDBExtension
       return restAddress;
     }
     final String base = restAddress.toString().replaceAll("/+$", "");
-    return URI.create(base + "/physical-tenants/" + physicalTenantId);
+    // keep the trailing slash so the physical-tenant address follows the same convention as the
+    // root REST address; raw-HTTP tests concatenate a relative path onto it
+    return URI.create(base + "/physical-tenants/" + physicalTenantId + "/");
   }
 
   private void setupTestApplication(final Class<?> testClass) {
@@ -667,9 +713,11 @@ public class CamundaMultiDBExtension
               .filter(id -> !id.isBlank())
               .orElse(null);
     }
-    if (physicalTenantId != null && !databaseType.storageType().isRdbms()) {
+    if (physicalTenantId != null
+        && !databaseType.storageType().isRdbms()
+        && !databaseType.storageType().isElasticSearch()) {
       throw new IllegalStateException(
-          "Physical-tenant mode (%s) is only supported on RDBMS storage; got %s."
+          "Physical-tenant mode (%s) is only supported on RDBMS or Elasticsearch storage; got %s."
               .formatted(TEST_INTEGRATION_PHYSICAL_TENANT, databaseType));
     }
 
@@ -677,9 +725,10 @@ public class CamundaMultiDBExtension
     final MultiDbPhysicalTenants multiPtAnnotation =
         AnnotationSupport.findAnnotation(testClass, MultiDbPhysicalTenants.class).orElse(null);
     if (multiPtAnnotation != null) {
-      if (!databaseType.storageType().isRdbms()) {
+      if (!databaseType.storageType().isRdbms() && !databaseType.storageType().isElasticSearch()) {
         throw new IllegalStateException(
-            "@MultiDbPhysicalTenants is only supported on RDBMS storage; got " + databaseType);
+            "@MultiDbPhysicalTenants is only supported on RDBMS or Elasticsearch storage; got "
+                + databaseType);
       }
       multiPhysicalTenantIds = validatedPhysicalTenantIds(multiPtAnnotation.value());
       // In multi-PT mode the single-PT path is inactive
@@ -698,12 +747,14 @@ public class CamundaMultiDBExtension
             elasticSearchUrl, testPrefix, isHistoryRelatedTest);
         final var expectedDescriptors = new IndexDescriptors(testPrefix, true).all();
         setupHelper = new ElasticsearchSetupHelper(elasticSearchUrl, expectedDescriptors);
+        ptSetupHelper = physicalTenantSetupHelper();
       }
       case ES -> {
         multiDbConfigurator.configureElasticsearchSupport(
             DEFAULT_ES_URL, testPrefix, isHistoryRelatedTest);
         final var expectedDescriptors = new IndexDescriptors(testPrefix, true).all();
         setupHelper = new ElasticsearchSetupHelper(DEFAULT_ES_URL, expectedDescriptors);
+        ptSetupHelper = physicalTenantSetupHelper();
       }
       case OS -> {
         multiDbConfigurator.configureOpenSearchSupport(
@@ -764,6 +815,9 @@ public class CamundaMultiDBExtension
       switch (getDatabaseType(context)) {
         case ES, LOCAL:
           setupHelper.applyIndexPoliciesPollInterval(Duration.ofSeconds(1));
+          // a physical tenant on its own cluster needs the same ILM cadence for cleanup;
+          // no-op when there is no separate physical tenant cluster
+          ptSetupHelper.applyIndexPoliciesPollInterval(Duration.ofSeconds(1));
           break;
         case OS:
           setupHelper.applyIndexPoliciesPollInterval(
@@ -992,8 +1046,13 @@ public class CamundaMultiDBExtension
     final var application = applicationUnderTest.application;
     closeables.add(application);
     application.start();
+    final var clusterCfg = application.unifiedConfig().getCluster();
     application.awaitCompleteTopology(
-        application.unifiedConfig(), authenticatedClientFactory.getAdminCamundaClient());
+        clusterCfg.getSize(),
+        clusterCfg.getPartitionCount(),
+        clusterCfg.getReplicationFactor(),
+        Duration.ofSeconds(30),
+        authenticatedClientFactory.getAdminCamundaClient());
 
     Awaitility.await("Await exporter readiness")
         .timeout(TIMEOUT_DATABASE_EXPORTER_READINESS)
@@ -1125,8 +1184,17 @@ public class CamundaMultiDBExtension
       } catch (final Exception e) {
         LOGGER.warn("Failed to cleanup indices with prefix {}", testPrefix, e);
       }
+      try {
+        // a physical tenant on its own cluster accumulates each class's schema otherwise, until
+        // the cluster's shard limit blocks schema creation and stalls the next application start;
+        // no-op when there is no separate physical tenant cluster
+        ptSetupHelper.cleanup(testPrefix);
+      } catch (final Exception e) {
+        LOGGER.warn("Failed to cleanup physical tenant indices with prefix {}", testPrefix, e);
+      }
     }
     CloseHelper.quietClose(setupHelper);
+    CloseHelper.quietClose(ptSetupHelper);
 
     // 4. Reset exporter to make sure it doesn't interfere with other tests
     RecordingExporter.reset();

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -660,9 +660,7 @@ public class CamundaMultiDBExtension
       return restAddress;
     }
     final String base = restAddress.toString().replaceAll("/+$", "");
-    // keep the trailing slash so the physical-tenant address follows the same convention as the
-    // root REST address; raw-HTTP tests concatenate a relative path onto it
-    return URI.create(base + "/physical-tenants/" + physicalTenantId + "/");
+    return URI.create(base + "/physical-tenants/" + physicalTenantId);
   }
 
   private void setupTestApplication(final Class<?> testClass) {

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbPhysicalTenants.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbPhysicalTenants.java
@@ -21,15 +21,16 @@ import org.junit.jupiter.api.Tag;
  * provision when the test runs. Each tenant gets its own isolated secondary storage, a seeded
  * {@code <tenantId>-admin} user, and an {@code admin} default role for that user.
  *
- * <p>The storage-isolation primitive is dialect-specific: {@code RDBMS_H2} gives each tenant a
- * fresh dedicated in-memory database; PostgreSQL/Aurora, MySQL/MariaDB and SQL Server give each
- * tenant a dedicated namespace named {@code <basePrefix>_<tenantId>} (a schema or database); and
- * Oracle gives each tenant a per-tenant table prefix in the shared schema (a dedicated user would
- * need DBA and is rejected by the production isolation check). See {@link
- * PhysicalTenantSchemaProvisioner} for the per-dialect details.
+ * <p>The storage-isolation primitive is dialect-specific: Elasticsearch gives each tenant a
+ * per-tenant index prefix on the shared cluster; {@code RDBMS_H2} gives each tenant a fresh
+ * dedicated in-memory database; PostgreSQL/Aurora, MySQL/MariaDB and SQL Server give each tenant a
+ * dedicated namespace named {@code <basePrefix>_<tenantId>} (a schema or database); and Oracle
+ * gives each tenant a per-tenant table prefix in the shared schema (a dedicated user would need DBA
+ * and is rejected by the production isolation check). See {@link PhysicalTenantSchemaProvisioner}
+ * for the per-dialect details.
  *
- * <p>Only valid in combination with {@link MultiDbTest} and an RDBMS database type (RDBMS-only,
- * because per-PT secondary-storage schema init is not available for ES/OS yet).
+ * <p>Only valid in combination with {@link MultiDbTest} and an RDBMS or Elasticsearch database type
+ * (per-PT secondary-storage provisioning is not available for OpenSearch yet).
  *
  * <p>The extension injects a {@code static MultiPhysicalTenantClients} field on the test class,
  * which provides per-PT admin clients via {@link MultiPhysicalTenantClients#admin(String)}.


### PR DESCRIPTION
## Description

Extends the `physical-tenant-acceptance-tests` CI job to also run against Elasticsearch, as suggested in the review of #57269 (https://github.com/camunda/camunda/pull/57269#pullrequestreview-4663527377).

The job is converted into a small H2/ES 8.x matrix over the existing `ci-database-integration-tests-reusable.yml` workflow, following the same pattern as the other database test jobs (`identity-tests`, `history-tests`). The ES image version comes from `generate-db-versions` (latest ES 8.x from `.ci/db-versions.yml`); the reusable workflow already handles starting the `elasticsearch` docker-compose service for non-H2 database types. Also drops the now-outdated "Only supported with RDBMS" note on the `physical-tenant` input.

Related to #55350.