### PR TITLE
fix: downgrade per-record rejection logs from DEBUG to TRACE in exporter filters

### DIFF
--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/BpmnProcessFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/BpmnProcessFilter.java
@@ -100,8 +100,8 @@ public final class BpmnProcessFilter implements ExporterRecordFilter, RecordVers
       accepted = allowedBpmnProcesses.contains(bpmnProcessId);
     }
 
-    if (!accepted && LOG.isDebugEnabled()) {
-      LOG.debug(
+    if (!accepted && LOG.isTraceEnabled()) {
+      LOG.trace(
           "BpmnProcessFilter rejected record {} (valueType={}): bpmnProcessId '{}' did not pass inclusion/exclusion rules",
           record.getKey(),
           record.getValueType(),

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportLocalVariablesFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/ExportLocalVariablesFilter.java
@@ -43,8 +43,8 @@ public final class ExportLocalVariablesFilter implements ExporterRecordFilter, R
       return true;
     }
     final boolean isLocal = VariableScope.isLocal(variableRecordValue);
-    if (isLocal && LOG.isDebugEnabled()) {
-      LOG.debug(
+    if (isLocal && LOG.isTraceEnabled()) {
+      LOG.trace(
           "ExportLocalVariablesFilter rejected record {}: variable '{}' is local (scopeKey={} != processInstanceKey={})",
           record.getKey(),
           variableRecordValue.getName(),

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/OptimizeModeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/OptimizeModeFilter.java
@@ -85,8 +85,8 @@ public final class OptimizeModeFilter implements ExporterRecordFilter, RecordVer
           case AGENT_INSTANCE -> isAcceptedAgentInstance(record);
           default -> false;
         };
-    if (!accepted && LOG.isDebugEnabled()) {
-      LOG.debug(
+    if (!accepted && LOG.isTraceEnabled()) {
+      LOG.trace(
           "OptimizeModeFilter rejected record {} (valueType={}, intent={}): not relevant for Optimize",
           record.getKey(),
           record.getValueType(),

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableNameFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableNameFilter.java
@@ -35,8 +35,8 @@ public final class VariableNameFilter implements ExporterRecordFilter, RecordVer
     }
 
     final boolean accepted = nameFilter.accept(variableRecordValue.getName());
-    if (!accepted && LOG.isDebugEnabled()) {
-      LOG.debug(
+    if (!accepted && LOG.isTraceEnabled()) {
+      LOG.trace(
           "VariableNameFilter rejected record {}: variable name '{}' did not match name rules",
           record.getKey(),
           variableRecordValue.getName());

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableNameScopeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableNameScopeFilter.java
@@ -67,8 +67,8 @@ public final class VariableNameScopeFilter implements ExporterRecordFilter, Reco
       accepted = !hasRootRules || rootFilter.accept(variableRecordValue.getName());
     }
 
-    if (!accepted && LOG.isDebugEnabled()) {
-      LOG.debug(
+    if (!accepted && LOG.isTraceEnabled()) {
+      LOG.trace(
           "VariableNameScopeFilter rejected record {}: {} variable name '{}' did not match name rules",
           record.getKey(),
           scope,

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeFilter.java
@@ -56,8 +56,8 @@ public final class VariableTypeFilter implements ExporterRecordFilter, RecordVer
         VariableValueType.infer(objectMapper, variableRecordValue.getValue());
 
     final boolean accepted = allowedTypes.contains(inferredType);
-    if (!accepted && LOG.isDebugEnabled()) {
-      LOG.debug(
+    if (!accepted && LOG.isTraceEnabled()) {
+      LOG.trace(
           "VariableTypeFilter rejected record {}: inferred type {} is not in allowed types {}",
           record.getKey(),
           inferredType,

--- a/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeScopeFilter.java
+++ b/zeebe/exporter-filter/src/main/java/io/camunda/zeebe/exporter/filter/VariableTypeScopeFilter.java
@@ -83,8 +83,8 @@ public final class VariableTypeScopeFilter implements ExporterRecordFilter, Reco
       final VariableValueType inferredType =
           VariableValueType.infer(objectMapper, variableRecordValue.getValue());
       final boolean accepted = allowedLocalTypes.contains(inferredType);
-      if (!accepted && LOG.isDebugEnabled()) {
-        LOG.debug(
+      if (!accepted && LOG.isTraceEnabled()) {
+        LOG.trace(
             "VariableTypeScopeFilter rejected record {}: {} variable '{}' has inferred type {} which is not in allowed {} types {}",
             record.getKey(),
             scope,
@@ -101,8 +101,8 @@ public final class VariableTypeScopeFilter implements ExporterRecordFilter, Reco
       final VariableValueType inferredType =
           VariableValueType.infer(objectMapper, variableRecordValue.getValue());
       final boolean accepted = allowedRootTypes.contains(inferredType);
-      if (!accepted && LOG.isDebugEnabled()) {
-        LOG.debug(
+      if (!accepted && LOG.isTraceEnabled()) {
+        LOG.trace(
             "VariableTypeScopeFilter rejected record {}: {} variable '{}' has inferred type {} which is not in allowed {} types {}",
             record.getKey(),
             scope,


### PR DESCRIPTION
## Description

`OptimizeModeFilter` and six other exporter filters (added in #48107) emit a `LOG.debug()` line for every rejected record. With `optimizeModeEnabled=true` by default and `ZEEBE_LOG_LEVEL=DEBUG` set in load-test environments, this generates millions of log lines per minute and floods Cloud Logging (INC-6503).

`TRACE` is the correct level for hot-path per-record diagnostics. `DEBUG` should be reserved for meaningful lifecycle events, not rejection of every single record on the exporter pipeline. The config-time `parseTypes()` logs in `VariableTypeFilter` intentionally remain at `DEBUG`.

Changed in all 7 filters:
- `BpmnProcessFilter`
- `ExportLocalVariablesFilter`
- `OptimizeModeFilter`
- `VariableNameFilter`
- `VariableNameScopeFilter`
- `VariableTypeFilter` (reject path only, not `parseTypes()`)
- `VariableTypeScopeFilter`

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Closes INC-6503

🤖 Generated with [Claude Code](https://claude.com/claude-code)