### PR TITLE
feat: opt-in type-aware exporter args merge for physical tenants (ExporterConfigMerger SPI)

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -214,6 +214,7 @@ mwnw*                       @camunda/monorepo-devops-team
 /zeebe/feel/                @camunda/core-features
 /zeebe/feel-tagged-parameters/ @camunda/core-features
 /zeebe/exporter-api/        @camunda/core-features
+/zeebe/exporter-config-support/ @camunda/core-features
 
 # Engine-expert skill
 /.claude/skills/engine-expert/ @korthout @camunda/core-features

--- a/configuration/pom.xml
+++ b/configuration/pom.xml
@@ -58,6 +58,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
 

--- a/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationException.java
+++ b/configuration/src/main/java/io/camunda/configuration/UnifiedConfigurationException.java
@@ -18,4 +18,8 @@ public class UnifiedConfigurationException extends RuntimeException {
   public UnifiedConfigurationException(final String message) {
     super(message);
   }
+
+  public UnifiedConfigurationException(final String message, final Exception cause) {
+    super(message, cause);
+  }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -91,9 +91,11 @@ import org.springframework.context.annotation.Profile;
 public class BrokerBasedPropertiesOverride {
 
   public static final String RDBMS_EXPORTER_NAME = "rdbms";
+  // also referenced by the per-physical-tenant exporter resolution, which must treat the
+  // autoconfigured exporter ids as outside the generic-exporter catalog (ADR-0008 §1)
+  public static final String CAMUNDA_EXPORTER_NAME = "camundaexporter";
   private static final Logger LOGGER = LoggerFactory.getLogger(BrokerBasedPropertiesOverride.class);
   private static final String CAMUNDA_EXPORTER_CLASS_NAME = "io.camunda.exporter.CamundaExporter";
-  private static final String CAMUNDA_EXPORTER_NAME = "camundaexporter";
   private static final String RDBMS_EXPORTER_CLASS_NAME = "io.camunda.exporter.rdbms.RdbmsExporter";
   private final UnifiedConfiguration unifiedConfiguration;
   private final LegacyBrokerBasedProperties legacyBrokerBasedProperties;

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurations.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Exporter;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
+
+/**
+ * Per-tenant {@code data.exporters} resolution (ADR-0008 §2/§5): recomputes a physical tenant's
+ * exporter entries after the generic two-bind, whose native {@code MapBinder} semantics build a
+ * <em>fresh</em> entry from only the tenant's own keys (dropping the root entry's {@code className}
+ * and untouched args). For every exporter id the tenant touches that is also declared in the root
+ * catalog, this step instead:
+ *
+ * <ul>
+ *   <li>rejects a {@code className}/{@code jarPath} diverging from the root entry (assigning an id
+ *       means running root's exporter — a different class belongs under a new, tenant-private id);
+ *   <li>inherits root's {@code className}/{@code jarPath};
+ *   <li>deep-merges the args if the exporter class ships an {@link ExporterConfigMerger}
+ *       (discovered via {@link ServiceLoader}), and otherwise takes the tenant's args exactly as
+ *       declared (whole-map replace — partial inheritance is not offered for classes whose config
+ *       model we cannot introspect).
+ * </ul>
+ *
+ * <p>Entries the tenant does not touch stay inherited from root unchanged; ids the tenant declares
+ * that root does not know are tenant-private and taken exactly as declared. The autoconfigured
+ * exporters ({@value BrokerBasedPropertiesOverride#CAMUNDA_EXPORTER_NAME} and {@value
+ * BrokerBasedPropertiesOverride#RDBMS_EXPORTER_NAME}) sit outside the catalog: their configuration
+ * is derived downstream from the tenant's secondary-storage properties, and args-tuning declared
+ * for them is taken as-is.
+ *
+ * <p><b>Deliberately not implemented yet (ADR-0008 §6 step 2, gated on <a
+ * href="https://github.com/camunda/camunda/issues/56652">#56652</a>):</b> the {@code
+ * data.exporters-assigned} manifest — mandatory-explicit validation, narrowing unassigned catalog
+ * entries out of the tenant's resolved map, and the configured-but-unassigned boot error. As long
+ * as the initial dynamic cluster configuration derives the per-partition exporter <em>enable</em>
+ * state from the root {@code BrokerCfg} only, a narrowed-away id would remain enabled on the
+ * tenant's partitions and be instantiated as a {@code BlockingExporter}, stalling exporting and log
+ * compaction. This step therefore changes only entry <em>contents</em>, never which ids exist for a
+ * tenant.
+ */
+@NullMarked
+final class PhysicalTenantExporterConfigurations {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(PhysicalTenantExporterConfigurations.class);
+
+  private static final String PHYSICAL_TENANTS_PREFIX = Camunda.PREFIX + ".physical-tenants";
+
+  /** Autoconfigured exporter ids, always outside the generic-exporter catalog (ADR-0008 §1). */
+  private static final Set<String> AUTOCONFIGURED_EXPORTER_IDS =
+      Set.of(
+          BrokerBasedPropertiesOverride.CAMUNDA_EXPORTER_NAME,
+          BrokerBasedPropertiesOverride.RDBMS_EXPORTER_NAME);
+
+  private PhysicalTenantExporterConfigurations() {}
+
+  /**
+   * Recomputes {@code physicalTenant}'s {@code data.exporters} from the root catalog (the
+   * resolver's authoritative, pre-overlay root {@link Camunda}) and the tenant's own declarations
+   * (a targeted re-bind of {@code camunda.physical-tenants.<tenantId>.data.exporters}).
+   */
+  static void apply(
+      final Camunda root,
+      final Camunda physicalTenant,
+      final String tenantId,
+      final Environment environment) {
+    final Map<String, Exporter> tenantDeclared = bindTenantDeclared(environment, tenantId);
+    if (tenantDeclared.isEmpty()) {
+      // the two-bind left every root entry untouched on this tenant — nothing to recompute
+      return;
+    }
+
+    final Map<String, Exporter> catalog = root.getData().getExporters();
+    final List<ExporterConfigMerger> mergers =
+        ServiceLoader.load(ExporterConfigMerger.class).stream()
+            .map(ServiceLoader.Provider::get)
+            .toList();
+
+    final Map<String, Exporter> resolved =
+        new LinkedHashMap<>(physicalTenant.getData().getExporters());
+    tenantDeclared.forEach(
+        (exporterId, tenantEntry) -> {
+          final Exporter rootEntry = catalog.get(exporterId);
+          if (rootEntry == null || AUTOCONFIGURED_EXPORTER_IDS.contains(exporterId)) {
+            // tenant-private exporter, or args-tuning of an autoconfigured exporter: taken exactly
+            // as declared — which is what the two-bind already produced
+            return;
+          }
+          validateNoClassDivergence(tenantId, exporterId, rootEntry, tenantEntry);
+          final Exporter merged = new Exporter();
+          merged.setClassName(rootEntry.getClassName());
+          merged.setJarPath(rootEntry.getJarPath());
+          merged.setArgs(resolveArgs(mergers, tenantId, exporterId, rootEntry, tenantEntry));
+          resolved.put(exporterId, merged);
+        });
+    physicalTenant.getData().setExporters(resolved);
+  }
+
+  private static Map<String, Exporter> bindTenantDeclared(
+      final Environment environment, final String tenantId) {
+    return Binder.get(environment)
+        .bind(
+            PHYSICAL_TENANTS_PREFIX + "." + tenantId + ".data.exporters",
+            Bindable.mapOf(String.class, Exporter.class))
+        .orElseGet(Map::of);
+  }
+
+  /**
+   * Overriding a root-declared exporter means running root's exporter: a tenant may restate the
+   * root {@code className}/{@code jarPath} but never change them — a different class belongs under
+   * a new, tenant-private exporter id (ADR-0008 §2).
+   */
+  private static void validateNoClassDivergence(
+      final String tenantId,
+      final String exporterId,
+      final Exporter rootEntry,
+      final Exporter tenantEntry) {
+    requireSameIfRestated(
+        tenantId, exporterId, "class-name", rootEntry.getClassName(), tenantEntry.getClassName());
+    requireSameIfRestated(
+        tenantId, exporterId, "jar-path", rootEntry.getJarPath(), tenantEntry.getJarPath());
+  }
+
+  private static void requireSameIfRestated(
+      final String tenantId,
+      final String exporterId,
+      final String field,
+      final @Nullable String rootValue,
+      final @Nullable String tenantValue) {
+    if (tenantValue != null && !Objects.equals(rootValue, tenantValue)) {
+      throw new UnifiedConfigurationException(
+          String.format(
+              "Physical tenant '%s' declares '%s: %s' for exporter '%s', diverging from the root "
+                  + "entry's '%s'. Overriding a root-declared exporter means running the root's "
+                  + "exporter with adjusted args; to run a different exporter class, declare it "
+                  + "under a new, tenant-private exporter id instead.",
+              tenantId, field, tenantValue, exporterId, rootValue));
+    }
+  }
+
+  private static @Nullable Map<String, Object> resolveArgs(
+      final List<ExporterConfigMerger> mergers,
+      final String tenantId,
+      final String exporterId,
+      final Exporter rootEntry,
+      final Exporter tenantEntry) {
+    final ExporterConfigMerger merger =
+        findMerger(mergers, tenantId, exporterId, rootEntry.getClassName());
+    if (merger == null) {
+      // no merger for this class: whole-map replace, the tenant's args exactly as declared
+      LOG.debug(
+          "No ExporterConfigMerger for exporter '{}' (class '{}') of physical tenant '{}'; "
+              + "the tenant's args replace the root args wholesale.",
+          exporterId,
+          rootEntry.getClassName(),
+          tenantId);
+      return tenantEntry.getArgs();
+    }
+    LOG.debug(
+        "Deep-merging tenant args over root args for exporter '{}' (class '{}') of physical tenant "
+            + "'{}' using merger '{}'.",
+        exporterId,
+        rootEntry.getClassName(),
+        tenantId,
+        merger.getClass().getName());
+    // defensive: a merger is third-party SPI code, so hand it immutable copies rather than the
+    // resolver's live args maps — the SPI contract forbids mutating its inputs, and this enforces
+    // it
+    final Map<String, Object> rootArgs = immutableCopy(rootEntry.getArgs());
+    final Map<String, Object> tenantArgs = immutableCopy(tenantEntry.getArgs());
+    try {
+      return merger.merge(rootArgs, tenantArgs);
+    } catch (final RuntimeException e) {
+      throw new UnifiedConfigurationException(
+          String.format(
+              "Failed to merge exporter args for exporter '%s' of physical tenant '%s': %s",
+              exporterId, tenantId, e.getMessage()),
+          e);
+    }
+  }
+
+  private static @Nullable ExporterConfigMerger findMerger(
+      final List<ExporterConfigMerger> mergers,
+      final String tenantId,
+      final String exporterId,
+      final @Nullable String className) {
+    if (className == null) {
+      return null;
+    }
+    final List<ExporterConfigMerger> claimants =
+        mergers.stream().filter(merger -> merger.supports(className)).toList();
+    if (claimants.size() > 1) {
+      throw new UnifiedConfigurationException(
+          String.format(
+              "Multiple ExporterConfigMerger implementations claim exporter class '%s' "
+                  + "(exporter '%s' of physical tenant '%s'): %s. Exactly one merger may support "
+                  + "a given exporter class.",
+              className,
+              exporterId,
+              tenantId,
+              claimants.stream().map(m -> m.getClass().getName()).toList()));
+    }
+    return claimants.isEmpty() ? null : claimants.getFirst();
+  }
+
+  private static Map<String, Object> immutableCopy(final @Nullable Map<String, Object> args) {
+    return args == null ? Map.of() : Collections.unmodifiableMap(new LinkedHashMap<>(args));
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantResolver.java
@@ -101,6 +101,10 @@ public final class PhysicalTenantResolver implements PhysicalTenantIds {
       // MapBinder defect: a partial PT override drops the entry's root fields. Recompute every
       // registered map config with the merge-aware overlay engine.
       PhysicalTenantMapOverlays.apply(physicalTenant, physicalTenantId, environment);
+      // Exporter entries have the same defect but raw Map<String, Object> args that the typed
+      // overlay engine cannot merge — recompute them with the dedicated exporter step (ADR-0008).
+      PhysicalTenantExporterConfigurations.apply(
+          camunda, physicalTenant, physicalTenantId, environment);
       resolvedPhysicalTenants.put(physicalTenantId, physicalTenant);
     }
     if (!resolvedPhysicalTenants.containsKey(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)) {

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/ExporterArgsOverlayCharacterizationTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/ExporterArgsOverlayCharacterizationTest.java
@@ -23,30 +23,22 @@ import org.springframework.core.env.MapPropertySource;
 import org.springframework.mock.env.MockEnvironment;
 
 /**
- * Pinned characterization test for the collection merge policy of per-tenant configuration.
+ * Pinned characterization test for the resolved per-tenant exporter entry of a class
+ * <em>without</em> an {@code ExporterConfigMerger} — the whole-map-replace row of the ADR-0008 §2
+ * decision table.
  *
- * <p>The resolver binds {@code camunda.*} then {@code camunda.physical-tenants.<id>.*} into the
- * same {@link Camunda} instance. For a {@code Map}-typed property such as an exporter's {@code
- * args} ({@code Map<String, Object>}), it is not obvious whether Spring's Binder deep-merges the
- * tenant override onto the root entry (preserving sibling keys) or replaces the whole value.
+ * <p>Spring's native Binder constructs a <em>fresh</em> {@link Exporter} when the tenant touches
+ * any key under {@code data.exporters.<id>.*}: sibling args and the root's {@code className} are
+ * discarded (the historic behavior this test originally pinned). Since {@link
+ * PhysicalTenantExporterConfigurations} recomputes the entry, the {@code className} is inherited
+ * from the root entry again — but the <b>args replacement stands</b>: for an exporter class without
+ * a discoverable merger (custom exporters), partial args inheritance is not offered, and the
+ * tenant's args are taken exactly as declared. The seed: root {@code myexp} with {@code
+ * className=X}, {@code args.a=1}, {@code args.b=2}; tenant {@code tenanta} overrides only {@code
+ * args.b=99}.
  *
- * <p>This test pins the observed behavior so the merge policy can be decided from evidence rather
- * than intuition. The seed: root {@code myexp} with {@code className=X}, {@code args.a=1}, {@code
- * args.b=2}; tenant {@code tenanta} overrides only {@code args.b=99}.
- *
- * <p><b>Observed outcome: REPLACE, not deep-merge.</b> When the tenant sets any key under {@code
- * data.exporters.myexp.args}, Spring's Binder constructs a <em>fresh</em> {@link Exporter} for the
- * {@code myexp} map key instead of binding into the root's existing instance. The result is an
- * exporter with {@code args == {b=99}} only: the sibling {@code args.a=1} and the root {@code
- * className=X} are both discarded. (This differs from a nested non-map bean such as {@code
- * cluster}, whose sibling fields survive — see {@code PhysicalTenantBinderTest} — because a {@code
- * Map} <em>value</em> is not seeded from the existing entry during the second bind.)
- *
- * <p><b>Consequence for the merge policy:</b> native Spring overlay does NOT satisfy the issue's
- * deep-merge requirement for {@code Map<String, Object>} exporter args. A custom overlay is
- * therefore required — but that is a separate deliverable to be agreed with the user before
- * building; this test only locks in the native behavior so a future merge implementation has a
- * baseline to change.
+ * <p>The merge path (a class <em>with</em> a merger) and the remaining decision-table rows are
+ * covered by {@link PhysicalTenantExporterConfigurationsTest}.
  */
 class ExporterArgsOverlayCharacterizationTest {
 
@@ -89,19 +81,21 @@ class ExporterArgsOverlayCharacterizationTest {
     final Camunda tenantA =
         PhysicalTenantResolver.of(environment, camunda).forPhysicalTenant("tenanta");
 
-    // then the tenant's exporter entry has been REPLACED, not merged onto the root entry
+    // then the tenant's args have been REPLACED (class X has no merger), not merged
     final Exporter myexp = tenantA.getData().getExporters().get("myexp");
     assertThat(myexp).as("the exporter entry itself survives the overlay").isNotNull();
     // the overriding key is present with the tenant value
     assertThat(myexp.getArgs())
         .as("overridden args.b takes the tenant value")
         .containsEntry("b", 99);
-    // and everything not restated by the tenant is lost: a fresh Exporter was constructed
+    // and args the tenant did not restate are lost: no partial args inheritance without a merger
     assertThat(myexp.getArgs())
         .as("args is replaced wholesale — sibling args.a from the root is discarded")
         .containsOnlyKeys("b");
     assertThat(myexp.getClassName())
-        .as("className from the root is discarded by the replace overlay")
-        .isNull();
+        .as(
+            "className is inherited from the root entry by the exporter resolution step "
+                + "(diverging from it is a boot error)")
+        .isEqualTo("X");
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/MapOverlaySurface.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/MapOverlaySurface.java
@@ -56,9 +56,10 @@ final class MapOverlaySurface {
    * reached <em>through</em> another map's value type).
    *
    * <ul>
-   *   <li>{@code camunda.data.exporters} — the exporter entry is default-merged; deep-merging its
-   *       {@code args} is a separate, opt-in mechanism (see {@link
-   *       ExporterArgsOverlayCharacterizationTest}), not this overlay engine.
+   *   <li>{@code camunda.data.exporters} — recomputed by the dedicated {@link
+   *       PhysicalTenantExporterConfigurations} resolver step (ADR-0008), not this overlay engine:
+   *       its raw {@code Map<String, Object>} args cannot be field-enumerated, and deep-merging
+   *       them is opt-in per exporter class via {@code ExporterConfigMerger}.
    *   <li>the OIDC {@code authorize-request-configuration.additional-parameters} maps ({@code
    *       Map<String, Object>} of opaque request parameters) — a touched entry has no bindable
    *       sub-fields to lose, so wholesale replacement is harmless. Reachable both via the flat

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurationsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantExporterConfigurationsTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Exporter;
+import io.camunda.configuration.UnifiedConfigurationException;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Covers the step-1 rows of the ADR-0008 §2 decision table against the test-only mergers registered
+ * via {@code src/test/resources/META-INF/services} (real-merger end-to-end coverage lives in {@code
+ * PhysicalTenantExporterConfigIT}). The step-2 rows — the {@code exporters-assigned} manifest,
+ * narrowing, and the configured-but-unassigned error — are gated on #56652 and deliberately absent
+ * here; see {@link PhysicalTenantExporterConfigurations}.
+ */
+class PhysicalTenantExporterConfigurationsTest {
+
+  private static final String TENANT = "tenanta";
+
+  private MockEnvironment environment;
+  private Map<String, Object> properties;
+
+  @BeforeEach
+  void setUp() {
+    environment = new MockEnvironment();
+    UnifiedConfigurationHelper.setCustomEnvironment(environment);
+    properties = new HashMap<>();
+    // distinct storage location so the tenant does not collide with the synthesized 'default',
+    // and the mandatory per-PT security initialization
+    properties.put(
+        "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+        TENANT);
+    properties.put(
+        "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
+        "tenanta-admin");
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  private Camunda resolveTenantA() {
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+    final Camunda camunda = new Camunda();
+    Binder.get(environment).bind(Camunda.PREFIX, Bindable.ofInstance(camunda));
+    return PhysicalTenantResolver.of(environment, camunda).forPhysicalTenant(TENANT);
+  }
+
+  @Test
+  void shouldInheritRootEntryUnchangedWhenTenantDoesNotTouchIt() {
+    // given — a root catalog entry the tenant never mentions
+    properties.put("camunda.data.exporters.untouched.class-name", "com.acme.CustomExporter");
+    properties.put("camunda.data.exporters.untouched.args.a", 1);
+
+    // when
+    final Exporter resolved = resolveTenantA().getData().getExporters().get("untouched");
+
+    // then
+    assertThat(resolved).isNotNull();
+    assertThat(resolved.getClassName()).isEqualTo("com.acme.CustomExporter");
+    assertThat(resolved.getArgs()).containsEntry("a", 1);
+  }
+
+  @Test
+  void shouldDeepMergeArgsWhenExporterClassHasMerger() {
+    // given — a catalog entry whose class has a merger, partially overridden by the tenant
+    properties.put(
+        "camunda.data.exporters.mergeable.class-name", TestExporterConfigMergers.MERGEABLE_CLASS);
+    properties.put("camunda.data.exporters.mergeable.args.a", 1);
+    properties.put("camunda.data.exporters.mergeable.args.b", 2);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters.mergeable.args.b", 99);
+
+    // when
+    final Exporter resolved = resolveTenantA().getData().getExporters().get("mergeable");
+
+    // then — root className inherited, args merged by the discovered merger (tenant wins)
+    assertThat(resolved.getClassName()).isEqualTo(TestExporterConfigMergers.MERGEABLE_CLASS);
+    assertThat(resolved.getArgs())
+        .containsEntry("a", 1)
+        .containsEntry("b", 99)
+        .containsEntry(
+            TestExporterConfigMergers.MERGED_BY_KEY, TestExporterConfigMergers.MERGED_BY_VALUE);
+  }
+
+  @Test
+  void shouldTakeTenantArgsAsDeclaredWhenExporterClassHasNoMerger() {
+    // given — a catalog entry of a class without a merger (e.g. a custom exporter)
+    properties.put("camunda.data.exporters.custom.class-name", "com.acme.CustomExporter");
+    properties.put("camunda.data.exporters.custom.args.a", 1);
+    properties.put("camunda.data.exporters.custom.args.b", 2);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters.custom.args.b", 99);
+
+    // when
+    final Exporter resolved = resolveTenantA().getData().getExporters().get("custom");
+
+    // then — className/jarPath inherited from root, args exactly as the tenant declared
+    // (whole-map replace: root args are not merged in)
+    assertThat(resolved.getClassName()).isEqualTo("com.acme.CustomExporter");
+    assertThat(resolved.getArgs()).containsOnlyKeys("b").containsEntry("b", 99);
+  }
+
+  @Test
+  void shouldAllowRestatingTheRootClassName() {
+    // given — the tenant restates the root's exact className alongside its partial args
+    properties.put("camunda.data.exporters.custom.class-name", "com.acme.CustomExporter");
+    properties.put("camunda.data.exporters.custom.args.a", 1);
+    properties.put(
+        "camunda.physical-tenants.tenanta.data.exporters.custom.class-name",
+        "com.acme.CustomExporter");
+    properties.put("camunda.physical-tenants.tenanta.data.exporters.custom.args.b", 5);
+
+    // when
+    final Exporter resolved = resolveTenantA().getData().getExporters().get("custom");
+
+    // then
+    assertThat(resolved.getClassName()).isEqualTo("com.acme.CustomExporter");
+    assertThat(resolved.getArgs()).containsOnlyKeys("b");
+  }
+
+  @Test
+  void shouldRejectClassNameDivergingFromRoot() {
+    // given — the tenant changes the class of a root-declared exporter id
+    properties.put("camunda.data.exporters.custom.class-name", "com.acme.CustomExporter");
+    properties.put(
+        "camunda.physical-tenants.tenanta.data.exporters.custom.class-name",
+        "com.acme.OtherExporter");
+
+    // when / then
+    assertThatThrownBy(this::resolveTenantA)
+        .isInstanceOf(UnifiedConfigurationException.class)
+        .hasMessageContaining("tenanta")
+        .hasMessageContaining("custom")
+        .hasMessageContaining("com.acme.OtherExporter")
+        .hasMessageContaining("tenant-private");
+  }
+
+  @Test
+  void shouldRejectJarPathDivergingFromRoot() {
+    // given
+    properties.put("camunda.data.exporters.custom.class-name", "com.acme.CustomExporter");
+    properties.put("camunda.data.exporters.custom.jar-path", "/opt/root.jar");
+    properties.put(
+        "camunda.physical-tenants.tenanta.data.exporters.custom.jar-path", "/opt/tenant.jar");
+
+    // when / then
+    assertThatThrownBy(this::resolveTenantA)
+        .isInstanceOf(UnifiedConfigurationException.class)
+        .hasMessageContaining("jar-path")
+        .hasMessageContaining("/opt/tenant.jar");
+  }
+
+  @Test
+  void shouldKeepTenantPrivateExporterExactlyAsDeclared() {
+    // given — an id root does not declare
+    properties.put(
+        "camunda.physical-tenants.tenanta.data.exporters.private.class-name",
+        "com.acme.TenantOnlyExporter");
+    properties.put("camunda.physical-tenants.tenanta.data.exporters.private.args.x", "y");
+
+    // when
+    final Exporter resolved = resolveTenantA().getData().getExporters().get("private");
+
+    // then
+    assertThat(resolved.getClassName()).isEqualTo("com.acme.TenantOnlyExporter");
+    assertThat(resolved.getArgs()).containsEntry("x", "y");
+  }
+
+  @Test
+  void shouldTakeAutoconfiguredExporterTuningAsDeclared() {
+    // given — root args-tuning for the autoconfigured camundaexporter, partially overridden by
+    // the tenant; the id is outside the catalog, so no merge and no divergence rules apply
+    properties.put("camunda.data.exporters.camundaexporter.args.a", 1);
+    properties.put("camunda.data.exporters.camundaexporter.args.b", 2);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters.camundaexporter.args.b", 99);
+
+    // when
+    final Exporter resolved = resolveTenantA().getData().getExporters().get("camundaexporter");
+
+    // then — the tenant's declaration is taken as-is (native binder semantics, no merge step)
+    assertThat(resolved.getArgs()).containsOnlyKeys("b").containsEntry("b", 99);
+  }
+
+  @Test
+  void shouldWrapMergeFailureWithExporterAndTenantId() {
+    // given — a catalog entry whose merger throws
+    properties.put(
+        "camunda.data.exporters.failing.class-name", TestExporterConfigMergers.FAILING_CLASS);
+    properties.put("camunda.data.exporters.failing.args.a", 1);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters.failing.args.a", 2);
+
+    // when / then
+    assertThatThrownBy(this::resolveTenantA)
+        .isInstanceOf(UnifiedConfigurationException.class)
+        .hasMessageContaining("failing")
+        .hasMessageContaining("tenanta")
+        .hasMessageContaining("intentional test merge failure");
+  }
+
+  @Test
+  void shouldRejectMultipleMergersClaimingTheSameClass() {
+    // given — a catalog entry whose class two discovered mergers claim
+    properties.put(
+        "camunda.data.exporters.dup.class-name", TestExporterConfigMergers.DUPLICATE_CLAIMED_CLASS);
+    properties.put("camunda.physical-tenants.tenanta.data.exporters.dup.args.a", 1);
+
+    // when / then
+    assertThatThrownBy(this::resolveTenantA)
+        .isInstanceOf(UnifiedConfigurationException.class)
+        .hasMessageContaining("Multiple ExporterConfigMerger implementations")
+        .hasMessageContaining(TestExporterConfigMergers.DUPLICATE_CLAIMED_CLASS);
+  }
+
+  @Test
+  void shouldNotRunTheExporterStepForTenantsWithoutExporterDeclarations() {
+    // given — a root catalog only; the tenant declares nothing under data.exporters
+    properties.put(
+        "camunda.data.exporters.mergeable.class-name", TestExporterConfigMergers.MERGEABLE_CLASS);
+    properties.put("camunda.data.exporters.mergeable.args.a", 1);
+
+    // when
+    final Exporter resolved = resolveTenantA().getData().getExporters().get("mergeable");
+
+    // then — inherited via the two-bind, no merger marker present
+    assertThat(resolved.getArgs())
+        .containsEntry("a", 1)
+        .doesNotContainKey(TestExporterConfigMergers.MERGED_BY_KEY);
+  }
+
+  /**
+   * Pins the Binder behavior ADR-0008 step 2 depends on (its consequences section flags it as
+   * fragile): an explicit {@code exporters-assigned: []}/{@code ""} must be distinguishable from an
+   * absent key, since for exporters an empty manifest is valid ("no generic exporters") while an
+   * absent one must be a boot error. Verified here ahead of step 2 so the fallback documented in
+   * the ADR is not needed.
+   */
+  @Test
+  void shouldDistinguishBoundEmptyExportersAssignedFromAbsentKey() {
+    // given — an explicit empty exporters-assigned (yaml `[]` surfaces as an empty string value)
+    properties.put("camunda.physical-tenants.tenanta.data.exporters-assigned", "");
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+    final Binder binder = Binder.get(environment);
+
+    // when
+    final var boundEmpty =
+        binder.bind(
+            "camunda.physical-tenants.tenanta.data.exporters-assigned",
+            Bindable.listOf(String.class));
+    final var absent =
+        binder.bind(
+            "camunda.physical-tenants.tenantb.data.exporters-assigned",
+            Bindable.listOf(String.class));
+
+    // then
+    assertThat(boundEmpty.isBound()).isTrue();
+    assertThat(boundEmpty.get()).isEmpty();
+    assertThat(absent.isBound()).isFalse();
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/TestExporterConfigMergers.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/TestExporterConfigMergers.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Test-only {@link ExporterConfigMerger}s registered via {@code
+ * src/test/resources/META-INF/services} so the resolver's {@code ServiceLoader} discovery and the
+ * decision table of ADR-0008 §2 can be exercised without depending on the real ES/OS exporter
+ * modules (which {@code configuration/} deliberately does not see — real-merger coverage lives in
+ * the end-to-end {@code PhysicalTenantExporterConfigIT}).
+ */
+final class TestExporterConfigMergers {
+
+  /** Exporter class name with exactly one merger — the merge path of the decision table. */
+  static final String MERGEABLE_CLASS = "io.camunda.configuration.test.MergeableExporter";
+
+  /** Exporter class name whose merger always fails — exercises the error wrapping. */
+  static final String FAILING_CLASS = "io.camunda.configuration.test.FailingMergeExporter";
+
+  /** Exporter class name claimed by two mergers — must fail startup. */
+  static final String DUPLICATE_CLAIMED_CLASS =
+      "io.camunda.configuration.test.DuplicateClaimedExporter";
+
+  /** Marker key the recording merger adds so tests can prove the merger ran. */
+  static final String MERGED_BY_KEY = "mergedby";
+
+  static final String MERGED_BY_VALUE = "test-merger";
+
+  private TestExporterConfigMergers() {}
+
+  public static final class RecordingMerger implements ExporterConfigMerger {
+
+    @Override
+    public boolean supports(final String className) {
+      return MERGEABLE_CLASS.equals(className);
+    }
+
+    @Override
+    public Map<String, Object> merge(
+        final Map<String, Object> rootArgs, final Map<String, Object> tenantArgs) {
+      // top-level merge, tenant wins — plus a marker so tests can tell merger output apart from
+      // anything the plain binder could have produced
+      final Map<String, Object> merged = new LinkedHashMap<>(rootArgs);
+      merged.putAll(tenantArgs);
+      merged.put(MERGED_BY_KEY, MERGED_BY_VALUE);
+      return merged;
+    }
+  }
+
+  public static final class FailingMerger implements ExporterConfigMerger {
+
+    @Override
+    public boolean supports(final String className) {
+      return FAILING_CLASS.equals(className);
+    }
+
+    @Override
+    public Map<String, Object> merge(
+        final Map<String, Object> rootArgs, final Map<String, Object> tenantArgs) {
+      throw new IllegalStateException("intentional test merge failure");
+    }
+  }
+
+  public static final class FirstDuplicateClaimant implements ExporterConfigMerger {
+
+    @Override
+    public boolean supports(final String className) {
+      return DUPLICATE_CLAIMED_CLASS.equals(className);
+    }
+
+    @Override
+    public Map<String, Object> merge(
+        final Map<String, Object> rootArgs, final Map<String, Object> tenantArgs) {
+      return tenantArgs;
+    }
+  }
+
+  public static final class SecondDuplicateClaimant implements ExporterConfigMerger {
+
+    @Override
+    public boolean supports(final String className) {
+      return DUPLICATE_CLAIMED_CLASS.equals(className);
+    }
+
+    @Override
+    public Map<String, Object> merge(
+        final Map<String, Object> rootArgs, final Map<String, Object> tenantArgs) {
+      return tenantArgs;
+    }
+  }
+}

--- a/configuration/src/test/resources/META-INF/services/io.camunda.zeebe.exporter.api.ExporterConfigMerger
+++ b/configuration/src/test/resources/META-INF/services/io.camunda.zeebe.exporter.api.ExporterConfigMerger
@@ -1,0 +1,4 @@
+io.camunda.configuration.physicaltenants.TestExporterConfigMergers$RecordingMerger
+io.camunda.configuration.physicaltenants.TestExporterConfigMergers$FailingMerger
+io.camunda.configuration.physicaltenants.TestExporterConfigMergers$FirstDuplicateClaimant
+io.camunda.configuration.physicaltenants.TestExporterConfigMergers$SecondDuplicateClaimant

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -481,6 +481,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>zeebe-exporter-config-support</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>zeebe-exporter-filter</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -88,6 +88,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-config-support</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-stream-platform</artifactId>
     </dependency>
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
@@ -14,7 +14,6 @@ import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.MapperFeature;
@@ -27,15 +26,12 @@ import com.fasterxml.jackson.databind.util.TokenBuffer;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.exporter.api.context.StrictConfiguration;
+import io.camunda.zeebe.exporter.support.ExporterConfigMergeSupport;
 import io.camunda.zeebe.util.ReflectUtil;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.nio.file.Path;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.slf4j.Logger;
@@ -109,8 +105,10 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
       // Normalize all keys to lowercase-no-separator so that camelCase, kebab-case, and the
       // all-lowercase concatenated form produced by Spring Boot env var lowercasing are all
       // equivalent. ACCEPT_CASE_INSENSITIVE_PROPERTIES then matches the normalised key to the
-      // Java field name regardless of original casing.
-      final var normalized = normalizeKeys(values, MAPPER.constructType(configClass));
+      // Java field name regardless of original casing. The type-aware walk is shared with the
+      // per-physical-tenant ExporterConfigMerger implementations (single owner of the
+      // normalization semantics, ADR-0008 §4).
+      final var normalized = ExporterConfigMergeSupport.normalize(configClass, values);
       final var mapper =
           configClass.isAnnotationPresent(StrictConfiguration.class) ? STRICT_MAPPER : MAPPER;
       try {
@@ -143,148 +141,6 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
     } else {
       return ReflectUtil.newInstance(configClass);
     }
-  }
-
-  /**
-   * Normalises keys that represent configuration properties to lowercase with separators stripped,
-   * so that {@code myField}, {@code my-field}, {@code MY-FIELD}, and {@code myfield} all map to the
-   * same canonical key.
-   *
-   * <p>The normalisation is type-aware: object-property maps are normalised recursively, while map
-   * keys of {@code Map<K, V>} fields are preserved as user data.
-   *
-   * @param map the raw exporter args map
-   * @return the same structure with normalised lowercase keys
-   */
-  private static Map<String, Object> normalizeKeys(
-      final Map<String, Object> map, final JavaType targetType) {
-    final var result = new LinkedHashMap<String, Object>(map.size());
-    final var propertyTypesByKey = propertyTypesByNormalizedKey(targetType);
-    final var indexedElementType = indexedElementType(targetType, map);
-    for (final var entry : map.entrySet()) {
-      final var normalizedKey = normalizeKey(entry.getKey());
-      var propertyType = propertyTypesByKey.get(normalizedKey);
-      if (propertyType == null) {
-        propertyType = indexedElementType;
-      }
-      result.put(normalizedKey, normalizeValue(entry.getValue(), propertyType));
-    }
-    return result;
-  }
-
-  private static JavaType indexedElementType(
-      final JavaType targetType, final Map<String, Object> map) {
-    if (targetType == null || (!targetType.isCollectionLikeType() && !targetType.isArrayType())) {
-      return null;
-    }
-
-    var hasNumericKeys = false;
-    var hasNonNumericKeys = false;
-    for (final var key : map.keySet()) {
-      try {
-        Integer.parseInt(key);
-        hasNumericKeys = true;
-      } catch (final NumberFormatException e) {
-        hasNonNumericKeys = true;
-      }
-    }
-
-    if (hasNumericKeys && hasNonNumericKeys) {
-      throw new IllegalArgumentException(
-          "Cannot mix indexed (numeric) and named keys in configuration map targeting a collection: "
-              + map.keySet());
-    }
-
-    return hasNumericKeys ? targetType.getContentType() : null;
-  }
-
-  private static Map<String, JavaType> propertyTypesByNormalizedKey(final JavaType targetType) {
-    if (targetType == null || targetType.isMapLikeType() || targetType.isContainerType()) {
-      return Map.of();
-    }
-
-    final var properties =
-        MAPPER.getDeserializationConfig().introspect(targetType).findProperties();
-    if (properties.isEmpty()) {
-      return Map.of();
-    }
-
-    final var propertyTypes = new LinkedHashMap<String, JavaType>(properties.size());
-    for (final var property : properties) {
-      final var propertyType = property.getPrimaryType();
-      if (propertyType != null) {
-        propertyTypes.put(normalizeKey(property.getName()), propertyType);
-      }
-    }
-    return propertyTypes;
-  }
-
-  private static Object normalizeValue(final Object value, final JavaType targetType) {
-    if (value instanceof final Map<?, ?> nestedMap) {
-      return normalizeMapValue(nestedMap, targetType);
-    }
-
-    if (value instanceof final Iterable<?> iterable) {
-      return normalizeIterableValue(iterable, targetType);
-    }
-
-    if (value != null && value.getClass().isArray()) {
-      return normalizeArrayValue(value, targetType);
-    }
-
-    return value;
-  }
-
-  private static Object normalizeMapValue(final Map<?, ?> nestedMap, final JavaType targetType) {
-    if (targetType == null || targetType.hasRawClass(Object.class)) {
-      return nestedMap;
-    }
-
-    if (targetType.isMapLikeType()) {
-      return normalizeMapValues(nestedMap, targetType.getContentType());
-    }
-
-    @SuppressWarnings("unchecked")
-    final var typedNested = (Map<String, Object>) nestedMap;
-    return normalizeKeys(typedNested, targetType);
-  }
-
-  private static List<Object> normalizeIterableValue(
-      final Iterable<?> iterable, final JavaType targetType) {
-    final var contentType =
-        targetType != null && targetType.isCollectionLikeType()
-            ? targetType.getContentType()
-            : null;
-    final var normalized = new ArrayList<>();
-    for (final var item : iterable) {
-      normalized.add(normalizeValue(item, contentType));
-    }
-    return normalized;
-  }
-
-  private static Object[] normalizeArrayValue(final Object value, final JavaType targetType) {
-    final var length = Array.getLength(value);
-    final var contentType =
-        targetType != null && targetType.isArrayType() ? targetType.getContentType() : null;
-    final var normalized = new Object[length];
-    for (int i = 0; i < length; i++) {
-      normalized[i] = normalizeValue(Array.get(value, i), contentType);
-    }
-    return normalized;
-  }
-
-  private static Map<Object, Object> normalizeMapValues(
-      final Map<?, ?> map, final JavaType contentType) {
-    final var result = new LinkedHashMap<Object, Object>(map.size());
-    for (final var entry : map.entrySet()) {
-      result.put(entry.getKey(), normalizeValue(entry.getValue(), contentType));
-    }
-    return result;
-  }
-
-  /** Strips hyphens and lowercases a key so all naming styles map to the same canonical form. */
-  private static String normalizeKey(final String name) {
-    return name.replace("-", "").toLowerCase(Locale.ROOT);
   }
 
   /**

--- a/zeebe/exporter-api/pom.xml
+++ b/zeebe/exporter-api/pom.xml
@@ -39,6 +39,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/ExporterConfigMerger.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/ExporterConfigMerger.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.exporter.api;
+
+import java.util.Map;
+
+/**
+ * Opt-in, per-exporter-class deep merge of exporter {@code args} maps, used when resolving
+ * per-physical-tenant configuration: a tenant that partially overrides a root-declared exporter's
+ * {@code args} gets the root args and its own args deep-merged (tenant wins where both set a key) —
+ * but only if the exporter's class ships a merger, because only code that owns the exporter's
+ * configuration class can merge its args safely (property keys must be normalized against the
+ * config class while the content of {@code Map}-typed fields is user data that must not be
+ * rewritten).
+ *
+ * <p>Implementations are discovered via {@link java.util.ServiceLoader} at configuration-resolution
+ * time. An exporter class without a discoverable merger keeps whole-map-replace semantics: the
+ * tenant's args are taken exactly as declared. Two discovered mergers claiming the same class name
+ * fail startup.
+ *
+ * <p>Implementations should be stateless; {@link #merge(Map, Map)} must not mutate its inputs.
+ */
+public interface ExporterConfigMerger {
+
+  /**
+   * Whether this merger owns the configuration model of the given exporter class. Matched against
+   * the fully qualified {@code className} of the root-declared exporter entry.
+   *
+   * @param className the fully qualified class name of the exporter (never {@code null})
+   * @return true if this merger can merge args for the given exporter class
+   */
+  boolean supports(String className);
+
+  /**
+   * Deep-merges a tenant's partial {@code args} over the root-declared {@code args} of the same
+   * exporter entry.
+   *
+   * @param rootArgs the root entry's args (never {@code null}, possibly empty; must not be mutated)
+   * @param tenantArgs the tenant's overriding args (never {@code null}, possibly empty; must not be
+   *     mutated)
+   * @return the merged args map
+   */
+  Map<String, Object> merge(Map<String, Object> rootArgs, Map<String, Object> tenantArgs);
+}

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/ExporterConfigMerger.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/ExporterConfigMerger.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.exporter.api;
 
 import java.util.Map;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Opt-in, per-exporter-class deep merge of exporter {@code args} maps, used when resolving
@@ -33,6 +34,7 @@ import java.util.Map;
  *
  * <p>Implementations should be stateless; {@link #merge(Map, Map)} must not mutate its inputs.
  */
+@NullMarked
 public interface ExporterConfigMerger {
 
   /**

--- a/zeebe/exporter-config-support/pom.xml
+++ b/zeebe/exporter-config-support/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.10.0-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>zeebe-exporter-config-support</artifactId>
+
+  <name>Zeebe Exporter Config Support</name>
+
+  <!--
+    Internal support module hosting the type-aware exporter-args normalization and deep-merge
+    machinery shared by the broker and the exporter modules' ExporterConfigMerger implementations
+    (ADR-0008). Deliberately NOT part of the public exporter SDK (zeebe-exporter-api) so the SDK
+    stays free of the jackson-databind dependency and the helper's semantics are not frozen under
+    API-compatibility guarantees.
+  -->
+
+  <dependencies>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <!-- testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/zeebe/exporter-config-support/src/main/java/io/camunda/zeebe/exporter/support/ExporterConfigMergeSupport.java
+++ b/zeebe/exporter-config-support/src/main/java/io/camunda/zeebe/exporter/support/ExporterConfigMergeSupport.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.support;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Single owner of the type-aware exporter-args key normalization and deep-merge semantics (ADR-0008
+ * §4). Two callers share it so their semantics cannot drift apart:
+ *
+ * <ul>
+ *   <li>the broker's {@code ExporterConfiguration.fromArgs} normalizes an args map against the
+ *       exporter's config class before binding it, so relaxed spellings ({@code index-prefix},
+ *       {@code INDEX_PREFIX}, {@code indexPrefix}) collapse to one canonical key;
+ *   <li>{@code ExporterConfigMerger} implementations normalize the root and tenant args maps the
+ *       same way before deep-merging them per physical tenant.
+ * </ul>
+ *
+ * <p>Both operations are <em>type-aware</em>: the exporter's config class is introspected via
+ * Jackson, and only keys that correspond to configuration properties are normalized (and merged
+ * recursively for nested POJO properties), while the keys of {@code Map}-typed fields are user data
+ * and preserved untouched.
+ */
+public final class ExporterConfigMergeSupport {
+
+  /**
+   * Used only to construct {@link JavaType}s and introspect config classes for their properties —
+   * never to bind or convert values. Property discovery does not depend on any of the lenient
+   * deserialization features the broker's binding mapper configures, so a plain mapper yields the
+   * same property set.
+   */
+  private static final ObjectMapper INTROSPECTION_MAPPER = new ObjectMapper();
+
+  private ExporterConfigMergeSupport() {}
+
+  /**
+   * Normalises keys that represent configuration properties of {@code configClass} to lowercase
+   * with separators stripped, so that {@code myField}, {@code my-field}, {@code MY-FIELD}, and
+   * {@code myfield} all map to the same canonical key.
+   *
+   * <p>The normalisation is type-aware: object-property maps are normalised recursively, while map
+   * keys of {@code Map<K, V>} fields are preserved as user data.
+   *
+   * @param configClass the exporter's configuration class the args bind into
+   * @param args the raw exporter args map
+   * @return the same structure with normalised lowercase keys
+   */
+  public static Map<String, Object> normalize(
+      final Class<?> configClass, final Map<String, Object> args) {
+    return normalizeKeys(args, INTROSPECTION_MAPPER.constructType(configClass));
+  }
+
+  private static Map<String, Object> normalizeKeys(
+      final Map<String, Object> map, final JavaType targetType) {
+    final var result = new LinkedHashMap<String, Object>(map.size());
+    final var propertyTypesByKey = propertyTypesByNormalizedKey(targetType);
+    final var indexedElementType = indexedElementType(targetType, map);
+    for (final var entry : map.entrySet()) {
+      final var normalizedKey = normalizeKey(entry.getKey());
+      var propertyType = propertyTypesByKey.get(normalizedKey);
+      if (propertyType == null) {
+        propertyType = indexedElementType;
+      }
+      result.put(normalizedKey, normalizeValue(entry.getValue(), propertyType));
+    }
+    return result;
+  }
+
+  private static JavaType indexedElementType(
+      final JavaType targetType, final Map<String, Object> map) {
+    if (targetType == null || (!targetType.isCollectionLikeType() && !targetType.isArrayType())) {
+      return null;
+    }
+
+    var hasNumericKeys = false;
+    var hasNonNumericKeys = false;
+    for (final var key : map.keySet()) {
+      try {
+        Integer.parseInt(key);
+        hasNumericKeys = true;
+      } catch (final NumberFormatException e) {
+        hasNonNumericKeys = true;
+      }
+    }
+
+    if (hasNumericKeys && hasNonNumericKeys) {
+      throw new IllegalArgumentException(
+          "Cannot mix indexed (numeric) and named keys in configuration map targeting a collection: "
+              + map.keySet());
+    }
+
+    return hasNumericKeys ? targetType.getContentType() : null;
+  }
+
+  private static Map<String, JavaType> propertyTypesByNormalizedKey(final JavaType targetType) {
+    if (targetType == null || targetType.isMapLikeType() || targetType.isContainerType()) {
+      return Map.of();
+    }
+
+    final var properties =
+        INTROSPECTION_MAPPER.getDeserializationConfig().introspect(targetType).findProperties();
+    if (properties.isEmpty()) {
+      return Map.of();
+    }
+
+    final var propertyTypes = new LinkedHashMap<String, JavaType>(properties.size());
+    for (final var property : properties) {
+      final var propertyType = property.getPrimaryType();
+      if (propertyType != null) {
+        propertyTypes.put(normalizeKey(property.getName()), propertyType);
+      }
+    }
+    return propertyTypes;
+  }
+
+  private static Object normalizeValue(final Object value, final JavaType targetType) {
+    if (value instanceof final Map<?, ?> nestedMap) {
+      return normalizeMapValue(nestedMap, targetType);
+    }
+
+    if (value instanceof final Iterable<?> iterable) {
+      return normalizeIterableValue(iterable, targetType);
+    }
+
+    if (value != null && value.getClass().isArray()) {
+      return normalizeArrayValue(value, targetType);
+    }
+
+    return value;
+  }
+
+  private static Object normalizeMapValue(final Map<?, ?> nestedMap, final JavaType targetType) {
+    if (targetType == null || targetType.hasRawClass(Object.class)) {
+      return nestedMap;
+    }
+
+    if (targetType.isMapLikeType()) {
+      return normalizeMapValues(nestedMap, targetType.getContentType());
+    }
+
+    @SuppressWarnings("unchecked")
+    final var typedNested = (Map<String, Object>) nestedMap;
+    return normalizeKeys(typedNested, targetType);
+  }
+
+  private static List<Object> normalizeIterableValue(
+      final Iterable<?> iterable, final JavaType targetType) {
+    final var contentType =
+        targetType != null && targetType.isCollectionLikeType()
+            ? targetType.getContentType()
+            : null;
+    final var normalized = new ArrayList<>();
+    for (final var item : iterable) {
+      normalized.add(normalizeValue(item, contentType));
+    }
+    return normalized;
+  }
+
+  private static Object[] normalizeArrayValue(final Object value, final JavaType targetType) {
+    final var length = Array.getLength(value);
+    final var contentType =
+        targetType != null && targetType.isArrayType() ? targetType.getContentType() : null;
+    final var normalized = new Object[length];
+    for (int i = 0; i < length; i++) {
+      normalized[i] = normalizeValue(Array.get(value, i), contentType);
+    }
+    return normalized;
+  }
+
+  private static Map<Object, Object> normalizeMapValues(
+      final Map<?, ?> map, final JavaType contentType) {
+    final var result = new LinkedHashMap<Object, Object>(map.size());
+    for (final var entry : map.entrySet()) {
+      result.put(entry.getKey(), normalizeValue(entry.getValue(), contentType));
+    }
+    return result;
+  }
+
+  /** Strips hyphens and lowercases a key so all naming styles map to the same canonical form. */
+  private static String normalizeKey(final String name) {
+    return name.replace("-", "").toLowerCase(Locale.ROOT);
+  }
+}

--- a/zeebe/exporter-config-support/src/main/java/io/camunda/zeebe/exporter/support/ExporterConfigMergeSupport.java
+++ b/zeebe/exporter-config-support/src/main/java/io/camunda/zeebe/exporter/support/ExporterConfigMergeSupport.java
@@ -62,6 +62,68 @@ public final class ExporterConfigMergeSupport {
     return normalizeKeys(args, INTROSPECTION_MAPPER.constructType(configClass));
   }
 
+  /**
+   * Deep-merges a tenant's partial exporter {@code args} over the root-declared {@code args},
+   * type-aware against {@code configClass} (ADR-0008 §4). Both maps are first normalized exactly
+   * like {@link #normalize(Class, Map)} so differently spelled property keys collapse before
+   * merging; consequently the returned map carries normalized property keys.
+   *
+   * <p>Merge semantics per key: nested POJO properties recurse; scalars and lists replace; {@code
+   * Map}-typed properties replace wholesale (their content is user data the merge does not
+   * interpret); keys not matching any property of {@code configClass} replace. The tenant wins
+   * wherever both maps set the same key. Neither input is mutated.
+   *
+   * @param configClass the exporter's configuration class both args maps bind into
+   * @param rootArgs the root entry's args (may be empty, not {@code null})
+   * @param tenantArgs the tenant's overriding args (may be empty, not {@code null})
+   * @return the merged args map
+   */
+  public static Map<String, Object> merge(
+      final Class<?> configClass,
+      final Map<String, Object> rootArgs,
+      final Map<String, Object> tenantArgs) {
+    final JavaType targetType = INTROSPECTION_MAPPER.constructType(configClass);
+    return mergeMaps(
+        normalizeKeys(rootArgs, targetType), normalizeKeys(tenantArgs, targetType), targetType);
+  }
+
+  private static Map<String, Object> mergeMaps(
+      final Map<String, Object> root, final Map<String, Object> tenant, final JavaType targetType) {
+    final var result = new LinkedHashMap<>(root);
+    final var propertyTypesByKey = propertyTypesByNormalizedKey(targetType);
+    for (final var entry : tenant.entrySet()) {
+      final var key = entry.getKey();
+      final var tenantValue = entry.getValue();
+      final var rootValue = result.get(key);
+      final var propertyType = propertyTypesByKey.get(key);
+      if (isPojoProperty(propertyType)
+          && rootValue instanceof final Map<?, ?> rootMap
+          && tenantValue instanceof final Map<?, ?> tenantMap) {
+        @SuppressWarnings("unchecked")
+        final var typedRoot = (Map<String, Object>) rootMap;
+        @SuppressWarnings("unchecked")
+        final var typedTenant = (Map<String, Object>) tenantMap;
+        result.put(key, mergeMaps(typedRoot, typedTenant, propertyType));
+      } else {
+        result.put(key, tenantValue);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Only a known, non-{@code Object}, non-container property is a POJO the merge may recurse into.
+   * A {@code Map}-typed property holds user data (replace wholesale), a collection/array replaces
+   * by definition, and an unknown or {@code Object}-typed value cannot be introspected — the same
+   * reasoning that keeps custom exporters out of merge scope keeps the merge from guessing here.
+   */
+  private static boolean isPojoProperty(final JavaType propertyType) {
+    return propertyType != null
+        && !propertyType.hasRawClass(Object.class)
+        && !propertyType.isMapLikeType()
+        && !propertyType.isContainerType();
+  }
+
   private static Map<String, Object> normalizeKeys(
       final Map<String, Object> map, final JavaType targetType) {
     final var result = new LinkedHashMap<String, Object>(map.size());

--- a/zeebe/exporter-config-support/src/test/java/io/camunda/zeebe/exporter/support/ExporterConfigMergeSupportTest.java
+++ b/zeebe/exporter-config-support/src/test/java/io/camunda/zeebe/exporter/support/ExporterConfigMergeSupportTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class ExporterConfigMergeSupportTest {
+
+  @Test
+  void shouldCollapseRelaxedPropertyKeySpellingsBeforeMerging() {
+    // given — root and tenant spell the same property differently
+    final Map<String, Object> rootArgs = Map.of("index-prefix", "root");
+    final Map<String, Object> tenantArgs = Map.of("indexPrefix", "tenant");
+
+    // when
+    final var merged = ExporterConfigMergeSupport.merge(SampleConfig.class, rootArgs, tenantArgs);
+
+    // then — both collapse to the canonical key, tenant wins
+    assertThat(merged).containsOnly(Map.entry("indexprefix", "tenant"));
+  }
+
+  @Test
+  void shouldRecurseIntoNestedPojoProperties() {
+    // given — a nested POJO property partially overridden by the tenant
+    final Map<String, Object> rootArgs =
+        Map.of("nested", Map.of("size", 1000, "delay", 5), "url", "http://root:9200");
+    final Map<String, Object> tenantArgs = Map.of("nested", Map.of("delay", 9));
+
+    // when
+    final var merged = ExporterConfigMergeSupport.merge(SampleConfig.class, rootArgs, tenantArgs);
+
+    // then — the untouched nested sibling and the untouched top-level property survive
+    assertThat(merged)
+        .containsEntry("url", "http://root:9200")
+        .containsEntry("nested", Map.of("size", 1000, "delay", 9));
+  }
+
+  @Test
+  void shouldReplaceMapTypedPropertiesWholesale() {
+    // given — a Map-typed property whose keys are user data
+    final Map<String, Object> rootArgs =
+        Map.of("userData", Map.of("Root-Key", "a", "shared", "root"));
+    final Map<String, Object> tenantArgs = Map.of("userData", Map.of("Tenant-Key", "b"));
+
+    // when
+    final var merged = ExporterConfigMergeSupport.merge(SampleConfig.class, rootArgs, tenantArgs);
+
+    // then — no per-key merge inside the user-data map, and its keys are not normalized
+    assertThat(merged).containsEntry("userdata", Map.of("Tenant-Key", "b"));
+  }
+
+  @Test
+  void shouldPreserveMapTypedPropertyKeysWhenNormalizing() {
+    // given — only the root sets the user-data map
+    final Map<String, Object> rootArgs =
+        Map.of("user-data", Map.of("Kebab-Cased-User-Key", "kept"));
+
+    // when
+    final var merged = ExporterConfigMergeSupport.merge(SampleConfig.class, rootArgs, Map.of());
+
+    // then — the property key normalizes, the user-data keys inside do not
+    assertThat(merged).containsEntry("userdata", Map.of("Kebab-Cased-User-Key", "kept"));
+  }
+
+  @Test
+  void shouldReplaceScalarsAndLists() {
+    // given
+    final Map<String, Object> rootArgs = Map.of("url", "http://root:9200", "hosts", List.of("a"));
+    final Map<String, Object> tenantArgs =
+        Map.of("url", "http://tenant:9200", "hosts", List.of("b", "c"));
+
+    // when
+    final var merged = ExporterConfigMergeSupport.merge(SampleConfig.class, rootArgs, tenantArgs);
+
+    // then — lists are not concatenated, scalars are not kept
+    assertThat(merged)
+        .containsEntry("url", "http://tenant:9200")
+        .containsEntry("hosts", List.of("b", "c"));
+  }
+
+  @Test
+  void shouldReplaceUnknownKeysWithoutRecursion() {
+    // given — keys that match no property of the config class (cannot be introspected)
+    final Map<String, Object> rootArgs = Map.of("unknown", Map.of("a", 1, "b", 2));
+    final Map<String, Object> tenantArgs = Map.of("unknown", Map.of("b", 99));
+
+    // when
+    final var merged = ExporterConfigMergeSupport.merge(SampleConfig.class, rootArgs, tenantArgs);
+
+    // then — replaced wholesale, no guessing about a model we cannot see
+    assertThat(merged).containsEntry("unknown", Map.of("b", 99));
+  }
+
+  @Test
+  void shouldKeepRootEntriesTheTenantDoesNotTouch() {
+    // given
+    final Map<String, Object> rootArgs = Map.of("url", "http://root:9200", "indexPrefix", "root");
+    final Map<String, Object> tenantArgs = Map.of("indexPrefix", "tenant");
+
+    // when
+    final var merged = ExporterConfigMergeSupport.merge(SampleConfig.class, rootArgs, tenantArgs);
+
+    // then
+    assertThat(merged)
+        .containsOnly(Map.entry("url", "http://root:9200"), Map.entry("indexprefix", "tenant"));
+  }
+
+  @Test
+  void shouldNotMutateItsInputs() {
+    // given
+    final Map<String, Object> rootArgs = new LinkedHashMap<>(Map.of("nested", nested(1, 5)));
+    final Map<String, Object> tenantArgs = new LinkedHashMap<>(Map.of("nested", Map.of("size", 2)));
+
+    // when
+    ExporterConfigMergeSupport.merge(SampleConfig.class, rootArgs, tenantArgs);
+
+    // then
+    assertThat(rootArgs).containsEntry("nested", nested(1, 5));
+    assertThat(tenantArgs).containsEntry("nested", Map.of("size", 2));
+  }
+
+  private static Map<String, Object> nested(final int size, final int delay) {
+    return Map.of("size", size, "delay", delay);
+  }
+
+  /** Minimal stand-in for an exporter configuration class. */
+  @SuppressWarnings("unused")
+  public static final class SampleConfig {
+    public String url;
+    public String indexPrefix;
+    public List<String> hosts;
+    public NestedConfig nested = new NestedConfig();
+    public Map<String, String> userData;
+
+    public static final class NestedConfig {
+      public int size;
+      public int delay;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -32,6 +32,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-config-support</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-exporter-common</artifactId>
     </dependency>
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/CamundaExporterConfigMerger.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/CamundaExporterConfigMerger.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.config;
+
+import io.camunda.exporter.CamundaExporter;
+import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
+import io.camunda.zeebe.exporter.support.ExporterConfigMergeSupport;
+import java.util.Map;
+
+/**
+ * Enables per-physical-tenant partial overrides of an <em>explicitly declared</em> CamundaExporter
+ * catalog entry's {@code args} — the multi-region duplication setup, where a second CamundaExporter
+ * is declared under {@code data.exporters} (ADR-0008 §3). The <em>autoconfigured</em> {@code
+ * camundaexporter} entry never goes through a merger: its configuration is derived from the
+ * tenant's (already per-tenant-resolved) secondary-storage properties. Registered via {@code
+ * META-INF/services}, discovered with {@link java.util.ServiceLoader} at configuration-resolution
+ * time.
+ */
+public final class CamundaExporterConfigMerger implements ExporterConfigMerger {
+
+  @Override
+  public boolean supports(final String className) {
+    return CamundaExporter.class.getName().equals(className);
+  }
+
+  @Override
+  public Map<String, Object> merge(
+      final Map<String, Object> rootArgs, final Map<String, Object> tenantArgs) {
+    return ExporterConfigMergeSupport.merge(ExporterConfiguration.class, rootArgs, tenantArgs);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/CamundaExporterConfigMerger.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/CamundaExporterConfigMerger.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.CamundaExporter;
 import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
 import io.camunda.zeebe.exporter.support.ExporterConfigMergeSupport;
 import java.util.Map;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Enables per-physical-tenant partial overrides of an <em>explicitly declared</em> CamundaExporter
@@ -21,6 +22,7 @@ import java.util.Map;
  * META-INF/services}, discovered with {@link java.util.ServiceLoader} at configuration-resolution
  * time.
  */
+@NullMarked
 public final class CamundaExporterConfigMerger implements ExporterConfigMerger {
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/resources/META-INF/services/io.camunda.zeebe.exporter.api.ExporterConfigMerger
+++ b/zeebe/exporters/camunda-exporter/src/main/resources/META-INF/services/io.camunda.zeebe.exporter.api.ExporterConfigMerger
@@ -1,0 +1,1 @@
+io.camunda.exporter.config.CamundaExporterConfigMerger

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/CamundaExporterConfigMergerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/CamundaExporterConfigMergerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.CamundaExporter;
+import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
+import java.util.Map;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+
+final class CamundaExporterConfigMergerTest {
+
+  private final CamundaExporterConfigMerger merger = new CamundaExporterConfigMerger();
+
+  @Test
+  void shouldSupportExactlyTheCamundaExporterClass() {
+    assertThat(merger.supports(CamundaExporter.class.getName())).isTrue();
+    assertThat(merger.supports("io.camunda.zeebe.exporter.ElasticsearchExporter")).isFalse();
+    assertThat(merger.supports("com.acme.CustomExporter")).isFalse();
+  }
+
+  @Test
+  void shouldMergeTenantArgsOverRootArgsTypeAware() {
+    // given — an explicitly declared (multi-region duplication) CamundaExporter entry: the root
+    // sets the connection and bulk tuning, the tenant redirects only the target
+    final Map<String, Object> rootArgs =
+        Map.of(
+            "connect", Map.of("url", "http://region-b:9200", "indexPrefix", "root"),
+            "bulk", Map.of("size", 500));
+    final Map<String, Object> tenantArgs = Map.of("connect", Map.of("index-prefix", "tenant-a"));
+
+    // when
+    final Map<String, Object> merged = merger.merge(rootArgs, tenantArgs);
+
+    // then — nested POJO merge: the untouched url and bulk tuning survive, the prefix moves,
+    // and the differently spelled property keys collapse to one canonical key
+    assertThat(merged)
+        .containsEntry("connect", Map.of("url", "http://region-b:9200", "indexprefix", "tenant-a"))
+        .containsEntry("bulk", Map.of("size", 500));
+  }
+
+  @Test
+  void shouldBeDiscoverableViaServiceLoader() {
+    assertThat(ServiceLoader.load(ExporterConfigMerger.class))
+        .anySatisfy(m -> assertThat(m).isInstanceOf(CamundaExporterConfigMerger.class));
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -23,6 +23,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-config-support</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-exporter-filter</artifactId>
     </dependency>
 

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -27,6 +27,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-exporter-filter</artifactId>
     </dependency>

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigMerger.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigMerger.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
+import io.camunda.zeebe.exporter.support.ExporterConfigMergeSupport;
+import java.util.Map;
+
+/**
+ * Enables per-physical-tenant partial overrides of a root-declared Elasticsearch exporter's {@code
+ * args} (ADR-0008 §3): registered via {@code META-INF/services}, discovered with {@link
+ * java.util.ServiceLoader} at configuration-resolution time.
+ */
+public final class ElasticsearchExporterConfigMerger implements ExporterConfigMerger {
+
+  @Override
+  public boolean supports(final String className) {
+    return ElasticsearchExporter.class.getName().equals(className);
+  }
+
+  @Override
+  public Map<String, Object> merge(
+      final Map<String, Object> rootArgs, final Map<String, Object> tenantArgs) {
+    return ExporterConfigMergeSupport.merge(
+        ElasticsearchExporterConfiguration.class, rootArgs, tenantArgs);
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigMerger.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigMerger.java
@@ -10,12 +10,14 @@ package io.camunda.zeebe.exporter;
 import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
 import io.camunda.zeebe.exporter.support.ExporterConfigMergeSupport;
 import java.util.Map;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Enables per-physical-tenant partial overrides of a root-declared Elasticsearch exporter's {@code
  * args} (ADR-0008 §3): registered via {@code META-INF/services}, discovered with {@link
  * java.util.ServiceLoader} at configuration-resolution time.
  */
+@NullMarked
 public final class ElasticsearchExporterConfigMerger implements ExporterConfigMerger {
 
   @Override

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/META-INF/services/io.camunda.zeebe.exporter.api.ExporterConfigMerger
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/META-INF/services/io.camunda.zeebe.exporter.api.ExporterConfigMerger
@@ -1,0 +1,1 @@
+io.camunda.zeebe.exporter.ElasticsearchExporterConfigMerger

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigMergerTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfigMergerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
+import java.util.Map;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+
+final class ElasticsearchExporterConfigMergerTest {
+
+  private final ElasticsearchExporterConfigMerger merger = new ElasticsearchExporterConfigMerger();
+
+  @Test
+  void shouldSupportExactlyTheElasticsearchExporterClass() {
+    assertThat(merger.supports(ElasticsearchExporter.class.getName())).isTrue();
+    assertThat(merger.supports("io.camunda.zeebe.exporter.opensearch.OpensearchExporter"))
+        .isFalse();
+    assertThat(merger.supports("com.acme.CustomExporter")).isFalse();
+  }
+
+  @Test
+  void shouldMergeTenantArgsOverRootArgsTypeAware() {
+    // given — root sets url, bulk tuning and an index prefix; the tenant overrides only the prefix
+    // (spelled differently), the headline use case of per-tenant exporter config
+    final Map<String, Object> rootArgs =
+        Map.of(
+            "url", "http://root-es:9200",
+            "bulk", Map.of("size", 1000, "delay", 5),
+            "index", Map.of("prefix", "root"));
+    final Map<String, Object> tenantArgs = Map.of("index", Map.of("PREFIX", "tenant-a"));
+
+    // when
+    final Map<String, Object> merged = merger.merge(rootArgs, tenantArgs);
+
+    // then — the target moves, everything else is inherited
+    assertThat(merged)
+        .containsEntry("url", "http://root-es:9200")
+        .containsEntry("bulk", Map.of("size", 1000, "delay", 5))
+        .containsEntry("index", Map.of("prefix", "tenant-a"));
+
+    // and the merged args bind into the real config class with the merged values
+    final var config =
+        io.camunda.zeebe.broker.exporter.context.ExporterConfiguration.fromArgs(
+            ElasticsearchExporterConfiguration.class, merged);
+    assertThat(config.url).isEqualTo("http://root-es:9200");
+    assertThat(config.index.prefix).isEqualTo("tenant-a");
+    assertThat(config.bulk.size).isEqualTo(1000);
+  }
+
+  @Test
+  void shouldBeDiscoverableViaServiceLoader() {
+    assertThat(ServiceLoader.load(ExporterConfigMerger.class))
+        .anySatisfy(m -> assertThat(m).isInstanceOf(ElasticsearchExporterConfigMerger.class));
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -23,6 +23,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-config-support</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-exporter-filter</artifactId>
     </dependency>
 

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -27,6 +27,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-exporter-filter</artifactId>
     </dependency>

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfigMerger.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfigMerger.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
+import io.camunda.zeebe.exporter.support.ExporterConfigMergeSupport;
+import java.util.Map;
+
+/**
+ * Enables per-physical-tenant partial overrides of a root-declared OpenSearch exporter's {@code
+ * args} (ADR-0008 §3): registered via {@code META-INF/services}, discovered with {@link
+ * java.util.ServiceLoader} at configuration-resolution time.
+ */
+public final class OpensearchExporterConfigMerger implements ExporterConfigMerger {
+
+  @Override
+  public boolean supports(final String className) {
+    return OpensearchExporter.class.getName().equals(className);
+  }
+
+  @Override
+  public Map<String, Object> merge(
+      final Map<String, Object> rootArgs, final Map<String, Object> tenantArgs) {
+    return ExporterConfigMergeSupport.merge(
+        OpensearchExporterConfiguration.class, rootArgs, tenantArgs);
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfigMerger.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfigMerger.java
@@ -10,12 +10,14 @@ package io.camunda.zeebe.exporter.opensearch;
 import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
 import io.camunda.zeebe.exporter.support.ExporterConfigMergeSupport;
 import java.util.Map;
+import org.jspecify.annotations.NullMarked;
 
 /**
  * Enables per-physical-tenant partial overrides of a root-declared OpenSearch exporter's {@code
  * args} (ADR-0008 §3): registered via {@code META-INF/services}, discovered with {@link
  * java.util.ServiceLoader} at configuration-resolution time.
  */
+@NullMarked
 public final class OpensearchExporterConfigMerger implements ExporterConfigMerger {
 
   @Override

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/META-INF/services/io.camunda.zeebe.exporter.api.ExporterConfigMerger
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/META-INF/services/io.camunda.zeebe.exporter.api.ExporterConfigMerger
@@ -1,0 +1,1 @@
+io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfigMerger

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfigMergerTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfigMergerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.api.ExporterConfigMerger;
+import java.util.Map;
+import java.util.ServiceLoader;
+import org.junit.jupiter.api.Test;
+
+final class OpensearchExporterConfigMergerTest {
+
+  private final OpensearchExporterConfigMerger merger = new OpensearchExporterConfigMerger();
+
+  @Test
+  void shouldSupportExactlyTheOpensearchExporterClass() {
+    assertThat(merger.supports(OpensearchExporter.class.getName())).isTrue();
+    assertThat(merger.supports("io.camunda.zeebe.exporter.ElasticsearchExporter")).isFalse();
+    assertThat(merger.supports("com.acme.CustomExporter")).isFalse();
+  }
+
+  @Test
+  void shouldMergeTenantArgsOverRootArgsTypeAware() {
+    // given — root sets url, bulk tuning and an index prefix; the tenant overrides only the prefix
+    final Map<String, Object> rootArgs =
+        Map.of(
+            "url", "http://root-os:9200",
+            "bulk", Map.of("size", 1000, "delay", 5),
+            "index", Map.of("prefix", "root"));
+    final Map<String, Object> tenantArgs = Map.of("index", Map.of("PREFIX", "tenant-a"));
+
+    // when
+    final Map<String, Object> merged = merger.merge(rootArgs, tenantArgs);
+
+    // then — the target moves, everything else is inherited
+    assertThat(merged)
+        .containsEntry("url", "http://root-os:9200")
+        .containsEntry("bulk", Map.of("size", 1000, "delay", 5))
+        .containsEntry("index", Map.of("prefix", "tenant-a"));
+
+    // and the merged args bind into the real config class with the merged values
+    final var config =
+        io.camunda.zeebe.broker.exporter.context.ExporterConfiguration.fromArgs(
+            OpensearchExporterConfiguration.class, merged);
+    assertThat(config.url).isEqualTo("http://root-os:9200");
+    assertThat(config.index.prefix).isEqualTo("tenant-a");
+    assertThat(config.bulk.size).isEqualTo(1000);
+  }
+
+  @Test
+  void shouldBeDiscoverableViaServiceLoader() {
+    assertThat(ServiceLoader.load(ExporterConfigMerger.class))
+        .anySatisfy(m -> assertThat(m).isInstanceOf(OpensearchExporterConfigMerger.class));
+  }
+}

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -38,6 +38,7 @@
     <module>gateway-rest</module>
     <module>exporter-api</module>
     <module>exporter-common</module>
+    <module>exporter-config-support</module>
     <module>exporter-filter</module>
     <module>exporter-test</module>
     <module>protocol-asserts</module>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -112,6 +112,14 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Needed for PhysicalTenantExporterConfigIT: references ElasticsearchExporter.class to
+         exercise the ExporterConfigMerger deep-merge path with a real bundled exporter -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-elasticsearch-exporter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Needed on the classpath for runtime classloading in AnalyticsExporterIT -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/physicaltenant/PhysicalTenantExporterConfigIT.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.it.physicaltenant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
@@ -21,6 +23,14 @@ import io.camunda.zeebe.qa.util.cluster.PhysicalTenantsITHelper.Storage;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -31,16 +41,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 /**
  * Verifies that per-physical-tenant exporter configuration is applied at the exporter level.
  *
- * <p>Supported today: an exporter declared in the <b>root</b> configuration can be redeclared per
- * physical tenant under {@code camunda.physical-tenants.<tenantId>.data.exporters.<id>.*} with
- * different properties. The per-tenant declaration must be complete (class-name and all args):
- * partial overrides do not inherit the root entry's remaining fields (Spring's MapBinder replaces
- * the whole map entry; a merge strategy is discussed in a separate issue). Each tenant's partition
- * group then runs the exporter with that tenant's configuration.
+ * <p>Supported today: an exporter declared in the <b>root</b> configuration can be overridden per
+ * physical tenant under {@code camunda.physical-tenants.<tenantId>.data.exporters.<id>.*}. The root
+ * entry's {@code className}/{@code jarPath} are always inherited (diverging from them is a boot
+ * error). If the exporter's class ships an {@code ExporterConfigMerger} (the bundled ES/OS and
+ * Camunda exporters do), a partial override is deep-merged over the root args; for any other class
+ * the tenant's args replace the root args wholesale and must therefore be complete (ADR-0008 step
+ * 1). Each tenant's partition group then runs the exporter with that tenant's resolved
+ * configuration.
  *
  * <p>Not yet supported: declaring an exporter <b>only</b> for a physical tenant (absent from the
  * root config). The initial cluster configuration — which decides which exporter ids are enabled on
@@ -60,14 +73,35 @@ final class PhysicalTenantExporterConfigIT {
 
   private static final String TENANT_A_ONLY_EXPORTER_ID = "tenanta-exporter";
 
+  private static final String ES_MERGE_EXPORTER_ID = "esmerge";
+  private static final String ROOT_INDEX_PREFIX = "rootmergeprefix";
+  private static final String TENANT_A_INDEX_PREFIX = "tenantamergeprefix";
+
+  @SuppressWarnings("resource")
+  private static final ElasticsearchContainer ES =
+      TestSearchContainers.createDefaultElasticsearchContainer();
+
+  private static final String ES_URL;
+
+  static {
+    ES.start();
+    ES_URL = "http://" + ES.getHttpHostAddress();
+  }
+
+  private static final HttpClient HTTP = HttpClient.newHttpClient();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
   private static final PhysicalTenantsITHelper TENANTS =
       PhysicalTenantsITHelper.builder()
           .withTenant(PhysicalTenantsITHelper.DEFAULT_TENANT_ID, Storage.none())
           .withTenant(TENANT_A, Storage.none())
           .build();
 
-  // The exporter is declared in the ROOT config (so it is enabled on every partition group), and
-  // tenantA redeclares it fully with a different "target" arg. The tenantA-only exporter
+  // The exporters are declared in the ROOT config (so they are enabled on every partition group).
+  // tenantA redeclares the location exporter fully with a different "target" arg (the
+  // whole-entry-replace path for a class without a merger), and overrides ONLY the index prefix
+  // of the Elasticsearch exporter (the deep-merge path: its class ships an ExporterConfigMerger,
+  // so url and bulk tuning are inherited from the root entry). The tenantA-only exporter
   // exercises the not-yet-supported case and is used by the disabled test only.
   @TestZeebe
   private final TestStandaloneBroker broker =
@@ -79,6 +113,16 @@ final class PhysicalTenantExporterConfigIT {
                 cfg.setClassName(LocationRecordingExporter.class.getName());
                 cfg.setArgs(Map.of(TARGET_ARG, ROOT_TARGET));
               })
+          .withExporter(
+              ES_MERGE_EXPORTER_ID,
+              cfg -> {
+                cfg.setClassName(ElasticsearchExporter.class.getName());
+                cfg.setArgs(
+                    Map.of(
+                        "url", ES_URL,
+                        "bulk", Map.of("size", 1, "delay", 1),
+                        "index", Map.of("prefix", ROOT_INDEX_PREFIX)));
+              })
           .withPtConfig(
               TENANT_A,
               camunda -> {
@@ -86,6 +130,11 @@ final class PhysicalTenantExporterConfigIT {
                 exporter.setClassName(LocationRecordingExporter.class.getName());
                 exporter.setArgs(Map.of(TARGET_ARG, TENANT_A_TARGET));
                 camunda.getData().getExporters().put(LOCATION_EXPORTER_ID, exporter);
+
+                // partial override: no className, no url, no bulk tuning — only the index prefix
+                final var esOverride = new io.camunda.configuration.Exporter();
+                esOverride.setArgs(Map.of("index", Map.of("prefix", TENANT_A_INDEX_PREFIX)));
+                camunda.getData().getExporters().put(ES_MERGE_EXPORTER_ID, esOverride);
 
                 final var tenantOnlyExporter = new io.camunda.configuration.Exporter();
                 tenantOnlyExporter.setClassName(TenantAExporter.class.getName());
@@ -161,6 +210,52 @@ final class PhysicalTenantExporterConfigIT {
     await("tenant-only exporter is opened and receives records from tenantA's partition")
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(() -> assertThat(TenantAExporter.RECORDS).isNotEmpty());
+  }
+
+  /**
+   * Asserts the ADR-0008 merge path end-to-end with the real ServiceLoader discovery on a real
+   * broker classpath: the root declares an Elasticsearch exporter (url, bulk tuning, index prefix),
+   * and tenantA overrides <b>only</b> {@code args.index.prefix}. Because the exporter's class ships
+   * an {@code ExporterConfigMerger}, tenantA's partition group must run the exporter with the
+   * root's url and bulk tuning but its own index prefix — records of both tenants land in the same
+   * cluster under their respective prefixes, and neither tenant's records leak into the other's
+   * indices.
+   */
+  @Test
+  void shouldDeepMergePartialExporterArgsOverride() throws Exception {
+    // given — records flow through both tenants' partition groups
+    deployAndCreateInstance(defaultClient, "default-merge-process");
+    deployAndCreateInstance(tenantAClient, "tenanta-merge-process");
+
+    // then — the default partition group exports under the root prefix, and tenantA's partition
+    // group exports under its overridden prefix to the root-configured url
+    await("both tenants' records are exported under their own index prefix")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              assertThat(countDocuments(ROOT_INDEX_PREFIX, "default-merge-process")).isPositive();
+              assertThat(countDocuments(TENANT_A_INDEX_PREFIX, "tenanta-merge-process"))
+                  .isPositive();
+            });
+
+    // and neither tenant's records were exported under the other tenant's prefix
+    assertThat(countDocuments(ROOT_INDEX_PREFIX, "tenanta-merge-process")).isZero();
+    assertThat(countDocuments(TENANT_A_INDEX_PREFIX, "default-merge-process")).isZero();
+  }
+
+  /** Counts documents matching the process id across all indices under the given prefix. */
+  private static long countDocuments(final String indexPrefix, final String processId)
+      throws IOException, InterruptedException {
+    // the zeebe ES exporter indexes raw records: the process id sits under value.bpmnProcessId
+    final var query =
+        URLEncoder.encode("value.bpmnProcessId:\"" + processId + "\"", StandardCharsets.UTF_8);
+    final var request =
+        HttpRequest.newBuilder(URI.create(ES_URL + "/" + indexPrefix + "*/_count?q=" + query))
+            .GET()
+            .build();
+    final var response = HTTP.send(request, BodyHandlers.ofString());
+    assertThat(response.statusCode()).isEqualTo(200);
+    return MAPPER.readTree(response.body()).path("count").asLong();
   }
 
   private static void deployAndCreateInstance(final CamundaClient client, final String processId) {


### PR DESCRIPTION
## Description

Implements the **merge** half of the per-physical-tenant exporter overlay from ADR-0008 (#57337) — decisions D3, D4, D5, and D6 step 1. It closes the headline use case of #55155: a tenant can inherit a root-declared Elasticsearch, OpenSearch, or Camunda exporter and override a single arg (e.g. `index.prefix`) instead of restating the whole entry, without imposing an unsafe generic merge on exporters whose configuration model we do not own.

**Combination semantics (step 1 — inherit-all still in effect, no `exporters-assigned` yet).** For an exporter id a tenant declares that is also present in the root catalog: `className`/`jarPath` are always inherited from the root entry (diverging from them is a boot error; restating the same value is allowed); if the exporter's class ships an `ExporterConfigMerger`, the tenant's partial args are deep-merged over the root args (tenant wins per key); for any other class the tenant's args replace the root args wholesale and must therefore be complete. Tenant-private ids and the autoconfigured `camundaexporter`/`rdbms` entries pass through untouched. This replaces today's silent construction of a fresh entry with `className: null`.

## Changes (by commit)

- `refactor:` extract the broker's type-aware exporter-args key normalization out of `ExporterConfiguration` into a new internal module `zeebe-exporter-config-support`; the broker now delegates to it, making it the single owner of the normalization semantics (zero behavior change). Adds the new module's `.codeowners` entry.
- `feat:` add the `ExporterConfigMerger` SPI to `zeebe-exporter-api` (dependency-free, revapi-guarded), the type-aware deep-merge helper in the support module, and `ServiceLoader`-registered mergers for the Elasticsearch, OpenSearch, and Camunda exporters.
- `feat:` add the `PhysicalTenantExporterConfigurations` resolver step in `configuration/`, running right after the map overlays in `PhysicalTenantResolver.of()`: it inherits the root `className`/`jarPath`, deep-merges args via a discovered merger (handing the merger immutable copies of the args maps), or replaces wholesale when no merger claims the class, and fails fast on class divergence or on two mergers claiming the same class.
- `test:` extend `PhysicalTenantExporterConfigIT` end-to-end (real `ServiceLoader` discovery on a real broker classpath): a root-declared Elasticsearch exporter with a tenant overriding only `index.prefix` runs with the root's url and bulk settings merged in, with no cross-tenant index leakage.
- `refactor:` annotate the new SPI and merger classes with jspecify `@NullMarked` (the helper is intentionally left unmarked — it walks `Map<String, Object>` args whose values may legitimately be null).

## Out of scope

Step 2 of ADR-0008 — the `exporters-assigned` manifest (mandatory-explicit validation plus narrowing unassigned catalog entries out of a tenant's resolved map) — is deliberately not in this PR. It is tracked in #57591 and gated on #56652: narrowing before per-tenant exporter enable state exists in dynamic cluster config would leave a narrowed-away-but-still-enabled id instantiated as a `BlockingExporter`, stalling exporting and log compaction. This PR changes only entry contents, never which exporter ids exist for a tenant.

## Testing

- `configuration/` resolver tests cover the decision-table rows against a test-only merger registered via `src/test/resources/META-INF/services` (`configuration/` does not depend on the ES/OS modules).
- The support module unit-tests the type-aware merge: `Map`-field key preservation, relaxed-key collapse, nested-POJO recursion, and list/scalar replace.
- The ES, OS, and Camunda modules test their mergers against their real config classes.
- End-to-end merge scenario in `PhysicalTenantExporterConfigIT`.

No backport (feature work).

## Related issues

Closes #57590
relates to #55155
ADR-0008: #57337
