### PR TITLE
fix: improve logging when snapshot name is already in use during backup

### DIFF
--- a/webapps-backup/pom.xml
+++ b/webapps-backup/pom.xml
@@ -97,6 +97,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/webapps-backup/pom.xml
+++ b/webapps-backup/pom.xml
@@ -96,6 +96,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-schema-manager</artifactId>
     </dependency>

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -56,9 +56,9 @@ import org.slf4j.LoggerFactory;
 
 public class ElasticsearchBackupRepository implements BackupRepository {
   public static final String SNAPSHOT_MISSING_EXCEPTION_TYPE = "snapshot_missing_exception";
-  private static final String REPOSITORY_MISSING_EXCEPTION_TYPE = "repository_missing_exception";
   public static final String SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE =
       "snapshot_name_already_in_use_exception";
+  private static final String REPOSITORY_MISSING_EXCEPTION_TYPE = "repository_missing_exception";
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchBackupRepository.class);
   private final ElasticsearchClient esClient;
   private final BackupRepositoryProps backupProps;
@@ -586,10 +586,9 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       } else if (isSnapshotNameAlreadyInUseException(ex)) {
         LOGGER.warn(
             "Snapshot [{}] for backup id [{}] already exists in Elasticsearch. "
-                + "This can happen when retrying a failed backup before deletion of the previous "
-                + "attempt has fully completed. Use a different backup ID, or wait for the existing "
-                + "snapshot to be fully deleted before retrying with the same ID. "
-                + "The underlying race condition is tracked in https://github.com/camunda/camunda/issues/20443.",
+                + "A previous backup attempt with the same ID may still be in the process of being deleted. "
+                + "To retry with the same backup ID, wait for the deletion to complete first. "
+                + "To proceed immediately, use a different backup ID.",
             snapshotRequest.snapshotName(),
             backupId);
         onFailure.run();

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -57,6 +57,8 @@ import org.slf4j.LoggerFactory;
 public class ElasticsearchBackupRepository implements BackupRepository {
   public static final String SNAPSHOT_MISSING_EXCEPTION_TYPE = "snapshot_missing_exception";
   private static final String REPOSITORY_MISSING_EXCEPTION_TYPE = "repository_missing_exception";
+  public static final String SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE =
+      "snapshot_name_already_in_use_exception";
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchBackupRepository.class);
   private final ElasticsearchClient esClient;
   private final BackupRepositoryProps backupProps;
@@ -347,6 +349,10 @@ public class ElasticsearchBackupRepository implements BackupRepository {
     return isErrorType(e, REPOSITORY_MISSING_EXCEPTION_TYPE);
   }
 
+  private boolean isSnapshotNameAlreadyInUseException(final Exception e) {
+    return isErrorType(e, SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE);
+  }
+
   // Check: see inner
   public List<SnapshotInfo> findSnapshots(final String repositoryName, final Long backupId) {
     final GetSnapshotRequest snapshotsStatusRequest =
@@ -577,6 +583,16 @@ public class ElasticsearchBackupRepository implements BackupRepository {
         } else {
           onFailure.run();
         }
+      } else if (isSnapshotNameAlreadyInUseException(ex)) {
+        LOGGER.warn(
+            "Snapshot [{}] for backup id [{}] already exists in Elasticsearch. "
+                + "This can happen when retrying a failed backup before deletion of the previous "
+                + "attempt has fully completed. Use a different backup ID, or wait for the existing "
+                + "snapshot to be fully deleted before retrying with the same ID. "
+                + "The underlying race condition is tracked in https://github.com/camunda/camunda/issues/20443.",
+            snapshotRequest.snapshotName(),
+            backupId);
+        onFailure.run();
       } else {
         LOGGER.error(
             "Exception while creating snapshot [{}] for backup id [{}].",

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
@@ -339,10 +339,9 @@ public class OpensearchBackupRepository implements BackupRepository {
               } else if (isErrorType(e, SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE)) {
                 LOGGER.warn(
                     "Snapshot [{}] for backup id [{}] already exists in OpenSearch. "
-                        + "This can happen when retrying a failed backup before deletion of the previous "
-                        + "attempt has fully completed. Use a different backup ID, or wait for the existing "
-                        + "snapshot to be fully deleted before retrying with the same ID. "
-                        + "The underlying race condition is tracked in https://github.com/camunda/camunda/issues/20443.",
+                        + "A previous backup attempt with the same ID may still be in the process of being deleted. "
+                        + "To retry with the same backup ID, wait for the deletion to complete first. "
+                        + "To proceed immediately, use a different backup ID.",
                     snapshotRequest.snapshotName(),
                     backupId);
                 onFailure.run();

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
@@ -61,6 +61,8 @@ import org.slf4j.LoggerFactory;
 public class OpensearchBackupRepository implements BackupRepository {
   public static final String SNAPSHOT_MISSING_EXCEPTION_TYPE = "snapshot_missing_exception";
   public static final String REPOSITORY_MISSING_EXCEPTION_TYPE = "repository_missing_exception";
+  public static final String SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE =
+      "snapshot_name_already_in_use_exception";
   private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchBackupRepository.class);
 
   private final OpenSearchClient openSearchClient;
@@ -334,6 +336,16 @@ public class OpensearchBackupRepository implements BackupRepository {
                     break;
                   }
                 }
+              } else if (isErrorType(e, SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE)) {
+                LOGGER.warn(
+                    "Snapshot [{}] for backup id [{}] already exists in OpenSearch. "
+                        + "This can happen when retrying a failed backup before deletion of the previous "
+                        + "attempt has fully completed. Use a different backup ID, or wait for the existing "
+                        + "snapshot to be fully deleted before retrying with the same ID. "
+                        + "The underlying race condition is tracked in https://github.com/camunda/camunda/issues/20443.",
+                    snapshotRequest.snapshotName(),
+                    backupId);
+                onFailure.run();
               } else {
                 LOGGER.error(
                     "Exception while creating snapshot [{}] for backup id [{}].",

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.webapps.backup.repository.elasticsearch;
 
+import static io.camunda.webapps.backup.repository.elasticsearch.ElasticsearchBackupRepository.SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
@@ -21,6 +22,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.ErrorCause;
+import co.elastic.clients.elasticsearch._types.ErrorResponse;
 import co.elastic.clients.elasticsearch.indices.GetIndexRequest;
 import co.elastic.clients.elasticsearch.indices.GetIndexResponse;
 import co.elastic.clients.elasticsearch.snapshot.CreateSnapshotRequest;
@@ -229,6 +233,40 @@ public class ElasticsearchBackupRepositoryTest {
     // 1 element array to bypass closures over final fields
     backupRepository.executeSnapshotting(
         snapshotRequest, () -> {}, () -> fail("Snapshotting failed"));
+  }
+
+  @Test
+  void shouldCallOnFailureWhenSnapshotNameAlreadyInUse() throws IOException {
+    // given
+    final var metadata = new Metadata(1L, "1", 1, 1);
+    final var snapshotRequest =
+        new SnapshotRequest(
+            "repo-name-1",
+            snapshotNameProvider.getSnapshotName(metadata),
+            new SnapshotIndexCollection(List.of("index-1"), List.of()),
+            metadata);
+    final var exception =
+        new ElasticsearchException(
+            "es/snapshot.create",
+            ErrorResponse.of(
+                b ->
+                    b.status(400)
+                        .error(
+                            ErrorCause.of(
+                                e ->
+                                    e.type(SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE)
+                                        .reason("snapshot with the same name already exists")))));
+    when(esClient.snapshot().create((CreateSnapshotRequest) any())).thenThrow(exception);
+    final boolean[] onFailureCalled = {false};
+
+    // when
+    backupRepository.executeSnapshotting(
+        snapshotRequest,
+        () -> fail("onSuccess should not be called"),
+        () -> onFailureCalled[0] = true);
+
+    // then
+    assertThat(onFailureCalled[0]).isTrue();
   }
 
   @Test

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
@@ -56,6 +56,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -259,14 +263,41 @@ public class ElasticsearchBackupRepositoryTest {
     when(esClient.snapshot().create((CreateSnapshotRequest) any())).thenThrow(exception);
     final boolean[] onFailureCalled = {false};
 
-    // when
-    backupRepository.executeSnapshotting(
-        snapshotRequest,
-        () -> fail("onSuccess should not be called"),
-        () -> onFailureCalled[0] = true);
+    final String loggerName = ElasticsearchBackupRepository.class.getName();
+    final ListAppender appender = new ListAppender("test-list-appender");
+    appender.start();
+    final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+    final var loggerConfig =
+        new org.apache.logging.log4j.core.config.LoggerConfig(loggerName, Level.ALL, true);
+    loggerConfig.addAppender(appender, null, null);
+    ctx.getConfiguration().addLogger(loggerName, loggerConfig);
+    ctx.updateLoggers();
 
-    // then
-    assertThat(onFailureCalled[0]).isTrue();
+    try {
+      // when
+      backupRepository.executeSnapshotting(
+          snapshotRequest,
+          () -> fail("onSuccess should not be called"),
+          () -> onFailureCalled[0] = true);
+
+      // then
+      assertThat(onFailureCalled[0]).isTrue();
+      assertThat(appender.getEvents())
+          .singleElement()
+          .satisfies(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                final String message = event.getMessage().getFormattedMessage();
+                assertThat(message)
+                    .contains(snapshotRequest.snapshotName())
+                    .contains("already exists")
+                    .contains("use a different backup ID");
+              });
+    } finally {
+      ctx.getConfiguration().removeLogger(loggerName);
+      ctx.updateLoggers();
+      appender.stop();
+    }
   }
 
   @Test

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.backup.repository.opensearch;
 
 import static io.camunda.webapps.backup.repository.opensearch.OpensearchBackupRepository.REPOSITORY_MISSING_EXCEPTION_TYPE;
 import static io.camunda.webapps.backup.repository.opensearch.OpensearchBackupRepository.SNAPSHOT_MISSING_EXCEPTION_TYPE;
+import static io.camunda.webapps.backup.repository.opensearch.OpensearchBackupRepository.SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.fail;
@@ -159,6 +160,39 @@ class OpensearchBackupRepositoryTest {
         .thenReturn(CompletableFuture.failedFuture(new SocketTimeoutException("no internet")));
 
     repository.executeSnapshotting(snapshotRequest, onSuccess, onFailure);
+  }
+
+  @Test
+  void shouldCallOnFailureWhenSnapshotNameAlreadyInUse() throws IOException {
+    // given
+    final var snapshotRequest =
+        new SnapshotRequest(
+            "repo",
+            "camunda_webapps_1_8.7.0_part_1_of_1",
+            new SnapshotIndexCollection(List.of("index-1"), List.of()),
+            new Metadata(1L, "1", 1, 1));
+    final boolean[] onFailureCalled = {false};
+    when(openSearchAsyncClient.snapshot().create((CreateSnapshotRequest) any()))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new OpenSearchException(
+                    new ErrorResponse.Builder()
+                        .status(400)
+                        .error(
+                            new ErrorCause.Builder()
+                                .type(SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE)
+                                .reason("snapshot with the same name already exists")
+                                .build())
+                        .build())));
+
+    // when
+    repository.executeSnapshotting(
+        snapshotRequest,
+        () -> fail("onSuccess should not be called"),
+        () -> onFailureCalled[0] = true);
+
+    // then
+    assertThat(onFailureCalled[0]).isTrue();
   }
 
   @Test

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
@@ -36,6 +36,10 @@ import java.net.SocketTimeoutException;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -185,14 +189,41 @@ class OpensearchBackupRepositoryTest {
                                 .build())
                         .build())));
 
-    // when
-    repository.executeSnapshotting(
-        snapshotRequest,
-        () -> fail("onSuccess should not be called"),
-        () -> onFailureCalled[0] = true);
+    final String loggerName = OpensearchBackupRepository.class.getName();
+    final ListAppender appender = new ListAppender("test-list-appender");
+    appender.start();
+    final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+    final var loggerConfig =
+        new org.apache.logging.log4j.core.config.LoggerConfig(loggerName, Level.ALL, true);
+    loggerConfig.addAppender(appender, null, null);
+    ctx.getConfiguration().addLogger(loggerName, loggerConfig);
+    ctx.updateLoggers();
 
-    // then
-    assertThat(onFailureCalled[0]).isTrue();
+    try {
+      // when
+      repository.executeSnapshotting(
+          snapshotRequest,
+          () -> fail("onSuccess should not be called"),
+          () -> onFailureCalled[0] = true);
+
+      // then
+      assertThat(onFailureCalled[0]).isTrue();
+      assertThat(appender.getEvents())
+          .singleElement()
+          .satisfies(
+              event -> {
+                assertThat(event.getLevel()).isEqualTo(Level.WARN);
+                final String message = event.getMessage().getFormattedMessage();
+                assertThat(message)
+                    .contains(snapshotRequest.snapshotName())
+                    .contains("already exists")
+                    .contains("use a different backup ID");
+              });
+    } finally {
+      ctx.getConfiguration().removeLogger(loggerName);
+      ctx.updateLoggers();
+      appender.stop();
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

Relates to #50306.

When a backup is retried before deletion of a prior attempt fully completes, Elasticsearch/OpenSearch throws `snapshot_name_already_in_use_exception`. Previously this fell into the generic exception path in both `ElasticsearchBackupRepository` and `OpensearchBackupRepository`, which:
- Logged at **ERROR** level (misleading - this is an operator-correctable situation, not a software defect)
- Emitted the raw exception message with no remediation guidance

This PR improves the handling by detecting the specific exception type and emitting a **WARN**-level message that explains the conflict and guides the operator to resolution (use a different backup ID, or wait for deletion to complete before retrying).

The underlying TOCTOU race condition (the `validateNoDuplicateBackupId` check-then-act gap) is a separate concern and will be addressed in #20443.

## Changes

- `ElasticsearchBackupRepository`: add `SNAPSHOT_NAME_ALREADY_IN_USE_EXCEPTION_TYPE` constant + helper, handle in `CreateSnapshotListener.onFailure()`
- `OpensearchBackupRepository`: same constant + branch in `exceptionally()` block
- Tests for both: verify `onFailure` is called (not `onSuccess`) when this exception is thrown

## Test plan

- `./mvnw verify -pl webapps-backup -DskipTests=false -DskipITs -Dquickly` - all 55 unit tests pass