### PR TITLE
Fence job commands against a stale lease token

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -160,6 +160,7 @@ public final class JobCompleteProcessor implements TypedRecordProcessor<JobRecor
             "complete",
             List.of(State.ACTIVATABLE, State.ACTIVATED),
             List.of(
+                JobLeaseFencingCheck.forLifecycleCommand(),
                 this::checkAdHocSubprocessActivationTargetsAreValid,
                 this::checkAdHocSubprocessInstanceIsActive,
                 this::checkAdHocSubProcessCompletionConditionNotFulfilledForElementActivation,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -92,6 +92,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
             state.getBannedInstanceState(),
             "fail",
             List.of(State.ACTIVATABLE, State.ACTIVATED),
+            List.of(JobLeaseFencingCheck.forLifecycleCommand()),
             authCheckBehavior);
     this.keyGenerator = keyGenerator;
     this.jobBackoffChecker = jobBackoffChecker;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobLeaseFencingCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobLeaseFencingCheck.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.util.Either;
+
+/**
+ * Fences job commands against a stale lease token.
+ *
+ * <p>A stored (persisted) job carries a {@code leaseToken} that is non-empty only when the job was
+ * activated with a lease. Incoming commands carry a {@code leaseToken} as well. Two flavors of
+ * fencing are provided:
+ *
+ * <ul>
+ *   <li>{@link #forLifecycleCommand()} - used by lifecycle commands (complete, fail, throw error)
+ *       that must always supply a matching lease token when the stored job is leased.
+ *   <li>{@link #forUpdateCommand()} - used by property-update commands (update, update timeout,
+ *       update retries) that only need to match the lease token when both stored and supplied
+ *       tokens are present.
+ * </ul>
+ *
+ * Engine-internal transitions (time-out, cancel, yield, recur-after-backoff) should never run these
+ * checks.
+ *
+ * <p>Rejection reasons never include the actual lease token values (stored or supplied) to avoid
+ * leaking the token into exported records or logs.
+ */
+public final class JobLeaseFencingCheck {
+
+  private static final String LEASE_TOKEN_MISSING_MESSAGE =
+      "Expected to process job with key '%d', but a matching lease token must be provided "
+          + "because the job is currently leased";
+  private static final String LEASE_TOKEN_MISMATCH_MESSAGE =
+      "Expected to process job with key '%d', but the supplied lease token does not match "
+          + "the lease token of the job";
+
+  private JobLeaseFencingCheck() {}
+
+  /**
+   * Fences lifecycle commands: if the stored job is leased, the command must supply a matching
+   * lease token. If the stored job is not leased, the command is always accepted.
+   */
+  public static JobCommandCheck forLifecycleCommand() {
+    return (command, jobRecord) -> {
+      final var storedLeaseToken = jobRecord.getLeaseToken();
+      if (storedLeaseToken.isEmpty()) {
+        return Either.right(jobRecord);
+      }
+
+      final var suppliedLeaseToken = command.getValue().getLeaseToken();
+      if (suppliedLeaseToken.isEmpty()) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_STATE,
+                LEASE_TOKEN_MISSING_MESSAGE.formatted(command.getKey())));
+      }
+
+      if (!suppliedLeaseToken.equals(storedLeaseToken)) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_STATE,
+                LEASE_TOKEN_MISMATCH_MESSAGE.formatted(command.getKey())));
+      }
+
+      return Either.right(jobRecord);
+    };
+  }
+
+  /**
+   * Fences property-update commands: only rejects when both the stored job and the command supply a
+   * non-empty lease token and they differ so that job workers can use the lease mechanism for
+   * updates. Any other combination (stored empty, or supplied empty) is accepted such that leased
+   * jobs can still be updated without a lease by operators.
+   */
+  public static JobCommandCheck forUpdateCommand() {
+    return (command, jobRecord) -> {
+      final var storedLeaseToken = jobRecord.getLeaseToken();
+      final var suppliedLeaseToken = command.getValue().getLeaseToken();
+
+      if (storedLeaseToken.isEmpty() || suppliedLeaseToken.isEmpty()) {
+        return Either.right(jobRecord);
+      }
+
+      if (!suppliedLeaseToken.equals(storedLeaseToken)) {
+        return Either.left(
+            new Rejection(
+                RejectionType.INVALID_STATE,
+                LEASE_TOKEN_MISMATCH_MESSAGE.formatted(command.getKey())));
+      }
+
+      return Either.right(jobRecord);
+    };
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobLeaseFencingCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobLeaseFencingCheck.java
@@ -38,8 +38,8 @@ public final class JobLeaseFencingCheck {
       "Expected to process job with key '%d', but a matching lease token must be provided "
           + "because the job is currently leased";
   private static final String LEASE_TOKEN_MISMATCH_MESSAGE =
-      "Expected to process job with key '%d', but the supplied lease token does not match "
-          + "the lease token of the job";
+      "Expected to process job with key '%d', but the supplied lease token does not match. "
+          + "The job may have been re-activated by another worker.";
 
   private JobLeaseFencingCheck() {}
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -108,6 +108,7 @@ public class JobThrowErrorProcessor implements TypedRecordProcessor<JobRecord> {
             state.getBannedInstanceState(),
             "throw an error for",
             List.of(State.ACTIVATABLE, State.ACTIVATED),
+            List.of(JobLeaseFencingCheck.forLifecycleCommand()),
             authCheckBehavior);
 
     stateAnalyzer = new CatchEventAnalyzer(state.getProcessState(), elementInstanceState);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.job.JobCommandPreconditionValidator;
+import io.camunda.zeebe.engine.processing.job.JobLeaseFencingCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.JobState;
@@ -54,6 +55,7 @@ public class JobUpdateBehaviour {
             processingStateState.getBannedInstanceState(),
             "update",
             List.of(State.ACTIVATABLE, State.ACTIVATED, State.FAILED, State.ERROR_THROWN),
+            List.of(JobLeaseFencingCheck.forUpdateCommand()),
             authCheckBehavior);
     this.authCheckBehavior = authCheckBehavior;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobProcessingMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobProcessingMetricsTest.java
@@ -123,8 +123,23 @@ public class JobProcessingMetricsTest {
     final long processInstanceKey = createProcessInstanceWithJob(jobType);
 
     // lease the job, then fail it back to activatable so it stays leased but activatable
-    engine.jobs().withType(jobType).withLease().activate();
-    engine.job().ofInstance(processInstanceKey).withType(jobType).withRetries(1).fail();
+    final String leaseToken =
+        engine
+            .jobs()
+            .withType(jobType)
+            .withLease()
+            .activate()
+            .getValue()
+            .getJobs()
+            .get(0)
+            .getLeaseToken();
+    engine
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(jobType)
+        .withLeaseToken(leaseToken)
+        .withRetries(1)
+        .fail();
     RecordingExporter.jobRecords(JobIntent.FAILED)
         .withProcessInstanceKey(processInstanceKey)
         .await();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
@@ -90,7 +90,7 @@ public final class ActivateJobsWithLeaseTest {
             .getJobs()
             .get(0)
             .getLeaseToken();
-    ENGINE.job().withKey(jobKey).withRetries(1).fail();
+    ENGINE.job().withKey(jobKey).withLeaseToken(firstToken).withRetries(1).fail();
     jobRecords(JobIntent.FAILED).withRecordKey(jobKey).await();
 
     // when it is leased again
@@ -129,7 +129,7 @@ public final class ActivateJobsWithLeaseTest {
             .getLeaseToken();
 
     // when it fails back to activatable
-    ENGINE.job().withKey(jobKey).withRetries(1).fail();
+    ENGINE.job().withKey(jobKey).withLeaseToken(leaseToken).withRetries(1).fail();
 
     // then
     final Record<JobRecordValue> failed =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivateJobsWithLeaseTest.java
@@ -203,8 +203,17 @@ public final class ActivateJobsWithLeaseTest {
   public void shouldSkipLeasedJobWhenActivatingWithoutLease() {
     // given a leased job that failed back to activatable, alongside two unleased jobs
     final long leasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
-    ENGINE.jobs().withType(jobType).withLease().activate();
-    ENGINE.job().withKey(leasedJobKey).withRetries(1).fail();
+    final String leaseToken =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withLease()
+            .activate()
+            .getValue()
+            .getJobs()
+            .get(0)
+            .getLeaseToken();
+    ENGINE.job().withKey(leasedJobKey).withLeaseToken(leaseToken).withRetries(1).fail();
     jobRecords(JobIntent.FAILED).withRecordKey(leasedJobKey).await();
     final long unleasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
     final long otherUnleasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
@@ -225,8 +234,17 @@ public final class ActivateJobsWithLeaseTest {
     // given a leased job that failed back to activatable, alongside two unleased jobs.
     // The leased job is created first (lowest key) so it is visited before the batch fills.
     final long leasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
-    ENGINE.jobs().withType(jobType).withLease().activate();
-    ENGINE.job().withKey(leasedJobKey).withRetries(1).fail();
+    final String leaseToken =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withLease()
+            .activate()
+            .getValue()
+            .getJobs()
+            .get(0)
+            .getLeaseToken();
+    ENGINE.job().withKey(leasedJobKey).withLeaseToken(leaseToken).withRetries(1).fail();
     jobRecords(JobIntent.FAILED).withRecordKey(leasedJobKey).await();
     final long unleasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
     final long otherUnleasedJobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -431,6 +431,114 @@ public final class CompleteJobTest {
   }
 
   @Test
+  public void shouldCompleteLeasedJobWithMatchingLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate(username);
+    final Long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = batchRecord.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> completedRecord =
+        ENGINE.job().withKey(jobKey).withLeaseToken(leaseToken).complete();
+
+    // then
+    Assertions.assertThat(completedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(JobIntent.COMPLETED);
+  }
+
+  @Test
+  public void shouldRejectCompleteOnLeasedJobWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate(username);
+    final Long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = batchRecord.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE.job().withKey(jobKey).expectRejection().complete();
+
+    // then
+    Assertions.assertThat(rejection)
+        .describedAs("A complete command without a lease token on a leased job is rejected")
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .describedAs("missing-lease rejection tells the worker a matching lease must be provided")
+        .contains("must be provided")
+        .doesNotContain(leaseToken);
+  }
+
+  @Test
+  public void shouldRejectCompleteOnLeasedJobWithWrongLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate(username);
+    final Long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = batchRecord.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withLeaseToken("stale-lease-token")
+            .expectRejection()
+            .complete();
+
+    // then
+    Assertions.assertThat(rejection)
+        .describedAs("A complete command with a non-matching lease token is rejected")
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .describedAs("mismatched-lease rejection tells the worker the lease does not match")
+        .contains("does not match")
+        .doesNotContain(leaseToken);
+  }
+
+  @Test
+  public void shouldCompleteNonLeasedJobWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).activate(username);
+    final Long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    // when
+    final Record<JobRecordValue> completedRecord = ENGINE.job().withKey(jobKey).complete();
+
+    // then
+    Assertions.assertThat(completedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(JobIntent.COMPLETED);
+  }
+
+  @Test
+  public void shouldCompleteNonLeasedJobEvenWhenLeaseSupplied() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).activate(username);
+    final Long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    // when
+    final Record<JobRecordValue> completedRecord =
+        ENGINE.job().withKey(jobKey).withLeaseToken("some-token").complete();
+
+    // then
+    Assertions.assertThat(completedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(JobIntent.COMPLETED);
+  }
+
+  @Test
   public void shouldRejectJobCompleteForBannedProcessInstance() {
     // given
     final Record<JobRecordValue> jobCreated = ENGINE.createJob(jobType, PROCESS_ID);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -431,6 +431,115 @@ public final class FailJobTest {
   }
 
   @Test
+  public void shouldFailLeasedJobWithMatchingLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate(username);
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = job.getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> failRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .ofInstance(job.getProcessInstanceKey())
+            .withLeaseToken(leaseToken)
+            .withRetries(3)
+            .fail();
+
+    // then
+    Assertions.assertThat(failRecord)
+        .describedAs("expect fail to be accepted when the lease token matches")
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(FAILED);
+  }
+
+  @Test
+  public void shouldRejectFailOnLeasedJobWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate(username);
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = job.getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> jobRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .ofInstance(job.getProcessInstanceKey())
+            .withRetries(3)
+            .expectRejection()
+            .fail();
+
+    // then
+    Assertions.assertThat(jobRecord)
+        .describedAs("expect fail without a lease token to be rejected")
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(jobRecord.getRejectionReason())
+        .contains("must be provided")
+        .doesNotContain(leaseToken);
+  }
+
+  @Test
+  public void shouldRejectFailOnLeasedJobWithWrongLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate(username);
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = job.getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> jobRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .ofInstance(job.getProcessInstanceKey())
+            .withLeaseToken("stale-lease-token")
+            .withRetries(3)
+            .expectRejection()
+            .fail();
+
+    // then
+    Assertions.assertThat(jobRecord)
+        .describedAs("expect fail with a mismatching lease token to be rejected")
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(jobRecord.getRejectionReason())
+        .contains("does not match")
+        .doesNotContain(leaseToken);
+  }
+
+  @Test
+  public void shouldFailNonLeasedJobWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).activate(username);
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    // when
+    final Record<JobRecordValue> failRecord =
+        ENGINE.job().withKey(jobKey).ofInstance(job.getProcessInstanceKey()).withRetries(3).fail();
+
+    // then
+    Assertions.assertThat(failRecord)
+        .describedAs("expect fail to be accepted for a non-leased job without a lease token")
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(FAILED);
+  }
+
+  @Test
   public void shouldRejectJobFailForBannedProcessInstance() {
     // given
     final Record<JobRecordValue> jobCreated = ENGINE.createJob(jobType, PROCESS_ID);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -540,6 +540,46 @@ public final class FailJobTest {
   }
 
   @Test
+  public void shouldRecurAfterBackoffWithoutLeaseWhenFailedWithMatchingLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate(username);
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = job.getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    final Duration backOff = Duration.ofDays(1);
+    final Record<JobRecordValue> failRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .ofInstance(job.getProcessInstanceKey())
+            .withLeaseToken(leaseToken)
+            .withRetries(3)
+            .withBackOff(backOff)
+            .fail();
+    Assertions.assertThat(failRecord)
+        .describedAs("fail is fenced, so it needs the matching lease token to be accepted")
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(FAILED);
+
+    // when the backoff elapses
+    ENGINE.increaseTime(
+        backOff.plus(Duration.ofMillis(JobBackoffCheckScheduler.BACKOFF_RESOLUTION)));
+
+    // then
+    final Record<JobRecordValue> recurredRecord =
+        jobRecords(JobIntent.RECURRED_AFTER_BACKOFF).withType(jobType).getFirst();
+    Assertions.assertThat(recurredRecord)
+        .describedAs("recur-after-backoff is engine-internal and must never be fenced")
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(JobIntent.RECURRED_AFTER_BACKOFF)
+        .hasKey(jobKey);
+  }
+
+  @Test
   public void shouldRejectJobFailForBannedProcessInstance() {
     // given
     final Record<JobRecordValue> jobCreated = ENGINE.createJob(jobType, PROCESS_ID);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCancelWithLeaseTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCancelWithLeaseTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Proves that terminating the process instance of a job that was activated with a lease still
+ * cancels the job, i.e. the engine-internal CANCEL command must never be fenced by a lease token.
+ */
+public final class JobCancelWithLeaseTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+  private static String jobType;
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Before
+  public void setup() {
+    jobType = Strings.newRandomValidBpmnId();
+  }
+
+  @Test
+  public void shouldCancelLeasedJobWithoutLeaseWhenProcessInstanceIsTerminated() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final long jobKey = batch.getValue().getJobKeys().get(0);
+    final String leaseToken = batch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then
+    final Record<JobRecordValue> canceledRecord =
+        RecordingExporter.jobRecords(JobIntent.CANCELED).withRecordKey(jobKey).getFirst();
+    Assertions.assertThat(canceledRecord)
+        .describedAs("cancel is engine-internal and must never be fenced by a lease token")
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(JobIntent.CANCELED);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
@@ -478,6 +478,93 @@ public final class JobThrowErrorTest {
   }
 
   @Test
+  public void shouldThrowErrorOnLeasedJobWithMatchingLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withLease().activate(username);
+    final Long jobKey = batch.getValue().getJobKeys().get(0);
+    final String leaseToken = batch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> result =
+        ENGINE.job().withKey(jobKey).withLeaseToken(leaseToken).withErrorCode("error").throwError();
+
+    // then
+    Assertions.assertThat(result)
+        .describedAs("A throw-error command with a matching lease token is accepted")
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(ERROR_THROWN);
+    Assertions.assertThat(result.getValue()).hasErrorCode("error");
+  }
+
+  @Test
+  public void shouldRejectThrowErrorOnLeasedJobWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withLease().activate(username);
+    final Long jobKey = batch.getValue().getJobKeys().get(0);
+    final String leaseToken = batch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> result =
+        ENGINE.job().withKey(jobKey).withErrorCode("error").expectRejection().throwError();
+
+    // then
+    Assertions.assertThat(result)
+        .describedAs("A throw-error command without a lease token on a leased job is rejected")
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(result.getRejectionReason()).contains("must be provided").doesNotContain(leaseToken);
+  }
+
+  @Test
+  public void shouldRejectThrowErrorOnLeasedJobWithWrongLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withLease().activate(username);
+    final Long jobKey = batch.getValue().getJobKeys().get(0);
+    final String leaseToken = batch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> result =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withLeaseToken("stale-lease-token")
+            .withErrorCode("error")
+            .expectRejection()
+            .throwError();
+
+    // then
+    Assertions.assertThat(result)
+        .describedAs("A throw-error command with a non-matching lease token is rejected")
+        .hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(result.getRejectionReason()).contains("does not match").doesNotContain(leaseToken);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNonLeasedJobWithoutLease() {
+    // given
+    final var job = ENGINE.createJob(jobType, PROCESS_ID);
+
+    // when
+    final Record<JobRecordValue> result =
+        ENGINE.job().withKey(job.getKey()).withErrorCode("error").throwError();
+
+    // then
+    Assertions.assertThat(result)
+        .describedAs("A throw-error command on a non-leased job is accepted without a lease token")
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(ERROR_THROWN);
+    Assertions.assertThat(result.getValue()).hasErrorCode("error");
+  }
+
+  @Test
   public void shouldRejectJobThrowErrorForBannedProcessInstance() {
     // given
     final Record<JobRecordValue> jobCreated = ENGINE.createJob(jobType, PROCESS_ID);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -95,10 +95,11 @@ public final class JobTimeOutTest {
         .hasRecordType(RecordType.EVENT)
         .hasIntent(TIMED_OUT);
 
-    // and
-    final Record<JobBatchRecordValue> reactivatedBatch = ENGINE.jobs().withType(jobType).activate();
+    // and it stays leased, so only a leasing worker re-activates it
+    final Record<JobBatchRecordValue> reactivatedBatch =
+        ENGINE.jobs().withType(jobType).withLease().activate();
     assertThat(reactivatedBatch.getValue().getJobKeys())
-        .describedAs("the timed-out job became activatable again")
+        .describedAs("the timed-out job stays leased and is re-activated by a leasing worker")
         .containsExactly(jobKey);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -18,10 +18,12 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -69,6 +71,35 @@ public final class JobTimeOutTest {
     assertThat(jobEvents)
         .extracting(Record::getIntent)
         .containsExactly(JobIntent.CREATED, JobIntent.TIMED_OUT);
+  }
+
+  @Test
+  public void shouldTimeOutLeasedJobWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final long timeout = 10L;
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withTimeout(timeout).withLease().activate();
+    final long jobKey = batch.getValue().getJobKeys().get(0);
+    final String leaseToken = batch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("A leased job has a non-empty lease token").isNotEmpty();
+
+    // when
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
+
+    // then
+    final Record<JobRecordValue> timedOutRecord =
+        jobRecords(TIMED_OUT).withRecordKey(jobKey).getFirst();
+    Assertions.assertThat(timedOutRecord)
+        .describedAs("time-out is engine-internal and must never be fenced by a lease token")
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(TIMED_OUT);
+
+    // and
+    final Record<JobBatchRecordValue> reactivatedBatch = ENGINE.jobs().withType(jobType).activate();
+    assertThat(reactivatedBatch.getValue().getJobKeys())
+        .describedAs("the timed-out job became activatable again")
+        .containsExactly(jobKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
@@ -217,4 +217,88 @@ public final class JobUpdateRetriesTest {
             "Expected to process command for process instance with key '%d', but the process instance is banned due to previous errors. The process instance can't be recovered, but it can be cancelled."
                 .formatted(processInstanceKey));
   }
+
+  @Test
+  public void shouldUpdateRetriesOnLeasedJobWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = job.getLeaseToken();
+    assertThat(leaseToken).describedAs("job was leased").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> updatedRecord =
+        ENGINE.job().withKey(jobKey).withRetries(NEW_RETRIES).updateRetries();
+
+    // then
+    Assertions.assertThat(updatedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(JobIntent.RETRIES_UPDATED);
+    assertThat(updatedRecord.getKey()).isEqualTo(jobKey);
+    assertThat(updatedRecord.getValue().getRetries())
+        .describedAs("retries are updated even without a lease token on a leased job")
+        .isEqualTo(NEW_RETRIES);
+  }
+
+  @Test
+  public void shouldUpdateRetriesOnLeasedJobWithMatchingLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = job.getLeaseToken();
+    assertThat(leaseToken).describedAs("job was leased").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> updatedRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withRetries(NEW_RETRIES)
+            .withLeaseToken(leaseToken)
+            .updateRetries();
+
+    // then
+    Assertions.assertThat(updatedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(JobIntent.RETRIES_UPDATED);
+    assertThat(updatedRecord.getKey()).isEqualTo(jobKey);
+    assertThat(updatedRecord.getValue().getRetries())
+        .describedAs("retries are updated when the supplied lease token matches")
+        .isEqualTo(NEW_RETRIES);
+  }
+
+  @Test
+  public void shouldRejectUpdateRetriesOnLeasedJobWithStaleLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = job.getLeaseToken();
+    assertThat(leaseToken).describedAs("job was leased").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withRetries(NEW_RETRIES)
+            .withLeaseToken("stale-lease-token")
+            .expectRejection()
+            .updateRetries();
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .describedAs("mismatch rejection explains the lease no longer matches")
+        .contains("does not match")
+        .doesNotContain(leaseToken);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTest.java
@@ -262,6 +262,110 @@ public class JobUpdateTest {
   }
 
   @Test
+  public void shouldUpdateWithTimeoutChangesetOnLeasedJobWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final long jobKey = batch.getValue().getJobKeys().get(0);
+    final String leaseToken = batch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("job was leased").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> updated =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withTimeout(Duration.ofMinutes(5).toMillis())
+            .withChangeset(Set.of("timeout"))
+            .update();
+
+    // then
+    assertThat(updated.getIntent())
+        .describedAs("accepted regardless of the existing lease; timeout changeset emits its event")
+        .isEqualTo(JobIntent.TIMEOUT_UPDATED);
+  }
+
+  @Test
+  public void shouldRejectUpdateWithTimeoutChangesetOnLeasedJobWithStaleLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final long jobKey = batch.getValue().getJobKeys().get(0);
+    final String leaseToken = batch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("job was leased").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withTimeout(Duration.ofMinutes(5).toMillis())
+            .withChangeset(Set.of("timeout"))
+            .withLeaseToken("stale-lease-token")
+            .expectRejection()
+            .update();
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .describedAs("mismatch rejection explains the lease no longer matches")
+        .contains("does not match")
+        .doesNotContain(leaseToken);
+  }
+
+  @Test
+  public void shouldUpdateWithPriorityChangesetOnLeasedJobWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final long jobKey = batch.getValue().getJobKeys().get(0);
+    final String leaseToken = batch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("job was leased").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> updated =
+        ENGINE.job().withKey(jobKey).withPriority(10).withChangeset(Set.of("priority")).update();
+
+    // then
+    assertThat(updated.getIntent())
+        .describedAs(
+            "accepted regardless of the existing lease; priority changeset emits its event")
+        .isEqualTo(JobIntent.PRIORITY_UPDATED);
+  }
+
+  @Test
+  public void shouldRejectUpdateWithPriorityChangesetOnLeasedJobWithStaleLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batch =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final long jobKey = batch.getValue().getJobKeys().get(0);
+    final String leaseToken = batch.getValue().getJobs().get(0).getLeaseToken();
+    assertThat(leaseToken).describedAs("job was leased").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withPriority(10)
+            .withChangeset(Set.of("priority"))
+            .withLeaseToken("stale-lease-token")
+            .expectRejection()
+            .update();
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .describedAs("mismatch rejection explains the lease no longer matches")
+        .contains("does not match")
+        .doesNotContain(leaseToken);
+  }
+
+  @Test
   public void shouldRejectJobUpdateForBannedProcessInstance() {
     // given
     final Record<JobRecordValue> jobCreated = ENGINE.createJob(jobType, PROCESS_ID);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.Strings;
@@ -270,6 +271,118 @@ public class JobUpdateTimeoutTest {
         .hasRejectionReason(
             "Expected to process command for process instance with key '%d', but the process instance is banned due to previous errors. The process instance can't be recovered, but it can be cancelled."
                 .formatted(processInstanceKey));
+  }
+
+  @Test
+  public void shouldUpdateTimeoutOnLeasedJobWithoutLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withTimeout(Duration.ofMinutes(5).toMillis())
+            .withLease()
+            .activate(username);
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final long timeout = Duration.ofMinutes(10).toMillis();
+
+    // when
+    final var updatedRecord = ENGINE.job().withKey(jobKey).withTimeout(timeout).updateTimeout();
+
+    // then
+    assertJobDeadline(updatedRecord, jobKey, job, timeout);
+  }
+
+  @Test
+  public void shouldUpdateTimeoutOnLeasedJobWithMatchingLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withTimeout(Duration.ofMinutes(5).toMillis())
+            .withLease()
+            .activate(username);
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = job.getLeaseToken();
+    final long timeout = Duration.ofMinutes(10).toMillis();
+
+    // when
+    final var updatedRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withTimeout(timeout)
+            .withLeaseToken(leaseToken)
+            .updateTimeout();
+
+    // then
+    assertJobDeadline(updatedRecord, jobKey, job, timeout);
+  }
+
+  @Test
+  public void shouldRejectUpdateTimeoutOnLeasedJobWithStaleLease() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withTimeout(Duration.ofMinutes(5).toMillis())
+            .withLease()
+            .activate(username);
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = job.getLeaseToken();
+    final long timeout = Duration.ofMinutes(10).toMillis();
+
+    // when
+    final Record<JobRecordValue> rejection =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withTimeout(timeout)
+            .withLeaseToken("stale-lease-token")
+            .expectRejection()
+            .updateTimeout();
+
+    // then
+    Assertions.assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection.getRejectionReason())
+        .describedAs("rejection reason should explain the mismatch without echoing the token")
+        .contains("does not match")
+        .doesNotContain(leaseToken);
+  }
+
+  @Test
+  public void shouldUpdateTimeoutOnNonLeasedJobEvenWhenLeaseSupplied() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE
+            .jobs()
+            .withType(jobType)
+            .withTimeout(Duration.ofMinutes(5).toMillis())
+            .activate(username);
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final long timeout = Duration.ofMinutes(10).toMillis();
+
+    // when
+    final var updatedRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withTimeout(timeout)
+            .withLeaseToken("some-token")
+            .updateTimeout();
+
+    // then
+    assertJobDeadline(updatedRecord, jobKey, job, timeout);
   }
 
   private static void assertJobDeadline(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/YieldJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/YieldJobTest.java
@@ -89,10 +89,11 @@ public final class YieldJobTest {
         .hasRecordType(RecordType.EVENT)
         .hasIntent(JobIntent.YIELDED);
 
-    // and
-    final Record<JobBatchRecordValue> reactivatedBatch = ENGINE.jobs().withType(jobType).activate();
+    // and it stays leased, so only a leasing worker re-activates it
+    final Record<JobBatchRecordValue> reactivatedBatch =
+        ENGINE.jobs().withType(jobType).withLease().activate();
     assertThat(reactivatedBatch.getValue().getJobKeys())
-        .describedAs("the yielded job became activatable again")
+        .describedAs("the yielded job stays leased and is re-activated by a leasing worker")
         .containsExactly(jobKey);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/YieldJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/YieldJobTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Assertions;
@@ -59,6 +61,39 @@ public final class YieldJobTest {
     // then
     Assertions.assertThat(yieldRecord).hasRecordType(RecordType.EVENT).hasIntent(JobIntent.YIELDED);
     Assertions.assertThat(yieldRecord.getValue()).hasWorker(job.getWorker()).hasType(job.getType());
+  }
+
+  @Test
+  public void shouldYieldLeasedJobWithoutLeaseAndBecomeActivatableAgain() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final Record<JobBatchRecordValue> batchRecord =
+        ENGINE.jobs().withType(jobType).withLease().activate();
+    final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+    final String leaseToken = job.getLeaseToken();
+    assertThat(leaseToken).describedAs("job was leased").isNotEmpty();
+
+    // when
+    final Record<JobRecordValue> yieldRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withType(jobType)
+            .ofInstance(job.getProcessInstanceKey())
+            .yield();
+
+    // then
+    Assertions.assertThat(yieldRecord)
+        .describedAs("yield is engine-internal and must never be fenced by a lease token")
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(JobIntent.YIELDED);
+
+    // and
+    final Record<JobBatchRecordValue> reactivatedBatch = ENGINE.jobs().withType(jobType).activate();
+    assertThat(reactivatedBatch.getValue().getJobKeys())
+        .describedAs("the yielded job became activatable again")
+        .containsExactly(jobKey);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
@@ -132,6 +132,11 @@ public final class JobClient {
     return this;
   }
 
+  public JobClient withLeaseToken(final String leaseToken) {
+    jobRecord.setLeaseToken(leaseToken);
+    return this;
+  }
+
   public JobClient expectRejection() {
     expectation = REJECTION_SUPPLIER;
     return this;


### PR DESCRIPTION
## Description

The engine now fences job commands against the lease token stored on the activated job, so a worker whose lease has been superseded (for example after the job was reactivated to a different worker) can no longer act on it. This is the engine-side enforcement of the job-lease design ([ADR 0005-810](https://github.com/camunda/camunda/blob/main/zeebe/docs/adr/0005-810-job-lease.md), decision D4); the client/API plumbing that lets a real worker supply the token follows in PR2/PR3 of this stack. Landing the engine first delivers the safety property (defense-in-depth) independently and lets the later PRs prove the round-trip end to end.

Validation is gated on the **stored** token — a job that was never activated with a lease stores an empty token and is never fenced, so this is fully backward compatible. Two flavors:

- **Lifecycle commands** (complete, fail, throw-error) require a matching token whenever the stored job is leased: a missing token is rejected `INVALID_STATE` ("must be provided"), a non-matching token `INVALID_STATE` ("does not match").
- **Property-update commands** (update, update-timeout, update-retries) validate-if-present: they only reject when both the stored and the supplied token are non-empty and differ, so operator/bulk paths that omit the lease keep working on a leased job.

Engine-internal transitions (time-out, cancel, yield, recur-after-backoff) never run these checks and remain unfenced — dedicated tests lock this in so a future change can't silently start fencing an internal transition. Rejection reasons carry only the job key, never the token values, to avoid leaking the lease into exported records or logs.

The check is implemented as a small `JobCommandCheck` (`JobLeaseFencingCheck`) reused through the existing precondition-validator seam, so the fence stays scoped to exactly the intended processors.

This is the base of a stacked PR and targets `main`. PR2 (API plumbing + Java client) branches off this branch.

## Checklist

- [ ] Enable backports when necessary. Not needed — this is a feature, not a bug fix / CI / docs change.

## Related issues

Relates to #54847 (this is PR 1 of 3; the issue's acceptance criteria are completed by PR2).
