### PR TITLE
build: disable AWS OS slack notification

### DIFF
--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -203,7 +203,12 @@ jobs:
     name: "Send slack notification on fail"
     runs-on: ubuntu-latest
     needs: integration-tests
-    if: (failure() || cancelled()) && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
+
+    # TODO: Re-enable this once the pipeline is in a healthy and meaningful state
+    # currently tracked in https://github.com/camunda/camunda/issues/52892
+    # if: (failure() || cancelled()) && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/'))
+    if: ${{ false }}
+
     permissions:
       contents: read
       actions: write


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Temporarily disables the Slack failure notification job for the AWS OS pipeline while the pipeline is in an unhealthy state, to avoid noise from expected failures.
The job condition is commented out and replaced with if: false so it can be re-enabled easily once the pipeline is stable again.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
