### PR TITLE
feat: add actuator API to migrate a zone to be named

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
@@ -484,6 +485,19 @@ public class ClusterEndpoint {
       final var updateRequest = new UpdatePartitionDistributorConfigRequest(internalConfig, dryRun);
       return ClusterApiUtils.mapOperationResponse(
           requestSender.updatePartitionDistribution(updateRequest).join());
+    } catch (final Exception exception) {
+      return ClusterApiUtils.mapError(exception);
+    }
+  }
+
+  @PutMapping(path = "/zones", consumes = "application/json")
+  public ResponseEntity<?> migrateZone(
+      @RequestBody final io.camunda.zeebe.management.cluster.ClusterZoneMigrationRequest request,
+      @RequestParam(defaultValue = "false") final boolean dryRun) {
+    try {
+      final var migrationRequest = new ClusterZoneMigrationRequest(request.getZone(), dryRun);
+      return ClusterApiUtils.mapOperationResponse(
+          requestSender.migrateToZones(migrationRequest).join());
     } catch (final Exception exception) {
       return ClusterApiUtils.mapError(exception);
     }

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -187,10 +187,12 @@ paths:
   /partition-distribution:
     put:
       summary:
-        Update the partition distribution configuration for a zone-aware cluster. The
-        new configuration is applied immediately by computing and executing the necessary
-        partition join, leave, and priority-reconfiguration operations. Only ZONE_AWARE
-        clusters and ZONE_AWARE config bodies are accepted.
+        Update the partition distribution configuration. The new configuration is persisted and applied immediately
+        by computing the necessary partition join, leave, and priority-reconfiguration operations. When migrating
+        a bare or partially zoned cluster to zone-aware (see `PUT /cluster/zones`), list zones in the order they
+        should receive the existing (bare) nodes — the first zone in the list receives node 0, the second zone
+        node 1, and so on, wrapping around by zone count. This order only matters for that one-time migration;
+        once all zones are migrated, every other API addresses zones by name.
       requestBody:
         required: true
         content:
@@ -216,6 +218,41 @@ paths:
           $ref: 'components.yaml#/responses/GatewayError'
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
+
+  /zones:
+    put:
+      summary:
+        Migrate one zone of a bare or partially zoned cluster to a zone-aware topology. The request
+        contains only the zone name. Before migrating a zone, update the persisted partition
+        distribution with `PUT /cluster/partition-distribution` with a zone aware partition distribution.
+        For dual-region clusters, migrate the secondary zone first (odd-numbered nodes) and then the primary zone.
+
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "components.yaml#/schemas/ClusterZoneMigrationRequest"
+      parameters:
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        '202':
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+      x-added-in-version: "8.10.0"
 
 components:
   parameters:

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -164,7 +164,12 @@ schemas:
           defined in each broker's local configuration.
       zones:
         type: array
-        description: Zone specifications; present only when type is ZONE_AWARE.
+        description: >
+          Zone specifications; present only when type is ZONE_AWARE. While migrating a bare or
+          partially zoned cluster to zone-aware, the order of this array matters: it determines
+          which existing (bare) nodes get migrated into which zone. Outside of migration, order is
+          irrelevant — every operation addresses a zone by its `name`, never by its position in
+          this array.
         items:
           $ref: "components.yaml#/schemas/ZoneSpec"
 
@@ -190,6 +195,24 @@ schemas:
         format: int32
         description: Preferred-leader ranking; higher value wins
         example: 1000
+
+  ClusterZoneMigrationRequest:
+    description: >
+      Request to migrate one zone from a bare or partially zoned cluster. The complete zone order,
+      priorities, and replica counts must already be persisted through the partition-distribution
+      configuration — that persisted order is what determines which existing (bare) nodes are
+      migrated into this zone. When all configured zones have been migrated, the cluster becomes
+      fully zoned and subsequent operations address zones by name.
+    type: object
+    required:
+      - zone
+    properties:
+      zone:
+        type: string
+        description: >
+          Name of the zone to migrate. The zone must already exist in the persisted
+          partition-distribution configuration.
+        example: eu-west-1
 
   RoutingState:
     description: The routing state, i.e. where requests are sent to and how messages are correlated

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
@@ -67,6 +68,9 @@ public interface ClusterConfigurationManagementApi {
 
   ActorFuture<ClusterConfigurationChangeResponse> updatePartitionDistribution(
       UpdatePartitionDistributorConfigRequest request);
+
+  ActorFuture<ClusterConfigurationChangeResponse> migrateZone(
+      ClusterZoneMigrationRequest zoneMigrationRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> purge(PurgeRequest purgeRequest);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -17,9 +17,11 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /** Defines the supported requests for the configuration management. */
+@NullMarked
 public sealed interface ClusterConfigurationManagementRequest {
 
   /**
@@ -102,6 +104,18 @@ public sealed interface ClusterConfigurationManagementRequest {
 
   record UpdatePartitionDistributorConfigRequest(PartitionDistributorConfig config, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
+
+  /**
+   * Migrates one persisted zone stage from a bare or partially zoned cluster. The request names the
+   * zone to migrate; the persisted {@code ZoneAwareConfig} remains the single source of truth for
+   * zone order, priorities, and replica counts.
+   */
+  record ClusterZoneMigrationRequest(String zone, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {
+    public ClusterZoneMigrationRequest {
+      assertNonEmpty("zone").accept(zone);
+    }
+  }
 
   record ForceRemoveBrokersRequest(Set<MemberId> membersToRemove, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
@@ -241,6 +242,17 @@ public final class ClusterConfigurationManagementRequestSender {
         ClusterConfigurationRequestTopics.UPDATE_PARTITION_DISTRIBUTION.topic(),
         request,
         serializer::encodeUpdatePartitionDistributorConfigRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      migrateToZones(final ClusterZoneMigrationRequest request) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.ZONE_MIGRATION.topic(),
+        request,
+        serializer::encodeClusterZoneMigrationRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
@@ -241,6 +242,14 @@ public final class ClusterConfigurationManagementRequestsHandler
   @Override
   public ActorFuture<ClusterConfigurationChangeResponse> restore(final RestoreRequest request) {
     return handleRequest(request.dryRun(), new RestoreRequestTransformer(request));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> migrateZone(
+      final ClusterZoneMigrationRequest zoneMigrationRequest) {
+    return handleRequest(
+        zoneMigrationRequest.dryRun(),
+        new ZoneMigrationRequestTransformer(zoneMigrationRequest.zone()));
   }
 
   private ActorFuture<ClusterConfigurationChangeResponse> handleRequest(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -51,6 +51,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerClusterPatchRequestHandler();
     registerUpdateRoutingStateHandler();
     registerUpdatePartitionDistributionHandler();
+    registerZoneMigrationHandler();
     registerForceRemoveBrokersRequestHandler();
     registerPurgeRequestHandler();
     registerModeChangeHandler();
@@ -216,6 +217,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         serializer::decodeUpdatePartitionDistributorConfigRequest,
         request ->
             mapResponse(clusterConfigurationManagementApi.updatePartitionDistribution(request)),
+        this::encodeResponse);
+  }
+
+  private void registerZoneMigrationHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.ZONE_MIGRATION.topic(),
+        serializer::decodeClusterZoneMigrationRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.migrateZone(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -28,7 +28,8 @@ public enum ClusterConfigurationRequestTopics {
   UPDATE_ROUTING_STATE("topology-cluster-update-routing-state"),
   UPDATE_PARTITION_DISTRIBUTION("topology-cluster-update-partition-distribution"),
   MODE_CHANGE("topology-mode-change"),
-  RESTORE("cluster-restore");
+  RESTORE("cluster-restore"),
+  ZONE_MIGRATION("topology-cluster-zone-migration");
 
   private final String topic;
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.serializer;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RestoreRequest;
@@ -62,6 +63,8 @@ public interface ClusterConfigurationRequestsSerializer {
 
   byte[] encodeUpdatePartitionDistributorConfigRequest(
       UpdatePartitionDistributorConfigRequest request);
+
+  byte[] encodeClusterZoneMigrationRequest(ClusterZoneMigrationRequest request);
 
   ClusterConfigurationManagementRequest.AddMembersRequest decodeAddMembersRequest(
       byte[] encodedState);
@@ -118,6 +121,8 @@ public interface ClusterConfigurationRequestsSerializer {
 
   UpdatePartitionDistributorConfigRequest decodeUpdatePartitionDistributorConfigRequest(
       byte[] bytes);
+
+  ClusterZoneMigrationRequest decodeClusterZoneMigrationRequest(byte[] bytes);
 
   byte[] encodeModeChangeRequest(ModeChangeRequest modeChangeRequest);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
@@ -1071,6 +1072,15 @@ public class ProtoBufSerializer
   }
 
   @Override
+  public byte[] encodeClusterZoneMigrationRequest(final ClusterZoneMigrationRequest request) {
+    return Requests.ClusterZoneMigrationRequest.newBuilder()
+        .setZone(request.zone())
+        .setDryRun(request.dryRun())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
   public AddMembersRequest decodeAddMembersRequest(final byte[] encodedState) {
     try {
       final var addMemberRequest = Requests.AddMembersRequest.parseFrom(encodedState);
@@ -1387,6 +1397,17 @@ public class ProtoBufSerializer
                         new IllegalArgumentException(
                             "UpdatePartitionDistributorConfigRequest has empty config")));
     return new UpdatePartitionDistributorConfigRequest(config, proto.getDryRun());
+  }
+
+  @Override
+  public ClusterZoneMigrationRequest decodeClusterZoneMigrationRequest(final byte[] bytes) {
+    final Requests.ClusterZoneMigrationRequest proto;
+    try {
+      proto = Requests.ClusterZoneMigrationRequest.parseFrom(bytes);
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+    return new ClusterZoneMigrationRequest(proto.getZone(), proto.getDryRun());
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -64,6 +64,11 @@ message UpdatePartitionDistributorConfigRequest {
   bool dryRun = 2;
 }
 
+message ClusterZoneMigrationRequest {
+  string zone = 1;
+  bool dryRun = 2;
+}
+
 message ForceRemoveBrokersRequest {
   repeated string membersToRemove = 1;
   bool dryRun = 2;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDeleteRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
@@ -48,6 +49,19 @@ import org.junit.jupiter.params.provider.ValueSource;
 final class ProtoBufSerializerTest {
 
   private final ProtoBufSerializer protoBufSerializer = new ProtoBufSerializer();
+
+  @Test
+  void shouldEncodeAndDecodeClusterZoneMigrationRequest() {
+    // given
+    final var request = new ClusterZoneMigrationRequest("us-west-1", true);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeClusterZoneMigrationRequest(request);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeClusterZoneMigrationRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(request);
+  }
 
   @Test
   void shouldEncodeAndDecodeAddMembersRequest() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/NonZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/NonZoneAwareClusterEndpointIT.java
@@ -7,10 +7,43 @@
  */
 package io.camunda.zeebe.it.cluster.management;
 
+import static io.camunda.zeebe.qa.util.cluster.util.ZoneFixtures.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.configuration.Partitioning.Scheme;
+import io.camunda.configuration.Zone;
+import io.camunda.configuration.ZoneAware;
 import io.camunda.zeebe.management.cluster.BrokerId;
+import io.camunda.zeebe.management.cluster.BrokerState;
+import io.camunda.zeebe.management.cluster.ClusterZoneMigrationRequest;
+import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
+import io.camunda.zeebe.management.cluster.PartitionDistributionConfig.TypeEnum;
+import io.camunda.zeebe.management.cluster.PartitionState;
+import io.camunda.zeebe.management.cluster.ZoneSpec;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.test.DynamicAutoCloseable;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 final class NonZoneAwareClusterEndpointIT extends ClusterEndpointIT {
+
+  private static final String CLUSTER_NAME = "non-zone-aware-cluster-endpoint-it";
+
+  @AutoClose private final DynamicAutoCloseable closeables = new DynamicAutoCloseable();
 
   @Override
   protected int brokerCount() {
@@ -27,6 +60,7 @@ final class NonZoneAwareClusterEndpointIT extends ClusterEndpointIT {
   protected TestCluster createCluster(
       final int brokerCount, final int partitionCount, final int replicationFactor) {
     return TestCluster.builder()
+        .withName(CLUSTER_NAME)
         .withEmbeddedGateway(true)
         .withBrokersCount(brokerCount)
         .withPartitionsCount(partitionCount)
@@ -44,4 +78,202 @@ final class NonZoneAwareClusterEndpointIT extends ClusterEndpointIT {
   protected BrokerId brokerId(final int nodeIdx) {
     return new BrokerId.Integer(nodeIdx);
   }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("zoneMigrationScenarios")
+  void shouldMigrateUnzonedClusterToZoneAwareConfiguration(
+      final String description, final ZoneMigrationScenario scenario) {
+    try (final var cluster =
+        createCluster(
+            scenario.brokerCount(), scenario.partitionCount(), scenario.replicationFactor())) {
+      // given
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      final var distributionUpdate =
+          actuator.patchPartitionDistribution(scenario.expectedDistribution(), false);
+      assertThat(distributionUpdate.getPlannedChanges()).isNotEmpty();
+      Awaitility.await()
+          .atMost(Duration.ofMinutes(1))
+          .untilAsserted(
+              () -> {
+                final var topology = actuator.getTopology();
+                assertThat(topology.getPendingChange()).isNull();
+                assertThat(topology.getPartitionDistribution())
+                    .isEqualTo(scenario.expectedDistribution());
+              });
+
+      // start brokers in the first migration stage
+      startReplacementBrokers(cluster, scenario.initialReplacementBrokerIds(), scenario);
+
+      // when
+      for (int i = 0; i < scenario.migrationZones().size(); i++) {
+        final var response =
+            actuator.migrateZone(zoneMigrationRequest(scenario.migrationZones().get(i)), false);
+
+        // then
+        assertThat(response.getPlannedChanges()).isNotEmpty();
+        Awaitility.await()
+            .atMost(Duration.ofMinutes(1))
+            .untilAsserted(() -> assertThat(actuator.getTopology().getPendingChange()).isNull());
+        if (i == 0 && !scenario.delayedReplacementBrokerIds().isEmpty()) {
+          startReplacementBrokers(cluster, scenario.delayedReplacementBrokerIds(), scenario);
+        }
+      }
+
+      // then
+      Awaitility.await()
+          .atMost(Duration.ofMinutes(1))
+          .untilAsserted(
+              () -> {
+                final var topology = actuator.getTopology();
+                assertThat(topology.getPendingChange()).isNull();
+                assertThat(topology.getPartitionDistribution())
+                    .isEqualTo(scenario.expectedDistribution());
+                assertThat(topology.getBrokers())
+                    .extracting(BrokerState::getId)
+                    .allMatch(BrokerId.String.class::isInstance)
+                    .map(id -> id.brokerId().memberId())
+                    .containsExactlyInAnyOrderElementsOf(scenario.expectedBrokerIds());
+                assertThat(partitionsByZone(topology.getBrokers()))
+                    .allSatisfy(
+                        (partitionId, zones) ->
+                            assertThat(zones)
+                                .describedAs(
+                                    "partition %s should span the expected number of zones",
+                                    partitionId)
+                                .hasSize(scenario.expectedZonesPerPartition()));
+              });
+    }
+  }
+
+  private static Stream<Arguments> zoneMigrationScenarios() {
+    final var singleRegionBrokerIds = zoneANodes(3);
+
+    return Stream.of(
+        Arguments.of(
+            "single region",
+            new ZoneMigrationScenario(
+                3,
+                3,
+                3,
+                List.of(new Zone(ZONE_A, 3, 3, 100)),
+                List.of(ZONE_A),
+                new PartitionDistributionConfig()
+                    .type(TypeEnum.ZONE_AWARE)
+                    .zones(List.of(new ZoneSpec().name(ZONE_A).numberOfReplicas(3).priority(100))),
+                singleRegionBrokerIds,
+                singleRegionBrokerIds,
+                List.of(),
+                1)),
+        Arguments.of(
+            "dual region",
+            new ZoneMigrationScenario(
+                4,
+                2,
+                4,
+                List.of(new Zone(ZONE_A, 2, 2, 100), new Zone(ZONE_B, 2, 2, 100)),
+                List.of(ZONE_B, ZONE_A),
+                new PartitionDistributionConfig()
+                    .type(TypeEnum.ZONE_AWARE)
+                    .zones(
+                        List.of(
+                            new ZoneSpec().name(ZONE_A).numberOfReplicas(2).priority(100),
+                            new ZoneSpec().name(ZONE_B).numberOfReplicas(2).priority(100))),
+                List.of(ZONE_A_0, ZONE_A_1, ZONE_B_0, ZONE_B_1),
+                List.of(ZONE_B_0, ZONE_B_1),
+                List.of(ZONE_A_0, ZONE_A_1),
+                2)));
+  }
+
+  private void startReplacementBrokers(
+      final TestCluster cluster,
+      final List<MemberId> brokerIds,
+      final ZoneMigrationScenario scenario) {
+    final var brokers =
+        brokerIds.stream()
+            .map(
+                memberId ->
+                    startReplacementBroker(
+                        cluster,
+                        scenario.targetZones(),
+                        scenario.partitionCount(),
+                        scenario.replicationFactor(),
+                        memberId))
+            .toList();
+    brokers.forEach(broker -> broker.await(TestHealthProbe.READY, Duration.ofMinutes(1)));
+  }
+
+  @SuppressWarnings("resource")
+  private TestStandaloneBroker startReplacementBroker(
+      final TestCluster cluster,
+      final List<Zone> targetZones,
+      final int partitionCount,
+      final int replicationFactor,
+      final MemberId memberId) {
+    final var contactPoint =
+        cluster.brokers().values().iterator().next().address(TestZeebePort.CLUSTER);
+    final var broker =
+        new TestStandaloneBroker()
+            .withUnauthenticatedAccess()
+            .withUnifiedConfig(
+                cfg -> {
+                  final var clusterCfg = cfg.getCluster();
+                  clusterCfg.setName(CLUSTER_NAME);
+                  clusterCfg.setInitialContactPoints(List.of(contactPoint));
+                  clusterCfg.setZone(memberId.zone());
+                  clusterCfg.setNodeId(memberId.nodeIdx());
+                  clusterCfg.setSize(cluster.brokers().size());
+                  clusterCfg.setPartitionCount(partitionCount);
+                  clusterCfg.setReplicationFactor(replicationFactor);
+                  clusterCfg.getPartitioning().setScheme(Scheme.ZONE_AWARE);
+                  clusterCfg.getPartitioning().setZoneAware(new ZoneAware(targetZones));
+                  cfg.getData().getSecondaryStorage().setAutoconfigureCamundaExporter(false);
+                });
+
+    final var startThread = Thread.ofVirtual().name("start-" + memberId).start(broker::start);
+    closeables.manage(
+        () -> {
+          broker.close();
+          startThread.interrupt();
+          startThread.join(Duration.ofSeconds(30));
+        });
+    return broker;
+  }
+
+  private static ClusterZoneMigrationRequest zoneMigrationRequest(final String zone) {
+    return new ClusterZoneMigrationRequest().zone(zone);
+  }
+
+  private static Map<Integer, Set<String>> partitionsByZone(final List<BrokerState> brokers) {
+    return brokers.stream()
+        .filter(broker -> broker.getId() instanceof BrokerId.String)
+        .collect(
+            Collectors.groupingBy(
+                broker -> MemberId.from(((BrokerId.String) broker.getId()).value()).zone(),
+                Collectors.flatMapping(
+                    broker -> broker.getPartitions().stream().map(PartitionState::getId),
+                    Collectors.toSet())))
+        .entrySet()
+        .stream()
+        .flatMap(
+            entry ->
+                entry.getValue().stream()
+                    .map(partitionId -> Map.entry(partitionId, entry.getKey())))
+        .collect(
+            Collectors.groupingBy(
+                Map.Entry::getKey, Collectors.mapping(Map.Entry::getValue, Collectors.toSet())));
+  }
+
+  private record ZoneMigrationScenario(
+      int brokerCount,
+      int partitionCount,
+      int replicationFactor,
+      List<Zone> targetZones,
+      List<String> migrationZones,
+      PartitionDistributionConfig expectedDistribution,
+      List<MemberId> expectedBrokerIds,
+      List<MemberId> initialReplacementBrokerIds,
+      List<MemberId> delayedReplacementBrokerIds,
+      int expectedZonesPerPartition) {}
 }

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -23,6 +23,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-cluster-config</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>configuration</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -22,6 +22,7 @@ import feign.jackson.JacksonEncoder;
 import io.camunda.container.cluster.BrokerNode;
 import io.camunda.zeebe.management.cluster.BrokerId;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
+import io.camunda.zeebe.management.cluster.ClusterZoneMigrationRequest;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.PartitionDistributionConfig;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
@@ -358,6 +359,11 @@ public interface ClusterActuator {
   @Headers({"Content-Type: application/json", "accept: application/json"})
   PlannedOperationsResponse patchPartitionDistribution(
       @RequestBody final PartitionDistributionConfig config, @Param boolean dryRun);
+
+  @RequestLine("PUT /zones?dryRun={dryRun}")
+  @Headers({"Content-Type: application/json", "accept: application/json"})
+  PlannedOperationsResponse migrateZone(
+      @RequestBody final ClusterZoneMigrationRequest request, @Param boolean dryRun);
 
   /**
    * Requests a cluster mode change.

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/util/ZoneFixtures.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/util/ZoneFixtures.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.cluster.util;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ZoneFixtures {
+
+  // zones
+  public static final String ZONE_A = "zone-a";
+  public static final String ZONE_B = "zone-b";
+  public static final String ZONE_C = "zone-c";
+
+  // bare node ids
+  public static final MemberId BARE_0 = MemberId.from(0);
+  public static final MemberId BARE_1 = MemberId.from(1);
+  public static final MemberId BARE_2 = MemberId.from(2);
+  public static final MemberId BARE_3 = MemberId.from(3);
+  // zone A
+  public static final MemberId ZONE_A_0 = MemberId.from(ZONE_A, 0);
+  public static final MemberId ZONE_A_1 = MemberId.from(ZONE_A, 1);
+  public static final MemberId ZONE_A_2 = MemberId.from(ZONE_A, 2);
+  // zone B
+  public static final MemberId ZONE_B_0 = MemberId.from(ZONE_B, 0);
+  public static final MemberId ZONE_B_1 = MemberId.from(ZONE_B, 1);
+  public static final MemberId ZONE_B_2 = MemberId.from(ZONE_B, 2);
+  // Zone configs
+  public static final List<ZoneSpec> SINGLE_REGION = List.of(new ZoneSpec(ZONE_A, 3, 100));
+  public static final List<ZoneSpec> DUAL_REGION =
+      List.of(new ZoneSpec(ZONE_A, 2, 100), new ZoneSpec(ZONE_B, 2, 100));
+
+  public static List<MemberId> zoneANodes(final int count) {
+    return IntStream.range(0, count).mapToObj(i -> MemberId.from(ZONE_A, i)).toList();
+  }
+
+  public static Set<MemberId> bareNodes(final int n) {
+    return IntStream.range(0, n).mapToObj(MemberId::from).collect(Collectors.toSet());
+  }
+}


### PR DESCRIPTION
## Description
Added PUT /zones actuator endpoint that allows to migrate a zone to be a named zoned.

Includes an IT in NonZoneAwareClusterEndpointIT that tests a single and a dual-region setup.

The API just delegates to the implementation done in PR #57275


## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #51986
