### PR TITLE
Declare /post-logout OIDC post-logout route

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
@@ -8,6 +8,7 @@
 package io.camunda.authentication.config.spi;
 
 import io.camunda.security.core.port.out.SecurityPathPort;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -58,6 +59,7 @@ public class SecurityPathAdapter implements SecurityPathPort {
           "/",
           "/sso-callback/**",
           "/oauth2/authorization/**",
+          "/post-logout",
           "/processes",
           "/processes/*",
           "/{regex:[\\d]+}",
@@ -74,6 +76,7 @@ public class SecurityPathAdapter implements SecurityPathPort {
 
   private static final Set<String> UNAUTHENTICATED_WEBAPP_PATHS =
       Set.of(
+          "/post-logout",
           "/default-ui.css",
           "/tasklist/assets/**",
           "/tasklist/client-config.js",
@@ -136,6 +139,11 @@ public class SecurityPathAdapter implements SecurityPathPort {
   @Override
   public Set<String> adminFilterBypassPaths() {
     return ADMIN_FILTER_BYPASS_PATHS;
+  }
+
+  @Override
+  public Optional<String> postLogoutRedirectPath() {
+    return Optional.of("/post-logout");
   }
 
   // staticResourceSuffixes() inherits the SPI default which already matches OC's source set.

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SecurityPathAdapter.java
@@ -39,14 +39,7 @@ public class SecurityPathAdapter implements SecurityPathPort {
           "/.well-known/oauth-protected-resource/**");
 
   private static final Set<String> UNPROTECTED_PATHS =
-      Set.of(
-          "/error",
-          "/actuator/**",
-          "/ready",
-          "/health",
-          "/startup",
-          "/post-logout",
-          "/favicon.ico");
+      Set.of("/error", "/actuator/**", "/ready", "/health", "/startup", "/favicon.ico");
 
   private static final Set<String> WEBAPP_PATHS =
       Set.of(

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
@@ -98,11 +98,7 @@ public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfi
         .isEqualTo(LOGIN_HINT);
     // CSL builds the primary chain's handler from SecurityPathAdapter#postLogoutRedirectPath (empty
     // prefix), so the IdP is told to send the browser back to the host's post-logout route.
-    assertThat(
-            URLDecoder.decode(
-                Objects.requireNonNull(query.getFirst("post_logout_redirect_uri")),
-                StandardCharsets.UTF_8))
-        .isEqualTo("https://localhost:80/post-logout");
+    assertPrimaryPostLogoutRedirectUri(query);
   }
 
   @Test
@@ -126,11 +122,7 @@ public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfi
     final MultiValueMap<String, String> query =
         queryParams(location, "idp.example.com", "/protocol/openid-connect/logout");
     assertThat(query.getFirst("id_token_hint")).isNotBlank();
-    assertThat(
-            URLDecoder.decode(
-                Objects.requireNonNull(query.getFirst("post_logout_redirect_uri")),
-                StandardCharsets.UTF_8))
-        .isEqualTo("https://localhost:80/post-logout");
+    assertPrimaryPostLogoutRedirectUri(query);
   }
 
   private static MultiValueMap<String, String> queryParams(
@@ -140,6 +132,18 @@ public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfi
     assertThat(parsed.getHost()).isEqualTo(expectedHost);
     assertThat(parsed.getPath()).isEqualTo(expectedPath);
     return parsed.getQueryParams();
+  }
+
+  private static void assertPrimaryPostLogoutRedirectUri(
+      final MultiValueMap<String, String> query) {
+    final UriComponents redirect =
+        UriComponentsBuilder.fromUriString(
+                URLDecoder.decode(
+                    Objects.requireNonNull(query.getFirst("post_logout_redirect_uri")),
+                    StandardCharsets.UTF_8))
+            .build();
+    assertThat(redirect.getHost()).isEqualTo("localhost");
+    assertThat(redirect.getPath()).isEqualTo("/post-logout");
   }
 
   /**

--- a/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/OidcLogoutSuccessHandlerWiringTest.java
@@ -96,6 +96,13 @@ public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfi
             URLDecoder.decode(
                 Objects.requireNonNull(query.getFirst("logout_hint")), StandardCharsets.UTF_8))
         .isEqualTo(LOGIN_HINT);
+    // CSL builds the primary chain's handler from SecurityPathAdapter#postLogoutRedirectPath (empty
+    // prefix), so the IdP is told to send the browser back to the host's post-logout route.
+    assertThat(
+            URLDecoder.decode(
+                Objects.requireNonNull(query.getFirst("post_logout_redirect_uri")),
+                StandardCharsets.UTF_8))
+        .isEqualTo("https://localhost:80/post-logout");
   }
 
   @Test
@@ -119,6 +126,11 @@ public class OidcLogoutSuccessHandlerWiringTest extends AbstractWebSecurityConfi
     final MultiValueMap<String, String> query =
         queryParams(location, "idp.example.com", "/protocol/openid-connect/logout");
     assertThat(query.getFirst("id_token_hint")).isNotBlank();
+    assertThat(
+            URLDecoder.decode(
+                Objects.requireNonNull(query.getFirst("post_logout_redirect_uri")),
+                StandardCharsets.UTF_8))
+        .isEqualTo("https://localhost:80/post-logout");
   }
 
   private static MultiValueMap<String, String> queryParams(

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
@@ -39,13 +39,7 @@ class SecurityPathAdapterTest {
   void shouldExposeUnprotectedPaths() {
     assertThat(port.unprotectedPaths())
         .containsExactlyInAnyOrder(
-            "/error",
-            "/actuator/**",
-            "/ready",
-            "/health",
-            "/startup",
-            "/post-logout",
-            "/favicon.ico");
+            "/error", "/actuator/**", "/ready", "/health", "/startup", "/favicon.ico");
   }
 
   @Test

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SecurityPathAdapterTest.java
@@ -61,6 +61,7 @@ class SecurityPathAdapterTest {
             "/",
             "/sso-callback/**",
             "/oauth2/authorization/**",
+            "/post-logout",
             "/processes",
             "/processes/*",
             "/{regex:[\\d]+}",
@@ -85,6 +86,7 @@ class SecurityPathAdapterTest {
   void shouldExposeUnauthenticatedWebappPaths() {
     assertThat(port.unauthenticatedWebappPaths())
         .containsExactlyInAnyOrder(
+            "/post-logout",
             "/default-ui.css",
             "/tasklist/assets/**",
             "/tasklist/client-config.js",

--- a/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
+++ b/authentication/src/test/java/io/camunda/authentication/pt/PhysicalTenantApiChainIsolationIT.java
@@ -24,7 +24,6 @@ import io.camunda.authentication.config.spi.SecurityPathAdapter;
 import io.camunda.security.api.model.config.ScopedSecurityDescriptor;
 import io.camunda.security.core.port.out.SecurityPathPort;
 import io.camunda.security.spring.CamundaSecurityConfiguration;
-import io.camunda.security.spring.CamundaSecurityLibraryProperties;
 import io.camunda.security.spring.handler.AuthFailureHandlerConfiguration;
 import io.camunda.security.spring.oidc.JWSKeySelectorFactory;
 import io.camunda.security.spring.oidc.OidcAccessTokenDecoderFactory;
@@ -34,7 +33,6 @@ import io.camunda.security.spring.oidc.TokenValidatorFactory;
 import io.camunda.security.spring.scope.ScopedApiSecurityChainBuilder;
 import io.camunda.security.spring.scope.ScopedApiSecurityChainBuilderConfiguration;
 import io.camunda.security.spring.security.BaseSecurityConfiguration;
-import io.camunda.security.spring.security.OidcResourceServerCustomizer;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyPairGenerator;
@@ -46,7 +44,6 @@ import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -468,18 +465,9 @@ class PhysicalTenantApiChainIsolationIT {
     final var scopedJwtDecoderFactory =
         new ScopedJwtDecoderFactory(registrationFactory, decoderFactory);
 
-    // CSL chain builder from the Spring context (so it inherits the wired SecurityPathPort etc.)
-    final var properties = ctx.getBean(CamundaSecurityLibraryProperties.class);
-    final var authFailureHandler =
-        ctx.getBean(io.camunda.security.spring.handler.AuthFailureHandler.class);
-    final var pathPort = ctx.getBean(SecurityPathPort.class);
-    @SuppressWarnings("unchecked")
-    final ObjectProvider<OidcResourceServerCustomizer> customizers =
-        (ObjectProvider<OidcResourceServerCustomizer>)
-            ctx.getBeanProvider(OidcResourceServerCustomizer.class);
-
-    final var chainBuilder =
-        new ScopedApiSecurityChainBuilder(properties, authFailureHandler, pathPort, customizers);
+    // CSL chain builder from the Spring context (so it inherits the wired SecurityPathPort etc.
+    // and stays resilient to constructor changes in ScopedApiSecurityChainBuilderConfiguration).
+    final var chainBuilder = ctx.getBean(ScopedApiSecurityChainBuilder.class);
 
     final var chains = new java.util.ArrayList<SecurityFilterChain>();
     for (final var descriptor : descriptors) {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha45</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha47</version.camunda-security-library>
     <version.checkstyle>13.7.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMapping.java
@@ -29,7 +29,7 @@ public class PhysicalTenantRequestMappingHandlerMapping extends RequestMappingHa
   // Controllers on other paths are therefore never auto-enrolled in PT routing.
   private static final Set<String> PREFIXABLE_ROOTS =
       Stream.concat(
-              Stream.of("/v2", "/v3/api-docs", "/webapp"),
+              Stream.of("/v2", "/webapp", "/v3/api-docs", "/post-logout"),
               WebAppProviderAdapter.WEB_APPS.stream().map("/"::concat))
           .collect(Collectors.toUnmodifiableSet());
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMappingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/mapper/PhysicalTenantRequestMappingHandlerMappingTest.java
@@ -78,6 +78,8 @@ class PhysicalTenantRequestMappingHandlerMappingTest {
         Arguments.of("/admin/users", EXPECTED_PREFIX + "/admin/users"),
         Arguments.of("/webapp", EXPECTED_PREFIX + "/webapp"),
         Arguments.of("/webapp/some-route", EXPECTED_PREFIX + "/webapp/some-route"),
+        // post-logout landing gets a per-tenant sibling so scoped OIDC logout can return to it
+        Arguments.of("/post-logout", EXPECTED_PREFIX + "/post-logout"),
         // non-matching: different prefix
         Arguments.of("/v1/widgets", null),
         // non-matching: word boundary guards (no trailing slash → not a root)
@@ -134,7 +136,12 @@ class PhysicalTenantRequestMappingHandlerMappingTest {
             "plain webapp controller /tasklist/tasks keeps original and adds prefixed sibling",
             new PlainController(),
             "/tasklist/tasks",
-            List.of("/tasklist/tasks", EXPECTED_PREFIX + "/tasklist/tasks")));
+            List.of("/tasklist/tasks", EXPECTED_PREFIX + "/tasklist/tasks")),
+        Arguments.of(
+            "plain /post-logout controller keeps original and adds prefixed sibling",
+            new PlainController(),
+            "/post-logout",
+            List.of("/post-logout", EXPECTED_PREFIX + "/post-logout")));
   }
 
   @ParameterizedTest(name = "[{index}] {0}")


### PR DESCRIPTION
## Description

Make sure OIDC post-logout works for both cluster and per-tenant scoped chains.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Relates to camunda/camunda-security-library#499
