### PR TITLE
ci: drop Elasticsearch 9.3 from test matrix

### DIFF
--- a/.ci/db-versions.yml
+++ b/.ci/db-versions.yml
@@ -19,7 +19,6 @@ elasticsearch:
     # renovate: datasource=docker depName=docker.elastic.co/elasticsearch/elasticsearch
     - &saas '8.19.16'
   es9:
-    - "9.3.0"
     - "9.4.0"
   saas: *saas
 


### PR DESCRIPTION
## Summary

Removes Elasticsearch 9.3.0 from the CI test matrix. Elasticsearch 9.4 is now the minimum supported 9.x version.

The only change is removing `"9.3.0"` from `.ci/db-versions.yml`. All CI workflows consume this file dynamically via `.github/actions/read-db-versions`, so no workflow or script changes are needed. The `min_max()` helper in `generate-db-versions.py` already handles single-element version lists correctly.

No Java or application code changes are required — ES9 support is exercised purely at the CI matrix level.

## Docs

https://github.com/camunda/camunda-docs/pull/9354

## Related

Closes #56282