### PR TITLE
feat: introduce CurrentClusterConfiguration record with merge and phased change transitions

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -138,6 +138,13 @@ public record CurrentClusterConfiguration(
    * phasedChangeState} is merged by {@link PhasedChangeState#merge(PhasedChangeState)}.
    */
   public CurrentClusterConfiguration merge(final CurrentClusterConfiguration other) {
+    if (other.version() != version) {
+      throw new IllegalStateException(
+          String.format(
+              "Cannot merge cluster configurations with different versions: this=%d, other=%d",
+              version, other.version()));
+    }
+
     final var mergedGlobal = globalConfiguration.merge(other.globalConfiguration);
 
     final Map<String, PartitionGroupConfiguration> mergedGroups = new HashMap<>(partitionGroups);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -264,16 +264,30 @@ public record CurrentClusterConfiguration(
     return switch (plan.currentPhase()) {
       case final GlobalPhase globalPhase ->
           updateGlobalConfiguration(
-              global ->
-                  global.startConfigurationChange(
-                      List.<ClusterConfigurationChangeOperation>copyOf(globalPhase.operations())));
+              global -> {
+                if (global.hasPendingChanges()) {
+                  throw new IllegalStateException(
+                      "Cannot activate global phase: global configuration already has pending changes");
+                }
+                return global.startConfigurationChange(
+                    List.<ClusterConfigurationChangeOperation>copyOf(globalPhase.operations()));
+              });
       case final PartitionGroupParallelPhase parallelPhase -> {
         var result = this;
         for (final var entry : parallelPhase.groupOperations().entrySet()) {
+          final var groupId = entry.getKey();
           final var operations = List.<ClusterConfigurationChangeOperation>copyOf(entry.getValue());
           result =
               result.updatePartitionGroupConfig(
-                  entry.getKey(), group -> group.startConfigurationChange(operations));
+                  groupId,
+                  group -> {
+                    if (group.hasPendingChanges()) {
+                      throw new IllegalStateException(
+                          "Cannot activate partition-group phase for %s: group already has pending changes"
+                              .formatted(groupId));
+                    }
+                    return group.startConfigurationChange(operations);
+                  });
         }
         yield result;
       }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -186,6 +186,97 @@ public record CurrentClusterConfiguration(
         version, globalConfiguration, updatedGroups, phasedChangeState);
   }
 
+  /**
+   * Initializes a new phased change plan from {@code phases} and activates its first phase (phase
+   * 0) into the sub-configurations. The plan id is derived inside {@link PhasedChangeState} from
+   * the last completed change, so callers never supply an id (see Amendment 1 of the solution
+   * spec).
+   *
+   * <p>Consecutive phases must not target the same sub-configuration: activating a phase starts a
+   * configuration change on the affected sub-config, and a later phase targeting the same
+   * sub-config can only be activated once that change has been fully advanced (drained) — otherwise
+   * {@link #activateNextPhase()} throws because a change is still in progress.
+   *
+   * @throws IllegalArgumentException if {@code phases} is empty
+   * @throws IllegalStateException if a plan is already pending
+   */
+  public CurrentClusterConfiguration initPlan(final List<Phase> phases) {
+    if (phases.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Expected to init a plan with at least one phase, but the phase list is empty");
+    }
+    final var newState = phasedChangeState.initPlan(phases);
+    final var plan = newState.pending().orElseThrow();
+    return withPhasedChangeState(newState).applyPhase(plan);
+  }
+
+  /**
+   * Advances the pending plan to the next phase and activates that phase into the
+   * sub-configurations.
+   *
+   * <p>The next phase must not target a sub-configuration that still has the previous phase's
+   * change in progress (see {@link #initPlan(List)}); if it does, this throws because a
+   * configuration change is already in progress on that sub-config.
+   *
+   * @throws IllegalStateException if no plan is pending, or the plan is already on its last phase
+   */
+  public CurrentClusterConfiguration activateNextPhase() {
+    final var plan =
+        phasedChangeState
+            .pending()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Cannot activate the next phase when no plan is pending"));
+    if (!plan.hasNextPhase()) {
+      throw new IllegalStateException(
+          "Cannot activate the next phase: the plan is already on its last phase");
+    }
+    final var advanced = plan.withNextPhase();
+    final var newState =
+        new PhasedChangeState(Optional.of(advanced), phasedChangeState.lastChange());
+    return withPhasedChangeState(newState).applyPhase(advanced);
+  }
+
+  /**
+   * Completes the pending plan with the given terminal status, moving it into the last-completed
+   * change. Sub-configuration changes activated by the plan are left untouched.
+   *
+   * @throws IllegalStateException if no plan is pending
+   */
+  public CurrentClusterConfiguration completePlan(final PhasedChangePlanStatus status) {
+    return withPhasedChangeState(phasedChangeState.completePlan(status));
+  }
+
+  /**
+   * Activates the plan's current phase by copying its operations into the affected sub-config(s): a
+   * {@link GlobalPhase} starts a configuration change on {@link GlobalConfiguration} only; a {@link
+   * PartitionGroupParallelPhase} starts one on each named partition group only.
+   */
+  private CurrentClusterConfiguration applyPhase(final PhasedChangePlan plan) {
+    return switch (plan.currentPhase()) {
+      case final GlobalPhase globalPhase ->
+          updateGlobalConfiguration(
+              global ->
+                  global.startConfigurationChange(
+                      List.<ClusterConfigurationChangeOperation>copyOf(globalPhase.operations())));
+      case final PartitionGroupParallelPhase parallelPhase -> {
+        var result = this;
+        for (final var entry : parallelPhase.groupOperations().entrySet()) {
+          final var operations = List.<ClusterConfigurationChangeOperation>copyOf(entry.getValue());
+          result =
+              result.updatePartitionGroupConfig(
+                  entry.getKey(), group -> group.startConfigurationChange(operations));
+        }
+        yield result;
+      }
+    };
+  }
+
+  private CurrentClusterConfiguration withPhasedChangeState(final PhasedChangeState newState) {
+    return new CurrentClusterConfiguration(version, globalConfiguration, partitionGroups, newState);
+  }
+
   public boolean hasPartitionGroup(final String groupId) {
     return partitionGroups.containsKey(groupId);
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Top-level wrapper for the multi-partition-group cluster configuration model. Holds all cluster
+ * state: the cluster-wide {@link GlobalConfiguration} (broker lifecycle and cluster-level config),
+ * the per-group {@link PartitionGroupConfiguration}s keyed by group id, and the {@link
+ * PhasedChangeState} for operations that span both.
+ *
+ * <p>{@code version} is always {@link #INITIAL_VERSION} and is reserved for a potential future
+ * root-level merge fast path — it is <em>not</em> used in merge decisions today. Merge is always a
+ * structural merge that delegates to the sub-configurations (which carry their own versions).
+ *
+ * <p>This class is immutable; every mutating method returns a new instance.
+ *
+ * @param version reserved, always {@link #INITIAL_VERSION}
+ * @param globalConfiguration cluster-wide broker lifecycle and configuration
+ * @param partitionGroups per-group partition configuration, keyed by group id
+ * @param phasedChangeState the lifecycle state of the cluster-spanning change plan
+ */
+@NullMarked
+public record CurrentClusterConfiguration(
+    long version,
+    GlobalConfiguration globalConfiguration,
+    Map<String, PartitionGroupConfiguration> partitionGroups,
+    PhasedChangeState phasedChangeState) {
+
+  public static final long INITIAL_VERSION = 0;
+  public static final String DEFAULT_GROUP = "default";
+
+  public CurrentClusterConfiguration {
+    Objects.requireNonNull(globalConfiguration, "globalConfiguration must not be null");
+    Objects.requireNonNull(partitionGroups, "partitionGroups must not be null");
+    Objects.requireNonNull(phasedChangeState, "phasedChangeState must not be null");
+    partitionGroups = Map.copyOf(partitionGroups);
+  }
+
+  /**
+   * Creates an empty configuration with an initial global configuration and no partition groups.
+   */
+  public static CurrentClusterConfiguration init() {
+    return new CurrentClusterConfiguration(
+        INITIAL_VERSION, GlobalConfiguration.init(), Map.of(), PhasedChangeState.empty());
+  }
+
+  /**
+   * Migration factory: converts a legacy {@link ClusterConfiguration} (single partition group) into
+   * the new model. Broker lifecycle state is extracted into {@link GlobalConfiguration}; partition
+   * assignment is extracted into the {@link #DEFAULT_GROUP} partition group.
+   *
+   * <p>Field placement:
+   *
+   * <ul>
+   *   <li>{@code clusterId} and {@code partitionDistributorConfig} → {@link GlobalConfiguration}.
+   *   <li>{@code routingState} and {@code incarnationNumber} → the default {@link
+   *       PartitionGroupConfiguration}.
+   *   <li>{@code pendingChanges} → the {@link PhasedChangeState} pending plan. The legacy plan
+   *       mixes {@link GlobalChangeOperation}s and {@link PartitionGroupOperation}s in one flat
+   *       list; those cannot all live on the default group. They are re-expressed as phases,
+   *       preserving order: each maximal run of consecutive operations of the same kind becomes one
+   *       phase (see {@link #toPhases(List)}).
+   *   <li>{@code lastChange} → the {@link PhasedChangeState} last completed change. Its status must
+   *       be terminal (COMPLETED / FAILED / CANCELLED); an {@code IN_PROGRESS} legacy last change
+   *       is rejected.
+   *   <li>every member appears in {@link GlobalConfiguration}; a member appears in the default
+   *       group only if it currently replicates at least one partition.
+   *   <li>a legacy {@code RECOVERING} member maps to a lifecycle {@link BrokerState.State#ACTIVE}
+   *       broker whose default-group {@link BrokerPartitionState} is in {@link Mode#RECOVERING},
+   *       since recovery is now per-group.
+   * </ul>
+   *
+   * @throws IllegalStateException if the legacy {@code lastChange} has {@code IN_PROGRESS} status
+   */
+  public static CurrentClusterConfiguration ofDefault(final ClusterConfiguration legacy) {
+    final long version = legacy.version();
+
+    final Map<MemberId, BrokerState> brokerStates =
+        legacy.members().entrySet().stream()
+            .collect(Collectors.toMap(Entry::getKey, e -> toBrokerState(e.getValue())));
+
+    final var globalConfiguration =
+        new GlobalConfiguration(
+            version,
+            legacy.clusterId(),
+            brokerStates,
+            legacy.partitionDistributorConfig(),
+            Optional.empty(),
+            Optional.empty());
+
+    final Map<MemberId, BrokerPartitionState> partitionStates =
+        legacy.members().entrySet().stream()
+            .filter(e -> !e.getValue().partitions().isEmpty())
+            .collect(Collectors.toMap(Entry::getKey, e -> toBrokerPartitionState(e.getValue())));
+
+    final var defaultGroup =
+        new PartitionGroupConfiguration(
+            version,
+            legacy.incarnationNumber(),
+            partitionStates,
+            legacy.routingState(),
+            Optional.empty(),
+            Optional.empty());
+
+    return new CurrentClusterConfiguration(
+        INITIAL_VERSION,
+        globalConfiguration,
+        Map.of(DEFAULT_GROUP, defaultGroup),
+        toPhasedChangeState(legacy));
+  }
+
+  /**
+   * Returns a new configuration after merging this and {@code other}. This is always a structural
+   * merge — the top-level {@code version} is ignored. {@code globalConfiguration} and each
+   * partition group are merged by delegating to their own {@code merge}; partition-group keys use
+   * union semantics (a group present on only one side is adopted directly); the {@code
+   * phasedChangeState} is merged by {@link PhasedChangeState#merge(PhasedChangeState)}.
+   */
+  public CurrentClusterConfiguration merge(final CurrentClusterConfiguration other) {
+    final var mergedGlobal = globalConfiguration.merge(other.globalConfiguration);
+
+    final Map<String, PartitionGroupConfiguration> mergedGroups = new HashMap<>(partitionGroups);
+    other.partitionGroups.forEach(
+        (groupId, group) -> mergedGroups.merge(groupId, group, PartitionGroupConfiguration::merge));
+
+    final var mergedPhasedChangeState = phasedChangeState.merge(other.phasedChangeState);
+
+    return new CurrentClusterConfiguration(
+        version, mergedGlobal, mergedGroups, mergedPhasedChangeState);
+  }
+
+  /**
+   * Applies {@code updater} to the global configuration. Returns {@code this} if the global
+   * configuration is unchanged.
+   */
+  public CurrentClusterConfiguration updateGlobalConfiguration(
+      final UnaryOperator<GlobalConfiguration> updater) {
+    final var updated = updater.apply(globalConfiguration);
+    if (updated.equals(globalConfiguration)) {
+      return this;
+    }
+    return new CurrentClusterConfiguration(version, updated, partitionGroups, phasedChangeState);
+  }
+
+  /**
+   * Applies {@code updater} to the named partition group. Returns {@code this} if the group is
+   * unchanged.
+   *
+   * @throws IllegalStateException if the group does not exist
+   */
+  public CurrentClusterConfiguration updatePartitionGroupConfig(
+      final String groupId, final UnaryOperator<PartitionGroupConfiguration> updater) {
+    final PartitionGroupConfiguration current = partitionGroups.get(groupId);
+    if (current == null) {
+      throw new IllegalStateException(
+          String.format("Expected to update partition group %s, but it does not exist", groupId));
+    }
+    final var updated = updater.apply(current);
+    if (updated.equals(current)) {
+      return this;
+    }
+    final var updatedGroups = new HashMap<>(partitionGroups);
+    updatedGroups.put(groupId, updated);
+    return new CurrentClusterConfiguration(
+        version, globalConfiguration, updatedGroups, phasedChangeState);
+  }
+
+  public boolean hasPartitionGroup(final String groupId) {
+    return partitionGroups.containsKey(groupId);
+  }
+
+  public @Nullable PartitionGroupConfiguration partitionGroup(final String groupId) {
+    return partitionGroups.get(groupId);
+  }
+
+  private static PhasedChangeState toPhasedChangeState(final ClusterConfiguration legacy) {
+    final Optional<CompletedPhasedChange> lastChange =
+        legacy.lastChange().map(CurrentClusterConfiguration::toCompletedPhasedChange);
+    final Optional<PhasedChangePlan> pending =
+        legacy.pendingChanges().flatMap(CurrentClusterConfiguration::toPhasedChangePlan);
+    return new PhasedChangeState(pending, lastChange);
+  }
+
+  private static Optional<PhasedChangePlan> toPhasedChangePlan(final ClusterChangePlan plan) {
+    final var phases = toPhases(plan.pendingOperations());
+    if (phases.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(new PhasedChangePlan(plan.id(), 0, phases, plan.startedAt()));
+  }
+
+  /**
+   * Splits a flat legacy operation list into phases, preserving order: each maximal run of
+   * consecutive operations of the same kind becomes one phase — a run of {@link
+   * GlobalChangeOperation} becomes a {@link GlobalPhase}, a run of {@link PartitionGroupOperation}
+   * becomes a {@link PartitionGroupParallelPhase} targeting the default group. For example {@code
+   * [MemberJoin, PartitionJoin, PartitionLeave, MemberLeave]} yields three phases: a global phase,
+   * a default-group phase with the two partition operations, and another global phase.
+   */
+  private static List<Phase> toPhases(final List<ClusterConfigurationChangeOperation> operations) {
+    final List<Phase> phases = new ArrayList<>();
+    final List<GlobalChangeOperation> globalRun = new ArrayList<>();
+    final List<PartitionGroupOperation> partitionRun = new ArrayList<>();
+    for (final ClusterConfigurationChangeOperation operation : operations) {
+      switch (operation) {
+        case final GlobalChangeOperation global -> {
+          flushPartitionRun(phases, partitionRun);
+          globalRun.add(global);
+        }
+        case final PartitionGroupOperation partition -> {
+          flushGlobalRun(phases, globalRun);
+          partitionRun.add(partition);
+        }
+      }
+    }
+    flushGlobalRun(phases, globalRun);
+    flushPartitionRun(phases, partitionRun);
+    return phases;
+  }
+
+  private static void flushGlobalRun(
+      final List<Phase> phases, final List<GlobalChangeOperation> run) {
+    if (!run.isEmpty()) {
+      phases.add(new GlobalPhase(List.copyOf(run)));
+      run.clear();
+    }
+  }
+
+  private static void flushPartitionRun(
+      final List<Phase> phases, final List<PartitionGroupOperation> run) {
+    if (!run.isEmpty()) {
+      phases.add(new PartitionGroupParallelPhase(Map.of(DEFAULT_GROUP, List.copyOf(run))));
+      run.clear();
+    }
+  }
+
+  private static CompletedPhasedChange toCompletedPhasedChange(final CompletedChange change) {
+    final var status =
+        switch (change.status()) {
+          case COMPLETED -> PhasedChangePlanStatus.COMPLETED;
+          case FAILED -> PhasedChangePlanStatus.FAILED;
+          case CANCELLED -> PhasedChangePlanStatus.CANCELLED;
+          case IN_PROGRESS ->
+              throw new IllegalStateException(
+                  "Cannot migrate a legacy last change with IN_PROGRESS status: " + change);
+        };
+    return new CompletedPhasedChange(change.id(), status, change.startedAt(), change.completedAt());
+  }
+
+  private static BrokerState toBrokerState(final MemberState memberState) {
+    return new BrokerState(
+        memberState.version(), memberState.lastUpdated(), toLifecycleState(memberState.state()));
+  }
+
+  private static BrokerPartitionState toBrokerPartitionState(final MemberState memberState) {
+    final var mode =
+        memberState.state() == MemberState.State.RECOVERING ? Mode.RECOVERING : Mode.PROCESSING;
+    return new BrokerPartitionState(
+        memberState.version(), memberState.lastUpdated(), memberState.partitions(), mode);
+  }
+
+  private static BrokerState.State toLifecycleState(final MemberState.State state) {
+    return switch (state) {
+      case UNINITIALIZED -> BrokerState.State.UNINITIALIZED;
+      case JOINING -> BrokerState.State.JOINING;
+      // A recovering broker is lifecycle-active; recovery is tracked per group as a Mode.
+      case ACTIVE, RECOVERING -> BrokerState.State.ACTIVE;
+      case LEAVING -> BrokerState.State.LEAVING;
+      case LEFT -> BrokerState.State.LEFT;
+    };
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -93,7 +93,7 @@ public record CurrentClusterConfiguration(
    *
    * @throws IllegalStateException if the legacy {@code lastChange} has {@code IN_PROGRESS} status
    */
-  public static CurrentClusterConfiguration ofDefault(final ClusterConfiguration legacy) {
+  public static CurrentClusterConfiguration fromLegacy(final ClusterConfiguration legacy) {
     final long version = legacy.version();
 
     final Map<MemberId, BrokerState> brokerStates =

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfiguration.java
@@ -288,17 +288,28 @@ public record CurrentClusterConfiguration(
   private static PhasedChangeState toPhasedChangeState(final ClusterConfiguration legacy) {
     final Optional<CompletedPhasedChange> lastChange =
         legacy.lastChange().map(CurrentClusterConfiguration::toCompletedPhasedChange);
+    final long lastChangeId = lastChange.map(CompletedPhasedChange::id).orElse(0L);
     final Optional<PhasedChangePlan> pending =
-        legacy.pendingChanges().flatMap(CurrentClusterConfiguration::toPhasedChangePlan);
+        legacy.pendingChanges().flatMap(plan -> toPhasedChangePlan(plan, lastChangeId));
     return new PhasedChangeState(pending, lastChange);
   }
 
-  private static Optional<PhasedChangePlan> toPhasedChangePlan(final ClusterChangePlan plan) {
+  /**
+   * Builds the pending {@link PhasedChangePlan}, normalizing the plan id. Legacy restore plans use
+   * a negative sentinel id ({@code ClusterChangePlan.RESTORE_CHANGE_ID = -2}), but {@link
+   * PhasedChangePlan} requires a positive id and {@link PhasedChangeState} requires the pending id
+   * to exceed the last completed change id. Any legacy id that is not positive or not greater than
+   * {@code lastChangeId} is replaced with {@code lastChangeId + 1}, keeping ids positive and
+   * monotonic after migration.
+   */
+  private static Optional<PhasedChangePlan> toPhasedChangePlan(
+      final ClusterChangePlan plan, final long lastChangeId) {
     final var phases = toPhases(plan.pendingOperations());
     if (phases.isEmpty()) {
       return Optional.empty();
     }
-    return Optional.of(new PhasedChangePlan(plan.id(), 0, phases, plan.startedAt()));
+    final long id = plan.id() > 0 && plan.id() > lastChangeId ? plan.id() : lastChangeId + 1;
+    return Optional.of(new PhasedChangePlan(id, 0, phases, plan.startedAt()));
   }
 
   /**
@@ -356,7 +367,12 @@ public record CurrentClusterConfiguration(
               throw new IllegalStateException(
                   "Cannot migrate a legacy last change with IN_PROGRESS status: " + change);
         };
-    return new CompletedPhasedChange(change.id(), status, change.startedAt(), change.completedAt());
+    // A completed legacy restore keeps the negative sentinel id
+    // (ClusterChangePlan.RESTORE_CHANGE_ID
+    // = -2). Clamp non-positive ids to 0 so the next derived plan id (lastChange.id() + 1) stays
+    // positive and PhasedChangePlan's id-must-be-positive invariant is preserved.
+    final long id = Math.max(change.id(), 0);
+    return new CompletedPhasedChange(id, status, change.startedAt(), change.completedAt());
   }
 
   private static BrokerState toBrokerState(final MemberState memberState) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -91,7 +91,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — every member is in the global config with its lifecycle state
       assertThat(migrated.globalConfiguration().members()).containsOnlyKeys(MEMBER_0, MEMBER_1);
@@ -120,7 +120,7 @@ class CurrentClusterConfigurationTest {
           ClusterConfiguration.builder().version(1).members(Map.of(MEMBER_0, recovering)).build();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — lifecycle is ACTIVE, per-group mode is RECOVERING
       assertThat(migrated.globalConfiguration().getMember(MEMBER_0).state())
@@ -151,7 +151,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — the ops become three phases in order: [global], [default: 2 partition ops], [global]
       final var plan = migrated.phasedChangeState().pending().orElseThrow();
@@ -184,7 +184,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — the last change moves to the PhasedChangeState, status preserved
       final var lastChange = migrated.phasedChangeState().lastChange().orElseThrow();
@@ -209,7 +209,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when / then
-      assertThatThrownBy(() -> CurrentClusterConfiguration.ofDefault(legacy))
+      assertThatThrownBy(() -> CurrentClusterConfiguration.fromLegacy(legacy))
           .isInstanceOf(IllegalStateException.class);
     }
 
@@ -219,7 +219,7 @@ class CurrentClusterConfigurationTest {
       final var legacy = ClusterConfiguration.init();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — an empty global config and an empty default group
       assertThat(migrated.globalConfiguration().members()).isEmpty();
@@ -240,7 +240,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when — migration must not fail on the non-positive id
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — the pending plan id is normalized to a positive value
       final var plan = migrated.phasedChangeState().pending().orElseThrow();
@@ -260,7 +260,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — the last change id is clamped to non-negative, so a new plan can still be started
       assertThat(migrated.phasedChangeState().lastChange().orElseThrow().id()).isEqualTo(0);
@@ -282,7 +282,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — a single GlobalPhase holds both, in order
       assertThat(migrated.phasedChangeState().pending().orElseThrow().phases())
@@ -302,7 +302,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — a single default-group phase holds both, in order
       assertThat(migrated.phasedChangeState().pending().orElseThrow().phases())
@@ -326,7 +326,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — the status maps to the matching PhasedChangePlanStatus
       assertThat(migrated.phasedChangeState().lastChange().orElseThrow().status())
@@ -360,7 +360,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — startedAt of the pending plan and both timestamps of the last change are preserved
       assertThat(migrated.phasedChangeState().pending().orElseThrow().startedAt())
@@ -381,7 +381,7 @@ class CurrentClusterConfigurationTest {
               .build();
 
       // when
-      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+      final var migrated = CurrentClusterConfiguration.fromLegacy(legacy);
 
       // then — no pending phased plan is produced
       assertThat(migrated.phasedChangeState().pending()).isEmpty();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -1,0 +1,435 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.RoundRobinConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class CurrentClusterConfigurationTest {
+
+  private static final MemberId MEMBER_0 = MemberId.from("0");
+  private static final MemberId MEMBER_1 = MemberId.from("1");
+
+  private static PartitionState partition() {
+    return PartitionState.active(1, DynamicPartitionConfig.init());
+  }
+
+  private static MemberState activeMember() {
+    return new MemberState(1, Instant.EPOCH, MemberState.State.ACTIVE, Map.of(1, partition()));
+  }
+
+  private static BrokerState broker(final long version, final BrokerState.State state) {
+    return new BrokerState(version, Instant.EPOCH, state);
+  }
+
+  private static BrokerPartitionState brokerPartition(final int partitionId) {
+    return new BrokerPartitionState(
+        1, Instant.EPOCH, Map.of(partitionId, partition()), Mode.PROCESSING);
+  }
+
+  private static PartitionGroupConfiguration group(
+      final long version, final Map<MemberId, BrokerPartitionState> members) {
+    return new PartitionGroupConfiguration(
+        version, 0, members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static GlobalConfiguration global(
+      final long version, final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        version, Optional.empty(), members, Optional.empty(), Optional.empty(), Optional.empty());
+  }
+
+  private static CurrentClusterConfiguration config(
+      final GlobalConfiguration global,
+      final Map<String, PartitionGroupConfiguration> groups,
+      final PhasedChangeState phasedChangeState) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION, global, groups, phasedChangeState);
+  }
+
+  @Nested
+  class OfDefault {
+
+    @Test
+    void shouldSplitLifecycleAndPartitionState() {
+      // given — an active member with a partition, and a member that has left with no partitions
+      final var active =
+          new MemberState(4, Instant.EPOCH, MemberState.State.ACTIVE, Map.of(1, partition()));
+      final var left = new MemberState(2, Instant.EPOCH, MemberState.State.LEFT, Map.of());
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(7)
+              .members(Map.of(MEMBER_0, active, MEMBER_1, left))
+              .clusterId(Optional.of("cluster-x"))
+              .partitionDistributorConfig(Optional.of(new RoundRobinConfig()))
+              .incarnationNumber(3)
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — every member is in the global config with its lifecycle state
+      assertThat(migrated.globalConfiguration().members()).containsOnlyKeys(MEMBER_0, MEMBER_1);
+      assertThat(migrated.globalConfiguration().getMember(MEMBER_0))
+          .isEqualTo(broker(4, BrokerState.State.ACTIVE));
+      assertThat(migrated.globalConfiguration().getMember(MEMBER_1))
+          .isEqualTo(broker(2, BrokerState.State.LEFT));
+      // cluster-level settings live on the global config
+      assertThat(migrated.globalConfiguration().clusterId()).contains("cluster-x");
+      assertThat(migrated.globalConfiguration().partitionDistributorConfig())
+          .contains(new RoundRobinConfig());
+
+      // and — only members with partitions are in the default group
+      final var defaultGroup = migrated.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP);
+      assertThat(defaultGroup.members()).containsOnlyKeys(MEMBER_0);
+      assertThat(defaultGroup.getMember(MEMBER_0).mode()).isEqualTo(Mode.PROCESSING);
+      assertThat(defaultGroup.incarnationNumber()).isEqualTo(3);
+    }
+
+    @Test
+    void shouldMapRecoveringMemberToActiveBrokerWithRecoveringMode() {
+      // given — a recovering member with a partition
+      final var recovering =
+          new MemberState(5, Instant.EPOCH, MemberState.State.RECOVERING, Map.of(1, partition()));
+      final var legacy =
+          ClusterConfiguration.builder().version(1).members(Map.of(MEMBER_0, recovering)).build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — lifecycle is ACTIVE, per-group mode is RECOVERING
+      assertThat(migrated.globalConfiguration().getMember(MEMBER_0).state())
+          .isEqualTo(BrokerState.State.ACTIVE);
+      assertThat(
+              migrated
+                  .partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP)
+                  .getMember(MEMBER_0)
+                  .mode())
+          .isEqualTo(Mode.RECOVERING);
+    }
+
+    @Test
+    void shouldConvertMixedPendingOperationsIntoOrderedPhases() {
+      // given — a legacy pending plan mixing global and partition ops in one flat list
+      final var memberJoin = new MemberJoinOperation(MEMBER_0);
+      final var partitionJoin = new PartitionJoinOperation(MEMBER_0, 1, 1);
+      final var partitionLeave = new PartitionLeaveOperation(MEMBER_0, 1, 1);
+      final var memberLeave = new MemberLeaveOperation(MEMBER_0);
+      final var pending =
+          ClusterChangePlan.init(
+              9, List.of(memberJoin, partitionJoin, partitionLeave, memberLeave));
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(Optional.of(pending))
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — the ops become three phases in order: [global], [default: 2 partition ops], [global]
+      final var plan = migrated.phasedChangeState().pending().orElseThrow();
+      assertThat(plan.id()).isEqualTo(9);
+      assertThat(plan.currentPhaseIndex()).isZero();
+      assertThat(plan.phases())
+          .containsExactly(
+              new GlobalPhase(List.of(memberJoin)),
+              new PartitionGroupParallelPhase(
+                  Map.of(
+                      CurrentClusterConfiguration.DEFAULT_GROUP,
+                      List.of(partitionJoin, partitionLeave))),
+              new GlobalPhase(List.of(memberLeave)));
+      // and — the pending change is NOT left on the default group
+      assertThat(
+              migrated.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).pendingChanges())
+          .isEmpty();
+    }
+
+    @Test
+    void shouldConvertLegacyLastChangeIntoPhasedChangeState() {
+      // given — a legacy last completed change
+      final var last =
+          new CompletedChange(3, ClusterChangePlan.Status.FAILED, Instant.EPOCH, Instant.EPOCH);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .lastChange(Optional.of(last))
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — the last change moves to the PhasedChangeState, status preserved
+      final var lastChange = migrated.phasedChangeState().lastChange().orElseThrow();
+      assertThat(lastChange.id()).isEqualTo(3);
+      assertThat(lastChange.status()).isEqualTo(PhasedChangePlanStatus.FAILED);
+      // and — not left on the default group
+      assertThat(migrated.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).lastChange())
+          .isEmpty();
+    }
+
+    @Test
+    void shouldThrowWhenLegacyLastChangeIsInProgress() {
+      // given — a legacy last change with a non-terminal status
+      final var inProgress =
+          new CompletedChange(
+              3, ClusterChangePlan.Status.IN_PROGRESS, Instant.EPOCH, Instant.EPOCH);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .lastChange(Optional.of(inProgress))
+              .build();
+
+      // when / then
+      assertThatThrownBy(() -> CurrentClusterConfiguration.ofDefault(legacy))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldMigrateEmptyLegacyConfig() {
+      // given — a fresh legacy config with no members
+      final var legacy = ClusterConfiguration.init();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — an empty global config and an empty default group
+      assertThat(migrated.globalConfiguration().members()).isEmpty();
+      assertThat(migrated.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).members())
+          .isEmpty();
+    }
+  }
+
+  @Nested
+  class Merge {
+
+    @Test
+    void shouldAdoptPartitionGroupPresentOnlyOnOneSide() {
+      // given — "a" only on the left, "b" only on the right
+      final var left =
+          config(global(1, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty());
+      final var right =
+          config(global(1, Map.of()), Map.of("b", group(1, Map.of())), PhasedChangeState.empty());
+
+      // when
+      final var merged = left.merge(right);
+
+      // then — union of group keys
+      assertThat(merged.partitionGroups()).containsOnlyKeys("a", "b");
+    }
+
+    @Test
+    void shouldMergeOverlappingPartitionGroup() {
+      // given — both have group "a" at the same config version, with different members
+      final var left =
+          config(
+              global(1, Map.of()),
+              Map.of("a", group(3, Map.of(MEMBER_0, brokerPartition(1)))),
+              PhasedChangeState.empty());
+      final var right =
+          config(
+              global(1, Map.of()),
+              Map.of("a", group(3, Map.of(MEMBER_1, brokerPartition(2)))),
+              PhasedChangeState.empty());
+
+      // when
+      final var merged = left.merge(right);
+
+      // then — the group merge delegates to PartitionGroupConfiguration.merge (member union)
+      assertThat(merged.partitionGroup("a").members()).containsOnlyKeys(MEMBER_0, MEMBER_1);
+    }
+
+    @Test
+    void shouldDelegateGlobalConfigurationMergeToHigherVersion() {
+      // given — the right side has a higher global-config version
+      final var left = config(global(1, Map.of()), Map.of(), PhasedChangeState.empty());
+      final var higherGlobal = global(2, Map.of(MEMBER_0, broker(0, BrokerState.State.ACTIVE)));
+      final var right = config(higherGlobal, Map.of(), PhasedChangeState.empty());
+
+      // when
+      final var merged = left.merge(right);
+
+      // then
+      assertThat(merged.globalConfiguration()).isEqualTo(higherGlobal);
+    }
+
+    @Test
+    void shouldMergeGlobalMembersFieldByFieldAtEqualVersion() {
+      // given — equal global-config version; MEMBER_0 newer on the left, MEMBER_1 only on the right
+      final var left =
+          config(
+              global(3, Map.of(MEMBER_0, broker(9, BrokerState.State.ACTIVE))),
+              Map.of(),
+              PhasedChangeState.empty());
+      final var right =
+          config(
+              global(
+                  3,
+                  Map.of(
+                      MEMBER_0,
+                      broker(2, BrokerState.State.LEAVING),
+                      MEMBER_1,
+                      broker(1, BrokerState.State.ACTIVE))),
+              Map.of(),
+              PhasedChangeState.empty());
+
+      // when
+      final var merged = left.merge(right);
+
+      // then — higher per-member version wins and the member union is kept
+      assertThat(merged.globalConfiguration().members()).containsOnlyKeys(MEMBER_0, MEMBER_1);
+      assertThat(merged.globalConfiguration().getMember(MEMBER_0).version()).isEqualTo(9);
+    }
+
+    @Test
+    void shouldMergePhasedChangeStateLastChangeByHigherId() {
+      // given — no pending plan, but different last completed changes
+      final var older =
+          new PhasedChangeState(
+              Optional.empty(),
+              Optional.of(
+                  new CompletedPhasedChange(
+                      2, PhasedChangePlanStatus.COMPLETED, Instant.EPOCH, Instant.EPOCH)));
+      final var newer =
+          new PhasedChangeState(
+              Optional.empty(),
+              Optional.of(
+                  new CompletedPhasedChange(
+                      5, PhasedChangePlanStatus.FAILED, Instant.EPOCH, Instant.EPOCH)));
+      final var left = config(global(1, Map.of()), Map.of(), older);
+      final var right = config(global(1, Map.of()), Map.of(), newer);
+
+      // when / then — the higher-id last change wins, both merge directions
+      assertThat(left.merge(right).phasedChangeState().lastChange().orElseThrow().id())
+          .isEqualTo(5);
+      assertThat(right.merge(left).phasedChangeState().lastChange().orElseThrow().id())
+          .isEqualTo(5);
+    }
+
+    @Test
+    void shouldDelegatePhasedChangeStateMerge() {
+      // given — same plan id, this at phase 0, other at phase 1
+      final List<Phase> phases = List.of(new GlobalPhase(List.of()), new GlobalPhase(List.of()));
+      final var atPhase0 = PhasedChangeState.empty().initPlan(phases);
+      final var atPhase1 =
+          new PhasedChangeState(
+              Optional.of(atPhase0.pending().orElseThrow().withNextPhase()), Optional.empty());
+      final var left = config(global(1, Map.of()), Map.of(), atPhase0);
+      final var right = config(global(1, Map.of()), Map.of(), atPhase1);
+
+      // when
+      final var merged = left.merge(right);
+
+      // then — higher phase index wins (delegated to PhasedChangeState/PhasedChangePlan merge)
+      assertThat(merged.phasedChangeState().pending().orElseThrow().currentPhaseIndex())
+          .isEqualTo(1);
+    }
+  }
+
+  @Nested
+  class Updates {
+
+    @Test
+    void shouldUpdateGlobalConfiguration() {
+      // given
+      final var config =
+          config(global(4, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty());
+
+      // when
+      final var updated = config.updateGlobalConfiguration(g -> g.setClusterId("cluster-x"));
+
+      // then
+      assertThat(updated.globalConfiguration().clusterId()).contains("cluster-x");
+      assertThat(updated.partitionGroups()).isEqualTo(config.partitionGroups());
+    }
+
+    @Test
+    void shouldReturnSameWhenGlobalConfigurationUnchanged() {
+      // given
+      final var config = config(global(4, Map.of()), Map.of(), PhasedChangeState.empty());
+
+      // when / then
+      assertThat(config.updateGlobalConfiguration(UnaryOperator.identity())).isSameAs(config);
+    }
+
+    @Test
+    void shouldUpdatePartitionGroupConfig() {
+      // given
+      final var config =
+          config(global(1, Map.of()), Map.of("a", group(4, Map.of())), PhasedChangeState.empty());
+
+      // when — start a change on group "a"
+      final var updated =
+          config.updatePartitionGroupConfig(
+              "a", g -> g.startConfigurationChange(List.of(new DeleteHistoryOperation(MEMBER_0))));
+
+      // then
+      assertThat(updated.partitionGroup("a").hasPendingChanges()).isTrue();
+      assertThat(updated.partitionGroup("a").version()).isEqualTo(5);
+    }
+
+    @Test
+    void shouldThrowWhenUpdatingUnknownPartitionGroup() {
+      // given
+      final var config = config(global(1, Map.of()), Map.of(), PhasedChangeState.empty());
+
+      // when / then
+      assertThatThrownBy(
+              () -> config.updatePartitionGroupConfig("missing", UnaryOperator.identity()))
+          .isInstanceOf(IllegalStateException.class);
+    }
+  }
+
+  @Nested
+  class Validation {
+
+    @Test
+    void shouldThrowWhenGlobalConfigurationIsNull() {
+      assertThatThrownBy(
+              () -> new CurrentClusterConfiguration(0, null, Map.of(), PhasedChangeState.empty()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowWhenPartitionGroupsIsNull() {
+      assertThatThrownBy(
+              () ->
+                  new CurrentClusterConfiguration(
+                      0, GlobalConfiguration.init(), null, PhasedChangeState.empty()))
+          .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowWhenPhasedChangeStateIsNull() {
+      assertThatThrownBy(
+              () -> new CurrentClusterConfiguration(0, GlobalConfiguration.init(), Map.of(), null))
+          .isInstanceOf(NullPointerException.class);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -268,6 +268,124 @@ class CurrentClusterConfigurationTest {
           migrated.initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
       assertThat(withPlan.phasedChangeState().pending().orElseThrow().id()).isEqualTo(1);
     }
+
+    @Test
+    void shouldGroupConsecutiveGlobalOpsIntoSinglePhase() {
+      // given — two consecutive global operations
+      final var join = new MemberJoinOperation(MEMBER_0);
+      final var leave = new MemberLeaveOperation(MEMBER_0);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(Optional.of(ClusterChangePlan.init(2, List.of(join, leave))))
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — a single GlobalPhase holds both, in order
+      assertThat(migrated.phasedChangeState().pending().orElseThrow().phases())
+          .containsExactly(new GlobalPhase(List.of(join, leave)));
+    }
+
+    @Test
+    void shouldGroupConsecutivePartitionOpsIntoSinglePhase() {
+      // given — a pending plan with only partition operations
+      final var join = new PartitionJoinOperation(MEMBER_0, 1, 1);
+      final var leave = new PartitionLeaveOperation(MEMBER_0, 1, 1);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(Optional.of(ClusterChangePlan.init(2, List.of(join, leave))))
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — a single default-group phase holds both, in order
+      assertThat(migrated.phasedChangeState().pending().orElseThrow().phases())
+          .containsExactly(
+              new PartitionGroupParallelPhase(
+                  Map.of(CurrentClusterConfiguration.DEFAULT_GROUP, List.of(join, leave))));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = ClusterChangePlan.Status.class,
+        names = {"COMPLETED", "FAILED", "CANCELLED"})
+    void shouldConvertEachTerminalLegacyLastChangeStatus(final ClusterChangePlan.Status status) {
+      // given
+      final var last = new CompletedChange(3, status, Instant.EPOCH, Instant.EPOCH);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .lastChange(Optional.of(last))
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — the status maps to the matching PhasedChangePlanStatus
+      assertThat(migrated.phasedChangeState().lastChange().orElseThrow().status())
+          .isEqualTo(PhasedChangePlanStatus.valueOf(status.name()));
+    }
+
+    @Test
+    void shouldPreserveTimestampsDuringMigration() {
+      // given — a pending plan and a last change with distinct timestamps
+      final var pendingStartedAt = Instant.ofEpochSecond(300);
+      final var pending =
+          new ClusterChangePlan(
+              7,
+              1,
+              ClusterChangePlan.Status.IN_PROGRESS,
+              pendingStartedAt,
+              List.of(),
+              List.of(new DeleteHistoryOperation(MEMBER_0)));
+      final var last =
+          new CompletedChange(
+              3,
+              ClusterChangePlan.Status.COMPLETED,
+              Instant.ofEpochSecond(100),
+              Instant.ofEpochSecond(200));
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(8)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(Optional.of(pending))
+              .lastChange(Optional.of(last))
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — startedAt of the pending plan and both timestamps of the last change are preserved
+      assertThat(migrated.phasedChangeState().pending().orElseThrow().startedAt())
+          .isEqualTo(pendingStartedAt);
+      final var lastChange = migrated.phasedChangeState().lastChange().orElseThrow();
+      assertThat(lastChange.startedAt()).isEqualTo(Instant.ofEpochSecond(100));
+      assertThat(lastChange.completedAt()).isEqualTo(Instant.ofEpochSecond(200));
+    }
+
+    @Test
+    void shouldProduceNoPendingPlanWhenLegacyPendingHasNoOperations() {
+      // given — a pending change plan present but with no operations
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(Optional.of(ClusterChangePlan.init(2, List.of())))
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — no pending phased plan is produced
+      assertThat(migrated.phasedChangeState().pending()).isEmpty();
+    }
   }
 
   @Nested

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -226,6 +226,48 @@ class CurrentClusterConfigurationTest {
       assertThat(migrated.partitionGroup(CurrentClusterConfiguration.DEFAULT_GROUP).members())
           .isEmpty();
     }
+
+    @Test
+    void shouldNormalizeRestorePendingPlanId() {
+      // given — a legacy restore plan uses the negative sentinel id (RESTORE_CHANGE_ID = -2)
+      final var restore =
+          ClusterChangePlan.initForRestore(List.of(new DeleteHistoryOperation(MEMBER_0)));
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .pendingChanges(Optional.of(restore))
+              .build();
+
+      // when — migration must not fail on the non-positive id
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — the pending plan id is normalized to a positive value
+      final var plan = migrated.phasedChangeState().pending().orElseThrow();
+      assertThat(plan.id()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldNormalizeCompletedRestoreLastChangeIdSoNextPlanCanStart() {
+      // given — a completed restore keeps the negative sentinel id in lastChange
+      final var completedRestore =
+          new CompletedChange(-2, ClusterChangePlan.Status.COMPLETED, Instant.EPOCH, Instant.EPOCH);
+      final var legacy =
+          ClusterConfiguration.builder()
+              .version(5)
+              .members(Map.of(MEMBER_0, activeMember()))
+              .lastChange(Optional.of(completedRestore))
+              .build();
+
+      // when
+      final var migrated = CurrentClusterConfiguration.ofDefault(legacy);
+
+      // then — the last change id is clamped to non-negative, so a new plan can still be started
+      assertThat(migrated.phasedChangeState().lastChange().orElseThrow().id()).isEqualTo(0);
+      final var withPlan =
+          migrated.initPlan(List.of(new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)))));
+      assertThat(withPlan.phasedChangeState().pending().orElseThrow().id()).isEqualTo(1);
+    }
   }
 
   @Nested

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/CurrentClusterConfigurationTest.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import java.util.function.UnaryOperator;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class CurrentClusterConfigurationTest {
 
@@ -403,6 +405,146 @@ class CurrentClusterConfigurationTest {
       assertThatThrownBy(
               () -> config.updatePartitionGroupConfig("missing", UnaryOperator.identity()))
           .isInstanceOf(IllegalStateException.class);
+    }
+  }
+
+  @Nested
+  class PlanTransitions {
+
+    private static GlobalPhase globalPhase() {
+      return new GlobalPhase(List.of(new MemberJoinOperation(MEMBER_0)));
+    }
+
+    private static PartitionGroupParallelPhase parallelPhase(final String groupId) {
+      return new PartitionGroupParallelPhase(
+          Map.of(groupId, List.of(new DeleteHistoryOperation(MEMBER_0))));
+    }
+
+    @Test
+    void shouldInitPlanAndActivateFirstPhase() {
+      // given — an empty config
+      final var config = CurrentClusterConfiguration.init();
+
+      // when — init a plan whose first phase is a global phase
+      final var updated = config.initPlan(List.of(globalPhase()));
+
+      // then — the plan is pending at phase 0 (id derived by PhasedChangeState) and activated
+      assertThat(updated.phasedChangeState().pending()).isPresent();
+      assertThat(updated.phasedChangeState().pending().orElseThrow().currentPhaseIndex()).isZero();
+      assertThat(updated.phasedChangeState().pending().orElseThrow().id()).isEqualTo(1);
+      assertThat(updated.globalConfiguration().hasPendingChanges()).isTrue();
+    }
+
+    @Test
+    void shouldThrowWhenInitPlanWhileOneIsPending() {
+      // given
+      final var config = CurrentClusterConfiguration.init().initPlan(List.of(globalPhase()));
+
+      // when / then
+      assertThatThrownBy(() -> config.initPlan(List.of(globalPhase())))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldActivateNextPhase() {
+      // given — plan: phase 0 global, phase 1 targets group "a"
+      final var config =
+          config(global(1, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty())
+              .initPlan(List.of(globalPhase(), parallelPhase("a")));
+
+      // when
+      final var updated = config.activateNextPhase();
+
+      // then — now on phase 1, and group "a" has the activated change
+      assertThat(updated.phasedChangeState().pending().orElseThrow().currentPhaseIndex())
+          .isEqualTo(1);
+      assertThat(updated.partitionGroup("a").hasPendingChanges()).isTrue();
+    }
+
+    @Test
+    void shouldThrowWhenActivatingNextPhaseOnLastPhase() {
+      // given — a single-phase plan
+      final var config = CurrentClusterConfiguration.init().initPlan(List.of(globalPhase()));
+
+      // when / then
+      assertThatThrownBy(config::activateNextPhase).isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldThrowWhenActivatingNextPhaseWithNoPendingPlan() {
+      // given
+      final var config = CurrentClusterConfiguration.init();
+
+      // when / then
+      assertThatThrownBy(config::activateNextPhase).isInstanceOf(IllegalStateException.class);
+    }
+
+    @ParameterizedTest
+    @EnumSource(PhasedChangePlanStatus.class)
+    void shouldCompletePlanWithTerminalStatus(final PhasedChangePlanStatus status) {
+      // given
+      final var config = CurrentClusterConfiguration.init().initPlan(List.of(globalPhase()));
+
+      // when
+      final var completed = config.completePlan(status);
+
+      // then — the pending plan is moved into the last completed change with the given status
+      assertThat(completed.phasedChangeState().pending()).isEmpty();
+      assertThat(completed.phasedChangeState().lastChange()).isPresent();
+      assertThat(completed.phasedChangeState().lastChange().orElseThrow().status())
+          .isEqualTo(status);
+    }
+
+    @Test
+    void shouldThrowWhenInitPlanWithNoPhases() {
+      // given
+      final var config = CurrentClusterConfiguration.init();
+
+      // when / then
+      assertThatThrownBy(() -> config.initPlan(List.of()))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void shouldThrowWhenCompletingWithNoPendingPlan() {
+      // given
+      final var config = CurrentClusterConfiguration.init();
+
+      // when / then
+      assertThatThrownBy(() -> config.completePlan(PhasedChangePlanStatus.COMPLETED))
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldActivateOnlyGlobalConfigurationForGlobalPhase() {
+      // given — a config with a partition group and a global-phase plan
+      final var config =
+          config(global(1, Map.of()), Map.of("a", group(1, Map.of())), PhasedChangeState.empty());
+
+      // when
+      final var updated = config.initPlan(List.of(globalPhase()));
+
+      // then — only the global config is changed; the partition group is untouched
+      assertThat(updated.globalConfiguration().hasPendingChanges()).isTrue();
+      assertThat(updated.partitionGroup("a").hasPendingChanges()).isFalse();
+    }
+
+    @Test
+    void shouldActivateOnlyNamedGroupsForParallelPhase() {
+      // given — a config with groups "a" and "b" and a parallel phase targeting only "a"
+      final var config =
+          config(
+              global(1, Map.of()),
+              Map.of("a", group(1, Map.of()), "b", group(1, Map.of())),
+              PhasedChangeState.empty());
+
+      // when
+      final var updated = config.initPlan(List.of(parallelPhase("a")));
+
+      // then — only group "a" is changed; group "b" and the global config are untouched
+      assertThat(updated.partitionGroup("a").hasPendingChanges()).isTrue();
+      assertThat(updated.partitionGroup("b").hasPendingChanges()).isFalse();
+      assertThat(updated.globalConfiguration().hasPendingChanges()).isFalse();
     }
   }
 


### PR DESCRIPTION
## Description

Introduces the top-level `CurrentClusterConfiguration` record for multi-partition-group cluster configuration (physical tenants), implementing #56203 and #56205 (Phase 1 — Data layer of #56018).

`CurrentClusterConfiguration` wraps all cluster state:
- `GlobalConfiguration` — cluster-wide broker lifecycle + cluster-level config
- `Map<String, PartitionGroupConfiguration>` — per-group partition state, keyed by group id
- `PhasedChangeState` — the cluster-spanning change-plan lifecycle (pending plan + last completed change)

The top-level `version` is reserved (always `INITIAL_VERSION`) and not used in merge.

### #56203 — record + `merge()` + `ofDefault()`
- **`merge()`** is always a structural merge (no top-level version fast-path): delegates to `GlobalConfiguration.merge()`, per-group `PartitionGroupConfiguration.merge()` with union semantics for group keys, and `PhasedChangeState.merge()`.
- **`ofDefault(ClusterConfiguration)`** migrates the legacy single-group model: broker lifecycle → `GlobalConfiguration`; partition assignment → the `"default"` group; `clusterId`/`partitionDistributorConfig` → global; `routingState`/`incarnationNumber` → default group. A legacy `RECOVERING` member becomes a lifecycle-`ACTIVE` broker whose default-group partition state is in `Mode.RECOVERING` (recovery is per-group, per Amendment 2).
- **Legacy change-plan conversion:** the legacy pending plan mixes `GlobalChangeOperation` and `PartitionGroupOperation` in one flat list, so it can't live on the default group. It is converted into a `PhasedChangeState` pending plan, **preserving order** — each maximal run of consecutive same-kind ops becomes one phase (global run → `GlobalPhase`; partition run → default-group `PartitionGroupParallelPhase`). E.g. `[MemberJoin, PartitionJoin, PartitionLeave, MemberLeave]` → 3 phases. The legacy `lastChange` becomes the `PhasedChangeState` last completed change; a non-terminal `IN_PROGRESS` legacy last change is rejected.
- `updateGlobalConfiguration()` / `updatePartitionGroupConfig()` route mutations through the sub-configs so version changes stay consistent.

Per **Amendment 1 (Option B)** of the solution spec, the phased-change lifecycle is a `PhasedChangeState` wrapper rather than a bare `Optional<PhasedChangePlan>`, so plan IDs are derived internally and callers never supply one — keeping IDs monotonic across coordinator restarts (required for `PhasedChangePlan.merge()` convergence).

`withDerivedGlobalConfiguration()` is intentionally deferred (omitted).

### #56205 — plan transitions
- `initPlan(phases)` derives the id inside `PhasedChangeState` and activates phase 0; rejects an empty phase list; throws if a plan is already pending. Consecutive phases must not target the same sub-config (documented).
- `activateNextPhase()` advances + activates the next phase; overrun-guarded.
- `completePlan(status)` moves the pending plan into the last completed change.
- A shared `applyPhase()` dispatches a `GlobalPhase` to `GlobalConfiguration` only and a `PartitionGroupParallelPhase` to the named groups only.

### Migration id-safety fix
Legacy restore plans use a negative sentinel id (`RESTORE_CHANGE_ID = -2`), which would break `PhasedChangePlan` (id must be positive) and later `initPlan` (derives `-1`). `ofDefault` now normalizes non-positive legacy ids during migration (completed change clamped to `≥ 0`; pending plan replaced with `lastChangeId + 1` when not positive/greater).

## Testing

`CurrentClusterConfigurationTest` — 40 tests covering merge (structural delegation, group-key union, global equal-version member merge, phasedChangeState pending + lastChange), `ofDefault` (lifecycle/partition split, RECOVERING mapping, ordered phase conversion, single-kind runs, all terminal statuses, timestamp preservation, empty configs, restore-id normalization), the plan transitions, update helpers, and validation. All green.

## Commits

1. `feat: introduce CurrentClusterConfiguration record with merge()` (#56203)
2. `feat: add initPlan, activateNextPhase, completePlan to CurrentClusterConfiguration` (#56205)
3. `fix: normalize non-positive legacy change ids when migrating to CurrentClusterConfiguration`
4. `test: broaden CurrentClusterConfiguration legacy-migration coverage`

Closes #56203
Closes #56205

🤖 Generated with [Claude Code](https://claude.com/claude-code)
