### PR TITLE
test: backport DMN incident decision-navigation e2e test to stable/8.7 (#51618)

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstanceIncidents.spec.ts
@@ -464,4 +464,60 @@ test.describe('Process Instance Incident', () => {
       await expect(operateProcessInstancePage.diagram).toBeVisible();
     });
   });
+
+  test('Navigate to called decision instance from DMN incident', async ({
+    operateProcessInstancePage,
+    operateDecisionInstancePage,
+    operateHomePage,
+    operateProcessesPage,
+  }) => {
+    test.slow();
+
+    await test.step('Navigate to Processes tab and open the process instance', async () => {
+      await operateHomePage.clickProcessesTab();
+      await operateProcessesPage.filterByProcessName('Process-Incident');
+      await operateProcessesPage.clickProcessInstanceLink();
+    });
+
+    await test.step('Verify process diagram is visible and the incident banner is present', async () => {
+      await expect(operateProcessInstancePage.diagram).toBeVisible();
+      await expect(operateProcessInstancePage.diagramSpinner).toBeHidden({
+        timeout: 30000,
+      });
+      await expect(operateProcessInstancePage.incidentsBanner).toBeVisible();
+    });
+
+    await test.step('Click on the Business Rule Task in the diagram that triggered the decision', async () => {
+      await operateProcessInstancePage.clickOnElementInDiagram('Task_Decision');
+      await expect(operateProcessInstancePage.metadataPopover).toBeVisible();
+    });
+
+    await test.step('Verify the incident popover shows the decision evaluation error', async () => {
+      await expect(
+        operateProcessInstancePage.metadataPopover.getByText(
+          /Decision evaluation error/i,
+        ),
+      ).toBeVisible();
+    });
+
+    const decisionLink = operateProcessInstancePage.metadataPopover.getByRole(
+      'link',
+      {name: /Decision C \(Root Cause\)/i},
+    );
+
+    await test.step('Verify the popover includes a root cause decision link with the decision name and instance ID', async () => {
+      await expect(decisionLink).toBeVisible();
+      await expect(decisionLink).toHaveAccessibleName(
+        /Decision C \(Root Cause\).*?\d+/i,
+      );
+    });
+
+    await test.step('Click the link to navigate to the decision that caused the incident', async () => {
+      await decisionLink.click();
+    });
+
+    await test.step('Verify navigation to the decision instance page', async () => {
+      await expect(operateDecisionInstancePage.decisionPanel).toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
## Description

Backports the e2e test from #51618 ("Navigate to the called decision instance in case of an incident") to `stable/8.7`, **rewritten against the older Operate incidents UI** (metadata-popover model).

Like the 8.8 backport, the test opens the incident via the diagram element popover (`clickOnElementInDiagram` + `metadataPopover`) and follows the **"Root Cause Decision Instance"** link rendered in the popover (`aria-label="View root cause decision <name> - <id>"`, navigating to the decision instance). The decision-evaluation-error assertion uses a lenient substring match because 8.7 renders incident error text without trailing periods (e.g. "I/O mapping error", "Extract value error").

The `rootCauseDecision` feature is confirmed to exist in the 8.7 Operate client (`MetadataPopover/Incident/index.tsx`).

## Notes
- No new page-object methods were needed. The required setup (second `beforeAll` deploying `process_to_test_incidents.bpmn` + `decision_to_test-incident.dmn`) and locators (`metadataPopover`, `incidentsBanner`, `clickOnElementInDiagram`, `decisionPanel`) already exist on 8.7.
- `tsc` + `eslint` clean.

## Validation
Ran locally via `playwright test --ui` against the 8.7 split-architecture cluster (`operate:8.7-SNAPSHOT` + `zeebe:8.7-SNAPSHOT` + Elasticsearch) — test **passed**.

## Related
- Original PR: #51618
- Issue: https://github.com/camunda/camunda/issues/42659

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[Link to the test run ](https://github.com/camunda/camunda/actions/runs/29086447731)