### PR TITLE
feat: register one CamundaClient bean per configured client with a registry

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/bean/CamundaClientRegistry.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/bean/CamundaClientRegistry.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.bean;
+
+import io.camunda.client.CamundaClient;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Provides access to the {@link CamundaClient} instances configured under {@code
+ * camunda.clients.<name>.*} by their configured name.
+ *
+ * <p>Each configured client is also registered as an individual Spring bean named {@code
+ * <name>CamundaClient} (see the multi-client auto-configuration), so clients can additionally be
+ * injected directly with {@code @Qualifier}. The client marked {@code primary} — or the sole client
+ * when only one is configured — is the {@code @Primary} bean and is returned by {@link
+ * #getPrimary()}.
+ *
+ * <pre>{@code
+ * @Autowired CamundaClientRegistry registry;
+ *
+ * CamundaClient finance = registry.get("finance");
+ * CamundaClient primary = registry.getPrimary();
+ * }</pre>
+ */
+public interface CamundaClientRegistry {
+
+  /**
+   * Returns the client configured under the given name.
+   *
+   * @throws IllegalArgumentException if no client is configured under {@code clientName}
+   */
+  CamundaClient get(String clientName);
+
+  /** Returns the client configured under the given name, if any. */
+  Optional<CamundaClient> find(String clientName);
+
+  /**
+   * Returns the primary (default) client.
+   *
+   * @throws IllegalStateException if no primary client is designated (more than one client is
+   *     configured and none is marked {@code primary})
+   */
+  CamundaClient getPrimary();
+
+  /** Returns the names of all configured clients. */
+  Set<String> clientNames();
+
+  /** Returns all configured clients keyed by name. */
+  Map<String, CamundaClient> all();
+}

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/bean/DefaultCamundaClientRegistry.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/bean/DefaultCamundaClientRegistry.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.bean;
+
+import io.camunda.client.CamundaClient;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Default {@link CamundaClientRegistry} that resolves clients lazily, on demand: it holds the
+ * mapping of configured client name to Spring bean name and looks the client bean up only when it
+ * is actually requested. This preserves the per-client beans' lazy initialization — injecting the
+ * registry does not force every client to be created.
+ */
+public class DefaultCamundaClientRegistry implements CamundaClientRegistry {
+
+  private final Map<String, String> beanNamesByClientName;
+  private final Function<String, CamundaClient> clientByBeanName;
+  private final String primaryClientName;
+
+  /**
+   * @param beanNamesByClientName the configured client name to registered bean name mapping
+   * @param clientByBeanName resolves a {@link CamundaClient} bean by its bean name (e.g. via the
+   *     bean factory); invoked lazily on lookup
+   * @param primaryClientName the name of the primary client, or {@code null} if none is designated
+   */
+  public DefaultCamundaClientRegistry(
+      final Map<String, String> beanNamesByClientName,
+      final Function<String, CamundaClient> clientByBeanName,
+      final String primaryClientName) {
+    this.beanNamesByClientName =
+        Collections.unmodifiableMap(new LinkedHashMap<>(beanNamesByClientName));
+    this.clientByBeanName = clientByBeanName;
+    this.primaryClientName = primaryClientName;
+  }
+
+  @Override
+  public CamundaClient get(final String clientName) {
+    final String beanName = beanNamesByClientName.get(clientName);
+    if (beanName == null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "No CamundaClient configured under name '%s'. Available clients: %s",
+              clientName, beanNamesByClientName.keySet()));
+    }
+    return clientByBeanName.apply(beanName);
+  }
+
+  @Override
+  public Optional<CamundaClient> find(final String clientName) {
+    return beanNamesByClientName.containsKey(clientName)
+        ? Optional.of(get(clientName))
+        : Optional.empty();
+  }
+
+  @Override
+  public CamundaClient getPrimary() {
+    if (primaryClientName == null) {
+      throw new IllegalStateException(
+          String.format(
+              "No primary CamundaClient is designated. Mark one client with "
+                  + "'camunda.clients.<name>.primary=true'. Configured clients: %s",
+              beanNamesByClientName.keySet()));
+    }
+    return get(primaryClientName);
+  }
+
+  @Override
+  public Set<String> clientNames() {
+    return beanNamesByClientName.keySet();
+  }
+
+  @Override
+  public Map<String, CamundaClient> all() {
+    final Map<String, CamundaClient> clients = new LinkedHashMap<>();
+    beanNamesByClientName.keySet().forEach(name -> clients.put(name, get(name)));
+    return Collections.unmodifiableMap(clients);
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientFactory.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/CamundaClientFactory.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CamundaClientConfiguration;
+import io.camunda.client.CredentialsProvider;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.worker.JobExceptionHandler;
+import io.camunda.client.jobhandling.CamundaClientExecutorService;
+import io.camunda.client.spring.properties.CamundaClientProperties;
+import io.grpc.ClientInterceptor;
+import java.util.List;
+import org.apache.hc.client5.http.async.AsyncExecChainHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+
+/**
+ * Builds a stand-alone {@link CamundaClient} from a single resolved {@link CamundaClientProperties}
+ * entry, used by {@link MultiCamundaClientBeanDefinitionRegistryPostProcessor} to create one client
+ * per configured name.
+ *
+ * <p>The property mapping is delegated to {@link SpringCamundaClientConfiguration} — the same
+ * adapter the single-client path uses — so every {@link CamundaClientProperties} field (including
+ * the {@code physical-tenant-id} / {@code prefix-physical-tenant-path} scope) maps through one
+ * authoritative place and cannot drift as new client properties are added.
+ *
+ * <p>Collaborators that exist as beans in the multi-client context are reused: the per-client
+ * {@link CredentialsProvider} is derived from the entry's {@code auth.*} via {@link
+ * CredentialsProviderConfiguration}, and any user-defined {@link JsonMapper}, {@link
+ * ClientInterceptor}s and {@link AsyncExecChainHandler}s are applied. The single-client executor
+ * and exception-handler beans are not available in multi-client mode, so each client gets its own
+ * executor (owned -&gt; closed with the client) and the default exception handling; unifying those
+ * is tracked in the single-client/multi-client consolidation.
+ */
+public class CamundaClientFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CamundaClientFactory.class);
+
+  private final CredentialsProviderConfiguration credentialsProviderConfiguration;
+  private final ObjectProvider<JsonMapper> jsonMapper;
+  private final List<ClientInterceptor> interceptors;
+  private final List<AsyncExecChainHandler> chainHandlers;
+
+  public CamundaClientFactory(
+      final CredentialsProviderConfiguration credentialsProviderConfiguration,
+      final ObjectProvider<JsonMapper> jsonMapper,
+      final List<ClientInterceptor> interceptors,
+      final List<AsyncExecChainHandler> chainHandlers) {
+    this.credentialsProviderConfiguration = credentialsProviderConfiguration;
+    this.jsonMapper = jsonMapper;
+    this.interceptors = interceptors;
+    this.chainHandlers = chainHandlers;
+  }
+
+  public CamundaClient createClient(final String name, final CamundaClientProperties properties) {
+    LOG.debug("Creating CamundaClient '{}'", name);
+    final CredentialsProvider credentialsProvider =
+        credentialsProviderConfiguration.camundaClientCredentialsProvider(properties);
+
+    // Reuse the single-client adapter for the full property mapping, wired with the context
+    // collaborators. The json mapper falls back to the client default when no bean is defined; the
+    // executor and exception handler are self-contained (their single-client beans do not exist in
+    // multi-client mode) — each client gets its own owned executor.
+    final CamundaClientConfiguration configuration =
+        new SpringCamundaClientConfiguration(
+            properties,
+            jsonMapper.getIfAvailable(),
+            interceptors,
+            chainHandlers,
+            CamundaClientExecutorService.createDefault(properties.getExecutionThreads()),
+            credentialsProvider,
+            context -> JobExceptionHandler.createDefault());
+
+    return CamundaClient.newClientBuilder()
+        .withConfiguration(configuration)
+        // the resolved Spring properties are authoritative; don't let client-level environment
+        // variables override them (matching the single-client path)
+        .applyEnvironmentVariableOverrides(false)
+        .build();
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/MultiCamundaClientAutoConfiguration.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/MultiCamundaClientAutoConfiguration.java
@@ -15,10 +15,21 @@
  */
 package io.camunda.client.spring.configuration;
 
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.spring.bean.CamundaClientRegistry;
+import io.camunda.client.spring.bean.DefaultCamundaClientRegistry;
 import io.camunda.client.spring.configuration.condition.ConditionalOnCamundaClientEnabled;
 import io.camunda.client.spring.configuration.condition.OnMultiClientConfigurationCondition;
 import io.camunda.client.spring.properties.MultiCamundaClientProperties;
 import io.camunda.client.spring.properties.MultiCamundaClientPropertiesResolver;
+import io.grpc.ClientInterceptor;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hc.client5.http.async.AsyncExecChainHandler;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
@@ -27,9 +38,9 @@ import org.springframework.core.env.Environment;
 
 /**
  * Enables the generic multi-client configuration ({@code camunda.clients.<name>.*}) when at least
- * one client is configured under that prefix. Exposes the resolved per-client {@link
- * MultiCamundaClientProperties}; the registry and per-client beans are wired by a subsequent
- * configuration.
+ * one client is configured under that prefix. It registers one {@link CamundaClient} bean per
+ * configured client (via {@link MultiCamundaClientBeanDefinitionRegistryPostProcessor}) and exposes
+ * a {@link CamundaClientRegistry} for looking those clients up by name.
  *
  * <p>Like the single-client configuration, this is disabled when {@code camunda.client.enabled} is
  * {@code false}.
@@ -43,5 +54,58 @@ public class MultiCamundaClientAutoConfiguration {
   @ConditionalOnMissingBean
   public MultiCamundaClientProperties multiCamundaClientProperties(final Environment environment) {
     return MultiCamundaClientPropertiesResolver.resolve(environment);
+  }
+
+  /**
+   * The credential-provider builder, reused per client to derive its {@link
+   * io.camunda.client.CredentialsProvider} from the entry's {@code auth.*}. Registered as a plain
+   * bean (not imported as a configuration) so its {@code @Bean} methods, which need the
+   * single-client {@code CamundaClientProperties}, are not invoked in multi-client mode.
+   */
+  @Bean
+  @ConditionalOnMissingBean
+  public CredentialsProviderConfiguration credentialsProviderConfiguration() {
+    return new CredentialsProviderConfiguration();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public CamundaClientFactory camundaClientFactory(
+      final CredentialsProviderConfiguration credentialsProviderConfiguration,
+      final ObjectProvider<JsonMapper> jsonMapper,
+      final List<ClientInterceptor> interceptors,
+      final List<AsyncExecChainHandler> chainHandlers) {
+    return new CamundaClientFactory(
+        credentialsProviderConfiguration, jsonMapper, interceptors, chainHandlers);
+  }
+
+  /**
+   * Registers one {@link CamundaClient} bean per configured client. Must be {@code static} so it is
+   * instantiated early enough to contribute bean definitions before regular beans are created.
+   */
+  @Bean
+  public static MultiCamundaClientBeanDefinitionRegistryPostProcessor
+      multiCamundaClientBeanDefinitionRegistryPostProcessor() {
+    return new MultiCamundaClientBeanDefinitionRegistryPostProcessor();
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public CamundaClientRegistry camundaClientRegistry(
+      final MultiCamundaClientProperties properties, final BeanFactory beanFactory) {
+    // map each configured client name to its registered bean name (<name>CamundaClient); the client
+    // beans are resolved lazily from the bean factory only when actually requested, so injecting
+    // the
+    // registry does not eagerly instantiate every client
+    final Map<String, String> beanNamesByClientName = new LinkedHashMap<>();
+    for (final String configName : properties.getClients().keySet()) {
+      beanNamesByClientName.put(
+          configName,
+          MultiCamundaClientBeanDefinitionRegistryPostProcessor.beanNameFor(configName));
+    }
+    return new DefaultCamundaClientRegistry(
+        beanNamesByClientName,
+        beanName -> beanFactory.getBean(beanName, CamundaClient.class),
+        properties.getPrimaryClientName().orElse(null));
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/MultiCamundaClientBeanDefinitionRegistryPostProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/configuration/MultiCamundaClientBeanDefinitionRegistryPostProcessor.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.spring.properties.CamundaClientProperties;
+import io.camunda.client.spring.properties.MultiCamundaClientProperties;
+import io.camunda.client.spring.properties.MultiCamundaClientPropertiesResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+
+/**
+ * Registers one {@link CamundaClient} bean per client configured under {@code
+ * camunda.clients.<name>.*}, named {@code <name>CamundaClient} (kebab-case names are camel-cased
+ * for the bean-name prefix).
+ *
+ * <p>Each bean is built lazily via {@link CamundaClientFactory} from the resolved {@link
+ * MultiCamundaClientProperties}, with {@code destroy-method=close} so the client is shut down on
+ * context close. The designated primary client (see {@link
+ * MultiCamundaClientProperties#getPrimaryClientName()}) is marked {@code @Primary} so a plain
+ * {@code @Autowired CamundaClient} resolves to it.
+ *
+ * <p>Registered as a {@code static} bean by {@link MultiCamundaClientAutoConfiguration} so it runs
+ * before regular beans are instantiated.
+ */
+public class MultiCamundaClientBeanDefinitionRegistryPostProcessor
+    implements BeanDefinitionRegistryPostProcessor, EnvironmentAware, BeanFactoryAware {
+
+  private static final String BEAN_NAME_SUFFIX = "CamundaClient";
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MultiCamundaClientBeanDefinitionRegistryPostProcessor.class);
+
+  private Environment environment;
+  private BeanFactory beanFactory;
+
+  @Override
+  public void setEnvironment(final Environment environment) {
+    this.environment = environment;
+  }
+
+  @Override
+  public void setBeanFactory(final BeanFactory beanFactory) {
+    this.beanFactory = beanFactory;
+  }
+
+  @Override
+  public void postProcessBeanDefinitionRegistry(final BeanDefinitionRegistry registry)
+      throws BeansException {
+    final MultiCamundaClientProperties properties =
+        MultiCamundaClientPropertiesResolver.resolve(environment);
+    if (properties.getClients().isEmpty()) {
+      return;
+    }
+    LOG.debug("Registering CamundaClient beans for clients {}", properties.getClients().keySet());
+
+    final String primaryClientName = properties.getPrimaryClientName().orElse(null);
+
+    properties
+        .getClients()
+        .forEach(
+            (name, clientProperties) ->
+                registerClientBean(
+                    registry, name, clientProperties, name.equals(primaryClientName)));
+  }
+
+  @Override
+  public void postProcessBeanFactory(final ConfigurableListableBeanFactory beanFactory)
+      throws BeansException {
+    // no-op: only bean definitions are registered
+  }
+
+  private void registerClientBean(
+      final BeanDefinitionRegistry registry,
+      final String name,
+      final CamundaClientProperties properties,
+      final boolean primary) {
+    // resolve the CamundaClientFactory bean lazily, at client instantiation time (the factory bean
+    // does not exist yet while bean definitions are being registered)
+    final BeanDefinitionBuilder builder =
+        BeanDefinitionBuilder.genericBeanDefinition(
+                CamundaClient.class,
+                () ->
+                    beanFactory.getBean(CamundaClientFactory.class).createClient(name, properties))
+            .setDestroyMethodName("close");
+    final AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
+    beanDefinition.setPrimary(primary);
+    // build the client (and open its connection) only on first use, not eagerly at context refresh
+    beanDefinition.setLazyInit(true);
+
+    final String beanName = beanNameFor(name);
+    registry.registerBeanDefinition(beanName, beanDefinition);
+    LOG.debug("Registered CamundaClient bean '{}' (primary={})", beanName, primary);
+  }
+
+  /**
+   * The bean name for a configured client: the raw client name suffixed with {@code CamundaClient}.
+   * The name is used verbatim (no kebab-to-camel transform) so distinct client names always map to
+   * distinct bean names — bean names may contain dashes and {@code @Qualifier} accepts any string.
+   */
+  static String beanNameFor(final String clientName) {
+    return clientName + BEAN_NAME_SUFFIX;
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/MultiCamundaClientProperties.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/MultiCamundaClientProperties.java
@@ -18,24 +18,39 @@ package io.camunda.client.spring.properties;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * The resolved generic multi-client configuration: one fully-resolved {@link
- * CamundaClientProperties} per named client configured under {@code camunda.clients.<name>.*}.
+ * CamundaClientProperties} per named client configured under {@code camunda.clients.<name>.*}, plus
+ * the designated primary client name.
  *
  * <p>This is a plain data holder. The binding, overlay onto the shared {@code camunda.client.*}
- * base, and validation are performed by {@link MultiCamundaClientPropertiesResolver}.
+ * base, validation, and primary resolution are performed by {@link
+ * MultiCamundaClientPropertiesResolver}.
  */
 public final class MultiCamundaClientProperties {
 
   private final Map<String, CamundaClientProperties> clients;
+  private final String primaryClientName;
 
-  public MultiCamundaClientProperties(final Map<String, CamundaClientProperties> clients) {
+  public MultiCamundaClientProperties(
+      final Map<String, CamundaClientProperties> clients, final String primaryClientName) {
     this.clients = Collections.unmodifiableMap(new LinkedHashMap<>(clients));
+    this.primaryClientName = primaryClientName;
   }
 
   /** The resolved clients keyed by their configured name. */
   public Map<String, CamundaClientProperties> getClients() {
     return clients;
+  }
+
+  /**
+   * The name of the primary (default) client, if one is designated: the entry marked {@code
+   * primary=true}, or the sole entry when only one client is configured. Empty when several clients
+   * are configured and none is marked primary.
+   */
+  public Optional<String> getPrimaryClientName() {
+    return Optional.ofNullable(primaryClientName);
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolver.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolver.java
@@ -15,8 +15,10 @@
  */
 package io.camunda.client.spring.properties;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -48,6 +50,9 @@ import org.springframework.core.env.Environment;
  * and at most {@value #MAX_PHYSICAL_TENANT_ID_LENGTH} characters. The rule is mirrored from the
  * server-side {@code io.camunda.configuration.physicaltenants.PhysicalTenantResolver}; keep the two
  * in sync.
+ *
+ * <p>Exactly one entry may be marked with {@code camunda.clients.<name>.primary=true} to designate
+ * the default client; if only one client is configured it is the primary implicitly.
  */
 public final class MultiCamundaClientPropertiesResolver {
 
@@ -81,7 +86,37 @@ public final class MultiCamundaClientPropertiesResolver {
       validatePhysicalTenantId(name, properties.getPhysicalTenantId());
       resolved.put(name, properties);
     }
-    return new MultiCamundaClientProperties(resolved);
+    return new MultiCamundaClientProperties(resolved, resolvePrimaryClientName(binder, names));
+  }
+
+  /**
+   * Resolves which client is primary: the single entry flagged {@code
+   * camunda.clients.<name>.primary=true}, or — when none is flagged — the sole configured client.
+   *
+   * @throws IllegalArgumentException if more than one entry is flagged primary
+   */
+  private static String resolvePrimaryClientName(final Binder binder, final Set<String> names) {
+    final List<String> flagged = new ArrayList<>();
+    for (final String name : names) {
+      final boolean primary =
+          binder
+              .bind(CLIENTS_PREFIX + "." + name + ".primary", Bindable.of(Boolean.class))
+              .orElse(false);
+      if (primary) {
+        flagged.add(name);
+      }
+    }
+    if (flagged.size() > 1) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Multiple clients are marked primary (%s); at most one 'camunda.clients.<name>."
+                  + "primary=true' is allowed.",
+              flagged));
+    }
+    if (flagged.size() == 1) {
+      return flagged.get(0);
+    }
+    return names.size() == 1 ? names.iterator().next() : null;
   }
 
   /**

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/bean/DefaultCamundaClientRegistryTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/bean/DefaultCamundaClientRegistryTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.bean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.client.CamundaClient;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class DefaultCamundaClientRegistryTest {
+
+  private final CamundaClient finance = mock(CamundaClient.class);
+  private final CamundaClient risk = mock(CamundaClient.class);
+  // resolver from bean name -> client, matching the <name>CamundaClient convention
+  private final Map<String, CamundaClient> beansByName =
+      Map.of("financeCamundaClient", finance, "riskCamundaClient", risk);
+
+  private Map<String, String> beanNames() {
+    final Map<String, String> beanNames = new LinkedHashMap<>();
+    beanNames.put("finance", "financeCamundaClient");
+    beanNames.put("risk", "riskCamundaClient");
+    return beanNames;
+  }
+
+  private DefaultCamundaClientRegistry registry(final String primaryClientName) {
+    return new DefaultCamundaClientRegistry(beanNames(), beansByName::get, primaryClientName);
+  }
+
+  @Test
+  void shouldReturnClientByName() {
+    // given
+    final CamundaClientRegistry registry = registry("finance");
+
+    // when / then
+    assertThat(registry.get("finance")).isSameAs(finance);
+    assertThat(registry.get("risk")).isSameAs(risk);
+  }
+
+  @Test
+  void shouldThrowWhenClientNameUnknown() {
+    // given
+    final CamundaClientRegistry registry = registry("finance");
+
+    // when / then
+    assertThatThrownBy(() -> registry.get("unknown"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("unknown")
+        .hasMessageContaining("finance")
+        .hasMessageContaining("risk");
+  }
+
+  @Test
+  void shouldFindClientByName() {
+    // given
+    final CamundaClientRegistry registry = registry("finance");
+
+    // when / then
+    assertThat(registry.find("finance")).containsSame(finance);
+    assertThat(registry.find("unknown")).isEmpty();
+  }
+
+  @Test
+  void shouldReturnPrimaryClient() {
+    // given risk is designated primary
+    final CamundaClientRegistry registry = registry("risk");
+
+    // when / then
+    assertThat(registry.getPrimary()).isSameAs(risk);
+  }
+
+  @Test
+  void shouldThrowWhenNoPrimaryDesignated() {
+    // given no primary
+    final CamundaClientRegistry registry = registry(null);
+
+    // when / then
+    assertThatThrownBy(registry::getPrimary)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("primary");
+  }
+
+  @Test
+  void shouldExposeNamesAndAllClients() {
+    // given
+    final CamundaClientRegistry registry = registry("finance");
+
+    // when / then
+    assertThat(registry.clientNames()).containsExactly("finance", "risk");
+    assertThat(registry.all())
+        .containsExactly(Map.entry("finance", finance), Map.entry("risk", risk));
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/MultiCamundaClientAutoConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/MultiCamundaClientAutoConfigurationTest.java
@@ -17,6 +17,8 @@ package io.camunda.client.spring.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.CamundaClient;
+import io.camunda.client.spring.bean.CamundaClientRegistry;
 import io.camunda.client.spring.properties.CamundaClientProperties;
 import io.camunda.client.spring.properties.MultiCamundaClientProperties;
 import java.net.URI;
@@ -71,6 +73,73 @@ class MultiCamundaClientAutoConfigurationTest {
   }
 
   @Test
+  void shouldRegisterOneClientBeanPerConfiguredClient() {
+    contextRunner
+        .withPropertyValues(
+            "camunda.clients.finance.physical-tenant-id=finance",
+            "camunda.clients.risk.physical-tenant-id=riskproduction")
+        .run(
+            context -> {
+              // one CamundaClient bean per configured client, named <name>CamundaClient
+              assertThat(context).hasBean("financeCamundaClient");
+              assertThat(context).hasBean("riskCamundaClient");
+              assertThat(context.getBean("financeCamundaClient")).isInstanceOf(CamundaClient.class);
+              assertThat(context.getBeansOfType(CamundaClient.class)).hasSize(2);
+            });
+  }
+
+  @Test
+  void shouldExposeClientsViaRegistryByConfiguredName() {
+    contextRunner
+        .withPropertyValues(
+            "camunda.clients.finance.physical-tenant-id=finance",
+            "camunda.clients.risk.physical-tenant-id=riskproduction")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(CamundaClientRegistry.class);
+              final CamundaClientRegistry registry = context.getBean(CamundaClientRegistry.class);
+              assertThat(registry.clientNames()).containsExactlyInAnyOrder("finance", "risk");
+              // registry entries are the same instances as the named beans
+              assertThat(registry.get("finance"))
+                  .isSameAs(context.getBean("financeCamundaClient", CamundaClient.class));
+              assertThat(registry.get("risk"))
+                  .isSameAs(context.getBean("riskCamundaClient", CamundaClient.class));
+              assertThat(registry.all()).hasSize(2);
+            });
+  }
+
+  @Test
+  void shouldMarkDesignatedClientAsPrimaryBean() {
+    contextRunner
+        .withPropertyValues(
+            "camunda.clients.finance.physical-tenant-id=finance",
+            "camunda.clients.finance.primary=true",
+            "camunda.clients.risk.physical-tenant-id=riskproduction")
+        .run(
+            context -> {
+              // @Primary makes a plain CamundaClient lookup unambiguous and resolves to finance
+              final CamundaClient primary = context.getBean(CamundaClient.class);
+              assertThat(primary).isSameAs(context.getBean("financeCamundaClient"));
+              assertThat(context.getBean(CamundaClientRegistry.class).getPrimary())
+                  .isSameAs(primary);
+            });
+  }
+
+  @Test
+  void shouldUseRawClientNameForBeanName() {
+    // a kebab-case client name is used verbatim (no camel-casing) so distinct names cannot collapse
+    // onto the same bean name
+    contextRunner
+        .withPropertyValues("camunda.clients.my-client.physical-tenant-id=finance")
+        .run(
+            context -> {
+              assertThat(context).hasBean("my-clientCamundaClient");
+              assertThat(context.getBean(CamundaClientRegistry.class).clientNames())
+                  .containsExactly("my-client");
+            });
+  }
+
+  @Test
   void shouldNotConfigureMultiClientWhenNoClientsConfigured() {
     contextRunner
         .withPropertyValues("camunda.client.rest-address=https://oc.example.com")
@@ -93,7 +162,6 @@ class MultiCamundaClientAutoConfigurationTest {
             context -> {
               assertThat(context).hasFailed();
               assertThat(context.getStartupFailure())
-                  .rootCause()
                   .isInstanceOf(IllegalArgumentException.class)
                   .hasMessageContaining("physical-tenant-id")
                   .hasMessageContaining("risk-production");

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolverTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolverTest.java
@@ -136,4 +136,68 @@ class MultiCamundaClientPropertiesResolverTest {
         .hasMessageContaining("physical-tenant-id")
         .hasMessageContaining("risk-production");
   }
+
+  @Test
+  void shouldTreatSingleClientAsPrimary() {
+    // given a single client and no explicit primary flag
+    final StandardEnvironment environment =
+        environmentWith(Map.of("camunda.clients.finance.physical-tenant-id", "finance"));
+
+    // when
+    final MultiCamundaClientProperties properties =
+        MultiCamundaClientPropertiesResolver.resolve(environment);
+
+    // then it is the primary implicitly
+    assertThat(properties.getPrimaryClientName()).contains("finance");
+  }
+
+  @Test
+  void shouldResolveExplicitlyFlaggedPrimary() {
+    // given two clients with one flagged primary
+    final StandardEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.clients.finance.physical-tenant-id", "finance",
+                "camunda.clients.risk.physical-tenant-id", "riskproduction",
+                "camunda.clients.risk.primary", "true"));
+
+    // when
+    final MultiCamundaClientProperties properties =
+        MultiCamundaClientPropertiesResolver.resolve(environment);
+
+    // then
+    assertThat(properties.getPrimaryClientName()).contains("risk");
+  }
+
+  @Test
+  void shouldHaveNoPrimaryWhenMultipleClientsAndNoneFlagged() {
+    // given two clients and no primary flag
+    final StandardEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.clients.finance.physical-tenant-id", "finance",
+                "camunda.clients.risk.physical-tenant-id", "riskproduction"));
+
+    // when
+    final MultiCamundaClientProperties properties =
+        MultiCamundaClientPropertiesResolver.resolve(environment);
+
+    // then no primary is designated
+    assertThat(properties.getPrimaryClientName()).isEmpty();
+  }
+
+  @Test
+  void shouldRejectMoreThanOnePrimary() {
+    // given two clients both flagged primary
+    final StandardEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.clients.finance.primary", "true",
+                "camunda.clients.risk.primary", "true"));
+
+    // when / then
+    assertThatThrownBy(() -> MultiCamundaClientPropertiesResolver.resolve(environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("primary");
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add CamundaClientRegistry exposing the configured clients by name (get / find / getPrimary / clientNames / all). A BeanDefinitionRegistryPostProcessor registers one CamundaClient bean per camunda.clients.<name>.* entry, named <name>CamundaClient, built lazily by CamundaClientFactory with destroy-method close; the entry marked primary=true (or the sole client) is the @Primary bean. Each client is built from its resolved CamundaClientProperties overlay including its physical-tenant scope, reusing CredentialsProviderConfiguration for per-client auth. Multi- and single-client modes stay mutually exclusive via the existing conditions.

## Related issues

Closes #56724
