### PR TITLE
feat: operations emitted by PartitionReassignTransformer are sorted

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -147,4 +147,12 @@ public class MemberId extends NodeId {
       return null;
     }
   }
+
+  @Override
+  public int compareTo(final NodeId that) {
+    if (that instanceof final MemberId memberId) {
+      return ID_COMPARATOR.compare(this, memberId);
+    }
+    return super.compareTo(that);
+  }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/MemberIdTest.java
@@ -195,6 +195,9 @@ final class MemberIdTest {
       // when / then
       assertThat(MemberId.ID_COMPARATOR.compare(member2, member10)).isNegative();
       assertThat(MemberId.ID_COMPARATOR.compare(member10, member2)).isPositive();
+
+      assertThat(member2.compareTo(member10)).isNegative();
+      assertThat(member10.compareTo(member2)).isPositive();
     }
 
     @Test
@@ -205,6 +208,7 @@ final class MemberIdTest {
 
       // when / then
       assertThat(MemberId.ID_COMPARATOR.compare(usZone0, euZone1)).isNegative();
+      assertThat(usZone0.compareTo(euZone1)).isNegative();
     }
 
     @Test
@@ -216,6 +220,9 @@ final class MemberIdTest {
       // when / then — "eu" < "us"
       assertThat(MemberId.ID_COMPARATOR.compare(euZone0, usZone0)).isNegative();
       assertThat(MemberId.ID_COMPARATOR.compare(usZone0, euZone0)).isPositive();
+
+      assertThat(euZone0.compareTo(usZone0)).isNegative();
+      assertThat(usZone0.compareTo(euZone0)).isPositive();
     }
 
     @Test
@@ -226,6 +233,7 @@ final class MemberIdTest {
 
       // when / then
       assertThat(MemberId.ID_COMPARATOR.compare(bare, zoned)).isNegative();
+      assertThat(bare.compareTo(zoned)).isNegative();
     }
 
     @Test
@@ -236,6 +244,7 @@ final class MemberIdTest {
 
       // when / then
       assertThat(MemberId.ID_COMPARATOR.compare(indexed, anonymous)).isNegative();
+      assertThat(indexed.compareTo(anonymous)).isNegative();
     }
 
     @Test
@@ -251,10 +260,12 @@ final class MemberIdTest {
       final var members = List.of(bare10, us0, eu1, bare2, eu0, bare0);
 
       // when
-      final var sorted = members.stream().sorted(MemberId.ID_COMPARATOR).toList();
+      final var sorted = members.stream().sorted().toList();
+      final var sortedViaComparator = members.stream().sorted(MemberId.ID_COMPARATOR).toList();
 
       // then — bare0 first (nodeIdx=0, no zone), then eu0 (nodeIdx=0, "eu"), then us0 (nodeIdx=0,
       // "us"), then eu1, bare2, bare10
+      assertThat(sorted).isEqualTo(sortedViaComparator);
       assertThat(sorted).containsExactly(bare0, eu0, us0, eu1, bare2, bare10);
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation.ScaleUpOper
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -197,11 +198,13 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
                 newMember ->
                     new PartitionJoinOperation(
                         newMember, partitionId, newMetadata.getPriority(newMember)))
+            .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
             .toList();
     final var membersToLeave =
         oldMetadata.members().stream()
             .filter(member -> !newMetadata.members().contains(member))
             .map(oldMember -> new PartitionLeaveOperation(oldMember, partitionId, 1))
+            .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
             .toList();
     final var membersToChangePriority =
         oldMetadata.members().stream()
@@ -212,6 +215,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
                 memberId ->
                     new PartitionReconfigurePriorityOperation(
                         memberId, partitionId, newMetadata.getPriority(memberId)))
+            .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
             .toList();
 
     // TODO: interleave join and leave operation

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -176,7 +176,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
             primary, partitionId, newMetadata.getPriority(primary), true));
 
     // Join each remaining members to the partition
-    for (final MemberId member : newMetadata.members()) {
+    for (final MemberId member : newMetadata.members().stream().sorted().toList()) {
       if (!member.equals(primary)) {
         operations.add(
             new PartitionJoinOperation(member, partitionId, newMetadata.getPriority(member)));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -135,8 +135,8 @@ class UpdatePartitionDistributionTransformerTest {
             new UpdatePartitionDistributorConfigOperation(COORDINATOR, newConfig),
             new PartitionReconfigurePriorityOperation(ZONE_A_0, 1, 1),
             new PartitionReconfigurePriorityOperation(ZONE_B_0, 1, 2),
-            new PartitionReconfigurePriorityOperation(ZONE_A_1, 2, 1),
             new PartitionReconfigurePriorityOperation(ZONE_B_0, 2, 2),
+            new PartitionReconfigurePriorityOperation(ZONE_A_1, 2, 1),
             new PartitionReconfigurePriorityOperation(ZONE_A_0, 3, 1),
             new PartitionReconfigurePriorityOperation(ZONE_B_0, 3, 2));
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/UpdatePartitionDistributionTransformerTest.java
@@ -111,8 +111,8 @@ class UpdatePartitionDistributionTransformerTest {
             new PartitionReconfigurePriorityOperation(ZONE_A_0, 1, 1),
             new PartitionLeaveOperation(ZONE_A_1, 2, 1),
             new PartitionJoinOperation(ZONE_A_1, 3, 1),
-            new PartitionLeaveOperation(ZONE_B_0, 3, 1),
-            new PartitionLeaveOperation(ZONE_A_0, 3, 1));
+            new PartitionLeaveOperation(ZONE_A_0, 3, 1),
+            new PartitionLeaveOperation(ZONE_B_0, 3, 1));
   }
 
   @Test
@@ -133,12 +133,12 @@ class UpdatePartitionDistributionTransformerTest {
     assertThat(result.get())
         .containsExactly(
             new UpdatePartitionDistributorConfigOperation(COORDINATOR, newConfig),
-            new PartitionReconfigurePriorityOperation(ZONE_B_0, 1, 2),
             new PartitionReconfigurePriorityOperation(ZONE_A_0, 1, 1),
+            new PartitionReconfigurePriorityOperation(ZONE_B_0, 1, 2),
             new PartitionReconfigurePriorityOperation(ZONE_A_1, 2, 1),
             new PartitionReconfigurePriorityOperation(ZONE_B_0, 2, 2),
-            new PartitionReconfigurePriorityOperation(ZONE_B_0, 3, 2),
-            new PartitionReconfigurePriorityOperation(ZONE_A_0, 3, 1));
+            new PartitionReconfigurePriorityOperation(ZONE_A_0, 3, 1),
+            new PartitionReconfigurePriorityOperation(ZONE_B_0, 3, 2));
   }
 
   @Test


### PR DESCRIPTION
## Description

Without any ordering, operations emitted by PartitionReassignTransformer are randomly sorted, as we iterate over PartitionMetadata.members() which is an unordered set.

Ordering is done by memberId (ascending), but it's completely arbitrary. Potentially any stable ordering can be used

MemberId overrides NodeId's `compareTo` method in order to use `ID_COMPARATOR` if the argument is a `MemberId`

Noticed when testing #57275
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
