### PR TITLE
feat: add loop iteration markers to the conversation history

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -664,20 +664,20 @@ describe('<ConversationHistory />', () => {
         mockAgentInstanceHistoryItem({
           historyItemKey: '3',
           loopIteration: 2,
-          role: 'TOOL_RESULT',
-          content: [{contentType: 'TEXT', text: 'Second iteration message'}],
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'message 3'}],
         }),
         mockAgentInstanceHistoryItem({
           historyItemKey: '2',
           loopIteration: 2,
-          role: 'ASSISTANT',
-          content: [{contentType: 'TEXT', text: 'Second iteration message'}],
+          role: 'USER',
+          content: [{contentType: 'TEXT', text: 'message 2'}],
         }),
         mockAgentInstanceHistoryItem({
           historyItemKey: '1',
           loopIteration: 1,
           role: 'ASSISTANT',
-          content: [{contentType: 'TEXT', text: 'Only message'}],
+          content: [{contentType: 'TEXT', text: 'message 1'}],
         }),
       ]),
     );
@@ -706,10 +706,10 @@ describe('<ConversationHistory />', () => {
         Node.DOCUMENT_POSITION_PRECEDING,
     ).toBeTruthy();
 
-    const secondMarker = screen.getByText('1. loop iteration');
+    const secondMarker = screen.getByText('2. loop iteration');
     expect(secondMarker).toBeVisible();
-    const secondMessage = screen.getByTestId('conversation-message-1');
-    const thirdMessage = screen.getByTestId('conversation-message-1');
+    const secondMessage = screen.getByTestId('conversation-message-2');
+    const thirdMessage = screen.getByTestId('conversation-message-3');
     expect(
       secondMarker.compareDocumentPosition(secondMessage) &
         Node.DOCUMENT_POSITION_PRECEDING,
@@ -727,19 +727,19 @@ describe('<ConversationHistory />', () => {
           historyItemKey: '1',
           loopIteration: 1,
           role: 'ASSISTANT',
-          content: [{contentType: 'TEXT', text: 'Only message'}],
+          content: [{contentType: 'TEXT', text: 'message 1'}],
         }),
         mockAgentInstanceHistoryItem({
           historyItemKey: '2',
           loopIteration: 2,
-          role: 'ASSISTANT',
-          content: [{contentType: 'TEXT', text: 'Second iteration message'}],
+          role: 'USER',
+          content: [{contentType: 'TEXT', text: 'message 2'}],
         }),
         mockAgentInstanceHistoryItem({
           historyItemKey: '3',
           loopIteration: 2,
-          role: 'TOOL_RESULT',
-          content: [{contentType: 'TEXT', text: 'Second iteration message'}],
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'message 3'}],
         }),
       ]),
     );
@@ -773,10 +773,10 @@ describe('<ConversationHistory />', () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
 
-    const secondMarker = screen.getByText('1. loop iteration');
+    const secondMarker = screen.getByText('2. loop iteration');
     expect(secondMarker).toBeVisible();
-    const secondMessage = screen.getByTestId('conversation-message-1');
-    const thirdMessage = screen.getByTestId('conversation-message-1');
+    const secondMessage = screen.getByTestId('conversation-message-2');
+    const thirdMessage = screen.getByTestId('conversation-message-3');
     expect(
       secondMarker.compareDocumentPosition(secondMessage) &
         Node.DOCUMENT_POSITION_FOLLOWING,

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.test.tsx
@@ -657,4 +657,133 @@ describe('<ConversationHistory />', () => {
       ),
     );
   });
+
+  it('should insert loop iteration markers after messages in most-recent sorting order', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '3',
+          loopIteration: 2,
+          role: 'TOOL_RESULT',
+          content: [{contentType: 'TEXT', text: 'Second iteration message'}],
+        }),
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '2',
+          loopIteration: 2,
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'Second iteration message'}],
+        }),
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '1',
+          loopIteration: 1,
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'Only message'}],
+        }),
+      ]),
+    );
+
+    render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
+        enablePeriodicRefetch={false}
+        isVisible
+        selectedElementInstanceKey={null}
+        agentsElementInstanceKeys={[]}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    const firstMarker = screen.getByText('1. loop iteration');
+    expect(firstMarker).toBeVisible();
+    const firstMessage = screen.getByTestId('conversation-message-1');
+    expect(
+      firstMarker.compareDocumentPosition(firstMessage) &
+        Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy();
+
+    const secondMarker = screen.getByText('1. loop iteration');
+    expect(secondMarker).toBeVisible();
+    const secondMessage = screen.getByTestId('conversation-message-1');
+    const thirdMessage = screen.getByTestId('conversation-message-1');
+    expect(
+      secondMarker.compareDocumentPosition(secondMessage) &
+        Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy();
+    expect(
+      secondMarker.compareDocumentPosition(thirdMessage) &
+        Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy();
+  });
+
+  it('should insert loop iteration markers before messages in oldest first sorting order', async () => {
+    mockSearchAgentInstanceHistory().withSuccess(
+      searchResult([
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '1',
+          loopIteration: 1,
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'Only message'}],
+        }),
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '2',
+          loopIteration: 2,
+          role: 'ASSISTANT',
+          content: [{contentType: 'TEXT', text: 'Second iteration message'}],
+        }),
+        mockAgentInstanceHistoryItem({
+          historyItemKey: '3',
+          loopIteration: 2,
+          role: 'TOOL_RESULT',
+          content: [{contentType: 'TEXT', text: 'Second iteration message'}],
+        }),
+      ]),
+    );
+    // Mock data for initial "most recent" sorting
+    mockSearchAgentInstanceHistory().withSuccess(searchResult([]));
+
+    const {user} = render(
+      <ConversationHistory
+        agentInstanceKey={AGENT_INSTANCE_KEY}
+        availableTools={[]}
+        enablePeriodicRefetch={false}
+        isVisible
+        selectedElementInstanceKey={null}
+        agentsElementInstanceKeys={[]}
+      />,
+      {wrapper: createWrapper()},
+    );
+
+    await waitForElementToBeRemoved(
+      screen.queryByTestId('conversation-history-skeleton'),
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Most recent first'}));
+    expect(screen.getByRole('button', {name: 'Oldest first'})).toBeVisible();
+
+    const firstMarker = await screen.findByText('1. loop iteration');
+    expect(firstMarker).toBeVisible();
+    const firstMessage = screen.getByTestId('conversation-message-1');
+    expect(
+      firstMarker.compareDocumentPosition(firstMessage) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    const secondMarker = screen.getByText('1. loop iteration');
+    expect(secondMarker).toBeVisible();
+    const secondMessage = screen.getByTestId('conversation-message-1');
+    const thirdMessage = screen.getByTestId('conversation-message-1');
+    expect(
+      secondMarker.compareDocumentPosition(secondMessage) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      secondMarker.compareDocumentPosition(thirdMessage) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
 });

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/index.tsx
@@ -6,10 +6,12 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useState} from 'react';
+import {Fragment, useState} from 'react';
 import {SkeletonText} from '@carbon/react';
 import type {
+  AgentInstanceHistoryItem,
   AgentTool,
+  QueryAgentInstanceHistoryResponseBody,
   QuerySortOrder,
 } from '@camunda/camunda-api-zod-schemas/8.10';
 import {useAgentInstanceHistory} from 'modules/queries/agentInstances/useAgentInstanceHistory';
@@ -20,9 +22,32 @@ import {
   Messages,
   StatusHint,
   ShowMoreButton,
+  LoopIterationMarker,
 } from './styled';
 import {flattenPaginatedPages} from 'modules/queries/flattenPaginatedPages';
 import {ToolResultMessage} from '../ConversationMessage/ToolResultMessage';
+import type {InfiniteData} from '@tanstack/react-query';
+
+function mapIntoLoopIterationChunks(
+  pages: InfiniteData<QueryAgentInstanceHistoryResponseBody>,
+): [number, AgentInstanceHistoryItem[]][] {
+  const history = flattenPaginatedPages(pages).items;
+  const loopIterationMap = new Map<number, AgentInstanceHistoryItem[]>();
+
+  for (const item of history) {
+    const iteration = item.loopIteration;
+    if (iteration === null) {
+      // The connector never set's null and actively guards against it.
+      // Properly grouping those messages is non trivial. To avoid accidental
+      // complexity, this theoretical case is dropped.
+      continue;
+    }
+    const bucket = loopIterationMap.get(iteration) ?? [];
+    bucket.push(item);
+    loopIterationMap.set(iteration, bucket);
+  }
+  return Array.from(loopIterationMap);
+}
 
 type ConversationHistoryProps = {
   agentInstanceKey: string;
@@ -60,7 +85,7 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
     sortOrder,
     elementInstanceKey:
       canBeScoped && isScoped ? selectedElementInstanceKey : null,
-    select: flattenPaginatedPages,
+    select: mapIntoLoopIterationChunks,
   });
 
   if (status === 'pending') {
@@ -87,32 +112,45 @@ const ConversationHistory: React.FC<ConversationHistoryProps> = ({
         onToggleScope={() => setIsScoped((prev) => !prev)}
       />
       <Messages data-dimmed={isPlaceholderData}>
-        {data.items.length === 0 ? (
+        {data.length === 0 ? (
           <StatusHint>
             {canBeScoped && isScoped
               ? 'No scoped conversation with the agent instance found.'
               : 'No conversation with this agent instance found.'}
           </StatusHint>
         ) : (
-          data.items.map((item) =>
-            item.role === 'TOOL_RESULT' ? (
-              <ToolResultMessage
-                key={item.historyItemKey}
-                availableTools={availableTools}
-                toolCalls={item.toolCalls}
-                content={item.content}
-              />
-            ) : (
-              <ConversationMessage
-                key={item.historyItemKey}
-                historyItemKey={item.historyItemKey}
-                actor={item.role}
-                content={item.content}
-                toolCalls={item.toolCalls}
-                metrics={item.metrics}
-              />
-            ),
-          )
+          data.map(([iteration, items]) => {
+            const loopIterationNode = (
+              <LoopIterationMarker>
+                {iteration}.&nbsp;loop&nbsp;iteration
+              </LoopIterationMarker>
+            );
+            return (
+              <Fragment key={iteration}>
+                {sortOrder === 'asc' && loopIterationNode}
+                {items.map((item) =>
+                  item.role === 'TOOL_RESULT' ? (
+                    <ToolResultMessage
+                      key={item.historyItemKey}
+                      availableTools={availableTools}
+                      toolCalls={item.toolCalls}
+                      content={item.content}
+                    />
+                  ) : (
+                    <ConversationMessage
+                      key={item.historyItemKey}
+                      historyItemKey={item.historyItemKey}
+                      actor={item.role}
+                      content={item.content}
+                      toolCalls={item.toolCalls}
+                      metrics={item.metrics}
+                    />
+                  ),
+                )}
+                {sortOrder === 'desc' && loopIterationNode}
+              </Fragment>
+            );
+          })
         )}
       </Messages>
       {isFetchingNextPage && <SkeletonText paragraph lineCount={2} />}

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/ConversationHistory/styled.ts
@@ -40,8 +40,36 @@ const StatusHint = styled.span`
   color: var(--cds-text-secondary);
 `;
 
+const LoopIterationMarker = styled.span`
+  display: inline-flex;
+  gap: var(--cds-spacing-04);
+  justify-content: center;
+  align-items: center;
+  font-size: var(--cds-label-01-font-size);
+  font-weight: var(--cds-label-01-font-weight);
+  line-height: var(--cds-label-01-line-height);
+  letter-spacing: var(--cds-label-01-letter-spacing);
+  color: var(--cds-text-secondary);
+
+  &::before,
+  &::after {
+    content: '';
+    display: inline-block;
+    inline-size: 8ch;
+    height: 1px;
+    background-color: var(--cds-border-subtle-01);
+    border-radius: 1px;
+  }
+`;
+
 const ShowMoreButton = styled(Button)`
   align-self: center;
 `;
 
-export {ConversationContainer, Messages, StatusHint, ShowMoreButton};
+export {
+  ConversationContainer,
+  Messages,
+  StatusHint,
+  LoopIterationMarker,
+  ShowMoreButton,
+};


### PR DESCRIPTION
## Description

This PR inserts loop iteration markers between history conversation messages. The markers are respecting the sort order of the history. This has to be evaluated with usage feedback. It may or may not be intuitive to users.

<img width="1059" height="635" alt="Screenshot 2026-07-10 at 15 44 40" src="https://github.com/user-attachments/assets/bca642e3-49f5-415e-9d9b-71602776ce4e" />

Context: https://camunda.slack.com/archives/C0AH08C7UA2/p1783596564344559

## Related issues

closes #56102
