### PR TITLE
perf: replace Tasklist task archiver aggregation with plain sorted query (8.7 backport)

### DIFF
--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -164,6 +164,7 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
     if (hits.length == 0) {
       return null;
     }
+    DateOfArchivedDocumentsUtil.validateRolloverConfiguration(rolloverInterval, dateFormat);
     final String firstEndDate = hits[0].field(dateField).getValue();
     final String bucketStart =
         DateOfArchivedDocumentsUtil.getBucketStart(firstEndDate, rolloverInterval, dateFormat);

--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/OpensearchArchiverRepository.java
@@ -625,6 +625,7 @@ public class OpensearchArchiverRepository implements ArchiverRepository {
     if (hits.isEmpty()) {
       return null;
     }
+    DateOfArchivedDocumentsUtil.validateRolloverConfiguration(rolloverInterval, dateFormat);
     final String firstEndDate = endDateOf(hits.get(0), dateField);
     final String bucketStart =
         DateOfArchivedDocumentsUtil.getBucketStart(firstEndDate, rolloverInterval, dateFormat);

--- a/tasklist/archiver/pom.xml
+++ b/tasklist/archiver/pom.xml
@@ -141,6 +141,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/TaskArchiverJobElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/TaskArchiverJobElasticSearch.java
@@ -9,13 +9,11 @@ package io.camunda.tasklist.archiver.es;
 
 import static io.camunda.tasklist.util.ElasticsearchUtil.joinWithAnd;
 import static org.elasticsearch.index.query.QueryBuilders.*;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.dateHistogram;
-import static org.elasticsearch.search.aggregations.AggregationBuilders.topHits;
-import static org.elasticsearch.search.aggregations.PipelineAggregatorBuilders.bucketSort;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
 import io.camunda.tasklist.Metrics;
 import io.camunda.tasklist.archiver.TaskArchiverJob;
+import io.camunda.tasklist.archiver.util.DateOfArchivedDocumentsUtil;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
@@ -23,11 +21,9 @@ import io.camunda.tasklist.schema.templates.TaskTemplate;
 import io.camunda.tasklist.schema.templates.TaskVariableTemplate;
 import io.camunda.tasklist.util.Either;
 import io.micrometer.core.instrument.Timer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -35,13 +31,8 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
-import org.elasticsearch.search.SearchHits;
-import org.elasticsearch.search.aggregations.AggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
-import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
-import org.elasticsearch.search.aggregations.metrics.TopHits;
+import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,8 +49,6 @@ public class TaskArchiverJobElasticSearch extends AbstractArchiverJobElasticSear
     implements TaskArchiverJob {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskArchiverJobElasticSearch.class);
-  private static final String DATES_AGG = "datesAgg";
-  private static final String INSTANCES_AGG = "instancesAgg";
 
   @Autowired private TaskTemplate taskTemplate;
 
@@ -122,8 +111,7 @@ public class TaskArchiverJobElasticSearch extends AbstractArchiverJobElasticSear
   @Override
   public CompletableFuture<ArchiveBatch> getNextBatch() {
     final var batchFuture = new CompletableFuture<ArchiveBatch>();
-    final var aggregation = createFinishedTasksAggregation(DATES_AGG, INSTANCES_AGG);
-    final var searchRequest = createFinishedTasksSearchRequest(aggregation);
+    final var searchRequest = createFinishedTasksSearchRequest();
 
     final var startTimer = Timer.start();
     sendSearchRequest(searchRequest)
@@ -153,7 +141,7 @@ public class TaskArchiverJobElasticSearch extends AbstractArchiverJobElasticSear
     return Either.right(batch);
   }
 
-  private SearchRequest createFinishedTasksSearchRequest(AggregationBuilder agg) {
+  private SearchRequest createFinishedTasksSearchRequest() {
     final QueryBuilder endDateQ =
         rangeQuery(TaskTemplate.COMPLETION_TIME)
             .lte(tasklistProperties.getArchiver().getArchivingTimepoint());
@@ -165,58 +153,45 @@ public class TaskArchiverJobElasticSearch extends AbstractArchiverJobElasticSear
             .source(
                 new SearchSourceBuilder()
                     .query(q)
-                    .aggregation(agg)
                     .fetchSource(false)
-                    .size(0)
+                    .docValueField(
+                        TaskTemplate.COMPLETION_TIME,
+                        tasklistProperties.getArchiver().getElsRolloverDateFormat())
+                    .size(tasklistProperties.getArchiver().getRolloverBatchSize())
                     .sort(TaskTemplate.COMPLETION_TIME, SortOrder.ASC))
             .requestCache(false); // we don't need to cache this, as each time we need new data
 
-    LOGGER.debug(
-        "Finished tasks for archiving request: \n{}\n and aggregation: \n{}",
-        q.toString(),
-        agg.toString());
+    LOGGER.debug("Finished tasks for archiving request: \n{}", q.toString());
     return searchRequest;
   }
 
-  private AggregationBuilder createFinishedTasksAggregation(
-      String datesAggName, String instancesAggName) {
-    return dateHistogram(datesAggName)
-        .field(TaskTemplate.COMPLETION_TIME)
-        .calendarInterval(
-            new DateHistogramInterval(
-                Optional.ofNullable(tasklistProperties.getArchiver().getRolloverInterval())
-                    .orElse("1d")))
-        .format(tasklistProperties.getArchiver().getElsRolloverDateFormat())
-        .keyed(true) // get result as a map (not an array)
-        // we want to get only one bucket at a time
-        .subAggregation(
-            bucketSort("datesSortedAgg", Arrays.asList(new FieldSortBuilder("_key"))).size(1))
-        // we need process instance ids, also taking into account batch size
-        .subAggregation(
-            topHits(instancesAggName)
-                .size(tasklistProperties.getArchiver().getRolloverBatchSize())
-                .sort(TaskTemplate.ID, SortOrder.ASC)
-                .fetchSource(TaskTemplate.ID, null));
-  }
-
   protected ArchiveBatch createArchiveBatch(final SearchResponse searchResponse) {
-    final List<? extends Histogram.Bucket> buckets =
-        ((Histogram) searchResponse.getAggregations().get(DATES_AGG)).getBuckets();
-
-    if (buckets.size() > 0) {
-      final Histogram.Bucket bucket = buckets.get(0);
-      final String finishDate = bucket.getKeyAsString();
-      final SearchHits hits = ((TopHits) bucket.getAggregations().get(INSTANCES_AGG)).getHits();
-      final ArrayList<String> ids =
-          Arrays.stream(hits.getHits())
-              .collect(
-                  ArrayList::new,
-                  (list, hit) -> list.add(hit.getId()),
-                  (list1, list2) -> list1.addAll(list2));
-      return new ArchiveBatch(finishDate, ids);
-    } else {
+    final SearchHit[] hits = searchResponse.getHits().getHits();
+    if (hits.length == 0) {
       return null;
     }
+    final String rolloverInterval = tasklistProperties.getArchiver().getRolloverInterval();
+    final String dateFormat = tasklistProperties.getArchiver().getElsRolloverDateFormat();
+    DateOfArchivedDocumentsUtil.validateRolloverConfiguration(rolloverInterval, dateFormat);
+    final String firstCompletionTime = completionTimeOf(hits[0]);
+    final String bucketStart =
+        DateOfArchivedDocumentsUtil.getBucketStart(
+            firstCompletionTime, rolloverInterval, dateFormat);
+    final String nextBucketStart =
+        DateOfArchivedDocumentsUtil.getNextBucketStart(
+            firstCompletionTime, rolloverInterval, dateFormat);
+    // hits are sorted by completionTime ASC, so the first hit defines the bucket.
+    // Only the exclusive upper bound needs to be checked.
+    final List<String> ids =
+        Arrays.stream(hits)
+            .takeWhile(hit -> completionTimeOf(hit).compareTo(nextBucketStart) < 0)
+            .map(SearchHit::getId)
+            .toList();
+    return new ArchiveBatch(bucketStart, ids);
+  }
+
+  private static String completionTimeOf(final SearchHit hit) {
+    return hit.field(TaskTemplate.COMPLETION_TIME).getValue();
   }
 
   private Timer getArchiverQueryTimer() {

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/TaskArchiverJobOpenSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/TaskArchiverJobOpenSearch.java
@@ -12,6 +12,7 @@ import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROT
 
 import io.camunda.tasklist.Metrics;
 import io.camunda.tasklist.archiver.TaskArchiverJob;
+import io.camunda.tasklist.archiver.util.DateOfArchivedDocumentsUtil;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
@@ -20,11 +21,8 @@ import io.camunda.tasklist.schema.templates.TaskVariableTemplate;
 import io.camunda.tasklist.util.Either;
 import io.camunda.tasklist.util.OpenSearchUtil;
 import io.micrometer.core.instrument.Timer;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonData;
@@ -32,7 +30,6 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldSort;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.SortOrder;
-import org.opensearch.client.opensearch._types.aggregations.*;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -53,8 +50,6 @@ public class TaskArchiverJobOpenSearch extends AbstractArchiverJobOpenSearch
     implements TaskArchiverJob {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskArchiverJobOpenSearch.class);
-  private static final String DATES_AGG = "datesAgg";
-  private static final String INSTANCES_AGG = "instancesAgg";
 
   @Autowired private TaskTemplate taskTemplate;
 
@@ -118,8 +113,7 @@ public class TaskArchiverJobOpenSearch extends AbstractArchiverJobOpenSearch
   @Override
   public CompletableFuture<ArchiveBatch> getNextBatch() {
     final var batchFuture = new CompletableFuture<ArchiveBatch>();
-    final var aggregation = createFinishedTasksAggregation(DATES_AGG, INSTANCES_AGG);
-    final var searchRequest = createFinishedTasksSearchRequest(aggregation);
+    final var searchRequest = createFinishedTasksSearchRequest();
 
     final var startTimer = Timer.start();
     sendSearchRequest(searchRequest)
@@ -149,10 +143,9 @@ public class TaskArchiverJobOpenSearch extends AbstractArchiverJobOpenSearch
     return Either.right(batch);
   }
 
-  private SearchRequest createFinishedTasksSearchRequest(final Aggregation agg) {
+  private SearchRequest createFinishedTasksSearchRequest() {
     final List<FieldValue> partitions =
         getPartitionIds().stream().map(m -> FieldValue.of(m)).collect(Collectors.toList());
-    final SearchRequest.Builder builder = new SearchRequest.Builder();
 
     final Query.Builder endDateQ = new Query.Builder();
     endDateQ.range(
@@ -169,106 +162,52 @@ public class TaskArchiverJobOpenSearch extends AbstractArchiverJobOpenSearch
             .constantScore(cs -> cs.filter(OpenSearchUtil.joinWithAnd(endDateQ, partitionQ)))
             .build();
 
-    builder
+    final String dateFormat = tasklistProperties.getArchiver().getElsRolloverDateFormat();
+
+    LOGGER.debug("Finished tasks for archiving request: \n{}", q.toString());
+
+    return new SearchRequest.Builder()
         .index(taskTemplate.getFullQualifiedName())
         .query(q)
+        .source(s -> s.fetch(false))
+        .fields(f -> f.field(TaskTemplate.COMPLETION_TIME).format(dateFormat))
+        .size(tasklistProperties.getArchiver().getRolloverBatchSize())
         .sort(
             s ->
                 s.field(
                     FieldSort.of(f -> f.field(TaskTemplate.COMPLETION_TIME).order(SortOrder.Asc))))
-        .aggregations(DATES_AGG, agg)
-        .size(0)
-        .requestCache(false);
-
-    LOGGER.debug(
-        "Finished tasks for archiving request: \n{}\n and aggregation: \n{}",
-        q.toString(),
-        agg.toString());
-
-    return builder.build();
-  }
-
-  private CalendarInterval calendarIntervalByAlias(final String alias) {
-    return Arrays.stream(CalendarInterval.values())
-        .filter(ci -> Arrays.asList(ci.aliases()).contains(alias))
-        .findFirst()
-        .orElseThrow(
-            () -> {
-              final List<String> legalAliases =
-                  Arrays.stream(CalendarInterval.values())
-                      .flatMap(v -> Arrays.stream(v.aliases()))
-                      .sorted()
-                      .toList();
-              return new TasklistRuntimeException(
-                  format(
-                      "Unknown CalendarInterval alias %s! Legal aliases: %s", alias, legalAliases));
-            });
-  }
-
-  private Aggregation createFinishedTasksAggregation(
-      final String datesAggName, final String instancesAggName) {
-
-    final Aggregation dateHistogram =
-        new Aggregation.Builder()
-            .dateHistogram(
-                d ->
-                    d.field(TaskTemplate.COMPLETION_TIME)
-                        .calendarInterval(
-                            calendarIntervalByAlias(
-                                tasklistProperties.getArchiver().getRolloverInterval()))
-                        .format(tasklistProperties.getArchiver().getElsRolloverDateFormat())
-                        .keyed(true))
-            .aggregations(
-                "datesSortedAgg",
-                new Aggregation.Builder()
-                    .bucketSort(
-                        bs ->
-                            bs.sort(
-                                    s ->
-                                        s.field(
-                                            FieldSort.of(
-                                                f -> f.field("_key").order(SortOrder.Desc))))
-                                // we want to get only one bucket at a time
-                                .size(1))
-                    .build())
-            .aggregations(
-                instancesAggName,
-                new Aggregation.Builder()
-                    .topHits(
-                        th ->
-                            th.size(tasklistProperties.getArchiver().getRolloverBatchSize())
-                                .sort(
-                                    s ->
-                                        s.field(f -> f.field(TaskTemplate.ID).order(SortOrder.Asc)))
-                                .source(s -> s.filter(sf -> sf.includes(List.of(TaskTemplate.ID)))))
-                    .build())
-            .build();
-
-    return dateHistogram;
+        .requestCache(false)
+        .build();
   }
 
   protected ArchiveBatch createArchiveBatch(final SearchResponse searchResponse) {
-    final Aggregate agg = ((Aggregate) searchResponse.aggregations().get(DATES_AGG));
-    final DateHistogramAggregate histogramAgg = (DateHistogramAggregate) agg._get();
-    final Buckets<DateHistogramBucket> buckets = histogramAgg.buckets();
-    final HashMap bucket = (HashMap) buckets._get();
-
-    if (bucket.size() > 0) {
-      final Set<Map.Entry<String, DateHistogramBucket>> bucketEntrySet = bucket.entrySet();
-      for (final Map.Entry<String, DateHistogramBucket> bucketItem : bucketEntrySet) {
-        final String finishDate = bucketItem.getKey();
-        final HitsMetadata hits =
-            bucketItem.getValue().aggregations().get(INSTANCES_AGG).topHits().hits();
-
-        final List<String> ids =
-            (List<String>)
-                hits.hits().stream().map(hit -> ((Hit) hit).id()).collect(Collectors.toList());
-        return new ArchiveBatch(finishDate, ids);
-      }
-      return null;
-    } else {
+    final HitsMetadata<?> metadata = searchResponse.hits();
+    final List<? extends Hit<?>> hits = metadata.hits();
+    if (hits.isEmpty()) {
       return null;
     }
+    final String rolloverInterval = tasklistProperties.getArchiver().getRolloverInterval();
+    final String dateFormat = tasklistProperties.getArchiver().getElsRolloverDateFormat();
+    DateOfArchivedDocumentsUtil.validateRolloverConfiguration(rolloverInterval, dateFormat);
+    final String firstCompletionTime = completionTimeOf(hits.get(0));
+    final String bucketStart =
+        DateOfArchivedDocumentsUtil.getBucketStart(
+            firstCompletionTime, rolloverInterval, dateFormat);
+    final String nextBucketStart =
+        DateOfArchivedDocumentsUtil.getNextBucketStart(
+            firstCompletionTime, rolloverInterval, dateFormat);
+    // hits are sorted by completionTime ASC, so the first hit defines the bucket.
+    // Only the exclusive upper bound needs to be checked.
+    final List<String> ids =
+        hits.stream()
+            .takeWhile(hit -> completionTimeOf(hit).compareTo(nextBucketStart) < 0)
+            .map(Hit::id)
+            .toList();
+    return new ArchiveBatch(bucketStart, ids);
+  }
+
+  private static String completionTimeOf(final Hit<?> hit) {
+    return hit.fields().get(TaskTemplate.COMPLETION_TIME).toJson().asJsonArray().getString(0);
   }
 
   private Timer getArchiverQueryTimer() {

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/util/DateOfArchivedDocumentsUtil.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/util/DateOfArchivedDocumentsUtil.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.operate.archiver.util;
+package io.camunda.tasklist.archiver.util;
 
 import java.time.DayOfWeek;
 import java.time.Duration;

--- a/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/TaskArchiverJobElasticSearchTest.java
+++ b/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/es/TaskArchiverJobElasticSearchTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.archiver.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.tasklist.archiver.AbstractArchiverJob.ArchiveBatch;
+import io.camunda.tasklist.archiver.ArchiverUtil;
+import io.camunda.tasklist.property.ArchiverProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.schema.templates.TaskTemplate;
+import io.camunda.tasklist.schema.templates.TaskVariableTemplate;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.common.document.DocumentField;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class TaskArchiverJobElasticSearchTest {
+
+  private static final String TASK_INDEX = "tasklist-task-index";
+  private static final String TASK_VAR_INDEX = "tasklist-task-variable-index";
+  private static final String FINISH_DATE = "2026-03-16";
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+  @InjectMocks
+  private TaskArchiverJobElasticSearch underTest = new TaskArchiverJobElasticSearch(List.of(1));
+
+  @Mock private ArchiverUtil archiverUtil;
+  @Mock private TaskTemplate taskTemplate;
+  @Mock private TaskVariableTemplate taskVariableTemplate;
+  @Mock private TasklistProperties tasklistProperties;
+  @Mock private ArchiverProperties archiverProperties;
+
+  @BeforeEach
+  public void setUp() {
+    when(taskTemplate.getFullQualifiedName()).thenReturn(TASK_INDEX);
+    when(taskVariableTemplate.getFullQualifiedName()).thenReturn(TASK_VAR_INDEX);
+    when(tasklistProperties.getArchiver()).thenReturn(archiverProperties);
+    when(archiverProperties.getRolloverInterval()).thenReturn("1d");
+    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
+  }
+
+  @Test
+  public void archiveBatchReturnsNothingToArchiveWhenBatchIsNull() {
+    final CompletableFuture<Map.Entry<String, Integer>> res = underTest.archiveBatch(null);
+
+    assertThat(res).succeedsWithin(TIMEOUT).extracting(Map.Entry::getValue).isEqualTo(0);
+    verify(archiverUtil, never()).moveDocuments(any(), any(), any(), any());
+  }
+
+  @Test
+  public void archiveBatchMovesTasksAndVariables() {
+    when(archiverUtil.moveDocuments(
+            eq(TASK_VAR_INDEX), eq(TaskVariableTemplate.TASK_ID), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(archiverUtil.moveDocuments(eq(TASK_INDEX), eq(TaskTemplate.ID), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final var batch = new ArchiveBatch(FINISH_DATE, List.of("task-1", "task-2"));
+    final CompletableFuture<Map.Entry<String, Integer>> res = underTest.archiveBatch(batch);
+
+    assertThat(res).succeedsWithin(TIMEOUT).extracting(Map.Entry::getValue).isEqualTo(2);
+    verify(archiverUtil)
+        .moveDocuments(
+            eq(TASK_VAR_INDEX), eq(TaskVariableTemplate.TASK_ID), eq(FINISH_DATE), any());
+    verify(archiverUtil).moveDocuments(eq(TASK_INDEX), eq(TaskTemplate.ID), eq(FINISH_DATE), any());
+  }
+
+  @Test
+  public void archiveBatchFailsWhenVariableMovesFail() {
+    final CompletableFuture<Void> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new RuntimeException("ES variable move failed"));
+    when(archiverUtil.moveDocuments(eq(TASK_VAR_INDEX), any(), any(), any())).thenReturn(failed);
+    when(archiverUtil.moveDocuments(eq(TASK_INDEX), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final var batch = new ArchiveBatch(FINISH_DATE, List.of("task-1"));
+    final CompletableFuture<Map.Entry<String, Integer>> res = underTest.archiveBatch(batch);
+
+    assertThat(res).failsWithin(TIMEOUT);
+  }
+
+  @Test
+  public void archiveBatchFailsWhenTaskMoveFails() {
+    when(archiverUtil.moveDocuments(eq(TASK_VAR_INDEX), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    final CompletableFuture<Void> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new RuntimeException("ES task move failed"));
+    when(archiverUtil.moveDocuments(eq(TASK_INDEX), any(), any(), any())).thenReturn(failed);
+
+    final var batch = new ArchiveBatch(FINISH_DATE, List.of("task-1"));
+    final CompletableFuture<Map.Entry<String, Integer>> res = underTest.archiveBatch(batch);
+
+    assertThat(res).failsWithin(TIMEOUT);
+  }
+
+  @Test
+  public void createArchiveBatchReturnsNullWhenNoHits() {
+    final SearchResponse response = mock(SearchResponse.class);
+    final SearchHits searchHits = mock(SearchHits.class);
+    when(response.getHits()).thenReturn(searchHits);
+    when(searchHits.getHits()).thenReturn(new SearchHit[0]);
+
+    assertThat(underTest.createArchiveBatch(response)).isNull();
+  }
+
+  @Test
+  public void createArchiveBatchIncludesAllHitsInSameBucket() {
+    final SearchResponse response =
+        mockSearchResponse(mockHit("id1", "2026-03-16"), mockHit("id2", "2026-03-16"));
+
+    final ArchiveBatch batch = underTest.createArchiveBatch(response);
+
+    assertThat(batch).isNotNull();
+    assertThat(batch.getFinishDate()).isEqualTo("2026-03-16");
+    assertThat(batch.getIds()).containsExactly("id1", "id2");
+  }
+
+  @Test
+  public void createArchiveBatchTrimsToCrossedBucketBoundary() {
+    final SearchResponse response =
+        mockSearchResponse(mockHit("id1", "2026-03-16"), mockHit("id2", "2026-03-17"));
+
+    final ArchiveBatch batch = underTest.createArchiveBatch(response);
+
+    assertThat(batch).isNotNull();
+    assertThat(batch.getFinishDate()).isEqualTo("2026-03-16");
+    assertThat(batch.getIds()).containsExactly("id1");
+  }
+
+  private SearchResponse mockSearchResponse(final SearchHit... hits) {
+    final SearchResponse response = mock(SearchResponse.class);
+    final SearchHits searchHits = mock(SearchHits.class);
+    when(response.getHits()).thenReturn(searchHits);
+    when(searchHits.getHits()).thenReturn(hits);
+    return response;
+  }
+
+  private SearchHit mockHit(final String id, final String completionTime) {
+    final SearchHit hit = mock(SearchHit.class);
+    final DocumentField field = mock(DocumentField.class);
+    when(field.<String>getValue()).thenReturn(completionTime);
+    when(hit.field(TaskTemplate.COMPLETION_TIME)).thenReturn(field);
+    when(hit.getId()).thenReturn(id);
+    return hit;
+  }
+}

--- a/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/os/TaskArchiverJobOpenSearchTest.java
+++ b/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/os/TaskArchiverJobOpenSearchTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.archiver.os;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.tasklist.archiver.AbstractArchiverJob.ArchiveBatch;
+import io.camunda.tasklist.archiver.ArchiverUtil;
+import io.camunda.tasklist.property.ArchiverProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.schema.templates.TaskTemplate;
+import io.camunda.tasklist.schema.templates.TaskVariableTemplate;
+import jakarta.json.JsonArray;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class TaskArchiverJobOpenSearchTest {
+
+  private static final String TASK_INDEX = "tasklist-task-index";
+  private static final String TASK_VAR_INDEX = "tasklist-task-variable-index";
+  private static final String FINISH_DATE = "2026-03-16";
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+  @InjectMocks
+  private TaskArchiverJobOpenSearch underTest = new TaskArchiverJobOpenSearch(List.of(1));
+
+  @Mock private ArchiverUtil archiverUtil;
+  @Mock private TaskTemplate taskTemplate;
+  @Mock private TaskVariableTemplate taskVariableTemplate;
+  @Mock private TasklistProperties tasklistProperties;
+  @Mock private ArchiverProperties archiverProperties;
+
+  @BeforeEach
+  public void setUp() {
+    when(taskTemplate.getFullQualifiedName()).thenReturn(TASK_INDEX);
+    when(taskVariableTemplate.getFullQualifiedName()).thenReturn(TASK_VAR_INDEX);
+    when(tasklistProperties.getArchiver()).thenReturn(archiverProperties);
+    when(archiverProperties.getRolloverInterval()).thenReturn("1d");
+    when(archiverProperties.getElsRolloverDateFormat()).thenReturn("date");
+  }
+
+  @Test
+  public void archiveBatchReturnsNothingToArchiveWhenBatchIsNull() {
+    final CompletableFuture<Map.Entry<String, Integer>> res = underTest.archiveBatch(null);
+
+    assertThat(res).succeedsWithin(TIMEOUT).extracting(Map.Entry::getValue).isEqualTo(0);
+    verify(archiverUtil, never()).moveDocuments(any(), any(), any(), any());
+  }
+
+  @Test
+  public void archiveBatchMovesTasksAndVariables() {
+    when(archiverUtil.moveDocuments(
+            eq(TASK_VAR_INDEX), eq(TaskVariableTemplate.TASK_ID), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    when(archiverUtil.moveDocuments(eq(TASK_INDEX), eq(TaskTemplate.ID), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final var batch = new ArchiveBatch(FINISH_DATE, List.of("task-1", "task-2"));
+    final CompletableFuture<Map.Entry<String, Integer>> res = underTest.archiveBatch(batch);
+
+    assertThat(res).succeedsWithin(TIMEOUT).extracting(Map.Entry::getValue).isEqualTo(2);
+    verify(archiverUtil)
+        .moveDocuments(
+            eq(TASK_VAR_INDEX), eq(TaskVariableTemplate.TASK_ID), eq(FINISH_DATE), any());
+    verify(archiverUtil).moveDocuments(eq(TASK_INDEX), eq(TaskTemplate.ID), eq(FINISH_DATE), any());
+  }
+
+  @Test
+  public void archiveBatchFailsWhenVariableMovesFail() {
+    final CompletableFuture<Void> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new RuntimeException("OS variable move failed"));
+    when(archiverUtil.moveDocuments(eq(TASK_VAR_INDEX), any(), any(), any())).thenReturn(failed);
+    when(archiverUtil.moveDocuments(eq(TASK_INDEX), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    final var batch = new ArchiveBatch(FINISH_DATE, List.of("task-1"));
+    final CompletableFuture<Map.Entry<String, Integer>> res = underTest.archiveBatch(batch);
+
+    assertThat(res).failsWithin(TIMEOUT);
+  }
+
+  @Test
+  public void archiveBatchFailsWhenTaskMoveFails() {
+    when(archiverUtil.moveDocuments(eq(TASK_VAR_INDEX), any(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    final CompletableFuture<Void> failed = new CompletableFuture<>();
+    failed.completeExceptionally(new RuntimeException("OS task move failed"));
+    when(archiverUtil.moveDocuments(eq(TASK_INDEX), any(), any(), any())).thenReturn(failed);
+
+    final var batch = new ArchiveBatch(FINISH_DATE, List.of("task-1"));
+    final CompletableFuture<Map.Entry<String, Integer>> res = underTest.archiveBatch(batch);
+
+    assertThat(res).failsWithin(TIMEOUT);
+  }
+
+  @Test
+  public void createArchiveBatchReturnsNullWhenNoHits() {
+    final SearchResponse<?> response = mockSearchResponse(List.of());
+
+    assertThat(underTest.createArchiveBatch(response)).isNull();
+  }
+
+  @Test
+  public void createArchiveBatchIncludesAllHitsInSameBucket() {
+    final SearchResponse<?> response =
+        mockSearchResponse(List.of(mockHit("id1", "2026-03-16"), mockHit("id2", "2026-03-16")));
+
+    final ArchiveBatch batch = underTest.createArchiveBatch(response);
+
+    assertThat(batch).isNotNull();
+    assertThat(batch.getFinishDate()).isEqualTo("2026-03-16");
+    assertThat(batch.getIds()).containsExactly("id1", "id2");
+  }
+
+  @Test
+  public void createArchiveBatchTrimsToCrossedBucketBoundary() {
+    final SearchResponse<?> response =
+        mockSearchResponse(List.of(mockHit("id1", "2026-03-16"), mockHit("id2", "2026-03-17")));
+
+    final ArchiveBatch batch = underTest.createArchiveBatch(response);
+
+    assertThat(batch).isNotNull();
+    assertThat(batch.getFinishDate()).isEqualTo("2026-03-16");
+    assertThat(batch.getIds()).containsExactly("id1");
+  }
+
+  @SuppressWarnings("unchecked")
+  private SearchResponse<?> mockSearchResponse(final List<Hit<?>> hits) {
+    final SearchResponse<Object> response = mock(SearchResponse.class);
+    final HitsMetadata<Object> metadata = mock(HitsMetadata.class);
+    when(response.hits()).thenReturn(metadata);
+    when(metadata.hits()).thenReturn((List) hits);
+    return response;
+  }
+
+  @SuppressWarnings("unchecked")
+  private Hit<?> mockHit(final String id, final String completionTime) {
+    final Hit<Object> hit = mock(Hit.class);
+    final JsonData jsonData = mock(JsonData.class);
+    final JsonArray jsonArray = mock(JsonArray.class);
+    when(jsonArray.getString(0)).thenReturn(completionTime);
+    when(jsonArray.asJsonArray()).thenReturn(jsonArray);
+    when(jsonData.toJson()).thenReturn(jsonArray);
+    when(hit.fields()).thenReturn(Map.of(TaskTemplate.COMPLETION_TIME, jsonData));
+    when(hit.id()).thenReturn(id);
+    return hit;
+  }
+}

--- a/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/util/DateOfArchivedDocumentsUtilTest.java
+++ b/tasklist/archiver/src/test/java/io/camunda/tasklist/archiver/util/DateOfArchivedDocumentsUtilTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.archiver.util;
+
+import static io.camunda.tasklist.archiver.util.DateOfArchivedDocumentsUtil.getBucketStart;
+import static io.camunda.tasklist.archiver.util.DateOfArchivedDocumentsUtil.getNextBucketStart;
+import static io.camunda.tasklist.archiver.util.DateOfArchivedDocumentsUtil.validateRolloverConfiguration;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DateOfArchivedDocumentsUtilTest {
+
+  @ParameterizedTest(name = "getBucketStart(\"{0}\", \"{1}\", \"{2}\") = \"{3}\"")
+  @MethodSource("bucketCases")
+  void shouldReturnCorrectBucketStart(
+      final String endDate,
+      final String rolloverInterval,
+      final String dateFormat,
+      final String expectedBucketStart,
+      final String expectedNextBucketStart) {
+    assertThat(getBucketStart(endDate, rolloverInterval, dateFormat))
+        .isEqualTo(expectedBucketStart);
+  }
+
+  @ParameterizedTest(name = "getNextBucketStart(\"{0}\", \"{1}\", \"{2}\") = \"{4}\"")
+  @MethodSource("bucketCases")
+  void shouldReturnCorrectNextBucketStart(
+      final String endDate,
+      final String rolloverInterval,
+      final String dateFormat,
+      final String expectedBucketStart,
+      final String expectedNextBucketStart) {
+    assertThat(getNextBucketStart(endDate, rolloverInterval, dateFormat))
+        .isEqualTo(expectedNextBucketStart);
+  }
+
+  // Each case asserts BOTH the bucket start and the (exclusive) next bucket start, where
+  // nextBucketStart = bucketStart + rolloverInterval, rendered with the same dateFormat.
+  private static Stream<Arguments> bucketCases() {
+    return Stream.of(
+        // endDate, interval, format, expectedBucketStart, expectedNextBucketStart
+
+        // -- DAYS interval --
+        Arguments.of("2026-03-16", "1d", "date", "2026-03-16", "2026-03-17"),
+
+        // -- WEEKS interval: ISO calendar weeks start on Monday (matches date_histogram). --
+        // 2026-03-18 is a Wednesday; the Monday of that week is 2026-03-16.
+        Arguments.of("2026-03-18", "1w", "date", "2026-03-16", "2026-03-23"),
+
+        // -- Sub-day intervals with a day-only format: bucket start AND next both collapse to the
+        //    day, so next == start. This is the documented limitation (use a date-time format for
+        //    sub-day rollover intervals). --
+        Arguments.of("2026-03-16", "1h", "date", "2026-03-16", "2026-03-16"),
+        Arguments.of("2026-03-16", "1m", "date", "2026-03-16", "2026-03-16"),
+        Arguments.of("2026-03-16", "1s", "date", "2026-03-16", "2026-03-16"),
+
+        // -- MONTHS interval --
+        Arguments.of("2026-03-16", "1M", "date", "2026-03-01", "2026-04-01"),
+        // first day of month is on boundary
+        Arguments.of("2026-03-01", "1M", "date", "2026-03-01", "2026-04-01"),
+
+        // -- Year boundary crossing --
+        Arguments.of("2026-01-01", "1d", "date", "2026-01-01", "2026-01-02"),
+        Arguments.of("2026-01-15", "1M", "date", "2026-01-01", "2026-02-01"),
+
+        // -- Epoch date --
+        Arguments.of("1970-01-01", "1d", "date", "1970-01-01", "1970-01-02"),
+        Arguments.of("1970-01-01", "1M", "date", "1970-01-01", "1970-02-01"),
+
+        // -- Custom date format: explicit "yyyy-MM-dd" pattern --
+        Arguments.of("2026-03-16", "1d", "yyyy-MM-dd", "2026-03-16", "2026-03-17"),
+        Arguments.of("2026-03-16", "1M", "yyyy-MM-dd", "2026-03-01", "2026-04-01"),
+
+        // -- Custom date format with hours: "yyyy-MM-dd-HH" --
+        Arguments.of("2026-03-16-14", "1h", "yyyy-MM-dd-HH", "2026-03-16-14", "2026-03-16-15"),
+        Arguments.of("2026-03-16-14", "1d", "yyyy-MM-dd-HH", "2026-03-16-00", "2026-03-17-00"),
+
+        // -- Custom date format with minutes: "yyyy-MM-dd-HH-mm" --
+        Arguments.of(
+            "2026-03-16-14-45", "1m", "yyyy-MM-dd-HH-mm", "2026-03-16-14-45", "2026-03-16-14-46"),
+        Arguments.of(
+            "2026-03-16-14-45", "1h", "yyyy-MM-dd-HH-mm", "2026-03-16-14-00", "2026-03-16-15-00"),
+        Arguments.of(
+            "2026-03-16-14-45", "1d", "yyyy-MM-dd-HH-mm", "2026-03-16-00-00", "2026-03-17-00-00"),
+
+        // -- Custom date format with seconds: "yyyy-MM-dd-HH-mm-ss" --
+        Arguments.of(
+            "2026-03-16-14-30-45",
+            "1s",
+            "yyyy-MM-dd-HH-mm-ss",
+            "2026-03-16-14-30-45",
+            "2026-03-16-14-30-46"),
+        Arguments.of(
+            "2026-03-16-14-30-45",
+            "1m",
+            "yyyy-MM-dd-HH-mm-ss",
+            "2026-03-16-14-30-00",
+            "2026-03-16-14-31-00"),
+        Arguments.of(
+            "2026-03-16-14-30-45",
+            "1h",
+            "yyyy-MM-dd-HH-mm-ss",
+            "2026-03-16-14-00-00",
+            "2026-03-16-15-00-00"));
+  }
+
+  @Test
+  void shouldThrowOnInvalidRolloverInterval() {
+    assertThatThrownBy(() -> getBucketStart("2026-03-16", "1x", "date"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> getNextBucketStart("2026-03-16", "1x", "date"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest(name = "multi-unit interval \"{0}\" should be rejected")
+  @MethodSource("multiUnitIntervals")
+  void shouldRejectMultiUnitRolloverIntervals(final String interval) {
+    assertThatThrownBy(() -> getBucketStart("2026-03-16", interval, "date"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Only single-unit values");
+    assertThatThrownBy(() -> getNextBucketStart("2026-03-16", interval, "date"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Only single-unit values");
+  }
+
+  private static Stream<Arguments> multiUnitIntervals() {
+    return Stream.of(
+        Arguments.of("2d"),
+        Arguments.of("3d"),
+        Arguments.of("7d"),
+        Arguments.of("2h"),
+        Arguments.of("6h"),
+        Arguments.of("30m"),
+        Arguments.of("30s"),
+        Arguments.of("2w"),
+        Arguments.of("2M"),
+        Arguments.of("3M"),
+        Arguments.of("6M"));
+  }
+
+  @Test
+  void shouldThrowOnInvalidDateString() {
+    assertThatThrownBy(() -> getBucketStart("not-a-date", "1d", "yyyy-MM-dd'T'HH:mm:ss"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> getNextBucketStart("not-a-date", "1d", "yyyy-MM-dd'T'HH:mm:ss"))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest(name = "validateRolloverConfiguration(\"{0}\", \"{1}\") rejected")
+  @MethodSource("tooCoarseConfigurations")
+  void shouldRejectDateFormatCoarserThanInterval(
+      final String rolloverInterval, final String dateFormat) {
+    assertThatThrownBy(() -> validateRolloverConfiguration(rolloverInterval, dateFormat))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  private static Stream<Arguments> tooCoarseConfigurations() {
+    return Stream.of(
+        // sub-day interval with a day-only format
+        Arguments.of("1h", "date"),
+        Arguments.of("1m", "date"),
+        Arguments.of("1s", "yyyy-MM-dd"),
+        // interval finer than the format's finest field
+        Arguments.of("1m", "yyyy-MM-dd-HH"),
+        Arguments.of("1s", "yyyy-MM-dd-HH-mm"),
+        // day/week interval with a month-only format
+        Arguments.of("1d", "yyyy-MM"),
+        Arguments.of("1w", "yyyy-MM"),
+        // month interval with a year-only format
+        Arguments.of("1M", "yyyy"));
+  }
+
+  @ParameterizedTest(name = "validateRolloverConfiguration(\"{0}\", \"{1}\") accepted")
+  @MethodSource("fineEnoughConfigurations")
+  void shouldAcceptDateFormatAtLeastAsFineAsInterval(
+      final String rolloverInterval, final String dateFormat) {
+    assertThatCode(() -> validateRolloverConfiguration(rolloverInterval, dateFormat))
+        .doesNotThrowAnyException();
+  }
+
+  private static Stream<Arguments> fineEnoughConfigurations() {
+    return Stream.of(
+        // default configuration
+        Arguments.of("1d", "date"),
+        Arguments.of("1d", "yyyy-MM-dd"),
+        // coarser interval than the format is always fine
+        Arguments.of("1M", "date"),
+        Arguments.of("1w", "date"),
+        // format granularity equal to the interval
+        Arguments.of("1h", "yyyy-MM-dd-HH"),
+        Arguments.of("1m", "yyyy-MM-dd-HH-mm"),
+        Arguments.of("1s", "yyyy-MM-dd'T'HH:mm:ss"),
+        // format finer than the interval
+        Arguments.of("1h", "yyyy-MM-dd-HH-mm"));
+  }
+}


### PR DESCRIPTION
## Description

The `TaskArchiverJob` (ES and OS) used a `date_histogram + top_hits + bucket_sort` aggregation to find the next batch of tasks to archive. On large task indices this computed `top_hits` for every date bucket but discarded all but one, making the query O(buckets) instead of O(1).

Replace it with a plain sorted query (`completionTime ASC`, `size = rolloverBatchSize`, `docValueField` for formatted date retrieval), then trim in code to the earliest date bucket using `DateOfArchivedDocumentsUtil` (`getBucketStart` / `getNextBucketStart`).

This is a backport of the same fix applied to Operate's `ProcessInstancesArchiverJob` in #56071. The `ProcessInstanceArchiverJob` in Tasklist was already using the plain-query approach; this brings `TaskArchiverJob` in line.

Note: `DateOfArchivedDocumentsUtil` is ported from `operate/archiver` into `tasklist/archiver/util` (package change only).

## Changes

- `TaskArchiverJobElasticSearch` - replace aggregation with plain sorted query + docValueField
- `TaskArchiverJobOpenSearch` - same for OpenSearch
- `DateOfArchivedDocumentsUtil` - ported from Operate (bucket floor/ceiling arithmetic)
- New unit tests for both job classes and the date utility

## Checklist

- [ ] Enable backports when necessary