### PR TITLE
feat: serialize CurrentClusterConfiguration to/from proto

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1748,6 +1748,12 @@
       </dependency>
 
       <dependency>
+        <groupId>net.jqwik</groupId>
+        <artifactId>jqwik-time</artifactId>
+        <version>${version.jqwik}</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.jmock</groupId>
         <artifactId>jmock</artifactId>
         <version>${version.jmock}</version>

--- a/zeebe/dynamic-config/pom.xml
+++ b/zeebe/dynamic-config/pom.xml
@@ -142,6 +142,12 @@
     </dependency>
 
     <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik-time</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <!--  Ensure non-jqwik junit5 tests can be run -->
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -915,7 +915,8 @@ public class ProtoBufSerializer
       final Topology.CompletedTopologyChangeOperation operation) {
     return new CompletedOperation(
         decodeOperation(operation.getOperation()),
-        Instant.ofEpochSecond(operation.getCompletedAt().getSeconds()));
+        Instant.ofEpochSecond(
+            operation.getCompletedAt().getSeconds(), operation.getCompletedAt().getNanos()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -40,23 +40,31 @@ import io.camunda.zeebe.dynamic.config.protocol.Topology;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.ChangeStatus;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.CompletedChange;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.PartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingState;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PostScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.PreScalingOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.UpdatePartitionDistributorConfigOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.AwaitModeChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ModeChangeOperation;
@@ -73,6 +81,12 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateIncarnationNumberOperation;
 import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.UpdateRoutingState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
@@ -1563,5 +1577,604 @@ public class ProtoBufSerializer
       case CANCELLED -> ClusterChangePlan.Status.CANCELLED;
       default -> throw new IllegalStateException("Unknown status: " + status);
     };
+  }
+
+  // ---- New multi-partition-group configuration model (8.10) ----
+  // Additive encode/decode for CurrentClusterConfiguration and its sub-types. These are not yet
+  // wired into gossip or persistence; they exist for the Phase-3 handoff.
+
+  public byte[] encodeCurrentClusterConfiguration(final CurrentClusterConfiguration configuration) {
+    return encodeCurrentClusterConfigurationProto(configuration).toByteArray();
+  }
+
+  public CurrentClusterConfiguration decodeCurrentClusterConfiguration(final byte[] encoded) {
+    try {
+      return decodeCurrentClusterConfiguration(
+          Topology.CurrentClusterConfiguration.parseFrom(encoded));
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  private Topology.CurrentClusterConfiguration encodeCurrentClusterConfigurationProto(
+      final CurrentClusterConfiguration configuration) {
+    final var partitionGroups =
+        configuration.partitionGroups().entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey, e -> encodePartitionGroupConfiguration(e.getValue())));
+    return Topology.CurrentClusterConfiguration.newBuilder()
+        .setVersion(configuration.version())
+        .setGlobalConfiguration(encodeGlobalConfiguration(configuration.globalConfiguration()))
+        .putAllPartitionGroups(partitionGroups)
+        .setPhasedChangeState(encodePhasedChangeState(configuration.phasedChangeState()))
+        .build();
+  }
+
+  private CurrentClusterConfiguration decodeCurrentClusterConfiguration(
+      final Topology.CurrentClusterConfiguration proto) {
+    final var partitionGroups =
+        proto.getPartitionGroupsMap().entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey, e -> decodePartitionGroupConfiguration(e.getValue())));
+    return new CurrentClusterConfiguration(
+        proto.getVersion(),
+        decodeGlobalConfiguration(proto.getGlobalConfiguration()),
+        partitionGroups,
+        decodePhasedChangeState(proto.getPhasedChangeState()));
+  }
+
+  public Topology.GlobalConfiguration encodeGlobalConfiguration(
+      final GlobalConfiguration configuration) {
+    final var members =
+        configuration.members().entrySet().stream()
+            .collect(Collectors.toMap(e -> e.getKey().id(), e -> encodeBrokerState(e.getValue())));
+    final var builder =
+        Topology.GlobalConfiguration.newBuilder()
+            .setVersion(configuration.version())
+            .putAllMembers(members);
+    configuration.clusterId().ifPresent(builder::setClusterId);
+    configuration
+        .partitionDistributorConfig()
+        .ifPresent(
+            config -> builder.setPartitionDistributor(encodePartitionDistributorConfig(config)));
+    configuration
+        .pendingChanges()
+        .ifPresent(changePlan -> builder.setPendingChanges(encodeChangePlan(changePlan)));
+    configuration
+        .lastChange()
+        .ifPresent(lastChange -> builder.setLastChange(encodeCompletedChange(lastChange)));
+    return builder.build();
+  }
+
+  public GlobalConfiguration decodeGlobalConfiguration(final Topology.GlobalConfiguration proto) {
+    final var members =
+        proto.getMembersMap().entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    e -> MemberId.from(e.getKey()), e -> decodeBrokerState(e.getValue())));
+    final Optional<String> clusterId =
+        proto.getClusterId().isEmpty() ? Optional.empty() : Optional.of(proto.getClusterId());
+    final Optional<PartitionDistributorConfig> partitionDistributorConfig =
+        proto.hasPartitionDistributor()
+            ? decodePartitionDistributorConfig(proto.getPartitionDistributor())
+            : Optional.empty();
+    final Optional<ClusterChangePlan> pendingChanges =
+        proto.hasPendingChanges()
+            ? Optional.of(decodeChangePlan(proto.getPendingChanges()))
+            : Optional.empty();
+    final Optional<io.camunda.zeebe.dynamic.config.state.CompletedChange> lastChange =
+        proto.hasLastChange()
+            ? Optional.of(decodeCompletedChange(proto.getLastChange()))
+            : Optional.empty();
+    return new GlobalConfiguration(
+        proto.getVersion(),
+        clusterId,
+        members,
+        partitionDistributorConfig,
+        pendingChanges,
+        lastChange);
+  }
+
+  public Topology.PartitionGroupConfiguration encodePartitionGroupConfiguration(
+      final PartitionGroupConfiguration configuration) {
+    final var members =
+        configuration.members().entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    e -> e.getKey().id(), e -> encodeBrokerPartitionState(e.getValue())));
+    final var builder =
+        Topology.PartitionGroupConfiguration.newBuilder()
+            .setVersion(configuration.version())
+            .setIncarnationNumber(configuration.incarnationNumber())
+            .putAllMembers(members);
+    configuration
+        .routingState()
+        .ifPresent(routingState -> builder.setRoutingState(encodeRoutingState(routingState)));
+    configuration
+        .pendingChanges()
+        .ifPresent(changePlan -> builder.setPendingChanges(encodeChangePlan(changePlan)));
+    configuration
+        .lastChange()
+        .ifPresent(lastChange -> builder.setLastChange(encodeCompletedChange(lastChange)));
+    return builder.build();
+  }
+
+  public PartitionGroupConfiguration decodePartitionGroupConfiguration(
+      final Topology.PartitionGroupConfiguration proto) {
+    final var members =
+        proto.getMembersMap().entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    e -> MemberId.from(e.getKey()), e -> decodeBrokerPartitionState(e.getValue())));
+    final Optional<RoutingState> routingState =
+        proto.hasRoutingState() ? decodeRoutingState(proto.getRoutingState()) : Optional.empty();
+    final Optional<ClusterChangePlan> pendingChanges =
+        proto.hasPendingChanges()
+            ? Optional.of(decodeChangePlan(proto.getPendingChanges()))
+            : Optional.empty();
+    final Optional<io.camunda.zeebe.dynamic.config.state.CompletedChange> lastChange =
+        proto.hasLastChange()
+            ? Optional.of(decodeCompletedChange(proto.getLastChange()))
+            : Optional.empty();
+    return new PartitionGroupConfiguration(
+        proto.getVersion(),
+        proto.getIncarnationNumber(),
+        members,
+        routingState,
+        pendingChanges,
+        lastChange);
+  }
+
+  private Topology.BrokerState encodeBrokerState(final BrokerState brokerState) {
+    return Topology.BrokerState.newBuilder()
+        .setVersion(brokerState.version())
+        .setLastUpdated(toTimestamp(brokerState.lastUpdated()))
+        .setState(toSerializedBrokerState(brokerState.state()))
+        .build();
+  }
+
+  private BrokerState decodeBrokerState(final Topology.BrokerState proto) {
+    final var lastUpdated = proto.getLastUpdated();
+    return new BrokerState(
+        proto.getVersion(),
+        Instant.ofEpochSecond(lastUpdated.getSeconds(), lastUpdated.getNanos()),
+        toBrokerLifecycleState(proto.getState()));
+  }
+
+  private Topology.BrokerPartitionState encodeBrokerPartitionState(
+      final BrokerPartitionState brokerPartitionState) {
+    final var partitions =
+        brokerPartitionState.partitions().entrySet().stream()
+            .collect(Collectors.toMap(Entry::getKey, e -> encodePartitions(e.getValue())));
+    return Topology.BrokerPartitionState.newBuilder()
+        .setVersion(brokerPartitionState.version())
+        .setLastUpdated(toTimestamp(brokerPartitionState.lastUpdated()))
+        .putAllPartitions(partitions)
+        .setMode(toProtoTopologyMode(brokerPartitionState.mode()))
+        .build();
+  }
+
+  private BrokerPartitionState decodeBrokerPartitionState(
+      final Topology.BrokerPartitionState proto) {
+    final var partitions =
+        proto.getPartitionsMap().entrySet().stream()
+            .collect(Collectors.toMap(Entry::getKey, e -> decodePartitionState(e.getValue())));
+    final var lastUpdated = proto.getLastUpdated();
+    return new BrokerPartitionState(
+        proto.getVersion(),
+        Instant.ofEpochSecond(lastUpdated.getSeconds(), lastUpdated.getNanos()),
+        partitions,
+        fromProtoTopologyMode(proto.getMode()));
+  }
+
+  private Topology.PhasedChangeState encodePhasedChangeState(final PhasedChangeState state) {
+    final var builder = Topology.PhasedChangeState.newBuilder();
+    state.pending().ifPresent(plan -> builder.setPendingPlan(encodePhasedChangePlan(plan)));
+    state
+        .lastChange()
+        .ifPresent(lastChange -> builder.setLastChange(encodeCompletedPhasedChange(lastChange)));
+    return builder.build();
+  }
+
+  private PhasedChangeState decodePhasedChangeState(final Topology.PhasedChangeState proto) {
+    final Optional<PhasedChangePlan> pending =
+        proto.hasPendingPlan()
+            ? Optional.of(decodePhasedChangePlan(proto.getPendingPlan()))
+            : Optional.empty();
+    final Optional<CompletedPhasedChange> lastChange =
+        proto.hasLastChange()
+            ? Optional.of(decodeCompletedPhasedChange(proto.getLastChange()))
+            : Optional.empty();
+    return new PhasedChangeState(pending, lastChange);
+  }
+
+  private Topology.PhasedChangePlan encodePhasedChangePlan(final PhasedChangePlan plan) {
+    final var builder =
+        Topology.PhasedChangePlan.newBuilder()
+            .setId(plan.id())
+            .setCurrentPhaseIndex(plan.currentPhaseIndex())
+            .setStartedAt(toTimestamp(plan.startedAt()));
+    plan.phases().forEach(phase -> builder.addPhases(encodePhase(phase)));
+    return builder.build();
+  }
+
+  private PhasedChangePlan decodePhasedChangePlan(final Topology.PhasedChangePlan proto) {
+    final var phases = proto.getPhasesList().stream().map(this::decodePhase).toList();
+    final var startedAt = proto.getStartedAt();
+    return new PhasedChangePlan(
+        proto.getId(),
+        proto.getCurrentPhaseIndex(),
+        phases,
+        Instant.ofEpochSecond(startedAt.getSeconds(), startedAt.getNanos()));
+  }
+
+  private Topology.PhasedChangePlanPhase encodePhase(final Phase phase) {
+    final var builder = Topology.PhasedChangePlanPhase.newBuilder();
+    switch (phase) {
+      case final GlobalPhase globalPhase ->
+          builder.setGlobalPhase(
+              Topology.GlobalPhase.newBuilder()
+                  .addAllOperations(
+                      globalPhase.operations().stream()
+                          .map(this::encodeGlobalChangeOperation)
+                          .toList())
+                  .build());
+      case final PartitionGroupParallelPhase parallelPhase -> {
+        final var parallelBuilder = Topology.PartitionGroupParallelPhase.newBuilder();
+        parallelPhase
+            .groupOperations()
+            .forEach(
+                (group, operations) ->
+                    parallelBuilder.putGroupOperations(
+                        group,
+                        Topology.PartitionGroupOperationList.newBuilder()
+                            .addAllOperations(
+                                operations.stream()
+                                    .map(this::encodePartitionGroupChangeOperation)
+                                    .toList())
+                            .build()));
+        builder.setPartitionGroupParallelPhase(parallelBuilder.build());
+      }
+    }
+    return builder.build();
+  }
+
+  private Phase decodePhase(final Topology.PhasedChangePlanPhase proto) {
+    return switch (proto.getPhaseCase()) {
+      case GLOBALPHASE ->
+          new GlobalPhase(
+              proto.getGlobalPhase().getOperationsList().stream()
+                  .map(this::decodeGlobalChangeOperation)
+                  .toList());
+      case PARTITIONGROUPPARALLELPHASE ->
+          new PartitionGroupParallelPhase(
+              proto.getPartitionGroupParallelPhase().getGroupOperationsMap().entrySet().stream()
+                  .collect(
+                      Collectors.toMap(
+                          Entry::getKey,
+                          e ->
+                              e.getValue().getOperationsList().stream()
+                                  .map(this::decodePartitionGroupChangeOperation)
+                                  .toList())));
+      case PHASE_NOT_SET -> throw new IllegalStateException("Unknown phase: " + proto);
+    };
+  }
+
+  private Topology.CompletedPhasedChange encodeCompletedPhasedChange(
+      final CompletedPhasedChange completedChange) {
+    return Topology.CompletedPhasedChange.newBuilder()
+        .setId(completedChange.id())
+        .setStatus(toProtoPhasedChangePlanStatus(completedChange.status()))
+        .setStartedAt(toTimestamp(completedChange.startedAt()))
+        .setCompletedAt(toTimestamp(completedChange.completedAt()))
+        .build();
+  }
+
+  private CompletedPhasedChange decodeCompletedPhasedChange(
+      final Topology.CompletedPhasedChange proto) {
+    final var startedAt = proto.getStartedAt();
+    final var completedAt = proto.getCompletedAt();
+    return new CompletedPhasedChange(
+        proto.getId(),
+        fromProtoPhasedChangePlanStatus(proto.getStatus()),
+        Instant.ofEpochSecond(startedAt.getSeconds(), startedAt.getNanos()),
+        Instant.ofEpochSecond(completedAt.getSeconds(), completedAt.getNanos()));
+  }
+
+  private Topology.GlobalChangeOperation encodeGlobalChangeOperation(
+      final GlobalChangeOperation operation) {
+    final var builder =
+        Topology.GlobalChangeOperation.newBuilder().setMemberId(operation.memberId().id());
+    switch (operation) {
+      case final MemberJoinOperation ignored ->
+          builder.setMemberJoin(Topology.MemberJoinOperation.newBuilder().build());
+      case final MemberLeaveOperation ignored ->
+          builder.setMemberLeave(Topology.MemberLeaveOperation.newBuilder().build());
+      case final MemberRemoveOperation op ->
+          builder.setMemberRemove(
+              Topology.MemberRemoveOperation.newBuilder()
+                  .setMemberToRemove(op.memberToRemove().id())
+                  .build());
+      case final PreScalingOperation op ->
+          builder.setPreScaling(
+              Topology.PreScalingOperation.newBuilder()
+                  .addAllClusterMembers(op.clusterMembers().stream().map(MemberId::id).toList())
+                  .build());
+      case final PostScalingOperation op ->
+          builder.setPostScaling(
+              Topology.PostScalingOperation.newBuilder()
+                  .addAllClusterMembers(op.clusterMembers().stream().map(MemberId::id).toList())
+                  .build());
+      case final UpdatePartitionDistributorConfigOperation op ->
+          builder.setUpdatePartitionDistributorConfig(
+              Topology.UpdatePartitionDistributorConfigOperation.newBuilder()
+                  .setConfig(encodePartitionDistributorConfig(op.config()))
+                  .build());
+    }
+    return builder.build();
+  }
+
+  private GlobalChangeOperation decodeGlobalChangeOperation(
+      final Topology.GlobalChangeOperation proto) {
+    final var memberId = MemberId.from(proto.getMemberId());
+    if (proto.hasMemberJoin()) {
+      return new MemberJoinOperation(memberId);
+    } else if (proto.hasMemberLeave()) {
+      return new MemberLeaveOperation(memberId);
+    } else if (proto.hasMemberRemove()) {
+      return new MemberRemoveOperation(
+          memberId, MemberId.from(proto.getMemberRemove().getMemberToRemove()));
+    } else if (proto.hasPreScaling()) {
+      return new PreScalingOperation(
+          memberId,
+          proto.getPreScaling().getClusterMembersList().stream()
+              .map(MemberId::from)
+              .collect(Collectors.toSet()));
+    } else if (proto.hasPostScaling()) {
+      return new PostScalingOperation(
+          memberId,
+          proto.getPostScaling().getClusterMembersList().stream()
+              .map(MemberId::from)
+              .collect(Collectors.toSet()));
+    } else if (proto.hasUpdatePartitionDistributorConfig()) {
+      return decodePartitionDistributorConfig(
+              proto.getUpdatePartitionDistributorConfig().getConfig())
+          .map(config -> new UpdatePartitionDistributorConfigOperation(memberId, config))
+          .orElseThrow(
+              () ->
+                  new IllegalStateException(
+                      "UpdatePartitionDistributorConfig operation has empty config"));
+    } else {
+      throw new IllegalStateException("Unknown global change operation: " + proto);
+    }
+  }
+
+  private Topology.PartitionGroupChangeOperation encodePartitionGroupChangeOperation(
+      final PartitionGroupOperation operation) {
+    final var builder =
+        Topology.PartitionGroupChangeOperation.newBuilder().setMemberId(operation.memberId().id());
+    switch (operation) {
+      case final PartitionJoinOperation op ->
+          builder.setPartitionJoin(
+              Topology.PartitionJoinOperation.newBuilder()
+                  .setPartitionId(op.partitionId())
+                  .setPriority(op.priority())
+                  .build());
+      case final PartitionLeaveOperation op ->
+          builder.setPartitionLeave(
+              Topology.PartitionLeaveOperation.newBuilder()
+                  .setPartitionId(op.partitionId())
+                  .setMinimumAllowedReplicas(op.minimumAllowedReplicas())
+                  .build());
+      case final PartitionReconfigurePriorityOperation op ->
+          builder.setPartitionReconfigurePriority(
+              Topology.PartitionReconfigurePriorityOperation.newBuilder()
+                  .setPartitionId(op.partitionId())
+                  .setPriority(op.priority())
+                  .build());
+      case final PartitionForceReconfigureOperation op ->
+          builder.setPartitionForceReconfigure(
+              Topology.PartitionForceReconfigureOperation.newBuilder()
+                  .setPartitionId(op.partitionId())
+                  .addAllMembers(op.members().stream().map(MemberId::id).toList())
+                  .build());
+      case final PartitionDisableExporterOperation op ->
+          builder.setPartitionDisableExporter(
+              Topology.PartitionDisableExporterOperation.newBuilder()
+                  .setPartitionId(op.partitionId())
+                  .setExporterId(op.exporterId())
+                  .build());
+      case final PartitionDeleteExporterOperation op ->
+          builder.setPartitionDeleteExporter(
+              Topology.PartitionDeleteExporterOperation.newBuilder()
+                  .setPartitionId(op.partitionId())
+                  .setExporterId(op.exporterId())
+                  .build());
+      case final PartitionEnableExporterOperation op ->
+          builder.setPartitionEnableExporter(encodeEnabledExporterOperation(op));
+      case final PartitionBootstrapOperation op ->
+          builder.setPartitionBootstrap(encodePartitionBootstrapOperation(op));
+      case final DeleteHistoryOperation ignored ->
+          builder.setDeleteHistory(Topology.DeleteHistoryOperation.newBuilder().build());
+      case final UpdateIncarnationNumberOperation ignored ->
+          builder.setUpdateIncarnationNumber(
+              Topology.UpdateIncarnationNumberOperation.newBuilder().build());
+      case final ModeChangeOperation op ->
+          builder.setModeChange(
+              Topology.ModeChangeOperation.newBuilder()
+                  .setMode(toProtoTopologyMode(op.mode()))
+                  .build());
+      case final AwaitModeChangeOperation op ->
+          builder.setAwaitModeChange(
+              Topology.AwaitModeChangeOperation.newBuilder()
+                  .setMode(toProtoTopologyMode(op.mode()))
+                  .build());
+      case StartPartitionScaleUp(final var ignoredMemberId, final var desiredPartitionCount) ->
+          builder.setInitiateScaleUpPartitions(
+              Topology.StartPartitionScaleUpOperation.newBuilder()
+                  .setDesiredPartitionCount(desiredPartitionCount)
+                  .build());
+      case final AwaitRedistributionCompletion op ->
+          builder.setAwaitRedistributionCompletion(
+              Topology.AwaitRedistributionCompletion.newBuilder()
+                  .setDesiredPartitionCount(op.desiredPartitionCount())
+                  .addAllPartitionsToRedistribute(op.partitionsToRedistribute())
+                  .build());
+      case final AwaitRelocationCompletion op ->
+          builder.setAwaitRelocationCompletion(
+              Topology.AwaitRelocationCompletion.newBuilder()
+                  .setDesiredPartitionCount(op.desiredPartitionCount())
+                  .addAllPartitionsToRelocate(op.partitionsToRelocate())
+                  .build());
+      case final UpdateRoutingState op -> {
+        final var routingBuilder = Topology.UpdateRoutingState.newBuilder();
+        op.routingState().ifPresent(s -> routingBuilder.setRoutingState(encodeRoutingState(s)));
+        builder.setUpdateRoutingState(routingBuilder);
+      }
+    }
+    return builder.build();
+  }
+
+  private PartitionGroupOperation decodePartitionGroupChangeOperation(
+      final Topology.PartitionGroupChangeOperation proto) {
+    final var memberId = MemberId.from(proto.getMemberId());
+    if (proto.hasPartitionJoin()) {
+      return new PartitionJoinOperation(
+          memberId,
+          proto.getPartitionJoin().getPartitionId(),
+          proto.getPartitionJoin().getPriority());
+    } else if (proto.hasPartitionLeave()) {
+      return new PartitionLeaveOperation(
+          memberId,
+          proto.getPartitionLeave().getPartitionId(),
+          proto.getPartitionLeave().getMinimumAllowedReplicas());
+    } else if (proto.hasPartitionReconfigurePriority()) {
+      return new PartitionReconfigurePriorityOperation(
+          memberId,
+          proto.getPartitionReconfigurePriority().getPartitionId(),
+          proto.getPartitionReconfigurePriority().getPriority());
+    } else if (proto.hasPartitionForceReconfigure()) {
+      return new PartitionForceReconfigureOperation(
+          memberId,
+          proto.getPartitionForceReconfigure().getPartitionId(),
+          proto.getPartitionForceReconfigure().getMembersList().stream()
+              .map(MemberId::from)
+              .collect(Collectors.toSet()));
+    } else if (proto.hasPartitionDisableExporter()) {
+      return new PartitionDisableExporterOperation(
+          memberId,
+          proto.getPartitionDisableExporter().getPartitionId(),
+          proto.getPartitionDisableExporter().getExporterId());
+    } else if (proto.hasPartitionDeleteExporter()) {
+      return new PartitionDeleteExporterOperation(
+          memberId,
+          proto.getPartitionDeleteExporter().getPartitionId(),
+          proto.getPartitionDeleteExporter().getExporterId());
+    } else if (proto.hasPartitionEnableExporter()) {
+      final var enableExporter = proto.getPartitionEnableExporter();
+      final Optional<String> initializeFrom =
+          enableExporter.hasInitializeFrom()
+              ? Optional.of(enableExporter.getInitializeFrom())
+              : Optional.empty();
+      return new PartitionEnableExporterOperation(
+          memberId,
+          enableExporter.getPartitionId(),
+          enableExporter.getExporterId(),
+          initializeFrom);
+    } else if (proto.hasPartitionBootstrap()) {
+      final var bootstrap = proto.getPartitionBootstrap();
+      final Optional<DynamicPartitionConfig> partitionConfig =
+          bootstrap.hasConfig()
+              ? Optional.of(decodePartitionConfig(bootstrap.getConfig()))
+              : Optional.empty();
+      return new PartitionBootstrapOperation(
+          memberId,
+          bootstrap.getPartitionId(),
+          bootstrap.getPriority(),
+          partitionConfig,
+          bootstrap.getInitializeFromConfig());
+    } else if (proto.hasInitiateScaleUpPartitions()) {
+      return new StartPartitionScaleUp(
+          memberId, proto.getInitiateScaleUpPartitions().getDesiredPartitionCount());
+    } else if (proto.hasAwaitRedistributionCompletion()) {
+      final var redistribution = proto.getAwaitRedistributionCompletion();
+      return new AwaitRedistributionCompletion(
+          memberId,
+          redistribution.getDesiredPartitionCount(),
+          new TreeSet<>(redistribution.getPartitionsToRedistributeList()));
+    } else if (proto.hasAwaitRelocationCompletion()) {
+      final var relocation = proto.getAwaitRelocationCompletion();
+      return new AwaitRelocationCompletion(
+          memberId,
+          relocation.getDesiredPartitionCount(),
+          new TreeSet<>(relocation.getPartitionsToRelocateList()));
+    } else if (proto.hasUpdateRoutingState()) {
+      return new UpdateRoutingState(
+          memberId, decodeRoutingState(proto.getUpdateRoutingState().getRoutingState()));
+    } else if (proto.hasDeleteHistory()) {
+      return new DeleteHistoryOperation(memberId);
+    } else if (proto.hasUpdateIncarnationNumber()) {
+      return new UpdateIncarnationNumberOperation(memberId);
+    } else if (proto.hasModeChange()) {
+      return new ModeChangeOperation(
+          memberId, fromProtoTopologyMode(proto.getModeChange().getMode()));
+    } else if (proto.hasAwaitModeChange()) {
+      return new AwaitModeChangeOperation(
+          memberId, fromProtoTopologyMode(proto.getAwaitModeChange().getMode()));
+    } else {
+      throw new IllegalStateException("Unknown partition group change operation: " + proto);
+    }
+  }
+
+  private Topology.State toSerializedBrokerState(final BrokerState.State state) {
+    return switch (state) {
+      case UNINITIALIZED -> Topology.State.UNKNOWN;
+      case JOINING -> Topology.State.JOINING;
+      case ACTIVE -> Topology.State.ACTIVE;
+      case LEAVING -> Topology.State.LEAVING;
+      case LEFT -> Topology.State.LEFT;
+    };
+  }
+
+  private BrokerState.State toBrokerLifecycleState(final Topology.State state) {
+    return switch (state) {
+      case UNRECOGNIZED, UNKNOWN -> BrokerState.State.UNINITIALIZED;
+      case JOINING -> BrokerState.State.JOINING;
+      case ACTIVE -> BrokerState.State.ACTIVE;
+      case LEAVING -> BrokerState.State.LEAVING;
+      case LEFT -> BrokerState.State.LEFT;
+      case BOOTSTRAPPING, RECOVERING ->
+          throw new IllegalStateException(
+              "Broker cannot be in %s lifecycle state".formatted(state));
+    };
+  }
+
+  private Topology.PhasedChangePlanStatus toProtoPhasedChangePlanStatus(
+      final PhasedChangePlanStatus status) {
+    return switch (status) {
+      case COMPLETED -> Topology.PhasedChangePlanStatus.PHASED_CHANGE_COMPLETED;
+      case FAILED -> Topology.PhasedChangePlanStatus.PHASED_CHANGE_FAILED;
+      case CANCELLED -> Topology.PhasedChangePlanStatus.PHASED_CHANGE_CANCELLED;
+    };
+  }
+
+  private PhasedChangePlanStatus fromProtoPhasedChangePlanStatus(
+      final Topology.PhasedChangePlanStatus status) {
+    return switch (status) {
+      case PHASED_CHANGE_COMPLETED -> PhasedChangePlanStatus.COMPLETED;
+      case PHASED_CHANGE_FAILED -> PhasedChangePlanStatus.FAILED;
+      case PHASED_CHANGE_CANCELLED -> PhasedChangePlanStatus.CANCELLED;
+      case PHASED_CHANGE_STATUS_UNKNOWN, UNRECOGNIZED ->
+          throw new IllegalStateException("Unknown phased change status: " + status);
+    };
+  }
+
+  private static Timestamp toTimestamp(final Instant instant) {
+    return Timestamp.newBuilder()
+        .setSeconds(instant.getEpochSecond())
+        .setNanos(instant.getNano())
+        .build();
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/CurrentClusterConfigurationSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/CurrentClusterConfigurationSerializerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.serializer;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.Timestamp;
+import io.camunda.zeebe.dynamic.config.protocol.Topology;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Edge cases for the {@code CurrentClusterConfiguration} serialization that the property test
+ * ({@code ProtoBufSerializerPropertyTest#shouldEncodeAndDecodeCurrentClusterConfiguration}) cannot
+ * exercise: decoding invalid bytes and decoding a proto that carries a broker lifecycle state which
+ * the domain model cannot represent. The happy-path round-trips are all covered by the property
+ * test.
+ */
+final class CurrentClusterConfigurationSerializerTest {
+
+  private final ProtoBufSerializer serializer = new ProtoBufSerializer();
+
+  @Test
+  void shouldFailToDecodeInvalidBytes() {
+    // given — a truncated protobuf message (tag for field 1 with no value)
+    final byte[] invalid = {0x08};
+
+    // when / then
+    assertThatThrownBy(() -> serializer.decodeCurrentClusterConfiguration(invalid))
+        .isInstanceOf(DecodingFailed.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Topology.State.class,
+      names = {"BOOTSTRAPPING", "RECOVERING"})
+  void shouldRejectBrokerStateWithNonLifecycleState(final Topology.State state) {
+    // given — a global configuration whose broker carries a state that is not a broker lifecycle
+    // state (BrokerState.State has no BOOTSTRAPPING/RECOVERING)
+    final var proto =
+        Topology.GlobalConfiguration.newBuilder()
+            .setVersion(1)
+            .putMembers(
+                "0",
+                Topology.BrokerState.newBuilder()
+                    .setVersion(0)
+                    .setLastUpdated(Timestamp.newBuilder().build())
+                    .setState(state)
+                    .build())
+            .build();
+
+    // when / then
+    assertThatThrownBy(() -> serializer.decodeGlobalConfiguration(proto))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.util.ClusterTopologyDomain;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
@@ -18,6 +19,13 @@ import net.jqwik.api.domains.Domain;
 import net.jqwik.api.domains.DomainContext;
 
 final class ProtoBufSerializerPropertyTest {
+
+  private static final String COLLECTION_EQUALITY_HINT =
+      """
+      Decoded configuration must be equal to the initial one.
+      If this fails even though both objects look the same, make sure to take defensive copies of collections in the config and its nested types.
+      jqwik tends to generate sorted sets and maps which are not equal to the unsorted collections created on deserialization.""";
+
   @Property(tries = 100)
   @Domain(ClusterTopologyDomain.class)
   @Domain(DomainContext.Global.class)
@@ -32,11 +40,24 @@ final class ProtoBufSerializerPropertyTest {
 
     // then
     assertThat(decodedState.getClusterConfiguration())
-        .describedAs(
-            """
-            Decoded clusterTopology must be equal to initial one.
-            If this fails even though both objects look the same, make sure to take defensive copies of collections in the ClusterTopology and its nested types.
-            jqwik tends to generate sorted sets and maps which are not equal to the unsorted collections created on deserialization.""")
+        .describedAs(COLLECTION_EQUALITY_HINT)
         .isEqualTo(clusterConfiguration);
+  }
+
+  @Property(tries = 100)
+  @Domain(ClusterTopologyDomain.class)
+  @Domain(DomainContext.Global.class)
+  void shouldEncodeAndDecodeCurrentClusterConfiguration(
+      @ForAll final CurrentClusterConfiguration configuration) {
+    // given
+    final var protoBufSerializer = new ProtoBufSerializer();
+
+    // when
+    final var decoded =
+        protoBufSerializer.decodeCurrentClusterConfiguration(
+            protoBufSerializer.encodeCurrentClusterConfiguration(configuration));
+
+    // then
+    assertThat(decoded).describedAs(COLLECTION_EQUALITY_HINT).isEqualTo(configuration);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.Active
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.util.ReflectUtil;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -54,6 +55,7 @@ import net.jqwik.api.domains.DomainContextBase;
 import net.jqwik.api.providers.ArbitraryProvider;
 import net.jqwik.api.providers.TypeUsage;
 import net.jqwik.api.support.CollectorsSupport;
+import net.jqwik.time.api.DateTimes;
 
 /**
  * Contains all arbitraries needed to generate a {@link ClusterConfiguration}. The topology is not
@@ -253,7 +255,7 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   Arbitrary<BrokerState> brokerStates() {
     final var version = Arbitraries.longs().greaterOrEqual(0);
     final var state = Arbitraries.of(BrokerState.State.values());
-    return Combinators.combine(version, instants(), state)
+    return Combinators.combine(version, nanoPrecisionInstants(), state)
         .as((v, lastUpdated, s) -> new BrokerState(v, lastUpdated, s));
   }
 
@@ -266,7 +268,7 @@ public final class ClusterTopologyDomain extends DomainContextBase {
                 Arbitraries.forType(PartitionState.class).enableRecursion())
             .ofMaxSize(4);
     final var mode = Arbitraries.of(Mode.values());
-    return Combinators.combine(version, instants(), partitions, mode)
+    return Combinators.combine(version, nanoPrecisionInstants(), partitions, mode)
         .as((v, lastUpdated, p, m) -> new BrokerPartitionState(v, lastUpdated, p, m));
   }
 
@@ -287,7 +289,7 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   Arbitrary<PhasedChangePlan> phasedChangePlans(final long minId) {
     final var id = Arbitraries.longs().between(minId, minId + 1000);
     final var phases = phases().list().ofMinSize(1).ofMaxSize(4);
-    return Combinators.combine(id, phases, instants())
+    return Combinators.combine(id, phases, nanoPrecisionInstants())
         .flatAs(
             (planId, phaseList, startedAt) ->
                 Arbitraries.integers()
@@ -310,7 +312,7 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   Arbitrary<CompletedPhasedChange> completedPhasedChanges() {
     final var id = Arbitraries.longs().between(0, 500);
     final var status = Arbitraries.of(PhasedChangePlanStatus.values());
-    return Combinators.combine(id, status, instants(), instants())
+    return Combinators.combine(id, status, nanoPrecisionInstants(), nanoPrecisionInstants())
         .as(
             (planId, s, startedAt, completedAt) ->
                 new CompletedPhasedChange(planId, s, startedAt, completedAt));
@@ -335,12 +337,12 @@ public final class ClusterTopologyDomain extends DomainContextBase {
     return Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(10);
   }
 
-  /**
-   * Whole-second instants. Serialization preserves nanos, but some reused legacy sub-type decoders
-   * read seconds only; whole-second fixtures keep every round-trip exact.
-   */
-  Arbitrary<Instant> instants() {
-    return Arbitraries.longs().between(0, 4_000_000_000L).map(Instant::ofEpochSecond);
+  /** Nanosecond-precision instants. The default precision in jqwik is seconds. */
+  @Provide
+  Arbitrary<Instant> nanoPrecisionInstants() {
+    return DateTimes.instants()
+        .between(Instant.ofEpochSecond(0), Instant.ofEpochSecond(4_000_000_000L))
+        .ofPrecision(ChronoUnit.NANOS);
   }
 
   @SuppressWarnings("unused")

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -8,20 +8,37 @@
 package io.camunda.zeebe.dynamic.config.util;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.BrokerPartitionState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.CompletedPhasedChange;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportingConfig;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.GlobalPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.PartitionGroupParallelPhase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlan.Phase;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangePlanStatus;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.util.ReflectUtil;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -181,6 +198,149 @@ public final class ClusterTopologyDomain extends DomainContextBase {
         .enableRecursion()
         .map(DynamicPartitionConfig::new)
         .filter(DynamicPartitionConfig::isInitialized);
+  }
+
+  // ---- New multi-partition-group model (8.10) ----
+
+  @Provide
+  Arbitrary<CurrentClusterConfiguration> currentClusterConfigurations() {
+    final var partitionGroups =
+        Arbitraries.maps(partitionGroupIds(), partitionGroupConfigurations()).ofMaxSize(4);
+    return Combinators.combine(globalConfigurations(), partitionGroups, phasedChangeStates())
+        .as(
+            (global, groups, phasedChangeState) ->
+                // version is always INITIAL_VERSION and reserved; it is not used in merge.
+                new CurrentClusterConfiguration(
+                    CurrentClusterConfiguration.INITIAL_VERSION,
+                    global,
+                    groups,
+                    phasedChangeState));
+  }
+
+  @Provide
+  Arbitrary<GlobalConfiguration> globalConfigurations() {
+    final var version = Arbitraries.longs().greaterOrEqual(0);
+    // clusterId must be non-empty: the serializer treats the empty string as "absent".
+    final var clusterId = Arbitraries.strings().ofMinLength(1).ofMaxLength(50).optional();
+    final var members = Arbitraries.maps(memberIds(), brokerStates()).ofMaxSize(6);
+    final var pendingChanges =
+        Arbitraries.forType(ClusterChangePlan.class).enableRecursion().optional();
+    final var lastChange = Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
+    return Combinators.combine(
+            version, clusterId, members, partitionDistributorConfigs(), pendingChanges, lastChange)
+        .as(
+            (v, cid, m, distributor, pending, last) ->
+                new GlobalConfiguration(v, cid, m, distributor, pending, last));
+  }
+
+  @Provide
+  Arbitrary<PartitionGroupConfiguration> partitionGroupConfigurations() {
+    final var version = Arbitraries.longs().greaterOrEqual(0);
+    final var incarnationNumber = Arbitraries.longs().greaterOrEqual(0);
+    final var members = Arbitraries.maps(memberIds(), brokerPartitionStates()).ofMaxSize(6);
+    final var routingState = routingStates().optional();
+    final var pendingChanges =
+        Arbitraries.forType(ClusterChangePlan.class).enableRecursion().optional();
+    final var lastChange = Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
+    return Combinators.combine(
+            version, incarnationNumber, members, routingState, pendingChanges, lastChange)
+        .as(
+            (v, inc, m, routing, pending, last) ->
+                new PartitionGroupConfiguration(v, inc, m, routing, pending, last));
+  }
+
+  @Provide
+  Arbitrary<BrokerState> brokerStates() {
+    final var version = Arbitraries.longs().greaterOrEqual(0);
+    final var state = Arbitraries.of(BrokerState.State.values());
+    return Combinators.combine(version, instants(), state)
+        .as((v, lastUpdated, s) -> new BrokerState(v, lastUpdated, s));
+  }
+
+  @Provide
+  Arbitrary<BrokerPartitionState> brokerPartitionStates() {
+    final var version = Arbitraries.longs().greaterOrEqual(0);
+    final var partitions =
+        Arbitraries.maps(
+                Arbitraries.integers().between(1, 20),
+                Arbitraries.forType(PartitionState.class).enableRecursion())
+            .ofMaxSize(4);
+    final var mode = Arbitraries.of(Mode.values());
+    return Combinators.combine(version, instants(), partitions, mode)
+        .as((v, lastUpdated, p, m) -> new BrokerPartitionState(v, lastUpdated, p, m));
+  }
+
+  @Provide
+  Arbitrary<PhasedChangeState> phasedChangeStates() {
+    return completedPhasedChanges()
+        .optional()
+        .flatMap(
+            lastChange -> {
+              // Pending plan id must be positive and greater than the last completed change id.
+              final long minPendingId = lastChange.map(c -> c.id() + 1).orElse(1L);
+              return phasedChangePlans(minPendingId)
+                  .optional()
+                  .map(pending -> new PhasedChangeState(pending, lastChange));
+            });
+  }
+
+  Arbitrary<PhasedChangePlan> phasedChangePlans(final long minId) {
+    final var id = Arbitraries.longs().between(minId, minId + 1000);
+    final var phases = phases().list().ofMinSize(1).ofMaxSize(4);
+    return Combinators.combine(id, phases, instants())
+        .flatAs(
+            (planId, phaseList, startedAt) ->
+                Arbitraries.integers()
+                    .between(0, phaseList.size() - 1)
+                    .map(index -> new PhasedChangePlan(planId, index, phaseList, startedAt)));
+  }
+
+  @Provide
+  Arbitrary<Phase> phases() {
+    final Arbitrary<Phase> globalPhases =
+        globalChangeOperations().list().ofMaxSize(3).<Phase>map(GlobalPhase::new);
+    final Arbitrary<Phase> parallelPhases =
+        Arbitraries.maps(partitionGroupIds(), partitionGroupChangeOperations().list().ofMaxSize(3))
+            .ofMaxSize(3)
+            .<Phase>map(PartitionGroupParallelPhase::new);
+    return Arbitraries.oneOf(globalPhases, parallelPhases);
+  }
+
+  @Provide
+  Arbitrary<CompletedPhasedChange> completedPhasedChanges() {
+    final var id = Arbitraries.longs().between(0, 500);
+    final var status = Arbitraries.of(PhasedChangePlanStatus.values());
+    return Combinators.combine(id, status, instants(), instants())
+        .as(
+            (planId, s, startedAt, completedAt) ->
+                new CompletedPhasedChange(planId, s, startedAt, completedAt));
+  }
+
+  @Provide
+  Arbitrary<GlobalChangeOperation> globalChangeOperations() {
+    return Arbitraries.of(
+            ReflectUtil.implementationsOfSealedInterface(GlobalChangeOperation.class).toList())
+        .flatMap(Arbitraries::forType);
+  }
+
+  @Provide
+  Arbitrary<PartitionGroupOperation> partitionGroupChangeOperations() {
+    return Arbitraries.of(
+            ReflectUtil.implementationsOfSealedInterface(PartitionGroupOperation.class).toList())
+        .flatMap(Arbitraries::forType);
+  }
+
+  @Provide
+  Arbitrary<String> partitionGroupIds() {
+    return Arbitraries.strings().alpha().ofMinLength(1).ofMaxLength(10);
+  }
+
+  /**
+   * Whole-second instants. Serialization preserves nanos, but some reused legacy sub-type decoders
+   * read seconds only; whole-second fixtures keep every round-trip exact.
+   */
+  Arbitrary<Instant> instants() {
+    return Arbitraries.longs().between(0, 4_000_000_000L).map(Instant::ofEpochSecond);
   }
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
## Description

Adds proto serialization for the new multi-partition-group model, implementing #56206 (Phase 1 — Data layer of #56018).

### What's added (all in `ProtoBufSerializer`, additive)
- `encode/decodeCurrentClusterConfiguration` — `byte[]` entry points.
- `encode/decodeGlobalConfiguration` and `encode/decodePartitionGroupConfiguration` — public proto-level helpers (for the gossip serializer in #56214).
- Internal encode/decode for `BrokerState`, `BrokerPartitionState`, `PhasedChangeState`, `PhasedChangePlan` (both phase types), and `CompletedPhasedChange`.
- New-model operations serialize through their own split proto wrappers (`GlobalChangeOperation` / `PartitionGroupChangeOperation`) via self-contained, compiler-exhaustive `switch` encoders; the non-trivial payload sub-helpers (partition bootstrap / enable-exporter, partition config, routing state, distributor config, `Mode`) and the sub-type helpers (`PartitionState`, `ClusterChangePlan`, `CompletedChange`, `RoutingState`, `PartitionDistributorConfig`) are **reused by call** — no existing method is modified.
- Two new enum mappings: `BrokerState.State` ↔ `Topology.State` (lifecycle only; `BOOTSTRAPPING`/`RECOVERING` rejected on decode) and `PhasedChangePlanStatus` ↔ `Topology.PhasedChangePlanStatus`.

### Scope note (deliberate deviation from the issue)
The issue also describes a persistence header-version bump and first-boot v1→v2 migration/write-back. That is **intentionally not included** here — it would be a production behaviour change, and these serializer methods are meant to be wired up later in Phase 3. This PR is purely additive serialization with no behaviour change. Gossip encoding is covered separately in #56214.

## Testing

Follows the existing `ProtoBufSerializerPropertyTest` pattern: a jqwik property generates arbitrary `CurrentClusterConfiguration`s (arbitraries added to `ClusterTopologyDomain`, reusing its existing sub-type arbitraries) and round-trips them through `encode/decodeCurrentClusterConfiguration` (100 tries). This subsumes the acceptance cases — two partition groups and a `PhasedChangePlan` with both phase types are generated across runs. Only the cases a property test cannot reach are kept as explicit tests in `CurrentClusterConfigurationSerializerTest`: decoding invalid bytes (→ `DecodingFailed`) and decoding a proto carrying a non-lifecycle broker state (`BOOTSTRAPPING`/`RECOVERING` → rejected). Existing serializer/persistence tests still pass (no regression); the domain additions don't alter existing arbitraries.


## Acceptance criteria

- [x] Round-trip test with two partition groups.
- [x] Round-trip test for `PhasedChangePlan` with both phase types.
- [ ] Persistence migration test — **out of scope** (no v1→v2 write-back; deferred to Phase 3 wiring).

Part of #56206

🤖 Generated with [Claude Code](https://claude.com/claude-code)
