### PR TITLE
feat: add physical tenants option to load tests

### DIFF
--- a/.github/workflows/camunda-load-test.yml
+++ b/.github/workflows/camunda-load-test.yml
@@ -79,6 +79,11 @@ on:
         type: boolean
         required: false
         default: false
+      physical-tenants:
+        description: 'Deploy a second physical tenant (testfoo) with its own load tester. Requires an rdbms secondary-storage-type.'
+        type: boolean
+        required: false
+        default: false
       enable-optimize-report-metrics:
         description: 'Enable the load-tester Optimize report-evaluation meter (requires Optimize backend)'
         type: boolean
@@ -184,6 +189,11 @@ on:
         type: boolean
         required: false
         default: false
+      physical-tenants:
+        description: 'Deploy a second physical tenant (testfoo) with its own load tester. Requires an rdbms secondary-storage-type.'
+        type: boolean
+        required: false
+        default: false
       enable-optimize-report-metrics:
         description: 'Enable the load-tester Optimize report-evaluation meter (requires Optimize backend)'
         type: boolean
@@ -246,6 +256,7 @@ env:
   OPTIMIZE_TAG: ${{ inputs.optimize-tag }}
   ORCHESTRATION_TAG: ${{ inputs.orchestration-tag }}
   PERFORM_READ_BENCHMARKS: ${{ inputs.perform-read-benchmarks }}
+  PHYSICAL_TENANTS: ${{ inputs.physical-tenants }}
   PLATFORM_HELM_VALUES: ${{ inputs.platform-helm-values }}
   REF: ${{ inputs.ref }}
   REUSE_TAG: ${{ inputs.reuse-tag}}
@@ -290,6 +301,7 @@ jobs:
           | Enable Optimize | \`${ENABLE_OPTIMIZE}\` |
           | Enable Optimize report metrics | \`${ENABLE_OPTIMIZE_METRICS}\` |
           | Enable chaos | \`${ENABLE_CHAOS}\` |
+          | Physical tenants | \`${PHYSICAL_TENANTS}\` |
           | Build frontend | \`${BUILD_FRONTEND}\` |
           | Perform read benchmarks | \`${PERFORM_READ_BENCHMARKS}\` |
           | Optimize tag | \`${OPTIMIZE_TAG:-—}\` |
@@ -703,6 +715,7 @@ jobs:
             secondary_storage="${SECONDARY_STORAGE_TYPE}" \
             enable_optimize="${ENABLE_OPTIMIZE}" \
             chaos="${ENABLE_CHAOS}" \
+            physical_tenants="${PHYSICAL_TENANTS}" \
             additional_platform_configuration="$additional_platform_config" \
             additional_load_test_configuration="$load_test_config" \
             additional_load_test_setup_configuration="$additional_load_test_setup_configuration"

--- a/load-tests/setup/README.md
+++ b/load-tests/setup/README.md
@@ -345,6 +345,45 @@ make template-load-test-setup-chaos
 
 In the GitHub workflow, set the `enable-chaos` input to `true`.
 
+#### Optional second physical tenant
+
+A load test can exercise **two physical tenants** (`default` and `testfoo`) on a single cluster that
+share one RDBMS, isolated by table prefix (`DEFAULT_` / `TESTFOO_`). This validates physical-tenant
+isolation and independent load per tenant.
+
+Because physical tenants are isolated by RDBMS table prefix, this only works with an rdbms
+`secondary_storage` (`postgresql`, `mysql`, `mariadb`, `mssql`, `oracle`); any other value fails fast.
+
+```sh
+make install physical_tenants=true secondary_storage=postgresql scenario=typical
+```
+
+When enabled, the Makefile:
+
+- Applies `camunda-platform-two-physical-tenants-shared-rdbms.yaml` (a copy of
+  `camunda-platform-values-rdbms.yaml` that also declares the `testfoo` tenant: its `TESTFOO_` prefix,
+  OIDC provider assignment, and orchestration-client authorizations) instead of the plain rdbms values.
+- Clones the generated `load-test-credentials` secret into `load-test-credentials-testfoo`, overriding
+  only the REST address to the tenant path `http://camunda:8080/physical-tenants/testfoo`.
+- Renders the `starter`/`worker` from the same chart, values, scenario and **image** as the default
+  tester, renames them to `starter-testfoo`/`worker-testfoo`, and applies them. The testfoo tester uses
+  REST (`global.preferRest.enabled=true`) because gRPC only routes to the default physical tenant.
+
+A second Helm release is not used because the `camunda-load-tests` subchart hardcodes the
+`starter`/`worker` resource names, which would collide in the same namespace.
+
+In the GitHub workflow, set the `physical-tenants` input to `true` (with an rdbms
+`secondary-storage-type`).
+
+Verify both tenants receive writes:
+
+```sh
+kubectl exec -n <namespace> postgresql-0 -- env PGPASSWORD=camunda \
+  psql -U camunda -d camunda -c "
+SELECT 'default' AS tenant, COUNT(*) FROM default_process_instance
+UNION ALL SELECT 'testfoo', COUNT(*) FROM testfoo_process_instance;"
+```
+
 This will deploy the full Camunda Platform (including `orchestration cluster`, `elasticsearch`, `optimize`, `connectors`, `identity` and `keycloak`) and load test applications (e.g. `starter` and `worker`).
 
 ### Running specific scenarios

--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -257,8 +257,7 @@ install-load-test-physical-tenant:
 	@# Clone the generated load-test-credentials secret, overriding only the REST address to the
 	@# testfoo tenant path. Inherits every real credential value (clientId/secret, authServer, audience).
 	kubectl get secret load-test-credentials -n $(namespace) -o json \
-	  | jq --arg addr "$$(printf %s 'http://camunda:8080/physical-tenants/testfoo' | base64 -w0)" \
-	      '.data.zeebeRestAddress=$$addr | .metadata.name="load-test-credentials-testfoo" | del(.metadata.uid,.metadata.resourceVersion,.metadata.creationTimestamp,.metadata.ownerReferences)' \
+	  | jq '.data.zeebeRestAddress = ("http://camunda:8080/physical-tenants/testfoo" | @base64) | .metadata.name = "load-test-credentials-testfoo" | del(.metadata.uid,.metadata.resourceVersion,.metadata.creationTimestamp,.metadata.ownerReferences,.metadata.managedFields)' \
 	  | kubectl apply -n $(namespace) -f -
 	@# Render only the subchart starter+worker, rename to *-testfoo, and apply.
 	helm template load-test-setup $(helm_chart_load_test_setup) \

--- a/load-tests/setup/main/Makefile
+++ b/load-tests/setup/main/Makefile
@@ -5,6 +5,10 @@ enable_optimize ?= __ENABLE_OPTIMIZE__
 # Enable the chaos-killer CronJob (randomly deletes one matching pod per run).
 # Use named targets (make install-chaos) or pass directly: make install chaos=true
 chaos ?= false
+# Deploy a second physical tenant (testfoo) alongside the default one, sharing the
+# same RDBMS but isolated by table prefix. Requires an rdbms secondary_storage.
+# Pass directly: make install physical_tenants=true secondary_storage=postgresql
+physical_tenants ?= false
 prometheus_elasticsearch_exporter_chart_version ?= 7.2.1
 # Optional: additional Helm configuration for the Camunda Platform release.
 # Use this to pass extra `--set`/`-f` flags, for example:
@@ -59,9 +63,23 @@ _load_test_setup_flags :=
 # The Docker image tag for the load test metrics exporter
 metrics_exporter_image_tag := latest
 
+# Physical tenants are isolated by RDBMS table prefix, so they only make sense with
+# an rdbms secondary storage. Fail fast on any other combination.
+# (Nested conditionals are left-aligned: a leading tab would make `$(error ...)` look like a recipe.)
+ifeq ($(physical_tenants),true)
+ifeq ($(filter $(secondary_storage),postgresql mysql mariadb mssql oracle),)
+$(error physical_tenants=true requires an rdbms secondary_storage (postgresql|mysql|mariadb|mssql|oracle), got '$(secondary_storage)')
+endif
+endif
+
 # Add secondary storage values
 ifneq ($(filter $(secondary_storage),postgresql mysql mariadb mssql oracle),)
-	platform_values += -f camunda-platform-values-rdbms.yaml
+	ifeq ($(physical_tenants),true)
+		# Same as camunda-platform-values-rdbms.yaml, plus a second physical tenant (testfoo).
+		platform_values += -f camunda-platform-two-physical-tenants-shared-rdbms.yaml
+	else
+		platform_values += -f camunda-platform-values-rdbms.yaml
+	endif
 else ifeq ($(secondary_storage),none)
 	_load_test_setup_flags += --set global.extraConfig.load-tester.monitor-data-availability=false
 endif
@@ -126,6 +144,13 @@ install: check-deadline install-load-test-setup install-storage install-platform
 
 .PHONY: install-stable
 install-stable: check-deadline install-load-test-setup install-storage install-platform-stable install-elasticsearch-exporter
+
+# When physical_tenants=true, also deploy the second (testfoo) load tester. Appended as the
+# last prerequisite so it runs after the platform is up and the load-test-credentials secret exists.
+ifeq ($(physical_tenants),true)
+install: install-load-test-physical-tenant
+install-stable: install-load-test-physical-tenant
+endif
 
 # Fail fast if the namespace TTL deadline (read from load-test-setup-values.yaml,
 # the single source of truth) is today or in the past — the TTL cleanup
@@ -220,6 +245,32 @@ ifeq ($(install_es_prom_exporter),true)
 else
 	@echo "Skipping Elasticsearch Prometheus Exporter installation (secondary_storage=$(secondary_storage))"
 endif
+
+# Deploy a second load tester that drives the `testfoo` physical tenant.
+# The camunda-load-tests subchart hardcodes the starter/worker resource names, so a second
+# Helm release would collide. Instead we render only those two templates from the same chart,
+# values, scenario and image as the default tester, rename them to *-testfoo, and apply.
+# REST is required because gRPC only routes to the default physical tenant.
+.PHONY: install-load-test-physical-tenant
+install-load-test-physical-tenant:
+	@echo "Deploying the testfoo physical-tenant load tester for namespace $(namespace)..."
+	@# Clone the generated load-test-credentials secret, overriding only the REST address to the
+	@# testfoo tenant path. Inherits every real credential value (clientId/secret, authServer, audience).
+	kubectl get secret load-test-credentials -n $(namespace) -o json \
+	  | jq --arg addr "$$(printf %s 'http://camunda:8080/physical-tenants/testfoo' | base64 -w0)" \
+	      '.data.zeebeRestAddress=$$addr | .metadata.name="load-test-credentials-testfoo" | del(.metadata.uid,.metadata.resourceVersion,.metadata.creationTimestamp,.metadata.ownerReferences)' \
+	  | kubectl apply -n $(namespace) -f -
+	@# Render only the subchart starter+worker, rename to *-testfoo, and apply.
+	helm template load-test-setup $(helm_chart_load_test_setup) \
+	    --namespace $(namespace) \
+	    -s charts/load-tester/templates/starter.yaml \
+	    -s charts/load-tester/templates/workers.yaml \
+	    $(load_test_setup_flags) \
+	    --set load-tester.enabled=true \
+	    --set global.preferRest.enabled=true \
+	    --set load-tester.saas.credentials.existingSecret=load-test-credentials-testfoo \
+	  | sed -E 's/: starter$$/: starter-testfoo/; s/: worker$$/: worker-testfoo/' \
+	  | kubectl apply -n $(namespace) -f -
 
 # Install/upgrade Camunda Platform helm chart
 .PHONY: install-platform

--- a/load-tests/setup/main/newLoadTest.sh
+++ b/load-tests/setup/main/newLoadTest.sh
@@ -152,10 +152,13 @@ case "$secondaryStorage" in
     fi
     ;;
   postgresql|mysql|mariadb)
-    cp -v "values/camunda-platform-values-rdbms.yaml"            "$TARGET_DIRECTORY/"
+    cp -v "values/camunda-platform-values-rdbms.yaml"                       "$TARGET_DIRECTORY/"
+    # Variant selected by `make install physical_tenants=true` (adds a second physical tenant).
+    cp -v "values/camunda-platform-two-physical-tenants-shared-rdbms.yaml"  "$TARGET_DIRECTORY/"
     ;;
   mssql|oracle)
-    cp -v "values/camunda-platform-values-rdbms.yaml"            "$TARGET_DIRECTORY/"
+    cp -v "values/camunda-platform-values-rdbms.yaml"                       "$TARGET_DIRECTORY/"
+    cp -v "values/camunda-platform-two-physical-tenants-shared-rdbms.yaml"  "$TARGET_DIRECTORY/"
     mkdir -p "$TARGET_DIRECTORY/databases"
     cp -v "databases/${secondaryStorage}.yaml"                   "$TARGET_DIRECTORY/databases/"
     ;;

--- a/load-tests/setup/main/values/camunda-platform-two-physical-tenants-shared-rdbms.yaml
+++ b/load-tests/setup/main/values/camunda-platform-two-physical-tenants-shared-rdbms.yaml
@@ -46,7 +46,7 @@ orchestration:
         camunda.data.secondary-storage.rdbms.history.min-history-cleanup-interval: PT1S
         camunda.data.secondary-storage.rdbms.history.max-history-cleanup-interval: PT1M
         # Physical tenants: shared RDBMS database, isolated by table prefix.
-        # The default tenant uses the root prefix; testfoo overrides with its own.
+        # The default tenant uses the DEFAULT_ prefix; testfoo uses the TESTFOO_ prefix.
         camunda.data.secondary-storage.rdbms.prefix: DEFAULT_
         camunda.physical-tenants.testfoo.data.secondary-storage.rdbms.prefix: TESTFOO_
         # testfoo tenant: grant the orchestration client the same permissions as the default tenant

--- a/load-tests/setup/main/values/camunda-platform-two-physical-tenants-shared-rdbms.yaml
+++ b/load-tests/setup/main/values/camunda-platform-two-physical-tenants-shared-rdbms.yaml
@@ -1,0 +1,77 @@
+########################################################################################
+################################################### Orchestration cluster configuration
+########################################################################################
+# Variant of camunda-platform-values-rdbms.yaml that additionally declares a second
+# physical tenant (testfoo) on the same shared RDBMS, isolated by table prefix.
+# Selected by the Makefile when `physical_tenants=true` (rdbms secondary storage only).
+orchestration:
+  exporters:
+    camunda:
+      enabled: false
+    rdbms:
+      enabled: true
+  data:
+    secondaryStorage:
+      type: rdbms
+      rdbms:
+        username: camunda
+        secret:
+          inlineSecret: camunda
+
+  # Overriding the extraConfiguration for the Platform chart
+  # to disable Camunda Exporter usage and make use of the RDBMS exporter instead, as well as to set some additional configuration for Camunda application
+  extraConfiguration:
+    - file: application.yml
+      content: |
+        # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+        zeebe.broker.executionMetricsExporterEnabled: "true"
+        camunda.flags.jfr.metrics: "true"
+        # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+        zeebe.broker.data.disk.freeSpace.processing: "3GB"
+        zeebe.broker.data.disk.freeSpace.replication: "2GB"
+        # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+        # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+        zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+        zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+        # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+        zeebe.broker.flowControl.write.enabled: "true"
+        zeebe.broker.flowControl.write.limit: 10000
+        zeebe.broker.flowControl.write.throttling.enabled: "true"
+        # History cleanup adjust batch sizes
+        camunda.data.secondary-storage.rdbms.history.history-cleanup-batch-size: 100000
+        camunda.data.secondary-storage.rdbms.history.history-cleanup-process-instance-batch-size: 2000
+        # set to 2001 and not 2000 to directly see when queue is full in metrics dashboard
+        camunda.data.secondary-storage.rdbms.queue-size: 2001
+        camunda.data.secondary-storage.rdbms.history.default-history-ttl: PT1H
+        camunda.data.secondary-storage.rdbms.history.min-history-cleanup-interval: PT1S
+        camunda.data.secondary-storage.rdbms.history.max-history-cleanup-interval: PT1M
+        # Physical tenants: shared RDBMS database, isolated by table prefix.
+        # The default tenant uses the root prefix; testfoo overrides with its own.
+        camunda.data.secondary-storage.rdbms.prefix: DEFAULT_
+        camunda.physical-tenants.testfoo.data.secondary-storage.rdbms.prefix: TESTFOO_
+        # testfoo tenant: grant the orchestration client the same permissions as the default tenant
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[0].ownerType: CLIENT
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[0].ownerId: orchestration
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[0].resourceType: RESOURCE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[0].resourceId: "*"
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[0].permissions[0]: CREATE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].ownerType: CLIENT
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].ownerId: orchestration
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].resourceType: PROCESS_DEFINITION
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].resourceId: "*"
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[0]: CREATE_PROCESS_INSTANCE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[1]: UPDATE_PROCESS_INSTANCE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[2]: READ_PROCESS_INSTANCE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[3]: READ_PROCESS_DEFINITION
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[2].ownerType: CLIENT
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[2].ownerId: orchestration
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[2].resourceType: MESSAGE
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[2].resourceId: "*"
+        camunda.physical-tenants.testfoo.security.initialization.authorizations[2].permissions[0]: CREATE
+        # testfoo tenant: assign the default OIDC provider (Keycloak) so this tenant can authenticate
+        camunda.physical-tenants.testfoo.security.authentication.providers.assigned[0]: oidc
+    # This file is loaded after application.yml (higher priority). It is empty by default,
+    # but can be overridden via --set-file for specific scenarios (e.g. max) to change settings
+    # like disabling consistency checks without duplicating the full application.yml content.
+    - file: application-override.yml
+      content: "# no overrides"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/clients-service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/clients-service.yaml
@@ -1,0 +1,42 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: clients
+  labels:
+    app.kubernetes.io/component: zeebe-client
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/component: zeebe-client
+  ports:
+  - name: http
+    port: 9600
+---
+# Source: load-test-setup/charts/load-tester/templates/clients-service.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: clients
+  labels:
+    release: monitoring
+
+    app.kubernetes.io/name: load-tester
+    app.kubernetes.io/instance: load-test-setup
+
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: zeebe-client
+  endpoints:
+  - honorLabels: true
+    # since - is not supported directly, we have to use the index function and quote "camunda-platform"
+    interval: 30s
+    path: /metrics
+    port: http

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/starter.yaml
@@ -1,0 +1,137 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/starter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: starter
+  labels:
+    app: starter
+spec:
+  selector:
+    matchLabels:
+      app: starter
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: starter
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: starter
+          image: "registry.camunda.cloud/team-zeebe/starter:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dapp.starter.rate=150
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.starter.processId="benchmark"
+                -Dapp.starter.bpmnXmlPath="bpmn/one_task.bpmn"
+                -Dapp.starter.businessKey="businessKey"
+                -Dapp.starter.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_STARTER_RATE
+              value: "150"
+            - name: LOAD_TESTER_STARTER_PROCESS_ID
+              value: "benchmark"
+            - name: LOAD_TESTER_STARTER_BPMN_XML_PATH
+              value: "bpmn/one_task.bpmn"
+            - name: LOAD_TESTER_STARTER_BUSINESS_KEY
+              value: "businessKey"
+            - name: LOAD_TESTER_STARTER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          envFrom:
+            - configMapRef:
+                name: starter-config
+                optional: true
+          resources:
+            limits:
+              cpu: 250m
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 2Gi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/charts/load-tester/templates/workers.yaml
@@ -1,0 +1,136 @@
+---
+# Source: load-test-setup/charts/load-tester/templates/workers.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  labels:
+    app: worker
+spec:
+  selector:
+    matchLabels:
+      app: worker
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: worker
+        app.kubernetes.io/component: zeebe-client
+      annotations:
+        
+        checksum/saas-credentials: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      containers:
+        - name: worker
+          image: "registry.camunda.cloud/team-zeebe/worker:SNAPSHOT"
+          imagePullPolicy: Always
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: >-
+                -Dconfig.override_with_env_vars=true
+                -Dapp.tls=true
+                -Dapp.preferRest=false
+                -Dapp.performReadBenchmarks=false
+                -Dzeebe.client.requestTimeout=62000
+                -Dapp.worker.capacity=60
+                -Dapp.worker.threads=10
+                -Dapp.worker.completionDelay=50ms
+                -Dapp.worker.workerName="worker"
+                -Dapp.worker.jobType="benchmark-task"
+                -Dapp.worker.payloadPath="bpmn/typical_payload.json"
+                -XX:+HeapDumpOnOutOfMemoryError
+            - name: LOG_LEVEL
+              value: "INFO"
+            - name: ZEEBE_REST_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeRestAddress
+            - name: ZEEBE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientId
+            - name: ZEEBE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: clientSecret
+            - name: ZEEBE_AUTHORIZATION_SERVER_URL
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authServer
+            - name: ZEEBE_TOKEN_AUDIENCE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authorizationAudience
+            - name: ZEEBE_AUTH_TYPE
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: authType
+            - name: ZEEBE_GRPC_ADDRESS
+              valueFrom:
+                secretKeyRef:
+                  name: load-test-credentials
+                  key: zeebeGrpcAddress
+            - name: LOAD_TESTER_LOG_APPENDER
+              value: "Stackdriver"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICENAME
+              value: "load-tester"
+            - name: LOAD_TESTER_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPTIMIZE_LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: identity-optimize-loadtest-client-secret
+                  name: camunda-credentials
+            ##
+            ## Spring Boot compatible env vars (for migrated load tester, ignored by old HOCON app)
+            ##
+            - name: CAMUNDA_CLIENT_PREFER_REST_OVER_GRPC
+              value: "false"
+            - name: LOAD_TESTER_PERFORM_READ_BENCHMARKS
+              value: "false"
+            - name: CAMUNDA_CLIENT_MODE
+              value: "saas"
+            - name: CAMUNDA_CLIENT_AUTH_METHOD
+              value: "oidc"
+            - name: LOAD_TESTER_WORKER_CAPACITY
+              value: "60"
+            - name: LOAD_TESTER_WORKER_THREADS
+              value: "10"
+            - name: LOAD_TESTER_WORKER_COMPLETION_DELAY
+              value: "50ms"
+            - name: LOAD_TESTER_WORKER_WORKER_NAME
+              value: "worker"
+            - name: LOAD_TESTER_WORKER_JOB_TYPE
+              value: "benchmark-task"
+            - name: LOAD_TESTER_WORKER_PAYLOAD_PATH
+              value: "bpmn/typical_payload.json"
+            - name: LOGGING_LEVEL_IO_CAMUNDA_ZEEBE
+              value: "INFO"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 512Mi
+            requests:
+              cpu: 500m
+              memory: 512Mi
+          ports:
+            - containerPort: 9600
+              name: "http"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/camunda-credentials.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/camunda-credentials.yaml
@@ -1,0 +1,19 @@
+---
+# Source: load-test-setup/templates/camunda-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: camunda-credentials
+type: Opaque
+stringData:
+  connectors-security-authentication-oidc-secret: "Jefa2:DovgLefa"
+  identity-admin-client-token: "XubyHejvNeco6$"
+  identity-firstuser-password: "RehoDuxnSawh2&"
+  identity-keycloak-admin-password: "Wido7-PojgYomi"
+  identity-keycloak-postgresql-admin-password: "KaqzParu2_Cuqo"
+  identity-keycloak-postgresql-user-password: "Liva1]LejiHukc"
+  identity-optimize-client-token: "Doce0%JakiZinb"
+  identity-optimize-loadtest-client-secret: "JedaTugePomo6/"
+  identity-postgresql-admin-password: "QimoKupaDaju5^"
+  identity-postgresql-user-password: "QiznXora5*Febi"
+  orchestration-security-authentication-oidc-secret: "SaciRijs9$Fimb"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/cronjob-leader-rebalance.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/cronjob-leader-rebalance.yaml
@@ -1,0 +1,32 @@
+---
+# Source: load-test-setup/templates/cronjob-leader-rebalance.yaml
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: leader-balancer
+  labels:
+    app: leader-balancer
+spec:
+  concurrencyPolicy: Allow
+  jobTemplate:
+    metadata:
+      name: leader-balancer
+    spec:
+      template:
+        metadata:
+          labels:
+            app: leader-balancer
+        spec:
+          containers:
+          - name: leader-balancer
+            image: curlimages/curl:7.87.0
+            command: ["/bin/sh", "-c"]
+            args:
+              - |-
+                curl -L -v -X POST "http://camunda:9600/actuator/rebalance"
+
+          restartPolicy: OnFailure
+  schedule: '*/10 * * * *'
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 3
+  suspend: false

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/load-test-credentials.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/load-test-credentials.yaml
@@ -1,0 +1,17 @@
+---
+# Source: load-test-setup/templates/load-test-credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: load-test-credentials
+type: Opaque
+stringData:
+  clientId: "orchestration"
+  # Same password as the one we are configuring through Keycloak in
+  # "camunda-credentials.yaml" for: "orchestration-security-authentication-oidc-secret"
+  clientSecret: "SaciRijs9$Fimb"
+  zeebeRestAddress: "http://camunda:8080"
+  authServer: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+  authType: OAUTH
+  zeebeGrpcAddress: "http://camunda:26500"
+  authorizationAudience: "orchestration-api"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/metrics-exporter.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/metrics-exporter.yaml
@@ -1,0 +1,72 @@
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+spec:
+  progressDeadlineSeconds: 60
+  replicas: 1
+  revisionHistoryLimit: 5
+  selector:
+    matchLabels:
+      app: metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: metrics-exporter
+    spec:
+      containers:
+      - name: metrics-exporter
+        image: registry.camunda.cloud/team-reliability-testing/metrics-exporter:latest
+        args:
+          - --es.addresses=http://elasticsearch-es-http:9200
+        ports:
+        - containerPort: 9600
+          name: metrics
+        readinessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          periodSeconds: 10
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      imagePullSecrets:
+      - name: harbor-registry
+
+      restartPolicy: Always
+
+      # Node scheduling
+      nodeSelector:
+        topology.kubernetes.io/zone: "europe-west1-d"
+      tolerations:
+      - effect: NoSchedule
+        key: nodepool
+        operator: Equal
+        value: n2-standard-4
+---
+# Source: load-test-setup/templates/metrics-exporter.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: metrics-exporter
+  labels:
+    app: metrics-exporter
+    release: monitoring # needed to be detected by Prometheus Operator
+spec:
+  podMetricsEndpoints:
+  - interval: 30s
+    path: /metrics
+    port: metrics
+    scrapeTimeout: 20s
+  selector:
+    matchLabels:
+      app: metrics-exporter

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/namespace.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/load-test-setup/templates/namespace.yaml
@@ -1,0 +1,13 @@
+---
+# Source: load-test-setup/templates/namespace.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    camunda.io/purpose: load-test
+    camunda.io/created-by: "golden-test"
+    deadline-date: TEST_DATE
+    registry: harbor
+  annotations:
+    topology.kubernetes.io/zone: "europe-west1-d"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
@@ -1,0 +1,27 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 5432

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
@@ -1,0 +1,187 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  replicas: 1
+  serviceName: keycloak-postgresql-hl
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+      app.kubernetes.io/name: postgresql
+      app.kubernetes.io/component: primary
+  template:
+    metadata:
+      name: keycloak-postgresql
+      labels:
+        app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: postgresql
+
+        app.kubernetes.io/component: primary
+    spec:
+      serviceAccountName: keycloak-postgresql
+      
+      automountServiceAccountToken: false
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+                    app.kubernetes.io/name: postgresql
+                    app.kubernetes.io/component: primary
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      hostNetwork: false
+      hostIPC: false
+      containers:
+        - name: postgresql
+          image: docker.io/bitnamilegacy/postgresql:15.10.0-debian-12-r2
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_VOLUME_DIR
+              value: "/bitnami/postgresql"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            # Authentication
+            - name: POSTGRES_USER
+              value: "camunda"
+            - name: POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-user-password
+            - name: POSTGRES_POSTGRES_PASSWORD_FILE
+              value: /opt/bitnami/postgresql/secrets/identity-keycloak-postgresql-admin-password
+            - name: POSTGRES_DATABASE
+              value: "camunda"
+            # LDAP
+            - name: POSTGRESQL_ENABLE_LDAP
+              value: "no"
+            # TLS
+            - name: POSTGRESQL_ENABLE_TLS
+              value: "no"
+            # Audit
+            - name: POSTGRESQL_LOG_HOSTNAME
+              value: "false"
+            - name: POSTGRESQL_LOG_CONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_LOG_DISCONNECTIONS
+              value: "false"
+            - name: POSTGRESQL_PGAUDIT_LOG_CATALOG
+              value: "off"
+            # Others
+            - name: POSTGRESQL_CLIENT_MIN_MESSAGES
+              value: "error"
+            - name: POSTGRESQL_SHARED_PRELOAD_LIBRARIES
+              value: "pgaudit"
+          ports:
+            - name: tcp-postgresql
+              containerPort: 5432
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - exec pg_isready -U "camunda" -d "dbname=camunda" -h 127.0.0.1 -p 5432
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - -e
+                - |
+                  exec pg_isready -U "camunda" -d "dbname=camunda" -h 127.0.0.1 -p 5432
+          resources:
+            limits:
+              cpu: 150m
+              ephemeral-storage: 2Gi
+              memory: 192Mi
+            requests:
+              cpu: 100m
+              ephemeral-storage: 50Mi
+              memory: 128Mi
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/postgresql/tmp
+              subPath: app-tmp-dir
+            - name: postgresql-password
+              mountPath: /opt/bitnami/postgresql/secrets/
+            - name: dshm
+              mountPath: /dev/shm
+            - name: data
+              mountPath: /bitnami/postgresql
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: postgresql-password
+          secret:
+            secretName: camunda-credentials
+        - name: dshm
+          emptyDir:
+            medium: Memory
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
@@ -1,0 +1,29 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql-hl
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+  annotations:
+spec:
+  type: ClusterIP
+  clusterIP: None
+  # We want all pods in the StatefulSet to have their addresses published for
+  # the sake of the other Postgresql pods even before they're ready, since they
+  # have to be able to talk to each other in order to become ready.
+  publishNotReadyAddresses: true
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
@@ -1,0 +1,25 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/primary/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+    app.kubernetes.io/component: primary
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: tcp-postgresql
+      port: 5432
+      targetPort: tcp-postgresql
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/name: postgresql
+    app.kubernetes.io/component: primary

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/charts/postgresql/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak-postgresql
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: postgresql
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
@@ -1,0 +1,31 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/configmap-env-vars.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: keycloak-env-vars
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+data:
+  KC_BOOTSTRAP_ADMIN_USERNAME: "admin"
+  KEYCLOAK_HTTP_PORT: "8080"
+  KC_PROXY_HEADERS: "xforwarded"
+  KC_METRICS_ENABLED: "false"
+  KEYCLOAK_DATABASE_HOST: "keycloak-postgresql"
+  KEYCLOAK_DATABASE_PORT: "5432"
+  KEYCLOAK_DATABASE_NAME: "camunda"
+  KEYCLOAK_DATABASE_SCHEMA: "public"
+  KEYCLOAK_DATABASE_USER: "camunda"
+  KEYCLOAK_PRODUCTION: "false"
+  KEYCLOAK_ENABLE_HTTPS: "false"
+  KC_CACHE_TYPE: "ispn"
+  KC_CACHE_STACK: "kubernetes"
+  KC_CACHE_CONFIG_FILE: "cache-ispn.xml"
+  JAVA_OPTS_APPEND: "-Djgroups.dns.query=keycloak-headless.c8-golden-main-rdbms-physical-tenants.svc.cluster.local"
+  KC_LOG_CONSOLE_OUTPUT: "default"
+  KC_LOG_LEVEL: "INFO"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/headless-service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/headless-service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/headless-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak-headless
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 8080
+      protocol: TCP
+      targetPort: http
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/networkpolicy.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/networkpolicy.yaml
@@ -1,0 +1,28 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/networkpolicy.yaml
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  policyTypes:
+    - Ingress
+    - Egress
+  egress:
+    - {}
+  ingress:
+    - ports:
+        - port: 7800
+        - port: 8080

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/pdb.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/pdb.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/pdb.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/service.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: http
+      nodePort: null
+  selector:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/name: keycloak
+    app.kubernetes.io/component: keycloak

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/charts/identityKeycloak/templates/statefulset.yaml
@@ -1,0 +1,221 @@
+---
+# Source: camunda-platform/charts/identityKeycloak/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: keycloak
+  namespace: "c8-golden-main-rdbms-physical-tenants"
+  labels:
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: keycloak
+
+    app.kubernetes.io/component: keycloak
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  podManagementPolicy: Parallel
+  serviceName: keycloak-headless
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+      app.kubernetes.io/name: keycloak
+      app.kubernetes.io/component: keycloak
+  template:
+    metadata:
+      annotations:
+        checksum/configmap-env-vars: 06bdd57d0efc69cb04c3cfffaf369688c7336ba92d6b3580b12b80f5758e15dd
+      labels:
+        app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: keycloak
+
+        app.kubernetes.io/component: keycloak
+        app.kubernetes.io/app-version: 26.3.3
+    spec:
+      serviceAccountName: keycloak
+      
+      automountServiceAccountToken: true
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+                    app.kubernetes.io/name: keycloak
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+      securityContext:
+        fsGroup: 1001
+        fsGroupChangePolicy: Always
+        runAsNonRoot: true
+        supplementalGroups: []
+        sysctls: []
+      enableServiceLinks: true
+      initContainers:
+        - name: prepare-write-dirs
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+          args:
+            - -ec
+            - |
+              . /opt/bitnami/scripts/liblog.sh
+
+              info "Copying writable dirs to empty dir"
+              # In order to not break the application functionality we need to make some
+              # directories writable, so we need to copy it to an empty dir volume
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/lib/quarkus /emptydir/app-quarkus-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/data /emptydir/app-data-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/providers /emptydir/app-providers-dir
+              cp -r --preserve=mode,timestamps /opt/bitnami/keycloak/themes /emptydir/app-themes-dir
+              info "Copy operation completed"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          volumeMounts:
+           - name: empty-dir
+             mountPath: /emptydir
+      containers:
+        - name: keycloak
+          image: docker.io/camunda/keycloak:26.3.3
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsGroup: 1001
+            runAsNonRoot: true
+            runAsUser: 1001
+            seLinuxOptions: {}
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: KC_BOOTSTRAP_ADMIN_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/identity-keycloak-admin-password
+            - name: KEYCLOAK_DATABASE_PASSWORD_FILE
+              value: /opt/bitnami/keycloak/secrets/db-identity-keycloak-postgresql-user-password
+            - name: KC_HTTP_RELATIVE_PATH
+              value: "/auth/"
+            - name: KC_SPI_ADMIN_REALM
+              value: "master"
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: json
+          envFrom:
+            - configMapRef:
+                name: keycloak-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: discovery
+              containerPort: 7800
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 300
+            periodSeconds: 1
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: http
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+            httpGet:
+              path: /auth/realms/master
+              port: http
+          volumeMounts:
+            - name: empty-dir
+              mountPath: /tmp
+              subPath: tmp-dir
+            - name: empty-dir
+              mountPath: /bitnami/keycloak
+              subPath: app-volume-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/conf
+              subPath: app-conf-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/lib/quarkus
+              subPath: app-quarkus-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/data
+              subPath: app-data-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/providers
+              subPath: app-providers-dir
+            - name: empty-dir
+              mountPath: /opt/bitnami/keycloak/themes
+              subPath: app-themes-dir
+            - name: keycloak-secrets
+              mountPath: /opt/bitnami/keycloak/secrets
+            - mountPath: /opt/bitnami/keycloak/data/tmp
+              name: data-tmp
+      volumes:
+        - name: empty-dir
+          emptyDir: {}
+        - name: keycloak-secrets
+          projected:
+            sources:
+              - secret:
+                  name: camunda-credentials
+              - secret:
+                  name: camunda-credentials
+                  items:
+                    - key: identity-keycloak-postgresql-user-password
+                      path: db-identity-keycloak-postgresql-user-password
+        - emptyDir: {}
+          name: data-tmp

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/common/configmap-documentstore.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/common/configmap-documentstore.yaml
@@ -1,0 +1,20 @@
+---
+# Source: camunda-platform/templates/common/configmap-documentstore.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-rdbms-physical-tenants-camunda-platform-documentstore-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  DOCUMENT_DEFAULT_STORE_ID: "inmemory"
+  DOCUMENT_STORE_INMEMORY_CLASS: "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/common/configmap-identity-auth.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/common/configmap-identity-auth.yaml
@@ -1,0 +1,22 @@
+---
+# Source: camunda-platform/templates/common/configmap-identity-auth.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-rdbms-physical-tenants-camunda-platform-identity-env-vars
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  CAMUNDA_IDENTITY_BASEURL: "http://identity:80"
+  CAMUNDA_IDENTITY_TYPE: "KEYCLOAK"
+  CAMUNDA_IDENTITY_ISSUER: "http://localhost:18080/auth/realms/camunda-platform"
+  CAMUNDA_IDENTITY_ISSUER_BACKEND_URL: "http://keycloak/auth/realms/camunda-platform"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/common/configmap-release.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/common/configmap-release.yaml
@@ -1,0 +1,69 @@
+---
+# Source: camunda-platform/templates/common/configmap-release.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: c8-golden-main-rdbms-physical-tenants-camunda-platform-release
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+  annotations:
+    {}
+data:
+  info: |-
+    - name: c8-golden-main-rdbms-physical-tenants
+      namespace: c8-golden-main-rdbms-physical-tenants
+      version: 15.0.0-alpha1
+      tags:
+      - dev
+      custom-properties: []
+      components:
+      - name: Keycloak
+        id: keycloak
+        version: 26.3.3
+        url: http://localhost:18080/auth
+      - name: Identity
+        id: identity
+        version: 8.10.0-alpha1
+        url: http://localhost:8080
+        readiness: http://identity.c8-golden-main-rdbms-physical-tenants:82/actuator/health
+        metrics: http://identity.c8-golden-main-rdbms-physical-tenants:82/actuator/prometheus
+      - name: Connectors
+        id: connectors
+        version: 8.10.0-alpha1
+        url: http://connectors.c8-golden-main-rdbms-physical-tenants:8080
+        readiness: http://connectors.c8-golden-main-rdbms-physical-tenants:8080/actuator/health/readiness
+        metrics: http://connectors.c8-golden-main-rdbms-physical-tenants:8080/actuator/prometheus
+      - name: Operate
+        id: operate
+        version: SNAPSHOT
+        url: http://localhost:8080/operate
+        readiness: http://camunda.c8-golden-main-rdbms-physical-tenants:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-rdbms-physical-tenants:9600/actuator/prometheus
+      - name: Tasklist
+        id: tasklist
+        version: SNAPSHOT
+        url: http://localhost:8080/tasklist
+        readiness: http://camunda.c8-golden-main-rdbms-physical-tenants:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-rdbms-physical-tenants:9600/actuator/prometheus
+      - name: Orchestration Admin
+        id: orchestrationIdentity
+        version: SNAPSHOT
+        url: http://localhost:8080/admin
+        readiness: http://camunda.c8-golden-main-rdbms-physical-tenants:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-rdbms-physical-tenants:9600/actuator/prometheus
+    
+      - name: Orchestration Cluster
+        id: orchestration
+        version: SNAPSHOT
+        urls:
+          grpc: http://localhost:26500
+          http: http://localhost:8080
+        readiness: http://camunda.c8-golden-main-rdbms-physical-tenants:9600/actuator/health/readiness
+        metrics: http://camunda.c8-golden-main-rdbms-physical-tenants:9600/actuator/prometheus

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/connectors/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/connectors/configmap.yaml
@@ -1,0 +1,65 @@
+---
+# Source: camunda-platform/templates/connectors/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: connectors-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+data:
+  application.yaml: |    
+    server:
+      port: 8080
+    
+    management:
+      context-path: /actuator
+      endpoints:
+        web:
+          exposure:
+            include: metrics,health,prometheus
+      endpoint:
+        health:
+          show-details: always
+          show-components: always
+          group:
+            readiness:
+              include:
+              - processDefinitionImport
+              - zeebeClient
+    
+    camunda:
+      client:
+        rest-address: http://camunda-gateway:8080
+        grpc-address: http://camunda-gateway:26500
+        worker:
+          defaults:
+            max-jobs-active: 32
+            stream-enabled: true
+        mode: selfManaged
+        auth:
+          token-url: http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token
+          client-id: "connectors"
+          client-secret: ${VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET}
+          audience: "orchestration-api"
+      connector:
+        headless:
+          service-url: "connectors-headless"
+        webhook:
+          enabled: true
+        polling:
+          enabled: true
+        agenticai:
+          enabled: true
+    
+    logging:
+      level:
+        io.camunda.connector: INFO

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/connectors/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/connectors/deployment.yaml
@@ -1,0 +1,128 @@
+---
+# Source: camunda-platform/templates/connectors/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+    {}
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: connectors
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: connectors
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: connectors
+          image: camunda/connectors-bundle:8.10.0-alpha1
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          env:
+            
+            - name: VALUES_CAMUNDA_IDENTITY_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            
+            
+            - name: CONNECTORS_LOG_APPENDER
+              value: stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-rdbms-physical-tenants-camunda-platform-identity-env-vars
+            - configMapRef:
+                name: c8-golden-main-rdbms-physical-tenants-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 1000m
+              memory: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /config/application.yaml
+              subPath: application.yaml
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: connectors-configuration
+      serviceAccountName: connectors
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/connectors/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/connectors/service-headless.yaml
@@ -1,0 +1,33 @@
+---
+# Source: camunda-platform/templates/connectors/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors-headless
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  clusterIP: None
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/connectors/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/connectors/service.yaml
@@ -1,0 +1,32 @@
+---
+# Source: camunda-platform/templates/connectors/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: connectors

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/connectors/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/connectors/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/connectors/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: connectors
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/configmap.yaml
@@ -1,0 +1,216 @@
+---
+# Source: camunda-platform/templates/identity/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+data:
+  application.yaml: |
+    # NOTE:
+    # It is possible to override the configuration via env vars following the Spring Boot convention.
+    # For example, the "identity.url" config path is presented as the "IDENTITY_URL" environment variable.
+    # However, it's not possilbe to mix between the configuration and environment variable for the same object
+    # like arrays and maps.
+    identity:
+      url: "http://localhost:8084"
+      flags:
+        multi-tenancy: "false"
+
+      authProvider:
+        issuer-url: "http://localhost:18080/auth/realms/camunda-platform"
+        backend-url: "http://keycloak/auth/realms/camunda-platform"
+      component-presets:
+        connectors:
+          applications:
+            - name: Connectors
+              id: ${CAMUNDA_CONNECTORS_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONNECTORS_CLIENT_ID:connectors}}
+              type: m2m
+              secret: ${CAMUNDA_CONNECTORS_SECRET:${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+        console:
+          applications:
+            - name: "Console"
+              id: ${CAMUNDA_CONSOLE_CLIENT_ID:${VALUES_KEYCLOAK_INIT_CONSOLE_CLIENT_ID:console}}
+              type: public
+              root-url: "http://localhost:8087"
+              redirect-uris:
+                - "/"
+          apis:
+            - name: Console API
+              audience: "console-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Console"
+              description: "Grants full access to Console"
+              permissions:
+                - audience: "console-api"
+                  definition: write:*
+        identity:
+          apis:
+            - name: "Camunda Identity Resource Server"
+              audience: "camunda-identity-resource-server"
+              permissions:
+                - definition: read
+                  description: "Read permission"
+                - definition: "read:users"
+                  description: "Read users permission"
+                - definition: write
+                  description: "Write permission"
+          roles:
+            - name: "ManagementIdentity"
+              description: "Provides full access to Management Identity"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read
+                - audience: "camunda-identity-resource-server"
+                  definition: write
+        orchestration:
+          applications:
+            - name: Orchestration
+              id: ${CAMUNDA_ORCHESTRATION_CLIENT_ID:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_CLIENT_ID:orchestration}}
+              type: confidential
+              secret: ${CAMUNDA_ORCHESTRATION_SECRET:${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}}
+              permissions:
+                - audience: "orchestration-api"
+                  definition: write:*
+              root-url: "http://localhost:8080"
+              redirect-uris:
+                - "/login/oauth2/code/orchestration"
+                - "/sso-callback"
+          apis:
+            - name: "Orchestration API"
+              audience: "orchestration-api"
+              permissions:
+                - definition: read:*
+                  description: "Read permission"
+                - definition: write:*
+                  description: "Write permission"
+          roles:
+            - name: "Orchestration"
+              description: "Grants full access to Orchestration"
+              permissions:
+                - audience: "orchestration-api"
+                  definition: read:*
+                - audience: "orchestration-api"
+                  definition: write:*
+        webmodeler:
+          applications:
+            - name: "Web Modeler"
+              id: ${CAMUNDA_WEBMODELER_CLIENT_ID:${VALUES_KEYCLOAK_INIT_WEBMODELER_CLIENT_ID:web-modeler}}
+              type: public
+              root-url: "http://localhost:8070"
+              redirect-uris:
+                - "/login-callback"
+          apis:
+            - name: Web Modeler Internal API
+              audience: "web-modeler-api"
+              permissions:
+                - definition: write:*
+                  description: "Write permission"
+                - definition: admin:*
+                  description: "Admin permission"
+            - name: Web Modeler API
+              audience: "web-modeler-public-api"
+              permissions:
+                - definition: create:*
+                  description: "Allows create access for all resources"
+                - definition: read:*
+                  description: "Allows read access to all resources"
+                - definition: update:*
+                  description: "Allows update access to all resources"
+                - definition: delete:*
+                  description: "Allows delete access for all resources"
+          roles:
+            - name: "Web Modeler"
+              description: "Grants full access to Web Modeler"
+              permissions:
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+            - name: "Web Modeler Admin"
+              description: "Grants elevated access to Web Modeler"
+              permissions:
+                - audience: "camunda-identity-resource-server"
+                  definition: read:users
+                - audience: "web-modeler-api"
+                  definition: write:*
+                - audience: "web-modeler-api"
+                  definition: admin:*
+    keycloak:
+      url: "http://keycloak/auth"
+      setup:
+        user: "admin"
+        password: ${VALUES_KEYCLOAK_SETUP_PASSWORD:}
+      init:
+        connectors:
+          secret: ${VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET:}
+        console:
+          root-url: "http://localhost:8087"
+        orchestration:
+          secret: ${VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET:}
+        webmodeler:
+          root-url: "http://localhost:8070"
+      clients:
+        - id: optimize-loadtest
+          name: Optimize Load Tester
+          secret: ${VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET:}
+          redirectUris: 
+          rootUrl: 
+          type: m2m
+          permissions:
+            - definition: write:*
+              resourceServerId: optimize-api
+      users:
+        - username: "demo"
+          password: ${VALUES_IDENTITY_FIRSTUSER_PASSWORD:}
+          firstName: "Demo"
+          lastName: "User"
+          email: "demo@example.org"
+          roles:
+            - ManagementIdentity
+            - Orchestration
+      environment:
+        clients:
+          - name: Identity
+            id: "camunda-identity"
+            type: CONFIDENTIAL
+            secret: ${CAMUNDA_IDENTITY_CLIENT_SECRET:${IDENTITY_CLIENT_SECRET}}
+            root-url: "http://localhost:8084"
+            redirect-uris:
+              - "/auth/login-callback"
+    server:
+      port: 8084
+
+    spring:
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+      profiles:
+        active: keycloak
+
+    camunda:
+      identity:
+        audience: "camunda-identity-resource-server"
+    logging:
+      level:
+        ROOT: INFO
+        io.camunda.identity: INFO

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/deployment.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/deployment.yaml
@@ -1,0 +1,148 @@
+---
+# Source: camunda-platform/templates/identity/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+    {}
+spec:
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: identity
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: identity
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: camunda-platform
+          image: camunda/identity:8.10.0-alpha1
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1001
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            
+            - name: VALUES_KEYCLOAK_INIT_CONNECTORS_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: connectors-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_INIT_ORCHESTRATION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: VALUES_KEYCLOAK_SETUP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-keycloak-admin-password
+            - name: VALUES_IDENTITY_FIRSTUSER_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-firstuser-password
+            - name: VALUES_OPTIMIZE-LOADTEST_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: identity-optimize-loadtest-client-secret
+            - name: IDENTITY_LOG_APPENDER
+              value: Stackdriver
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-rdbms-physical-tenants-camunda-platform-documentstore-env-vars
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 2Gi
+            requests:
+              cpu: 600m
+              memory: 400Mi
+          ports:
+            - containerPort: 8084
+              name: http
+              protocol: TCP
+            - containerPort: 8082
+              name: metrics
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              scheme: HTTP
+              port: metrics
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          volumeMounts:
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /app/config/application.yaml
+              subPath: application.yaml
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: identity-configuration
+      serviceAccountName: identity
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      tolerations:
+        
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/service.yaml
@@ -1,0 +1,36 @@
+---
+# Source: camunda-platform/templates/identity/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+  annotations:
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8084
+      protocol: TCP
+    - port: 82
+      name: metrics
+      targetPort: 8082
+      protocol: TCP
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: identity

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/identity/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/identity/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: identity
+
+automountServiceAccountToken: true

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/configmap.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/configmap.yaml
@@ -1,0 +1,294 @@
+---
+# Source: camunda-platform/templates/orchestration/configmap.yaml
+kind: ConfigMap
+metadata:
+  name: camunda-configuration
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+apiVersion: v1
+data:
+  startup.sh: |
+    # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+    # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+    export VALUES_ORCHESTRATION_NODE_ID="${VALUES_ORCHESTRATION_NODE_ID:-$[${K8S_NAME##*-} * 1 + 0]}"
+    echo "export VALUES_ORCHESTRATION_NODE_ID=${VALUES_ORCHESTRATION_NODE_ID}"
+
+    if [ "$ZEEBE_RESTORE" = "true" ]; then
+      if [ "${ZEEBE_RESTORE_FROM_BACKUP_ID:-}" ]; then
+        exec restore --backupId="${ZEEBE_RESTORE_FROM_BACKUP_ID}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ] && [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}" --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_FROM_TIMESTAMP:-}" ]; then
+        exec restore --from="${ZEEBE_RESTORE_FROM_TIMESTAMP}"
+      elif [ "${ZEEBE_RESTORE_TO_TIMESTAMP:-}" ]; then
+        exec restore --to="${ZEEBE_RESTORE_TO_TIMESTAMP}"
+      else
+        exec restore
+      fi
+    else
+      exec camunda
+    fi
+  application.yaml: |    
+    spring:
+      config:
+        import:
+          - optional:file:/usr/local/camunda/config/application.yml
+          - optional:file:/usr/local/camunda/config/application-override.yml
+      profiles:
+        active: "admin,broker,operate,tasklist,consolidated-auth"
+      servlet:
+        multipart:
+          max-file-size: "10MB"
+          max-request-size: "10MB"
+    
+    server:
+      address: 0.0.0.0
+      port: 8080
+    
+    management:
+      server:
+        address: 0.0.0.0
+        port: 9600
+        base-path: "/"
+    
+    camunda:
+      backup:
+        webapps:
+          enabled: false
+      license:
+        key: "${VALUES_ORCHESTRATION_LICENSE_KEY}"
+    
+      system:
+        cpu-thread-count: 3
+        io-thread-count: 3
+        clock-controlled: false
+        validate-restore-config: true
+        upgrade:
+          enable-version-check: true
+    
+      cluster:
+        # The Node ID depends on the StatefulSet Pod's name so it cannot be templated in the StatefulSet level.
+        # The value of "node-id" is calculated in the "startup.sh" file and exported as "VALUES_ORCHESTRATION_NODE_ID" env var.
+        node-id: "${VALUES_ORCHESTRATION_NODE_ID:}"
+        size: "3"
+        replication-factor: "3"
+        partition-count: "3"
+        # zeebe.broker.cluster
+        initial-contact-points:
+          - camunda-0.${K8S_SERVICE_NAME}:26502
+          - camunda-1.${K8S_SERVICE_NAME}:26502
+          - camunda-2.${K8S_SERVICE_NAME}:26502
+    
+      api:
+        grpc:
+          address: 0.0.0.0
+          port: 26500
+    
+      # Database configuration - Separated syntax.
+      database:
+    
+      data:
+        snapshot-period: "5m"
+        primary-storage:
+          disk:
+            free-space:
+              processing: "2GB"
+              replication: "1GB"
+        secondary-storage:
+          autoconfigure-camunda-exporter: false
+          type: "rdbms"
+          retention:
+            enabled: true
+            minimum-age: "1d"
+          rdbms:
+            aws-enabled: false
+            url: "jdbc:postgresql://postgresql:5432/camunda"
+            username: "camunda"
+            password: "${VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD:}"
+    
+      # Security configuration - Separated syntax.
+      security:
+        authentication:
+          oidc:
+            username-claim: "preferred_username"
+            client-id-claim: "client_id"
+            client-id: "orchestration"
+            client-secret: ${VALUES_ORCHESTRATION_CLIENT_SECRET:}
+            audiences:
+              - "orchestration"
+              - "orchestration-api"
+              - "web-modeler-api"
+            authorization-uri: "http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/auth"
+            jwk-set-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/certs"
+            token-uri: "http://keycloak/auth/realms/camunda-platform/protocol/openid-connect/token"
+            redirect-uri: "http://localhost:8080/sso-callback"
+            authenticationRefreshInterval: "PT30S"
+          method: "oidc"
+          unprotectedApi: false
+        authorizations:
+          enabled: true
+        initialization:
+          default-roles:
+            admin:
+              users:
+              - demo
+            connectors:
+              clients:
+              - connectors
+              users:
+              - connectors
+          authorizations:
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: RESOURCE
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE_PROCESS_INSTANCE
+              - UPDATE_PROCESS_INSTANCE
+              - READ_PROCESS_INSTANCE
+              - READ_PROCESS_DEFINITION
+              resourceId: '*'
+              resourceType: PROCESS_DEFINITION
+            - ownerId: orchestration
+              ownerType: CLIENT
+              permissions:
+              - CREATE
+              resourceId: '*'
+              resourceType: MESSAGE
+        multiTenancy:
+          checksEnabled: false
+          apiEnabled: true
+      identity:
+        clientId: "orchestration"
+        audience: "orchestration-api"
+      persistent:
+        sessions:
+          enabled: true
+    
+      #
+      # Camunda Operate Configuration - Separated syntax.
+      #
+      operate:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/operate"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+      #
+      # Camunda Tasklist Configuration - Separated syntax.
+      #
+      tasklist:
+        multiTenancy:
+          enabled: false
+        identity:
+          redirectRootUrl: "http://localhost:8080/tasklist"
+        # Zeebe instance
+        zeebe:
+          # Gateway address
+          gatewayAddress: "camunda-gateway:26500"
+          restAddress: "http://camunda-gateway:8080"
+        archiver:
+          ilmEnabled: true
+          ilmMinAgeForDeleteArchivedIndices: 1d
+    
+    #
+    # Camunda Zeebe Configuration - Separated syntax.
+    #
+    zeebe:
+      host: 0.0.0.0
+      log:
+        level: "info"
+    
+      broker:
+        # zeebe.broker.gateway
+        gateway:
+          enable: true
+          multitenancy:
+            enabled: false
+    
+        # zeebe.broker.network
+        network:
+          advertisedHost: "${K8S_NAME}.${K8S_SERVICE_NAME}"
+          host: 0.0.0.0
+          commandApi:
+            port: 26501
+          internalApi:
+            port: 26502
+    
+        # zeebe.broker.cluster
+        cluster:
+          clusterName: c8-golden-main-rdbms-physical-tenants-zeebe
+        # zeebe.broker.exporters
+        exporters: {}
+    
+  log4j2.xml: |
+  application.yml: |
+    # Enable execution metrics exporter to be able to see the execution metrics, like process instance and job completion times
+    zeebe.broker.executionMetricsExporterEnabled: "true"
+    camunda.flags.jfr.metrics: "true"
+    # Define when the broker should start to reject requests when the disk is almost full, for both processing and replication.
+    zeebe.broker.data.disk.freeSpace.processing: "3GB"
+    zeebe.broker.data.disk.freeSpace.replication: "2GB"
+    # We want to have this for long running load tests, to detect consistency issues early on and to have the foreign key checks enabled for better data integrity.
+    # Like endurance / soak tests  but not for our maximum stress tests, where we want to push the system to the limits and consistency checks might cause too much overhead.
+    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
+    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
+    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
+    zeebe.broker.flowControl.write.enabled: "true"
+    zeebe.broker.flowControl.write.limit: 10000
+    zeebe.broker.flowControl.write.throttling.enabled: "true"
+    # History cleanup adjust batch sizes
+    camunda.data.secondary-storage.rdbms.history.history-cleanup-batch-size: 100000
+    camunda.data.secondary-storage.rdbms.history.history-cleanup-process-instance-batch-size: 2000
+    # set to 2001 and not 2000 to directly see when queue is full in metrics dashboard
+    camunda.data.secondary-storage.rdbms.queue-size: 2001
+    camunda.data.secondary-storage.rdbms.history.default-history-ttl: PT1H
+    camunda.data.secondary-storage.rdbms.history.min-history-cleanup-interval: PT1S
+    camunda.data.secondary-storage.rdbms.history.max-history-cleanup-interval: PT1M
+    # Physical tenants: shared RDBMS database, isolated by table prefix.
+    # The default tenant uses the DEFAULT_ prefix; testfoo uses the TESTFOO_ prefix.
+    camunda.data.secondary-storage.rdbms.prefix: DEFAULT_
+    camunda.physical-tenants.testfoo.data.secondary-storage.rdbms.prefix: TESTFOO_
+    # testfoo tenant: grant the orchestration client the same permissions as the default tenant
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[0].ownerType: CLIENT
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[0].ownerId: orchestration
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[0].resourceType: RESOURCE
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[0].resourceId: "*"
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[0].permissions[0]: CREATE
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[1].ownerType: CLIENT
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[1].ownerId: orchestration
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[1].resourceType: PROCESS_DEFINITION
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[1].resourceId: "*"
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[0]: CREATE_PROCESS_INSTANCE
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[1]: UPDATE_PROCESS_INSTANCE
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[2]: READ_PROCESS_INSTANCE
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[1].permissions[3]: READ_PROCESS_DEFINITION
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[2].ownerType: CLIENT
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[2].ownerId: orchestration
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[2].resourceType: MESSAGE
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[2].resourceId: "*"
+    camunda.physical-tenants.testfoo.security.initialization.authorizations[2].permissions[0]: CREATE
+    # testfoo tenant: assign the default OIDC provider (Keycloak) so this tenant can authenticate
+    camunda.physical-tenants.testfoo.security.authentication.providers.assigned[0]: oidc
+  application-override.yml: |
+    # no overrides

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/service-headless.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/service-headless.yaml
@@ -1,0 +1,46 @@
+---
+# Source: camunda-platform/templates/orchestration/service-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+    {}
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  type: ClusterIP
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 26502
+      protocol: TCP
+      name: internal
+    - port: 26501
+      protocol: TCP
+      name: command
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/service.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/service.yaml
@@ -1,0 +1,39 @@
+---
+# Source: camunda-platform/templates/orchestration/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-gateway
+
+  annotations:
+    {}
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  ports:
+    - port: 9600
+      protocol: TCP
+      name: server
+    - port: 8080
+      protocol: TCP
+      name: http
+    - port: 26500
+      protocol: TCP
+      name: grpc
+  selector:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    app.kubernetes.io/component: zeebe-broker

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/serviceaccount.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/serviceaccount.yaml
@@ -1,0 +1,18 @@
+---
+# Source: camunda-platform/templates/orchestration/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+automountServiceAccountToken: false

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/statefulset.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/orchestration/statefulset.yaml
@@ -1,0 +1,211 @@
+---
+# Source: camunda-platform/templates/orchestration/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: camunda
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    app.kubernetes.io/component: zeebe-broker
+
+  annotations:
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/name: camunda-platform
+      app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+      app.kubernetes.io/managed-by: Helm
+      app.kubernetes.io/part-of: camunda-platform
+      app.kubernetes.io/component: zeebe-broker
+  serviceName: "camunda"
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: Parallel
+  template:
+    metadata:
+      labels:
+        app: camunda-platform
+        app.kubernetes.io/name: camunda-platform
+        app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/part-of: camunda-platform
+        camunda.io/created-by: golden-test
+        camunda.io/purpose: load-test
+
+        app.kubernetes.io/component: zeebe-broker
+
+      annotations:
+
+    spec:
+      imagePullSecrets:
+        - name: harbor-registry
+      initContainers:
+        []
+      containers:
+        - name: orchestration
+          image: docker.io/camunda/camunda:SNAPSHOT
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: true
+            privileged: true
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["bash", "/usr/local/bin/startup.sh"]
+          env:
+            - name: LC_ALL
+              value: C.UTF-8
+            - name: K8S_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: K8S_SERVICE_NAME
+              value: "camunda"
+            - name: K8S_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            
+            - name: VALUES_ORCHESTRATION_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: camunda-credentials
+                  key: orchestration-security-authentication-oidc-secret
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=25.0 -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/camunda/data -XX:ErrorFile=/usr/local/camunda/data/zeebe_error%p.log -XX:NativeMemoryTracking=summary -Xlog:gc*:file=/usr/local/camunda/data/gc.log:time:filecount=7,filesize=8M"
+            - name: K8S_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: ZEEBE_LOG_APPENDER
+              value: Stackdriver
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
+              value: zeebe
+            - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: ATOMIX_LOG_LEVEL
+              value: INFO
+            - name: ZEEBE_LOG_LEVEL
+              value: DEBUG
+            - name: SPRING_CONFIG_ADDITIONALLOCATION
+              value: /usr/local/camunda/config/application.yml,optional:/usr/local/camunda/config/application-override.yml
+            
+            
+            - name: VALUES_ORCHESTRATION_DATA_SECONDARYSTORAGE_RDBMS_PASSWORD
+              value: "camunda"
+            
+          envFrom:
+            - configMapRef:
+                name: c8-golden-main-rdbms-physical-tenants-camunda-platform-documentstore-env-vars
+          ports:
+            - containerPort: 8080
+              name: http
+            - containerPort: 26501
+              name: command
+            - containerPort: 26502
+              name: internal
+            - containerPort: 9600
+              name: server
+            - containerPort: 26500
+              name: grpc
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              scheme: HTTP
+              port: 9600
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            successThreshold: 1
+            failureThreshold: 5
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 3000m
+              memory: 2Gi
+            requests:
+              cpu: 3000m
+              memory: 2Gi
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/bin/startup.sh
+              subPath: startup.sh
+            - name: data
+              mountPath: /usr/local/camunda/data
+            - name: exporters
+              mountPath: /exporters
+            - mountPath: /tmp
+              name: tmp
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yaml
+              subPath: application.yaml
+            - name: config
+              mountPath: /usr/local/camunda/config/application.yml
+              subPath: application.yml
+            - name: config
+              mountPath: /usr/local/camunda/config/application-override.yml
+              subPath: application-override.yml
+            
+            - mountPath: /usr/local/camunda/logs
+              name: logs
+      volumes:
+        - name: config
+          configMap:
+            name: camunda-configuration
+            defaultMode: 492
+        - name: exporters
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+          
+        - emptyDir: {}
+          name: logs
+      serviceAccountName: camunda
+      securityContext:
+        fsGroup: 1001
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      nodeSelector:
+        component: benchmark-n2-standard-4
+        topology.kubernetes.io/zone: europe-west1-d
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - zeebe-broker
+              topologyKey: kubernetes.io/hostname
+      tolerations:
+        - effect: NoSchedule
+          key: nodepool
+          operator: Equal
+          value: n2-standard-4
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        annotations:
+          {}
+      spec:
+        accessModes: [ReadWriteOnce]
+        storageClassName: benchmark-ssd-zonal-v1
+        resources:
+          requests:
+            storage: "64Gi"

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/service-monitor/connectors-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/service-monitor/connectors-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/connectors-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-main-rdbms-physical-tenants-camunda-platform-connectors
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: connectors
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: http
+      interval: 30s

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/service-monitor/identity-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/service-monitor/identity-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/identity-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: c8-golden-main-rdbms-physical-tenants-camunda-platform-identity
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: identity
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: metrics
+      interval: 30s

--- a/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/service-monitor/orchestration-service-monitor.yaml
+++ b/load-tests/setup/test/golden/main/rdbms-physical-tenants/platform/templates/service-monitor/orchestration-service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+# Source: camunda-platform/templates/service-monitor/orchestration-service-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: camunda-gateway
+  labels:
+    app: camunda-platform
+    app.kubernetes.io/name: camunda-platform
+    app.kubernetes.io/instance: c8-golden-main-rdbms-physical-tenants
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: camunda-platform
+    camunda.io/created-by: golden-test
+    camunda.io/purpose: load-test
+
+    release: monitoring
+spec:
+  selector:
+    matchLabels:
+      app: camunda-platform
+      app.kubernetes.io/component: zeebe-gateway
+  endpoints:
+    - honorLabels: true
+      path: /actuator/prometheus
+      port: server
+      interval: 30s

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -31,12 +31,12 @@ var update = flag.Bool("update-golden", false,
 // PhysicalTenants, when true, passes physical_tenants=true to the platform
 // template target. Only supported for rdbms secondary_storage (main version only).
 type scenario struct {
-	Name           string
-	Storage        string // elasticsearch | opensearch | postgresql | none
-	Optimize       bool
-	Stable         bool
-	Workload       string // "" = default profile; e.g. "max", "realistic"
-	SetupTarget    string // named make target for template-load-test-setup variants
+	Name            string
+	Storage         string // elasticsearch | opensearch | postgresql | none
+	Optimize        bool
+	Stable          bool
+	Workload        string // "" = default profile; e.g. "max", "realistic"
+	SetupTarget     string // named make target for template-load-test-setup variants
 	PhysicalTenants bool
 }
 
@@ -73,8 +73,7 @@ var defaultScenarios = []scenario{
 	{Name: "chaos-killer", Storage: "elasticsearch", Optimize: false, SetupTarget: "template-load-test-setup-chaos"},
 	// physical_tenants=true deploys a second tenant alongside the default on a
 	// shared RDBMS (table-prefix isolation). Only supported for rdbms storage.
-	// Uncomment and run `make update-golden` to generate the golden files:
-	// {Name: "rdbms-physical-tenants", Storage: "postgresql", Optimize: false, PhysicalTenants: true},
+	{Name: "rdbms-physical-tenants", Storage: "postgresql", Optimize: false, PhysicalTenants: true},
 }
 
 // versions lists the setup directories under test, each the name of a directory

--- a/load-tests/setup/test/golden_test.go
+++ b/load-tests/setup/test/golden_test.go
@@ -27,13 +27,17 @@ var update = flag.Bool("update-golden", false,
 // load-test-setup chart only — used to test opt-in chart features that have a
 // dedicated make target (e.g. template-load-test-setup-chaos). This avoids
 // duplicating the full storage matrix for features that are orthogonal to storage.
+//
+// PhysicalTenants, when true, passes physical_tenants=true to the platform
+// template target. Only supported for rdbms secondary_storage (main version only).
 type scenario struct {
-	Name        string
-	Storage     string // elasticsearch | opensearch | postgresql | none
-	Optimize    bool
-	Stable      bool
-	Workload    string // "" = default profile; e.g. "max", "realistic"
-	SetupTarget string // named make target for template-load-test-setup variants
+	Name           string
+	Storage        string // elasticsearch | opensearch | postgresql | none
+	Optimize       bool
+	Stable         bool
+	Workload       string // "" = default profile; e.g. "max", "realistic"
+	SetupTarget    string // named make target for template-load-test-setup variants
+	PhysicalTenants bool
 }
 
 // versionedScenario defines a scenario with a specific version
@@ -67,6 +71,10 @@ var defaultScenarios = []scenario{
 	// Makefile target, verifying opt-in chart features without duplicating the
 	// full storage matrix.
 	{Name: "chaos-killer", Storage: "elasticsearch", Optimize: false, SetupTarget: "template-load-test-setup-chaos"},
+	// physical_tenants=true deploys a second tenant alongside the default on a
+	// shared RDBMS (table-prefix isolation). Only supported for rdbms storage.
+	// Uncomment and run `make update-golden` to generate the golden files:
+	// {Name: "rdbms-physical-tenants", Storage: "postgresql", Optimize: false, PhysicalTenants: true},
 }
 
 // versions lists the setup directories under test, each the name of a directory
@@ -107,6 +115,11 @@ func generateScenarios(versions []string, scenarios []scenario) []versionedScena
 					// Only elasticsearch is supported on 8.7
 					continue
 				}
+			}
+
+			// physical_tenants=true is only implemented in the main Makefile.
+			if s.PhysicalTenants && v != "main" {
+				continue
 			}
 
 			scenario := versionedScenario{
@@ -157,8 +170,13 @@ func TestGoldenFiles(t *testing.T) {
 				platformTarget = "template-stable"
 			}
 
-			renderAndAssert(t, s.Version, s.Name, "platform", ns, platformTarget, "")
-			renderAndAssert(t, s.Version, s.Name, "load-test-setup", ns, "template-load-test-setup", "")
+			var extraVars []string
+			if s.PhysicalTenants {
+				extraVars = append(extraVars, "physical_tenants=true")
+			}
+
+			renderAndAssert(t, s.Version, s.Name, "platform", ns, platformTarget, "", extraVars...)
+			renderAndAssert(t, s.Version, s.Name, "load-test-setup", ns, "template-load-test-setup", "", extraVars...)
 		})
 	}
 }
@@ -210,10 +228,11 @@ func TestInstallLoadTestSetupKeepsMakefileFlagsWhenAdditionalConfigurationIsProv
 
 // renderAndAssert renders a chart via the scaffolded Makefile's make target and
 // compares (or writes) the resulting manifest tree against the golden directory.
-func renderAndAssert(t *testing.T, version, scenario, chartName string, ns *ScaffoldedNamespace, makeTarget, workload string) {
+// extraVars are additional make variable assignments forwarded to Render.
+func renderAndAssert(t *testing.T, version, scenario, chartName string, ns *ScaffoldedNamespace, makeTarget, workload string, extraVars ...string) {
 	t.Helper()
 
-	srcDir := ns.Render(t, makeTarget, workload)
+	srcDir := ns.Render(t, makeTarget, workload, extraVars...)
 	assertGoldenDir(t, version, scenario, chartName, srcDir, *update)
 }
 

--- a/load-tests/setup/test/scaffold.go
+++ b/load-tests/setup/test/scaffold.go
@@ -70,10 +70,11 @@ func Scaffold(t *testing.T, setupDirName, namespace, storage, optimize string) *
 // per chart template, mirroring the chart structure). When workload is non-empty
 // it is passed as `scenario=<workload>` (e.g. max, realistic), selecting the
 // Makefile's workload profile flags — exactly as `make install scenario=<workload>`.
+// extraVars are additional make variable assignments (e.g. "physical_tenants=true").
 //
 // The template targets pin --namespace $(namespace), so .Release.Namespace matches
 // what `make install` produces and is deterministic across machines.
-func (ns *ScaffoldedNamespace) Render(t *testing.T, target, workload string) string {
+func (ns *ScaffoldedNamespace) Render(t *testing.T, target, workload string, extraVars ...string) string {
 	t.Helper()
 
 	// Render into an isolated, auto-cleaned dir via the Makefile's
@@ -83,6 +84,7 @@ func (ns *ScaffoldedNamespace) Render(t *testing.T, target, workload string) str
 	if workload != "" {
 		args = append(args, "scenario="+workload)
 	}
+	args = append(args, extraVars...)
 	cmd := exec.Command("make", args...)
 	cmd.Dir = ns.Dir
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Description

Adds a `physical_tenants` flag to the main load-test setup that deploys a second physical tenant (`testfoo`) alongside the default one on a **shared RDBMS**, isolated by table prefix (`DEFAULT_` / `TESTFOO_`). This lets a load test validate physical-tenant isolation and drive independent load per tenant, reusing the existing load-test workflow.

Enable it with an rdbms secondary storage:

```sh
make install physical_tenants=true secondary_storage=postgresql scenario=typical
```

or via the `physical-tenants: true` workflow input (`camunda-load-test.yml`).

## Changes

- **`camunda-platform-two-physical-tenants-shared-rdbms.yaml`** (new) — the rdbms platform values plus the `testfoo` tenant: `TESTFOO_` table prefix, OIDC provider assignment, and orchestration-client authorizations. Byte-identical to `camunda-platform-values-rdbms.yaml` except the tenant block.
- **`Makefile`** — `physical_tenants` flag (rdbms-only, guarded with a fail-fast error); selects the two-tenants values file; new `install-load-test-physical-tenant` target that:
  - clones the generated `load-test-credentials` secret into `load-test-credentials-testfoo`, overriding only the REST address to the tenant path `http://camunda:8080/physical-tenants/testfoo`;
  - renders the `camunda-load-tests` subchart `starter`/`worker` from the **same chart, values, scenario and image** as the default tester, renames them to `*-testfoo`, and applies. A second Helm release is not possible because the subchart hardcodes the `starter`/`worker` resource names. REST is used because gRPC only routes to the default physical tenant.
- **`newLoadTest.sh`** — scaffolds the new values file for rdbms storages.
- **`camunda-load-test.yml`** — new `physical-tenants` boolean input (both `workflow_call` and `workflow_dispatch`), threaded through to `make`.
- **`README.md`** — documents the flag and a verification query.

## Testing

Validated locally:
- Render + rename of the testfoo starter/worker produces valid YAML with correctly renamed Deployments/selectors and the same branch-built image tag.
- `make -n` confirms the rdbms guard, values-file selection, install-chain gating, and image-tag threading.
- Workflow YAML parses; `spotless:check` green.

Validated by a [manual workflow run](https://github.com/camunda/camunda/actions/runs/29046822372). 

closes #57265
