### PR TITLE
ci: Add CPT to Core Features project

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -44,6 +44,7 @@ jobs:
             || github.event.label.name == 'component/document-handling'
             || github.event.label.name == 'component/webapp'
             || github.event.label.name == 'component/mcp'
+            || github.event.label.name == 'component/camunda-process-test'
         name: Add to Core Features project
         uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
@@ -54,7 +55,7 @@ jobs:
             component/tasklist, component/optimize, component/c8-api,
             component/engine, component/camunda, component/backend, component/frontend,
             component/batch-operation, component/document-handling,
-            component/webapp, component/mcp
+            component/webapp, component/mcp, component/camunda-process-test
 
       # Distributed Systems / ZDP (#92)
       # component/zeebe routes here as a fallback when neither zeebe-engine nor zeebe-platform is set
@@ -196,7 +197,6 @@ jobs:
           github.event.action != 'labeled'
             || github.event.label.name == 'component/clients'
             || github.event.label.name == 'component/spring-boot-starter'
-            || github.event.label.name == 'component/camunda-process-test'
             || github.event.label.name == 'component/c8-api'
         name: Add to CamundaEx Team project
         uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
@@ -205,7 +205,7 @@ jobs:
           github-token: ${{ steps.github-token.outputs.token }}
           labeled: >
             component/clients, component/spring-boot-starter,
-            component/camunda-process-test, component/c8-api
+            component/c8-api
 
       # QA Issue Board (#162)
       - id: add-to-qa


### PR DESCRIPTION
## Description

Add issues with `component/camunda-process-test` to the Core Features project.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Related [Slack discussion](https://camunda.slack.com/archives/C0BFLTVHRTL/p1783583990655679)
