### PR TITLE
ci: fire Notify on Failure when smoke test jobs are cancelled

### DIFF
--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -374,9 +374,9 @@ jobs:
               .jobs
               | map(select(.conclusion == "failure" or .conclusion == "cancelled"))
               | map(
-                  (.name | capture("(?<v>8\\.[0-9]+)").v) as $ver |
+                  (try (.name | capture("(?<v>8\\.[0-9]+)").v) // .name) as $ver |
                   (if .name | test("Deploy") then "deploy" elif .name | test("Test") then "tests" else "job" end) as $type |
-                  "• *\($ver)* <\(.html_url)|\($type) \(if .conclusion == "cancelled" then "timed out" else "failed" end)>"
+                  "• *\($ver)* <\(.html_url)|\($type) \(if .conclusion == "cancelled" then "cancelled" else "failed" end)>"
                 )
               | join("\n")
             '

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -333,10 +333,10 @@ jobs:
       always() &&
       github.event_name == 'schedule' &&
       (
-        needs.deploy-8-8.result == 'failure' ||
-        needs.deploy-8-9.result == 'failure' ||
-        needs.deploy-8-10.result == 'failure' ||
-        needs.test.result == 'failure'
+        contains(fromJSON('["failure", "cancelled"]'), needs.deploy-8-8.result) ||
+        contains(fromJSON('["failure", "cancelled"]'), needs.deploy-8-9.result) ||
+        contains(fromJSON('["failure", "cancelled"]'), needs.deploy-8-10.result) ||
+        contains(fromJSON('["failure", "cancelled"]'), needs.test.result)
       )
     needs:
     - deploy-8-8
@@ -372,11 +372,11 @@ jobs:
             echo "jobs<<EOF"
             gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" --jq '
               .jobs
-              | map(select(.conclusion == "failure"))
+              | map(select(.conclusion == "failure" or .conclusion == "cancelled"))
               | map(
                   (.name | capture("(?<v>8\\.[0-9]+)").v) as $ver |
                   (if .name | test("Deploy") then "deploy" elif .name | test("Test") then "tests" else "job" end) as $type |
-                  "• *\($ver)* <\(.html_url)|\($type) failed>"
+                  "• *\($ver)* <\(.html_url)|\($type) \(if .conclusion == "cancelled" then "timed out" else "failed" end)>"
                 )
               | join("\n")
             '


### PR DESCRIPTION
## Summary

- The `notify-failure` job was silently skipped when smoke test jobs are cancelled, because a GHA job timeout sets conclusion to `cancelled`, not `failure` — and the `if:` condition only checked `== 'failure'`
- Changed the condition to use `contains(fromJSON('["failure", "cancelled"]'), ...)` for all four dependency results (three deploy jobs + test)
- Fixed the `get-failed-jobs` jq filter to also surface cancelled jobs in the Slack message, labelling them as "cancelled" instead of "failed"

Reproducer: https://github.com/camunda/camunda/actions/runs/26742194924 — three smoke test jobs `cancelled`, no Slack alert fired.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

related to [#inc-6469](https://camunda.slack.com/archives/C0BFP947W2D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)