### PR TITLE
test: backport DMN incident decision-navigation e2e test to stable/8.9 (#51618)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstance.spec.ts
@@ -426,4 +426,71 @@ test.describe('Process Instance Incident', () => {
       ).toBeVisible();
     });
   });
+
+  test('Navigate to called decision instance from DMN incident', async ({
+    operateProcessInstancePage,
+    operateDecisionInstancePage,
+    operateHomePage,
+    operateProcessesPage,
+  }) => {
+    test.slow();
+
+    await test.step('Navigate to Processes tab and open the process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateProcessesPage.filterByProcessName('Process-Incident');
+      await operateProcessesPage.clickProcessInstanceLink();
+    });
+
+    await test.step('Verify process diagram is visible and incidents tab is present', async () => {
+      await expect(operateProcessInstancePage.diagram).toBeVisible();
+      await expect(operateProcessInstancePage.diagramSpinner).toBeHidden({
+        timeout: 30000,
+      });
+      await expect(operateProcessInstancePage.incidentsTab).toBeVisible();
+    });
+
+    await test.step('Open incidents tab', async () => {
+      await operateProcessInstancePage.clickIncidentsTab();
+      await expect(operateProcessInstancePage.incidentsTab).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+    });
+
+    await test.step('Click on the Business Rule Task in the diagram that triggered the decision', async () => {
+      await operateProcessInstancePage.clickOnElementInDiagram('Task_Decision');
+    });
+
+    await test.step('Verify the incident tab displays the failed downstream decision', async () => {
+      await expect(
+        operateProcessInstancePage.getSelectedIncidentRow(
+          /Decision evaluation error\./i,
+        ),
+      ).toBeVisible();
+    });
+
+    await test.step('Verify the incident includes a link whose label contains the decision name and instance ID', async () => {
+      const incidentRow = operateProcessInstancePage.getSelectedIncidentRow(
+        /Decision evaluation error\./i,
+      );
+      const decisionLink = incidentRow.getByRole('link', {
+        name: /Decision C \(Root Cause\)/i,
+      });
+      await expect(decisionLink).toBeVisible();
+      await expect(decisionLink).toHaveAccessibleName(
+        /Decision C \(Root Cause\).*?\d+/i,
+      );
+    });
+
+    await test.step('Click the link to navigate to the decision that caused the incident', async () => {
+      await operateProcessInstancePage.navigateToFailingElementForIncident(
+        /Decision evaluation error\./i,
+        'Decision C (Root Cause)',
+      );
+    });
+
+    await test.step('Verify navigation to the decision instance page', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
## Description

Backports the e2e test added in #51618 ("Navigate to the called decision instance in case of an incident") to `stable/8.9`.

On 8.9 the incident tests live in `tests/operate/processInstance.spec.ts` (the rename to `processInstanceIncidents.spec.ts` from a later change was not applied on this branch), so the test is appended to the existing `Process Instance Incident` describe block there.

## Notes
- All page-object methods (`clickIncidentsTab`, `clickOnElementInDiagram`, `getSelectedIncidentRow`, `navigateToFailingElementForIncident`, `decisionPanel`) and the BPMN/DMN resources (`Task_Decision`, `Decision C (Root Cause)`) already exist on 8.9 — verbatim backport, no page-object changes.
- `tsc` + `eslint` clean.

## Validation
Ran locally via `playwright test --ui` against a `camunda/camunda:8.9-SNAPSHOT` + Elasticsearch cluster — test **passed** (JUnit `failures=0`, ~12.9s).

## Related
- Original PR: #51618
- Issue: https://github.com/camunda/camunda/issues/42659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Link to the test run ](https://github.com/camunda/camunda/actions/runs/29086363523)