### PR TITLE
test: reproduce and document the actual root cause of stale list-view incident flags (#54279)

### DIFF
--- a/zeebe/exporters/camunda-exporter/docs/issue-54279-root-cause-analysis.md
+++ b/zeebe/exporters/camunda-exporter/docs/issue-54279-root-cause-analysis.md
@@ -1,0 +1,97 @@
+# Root cause analysis: stale `incident=true` in Operate list view (#54279)
+
+Symptom: finished (canceled **or** completed) process instances keep `incident = true` in
+`operate-list-view-*` although their `operate-incident-*` documents are `RESOLVED`, and the
+post-importer queue contains `CREATED`/`RESOLVED` pairs for the affected instances. Observed in
+SUPPORT-33008 (8.9, SaaS, 45 terminated instances) and SUPPORT-33606 (8.9-based, OpenSearch,
+1185 **completed** instances, recurring "every time someone resolves a bunch of incidents").
+
+## Why the originally stated root cause is incomplete
+
+The issue attributes the staleness to `createPendingIncidentBatch` dropping `CREATED` when the
+matching `RESOLVED` is in the same batch
+([collapse](https://github.com/camunda/camunda/blob/615e2a60175a367b2839b0c58aec71b0c0bf9bcc/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java#L408)).
+That collapse alone cannot *create* the stale flag:
+
+- If the incident document is `ACTIVE` when the (collapsed) batch is processed, the active-incident
+  seeding finds it and the list-view flag is correctly cleared.
+- If the incident document is still `PENDING` (its `CREATED` was genuinely never processed), the
+  list-view flag was never set to `true` in the first place — the result is an *invisible*
+  incident, not a stale one. Only the `IncidentUpdateTask` ever writes the list-view `incident`
+  field; the export handlers do not.
+
+Every replay/rewind/collapse permutation lands in one of those two consistent outcomes. To produce
+a stale `true`, the state "list-view says `true`, but the incident document is not findable as
+`ACTIVE`" must already exist — the collapse (and the silent skip below) merely make it permanent.
+
+## Actual root cause: non-idempotent retry after a partially applied bulk
+
+The incident-state update and the list-view flag update travel in **one non-atomic bulk**:
+
+1. On `RESOLVED`, the task queues two items: incident `state → RESOLVED` and list-view
+   `incident → false`, gated by
+   [`changedState`](https://github.com/camunda/camunda/blob/b705400567efd38cf699733c5ed6257af63f3bd7/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java#L573-L577),
+   which is derived from
+   [a `state = ACTIVE` search](https://github.com/camunda/camunda/blob/615e2a60175a367b2839b0c58aec71b0c0bf9bcc/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java#L252-L268)
+   over the incident documents
+   ([`removeIncidentIdByPiId`](https://github.com/camunda/camunda/blob/6e4f05688557351aa8e6e62abf89a15bd7a9ee39/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/AdditionalData.java#L44)
+   returns `false` when the process instance was never seeded).
+2. If **any** bulk item fails, the whole attempt fails
+   ([bulkUpdate](https://github.com/camunda/camunda/blob/615e2a60175a367b2839b0c58aec71b0c0bf9bcc/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java#L223))
+   and the position is not advanced — but the **successful items stay applied** (Elasticsearch/
+   OpenSearch bulks are not transactional).
+3. On the retry, the incident document is already `RESOLVED`, so the `ACTIVE` search returns
+   nothing, `changedState` is `false`, and **the failed list-view item is never re-issued**. The
+   retry succeeds and
+   [advances the position unconditionally](https://github.com/camunda/camunda/blob/b705400567efd38cf699733c5ed6257af63f3bd7/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java#L175)
+   (the #42366 fix — which turned this from an infinite-retry stall into a silent, permanent skip).
+
+So the corrupting order is: *incident item applied, list-view item lost, retry*. Any per-item
+failure produces it — `document_missing_exception` (the archiver moved the list-view document
+between index capture and bulk execution), `es_rejected_execution`, version conflicts beyond
+`retryOnConflict`, or a bulk transport timeout where the server applied the request. The archiver
+is what makes it *correlated*: one archiver batch moving dozens of finished instances while one
+`IncidentUpdateTask` batch resolves their incidents corrupts all of them in a single retry cycle
+(45/46 at once in SUPPORT-33008). The mirror on the CREATE side: attempt applies
+`incident → true` but the `state → ACTIVE` item fails; the `RESOLVED` record arrives before the
+retry; the batch collapse then drops the `CREATED`, the document stays `PENDING`, and the
+`RESOLVED` is skipped the same way — this is where the collapse described in the issue
+participates.
+
+A single episode logs approximately one line (`ReschedulingTaskLogger` logs the first occurrence
+at ERROR, then suppresses to DEBUG), typically weeks before anyone investigates — hence "no errors
+in the logs" in both support cases. The `CREATED`/`RESOLVED` pairs found in the post-importer
+queue are residue (the task never deletes queue entries), not evidence that the pair was processed
+in one batch.
+
+## Second, independent mechanism: archiver lost update
+
+The archiver moves documents with reindex + `delete_by_query`, both with
+[`Conflicts.Proceed`](https://github.com/camunda/camunda/blob/835087667c163469ce24d8f93978ced93db2021e/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java#L306).
+An `IncidentUpdateTask` write that lands on the main-index copy *after* the reindex snapshot read
+it is silently discarded by the delete; the dated copy keeps the snapshotted `incident = true`.
+No error, no retry, nothing logged. This requires the task to be processing a `RESOLVED` more than
+the archiver wait period (default 1h) after the instance finished, and is **not** addressed by any
+fix inside the update task — it needs coordination between the archiver and in-flight incident
+updates.
+
+## Reproduction
+
+`IncidentUpdateRepositoryIT.PartialBulkRetryRegressionIT` reproduces mechanism 1 deterministically
+on both Elasticsearch and OpenSearch: it write-blocks the list-view index so exactly the list-view
+item of the bulk fails, lets the first attempt fail, unblocks, retries — the incident document is
+`RESOLVED`, the position advances past the batch, and the list-view document keeps
+`incident = true` forever. The test asserts the desired behavior (flag cleared), so it fails as
+long as #54279 is unfixed: verified red on current `main` against both Elasticsearch and
+OpenSearch (only the final assertion fails; all intermediate state assertions pass), and green
+with the seeding change from PR #55034 applied.
+
+## Fix directions
+
+- Mechanism 1: make the retry idempotent — the decision to update the list view must not depend on
+  the incident document's current state, e.g. by seeding the affected-instance map from the
+  `RESOLVED` queue entries themselves (PR #55034) or by unconditionally writing the recomputed
+  flag (`incident =` "any other ACTIVE incident covers this instance").
+- Mechanism 2: prevent the archiver from discarding concurrent incident updates (e.g. re-apply
+  updates newer than the reindex snapshot, or fence incident updates against instances being
+  archived).

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
@@ -89,6 +89,17 @@ final class ElasticsearchIncidentUpdateRepositoryIT extends IncidentUpdateReposi
   }
 
   @Override
+  protected void setListViewWriteBlock(final boolean blocked) throws IOException {
+    final var client = new ElasticsearchClient(transport);
+    client
+        .indices()
+        .putSettings(
+            r ->
+                r.index(listViewTemplate.getFullQualifiedName())
+                    .settings(s -> s.blocks(b -> b.write(blocked))));
+  }
+
+  @Override
   protected void assertRoutedEntriesAreColocatedOnSingleShard(
       final String index, final String routing, final String field, final int expectedHits)
       throws IOException {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.tasks.incident;
 
 import static io.camunda.search.test.utils.SearchDBExtension.INCIDENT_IDX_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -65,6 +66,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import java.util.stream.LongStream;
@@ -159,6 +161,14 @@ abstract class IncidentUpdateRepositoryIT {
       throws IOException {
     // no-op by default (see javadoc)
   }
+
+  /**
+   * Blocks or unblocks writes to the list view write index ({@code index.blocks.write}). Used to
+   * make exactly the list view items of an incident update bulk fail while the other items are
+   * applied, simulating a partially applied bulk (e.g. a rejected execution, a document moved by
+   * the archiver, or a version conflict on a single item).
+   */
+  protected abstract void setListViewWriteBlock(final boolean blocked) throws IOException;
 
   private IncidentEntity newIncident(final long key) {
     final var incident = new IncidentEntity();
@@ -466,6 +476,132 @@ abstract class IncidentUpdateRepositoryIT {
         Awaitility.await()
             .until(() -> metadata.getLastIncidentUpdatePosition() == incidentUpdatePosition);
       }
+    }
+  }
+
+  @DisabledIfSystemProperty(
+      named = SearchDBExtension.TEST_INTEGRATION_OPENSEARCH_AWS_URL,
+      matches = "^(?=\\s*\\S).*$",
+      disabledReason = "Excluding from AWS OS IT CI")
+  @Nested
+  final class PartialBulkRetryRegressionIT {
+    // The incident state update and the list view flag update travel in one non-atomic bulk. This
+    // test makes exactly the list view item fail (write-blocked index) while the incident item is
+    // applied, then lets the task retry the batch as it does after any transient failure. The
+    // retry derives "does the list view still need updating?" from a state=ACTIVE search over the
+    // incident documents - but the failed attempt already flipped the incident to RESOLVED, so the
+    // retry queues no list view update, succeeds, and advances the position past the batch,
+    // leaving a permanently stale incident=true on the list view document.
+    private static final long INCIDENT_KEY = 1L;
+    private static final long PIQ_POSITION = 10L;
+
+    @RegressionTest("https://github.com/camunda/camunda/issues/54279")
+    void shouldClearListViewIncidentFlagWhenResolveIsRetriedAfterPartialBulkFailure()
+        throws Exception {
+      // given - an ACTIVE incident already flagged on its list view process instance document, and
+      // a pending RESOLVED entry for it in the post-importer queue; the flow node instance key
+      // equals the process instance key, so the bulk contains exactly two items: the incident
+      // state update and the list view process instance update
+      final var metadata = new ExporterMetadata(new ObjectMapper());
+      final var repository = createRepository();
+      final var incidentNotifier = mock(IncidentNotifier.class);
+      when(incidentNotifier.notifyAsync(anyList()))
+          .thenReturn(CompletableFuture.completedFuture(null));
+
+      indexIncident(
+          newIncident(INCIDENT_KEY).setState(IncidentState.ACTIVE).setTreePath("PI_1/FN_1/FNI_1"));
+      indexListViewProcessInstanceWithIncident();
+      indexPendingResolve();
+
+      try (final var executor = Executors.newSingleThreadScheduledExecutor()) {
+        final var incidentUpdateTask =
+            new IncidentUpdateTask(
+                metadata,
+                repository,
+                true,
+                100,
+                executor,
+                incidentNotifier,
+                mock(CamundaExporterMetrics.class),
+                LOGGER);
+
+        // when - the first attempt partially applies the bulk: the incident update succeeds, the
+        // list view update is rejected, and the attempt fails without advancing the position
+        setListViewWriteBlock(true);
+        try {
+          assertThatThrownBy(() -> incidentUpdateTask.execute().toCompletableFuture().join())
+              .isInstanceOf(CompletionException.class);
+        } finally {
+          setListViewWriteBlock(false);
+        }
+
+        assertThat(incidentState()).isEqualTo(IncidentState.RESOLVED);
+        assertThat(listViewIncidentFlag()).isTrue();
+        assertThat(metadata.getLastIncidentUpdatePosition()).isNotEqualTo(PIQ_POSITION);
+
+        // when - the batch is retried after the transient failure is gone
+        incidentUpdateTask.execute().toCompletableFuture().join();
+
+        // then - the batch was consumed for good and the incident stays resolved
+        Awaitility.await().until(() -> metadata.getLastIncidentUpdatePosition() == PIQ_POSITION);
+        assertThat(incidentState()).isEqualTo(IncidentState.RESOLVED);
+
+        // then - the retried resolve must also clear the list view flag
+        assertThat(listViewIncidentFlag())
+            .describedAs(
+                "the retried resolve must clear the list view incident flag even though the "
+                    + "incident document was already updated by the failed attempt")
+            .isFalse();
+      }
+    }
+
+    private void indexListViewProcessInstanceWithIncident() throws PersistenceException {
+      final var processInstance =
+          new ProcessInstanceForListViewEntity()
+              .setProcessInstanceKey(INCIDENT_KEY)
+              .setTreePath("PI_1")
+              .setIncident(true);
+      processInstance.setPartitionId(PARTITION_ID);
+      final var batchRequest = clientAdapter.createBatchRequest();
+      batchRequest.addWithId(
+          listViewTemplate.getFullQualifiedName(), String.valueOf(INCIDENT_KEY), processInstance);
+      batchRequest.executeWithRefresh();
+    }
+
+    private void indexPendingResolve() throws PersistenceException {
+      final var update =
+          new PostImporterQueueEntity()
+              .setActionType(PostImporterActionType.INCIDENT)
+              .setIntent(IncidentIntent.RESOLVED.name())
+              .setKey(INCIDENT_KEY)
+              .setPosition(PIQ_POSITION)
+              .setPartitionId(PARTITION_ID)
+              .setProcessInstanceKey(INCIDENT_KEY);
+      final var batchRequest = clientAdapter.createBatchRequest();
+      batchRequest.add(postImporterQueueTemplate.getFullQualifiedName(), update);
+      batchRequest.executeWithRefresh();
+    }
+
+    private IncidentState incidentState() throws IOException {
+      final var incidents =
+          search(
+              incidentTemplate.getFullQualifiedName(),
+              "key",
+              List.of(String.valueOf(INCIDENT_KEY)),
+              IncidentEntity.class);
+      assertThat(incidents).hasSize(1);
+      return incidents.iterator().next().getState();
+    }
+
+    private boolean listViewIncidentFlag() throws IOException {
+      final var processInstances =
+          search(
+              listViewTemplate.getFullQualifiedName(),
+              "key",
+              List.of(String.valueOf(INCIDENT_KEY)),
+              ProcessInstanceForListViewEntity.class);
+      assertThat(processInstances).hasSize(1);
+      return processInstances.iterator().next().isIncident();
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/OpensearchIncidentUpdateRepositoryIT.java
@@ -83,6 +83,17 @@ final class OpensearchIncidentUpdateRepositoryIT extends IncidentUpdateRepositor
         .toList();
   }
 
+  @Override
+  protected void setListViewWriteBlock(final boolean blocked) throws IOException {
+    final var client = new OpenSearchClient(transport);
+    client
+        .indices()
+        .putSettings(
+            r ->
+                r.index(listViewTemplate.getFullQualifiedName())
+                    .settings(s -> s.blocksWrite(blocked)));
+  }
+
   private OpenSearchTransport createTransport() {
     try {
       return ApacheHttpClient5TransportBuilder.builder(


### PR DESCRIPTION
## Description

Deterministic reproduction and root-cause analysis for #54279 (stale `incident=true` in the Operate list view for finished process instances).

**The root cause as currently stated in the issue is incomplete**: the same-batch CREATED+RESOLVED collapse cannot *create* the stale flag on its own — it can only preserve an already-inconsistent state. The actual root cause is that the incident update bulk is **not atomic** and the **retry after a partial bulk failure is not idempotent**: the failed attempt already flipped the incident document to `RESOLVED`, so the retry — which re-derives the list-view update from a `state=ACTIVE` search — silently skips the very item that failed, then advances the position past the batch for good.

Full analysis (with permalinks and the trigger/evidence mapping from SUPPORT-33008 and SUPPORT-33606): `zeebe/exporters/camunda-exporter/docs/issue-54279-root-cause-analysis.md` in this PR.

The new `PartialBulkRetryRegressionIT` reproduces this end-to-end against real Elasticsearch **and** OpenSearch: it write-blocks the list-view index so exactly the list-view item of the bulk fails, lets the task retry, and asserts the flag is cleared.

- ❌ red on current `main` (both backends): only the final assertion fails — incident doc `RESOLVED`, position advanced, list-view stuck at `incident=true`
- ✅ green with the seeding change from #55034 applied — confirming that fix addresses the actual root cause (its description should be reframed from "symptom treatment" to "makes the retry idempotent")

**Note:** this PR is intentionally red in CI while #54279 is unfixed. It should be merged together with (or rebased onto) #55034. The archiver lost-update race described in the analysis (mechanism 2) is *not* covered by #55034 and needs a separate issue.

Related to #54279. Companion to #55034.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
