### PR TITLE
fix: annotate POST /restore with x-added-in-version

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml
@@ -100,6 +100,7 @@ paths:
 
   /restore:
     post:
+      x-added-in-version: "8.10"
       x-eventually-consistent: false
       tags:
         - Recovery


### PR DESCRIPTION
## Description

`POST /restore` was added to `zeebe/gateway-protocol/src/main/proto/v2/cluster.yaml` (4846cf148ac) without the `x-added-in-version` annotation. The `Lint / C8 REST OpenAPI x-added-in-version` job therefore fails on **every open PR** with:

```
Operation POST /restore exists in cluster.yaml but is not in version-map.json
```

This adds the missing annotation (`"8.10"`, matching the sibling `/mode` operation added in the same release line).

## Related issues

n/a — unblocks the lint job repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)