### PR TITLE
test: do not wait recovery when starting in replay mode

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -394,7 +394,8 @@ public final class EngineRule extends ExternalResource {
                     }
                   }),
               cfg -> cfg.streamProcessorMode(mode),
-              awaitOpening,
+              // when in replay mode, onRecovered callback is never called
+              awaitOpening && mode != StreamProcessorMode.REPLAY,
               securityConfig);
         });
     interPartitionCommandSenders.forEach(s -> s.initializeWriters(partitionCount));


### PR DESCRIPTION
## Description
ContinuousReplayTest was taking at least 15 seconds to execute

Discovered in PR #52869 from the verifying junit test report: it's the test with just one test case taking so much time. 
<img width="2046" height="309" alt="image" src="https://github.com/user-attachments/assets/4048d076-32e6-4574-b84b-424709d0e449" />


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
