### PR TITLE
fix: isolate index prefix and refresh scope per test across exporter ITs

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -9,7 +9,6 @@ package io.camunda.exporter;
 
 import static io.camunda.exporter.config.ConnectionTypes.ELASTICSEARCH;
 import static io.camunda.exporter.utils.CamundaExporterSchemaUtils.createSchemas;
-import static io.camunda.search.test.utils.SearchDBExtension.CUSTOM_PREFIX;
 import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -69,8 +68,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -83,7 +81,6 @@ import org.testcontainers.containers.GenericContainer;
  * This is a smoke test to verify that the exporter can connect to an Elasticsearch instance and
  * export records using the configured handlers.
  */
-@TestInstance(Lifecycle.PER_CLASS)
 final class CamundaExporterIT {
 
   @RegisterExtension private static SearchDBExtension searchDB = SearchDBExtension.create();
@@ -94,20 +91,29 @@ final class CamundaExporterIT {
 
   private final ProtocolFactory factory = new ProtocolFactory();
 
+  private String testPrefix;
+
+  @BeforeEach
+  public void beforeEach() {
+    testPrefix = RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
+  }
+
   @AfterEach
   public void afterEach() throws IOException {
     final var openSearchAwsInstanceUrl =
         Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL)).orElse("");
     if (openSearchAwsInstanceUrl.isEmpty()) {
-      searchDB.esClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+      searchDB.esClient().indices().delete(req -> req.index(testPrefix + "*"));
     }
-    searchDB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+    searchDB.osClient().indices().delete(req -> req.index(testPrefix + "*"));
   }
 
   @TestTemplate
   void shouldOpenDifferentPartitions(
       final ExporterConfiguration config, final SearchClientAdapter ignored) throws IOException {
     // given
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
     final var p1Exporter = new CamundaExporter();
     final var p1Context = getContextFromConfig(config, 1);
@@ -145,6 +151,8 @@ final class CamundaExporterIT {
   void shouldUpdateExporterPositionAfterFlushing(
       final ExporterConfiguration config, final SearchClientAdapter ignored) throws IOException {
     // given
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
     final var exporter = new CamundaExporter();
 
@@ -168,6 +176,8 @@ final class CamundaExporterIT {
   void shouldExportRecordOnceBulkSizeReached(
       final ExporterConfiguration config, final SearchClientAdapter ignored) throws IOException {
     // given
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
     config.getBulk().setSize(2);
     final var exporter = new CamundaExporter();
@@ -200,6 +210,8 @@ final class CamundaExporterIT {
       final GenericContainer<?> container) throws IOException {
     // given
     final var config = getConnectConfigForContainer(container);
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
     final var exporter = new CamundaExporter();
 
@@ -238,6 +250,8 @@ final class CamundaExporterIT {
   void shouldPeriodicallyFlushBasedOnConfiguration(
       final ExporterConfiguration config, final SearchClientAdapter ignored) throws IOException {
     // given
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
     final var duration = 2;
     config.getBulk().setDelay(duration);
@@ -263,6 +277,8 @@ final class CamundaExporterIT {
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws IOException {
     // given
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
     final var valueType = ValueType.VARIABLE;
     final Record record =
@@ -326,6 +342,8 @@ final class CamundaExporterIT {
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws IOException {
     // given
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
     final ValueType valueType = ValueType.INCIDENT;
     final long notExistingOperationReference = 9876543210L;
@@ -362,6 +380,8 @@ final class CamundaExporterIT {
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws IOException {
     // given
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
     final ValueType valueType = ValueType.INCIDENT;
     final long invalidTimestamp = 8109027450636607488L;
@@ -399,6 +419,10 @@ final class CamundaExporterIT {
   void shouldFailToOpenWhenSchemaMissingThenOpenAfterSchemaCreationAndExport(
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws IOException {
+    // given
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
+
     // Do not create schema yet
     final var exporter = spy(new CamundaExporter());
     final var context = getContextFromConfig(config);
@@ -517,6 +541,8 @@ final class CamundaExporterIT {
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws IOException {
     // given
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
     final var exporter = new CamundaExporter();
 
@@ -561,7 +587,7 @@ final class CamundaExporterIT {
       varDocumentIds.add(varHandler.generateIds(variableRecord).getFirst());
     }
 
-    clientAdapter.refresh();
+    clientAdapter.refresh(testPrefix);
 
     // then
     await()
@@ -589,6 +615,8 @@ final class CamundaExporterIT {
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws IOException {
     // given
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
     createSchemas(config);
     final Record record =
         factory.generateRecord(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterBulkConsistencyIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterBulkConsistencyIT.java
@@ -8,7 +8,6 @@
 package io.camunda.exporter;
 
 import static io.camunda.exporter.utils.CamundaExporterSchemaUtils.createSchemas;
-import static io.camunda.search.test.utils.SearchDBExtension.CUSTOM_PREFIX;
 import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -62,9 +61,9 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -72,7 +71,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * Verifies that the final indexed state produced by the CamundaExporter is identical regardless of
  * the bulk flush size.
  */
-@TestInstance(Lifecycle.PER_CLASS)
 final class ExporterBulkConsistencyIT {
 
   private static final int INSTANCE_COUNT = 20;
@@ -92,14 +90,21 @@ final class ExporterBulkConsistencyIT {
 
   private final ProtocolFactory factory = new ProtocolFactory();
 
+  private String testPrefix;
+
+  @BeforeEach
+  void beforeEach() {
+    testPrefix = RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase();
+  }
+
   @AfterEach
   void afterEach() throws IOException {
     final var openSearchAwsInstanceUrl =
         Optional.ofNullable(System.getProperty(TEST_INTEGRATION_OPENSEARCH_AWS_URL)).orElse("");
     if (openSearchAwsInstanceUrl.isEmpty()) {
-      SEARCH_DB.esClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+      SEARCH_DB.esClient().indices().delete(req -> req.index(testPrefix + "*"));
     }
-    SEARCH_DB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+    SEARCH_DB.osClient().indices().delete(req -> req.index(testPrefix + "*"));
   }
 
   /**
@@ -135,9 +140,10 @@ final class ExporterBulkConsistencyIT {
 
     // when — export at bulk size 500 (exceeds total record count, so always a single flush)
     final var referenceConfig = configWithBulkSize(baseConfig, 500, "ref");
+    referenceConfig.getIndex().setNumberOfReplicas(0);
     createSchemas(referenceConfig);
     runExporter(allRecords, referenceConfig);
-    clientAdapter.refresh();
+    clientAdapter.refresh(testPrefix);
     final var referenceSnapshot =
         captureSnapshot(
             clientAdapter,
@@ -223,9 +229,12 @@ final class ExporterBulkConsistencyIT {
 
     // then — each test bulk size must produce documents identical to the reference;
     // indices are created once and reused across all test bulk sizes
-    createSchemas(configWithBulkSize(baseConfig, 500, "work"));
+    final var newConfig = configWithBulkSize(baseConfig, 500, "work");
+    newConfig.getIndex().setNumberOfReplicas(0);
+    createSchemas(newConfig);
     for (final int bulkSize : testBulkSizes) {
       final var config = configWithBulkSize(baseConfig, bulkSize, "work");
+      config.getIndex().setNumberOfReplicas(0);
       clientAdapter.deleteAllDocuments(config.getConnect().getIndexPrefix());
       clientAdapter.refresh(); // make deletions visible before the next exporter opens
       runExporter(allRecords, config);
@@ -353,6 +362,7 @@ final class ExporterBulkConsistencyIT {
 
     // when — reference run (bulk 500)
     final var referenceConfig = configWithBulkSize(baseConfig, 500, "ref-del");
+    referenceConfig.getIndex().setNumberOfReplicas(0);
     createSchemas(referenceConfig);
     runExporter(phase1Records, referenceConfig);
     runExporter(phase2Records, referenceConfig);
@@ -367,9 +377,12 @@ final class ExporterBulkConsistencyIT {
         .isEmpty();
 
     // then — identical result at every test bulk size
-    createSchemas(configWithBulkSize(baseConfig, 500, "work-del"));
+    final var newConfig = configWithBulkSize(baseConfig, 500, "work-del");
+    newConfig.getIndex().setNumberOfReplicas(0);
+    createSchemas(newConfig);
     for (final int bulkSize : testBulkSizes) {
       final var config = configWithBulkSize(baseConfig, bulkSize, "work-del");
+      config.getIndex().setNumberOfReplicas(0);
       clientAdapter.deleteAllDocuments(config.getConnect().getIndexPrefix());
       clientAdapter.refresh();
       runExporter(phase1Records, config);
@@ -798,7 +811,7 @@ final class ExporterBulkConsistencyIT {
     config.getConnect().setInterceptorPlugins(base.getConnect().getInterceptorPlugins());
     config.getConnect().setAwsEnabled(base.getConnect().isAwsEnabled());
     config.getConnect().setProxy(base.getConnect().getProxy());
-    config.getConnect().setIndexPrefix(CUSTOM_PREFIX + "-" + suffix);
+    config.getConnect().setIndexPrefix(testPrefix + "-" + suffix);
     config.getBulk().setSize(bulkSize);
     // Suppress IncidentUpdateTask for the duration of this test. The task runs in a background
     // thread and modifies incident/flow-node fields after ES auto-refreshes documents. This test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AbstractProcessInstanceArchiverJobIT.java
@@ -76,7 +76,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
 
           store(listViewTemplate, client, processInstance);
 
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -112,7 +112,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
             store(listViewTemplate, client, processInstance);
           }
 
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -147,7 +147,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           store(listViewTemplate, client, finishedInstance);
           store(listViewTemplate, client, unfinishedInstance);
 
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -179,7 +179,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           store(listViewTemplate, client, finishedInstance);
           store(listViewTemplate, client, notOldEnoughInstance);
 
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -217,7 +217,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
             store(listViewTemplate, client, processInstance, child);
           }
 
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -259,7 +259,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
             store(listViewTemplate, client, processInstance, child);
           }
 
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -313,7 +313,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
             store(listViewTemplate, client, unfinishedInstance, child);
           }
 
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -369,7 +369,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
             }
           }
 
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -417,7 +417,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
             }
           }
 
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -455,7 +455,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
               store(dependent.template(), client, entity);
             }
           }
-          client.refresh();
+          client.refresh(testPrefix);
 
           // and - every dated destination index is pre-created with a write block, so the reindex
           // step cannot copy any document. Elasticsearch will report the rejected writes in
@@ -473,7 +473,7 @@ public abstract class AbstractProcessInstanceArchiverJobIT<T extends ProcessInst
           Awaitility.await("until the archive job has finished")
               .atMost(ARCHIVE_TIMEOUT)
               .until(result::isDone);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // then - nothing was copied to the write-blocked dated indices, so no source document may
           // have been deleted: the reindex failure must never lead to silent data loss

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/AuditLogArchiverJobIT.java
@@ -23,11 +23,8 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestTemplate;
 
-@TestInstance(Lifecycle.PER_CLASS)
 public class AuditLogArchiverJobIT extends ArchiverJobIT<AuditLogArchiverJob> {
   @Override
   AuditLogArchiverJob createArchiveJob(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobIT.java
@@ -20,11 +20,8 @@ import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity.BatchOperationState;
 import java.time.OffsetDateTime;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestTemplate;
 
-@TestInstance(Lifecycle.PER_CLASS)
 public class BatchOperationArchiverJobIT extends ArchiverJobIT<BatchOperationArchiverJob> {
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/JobBatchMetricsArchiverJobIT.java
@@ -15,11 +15,8 @@ import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.webapps.schema.descriptors.template.JobMetricsBatchTemplate;
 import io.camunda.webapps.schema.entities.jobmetricsbatch.JobMetricsBatchEntity;
 import java.time.OffsetDateTime;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestTemplate;
 
-@TestInstance(Lifecycle.PER_CLASS)
 public class JobBatchMetricsArchiverJobIT extends ArchiverJobIT<JobBatchMetricsArchiverJob> {
   @Override
   JobBatchMetricsArchiverJob createArchiveJob(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/StandaloneDecisionArchiverJobIT.java
@@ -20,11 +20,8 @@ import io.camunda.webapps.schema.entities.auditlog.AuditLogEntityType;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.dmn.DecisionInstanceState;
 import java.time.OffsetDateTime;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestTemplate;
 
-@TestInstance(Lifecycle.PER_CLASS)
 public class StandaloneDecisionArchiverJobIT extends ArchiverJobIT<StandaloneDecisionArchiverJob> {
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricArchiverJobIT.java
@@ -17,11 +17,8 @@ import io.camunda.webapps.schema.entities.metrics.UsageMetricsEntity;
 import io.camunda.webapps.schema.entities.metrics.UsageMetricsEventType;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestTemplate;
 
-@TestInstance(Lifecycle.PER_CLASS)
 public class UsageMetricArchiverJobIT extends ArchiverJobIT<UsageMetricArchiverJob> {
   @Override
   protected String getExpectedLifecyclePolicyName() {
@@ -53,7 +50,7 @@ public class UsageMetricArchiverJobIT extends ArchiverJobIT<UsageMetricArchiverJ
 
           final var metric = usageMetric("2020-01-15T10:00:00+00:00");
           store(usageMetricTemplate, client, metric);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -79,7 +76,7 @@ public class UsageMetricArchiverJobIT extends ArchiverJobIT<UsageMetricArchiverJ
 
           store(usageMetricTemplate, client, oldMetric);
           store(usageMetricTemplate, client, recentMetric);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -106,7 +103,7 @@ public class UsageMetricArchiverJobIT extends ArchiverJobIT<UsageMetricArchiverJ
 
           store(usageMetricTemplate, client, metric1);
           store(usageMetricTemplate, client, metric2);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -133,7 +130,7 @@ public class UsageMetricArchiverJobIT extends ArchiverJobIT<UsageMetricArchiverJ
 
           store(usageMetricTemplate, client, januaryMetric);
           store(usageMetricTemplate, client, marchMetric);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when - first execution archives the oldest batch
           final var firstBatch = job.execute();
@@ -144,7 +141,7 @@ public class UsageMetricArchiverJobIT extends ArchiverJobIT<UsageMetricArchiverJ
           verifyNotMoved(usageMetricTemplate, client, marchMetric);
 
           // when - second execution archives the next batch
-          client.refresh(); // refresh so we don't try to move the same batch
+          client.refresh(testPrefix); // refresh so we don't try to move the same batch
           final var secondBatch = job.execute();
 
           // then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/UsageMetricTUArchiverJobIT.java
@@ -16,11 +16,8 @@ import io.camunda.webapps.schema.descriptors.template.UsageMetricTUTemplate;
 import io.camunda.webapps.schema.entities.metrics.UsageMetricsTUEntity;
 import java.time.Duration;
 import java.time.OffsetDateTime;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestTemplate;
 
-@TestInstance(Lifecycle.PER_CLASS)
 public class UsageMetricTUArchiverJobIT extends ArchiverJobIT<UsageMetricTUArchiverJob> {
   @Override
   protected String getExpectedLifecyclePolicyName() {
@@ -52,7 +49,7 @@ public class UsageMetricTUArchiverJobIT extends ArchiverJobIT<UsageMetricTUArchi
 
           final var metric = usageMetricTU("2020-01-15T10:00:00+00:00");
           store(template, client, metric);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -78,7 +75,7 @@ public class UsageMetricTUArchiverJobIT extends ArchiverJobIT<UsageMetricTUArchi
 
           store(template, client, oldMetric);
           store(template, client, recentMetric);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -105,7 +102,7 @@ public class UsageMetricTUArchiverJobIT extends ArchiverJobIT<UsageMetricTUArchi
 
           store(template, client, metric1);
           store(template, client, metric2);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when
           final var archived = job.execute();
@@ -132,7 +129,7 @@ public class UsageMetricTUArchiverJobIT extends ArchiverJobIT<UsageMetricTUArchi
 
           store(template, client, januaryMetric);
           store(template, client, marchMetric);
-          client.refresh();
+          client.refresh(testPrefix);
 
           // when - first execution archives the oldest batch
           final var firstBatch = job.execute();
@@ -143,7 +140,7 @@ public class UsageMetricTUArchiverJobIT extends ArchiverJobIT<UsageMetricTUArchi
           verifyNotMoved(template, client, marchMetric);
 
           // when - second execution archives the next batch
-          client.refresh();
+          client.refresh(testPrefix);
           final var secondBatch = job.execute();
 
           // then


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Reduces inter-test interference on shared AWS OpenSearch clusters by
scoping index operations to a unique per-test prefix across multiple
integration test classes.

Changes:
- CamundaExporterIT and ExporterBulkConsistencyIT: replace the shared
  static CUSTOM_PREFIX with a randomly generated per-test prefix,
  applied to the exporter index config and used for targeted cleanup
  in @AfterEach
- AbstractProcessInstanceArchiverJobIT: replaces all cluster-wide
  client.refresh() calls with prefix-scoped equivalents
- AuditLogArchiverJobIT, BatchOperationArchiverJobIT,
  CamundaExporterIT, ExporterBulkConsistencyIT: removes
  @TestInstance(Lifecycle.PER_CLASS) for better test isolation

Last run:
https://github.com/camunda/camunda/actions/runs/29270229650/job/86886645699

NOTE: In this last run, the remaining failures after this changes are infrastructure-related (shard availability), meaning the test logic improved the degree of flakiness.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
