### PR TITLE
ci: backport the preview-env internal auth bypass to stable/8.9

### DIFF
--- a/.ci/preview-environments/charts/c8sm/templates/httproute.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/httproute.yml
@@ -13,11 +13,12 @@
 # because the backend service names, ports and context paths are derived from
 # the camunda-platform subchart templates.
 #
-# Known gap: the `global.preview.ingress.internalAuthBypass.enabled` source-IP
-# Vouch bypass (non-default) has no faithful Traefik Gateway API equivalent —
-# Traefik's ipAllowList rejects non-listed IPs rather than letting them skip
-# auth — and is therefore intentionally not translated here; revisit if a
-# consumer enables it.
+# Internal auth bypass: when `global.preview.ingress.internalAuthBypass.enabled`
+# is true (non-default; CI/testing only), a Traefik IngressRoute
+# (templates/internal-bypass-ingressroute.yml) lets requests from the internal
+# source ranges skip Vouch entirely — the nginx-era `satisfy: any` +
+# `whitelist-source-range` semantics, which Gateway API cannot express (no
+# source-IP match; Traefik's ipAllowList rejects instead of falling through).
 ---
 {{- $camundaPlatform := deepCopy (index .Subcharts "camunda-platform") -}}
 {{- $_ := set .Values "camundaPlatform" (deepCopy (index .Values "camunda-platform")) -}}

--- a/.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml
@@ -1,0 +1,59 @@
+# Internal auth bypass for CI/testing: requests from the internal source ranges
+# (Teleport tunnel / in-cluster network) skip Vouch/Okta entirely — nginx-era
+# `satisfy: any` + `whitelist-source-range` semantics. Source-IP matching is the
+# only selector that also covers browser-internal requests (service-worker
+# script fetches and service-worker-issued requests), which cannot carry
+# client-injected headers; Management Identity depends on its service worker to
+# remap its root-path /static and /api references under /identity, where its
+# path-scoped IDENTITY_JWT cookie applies.
+#
+# A Traefik IngressRoute rather than a Gateway API HTTPRoute because Gateway API
+# has no source-IP match and Traefik's ipAllowList middleware rejects
+# non-matching requests instead of falling through to the next rule.
+#
+# External traffic (public source IPs) never matches and is served by the
+# Vouch-protected HTTPRoute (templates/httproute.yml).
+{{- $iab := .Values.global.preview.ingress.internalAuthBypass | default dict -}}
+{{- if $iab.enabled }}
+{{- $camundaPlatform := deepCopy (index .Subcharts "camunda-platform") -}}
+{{- $_ := set .Values "camundaPlatform" (deepCopy (index .Values "camunda-platform")) -}}
+{{- $gateway := required "infra-preview-environments-gateway-api values block must be set" (index .Values "infra-preview-environments-gateway-api") -}}
+{{- $tlsSecret := required "infra-preview-environments-gateway-api.gateway.tls.secretName must be set" $gateway.gateway.tls.secretName -}}
+{{- $sourceRanges := required "internalAuthBypass.sourceRange must be set when the bypass is enabled" $iab.sourceRange -}}
+{{- $clientIP := printf "ClientIP(`%s`)" (join "`, `" $sourceRanges) -}}
+{{- $host := include "ingress.domain" $ -}}
+{{- $backends := list
+    (dict "path" .Values.camundaPlatform.console.contextPath "name" (include "console.fullname" $camundaPlatform) "port" .Values.camundaPlatform.console.service.port)
+    (dict "path" .Values.camundaPlatform.orchestration.contextPath "name" (printf "%s-gateway" (include "orchestration.fullname" $camundaPlatform)) "port" .Values.camundaPlatform.orchestration.service.httpPort)
+    (dict "path" (include "identity.keycloak.contextPath" $camundaPlatform) "name" (include "identity.keycloak.service" $camundaPlatform) "port" (include "identity.keycloak.port" $camundaPlatform | int))
+    (dict "path" .Values.camundaPlatform.identity.contextPath "name" (include "identity.fullname" $camundaPlatform) "port" .Values.camundaPlatform.identity.service.port)
+    (dict "path" .Values.camundaPlatform.optimize.contextPath "name" (include "optimize.fullname" $camundaPlatform) "port" .Values.camundaPlatform.optimize.service.port)
+    (dict "path" .Values.camundaPlatform.webModeler.contextPath "name" (include "webModeler.restapi.fullname" $camundaPlatform) "port" .Values.camundaPlatform.webModeler.restapi.service.port)
+    (dict "path" (include "webModeler.websocketContextPath" $camundaPlatform) "name" (include "webModeler.websockets.fullname" $camundaPlatform) "port" .Values.camundaPlatform.webModeler.websockets.service.port)
+    (dict "path" .Values.camundaPlatform.connectors.contextPath "name" (include "connectors.fullname" $camundaPlatform) "port" .Values.camundaPlatform.connectors.service.serverPort)
+}}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "camundaPlatform.fullname" $camundaPlatform }}-internal-bypass
+  labels: {{ include "commonLabels" $ | nindent 4 }}
+  annotations: {{ include "commonAnnotations" $ | nindent 4 }}
+spec:
+  entryPoints:
+  # The internal Traefik entrypoint terminating TLS for preview domains.
+  - websecure
+  tls:
+    secretName: {{ $tlsSecret }}
+  routes:
+  {{- range $b := $backends }}
+  - kind: Rule
+    # Outrank the Gateway API routers (Traefik computes their priorities from
+    # match specificity; an explicit high value wins deterministically).
+    priority: 42000000
+    match: Host(`{{ $host }}`) && {{ $clientIP }} && PathPrefix(`{{ $b.path }}`)
+    services:
+    - name: {{ $b.name }}
+      port: {{ $b.port }}
+  {{- end }}
+{{- end }}

--- a/.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml
+++ b/.ci/preview-environments/charts/c8sm/templates/internal-bypass-ingressroute.yml
@@ -19,7 +19,7 @@
 {{- $_ := set .Values "camundaPlatform" (deepCopy (index .Values "camunda-platform")) -}}
 {{- $gateway := required "infra-preview-environments-gateway-api values block must be set" (index .Values "infra-preview-environments-gateway-api") -}}
 {{- $tlsSecret := required "infra-preview-environments-gateway-api.gateway.tls.secretName must be set" $gateway.gateway.tls.secretName -}}
-{{- $sourceRanges := required "internalAuthBypass.sourceRange must be set when the bypass is enabled" $iab.sourceRange -}}
+{{- $sourceRanges := required "global.preview.ingress.internalAuthBypass.sourceRange must be set when internalAuthBypass.enabled is true" $iab.sourceRange -}}
 {{- $clientIP := printf "ClientIP(`%s`)" (join "`, `" $sourceRanges) -}}
 {{- $host := include "ingress.domain" $ -}}
 {{- $backends := list

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -32,13 +32,23 @@ global:
     ingress:
       # The domain name under which to expose the preview environment
       domain: camunda.camunda.cloud
-      # WARNING: When enabled, this bypasses Vouch/Okta authentication for all
-      # requests originating from the 10.0.0.0/8 internal IP range, granting
-      # unauthenticated access to any client within that network. This is
-      # intended only for tightly controlled CI/testing scenarios (for example,
-      # CI access via a Teleport TCP tunnel).
+      # WARNING: When enabled, requests from the `sourceRange` networks (the
+      # in-cluster / Teleport tunnel network) bypass Vouch/Okta authentication
+      # ENTIRELY via a high-priority Traefik IngressRoute
+      # (templates/internal-bypass-ingressroute.yml) — the nginx-era
+      # `satisfy: any` + `whitelist-source-range` semantics. This deliberately
+      # covers browser-internal requests (service-worker script fetches and
+      # service-worker-issued requests) that a header-based bypass can never
+      # reach, which Management Identity depends on. External traffic never
+      # matches and keeps the Vouch flow. Intended only for tightly controlled
+      # CI/testing scenarios (for example, CI access via a Teleport TCP tunnel).
       internalAuthBypass:
         enabled: false
+        # Source ranges permitted to skip Vouch. This is where security is
+        # enforced: nothing a client sends (headers, cookies) grants access —
+        # only the network it connects from.
+        sourceRange:
+        - 10.0.0.0/8
     secrets:
       name: camunda-credentials
 


### PR DESCRIPTION
## Description

Backport of #57030 (INC-6469) to the 8.9 preview-env chart: a high-priority Traefik `IngressRoute` matching `ClientIP(10.0.0.0/8)` lets requests from the internal network (CI via the Teleport tunnel) skip Vouch/Okta — the nginx-era `satisfy: any` + `whitelist-source-range` semantics that Gateway API cannot express (no source-IP match; Traefik's `ipAllowList` rejects instead of falling through). External traffic never matches and keeps the Vouch flow. Off by default; the nightly smoke-test workflow on `main` already passes `internalAuthBypass.enabled=true` to the 8.9 deploy.

Differences from the `main` version: none functionally — the 8.9 chart's Keycloak is the in-namespace Bitnami service (not the shared-ns operator), which the existing `identity.keycloak.service` helper already resolves, so the same template works verbatim (ExternalName-specific comments dropped).

Validated locally: `helm template` with the bypass enabled renders all 8 backend routes (console, orchestration-gateway, keycloak, identity, optimize, web-modeler restapi + websockets, connectors) against a well-formed doc set (78 docs, all with apiVersion/kind); disabled render emits nothing.

## Related issues

- INC-6469 / camunda/team-infrastructure#1107
- Backport of #57030

🤖 Generated with [Claude Code](https://claude.com/claude-code)