### PR TITLE
refactor: rename PhysicalTenantSessionStoreAdapter and improve related tests

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/spi/PhysicalTenantScopedSessionStorePortProvider.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/PhysicalTenantScopedSessionStorePortProvider.java
@@ -22,13 +22,13 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * <p>This lets CSL give each scoped {@code SessionRepositoryFilter} its own single-tenant store, so
  * a scope's persistent session reads/writes route to the correct storage <em>structurally</em> —
- * even during Spring Session's commit phase, when the request scope is gone. See ADR-0029.
+ * even during Spring Session's commit phase, when the request scope is gone. See CSL ADR-0029.
  *
  * <p>Adapters are built once per tenant and cached: CSL's expiry sweep deduplicates repositories by
  * backing {@link SessionStorePort} <em>instance</em>, so a caller that needs the default tenant's
  * store outside a basePath (the global session filter's default surface) should call {@link
  * #forPhysicalTenant} on this same shared instance rather than build its own adapter — that is what
- * makes the sweep's dedup of the default store actually collapse (ADR-0029 §4).
+ * makes the sweep's dedup of the default store actually collapse (CSL ADR-0029 §4).
  */
 public final class PhysicalTenantScopedSessionStorePortProvider
     implements ScopedSessionStorePortProvider {
@@ -52,8 +52,7 @@ public final class PhysicalTenantScopedSessionStorePortProvider
    */
   public SessionStorePort forPhysicalTenant(final String physicalTenantId) {
     return adaptersByPhysicalTenant.computeIfAbsent(
-        physicalTenantId,
-        id -> new PhysicalTenantSessionStoreAdapter(sessionClients.withPhysicalTenant(id)));
+        physicalTenantId, id -> new SessionStoreAdapter(sessionClients.withPhysicalTenant(id)));
   }
 
   private static String physicalTenantIdFrom(final String basePath) {

--- a/authentication/src/main/java/io/camunda/authentication/config/spi/SessionStoreAdapter.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/spi/SessionStoreAdapter.java
@@ -26,19 +26,19 @@ import org.slf4j.LoggerFactory;
  * storage — there is no request-context routing and no cross-tenant fan-out.
  *
  * <p>Scoped security chains use one instance per scope (via {@code ScopedSessionStorePortProvider},
- * ADR-0029), so a persistent session read/write routes to the correct store <em>structurally</em> —
- * decided by which scoped {@code SessionRepositoryFilter} handles the request — even during Spring
- * Session's commit phase, which runs after the request scope is torn down.
+ * CSL ADR-0029), so a persistent session read/write routes to the correct store
+ * <em>structurally</em> — decided by which scoped {@code SessionRepositoryFilter} handles the
+ * request — even during Spring Session's commit phase, which runs after the request scope is torn
+ * down.
  *
  * <p>Upserts are retried on transient storage failures with exponential backoff; once retries are
  * exhausted the failure is logged and swallowed so a storage blip never propagates into the session
  * save path. This resilience policy lives here (rather than in the library) because it inspects the
  * search-specific {@link CamundaSearchException} reasons to decide what is transient.
  */
-public final class PhysicalTenantSessionStoreAdapter implements SessionStorePort {
+public final class SessionStoreAdapter implements SessionStorePort {
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(PhysicalTenantSessionStoreAdapter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SessionStoreAdapter.class);
   private static final int MAX_RETRY_ATTEMPTS = 3;
   private static final long INITIAL_RETRY_DELAY_MS = 100;
 
@@ -48,12 +48,12 @@ public final class PhysicalTenantSessionStoreAdapter implements SessionStorePort
           RetryConfig.custom()
               .maxAttempts(MAX_RETRY_ATTEMPTS)
               .intervalFunction(IntervalFunction.ofExponentialBackoff(INITIAL_RETRY_DELAY_MS, 2))
-              .retryOnException(PhysicalTenantSessionStoreAdapter::isTransientFailure)
+              .retryOnException(SessionStoreAdapter::isTransientFailure)
               .build());
 
   private final PersistentWebSessionClient client;
 
-  public PhysicalTenantSessionStoreAdapter(final PersistentWebSessionClient client) {
+  public SessionStoreAdapter(final PersistentWebSessionClient client) {
     this.client = client;
   }
 
@@ -93,9 +93,7 @@ public final class PhysicalTenantSessionStoreAdapter implements SessionStorePort
     final var result = new ArrayList<PersistentSession>();
     final var items = client.getAllPersistentWebSessions().items();
     if (items != null) {
-      items.stream()
-          .map(PhysicalTenantSessionStoreAdapter::toPersistentSession)
-          .forEach(result::add);
+      items.stream().map(SessionStoreAdapter::toPersistentSession).forEach(result::add);
     }
     return result;
   }

--- a/authentication/src/test/java/io/camunda/authentication/config/spi/SessionStoreAdapterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/spi/SessionStoreAdapterTest.java
@@ -12,20 +12,22 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.entities.PersistentWebSessionEntity;
+import io.camunda.search.exception.CamundaSearchException;
+import io.camunda.search.exception.CamundaSearchException.Reason;
 import io.camunda.security.api.model.session.PersistentSession;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link PhysicalTenantSessionStoreAdapter}. */
-class PhysicalTenantSessionStoreAdapterTest {
+/** Unit tests for {@link SessionStoreAdapter}. */
+class SessionStoreAdapterTest {
 
   @Test
   void shouldOperateOnlyOnItsOwnClient() {
     // given — the adapter is bound to one client, with a second client left untouched
     final var own = new PersistentWebSessionClientStub();
     final var other = new PersistentWebSessionClientStub();
-    final var adapter = new PhysicalTenantSessionStoreAdapter(own);
+    final var adapter = new SessionStoreAdapter(own);
 
     // when
     adapter.upsert(new PersistentSession("s1", 100L, 200L, 1800L, Map.of("a", new byte[] {1})));
@@ -45,7 +47,7 @@ class PhysicalTenantSessionStoreAdapterTest {
   void shouldReturnOnlyItsOwnSessionsFromGetAll() {
     // given
     final var client = new PersistentWebSessionClientStub();
-    final var adapter = new PhysicalTenantSessionStoreAdapter(client);
+    final var adapter = new SessionStoreAdapter(client);
     client.upsertPersistentWebSession(
         new PersistentWebSessionEntity("s1", 1L, 2L, 1800L, Map.of()));
     client.upsertPersistentWebSession(
@@ -69,7 +71,7 @@ class PhysicalTenantSessionStoreAdapterTest {
             throw new RuntimeException("Connection refused");
           }
         };
-    final var adapter = new PhysicalTenantSessionStoreAdapter(failing);
+    final var adapter = new SessionStoreAdapter(failing);
 
     // when / then — retried three times, and the failure never propagates to the save path
     assertThatNoException()
@@ -78,8 +80,51 @@ class PhysicalTenantSessionStoreAdapterTest {
   }
 
   @Test
+  void shouldNotRetryNonTransientCamundaSearchException() {
+    // given — a client whose failure reason is not one of the transient reasons
+    final var attempts = new AtomicInteger();
+    final PersistentWebSessionClient failing =
+        new PersistentWebSessionClientStub() {
+          @Override
+          public void upsertPersistentWebSession(final PersistentWebSessionEntity entity) {
+            attempts.incrementAndGet();
+            throw new CamundaSearchException("invalid session", Reason.INVALID_ARGUMENT);
+          }
+        };
+    final var adapter = new SessionStoreAdapter(failing);
+
+    // when / then — not retried, and the failure never propagates to the save path
+    assertThatNoException()
+        .isThrownBy(() -> adapter.upsert(new PersistentSession("s1", 1L, 2L, 1800L, Map.of())));
+    assertThat(attempts.get()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldRecoverAfterTransientCamundaSearchException() {
+    // given — a client that fails transiently once, then succeeds
+    final var attempts = new AtomicInteger();
+    final PersistentWebSessionClient recovering =
+        new PersistentWebSessionClientStub() {
+          @Override
+          public void upsertPersistentWebSession(final PersistentWebSessionEntity entity) {
+            if (attempts.incrementAndGet() == 1) {
+              throw new CamundaSearchException("connection refused", Reason.CONNECTION_FAILED);
+            }
+            super.upsertPersistentWebSession(entity);
+          }
+        };
+    final var adapter = new SessionStoreAdapter(recovering);
+
+    // when
+    adapter.upsert(new PersistentSession("s1", 1L, 2L, 1800L, Map.of()));
+
+    // then — retried once and the second attempt succeeded, so the session is stored
+    assertThat(attempts.get()).isEqualTo(2);
+    assertThat(adapter.get("s1")).isNotNull();
+  }
+
+  @Test
   void shouldReturnNullOnGetWhenAbsent() {
-    assertThat(new PhysicalTenantSessionStoreAdapter(new PersistentWebSessionClientStub()).get("x"))
-        .isNull();
+    assertThat(new SessionStoreAdapter(new PersistentWebSessionClientStub()).get("x")).isNull();
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/identity/WebSessionRepositoryConfigurationTest.java
@@ -14,7 +14,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import io.camunda.authentication.config.spi.PhysicalTenantScopedSessionStorePortProvider;
-import io.camunda.authentication.config.spi.PhysicalTenantSessionStoreAdapter;
+import io.camunda.authentication.config.spi.SessionStoreAdapter;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.db.rdbms.sql.PersistentWebSessionMapper;
 import io.camunda.db.rdbms.write.RdbmsMapperBundle;
@@ -82,7 +82,7 @@ class WebSessionRepositoryConfigurationTest {
               assertThat(ctx).hasSingleBean(PhysicalTenantScopedPersistentWebSessionClient.class);
               assertThat(ctx)
                   .getBean(SessionStorePort.class)
-                  .isInstanceOf(PhysicalTenantSessionStoreAdapter.class);
+                  .isInstanceOf(SessionStoreAdapter.class);
               final var provider =
                   ctx.getBean(PhysicalTenantScopedPersistentWebSessionClient.class);
               assertThat(provider.withPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))
@@ -142,7 +142,7 @@ class WebSessionRepositoryConfigurationTest {
               assertThat(ctx).hasSingleBean(PhysicalTenantScopedPersistentWebSessionClient.class);
               assertThat(ctx)
                   .getBean(SessionStorePort.class)
-                  .isInstanceOf(PhysicalTenantSessionStoreAdapter.class);
+                  .isInstanceOf(SessionStoreAdapter.class);
               final var provider =
                   ctx.getBean(PhysicalTenantScopedPersistentWebSessionClient.class);
               assertThat(provider.withPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID))

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionCommitRoutingIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionCommitRoutingIT.java
@@ -91,9 +91,11 @@ public class PhysicalTenantWebSessionCommitRoutingIT {
               });
 
   @Test
-  void defaultPathSessionIsCommittedReusedAndInvalidatedOnLogout() {
+  void shouldCommitReuseAndInvalidateDefaultPathSessionOnLogout() {
+    // given
     try (final var loggedIn =
         CAMUNDA.newWebappClient().logIn(DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD)) {
+      // when / then
       assertAuthenticated(loggedIn, "first request must commit the session to the default store");
       assertAuthenticated(
           loggedIn, "second request must reuse the committed default-store session");
@@ -105,7 +107,8 @@ public class PhysicalTenantWebSessionCommitRoutingIT {
   }
 
   @Test
-  void physicalTenantSessionIsCommittedReusedAndInvalidatedOnLogout() {
+  void shouldCommitReuseAndInvalidatePhysicalTenantSessionOnLogout() {
+    // given / when / then
     assertPhysicalTenantSessionLifecycle(TENANT_A);
     assertPhysicalTenantSessionLifecycle(TENANT_B);
   }
@@ -126,13 +129,16 @@ public class PhysicalTenantWebSessionCommitRoutingIT {
   }
 
   @Test
-  void sessionFromOnePhysicalTenantIsRejectedOnAnotherPhysicalTenant() {
+  void shouldRejectSessionFromOnePhysicalTenantOnAnotherPhysicalTenant() {
+    // given
     try (final var loggedInA = logInUnderPhysicalTenant(TENANT_A)) {
       assertAuthenticated(loggedInA, "sanity check: tenant A's session must work under tenant A");
-
       final var sessionIdValue = findCookie(loggedInA, cookieNameFor(TENANT_A)).getValue();
+
+      // when
       final var response = sendWithForgedCookie(TENANT_B, cookieNameFor(TENANT_B), sessionIdValue);
 
+      // then
       assertThat(response.statusCode())
           .as(
               "tenant A's session id must not be honoured under tenant B's store — they are"
@@ -142,11 +148,15 @@ public class PhysicalTenantWebSessionCommitRoutingIT {
   }
 
   @Test
-  void sessionFromPhysicalTenantIsRejectedOnDefaultPath() {
+  void shouldRejectSessionFromPhysicalTenantOnDefaultPath() {
+    // given
     try (final var loggedInA = logInUnderPhysicalTenant(TENANT_A)) {
       final var sessionIdValue = findCookie(loggedInA, cookieNameFor(TENANT_A)).getValue();
+
+      // when
       final var response = sendWithForgedCookie(null, DEFAULT_SESSION_COOKIE, sessionIdValue);
 
+      // then
       assertThat(response.statusCode())
           .as("tenant A's session id must not be honoured under the default store")
           .isEqualTo(HttpStatus.UNAUTHORIZED.value());


### PR DESCRIPTION
## Summary
- Renames `PhysicalTenantSessionStoreAdapter` to `SessionStoreAdapter` — the class has no
  physical-tenant logic; the PT binding lives entirely in
  `PhysicalTenantScopedSessionStorePortProvider`.
- Qualifies both `ADR-0029` references in `PhysicalTenantScopedSessionStorePortProvider` as
  `CSL ADR-0029`, since the ADR lives in the CSL repo, not this monorepo.
- Restores the non-transient-`CamundaSearchException`-not-retried and
  recovery-after-transient-failure test cases dropped during the #57251 rewrite, re-exercising the
  `CamundaSearchException` reason-code classification in `isTransientFailure`.
- Aligns the 4 `@Test` methods in `PhysicalTenantWebSessionCommitRoutingIT` with the
  `should`-prefixed / `// given` / `// when` / `// then` convention used by its sibling unit tests.

These are the 4 non-blocking, non-functional review comments left by @megglos on #57251 that were
deliberately deferred to keep a dependent PR unblocked.

Closes #57343
