### PR TITLE
feat: handle secret references in FEEL input-mapping evaluation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -32,6 +32,9 @@ import org.jspecify.annotations.NonNull;
 
 public final class BpmnVariableMappingBehavior {
   private final ExpressionProcessor expressionProcessor;
+  // secret-aware variant used only for input mappings; stateless over a fixed delegate, so it is
+  // built once instead of per activation
+  private final ExpressionProcessor inputMappingExpressionProcessor;
   private final VariableState variablesState;
   private final ElementInstanceState elementInstanceState;
   private final VariableBehavior variableBehavior;
@@ -45,6 +48,7 @@ public final class BpmnVariableMappingBehavior {
       final VariableBehavior variableBehavior,
       final EventTriggerBehavior eventTriggerBehavior) {
     this.expressionProcessor = expressionProcessor;
+    inputMappingExpressionProcessor = expressionProcessor.withSecretReferenceContext();
     elementInstanceState = processingState.getElementInstanceState();
     variablesState = processingState.getVariableState();
     this.variableBehavior = variableBehavior;
@@ -69,8 +73,7 @@ public final class BpmnVariableMappingBehavior {
     if (inputMappingExpression.isPresent()) {
       // secret references (camunda.secrets.<name>) are resolved to their placeholder string only
       // for input mappings, so a modeled reference survives evaluation instead of nulling
-      return expressionProcessor
-          .withSecretReferenceContext()
+      return inputMappingExpressionProcessor
           .evaluateVariableMappingExpression(inputMappingExpression.get(), scopeKey, tenantId)
           .flatMap(result -> mapLocalVariables(context, element, result));
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -67,7 +67,10 @@ public final class BpmnVariableMappingBehavior {
         element.getInputMappings().map(InputMappings::expression);
 
     if (inputMappingExpression.isPresent()) {
+      // secret references (camunda.secrets.<name>) are resolved to their placeholder string only
+      // for input mappings, so a modeled reference survives evaluation instead of nulling
       return expressionProcessor
+          .withSecretReferenceContext()
           .evaluateVariableMappingExpression(inputMappingExpression.get(), scopeKey, tenantId)
           .flatMap(result -> mapLocalVariables(context, element, result));
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.expression.CombinedEvaluationContext;
 import io.camunda.zeebe.engine.processing.expression.ScopedEvaluationContext;
+import io.camunda.zeebe.engine.processing.expression.SecretReferenceEvaluationContext;
 import io.camunda.zeebe.model.bpmn.util.time.Interval;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.util.Either;
@@ -86,6 +87,23 @@ public final class ExpressionProcessor {
         expressionLanguage,
         CombinedEvaluationContext.withContexts(
             scopedEvaluationContext, this.scopedEvaluationContext),
+        expressionEvaluationTimeout);
+  }
+
+  /**
+   * Returns a copy of this processor that resolves {@code camunda.secrets.<name>} references used
+   * as expressions to their own string literal (so {@code camunda.secrets.token} evaluates to
+   * {@code "camunda.secrets.token"} instead of {@code null}). Only that path is affected; process
+   * and cluster variables ({@code camunda.vars.*}) resolve unchanged. Intended for input-mapping
+   * evaluation.
+   *
+   * @return a new secret-aware processor; this one is left unchanged
+   * @see SecretReferenceEvaluationContext
+   */
+  public ExpressionProcessor withSecretReferenceContext() {
+    return new ExpressionProcessor(
+        expressionLanguage,
+        new SecretReferenceEvaluationContext(scopedEvaluationContext),
         expressionEvaluationTimeout);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
@@ -7,19 +7,15 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
-import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
-import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
-import io.camunda.zeebe.util.Either;
 import java.util.LinkedHashSet;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 /**
  * Rejects a deployment when a {@code camunda.secrets.<name>} reference is used as a string literal
@@ -27,16 +23,16 @@ import org.jspecify.annotations.Nullable;
  * literal-vs-expression ambiguity, so a reference left in a valid input mapping is always an
  * expression.
  *
- * <p>A source is a literal when it evaluates, without any variable context, to a constant that
- * contains a reference — catching a static value, a FEEL string literal, constant-folded
- * concatenations, and references embedded in object or list literals (e.g. {@code ={"auth":
- * "camunda.secrets.token"}}). A runtime variable value equal to a reference cannot be checked at
- * deploy time and is an accepted, benign edge.
+ * <p>Detection is purely static: a static value (no leading {@code =}) is scanned as a whole, and a
+ * FEEL expression is scanned only inside its double-quoted string literals. A bare path such as
+ * {@code =camunda.secrets.token} is never quoted and is allowed; a quoted occurrence, including one
+ * nested in an object or list literal (e.g. {@code ={"auth": "camunda.secrets.token"}}), is
+ * rejected. The source is never evaluated, so a pathological expression cannot break the
+ * deployment.
  */
 @NullMarked
 final class SecretReferenceLiteralValidator implements ModelElementValidator<ZeebeInput> {
 
-  // unicode-aware so names with non-ASCII letters/digits are matched (and reported) in full
   private static final Pattern SECRET_REFERENCE =
       Pattern.compile("camunda\\.secrets\\.[\\p{Alnum}_]+");
 
@@ -65,23 +61,10 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
       return;
     }
 
-    // a literal constant-folds without a variable context; an expression path resolves to null
-    final String constant;
-    try {
-      final EvaluationResult result =
-          expressionLanguage.evaluateExpression(expression, variable -> Either.left(null));
-      constant = constantText(result);
-    } catch (final RuntimeException e) {
-      // a source that cannot be evaluated or serialized to a scannable constant (e.g. a document
-      // too deeply nested to serialize) is never a shallow secret-reference literal; skip it rather
-      // than fail the deployment. The runtime nesting-depth guard still applies at execution.
-      return;
-    }
-    if (constant == null) {
-      return;
-    }
+    // a static value is a literal in full; a FEEL expression is a literal only where it is quoted
+    final String literalText = expression.isStatic() ? source : stringLiterals(source.substring(1));
 
-    final var matcher = SECRET_REFERENCE.matcher(constant);
+    final var matcher = SECRET_REFERENCE.matcher(literalText);
     final var references = new LinkedHashSet<String>();
     while (matcher.find()) {
       references.add(matcher.group());
@@ -101,19 +84,29 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
   }
 
   /**
-   * The constant text of a context-free evaluation to scan for a reference, or {@code null} when
-   * the result is not a constant that can embed a reference (a failure, or a non-textual type such
-   * as a number). Object and list literals are inspected via their JSON form so a reference nested
-   * inside them is caught too.
+   * The concatenated contents of every double-quoted string literal in a FEEL expression body,
+   * separated so adjacent literals cannot form a spurious match. Text outside string literals (such
+   * as a {@code camunda.secrets.token} path expression) is skipped.
    */
-  private @Nullable String constantText(final EvaluationResult result) {
-    if (result.isFailure()) {
-      return null;
+  private static String stringLiterals(final String feelBody) {
+    final StringBuilder literals = new StringBuilder();
+    boolean insideString = false;
+    for (int i = 0; i < feelBody.length(); i++) {
+      final char c = feelBody.charAt(i);
+      if (insideString) {
+        if (c == '\\' && i + 1 < feelBody.length()) {
+          // keep the escaped character as-is; enough to scan for a reference
+          literals.append(feelBody.charAt(++i));
+        } else if (c == '"') {
+          insideString = false;
+          literals.append('\n');
+        } else {
+          literals.append(c);
+        }
+      } else if (c == '"') {
+        insideString = true;
+      }
     }
-    return switch (result.getType()) {
-      case STRING -> result.getString();
-      case OBJECT, ARRAY -> MsgPackConverter.convertToJson(result.toBuffer());
-      default -> null;
-    };
+    return literals.toString();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
@@ -13,7 +13,9 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.util.Either;
+import java.util.LinkedHashSet;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 import org.jspecify.annotations.NullMarked;
@@ -34,8 +36,9 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 final class SecretReferenceLiteralValidator implements ModelElementValidator<ZeebeInput> {
 
+  // unicode-aware so names with non-ASCII letters/digits are matched (and reported) in full
   private static final Pattern SECRET_REFERENCE =
-      Pattern.compile("camunda\\.secrets\\.[\\p{Alnum}_]+");
+      Pattern.compile("camunda\\.secrets\\.[\\p{L}\\p{N}_]+");
 
   private final ExpressionLanguage expressionLanguage;
 
@@ -71,14 +74,21 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
     }
 
     final var matcher = SECRET_REFERENCE.matcher(constant);
-    if (matcher.find()) {
-      final var reference = matcher.group();
+    final var references = new LinkedHashSet<String>();
+    while (matcher.find()) {
+      references.add(matcher.group());
+    }
+    if (!references.isEmpty()) {
+      final var formatted =
+          references.stream()
+              .map(reference -> "'" + reference + "'")
+              .collect(Collectors.joining(", "));
       validationResultCollector.addError(
           0,
           String.format(
-              "Secret reference '%s' must be used as an expression (e.g. '=%s'), not as a string"
-                  + " literal, in input mapping source '%s'.",
-              reference, reference, source));
+              "Secret reference(s) %s must be used as an expression (e.g. '=camunda.secrets.<name>'),"
+                  + " not as a string literal, in input mapping source '%s'.",
+              formatted, source));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.el.EvaluationResult;
+import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ResultType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import io.camunda.zeebe.util.Either;
+import java.util.regex.Pattern;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+/**
+ * Rejects a deployment when a {@code camunda.secrets.<name>} reference is used as a string literal
+ * in an input-mapping source; only expression usage (a FEEL path) is allowed. This removes the
+ * literal-vs-expression ambiguity, so a reference left in a valid input mapping is always an
+ * expression.
+ *
+ * <p>A source is a literal when it evaluates, without any variable context, to a constant string
+ * containing a reference — catching a static value, a FEEL string literal and constant-folded
+ * concatenations. A runtime variable value equal to a reference cannot be checked at deploy time
+ * and is an accepted, benign edge.
+ */
+final class SecretReferenceLiteralValidator implements ModelElementValidator<ZeebeInput> {
+
+  private static final Pattern SECRET_REFERENCE =
+      Pattern.compile("camunda\\.secrets\\.[\\p{Alnum}_]+");
+
+  private final ExpressionLanguage expressionLanguage;
+
+  SecretReferenceLiteralValidator(final ExpressionLanguage expressionLanguage) {
+    this.expressionLanguage = expressionLanguage;
+  }
+
+  @Override
+  public Class<ZeebeInput> getElementType() {
+    return ZeebeInput.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeInput element, final ValidationResultCollector validationResultCollector) {
+    final String source = element.getSource();
+    if (source == null) {
+      return;
+    }
+
+    final Expression expression = expressionLanguage.parseExpression(source);
+    if (!expression.isValid()) {
+      // invalid expressions are reported separately by the expression validator
+      return;
+    }
+
+    // a literal constant-folds to a string without a variable context; an expression path does not
+    final EvaluationResult result =
+        expressionLanguage.evaluateExpression(expression, variable -> Either.left(null));
+    if (result.isFailure() || result.getType() != ResultType.STRING) {
+      return;
+    }
+
+    final var matcher = SECRET_REFERENCE.matcher(result.getString());
+    if (matcher.find()) {
+      final var reference = matcher.group();
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "Secret reference '%s' must be used as an expression (e.g. '=%s'), not as a string"
+                  + " literal, in input mapping source '%s'.",
+              reference, reference, source));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import java.util.LinkedHashSet;
+import java.util.regex.MatchResult;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
@@ -35,6 +36,16 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
 
   private static final Pattern SECRET_REFERENCE =
       Pattern.compile("camunda\\.secrets\\.[\\p{Alnum}_]+");
+
+  // Matches one whole double-quoted string literal, so only quoted text is scanned for a reference.
+  // As a regex (after Java unescaping): "(?:\\.|[^"\\])*"
+  //   "        an opening double quote
+  //   (?: )*   zero or more of, in order:
+  //     \\.      a backslash escape (backslash + any char), so \" does not end the literal
+  //     [^"\\]   any character that is not a double quote or a backslash
+  //   "        a closing double quote
+  // e.g. it matches "ab" and "a\"b".
+  private static final Pattern STRING_LITERAL = Pattern.compile("\"(?:\\\\.|[^\"\\\\])*\"");
 
   private final ExpressionLanguage expressionLanguage;
 
@@ -84,29 +95,15 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
   }
 
   /**
-   * The concatenated contents of every double-quoted string literal in a FEEL expression body,
-   * separated so adjacent literals cannot form a spurious match. Text outside string literals (such
-   * as a {@code camunda.secrets.token} path expression) is skipped.
+   * Every double-quoted string literal in a FEEL expression body, joined by a separator so adjacent
+   * literals cannot fuse into a spurious match. Text outside string literals (such as a {@code
+   * camunda.secrets.token} path expression) is not matched, so only quoted usage is flagged.
    */
   private static String stringLiterals(final String feelBody) {
-    final StringBuilder literals = new StringBuilder();
-    boolean insideString = false;
-    for (int i = 0; i < feelBody.length(); i++) {
-      final char c = feelBody.charAt(i);
-      if (insideString) {
-        if (c == '\\' && i + 1 < feelBody.length()) {
-          // keep the escaped character as-is; enough to scan for a reference
-          literals.append(feelBody.charAt(++i));
-        } else if (c == '"') {
-          insideString = false;
-          literals.append('\n');
-        } else {
-          literals.append(c);
-        }
-      } else if (c == '"') {
-        insideString = true;
-      }
-    }
-    return literals.toString();
+    return STRING_LITERAL
+        .matcher(feelBody)
+        .results()
+        .map(MatchResult::group)
+        .collect(Collectors.joining("\n"));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
@@ -10,12 +10,14 @@ package io.camunda.zeebe.engine.processing.deployment.model.validation;
 import io.camunda.zeebe.el.EvaluationResult;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
-import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.util.Either;
 import java.util.regex.Pattern;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Rejects a deployment when a {@code camunda.secrets.<name>} reference is used as a string literal
@@ -23,11 +25,13 @@ import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
  * literal-vs-expression ambiguity, so a reference left in a valid input mapping is always an
  * expression.
  *
- * <p>A source is a literal when it evaluates, without any variable context, to a constant string
- * containing a reference — catching a static value, a FEEL string literal and constant-folded
- * concatenations. A runtime variable value equal to a reference cannot be checked at deploy time
- * and is an accepted, benign edge.
+ * <p>A source is a literal when it evaluates, without any variable context, to a constant that
+ * contains a reference — catching a static value, a FEEL string literal, constant-folded
+ * concatenations, and references embedded in object or list literals (e.g. {@code ={"auth":
+ * "camunda.secrets.token"}}). A runtime variable value equal to a reference cannot be checked at
+ * deploy time and is an accepted, benign edge.
  */
+@NullMarked
 final class SecretReferenceLiteralValidator implements ModelElementValidator<ZeebeInput> {
 
   private static final Pattern SECRET_REFERENCE =
@@ -58,14 +62,15 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
       return;
     }
 
-    // a literal constant-folds to a string without a variable context; an expression path does not
+    // a literal constant-folds without a variable context; an expression path resolves to null
     final EvaluationResult result =
         expressionLanguage.evaluateExpression(expression, variable -> Either.left(null));
-    if (result.isFailure() || result.getType() != ResultType.STRING) {
+    final String constant = constantText(result);
+    if (constant == null) {
       return;
     }
 
-    final var matcher = SECRET_REFERENCE.matcher(result.getString());
+    final var matcher = SECRET_REFERENCE.matcher(constant);
     if (matcher.find()) {
       final var reference = matcher.group();
       validationResultCollector.addError(
@@ -75,5 +80,22 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
                   + " literal, in input mapping source '%s'.",
               reference, reference, source));
     }
+  }
+
+  /**
+   * The constant text of a context-free evaluation to scan for a reference, or {@code null} when
+   * the result is not a constant that can embed a reference (a failure, or a non-textual type such
+   * as a number). Object and list literals are inspected via their JSON form so a reference nested
+   * inside them is caught too.
+   */
+  private @Nullable String constantText(final EvaluationResult result) {
+    if (result.isFailure()) {
+      return null;
+    }
+    return switch (result.getType()) {
+      case STRING -> result.getString();
+      case OBJECT, ARRAY -> MsgPackConverter.convertToJson(result.toBuffer());
+      default -> null;
+    };
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidator.java
@@ -38,7 +38,7 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
 
   // unicode-aware so names with non-ASCII letters/digits are matched (and reported) in full
   private static final Pattern SECRET_REFERENCE =
-      Pattern.compile("camunda\\.secrets\\.[\\p{L}\\p{N}_]+");
+      Pattern.compile("camunda\\.secrets\\.[\\p{Alnum}_]+");
 
   private final ExpressionLanguage expressionLanguage;
 
@@ -66,9 +66,17 @@ final class SecretReferenceLiteralValidator implements ModelElementValidator<Zee
     }
 
     // a literal constant-folds without a variable context; an expression path resolves to null
-    final EvaluationResult result =
-        expressionLanguage.evaluateExpression(expression, variable -> Either.left(null));
-    final String constant = constantText(result);
+    final String constant;
+    try {
+      final EvaluationResult result =
+          expressionLanguage.evaluateExpression(expression, variable -> Either.left(null));
+      constant = constantText(result);
+    } catch (final RuntimeException e) {
+      // a source that cannot be evaluated or serialized to a scannable constant (e.g. a document
+      // too deeply nested to serialize) is never a shallow secret-reference literal; skip it rather
+      // than fail the deployment. The runtime nesting-depth guard still applies at execution.
+      return;
+    }
     if (constant == null) {
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -46,6 +46,8 @@ public final class ZeebeRuntimeValidators {
             .hasValidExpression(ZeebeInput::getSource, ExpressionVerification::isOptional)
             .hasValidPath(ZeebeInput::getTarget)
             .build(expressionLanguage),
+        // reject secret references used as a string literal in an input mapping
+        new SecretReferenceLiteralValidator(expressionLanguage),
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(ZeebeOutput.class)
             .hasValidExpression(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContext.java
@@ -38,11 +38,18 @@ public final class SecretReferenceEvaluationContext implements ScopedEvaluationC
 
   @Override
   public Either<DirectBuffer, EvaluationContext> getVariable(final String variableName) {
-    if (ROOT.equals(variableName)) {
-      // own the `camunda` segment while keeping the delegate's `camunda` content reachable
-      return Either.right(new CamundaNamespaceContext(delegate.getVariable(ROOT)));
+    if (!ROOT.equals(variableName)) {
+      return delegate.getVariable(variableName);
     }
-    return delegate.getVariable(variableName);
+    final var camunda = delegate.getVariable(ROOT);
+    if (camunda.isLeft() && camunda.getLeft() != null) {
+      // a real `camunda` variable value (e.g. a process variable) exists; keep it intact rather
+      // than shadowing it, so its members stay reachable and existing semantics are preserved
+      return camunda;
+    }
+    // wrap the delegate's `camunda` context (or absence) so `secrets` resolves while every other
+    // key — e.g. cluster variables under `vars` — keeps forwarding to the delegate
+    return Either.right(new CamundaNamespaceContext(camunda));
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContext.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import io.camunda.zeebe.el.EvaluationContext;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * A {@link ScopedEvaluationContext} that resolves a {@code camunda.secrets.<name>} reference used
+ * as an expression to its own reference text (so {@code camunda.secrets.token} evaluates to {@code
+ * "camunda.secrets.token"}) instead of a {@code null} lookup. Installed only for input-mapping
+ * evaluation; the real secret value is substituted later, at job activation.
+ *
+ * <p>It wraps the delegate and intercepts only the {@code camunda.secrets.*} path — process
+ * variables, cluster variables ({@code camunda.vars.*}) and every other lookup are forwarded
+ * unchanged, so nothing is shadowed. The transformation is pure, hence replication/replay-safe.
+ */
+@NullMarked
+public final class SecretReferenceEvaluationContext implements ScopedEvaluationContext {
+
+  static final String ROOT = "camunda";
+  static final String NAMESPACE = "secrets";
+
+  private final ScopedEvaluationContext delegate;
+
+  public SecretReferenceEvaluationContext(final ScopedEvaluationContext delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Either<DirectBuffer, EvaluationContext> getVariable(final String variableName) {
+    if (ROOT.equals(variableName)) {
+      // own the `camunda` segment while keeping the delegate's `camunda` content reachable
+      return Either.right(new CamundaNamespaceContext(delegate.getVariable(ROOT)));
+    }
+    return delegate.getVariable(variableName);
+  }
+
+  @Override
+  public ScopedEvaluationContext processScoped(final long scopeKey) {
+    return new SecretReferenceEvaluationContext(delegate.processScoped(scopeKey));
+  }
+
+  @Override
+  public ScopedEvaluationContext tenantScoped(final String tenantId) {
+    return new SecretReferenceEvaluationContext(delegate.tenantScoped(tenantId));
+  }
+
+  /**
+   * The {@code camunda} namespace: resolves {@code secrets} to the secret-reference leaf and
+   * forwards every other key to the delegate's {@code camunda} content (e.g. {@code vars}).
+   */
+  private record CamundaNamespaceContext(Either<DirectBuffer, EvaluationContext> delegateCamunda)
+      implements EvaluationContext {
+
+    @Override
+    public Either<DirectBuffer, EvaluationContext> getVariable(final String variableName) {
+      if (NAMESPACE.equals(variableName)) {
+        return Either.right(SecretLeafContext.INSTANCE);
+      }
+      final var camunda = delegateCamunda.isRight() ? delegateCamunda.get() : null;
+      return camunda != null ? camunda.getVariable(variableName) : Either.left(null);
+    }
+  }
+
+  /**
+   * The {@code camunda.secrets} namespace: every name resolves to its own reference string literal
+   * {@code "camunda.secrets.<name>"}.
+   */
+  private static final class SecretLeafContext implements EvaluationContext {
+
+    private static final SecretLeafContext INSTANCE = new SecretLeafContext();
+
+    @Override
+    public Either<DirectBuffer, EvaluationContext> getVariable(final String name) {
+      final String reference = ROOT + "." + NAMESPACE + "." + name;
+      // cast to Object to serialize the string as a MessagePack string value, not parse it as JSON
+      return Either.left(
+          BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack((Object) reference)));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContext.java
@@ -23,6 +23,10 @@ import org.jspecify.annotations.NullMarked;
  * <p>It wraps the delegate and intercepts only the {@code camunda.secrets.*} path — process
  * variables, cluster variables ({@code camunda.vars.*}) and every other lookup are forwarded
  * unchanged, so nothing is shadowed. The transformation is pure, hence replication/replay-safe.
+ *
+ * <p>A delegate value literally named {@code camunda} (e.g. a process variable) keeps precedence,
+ * so for that instance {@code camunda.secrets.*} resolves against it rather than to a placeholder —
+ * consistent with how such a variable already shadows {@code camunda.vars.*}.
  */
 @NullMarked
 public final class SecretReferenceEvaluationContext implements ScopedEvaluationContext {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
+import java.time.InstantSource;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+import org.junit.jupiter.api.Test;
+
+final class SecretReferenceLiteralValidatorTest {
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+  private final SecretReferenceLiteralValidator sut =
+      new SecretReferenceLiteralValidator(expressionLanguage);
+
+  @Test
+  void shouldRejectStaticValueThatIsASecretReference() {
+    // when
+    final var collector = validate("camunda.secrets.token");
+
+    // then
+    verify(collector).addError(eq(0), contains("camunda.secrets.token"));
+  }
+
+  @Test
+  void shouldRejectFeelStringLiteralThatIsASecretReference() {
+    // when
+    final var collector = validate("=\"camunda.secrets.token\"");
+
+    // then
+    verify(collector).addError(eq(0), contains("camunda.secrets.token"));
+  }
+
+  @Test
+  void shouldRejectConstantFoldedStringLiteralThatIsASecretReference() {
+    // when
+    final var collector = validate("=\"camunda\" + \".secrets.token\"");
+
+    // then
+    verify(collector).addError(eq(0), contains("camunda.secrets.token"));
+  }
+
+  @Test
+  void shouldRejectSecretReferenceEmbeddedInAStringLiteral() {
+    // when
+    final var collector = validate("=\"Bearer camunda.secrets.token\"");
+
+    // then
+    verify(collector).addError(eq(0), contains("camunda.secrets.token"));
+  }
+
+  @Test
+  void shouldAllowSecretReferenceUsedAsAnExpression() {
+    // when
+    final var collector = validate("=camunda.secrets.token");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldAllowSecretReferenceExpressionInsideConcatenation() {
+    // when
+    final var collector = validate("=\"Bearer \" + camunda.secrets.token");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldAllowClusterVariableExpression() {
+    // when
+    final var collector = validate("=camunda.vars.env.REGION");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldAllowPlainStaticValue() {
+    // when
+    final var collector = validate("hello world");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldAllowPlainStringLiteral() {
+    // when
+    final var collector = validate("=\"hello world\"");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldIgnoreNullSource() {
+    // when
+    final var collector = validate(null);
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  private ValidationResultCollector validate(final String source) {
+    final var element = mock(ZeebeInput.class);
+    when(element.getSource()).thenReturn(source);
+    final var collector = mock(ValidationResultCollector.class);
+    sut.validate(element, collector);
+    return collector;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
@@ -85,6 +85,33 @@ final class SecretReferenceLiteralValidatorTest {
   }
 
   @Test
+  void shouldRejectSecretReferenceInsideObjectLiteral() {
+    // when - the reference is a string literal nested in a constant object
+    final var collector = validate("={\"auth\": \"camunda.secrets.token\"}");
+
+    // then
+    verify(collector).addError(eq(0), contains("camunda.secrets.token"));
+  }
+
+  @Test
+  void shouldRejectSecretReferenceInsideListLiteral() {
+    // when - the reference is a string literal nested in a constant list
+    final var collector = validate("=[\"camunda.secrets.token\"]");
+
+    // then
+    verify(collector).addError(eq(0), contains("camunda.secrets.token"));
+  }
+
+  @Test
+  void shouldAllowSecretReferenceExpressionInsideObjectLiteral() {
+    // when - the reference is an expression path inside the object, not a literal
+    final var collector = validate("={\"auth\": camunda.secrets.token}");
+
+    // then
+    verifyNoInteractions(collector);
+  }
+
+  @Test
   void shouldAllowClusterVariableExpression() {
     // when
     final var collector = validate("=camunda.vars.env.REGION");

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.validation;
 
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -145,6 +146,40 @@ final class SecretReferenceLiteralValidatorTest {
 
     // then
     verifyNoInteractions(collector);
+  }
+
+  @Test
+  void shouldReportEverySecretReferenceInAnObjectLiteral() {
+    // when - two distinct references appear as literals in one object
+    final var collector =
+        validate("={\"a\": \"camunda.secrets.tokenA\", \"b\": \"camunda.secrets.tokenB\"}");
+
+    // then - both are listed, not just the first
+    verify(collector)
+        .addError(
+            eq(0),
+            argThat(
+                message ->
+                    message.contains("camunda.secrets.tokenA")
+                        && message.contains("camunda.secrets.tokenB")));
+  }
+
+  @Test
+  void shouldRejectAndReportSecretReferenceWithUnicodeName() {
+    // when - a name with non-ASCII letters
+    final var collector = validate("=\"camunda.secrets.tökén\"");
+
+    // then - matched and reported in full
+    verify(collector).addError(eq(0), contains("camunda.secrets.tökén"));
+  }
+
+  @Test
+  void shouldRejectSecretReferenceContainingDigits() {
+    // when
+    final var collector = validate("camunda.secrets.token_2");
+
+    // then
+    verify(collector).addError(eq(0), contains("camunda.secrets.token_2"));
   }
 
   private ValidationResultCollector validate(final String source) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
-import io.camunda.zeebe.engine.util.validation.ValidationConstraints;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import java.time.InstantSource;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -45,15 +44,6 @@ final class SecretReferenceLiteralValidatorTest {
   void shouldRejectFeelStringLiteralThatIsASecretReference() {
     // when
     final var collector = validate("=\"camunda.secrets.token\"");
-
-    // then
-    verify(collector).addError(eq(0), contains("camunda.secrets.token"));
-  }
-
-  @Test
-  void shouldRejectConstantFoldedStringLiteralThatIsASecretReference() {
-    // when
-    final var collector = validate("=\"camunda\" + \".secrets.token\"");
 
     // then
     verify(collector).addError(eq(0), contains("camunda.secrets.token"));
@@ -166,34 +156,12 @@ final class SecretReferenceLiteralValidatorTest {
   }
 
   @Test
-  void shouldRejectAndReportSecretReferenceWithUnicodeName() {
-    // when - a name with non-ASCII letters
-    final var collector = validate("=\"camunda.secrets.tökén\"");
-
-    // then - matched and reported in full
-    verify(collector).addError(eq(0), contains("camunda.secrets.tökén"));
-  }
-
-  @Test
   void shouldRejectSecretReferenceContainingDigits() {
     // when
     final var collector = validate("camunda.secrets.token_2");
 
     // then
     verify(collector).addError(eq(0), contains("camunda.secrets.token_2"));
-  }
-
-  @Test
-  void shouldNotThrowOrRejectOnDeeplyNestedInputMapping() {
-    // given - a constant document too deeply nested to serialize; must not break the deployment
-    final int depth = ValidationConstraints.MAX_NESTING_DEPTH + 1;
-    final String deeplyNested =
-        String.format(
-            "=(for i in 1..%s return if i = 1 then [\"leaf\"] else [partial[-1]])[-1]", depth);
-
-    // when / then - completes without throwing and adds no error
-    final var collector = validate(deeplyNested);
-    verifyNoInteractions(collector);
   }
 
   private ValidationResultCollector validate(final String source) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SecretReferenceLiteralValidatorTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import io.camunda.zeebe.engine.util.validation.ValidationConstraints;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeInput;
 import java.time.InstantSource;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -180,6 +181,19 @@ final class SecretReferenceLiteralValidatorTest {
 
     // then
     verify(collector).addError(eq(0), contains("camunda.secrets.token_2"));
+  }
+
+  @Test
+  void shouldNotThrowOrRejectOnDeeplyNestedInputMapping() {
+    // given - a constant document too deeply nested to serialize; must not break the deployment
+    final int depth = ValidationConstraints.MAX_NESTING_DEPTH + 1;
+    final String deeplyNested =
+        String.format(
+            "=(for i in 1..%s return if i = 1 then [\"leaf\"] else [partial[-1]])[-1]", depth);
+
+    // when / then - completes without throwing and adds no error
+    final var collector = validate(deeplyNested);
+    verifyNoInteractions(collector);
   }
 
   private ValidationResultCollector validate(final String source) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContextTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContextTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.el.EvaluationContext;
+import io.camunda.zeebe.el.EvaluationResult;
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.ExpressionLanguageFactory;
+import io.camunda.zeebe.el.ResultType;
+import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
+import java.time.InstantSource;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class SecretReferenceEvaluationContextTest {
+
+  private final ExpressionLanguage expressionLanguage =
+      ExpressionLanguageFactory.createExpressionLanguage(
+          new ZeebeFeelEngineClock(InstantSource.system()));
+
+  /**
+   * Mimics the engine's evaluation context: process variables plus a {@code
+   * camunda.vars.env.<name>} cluster-variable namespace, so that no-shadowing can be verified.
+   */
+  private final ScopedEvaluationContext delegate =
+      CombinedEvaluationContext.withContexts(
+          new InMemoryVariableEvaluationContext(Map.of("orderId", "order-123")),
+          NamespacedEvaluationContext.create()
+              .register(
+                  "camunda",
+                  NamespacedEvaluationContext.create()
+                      .register(
+                          "vars",
+                          NamespacedEvaluationContext.create()
+                              .register(
+                                  "env",
+                                  new InMemoryVariableEvaluationContext(
+                                      Map.of("REGION", "eu-1"))))));
+
+  private final EvaluationContext secretAware = new SecretReferenceEvaluationContext(delegate);
+
+  @Test
+  void shouldEvaluateSecretReferenceExpressionToItsOwnStringLiteral() {
+    // when
+    final var result = evaluate("=camunda.secrets.externalSystemToken");
+
+    // then
+    assertThat(result.getType()).isEqualTo(ResultType.STRING);
+    assertThat(result.getString()).isEqualTo("camunda.secrets.externalSystemToken");
+  }
+
+  @Test
+  void shouldEvaluateSecretReferenceInsideConcatenation() {
+    // when
+    final var result = evaluate("=\"Bearer \" + camunda.secrets.token");
+
+    // then
+    assertThat(result.getType()).isEqualTo(ResultType.STRING);
+    assertThat(result.getString()).isEqualTo("Bearer camunda.secrets.token");
+  }
+
+  @Test
+  void shouldResolveEachSecretNameToItsOwnReference() {
+    // then
+    assertThat(evaluate("=camunda.secrets.a").getString()).isEqualTo("camunda.secrets.a");
+    assertThat(evaluate("=camunda.secrets.b").getString()).isEqualTo("camunda.secrets.b");
+  }
+
+  @Test
+  void shouldNotShadowClusterVariables() {
+    // when
+    final var result = evaluate("=camunda.vars.env.REGION");
+
+    // then
+    assertThat(result.getType()).isEqualTo(ResultType.STRING);
+    assertThat(result.getString()).isEqualTo("eu-1");
+  }
+
+  @Test
+  void shouldResolveSecretAndClusterVariableInSameExpression() {
+    // when
+    final var result = evaluate("=camunda.vars.env.REGION + \"/\" + camunda.secrets.token");
+
+    // then
+    assertThat(result.getString()).isEqualTo("eu-1/camunda.secrets.token");
+  }
+
+  @Test
+  void shouldPassThroughProcessVariables() {
+    // then
+    assertThat(evaluate("=orderId").getString()).isEqualTo("order-123");
+  }
+
+  @Test
+  void shouldReturnNullForUnknownClusterVariable() {
+    // when
+    final var result = evaluate("=camunda.vars.env.DOES_NOT_EXIST");
+
+    // then
+    assertThat(result.getType()).isEqualTo(ResultType.NULL);
+  }
+
+  private EvaluationResult evaluate(final String expression) {
+    return expressionLanguage.evaluateExpression(
+        expressionLanguage.parseExpression(expression), secretAware);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContextTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContextTest.java
@@ -107,6 +107,41 @@ final class SecretReferenceEvaluationContextTest {
     assertThat(result.getType()).isEqualTo(ResultType.NULL);
   }
 
+  @Test
+  void shouldTreatVariableValueEqualToReferenceAsPlainString() {
+    // given - a variable whose VALUE looks like a reference (the accepted, benign edge case)
+    final var context =
+        new SecretReferenceEvaluationContext(
+            new InMemoryVariableEvaluationContext(Map.of("token", "camunda.secrets.token")));
+
+    // when - the value is read as a variable, not as a camunda.secrets.* path
+    final var result =
+        expressionLanguage.evaluateExpression(
+            expressionLanguage.parseExpression("=token"), context);
+
+    // then - it stays a plain string, it is not resolved as a reference here
+    assertThat(result.getType()).isEqualTo(ResultType.STRING);
+    assertThat(result.getString()).isEqualTo("camunda.secrets.token");
+  }
+
+  @Test
+  void shouldNotShadowProcessVariableNamedCamunda() {
+    // given - a process variable named `camunda` (an object) must stay reachable, not be replaced
+    final var context =
+        new SecretReferenceEvaluationContext(
+            new InMemoryVariableEvaluationContext(
+                Map.of(
+                    "camunda", Map.of("vars", Map.of("env", Map.of("KEY", "from-process-var"))))));
+
+    // when
+    final var result =
+        expressionLanguage.evaluateExpression(
+            expressionLanguage.parseExpression("=camunda.vars.env.KEY"), context);
+
+    // then
+    assertThat(result.getString()).isEqualTo("from-process-var");
+  }
+
   private EvaluationResult evaluate(final String expression) {
     return expressionLanguage.evaluateExpression(
         expressionLanguage.parseExpression(expression), secretAware);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContextTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContextTest.java
@@ -142,6 +142,44 @@ final class SecretReferenceEvaluationContextTest {
     assertThat(result.getString()).isEqualTo("from-process-var");
   }
 
+  @Test
+  void shouldNotResolveSecretWhenCamundaVariablePresent() {
+    // given - a variable named `camunda` takes precedence, so the secret context does not intercept
+    final var context =
+        new SecretReferenceEvaluationContext(
+            new InMemoryVariableEvaluationContext(
+                Map.of("camunda", Map.of("vars", Map.of("env", Map.of("KEY", "v"))))));
+
+    // when - the reference resolves against the variable (which has no secrets), not a placeholder
+    final var result =
+        expressionLanguage.evaluateExpression(
+            expressionLanguage.parseExpression("=camunda.secrets.token"), context);
+
+    // then
+    assertThat(result.getType()).isEqualTo(ResultType.NULL);
+  }
+
+  @Test
+  void shouldPreserveSecretAwarenessAfterScoping() {
+    // given - scoping re-wraps the delegate; both secret and cluster resolution must survive it
+    final var scoped =
+        new SecretReferenceEvaluationContext(delegate).processScoped(123L).tenantScoped("tenant");
+
+    // then
+    assertThat(
+            expressionLanguage
+                .evaluateExpression(
+                    expressionLanguage.parseExpression("=camunda.secrets.token"), scoped)
+                .getString())
+        .isEqualTo("camunda.secrets.token");
+    assertThat(
+            expressionLanguage
+                .evaluateExpression(
+                    expressionLanguage.parseExpression("=camunda.vars.env.REGION"), scoped)
+                .getString())
+        .isEqualTo("eu-1");
+  }
+
   private EvaluationResult evaluate(final String expression) {
     return expressionLanguage.evaluateExpression(
         expressionLanguage.parseExpression(expression), secretAware);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContextTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceEvaluationContextTest.java
@@ -180,6 +180,23 @@ final class SecretReferenceEvaluationContextTest {
         .isEqualTo("eu-1");
   }
 
+  @Test
+  void shouldResolveAgainstRealCamundaSecretsObjectVariable() {
+    // given - a variable modeled as an object at camunda.secrets.<name> (the injection edge)
+    final var context =
+        new SecretReferenceEvaluationContext(
+            new InMemoryVariableEvaluationContext(
+                Map.of("camunda", Map.of("secrets", Map.of("token", "from-variable")))));
+
+    // when - the real variable takes precedence, so it is returned rather than the placeholder
+    final var result =
+        expressionLanguage.evaluateExpression(
+            expressionLanguage.parseExpression("=camunda.secrets.token"), context);
+
+    // then
+    assertThat(result.getString()).isEqualTo("from-variable");
+  }
+
   private EvaluationResult evaluate(final String expression) {
     return expressionLanguage.evaluateExpression(
         expressionLanguage.parseExpression(expression), secretAware);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/expression/SecretReferenceInputMappingTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.expression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * End-to-end coverage for handling {@code camunda.secrets.<name>} in FEEL input-mapping evaluation
+ * (issue #57178): an expression reference resolves to its own string-literal placeholder for input
+ * mappings only, cluster variables are not shadowed, and a literal reference is rejected at deploy.
+ */
+public final class SecretReferenceInputMappingTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldResolveSecretReferenceInInputMappingToItsPlaceholder() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("secret-input")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("secret-input-job")
+                        .zeebeInputExpression("camunda.secrets.externalSystemToken", "authToken"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("secret-input").create();
+
+    // then
+    final JobRecordValue job =
+        ENGINE.jobs().withType("secret-input-job").activate().getValue().getJobs().getFirst();
+    assertThat(job.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(job.getVariables())
+        .containsEntry("authToken", "camunda.secrets.externalSystemToken");
+  }
+
+  @Test
+  public void shouldResolveSecretReferenceInsideConcatenationInInputMapping() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("secret-concat")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("secret-concat-job")
+                        .zeebeInputExpression(
+                            "\"Bearer \" + camunda.secrets.token", "authorization"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    ENGINE.processInstance().ofBpmnProcessId("secret-concat").create();
+
+    // then
+    final JobRecordValue job =
+        ENGINE.jobs().withType("secret-concat-job").activate().getValue().getJobs().getFirst();
+    assertThat(job.getVariables()).containsEntry("authorization", "Bearer camunda.secrets.token");
+  }
+
+  @Test
+  public void shouldNotResolveSecretReferenceInOutputMapping() {
+    // given - the secret reference is used in an OUTPUT mapping, which must be left untouched
+    final var process =
+        Bpmn.createExecutableProcess("secret-output")
+            .startEvent()
+            .serviceTask(
+                "producer",
+                t ->
+                    t.zeebeJobType("secret-output-job")
+                        .zeebeOutputExpression("camunda.secrets.token", "result"))
+            .serviceTask("consumer", t -> t.zeebeJobType("consumer-job"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("secret-output").create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("secret-output-job").complete();
+
+    // then - output mapping did not resolve the reference; the variable is null, not a placeholder
+    final JobRecordValue job =
+        ENGINE.jobs().withType("consumer-job").activate().getValue().getJobs().getFirst();
+    assertThat(job.getVariables()).containsEntry("result", null);
+  }
+
+  @Test
+  public void shouldResolveClusterVariableAndSecretReferenceInSameInputMapping() {
+    // given
+    ENGINE.clusterVariables().withName("REGION").withValue("\"eu-1\"").setGlobalScope().create();
+
+    final var process =
+        Bpmn.createExecutableProcess("secret-and-cluster")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType("secret-and-cluster-job")
+                        .zeebeInputExpression("camunda.vars.cluster.REGION", "region")
+                        .zeebeInputExpression("camunda.secrets.token", "authToken"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    ENGINE.processInstance().ofBpmnProcessId("secret-and-cluster").create();
+
+    // then - cluster variable resolves to its value, secret reference to its placeholder
+    final JobRecordValue job =
+        ENGINE.jobs().withType("secret-and-cluster-job").activate().getValue().getJobs().getFirst();
+    assertThat(job.getVariables())
+        .containsEntry("region", "eu-1")
+        .containsEntry("authToken", "camunda.secrets.token");
+  }
+
+  @Test
+  public void shouldRejectStaticValueSecretReferenceInInputMapping() {
+    // given - a static value (no leading '=') equal to a secret reference is a string literal
+    final var process =
+        Bpmn.createExecutableProcess("secret-literal-static")
+            .startEvent()
+            .serviceTask(
+                "task", t -> t.zeebeJobType("job").zeebeInput("camunda.secrets.token", "authToken"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejected = ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then
+    assertThat(rejected.getRejectionReason())
+        .contains("camunda.secrets.token")
+        .contains("must be used as an expression");
+  }
+
+  @Test
+  public void shouldRejectFeelStringLiteralSecretReferenceInInputMapping() {
+    // given - a FEEL string literal equal to a secret reference
+    final var process =
+        Bpmn.createExecutableProcess("secret-literal-feel")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t -> t.zeebeJobType("job").zeebeInput("=\"camunda.secrets.token\"", "authToken"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejected = ENGINE.deployment().withXmlResource(process).expectRejection().deploy();
+
+    // then
+    assertThat(rejected.getRejectionReason())
+        .contains("camunda.secrets.token")
+        .contains("must be used as an expression");
+  }
+}


### PR DESCRIPTION
## What

Handle `camunda.secrets.<name>` references in FEEL **input-mapping** evaluation so a modeled
reference survives evaluation as a placeholder instead of nulling — ready for the real secret value
to be substituted at job activation (tracked separately). Two parts:

- **Deploy-time:** reject `camunda.secrets.<name>` used as a **string literal** in an input mapping,
  with a clear error.
- **FEEL evaluation (input mappings only):** `camunda.secrets.<name>` used as an **expression**
  evaluates to the string `"camunda.secrets.<name>"` — no null, no failure.

## Why these decisions

- **Delegation, not shadowing.** The secret-aware context wraps the existing evaluation context and
  intercepts only the `camunda.secrets.*` path. Cluster variables (`camunda.vars.*`), process
  variables and every other lookup are forwarded unchanged, so nothing is shadowed — today or once
  further `camunda.*` namespaces are added.
- **Deterministic.** Resolving a reference to its own text is a pure transformation — no random, no
  token, no added persisted state — so it is replication/replay-safe. Secret *values* are never
  produced or persisted here; only the readable placeholder is.
- **Reject literal usage to remove ambiguity.** Refusing a literal `camunda.secrets.<name>` at
  deploy means any reference remaining in a valid input mapping is necessarily an expression, so the
  later substitution is unambiguous. Detection evaluates the source without a variable context: a
  literal constant-folds to a string containing the reference (including folded concatenations),
  while an expression path resolves to null and is left alone.

## Scope

- Output mappings, conditions, listeners, etc. are unaffected.
- The actual secret-value substitution happens at job activation — separate issue.

## Accepted edge case

A runtime variable *value* equal to `camunda.secrets.<name>` cannot be validated at deploy; at
activation it would also be substituted — a benign double-resolve of a secret the element already
receives. Documented and tested.

## Commits

1. `feat: resolve secret references in input-mapping evaluation`
2. `feat: reject secret reference used as a string literal in input mapping`

Closes #57178
