### PR TITLE
test: backport DMN incident decision-navigation e2e test to stable/8.8 (#51618)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
@@ -439,4 +439,60 @@ test.describe('Process Instance Incident', () => {
       await expect(operateProcessInstancePage.diagram).toBeVisible();
     });
   });
+
+  test('Navigate to called decision instance from DMN incident', async ({
+    operateProcessInstancePage,
+    operateDecisionInstancePage,
+    operateHomePage,
+    operateProcessesPage,
+  }) => {
+    test.slow();
+
+    await test.step('Navigate to Processes tab and open the process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateProcessesPage.filterByProcessName('Process-Incident');
+      await operateProcessesPage.clickProcessInstanceLink();
+    });
+
+    await test.step('Verify process diagram is visible and the incident banner is present', async () => {
+      await expect(operateProcessInstancePage.diagram).toBeVisible();
+      await expect(operateProcessInstancePage.diagramSpinner).toBeHidden({
+        timeout: 30000,
+      });
+      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
+    });
+
+    await test.step('Click on the Business Rule Task in the diagram that triggered the decision', async () => {
+      await operateProcessInstancePage.clickOnElementInDiagram('Task_Decision');
+      await expect(operateProcessInstancePage.metadataPopover).toBeVisible();
+    });
+
+    await test.step('Verify the incident popover shows the decision evaluation error', async () => {
+      await expect(
+        operateProcessInstancePage.metadataPopover.getByText(
+          /Decision evaluation error\./i,
+        ),
+      ).toBeVisible();
+    });
+
+    const decisionLink = operateProcessInstancePage.metadataPopover.getByRole(
+      'link',
+      {name: /Decision C \(Root Cause\)/i},
+    );
+
+    await test.step('Verify the popover includes a root cause decision link with the decision name and instance ID', async () => {
+      await expect(decisionLink).toBeVisible();
+      await expect(decisionLink).toHaveAccessibleName(
+        /Decision C \(Root Cause\).*?\d+/i,
+      );
+    });
+
+    await test.step('Click the link to navigate to the decision that caused the incident', async () => {
+      await decisionLink.click();
+    });
+
+    await test.step('Verify navigation to the decision instance page', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
## Description

Backports the e2e test from #51618 ("Navigate to the called decision instance in case of an incident") to `stable/8.8`, **rewritten against the older Operate incidents UI**.

On 8.8 the incidents UI uses the **metadata-popover** model rather than the incidents-tab model used on 8.9/8.10, so the test:
- opens the incident via the diagram element popover (`clickOnElementInDiagram` + `metadataPopover`) instead of an incidents tab with `aria-current`, and
- follows the **"Root Cause Decision Instance"** link rendered in the popover (`aria-label="View root cause decision <name> - <id>"`, navigating to the decision instance) instead of a link in a selected incidents-table row.

The `rootCauseDecision` feature is confirmed to exist in the 8.8 Operate client (`MetadataPopover/Incident/index.tsx`).

## Notes
- No new page-object methods were needed; all locators (`metadataPopover`, `incidentsBanner`, `clickOnElementInDiagram`, `decisionPanel`) already exist. BPMN/DMN resources (`Task_Decision`, `Decision C (Root Cause)`) are present.
- `tsc` + `eslint` clean.

## Validation
Ran locally via `playwright test --ui` against a `camunda/camunda:8.8-SNAPSHOT` + Elasticsearch cluster — test **passed**.

## Related
- Original PR: #51618
- Issue: https://github.com/camunda/camunda/issues/42659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Link to the test run ](https://github.com/camunda/camunda/actions/runs/29086406496)