### PR TITLE
ci: allow overriding the 8.8/8.9 refs in the preview-env smoke test

### DIFF
--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -42,6 +42,24 @@ on:
         required: false
         type: boolean
         default: false
+      ref-8-8:
+        description: |
+          Git ref to build and deploy the 8.8 preview from (default:
+          stable/8.8). Lets stable-branch chart changes be smoke-tested
+          pre-merge from their PR branch. The reusable deploy workflow itself
+          still runs from stable/8.8 (static `uses:` ref).
+        required: false
+        type: string
+        default: ''
+      ref-8-9:
+        description: |
+          Git ref to build and deploy the 8.9 preview from (default:
+          stable/8.9). Lets stable-branch chart changes be smoke-tested
+          pre-merge from their PR branch. The reusable deploy workflow itself
+          still runs from stable/8.9 (static `uses:` ref).
+        required: false
+        type: string
+        default: ''
 
 env:
   TEST_OWNER: '@camunda/monorepo-devops-team'
@@ -55,7 +73,7 @@ jobs:
     secrets: inherit
     with:
       app-name: smoke88-${{ github.run_number }}
-      ref: stable/8.8
+      ref: ${{ inputs.ref-8-8 || 'stable/8.8' }}
       labels: |
         preview=smoke-test
         repo=camunda_camunda
@@ -70,7 +88,7 @@ jobs:
     secrets: inherit
     with:
       app-name: smoke89-${{ github.run_number }}
-      ref: stable/8.9
+      ref: ${{ inputs.ref-8-9 || 'stable/8.9' }}
       labels: |
         preview=smoke-test
         repo=camunda_camunda
@@ -293,7 +311,7 @@ jobs:
     secrets: inherit
     with:
       app-name: smoke88-${{ github.run_number }}
-      ref: stable/8.8
+      ref: ${{ inputs.ref-8-8 || 'stable/8.8' }}
 
   teardown-8-9:
     name: Teardown 8.9 Preview Environment
@@ -309,7 +327,7 @@ jobs:
     secrets: inherit
     with:
       app-name: smoke89-${{ github.run_number }}
-      ref: stable/8.9
+      ref: ${{ inputs.ref-8-9 || 'stable/8.9' }}
 
   teardown-8-10:
     name: Teardown 8.10 Preview Environment

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -66,9 +66,34 @@ env:
   E2E_DIR: e2e-tests
 
 jobs:
+  # Gate for the free-form ref-8-8/ref-8-9 dispatch inputs: they are forwarded
+  # as `ref` into the reusable deploy/teardown workflows, where they end up in
+  # shell-built ArgoCD arguments (--revision, --helm-set), so restrict them to
+  # git-ref characters before anything consumes them. Always runs (trivially
+  # green on scheduled runs, where inputs are empty) so the deploy jobs'
+  # implicit success() dependency doesn't skip the default path.
+  validate-ref-inputs:
+    name: Validate ref override inputs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Validate refs
+        env:
+          REF_8_8: ${{ inputs.ref-8-8 }}
+          REF_8_9: ${{ inputs.ref-8-9 }}
+        run: |
+          for ref in "$REF_8_8" "$REF_8_9"; do
+            if [[ -n "$ref" && ! "$ref" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+              echo "::error::Invalid ref override (allowed: A-Z a-z 0-9 . _ / -): ${ref}"
+              exit 1
+            fi
+          done
+          echo "✅ ref overrides valid (or empty)"
+
   deploy-8-8:
     name: Deploy 8.8 Preview Environment
     if: contains(fromJSON('["all", "8.8", ""]'), inputs.version)
+    needs: validate-ref-inputs
     uses: camunda/camunda/.github/workflows/preview-env-build-and-deploy.yml@stable/8.8
     secrets: inherit
     with:
@@ -84,6 +109,7 @@ jobs:
   deploy-8-9:
     name: Deploy 8.9 Preview Environment
     if: contains(fromJSON('["all", "8.9", ""]'), inputs.version)
+    needs: validate-ref-inputs
     uses: camunda/camunda/.github/workflows/preview-env-build-and-deploy.yml@stable/8.9
     secrets: inherit
     with:

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -44,22 +44,22 @@ on:
         default: false
       ref-8-8:
         description: |
-          Git ref to build and deploy the 8.8 preview from (default:
-          stable/8.8). Lets stable-branch chart changes be smoke-tested
-          pre-merge from their PR branch. The reusable deploy workflow itself
-          still runs from stable/8.8 (static `uses:` ref).
+          Git ref to build and deploy the 8.8 preview from. Lets stable-branch
+          chart changes be smoke-tested pre-merge from their PR branch. The
+          reusable deploy workflow itself still runs from stable/8.8 (static
+          `uses:` ref).
         required: false
         type: string
-        default: ''
+        default: 'stable/8.8'
       ref-8-9:
         description: |
-          Git ref to build and deploy the 8.9 preview from (default:
-          stable/8.9). Lets stable-branch chart changes be smoke-tested
-          pre-merge from their PR branch. The reusable deploy workflow itself
-          still runs from stable/8.9 (static `uses:` ref).
+          Git ref to build and deploy the 8.9 preview from. Lets stable-branch
+          chart changes be smoke-tested pre-merge from their PR branch. The
+          reusable deploy workflow itself still runs from stable/8.9 (static
+          `uses:` ref).
         required: false
         type: string
-        default: ''
+        default: 'stable/8.9'
 
 env:
   TEST_OWNER: '@camunda/monorepo-devops-team'
@@ -98,6 +98,10 @@ jobs:
     secrets: inherit
     with:
       app-name: smoke88-${{ github.run_number }}
+      # The || fallback stays despite the input default: input defaults only
+      # apply to workflow_dispatch — on scheduled runs the inputs context is
+      # empty, and an empty ref would make the cross-branch reusable workflow
+      # fall back to the caller's SHA (main). Same for every ref below.
       ref: ${{ inputs.ref-8-8 || 'stable/8.8' }}
       labels: |
         preview=smoke-test

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -76,6 +76,8 @@ jobs:
     name: Validate ref override inputs
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - name: Validate refs
         env:
@@ -89,6 +91,20 @@ jobs:
             fi
           done
           echo "✅ ref overrides valid (or empty)"
+      - name: Checkout
+        if: always()
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: .github
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   deploy-8-8:
     name: Deploy 8.8 Preview Environment


### PR DESCRIPTION
## Description

Optional `ref-8-8` / `ref-8-9` `workflow_dispatch` inputs (default: the stable branches) so stable-branch chart changes can be smoke-tested **pre-merge** from their PR branch. The reusable deploy/teardown workflow versions stay pinned to the stable branches (`uses:` refs must be static in GitHub Actions); only the git ref that gets built, deployed, and set as the ArgoCD target revision is overridden. Scheduled runs are unaffected (empty inputs fall back to `stable/8.8`/`stable/8.9`).

Proven in anger before this PR was opened: the backport PRs #57353 (stable/8.9) and #57354 (stable/8.8) were validated by dispatching this workflow from this branch with the refs pointed at the backport branches — both runs green end-to-end (deploy → smoke tests → teardown):
- 8.9: https://github.com/camunda/camunda/actions/runs/29082951619
- 8.8: https://github.com/camunda/camunda/actions/runs/29082949649

Same spirit as the existing `existing-host` / `fast-feedback` iteration shortcuts.

## Related issues

- INC-6469 / camunda/team-infrastructure#1107 (enabled the pre-merge validation of #57353 / #57354)

🤖 Generated with [Claude Code](https://claude.com/claude-code)