### PR TITLE
fix: render tool-call heat on AI Agent ad-hoc subprocess

### DIFF
--- a/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.js
+++ b/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.js
@@ -62,9 +62,9 @@ export default class HeatmapOverlay extends React.Component {
   }
 
   renderHeatmap = () => {
-    const {viewer, data, noSequenceHighlight} = this.props;
+    const {viewer, data, noSequenceHighlight, allowAdHocSubProcess} = this.props;
 
-    const heatmap = getHeatmap(viewer, data, noSequenceHighlight);
+    const heatmap = getHeatmap(viewer, data, noSequenceHighlight, allowAdHocSubProcess);
 
     if (this.heatmap) {
       viewer.get('canvas')._viewport.removeChild(this.heatmap);

--- a/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.test.js
+++ b/optimize/client/src/modules/components/HeatmapOverlay/HeatmapOverlay.test.js
@@ -43,7 +43,13 @@ const data = 'some heatmap data';
 it('create get a heatmap', () => {
   shallow(<HeatmapOverlay viewer={viewer} data={data} />);
 
-  expect(getHeatmap).toHaveBeenCalledWith(viewer, data, undefined);
+  expect(getHeatmap).toHaveBeenCalledWith(viewer, data, undefined, undefined);
+});
+
+it('should forward the allowAdHocSubProcess flag to getHeatmap', () => {
+  shallow(<HeatmapOverlay viewer={viewer} data={data} allowAdHocSubProcess />);
+
+  expect(getHeatmap).toHaveBeenCalledWith(viewer, data, undefined, true);
 });
 
 it('append the heatmap to the viewer viewport', () => {

--- a/optimize/client/src/modules/components/HeatmapOverlay/service.js
+++ b/optimize/client/src/modules/components/HeatmapOverlay/service.js
@@ -20,8 +20,8 @@ const COOLNESS = 2.5;
 const EDGE_BUFFER = 75;
 const RESOLUTION = 4;
 
-export function getHeatmap(viewer, data, noSequenceHighlight) {
-  const heat = generateHeatmap(viewer, data, noSequenceHighlight);
+export function getHeatmap(viewer, data, noSequenceHighlight, allowAdHocSubProcess) {
+  const heat = generateHeatmap(viewer, data, noSequenceHighlight, allowAdHocSubProcess);
   const node = document.createElementNS('http://www.w3.org/2000/svg', 'image');
 
   Object.keys(heat.dimensions).forEach((prop) => {
@@ -34,9 +34,15 @@ export function getHeatmap(viewer, data, noSequenceHighlight) {
   return node;
 }
 
-function generateHeatmap(viewer, data, noSequenceHighlight) {
+function generateHeatmap(viewer, data, noSequenceHighlight, allowAdHocSubProcess) {
   const dimensions = getDimensions(viewer);
-  let heatmapData = generateData(data, viewer, dimensions, noSequenceHighlight);
+  let heatmapData = generateData(
+    data,
+    viewer,
+    dimensions,
+    noSequenceHighlight,
+    allowAdHocSubProcess
+  );
 
   const map = createMap(dimensions);
   const heatmapDataValueMax = Math.max.apply(
@@ -106,11 +112,20 @@ function isBpmnType(element, types) {
   );
 }
 
-function isExcluded(element) {
+export function isExcluded(element, allowAdHocSubProcess) {
+  if (allowAdHocSubProcess && isBpmnType(element, 'AdHocSubProcess')) {
+    return false;
+  }
   return isBpmnType(element, 'SubProcess') && !element.collapsed;
 }
 
-function generateData(values, viewer, {x: xOffset, y: yOffset}, noSequenceHighlight) {
+function generateData(
+  values,
+  viewer,
+  {x: xOffset, y: yOffset},
+  noSequenceHighlight,
+  allowAdHocSubProcess
+) {
   const data = [];
   const elementRegistry = viewer.get('elementRegistry');
 
@@ -122,7 +137,7 @@ function generateData(values, viewer, {x: xOffset, y: yOffset}, noSequenceHighli
       continue;
     }
 
-    if (!isExcluded(element)) {
+    if (!isExcluded(element, allowAdHocSubProcess)) {
       // add multiple points evenly distributed in the area of the node. Number of points depends on area of node
       for (let i = 0; i < element.width + ACTIVITY_DENSITY / 2; i += ACTIVITY_DENSITY) {
         for (let j = 0; j < element.height + ACTIVITY_DENSITY / 2; j += ACTIVITY_DENSITY) {

--- a/optimize/client/src/modules/components/HeatmapOverlay/service.test.js
+++ b/optimize/client/src/modules/components/HeatmapOverlay/service.test.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {isExcluded} from './service';
+
+// creates a mock element whose businessObject.$instanceOf returns true for the given bpmn types,
+// mirroring how the isBpmnType helper inspects elements
+function createElement(bpmnTypes, {collapsed = false, type = 'shape'} = {}) {
+  return {
+    type,
+    collapsed,
+    businessObject: {
+      $instanceOf: (queriedType) => bpmnTypes.includes(queriedType),
+    },
+  };
+}
+
+describe('isExcluded', () => {
+  it('should not exclude an expanded ad-hoc subprocess when the flag is set', () => {
+    // given
+    const element = createElement(['bpmn:SubProcess', 'bpmn:AdHocSubProcess']);
+
+    // when
+    const excluded = isExcluded(element, true);
+
+    // then
+    expect(excluded).toBe(false);
+  });
+
+  it('should exclude an expanded ad-hoc subprocess when the flag is not set', () => {
+    // given
+    const element = createElement(['bpmn:SubProcess', 'bpmn:AdHocSubProcess']);
+
+    // when
+    const excluded = isExcluded(element);
+
+    // then
+    expect(excluded).toBe(true);
+  });
+
+  it('should still exclude a regular expanded subprocess when the flag is set', () => {
+    // given
+    const element = createElement(['bpmn:SubProcess']);
+
+    // when
+    const excluded = isExcluded(element, true);
+
+    // then
+    expect(excluded).toBe(true);
+  });
+
+  it('should not exclude a collapsed subprocess', () => {
+    // given
+    const element = createElement(['bpmn:SubProcess'], {collapsed: true});
+
+    // when
+    const excluded = isExcluded(element);
+
+    // then
+    expect(excluded).toBe(false);
+  });
+});

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Heatmap/Heatmap.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Heatmap/Heatmap.js
@@ -44,6 +44,10 @@ export default function Heatmap({report, context}) {
 
   const isDuration = properties[0].toLowerCase().includes('duration');
   const alwaysShow = isDuration ? alwaysShowAbsolute : alwaysShowAbsolute || alwaysShowRelative;
+  // Tool-call activity is attributed to the AI Agent ad-hoc subprocess, which is an expanded
+  // subprocess container. Heatmaps normally exclude expanded subprocesses from being colored, so
+  // for the tool-calls heatmap we allow the ad-hoc subprocess to be tinted.
+  const allowAdHocSubProcess = properties.includes('toolCalls');
 
   if (!xml || !result) {
     return <Loading />;
@@ -60,6 +64,7 @@ export default function Heatmap({report, context}) {
       <HeatmapOverlay
         key="heatmap"
         data={heat}
+        allowAdHocSubProcess={allowAdHocSubProcess}
         tooltipOptions={{alwaysShow}}
         formatter={(_, id) => {
           const target = formatters.convertToMilliseconds(
@@ -130,6 +135,7 @@ export default function Heatmap({report, context}) {
     heatmapComponent = (
       <HeatmapOverlay
         data={resultObj}
+        allowAdHocSubProcess={allowAdHocSubProcess}
         tooltipOptions={{alwaysShow}}
         formatter={(_data, id) => {
           if (

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Heatmap/Heatmap.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Heatmap/Heatmap.test.js
@@ -134,6 +134,23 @@ it('should display a heatmap overlay', () => {
   expect(node.find('HeatmapOverlay')).toExist();
 });
 
+it('should allow the ad-hoc subprocess when the report is a tool-calls heatmap', () => {
+  const node = shallow(
+    <Heatmap
+      {...props}
+      report={update(report, {data: {view: {properties: {$set: ['toolCalls']}}}})}
+    />
+  );
+
+  expect(node.find('HeatmapOverlay').prop('allowAdHocSubProcess')).toBe(true);
+});
+
+it('should not allow the ad-hoc subprocess for a non-tool-calls heatmap', () => {
+  const node = shallow(<Heatmap {...props} />);
+
+  expect(node.find('HeatmapOverlay').prop('allowAdHocSubProcess')).toBe(false);
+});
+
 it('should convert the data to target value heat when target value mode is active', () => {
   const heatmapTargetValue = {
     active: true,


### PR DESCRIPTION
related to #56791

## Description

The process heatmap deliberately excludes expanded subprocess containers from being coloured. For agentic processes, tool-call activity is attributed to the `AI_Agent` node (expanded ad-hoc subprocess), so the tool-calls heatmap rendered empty even though data existed.
This exempts `AdHocSubProcess` from the exclusion rule, but **only for the tool-calls heatmap**. A global exemption was rejected because it would change every heatmap containing an expanded ad-hoc subprocess.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56791
