### PR TITLE
tool calls details on AHSP agentic dashboard heat map

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterES.java
@@ -91,13 +91,22 @@ public class ProcessGroupByAgentFlowNodeInterpreterES extends AbstractProcessGro
     // Only add the (extra) flow-node-instance aggregation used to break an ad-hoc subprocess down
     // into per-tool heat when the model actually contains ad-hoc subprocess tool nodes. Reports
     // without them keep the exact same aggregation as before.
-    if (helper.resolveAdHocSubProcessStructure(context).childIds().isEmpty()) {
+    final Set<String> adHocSubProcessToolIds =
+        helper.resolveAdHocSubProcessStructure(context).childIds();
+    if (adHocSubProcessToolIds.isEmpty()) {
       return Map.of(AGENT_INSTANCES_AGG, nestedBuilder);
     }
 
+    // Restrict the terms aggregation to the known tool IDs so low-frequency tools are not pushed
+    // out of the top-N buckets by unrelated, higher-frequency flow nodes also nested under
+    // FLOW_NODE_INSTANCES.
     final Aggregation.Builder.ContainerBuilder flowNodeTermsBuilder =
         new Aggregation.Builder()
-            .terms(t -> t.size(bucketLimit).field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_ID));
+            .terms(
+                t ->
+                    t.size(bucketLimit)
+                        .field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_ID)
+                        .include(i -> i.terms(adHocSubProcessToolIds.stream().toList())));
     final Aggregation.Builder.ContainerBuilder flowNodeNestedBuilder =
         new Aggregation.Builder()
             .nested(n -> n.path(FLOW_NODE_INSTANCES))

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterES.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterES.java
@@ -10,9 +10,12 @@ package io.camunda.optimize.service.db.es.report.interpreter.groupby.process.flo
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_AGENT_FLOW_NODE;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.AGENT_INSTANCES;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.AGENT_INSTANCE_FLOW_NODE_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_INSTANCES;
 
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
 import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
 import co.elastic.clients.elasticsearch.core.search.ResponseBody;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
@@ -21,11 +24,13 @@ import io.camunda.optimize.service.db.es.report.interpreter.groupby.process.Abst
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
 import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.groupby.flownode.ProcessGroupByFlowNodeInterpreterHelper;
+import io.camunda.optimize.service.db.report.groupby.flownode.ProcessGroupByFlowNodeInterpreterHelper.AdHocSubProcessStructure;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -38,6 +43,8 @@ public class ProcessGroupByAgentFlowNodeInterpreterES extends AbstractProcessGro
 
   private static final String AGENT_INSTANCES_AGG = "agentInstances";
   private static final String BY_FLOW_NODE_ID_AGG = "byFlowNodeId";
+  private static final String FLOW_NODE_INSTANCES_AGG = "flowNodeInstances";
+  private static final String BY_FLOW_NODE_INSTANCE_ID_AGG = "byFlowNodeInstanceId";
 
   private final ConfigurationService configurationService;
   private final ProcessGroupByFlowNodeInterpreterHelper helper;
@@ -64,15 +71,14 @@ public class ProcessGroupByAgentFlowNodeInterpreterES extends AbstractProcessGro
   public Map<String, Aggregation.Builder.ContainerBuilder> createAggregation(
       final BoolQuery boolQuery,
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    final int bucketLimit =
+        configurationService.getElasticSearchConfiguration().getAggregationBucketLimit();
+
     final Aggregation.Builder.ContainerBuilder termsBuilder =
         new Aggregation.Builder()
             .terms(
                 t ->
-                    t.size(
-                            configurationService
-                                .getElasticSearchConfiguration()
-                                .getAggregationBucketLimit())
-                        .field(AGENT_INSTANCES + "." + AGENT_INSTANCE_FLOW_NODE_ID));
+                    t.size(bucketLimit).field(AGENT_INSTANCES + "." + AGENT_INSTANCE_FLOW_NODE_ID));
     distributedByInterpreter
         .createAggregations(context, boolQuery)
         .forEach((k, v) -> termsBuilder.aggregations(k, v.build()));
@@ -82,7 +88,23 @@ public class ProcessGroupByAgentFlowNodeInterpreterES extends AbstractProcessGro
             .nested(n -> n.path(AGENT_INSTANCES))
             .aggregations(BY_FLOW_NODE_ID_AGG, termsBuilder.build());
 
-    return Map.of(AGENT_INSTANCES_AGG, nestedBuilder);
+    // Only add the (extra) flow-node-instance aggregation used to break an ad-hoc subprocess down
+    // into per-tool heat when the model actually contains ad-hoc subprocess tool nodes. Reports
+    // without them keep the exact same aggregation as before.
+    if (helper.resolveAdHocSubProcessStructure(context).childIds().isEmpty()) {
+      return Map.of(AGENT_INSTANCES_AGG, nestedBuilder);
+    }
+
+    final Aggregation.Builder.ContainerBuilder flowNodeTermsBuilder =
+        new Aggregation.Builder()
+            .terms(t -> t.size(bucketLimit).field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_ID));
+    final Aggregation.Builder.ContainerBuilder flowNodeNestedBuilder =
+        new Aggregation.Builder()
+            .nested(n -> n.path(FLOW_NODE_INSTANCES))
+            .aggregations(BY_FLOW_NODE_INSTANCE_ID_AGG, flowNodeTermsBuilder.build());
+
+    return Map.of(
+        AGENT_INSTANCES_AGG, nestedBuilder, FLOW_NODE_INSTANCES_AGG, flowNodeNestedBuilder);
   }
 
   @Override
@@ -90,23 +112,50 @@ public class ProcessGroupByAgentFlowNodeInterpreterES extends AbstractProcessGro
       final CompositeCommandResult compositeCommandResult,
       final ResponseBody<?> response,
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
-    Optional.ofNullable(response.aggregations())
-        .filter(aggs -> !aggs.isEmpty())
-        // null-safe: yields an empty Optional when the nested agg key is absent
-        .map(aggs -> aggs.get(AGENT_INSTANCES_AGG))
+    if (response.aggregations() == null || response.aggregations().isEmpty()) {
+      return;
+    }
+
+    final List<StringTermsBucket> agentBuckets = extractAgentBuckets(response);
+    final List<StringTermsBucket> innerToolBuckets = extractInnerToolBuckets(response);
+    if (agentBuckets.isEmpty() && innerToolBuckets.isEmpty()) {
+      // No agent flow-node buckets located under the nested path: nothing to map (null-safe).
+      return;
+    }
+
+    final AdHocSubProcessStructure adHocSubProcessStructure =
+        helper.resolveAdHocSubProcessStructure(context);
+
+    compositeCommandResult.setGroups(
+        helper.mapAgentFlowNodeBucketsToGroupByResults(
+            agentBuckets,
+            bucket -> bucket.key().stringValue(),
+            bucket ->
+                distributedByInterpreter.retrieveResult(response, bucket.aggregations(), context),
+            innerToolBuckets,
+            bucket -> bucket.key().stringValue(),
+            bucket ->
+                helper.toFrequencyResult(
+                    distributedByInterpreter.createEmptyResult(context), bucket.docCount()),
+            adHocSubProcessStructure,
+            context,
+            distributedByInterpreter.createEmptyResult(context)));
+  }
+
+  private List<StringTermsBucket> extractAgentBuckets(final ResponseBody<?> response) {
+    return Optional.ofNullable(response.aggregations().get(AGENT_INSTANCES_AGG))
         .map(Aggregate::nested)
         .map(nested -> nested.aggregations().get(BY_FLOW_NODE_ID_AGG).sterms())
-        .ifPresent(
-            byFlowNodeId ->
-                compositeCommandResult.setGroups(
-                    helper.mapFlowNodeBucketsToGroupByResults(
-                        byFlowNodeId.buckets().array(),
-                        bucket -> bucket.key().stringValue(),
-                        bucket ->
-                            distributedByInterpreter.retrieveResult(
-                                response, bucket.aggregations(), context),
-                        context,
-                        distributedByInterpreter.createEmptyResult(context))));
+        .map(sterms -> sterms.buckets().array())
+        .orElseGet(List::of);
+  }
+
+  private List<StringTermsBucket> extractInnerToolBuckets(final ResponseBody<?> response) {
+    return Optional.ofNullable(response.aggregations().get(FLOW_NODE_INSTANCES_AGG))
+        .map(Aggregate::nested)
+        .map(nested -> nested.aggregations().get(BY_FLOW_NODE_INSTANCE_ID_AGG).sterms())
+        .map(sterms -> sterms.buckets().array())
+        .orElseGet(List::of);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterOS.java
@@ -88,13 +88,22 @@ public class ProcessGroupByAgentFlowNodeInterpreterOS extends AbstractProcessGro
     // Only add the (extra) flow-node-instance aggregation used to break an ad-hoc subprocess down
     // into per-tool heat when the model actually contains ad-hoc subprocess tool nodes. Reports
     // without them keep the exact same aggregation as before.
-    if (helper.resolveAdHocSubProcessStructure(context).childIds().isEmpty()) {
+    final Set<String> adHocSubProcessToolIds =
+        helper.resolveAdHocSubProcessStructure(context).childIds();
+    if (adHocSubProcessToolIds.isEmpty()) {
       return Map.of(AGENT_INSTANCES_AGG, nestedAgg);
     }
 
+    // Restrict the terms aggregation to the known tool IDs so low-frequency tools are not pushed
+    // out of the top-N buckets by unrelated, higher-frequency flow nodes also nested under
+    // FLOW_NODE_INSTANCES.
     final Aggregation flowNodeTermsAgg =
         new Aggregation.Builder()
-            .terms(termAggregation(FLOW_NODE_INSTANCES + "." + FLOW_NODE_ID, size))
+            .terms(
+                t ->
+                    t.field(FLOW_NODE_INSTANCES + "." + FLOW_NODE_ID)
+                        .size(size)
+                        .include(i -> i.terms(adHocSubProcessToolIds.stream().toList())))
             .build();
     final Aggregation flowNodeNestedAgg =
         new Aggregation.Builder()

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterOS.java
@@ -11,6 +11,8 @@ import static io.camunda.optimize.service.db.os.client.dsl.AggregationDSL.termAg
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_AGENT_FLOW_NODE;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.AGENT_INSTANCES;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.AGENT_INSTANCE_FLOW_NODE_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_INSTANCES;
 
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.service.db.os.report.interpreter.RawResult;
@@ -19,11 +21,13 @@ import io.camunda.optimize.service.db.os.report.interpreter.groupby.process.Abst
 import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.groupby.flownode.ProcessGroupByFlowNodeInterpreterHelper;
+import io.camunda.optimize.service.db.report.groupby.flownode.ProcessGroupByFlowNodeInterpreterHelper.AdHocSubProcessStructure;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -41,6 +45,8 @@ public class ProcessGroupByAgentFlowNodeInterpreterOS extends AbstractProcessGro
 
   private static final String AGENT_INSTANCES_AGG = "agentInstances";
   private static final String BY_FLOW_NODE_ID_AGG = "byFlowNodeId";
+  private static final String FLOW_NODE_INSTANCES_AGG = "flowNodeInstances";
+  private static final String BY_FLOW_NODE_INSTANCE_ID_AGG = "byFlowNodeInstanceId";
 
   private final ConfigurationService configurationService;
   private final ProcessGroupByFlowNodeInterpreterHelper helper;
@@ -78,7 +84,25 @@ public class ProcessGroupByAgentFlowNodeInterpreterOS extends AbstractProcessGro
             .nested(n -> n.path(AGENT_INSTANCES))
             .aggregations(BY_FLOW_NODE_ID_AGG, termsAgg)
             .build();
-    return Map.of(AGENT_INSTANCES_AGG, nestedAgg);
+
+    // Only add the (extra) flow-node-instance aggregation used to break an ad-hoc subprocess down
+    // into per-tool heat when the model actually contains ad-hoc subprocess tool nodes. Reports
+    // without them keep the exact same aggregation as before.
+    if (helper.resolveAdHocSubProcessStructure(context).childIds().isEmpty()) {
+      return Map.of(AGENT_INSTANCES_AGG, nestedAgg);
+    }
+
+    final Aggregation flowNodeTermsAgg =
+        new Aggregation.Builder()
+            .terms(termAggregation(FLOW_NODE_INSTANCES + "." + FLOW_NODE_ID, size))
+            .build();
+    final Aggregation flowNodeNestedAgg =
+        new Aggregation.Builder()
+            .nested(n -> n.path(FLOW_NODE_INSTANCES))
+            .aggregations(BY_FLOW_NODE_INSTANCE_ID_AGG, flowNodeTermsAgg)
+            .build();
+
+    return Map.of(AGENT_INSTANCES_AGG, nestedAgg, FLOW_NODE_INSTANCES_AGG, flowNodeNestedAgg);
   }
 
   @Override
@@ -86,23 +110,51 @@ public class ProcessGroupByAgentFlowNodeInterpreterOS extends AbstractProcessGro
       final CompositeCommandResult compositeCommandResult,
       final SearchResponse<RawResult> response,
       final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
-    Optional.ofNullable(response.aggregations())
-        .filter(aggs -> !aggs.isEmpty())
-        // null-safe: yields an empty Optional when the nested agg key is absent
-        .map(aggs -> aggs.get(AGENT_INSTANCES_AGG))
+    if (response.aggregations() == null || response.aggregations().isEmpty()) {
+      return;
+    }
+
+    final List<StringTermsBucket> agentBuckets = extractAgentBuckets(response);
+    final List<StringTermsBucket> innerToolBuckets = extractInnerToolBuckets(response);
+    if (agentBuckets.isEmpty() && innerToolBuckets.isEmpty()) {
+      // No agent flow-node buckets located under the nested path: nothing to map (null-safe).
+      return;
+    }
+
+    final AdHocSubProcessStructure adHocSubProcessStructure =
+        helper.resolveAdHocSubProcessStructure(context);
+
+    compositeCommandResult.setGroups(
+        helper.mapAgentFlowNodeBucketsToGroupByResults(
+            agentBuckets,
+            StringTermsBucket::key,
+            bucket ->
+                distributedByInterpreter.retrieveResult(response, bucket.aggregations(), context),
+            innerToolBuckets,
+            StringTermsBucket::key,
+            bucket ->
+                helper.toFrequencyResult(
+                    distributedByInterpreter.createEmptyResult(context), bucket.docCount()),
+            adHocSubProcessStructure,
+            context,
+            distributedByInterpreter.createEmptyResult(context)));
+  }
+
+  private List<StringTermsBucket> extractAgentBuckets(final SearchResponse<RawResult> response) {
+    return Optional.ofNullable(response.aggregations().get(AGENT_INSTANCES_AGG))
         .map(Aggregate::nested)
         .map(nested -> nested.aggregations().get(BY_FLOW_NODE_ID_AGG).sterms())
-        .ifPresent(
-            byFlowNodeId ->
-                compositeCommandResult.setGroups(
-                    helper.mapFlowNodeBucketsToGroupByResults(
-                        byFlowNodeId.buckets().array(),
-                        StringTermsBucket::key,
-                        bucket ->
-                            distributedByInterpreter.retrieveResult(
-                                response, bucket.aggregations(), context),
-                        context,
-                        distributedByInterpreter.createEmptyResult(context))));
+        .map(sterms -> sterms.buckets().array())
+        .orElseGet(List::of);
+  }
+
+  private List<StringTermsBucket> extractInnerToolBuckets(
+      final SearchResponse<RawResult> response) {
+    return Optional.ofNullable(response.aggregations().get(FLOW_NODE_INSTANCES_AGG))
+        .map(Aggregate::nested)
+        .map(nested -> nested.aggregations().get(BY_FLOW_NODE_INSTANCE_ID_AGG).sterms())
+        .map(sterms -> sterms.buckets().array())
+        .orElseGet(List::of);
   }
 
   @Override

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ExecutionContext.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/ExecutionContext.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class ExecutionContext<D extends SingleReportDataDto, P extends ExecutionPlan> {
 
@@ -64,6 +65,12 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
 
   private boolean multiIndexAlias = false;
 
+  // Per-request memoization cache for values that are derived from the (immutable) report data and
+  // are expensive to recompute, but may be needed by several phases of a single report evaluation
+  // (e.g. building the aggregation and mapping its result). Intentionally excluded from equals,
+  // hashCode and toString as it only caches values already derived from the fields above.
+  private final Map<String, Object> computedAttributes = new HashMap<>();
+
   public <R extends ReportDefinitionDto<D>> ExecutionContext(
       final ReportEvaluationContext<? extends R> reportEvaluationContext) {
     this(reportEvaluationContext, null);
@@ -93,6 +100,16 @@ public class ExecutionContext<D extends SingleReportDataDto, P extends Execution
   public void setAllDistributedByKeys(final Set<String> allDistributedByKeys) {
     allDistributedByKeysAndLabels =
         allDistributedByKeys.stream().collect(toMap(Function.identity(), Function.identity()));
+  }
+
+  /**
+   * Returns the value cached under {@code key}, computing and caching it with {@code supplier} on
+   * first access. Scoped to this (per-request) execution context, so it is safe for memoizing
+   * values derived from the report data across the phases of a single report evaluation.
+   */
+  @SuppressWarnings("unchecked")
+  public <T> T getOrComputeAttribute(final String key, final Supplier<T> supplier) {
+    return (T) computedAttributes.computeIfAbsent(key, ignored -> supplier.get());
   }
 
   private <R extends ReportDefinitionDto<D>> FilterContext createFilterContext(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelper.java
@@ -166,6 +166,18 @@ public class ProcessGroupByFlowNodeInterpreterHelper {
    * measure to {@code docCount}. Shared by the Elasticsearch and OpenSearch agent flow-node
    * interpreters, which build the per-tool heat of an ad-hoc subprocess from the raw activation
    * counts of its inner tool nodes.
+   *
+   * <p>The measures being overwritten here come from the TOOL_CALLS view's {@code
+   * createEmptyResult}, which tags each one with the report's configured aggregation type (AVERAGE
+   * by default, see {@code SingleReportConfigurationDto}). That labeling is only meaningful for the
+   * real avg/min/max/sum aggregation over the numeric tool-calls field; this value is a plain
+   * activation count, so on paper the label is misleading. It is deliberately left untouched
+   * anyway: {@code CompositeCommandResult#createMeasureMap} pre-seeds its output measures purely
+   * from the report's configured aggregation types (not from what any view interpreter actually
+   * computes), so every measure in this report — including this one — must keep exactly that
+   * identifier or it silently drops into a second, mismatched measure. That previously surfaced as
+   * a spurious aggregation-type selector in the report tile with an empty heatmap under the
+   * "expected" identifier and the real data hidden under the mismatched one.
    */
   public List<DistributedByResult> toFrequencyResult(
       final List<DistributedByResult> emptyDistributedByResult, final long docCount) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelper.java
@@ -116,7 +116,7 @@ public class ProcessGroupByFlowNodeInterpreterHelper {
   }
 
   /**
-   * Resolves, from the report's process definition model(s), which flow nodes are ad-hoc subprocess
+   * Resolves, from the report's process definition model, which flow nodes are ad-hoc subprocess
    * containers and which are their inner tool nodes. Used by the agent flow-node grouping to render
    * per-tool heat inside an expanded AI Agent (ad-hoc subprocess) while other agent nodes keep
    * their aggregated tool-call total. Ids that are themselves containers (nested ad-hoc
@@ -133,11 +133,20 @@ public class ProcessGroupByFlowNodeInterpreterHelper {
         () -> computeAdHocSubProcessStructure(context.getReportData()));
   }
 
+  /**
+   * Only the report's first definition is parsed: this grouping is exclusively paired with the
+   * heatmap views built by {@code AgenticControlDashboardService}, which only ever render a single
+   * concrete BPMN diagram (mirroring {@code ReportEvaluationHandler#populateHeatmapXml}, which
+   * likewise reads only the first definition for the diagram XML). BPMN flow-node IDs are unique
+   * only within a single model, not across definitions, so merging container/child IDs from more
+   * than one model would let an unrelated flow node in one definition collide with an ad-hoc
+   * subprocess container or tool ID in another, misclassifying it in every group's result.
+   */
   private AdHocSubProcessStructure computeAdHocSubProcessStructure(
       final ProcessReportDataDto reportData) {
     final Set<String> containerIds = new HashSet<>();
     final Set<String> childIds = new HashSet<>();
-    reportData.getDefinitions().stream()
+    reportData.getDefinitions().stream().findFirst().stream()
         .map(
             definitionDto ->
                 definitionService.getDefinition(

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelper.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelper.java
@@ -16,16 +16,22 @@ import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.plan.process.ProcessExecutionPlan;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult.DistributedByResult;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
+import io.camunda.optimize.service.util.BpmnModelUtil;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ProcessGroupByFlowNodeInterpreterHelper {
+  private static final String AD_HOC_SUB_PROCESS_STRUCTURE_ATTRIBUTE = "adHocSubProcessStructure";
+
   private final DefinitionService definitionService;
 
   public ProcessGroupByFlowNodeInterpreterHelper(final DefinitionService definitionService) {
@@ -108,4 +114,129 @@ public class ProcessGroupByFlowNodeInterpreterHelper {
             .map(ProcessDefinitionOptimizeDto.class::cast)
             .collect(Collectors.toList()));
   }
+
+  /**
+   * Resolves, from the report's process definition model(s), which flow nodes are ad-hoc subprocess
+   * containers and which are their inner tool nodes. Used by the agent flow-node grouping to render
+   * per-tool heat inside an expanded AI Agent (ad-hoc subprocess) while other agent nodes keep
+   * their aggregated tool-call total. Ids that are themselves containers (nested ad-hoc
+   * subprocesses) are excluded from the child set so nested containers are not tinted as tools.
+   *
+   * <p>Parsing the BPMN model is not free and the structure is needed by both the aggregation and
+   * the result-mapping phase of a single report evaluation, so the result is memoized on the
+   * (per-request) {@link ExecutionContext} to parse the model at most once per report.
+   */
+  public AdHocSubProcessStructure resolveAdHocSubProcessStructure(
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context) {
+    return context.getOrComputeAttribute(
+        AD_HOC_SUB_PROCESS_STRUCTURE_ATTRIBUTE,
+        () -> computeAdHocSubProcessStructure(context.getReportData()));
+  }
+
+  private AdHocSubProcessStructure computeAdHocSubProcessStructure(
+      final ProcessReportDataDto reportData) {
+    final Set<String> containerIds = new HashSet<>();
+    final Set<String> childIds = new HashSet<>();
+    reportData.getDefinitions().stream()
+        .map(
+            definitionDto ->
+                definitionService.getDefinition(
+                    DefinitionType.PROCESS,
+                    definitionDto.getKey(),
+                    definitionDto.getVersions(),
+                    definitionDto.getTenantIds()))
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(ProcessDefinitionOptimizeDto.class::cast)
+        .map(ProcessDefinitionOptimizeDto::getBpmn20Xml)
+        .filter(Objects::nonNull)
+        .forEach(
+            xml -> {
+              final Map<String, Set<String>> childIdsByContainer =
+                  BpmnModelUtil.extractAdHocSubProcessChildElementIds(xml);
+              containerIds.addAll(childIdsByContainer.keySet());
+              childIdsByContainer.values().forEach(childIds::addAll);
+            });
+    childIds.removeAll(containerIds);
+    return new AdHocSubProcessStructure(containerIds, childIds);
+  }
+
+  /**
+   * Populates the given (empty) distributed-by results with a frequency value, i.e. sets every view
+   * measure to {@code docCount}. Shared by the Elasticsearch and OpenSearch agent flow-node
+   * interpreters, which build the per-tool heat of an ad-hoc subprocess from the raw activation
+   * counts of its inner tool nodes.
+   */
+  public List<DistributedByResult> toFrequencyResult(
+      final List<DistributedByResult> emptyDistributedByResult, final long docCount) {
+    emptyDistributedByResult.forEach(
+        distributedByResult -> {
+          final var viewResult = distributedByResult.getViewResult();
+          if (viewResult != null && viewResult.getViewMeasures() != null) {
+            viewResult.getViewMeasures().forEach(measure -> measure.setValue((double) docCount));
+          }
+        });
+    return emptyDistributedByResult;
+  }
+
+  /**
+   * Hybrid variant of {@link #mapFlowNodeBucketsToGroupByResults} for the agent flow-node grouping.
+   * Agent-node buckets keep their aggregated value, except ad-hoc subprocess containers which are
+   * dropped (so the large AI Agent box is not tinted). Inner tool nodes of ad-hoc subprocesses are
+   * instead emitted from the flow-node-instance buckets, valued by their own activation counts, so
+   * the diagram shows per-tool heat inside the expanded container. All remaining model flow nodes
+   * are backfilled with empty results and hidden nodes are stripped, as in the standard mapping.
+   */
+  public <A, F> List<GroupByResult> mapAgentFlowNodeBucketsToGroupByResults(
+      final List<A> agentBuckets,
+      final Function<A, String> agentKeyExtractor,
+      final Function<A, List<DistributedByResult>> agentResultExtractor,
+      final List<F> innerToolBuckets,
+      final Function<F, String> innerToolKeyExtractor,
+      final Function<F, List<DistributedByResult>> innerToolResultExtractor,
+      final AdHocSubProcessStructure adHocSubProcessStructure,
+      final ExecutionContext<ProcessReportDataDto, ProcessExecutionPlan> context,
+      final List<DistributedByResult> emptyDistributedByResult) {
+    final Map<String, String> flowNodeNames = getFlowNodeNames(context.getReportData());
+    final List<GroupByResult> groupedData = new ArrayList<>();
+
+    for (final A bucket : agentBuckets) {
+      final String flowNodeKey = agentKeyExtractor.apply(bucket);
+      if (adHocSubProcessStructure.containerIds().contains(flowNodeKey)) {
+        // The ad-hoc subprocess container is represented by its inner tool nodes instead.
+        continue;
+      }
+      if (flowNodeNames.containsKey(flowNodeKey)) {
+        groupedData.add(
+            GroupByResult.createGroupByResult(
+                flowNodeKey, flowNodeNames.get(flowNodeKey), agentResultExtractor.apply(bucket)));
+        flowNodeNames.remove(flowNodeKey);
+      }
+    }
+
+    for (final F bucket : innerToolBuckets) {
+      final String flowNodeKey = innerToolKeyExtractor.apply(bucket);
+      if (!adHocSubProcessStructure.childIds().contains(flowNodeKey)) {
+        continue;
+      }
+      if (flowNodeNames.containsKey(flowNodeKey)) {
+        groupedData.add(
+            GroupByResult.createGroupByResult(
+                flowNodeKey,
+                flowNodeNames.get(flowNodeKey),
+                innerToolResultExtractor.apply(bucket)));
+        flowNodeNames.remove(flowNodeKey);
+      }
+    }
+
+    addMissingGroupByKeys(flowNodeNames, groupedData, context, emptyDistributedByResult);
+    removeHiddenModelElements(groupedData, context);
+    return groupedData;
+  }
+
+  /**
+   * The ad-hoc subprocess container ids and the ids of their inner tool nodes for a report's
+   * definition model(s).
+   */
+  public record AdHocSubProcessStructure(Set<String> containerIds, Set<String> childIds) {}
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/util/BpmnModelUtil.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/util/BpmnModelUtil.java
@@ -11,6 +11,7 @@ import io.camunda.optimize.dto.optimize.FlowNodeDataDto;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.BaseElement;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.Process;
@@ -98,6 +99,37 @@ public final class BpmnModelUtil {
       flowNodeNames.put(flowNode.getId(), flowNode.getName());
     }
     return flowNodeNames;
+  }
+
+  public static Map<String, Set<String>> extractAdHocSubProcessChildElementIds(
+      final String bpmn20Xml) {
+    return extractAdHocSubProcessChildElementIds(parseBpmnModel(bpmn20Xml));
+  }
+
+  /**
+   * Returns, for each ad-hoc subprocess in the model, the set of ids of its <em>activatable</em>
+   * child flow nodes (the "tools" of an AI Agent): the direct child flow nodes that have no
+   * incoming sequence flow within the ad-hoc subprocess. In an ad-hoc subprocess only such
+   * entry-point elements are directly activatable by the agent; any downstream node reached via a
+   * sequence flow is a deterministic follow-up step, not a tool call, so it is excluded here.
+   * Sequence flows and other non-flow-node elements are excluded as well so the ids line up with
+   * the {@code flowNodeInstances} recorded for tool activations.
+   */
+  public static Map<String, Set<String>> extractAdHocSubProcessChildElementIds(
+      final BpmnModelInstance model) {
+    final Map<String, Set<String>> childIdsByAdHocSubProcessId = new HashMap<>();
+    for (final AdHocSubProcess adHocSubProcess :
+        model.getModelElementsByType(AdHocSubProcess.class)) {
+      final Set<String> childIds =
+          adHocSubProcess.getFlowElements().stream()
+              .filter(FlowNode.class::isInstance)
+              .map(FlowNode.class::cast)
+              .filter(flowNode -> flowNode.getIncoming().isEmpty())
+              .map(BaseElement::getId)
+              .collect(Collectors.toSet());
+      childIdsByAdHocSubProcessId.put(adHocSubProcess.getId(), childIds);
+    }
+    return childIdsByAdHocSubProcessId;
   }
 
   public static Set<String> getCollapsedSubprocessElementIds(final String xmlString) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterESTest.java
@@ -10,6 +10,8 @@ package io.camunda.optimize.service.db.es.report.interpreter.groupby.process.flo
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_AGENT_FLOW_NODE;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.AGENT_INSTANCES;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.AGENT_INSTANCE_FLOW_NODE_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_INSTANCES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -29,12 +31,14 @@ import io.camunda.optimize.service.db.es.report.interpreter.distributedby.proces
 import io.camunda.optimize.service.db.es.report.interpreter.view.process.ProcessViewInterpreterFacadeES;
 import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.groupby.flownode.ProcessGroupByFlowNodeInterpreterHelper;
+import io.camunda.optimize.service.db.report.groupby.flownode.ProcessGroupByFlowNodeInterpreterHelper.AdHocSubProcessStructure;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.ElasticSearchConfiguration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +52,8 @@ class ProcessGroupByAgentFlowNodeInterpreterESTest {
 
   private static final String AGENT_INSTANCES_AGG = "agentInstances";
   private static final String BY_FLOW_NODE_ID_AGG = "byFlowNodeId";
+  private static final String FLOW_NODE_INSTANCES_AGG = "flowNodeInstances";
+  private static final String BY_FLOW_NODE_INSTANCE_ID_AGG = "byFlowNodeInstanceId";
 
   @Mock private ConfigurationService configurationService;
   @Mock private ElasticSearchConfiguration elasticSearchConfiguration;
@@ -80,6 +86,8 @@ class ProcessGroupByAgentFlowNodeInterpreterESTest {
     when(configurationService.getElasticSearchConfiguration())
         .thenReturn(elasticSearchConfiguration);
     when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
+    when(helper.resolveAdHocSubProcessStructure(any()))
+        .thenReturn(new AdHocSubProcessStructure(Set.of(), Set.of()));
 
     // when
     final Map<String, Aggregation.Builder.ContainerBuilder> result =
@@ -95,6 +103,38 @@ class ProcessGroupByAgentFlowNodeInterpreterESTest {
     assertThat(byFlowNodeId._kind()).isEqualTo(Aggregation.Kind.Terms);
     assertThat(byFlowNodeId.terms().field())
         .isEqualTo(AGENT_INSTANCES + "." + AGENT_INSTANCE_FLOW_NODE_ID);
+
+    // and no extra flow-node-instance aggregation is added when there are no ad-hoc subprocess
+    // tools
+    assertThat(result).doesNotContainKey(FLOW_NODE_INSTANCES_AGG);
+  }
+
+  @Test
+  void shouldAlsoBuildFlowNodeInstanceAggregationWhenAdHocSubProcessToolsPresent() {
+    // given a report whose model contains ad-hoc subprocess tool nodes
+    when(configurationService.getElasticSearchConfiguration())
+        .thenReturn(elasticSearchConfiguration);
+    when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
+    when(helper.resolveAdHocSubProcessStructure(any()))
+        .thenReturn(new AdHocSubProcessStructure(Set.of("ahsp"), Set.of("tool-a", "tool-b")));
+
+    // when
+    final Map<String, Aggregation.Builder.ContainerBuilder> result =
+        underTest.createAggregation(mock(BoolQuery.class), context);
+
+    // then a second nested aggregation over the flowNodeInstances path is added
+    final Aggregation flowNodeInstances = result.get(FLOW_NODE_INSTANCES_AGG).build();
+    assertThat(flowNodeInstances._kind()).isEqualTo(Aggregation.Kind.Nested);
+    assertThat(flowNodeInstances.nested().path()).isEqualTo(FLOW_NODE_INSTANCES);
+
+    final Aggregation byFlowNodeInstanceId =
+        flowNodeInstances.aggregations().get(BY_FLOW_NODE_INSTANCE_ID_AGG);
+    assertThat(byFlowNodeInstanceId._kind()).isEqualTo(Aggregation.Kind.Terms);
+    assertThat(byFlowNodeInstanceId.terms().field())
+        .isEqualTo(FLOW_NODE_INSTANCES + "." + FLOW_NODE_ID);
+
+    // and the original agent aggregation is still present
+    assertThat(result).containsKey(AGENT_INSTANCES_AGG);
   }
 
   @Test
@@ -106,8 +146,11 @@ class ProcessGroupByAgentFlowNodeInterpreterESTest {
             CompositeCommandResult.GroupByResult.createGroupByResult("task-a", "Task A", List.of()),
             CompositeCommandResult.GroupByResult.createGroupByResult(
                 "task-b", "Task B", List.of()));
-    when(helper.mapFlowNodeBucketsToGroupByResults(any(), any(), any(), any(), any()))
+    when(helper.mapAgentFlowNodeBucketsToGroupByResults(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(mappedGroups);
+    when(helper.resolveAdHocSubProcessStructure(any()))
+        .thenReturn(new AdHocSubProcessStructure(Set.of(), Set.of()));
     when(distributedByInterpreter.createEmptyResult(any())).thenReturn(List.of());
 
     final ResponseBody<?> response = mock(ResponseBody.class);
@@ -123,15 +166,23 @@ class ProcessGroupByAgentFlowNodeInterpreterESTest {
     // result
     assertThat(result.getGroups()).isSameAs(mappedGroups);
 
-    // and the buckets located under the nested path are handed over with a key extractor that reads
-    // the string term key
+    // and the agent buckets located under the nested path are handed over with a key extractor that
+    // reads the string term key
     final ArgumentCaptor<List<StringTermsBucket>> bucketsCaptor =
         ArgumentCaptor.forClass(List.class);
     final ArgumentCaptor<Function<StringTermsBucket, String>> keyExtractorCaptor =
         ArgumentCaptor.forClass(Function.class);
     verify(helper)
-        .mapFlowNodeBucketsToGroupByResults(
-            bucketsCaptor.capture(), keyExtractorCaptor.capture(), any(), any(), any());
+        .mapAgentFlowNodeBucketsToGroupByResults(
+            bucketsCaptor.capture(),
+            keyExtractorCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
     assertThat(bucketsCaptor.getValue())
         .extracting(keyExtractorCaptor.getValue()::apply)
         .containsExactly("task-a", "task-b");
@@ -151,7 +202,53 @@ class ProcessGroupByAgentFlowNodeInterpreterESTest {
 
     // then the missing key is handled null-safely: no NPE, and the helper is never invoked
     assertThat(result.getGroups()).isEmpty();
-    verify(helper, never()).mapFlowNodeBucketsToGroupByResults(any(), any(), any(), any(), any());
+    verify(helper, never())
+        .mapAgentFlowNodeBucketsToGroupByResults(
+            any(), any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldExtractInnerToolBucketsFromFlowNodeInstancesAggregation() {
+    // given a response containing both the agent aggregation and the flow-node-instance aggregation
+    when(helper.mapAgentFlowNodeBucketsToGroupByResults(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(List.of());
+    when(helper.resolveAdHocSubProcessStructure(any()))
+        .thenReturn(new AdHocSubProcessStructure(Set.of("ahsp"), Set.of("tool-a", "tool-b")));
+    when(distributedByInterpreter.createEmptyResult(any())).thenReturn(List.of());
+
+    final ResponseBody<?> response = mock(ResponseBody.class);
+    when(response.aggregations())
+        .thenReturn(
+            Map.of(
+                AGENT_INSTANCES_AGG, nestedStringTermsAggregate("ahsp"),
+                FLOW_NODE_INSTANCES_AGG, nestedFlowNodeInstanceTermsAggregate("tool-a", "tool-b")));
+
+    // when
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.TOOL_CALLS);
+    underTest.addQueryResult(result, response, context);
+
+    // then the inner-tool buckets (4th argument) are read from the flow-node-instance aggregation
+    final ArgumentCaptor<List<StringTermsBucket>> innerToolBucketsCaptor =
+        ArgumentCaptor.forClass(List.class);
+    final ArgumentCaptor<Function<StringTermsBucket, String>> innerKeyExtractorCaptor =
+        ArgumentCaptor.forClass(Function.class);
+    verify(helper)
+        .mapAgentFlowNodeBucketsToGroupByResults(
+            any(),
+            any(),
+            any(),
+            innerToolBucketsCaptor.capture(),
+            innerKeyExtractorCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any());
+    assertThat(innerToolBucketsCaptor.getValue())
+        .extracting(innerKeyExtractorCaptor.getValue()::apply)
+        .containsExactly("tool-a", "tool-b");
   }
 
   @Test
@@ -167,6 +264,16 @@ class ProcessGroupByAgentFlowNodeInterpreterESTest {
 
     // then
     assertThat(result.getGroups()).isEmpty();
+  }
+
+  private static Aggregate nestedFlowNodeInstanceTermsAggregate(final String... flowNodeIds) {
+    return Aggregate.of(
+        a ->
+            a.nested(
+                n ->
+                    n.docCount(flowNodeIds.length)
+                        .aggregations(
+                            BY_FLOW_NODE_INSTANCE_ID_AGG, stringTermsAggregate(flowNodeIds))));
   }
 
   private static Aggregate nestedStringTermsAggregate(final String... flowNodeIds) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterESTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/es/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterESTest.java
@@ -133,6 +133,11 @@ class ProcessGroupByAgentFlowNodeInterpreterESTest {
     assertThat(byFlowNodeInstanceId.terms().field())
         .isEqualTo(FLOW_NODE_INSTANCES + "." + FLOW_NODE_ID);
 
+    // and the terms aggregation is restricted to the resolved ad-hoc subprocess tool IDs, so
+    // low-frequency tools cannot be pushed out of the top-N buckets by unrelated flow nodes
+    assertThat(byFlowNodeInstanceId.terms().include().terms())
+        .containsExactlyInAnyOrder("tool-a", "tool-b");
+
     // and the original agent aggregation is still present
     assertThat(result).containsKey(AGENT_INSTANCES_AGG);
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterOSTest.java
@@ -131,6 +131,11 @@ class ProcessGroupByAgentFlowNodeInterpreterOSTest {
     assertThat(byFlowNodeInstanceId.terms().field())
         .isEqualTo(FLOW_NODE_INSTANCES + "." + FLOW_NODE_ID);
 
+    // and the terms aggregation is restricted to the resolved ad-hoc subprocess tool IDs, so
+    // low-frequency tools cannot be pushed out of the top-N buckets by unrelated flow nodes
+    assertThat(byFlowNodeInstanceId.terms().include().terms())
+        .containsExactlyInAnyOrder("tool-a", "tool-b");
+
     // and the original agent aggregation is still present
     assertThat(result).containsKey(AGENT_INSTANCES_AGG);
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterOSTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/os/report/interpreter/groupby/process/flownode/ProcessGroupByAgentFlowNodeInterpreterOSTest.java
@@ -10,6 +10,8 @@ package io.camunda.optimize.service.db.os.report.interpreter.groupby.process.flo
 import static io.camunda.optimize.service.db.report.plan.process.ProcessGroupBy.PROCESS_GROUP_BY_AGENT_FLOW_NODE;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.AGENT_INSTANCES;
 import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.AGENT_INSTANCE_FLOW_NODE_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_ID;
+import static io.camunda.optimize.service.db.schema.index.ProcessInstanceIndex.FLOW_NODE_INSTANCES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -24,12 +26,14 @@ import io.camunda.optimize.service.db.os.report.interpreter.distributedby.proces
 import io.camunda.optimize.service.db.os.report.interpreter.view.process.ProcessViewInterpreterFacadeOS;
 import io.camunda.optimize.service.db.report.ExecutionContext;
 import io.camunda.optimize.service.db.report.groupby.flownode.ProcessGroupByFlowNodeInterpreterHelper;
+import io.camunda.optimize.service.db.report.groupby.flownode.ProcessGroupByFlowNodeInterpreterHelper.AdHocSubProcessStructure;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.OpenSearchConfiguration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,6 +52,8 @@ class ProcessGroupByAgentFlowNodeInterpreterOSTest {
 
   private static final String AGENT_INSTANCES_AGG = "agentInstances";
   private static final String BY_FLOW_NODE_ID_AGG = "byFlowNodeId";
+  private static final String FLOW_NODE_INSTANCES_AGG = "flowNodeInstances";
+  private static final String BY_FLOW_NODE_INSTANCE_ID_AGG = "byFlowNodeInstanceId";
 
   @Mock private ConfigurationService configurationService;
   @Mock private OpenSearchConfiguration openSearchConfiguration;
@@ -80,6 +86,8 @@ class ProcessGroupByAgentFlowNodeInterpreterOSTest {
     when(configurationService.getOpenSearchConfiguration()).thenReturn(openSearchConfiguration);
     when(openSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);
     when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
+    when(helper.resolveAdHocSubProcessStructure(any()))
+        .thenReturn(new AdHocSubProcessStructure(Set.of(), Set.of()));
 
     // when
     final Map<String, Aggregation> result = underTest.createAggregation(mock(Query.class), context);
@@ -94,6 +102,37 @@ class ProcessGroupByAgentFlowNodeInterpreterOSTest {
     assertThat(byFlowNodeId._kind()).isEqualTo(Aggregation.Kind.Terms);
     assertThat(byFlowNodeId.terms().field())
         .isEqualTo(AGENT_INSTANCES + "." + AGENT_INSTANCE_FLOW_NODE_ID);
+
+    // and no extra flow-node-instance aggregation is added when there are no ad-hoc subprocess
+    // tools
+    assertThat(result).doesNotContainKey(FLOW_NODE_INSTANCES_AGG);
+  }
+
+  @Test
+  void shouldAlsoBuildFlowNodeInstanceAggregationWhenAdHocSubProcessToolsPresent() {
+    // given a report whose model contains ad-hoc subprocess tool nodes
+    when(configurationService.getOpenSearchConfiguration()).thenReturn(openSearchConfiguration);
+    when(openSearchConfiguration.getAggregationBucketLimit()).thenReturn(10);
+    when(distributedByInterpreter.createAggregations(any(), any())).thenReturn(Map.of());
+    when(helper.resolveAdHocSubProcessStructure(any()))
+        .thenReturn(new AdHocSubProcessStructure(Set.of("ahsp"), Set.of("tool-a", "tool-b")));
+
+    // when
+    final Map<String, Aggregation> result = underTest.createAggregation(mock(Query.class), context);
+
+    // then a second nested aggregation over the flowNodeInstances path is added
+    final Aggregation flowNodeInstances = result.get(FLOW_NODE_INSTANCES_AGG);
+    assertThat(flowNodeInstances._kind()).isEqualTo(Aggregation.Kind.Nested);
+    assertThat(flowNodeInstances.nested().path()).isEqualTo(FLOW_NODE_INSTANCES);
+
+    final Aggregation byFlowNodeInstanceId =
+        flowNodeInstances.aggregations().get(BY_FLOW_NODE_INSTANCE_ID_AGG);
+    assertThat(byFlowNodeInstanceId._kind()).isEqualTo(Aggregation.Kind.Terms);
+    assertThat(byFlowNodeInstanceId.terms().field())
+        .isEqualTo(FLOW_NODE_INSTANCES + "." + FLOW_NODE_ID);
+
+    // and the original agent aggregation is still present
+    assertThat(result).containsKey(AGENT_INSTANCES_AGG);
   }
 
   @Test
@@ -105,8 +144,11 @@ class ProcessGroupByAgentFlowNodeInterpreterOSTest {
             CompositeCommandResult.GroupByResult.createGroupByResult("task-a", "Task A", List.of()),
             CompositeCommandResult.GroupByResult.createGroupByResult(
                 "task-b", "Task B", List.of()));
-    when(helper.mapFlowNodeBucketsToGroupByResults(any(), any(), any(), any(), any()))
+    when(helper.mapAgentFlowNodeBucketsToGroupByResults(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
         .thenReturn(mappedGroups);
+    when(helper.resolveAdHocSubProcessStructure(any()))
+        .thenReturn(new AdHocSubProcessStructure(Set.of(), Set.of()));
     when(distributedByInterpreter.createEmptyResult(any())).thenReturn(List.of());
 
     final SearchResponse<RawResult> response = mock(SearchResponse.class);
@@ -122,18 +164,70 @@ class ProcessGroupByAgentFlowNodeInterpreterOSTest {
     // result
     assertThat(result.getGroups()).isSameAs(mappedGroups);
 
-    // and the buckets located under the nested path are handed over with a key extractor that reads
-    // the string term key
+    // and the agent buckets located under the nested path are handed over with a key extractor that
+    // reads the string term key
     final ArgumentCaptor<List<StringTermsBucket>> bucketsCaptor =
         ArgumentCaptor.forClass(List.class);
     final ArgumentCaptor<Function<StringTermsBucket, String>> keyExtractorCaptor =
         ArgumentCaptor.forClass(Function.class);
     verify(helper)
-        .mapFlowNodeBucketsToGroupByResults(
-            bucketsCaptor.capture(), keyExtractorCaptor.capture(), any(), any(), any());
+        .mapAgentFlowNodeBucketsToGroupByResults(
+            bucketsCaptor.capture(),
+            keyExtractorCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any());
     assertThat(bucketsCaptor.getValue())
         .extracting(keyExtractorCaptor.getValue()::apply)
         .containsExactly("task-a", "task-b");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldExtractInnerToolBucketsFromFlowNodeInstancesAggregation() {
+    // given a response containing both the agent aggregation and the flow-node-instance aggregation
+    when(helper.mapAgentFlowNodeBucketsToGroupByResults(
+            any(), any(), any(), any(), any(), any(), any(), any(), any()))
+        .thenReturn(List.of());
+    when(helper.resolveAdHocSubProcessStructure(any()))
+        .thenReturn(new AdHocSubProcessStructure(Set.of("ahsp"), Set.of("tool-a", "tool-b")));
+    when(distributedByInterpreter.createEmptyResult(any())).thenReturn(List.of());
+
+    final SearchResponse<RawResult> response = mock(SearchResponse.class);
+    when(response.aggregations())
+        .thenReturn(
+            Map.of(
+                AGENT_INSTANCES_AGG, nestedStringTermsAggregate("ahsp"),
+                FLOW_NODE_INSTANCES_AGG, nestedFlowNodeInstanceTermsAggregate("tool-a", "tool-b")));
+
+    // when
+    final CompositeCommandResult result =
+        new CompositeCommandResult(new ProcessReportDataDto(), ViewProperty.TOOL_CALLS);
+    underTest.addQueryResult(result, response, context);
+
+    // then the inner-tool buckets (4th argument) are read from the flow-node-instance aggregation
+    final ArgumentCaptor<List<StringTermsBucket>> innerToolBucketsCaptor =
+        ArgumentCaptor.forClass(List.class);
+    final ArgumentCaptor<Function<StringTermsBucket, String>> innerKeyExtractorCaptor =
+        ArgumentCaptor.forClass(Function.class);
+    verify(helper)
+        .mapAgentFlowNodeBucketsToGroupByResults(
+            any(),
+            any(),
+            any(),
+            innerToolBucketsCaptor.capture(),
+            innerKeyExtractorCaptor.capture(),
+            any(),
+            any(),
+            any(),
+            any());
+    assertThat(innerToolBucketsCaptor.getValue())
+        .extracting(innerKeyExtractorCaptor.getValue()::apply)
+        .containsExactly("tool-a", "tool-b");
   }
 
   @Test
@@ -150,7 +244,9 @@ class ProcessGroupByAgentFlowNodeInterpreterOSTest {
 
     // then the missing key is handled null-safely: no NPE, and the helper is never invoked
     assertThat(result.getGroups()).isEmpty();
-    verify(helper, never()).mapFlowNodeBucketsToGroupByResults(any(), any(), any(), any(), any());
+    verify(helper, never())
+        .mapAgentFlowNodeBucketsToGroupByResults(
+            any(), any(), any(), any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -166,6 +262,16 @@ class ProcessGroupByAgentFlowNodeInterpreterOSTest {
 
     // then
     assertThat(result.getGroups()).isEmpty();
+  }
+
+  private static Aggregate nestedFlowNodeInstanceTermsAggregate(final String... flowNodeIds) {
+    return Aggregate.of(
+        a ->
+            a.nested(
+                n ->
+                    n.docCount(flowNodeIds.length)
+                        .aggregations(
+                            BY_FLOW_NODE_INSTANCE_ID_AGG, stringTermsAggregate(flowNodeIds))));
   }
 
   private static Aggregate nestedStringTermsAggregate(final String... flowNodeIds) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelperTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
+import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.FilterApplicationLevel;
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
@@ -217,11 +219,14 @@ class ProcessGroupByFlowNodeInterpreterHelperTest {
   }
 
   @Test
-  void shouldSetEveryViewMeasureToDocCountInFrequencyResult() {
-    // given a distributed-by result with two (unset) view measures
+  void shouldSetEveryViewMeasureToDocCountInFrequencyResultWithoutChangingItsAggregationType() {
+    // given a distributed-by result with two view measures, each carrying the report's configured
+    // (default AVERAGE) aggregation type, as produced by the TOOL_CALLS view's createEmptyResult
     underTest = helper();
-    final ViewMeasure measureA = ViewMeasure.builder().value(null).build();
-    final ViewMeasure measureB = ViewMeasure.builder().value(null).build();
+    final ViewMeasure measureA =
+        ViewMeasure.builder().aggregationType(new AggregationDto(AggregationType.AVERAGE)).build();
+    final ViewMeasure measureB =
+        ViewMeasure.builder().aggregationType(new AggregationDto(AggregationType.AVERAGE)).build();
     final DistributedByResult result =
         DistributedByResult.createDistributedByNoneResult(
             ViewResult.builder().viewMeasures(List.of(measureA, measureB)).build());
@@ -230,10 +235,16 @@ class ProcessGroupByFlowNodeInterpreterHelperTest {
     final List<DistributedByResult> frequencyResult =
         underTest.toFrequencyResult(new ArrayList<>(List.of(result)), 7L);
 
-    // then every view measure carries the bucket's document count as its value
+    // then every view measure carries the bucket's document count as its value, and its
+    // aggregation type is left untouched so it keeps matching the sibling agent-node groups'
+    // measure identifier (see toFrequencyResult's javadoc for why)
     assertThat(frequencyResult).hasSize(1);
     assertThat(measureA.getValue()).isEqualTo(7.0);
+    assertThat(measureA.getAggregationType())
+        .isEqualTo(new AggregationDto(AggregationType.AVERAGE));
     assertThat(measureB.getValue()).isEqualTo(7.0);
+    assertThat(measureB.getAggregationType())
+        .isEqualTo(new AggregationDto(AggregationType.AVERAGE));
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelperTest.java
@@ -14,6 +14,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.optimize.dto.optimize.DefinitionType;
+import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
+import io.camunda.optimize.dto.optimize.query.report.single.ReportDataDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationDto;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.AggregationType;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
@@ -30,8 +33,10 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -141,6 +146,57 @@ class ProcessGroupByFlowNodeInterpreterHelperTest {
 
     // then no enrichment happens because the filter may legitimately exclude the missing node
     assertThat(groups).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldResolveAdHocSubProcessStructureFromOnlyTheFirstDefinition() {
+    // given a report with two definitions: the first has an ad-hoc subprocess ("ahsp") with tool
+    // "toolA", the second has an unrelated flow node that happens to share the ID "ahsp" (BPMN IDs
+    // are only unique within a single model, not across definitions)
+    underTest = helper();
+    final String firstDefinitionXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+            id="defs1" targetNamespace="http://bpmn.io/schema/bpmn">
+          <bpmn:process id="proc1" isExecutable="true">
+            <bpmn:adHocSubProcess id="ahsp">
+              <bpmn:serviceTask id="toolA" />
+            </bpmn:adHocSubProcess>
+          </bpmn:process>
+        </bpmn:definitions>
+        """;
+    final ReportDataDefinitionDto firstDefinition = new ReportDataDefinitionDto("first-key");
+    final ReportDataDefinitionDto secondDefinition = new ReportDataDefinitionDto("second-key");
+    final ProcessReportDataDto reportData = new ProcessReportDataDto();
+    reportData.setDefinitions(List.of(firstDefinition, secondDefinition));
+    when(context.getReportData()).thenReturn(reportData);
+    when(context.getOrComputeAttribute(any(), any()))
+        .thenAnswer(invocation -> ((Supplier<?>) invocation.getArgument(1)).get());
+    final ProcessDefinitionOptimizeDto firstDefinitionDto = new ProcessDefinitionOptimizeDto();
+    firstDefinitionDto.setBpmn20Xml(firstDefinitionXml);
+    when(definitionService.getDefinition(
+            DefinitionType.PROCESS,
+            firstDefinition.getKey(),
+            firstDefinition.getVersions(),
+            firstDefinition.getTenantIds()))
+        .thenReturn(Optional.of(firstDefinitionDto));
+
+    // when
+    final AdHocSubProcessStructure structure = underTest.resolveAdHocSubProcessStructure(context);
+
+    // then only the first definition's model is parsed: the second definition's model is never
+    // even fetched, so a coincidentally-shared ID from it cannot be misclassified as a container or
+    // tool
+    assertThat(structure.containerIds()).containsExactly("ahsp");
+    assertThat(structure.childIds()).containsExactly("toolA");
+    verify(definitionService, never())
+        .getDefinition(
+            DefinitionType.PROCESS,
+            secondDefinition.getKey(),
+            secondDefinition.getVersions(),
+            secondDefinition.getTenantIds());
   }
 
   @Test

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelperTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/db/report/groupby/flownode/ProcessGroupByFlowNodeInterpreterHelperTest.java
@@ -19,8 +19,12 @@ import io.camunda.optimize.dto.optimize.query.report.single.process.filter.Filte
 import io.camunda.optimize.dto.optimize.query.report.single.process.filter.ProcessFilterDto;
 import io.camunda.optimize.service.DefinitionService;
 import io.camunda.optimize.service.db.report.ExecutionContext;
+import io.camunda.optimize.service.db.report.groupby.flownode.ProcessGroupByFlowNodeInterpreterHelper.AdHocSubProcessStructure;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult.DistributedByResult;
 import io.camunda.optimize.service.db.report.result.CompositeCommandResult.GroupByResult;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult.ViewMeasure;
+import io.camunda.optimize.service.db.report.result.CompositeCommandResult.ViewResult;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -135,6 +139,115 @@ class ProcessGroupByFlowNodeInterpreterHelperTest {
 
     // then no enrichment happens because the filter may legitimately exclude the missing node
     assertThat(groups).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldSkipAdHocSubProcessContainerAndEmitInnerToolsFromFlowNodeBuckets() {
+    // given an AI Agent service task, an ad-hoc subprocess container and its two inner tool nodes
+    underTest = helper();
+    stubFlowNodeNames(
+        "agent-task", "Agent Task", "ahsp", "AI Agent", "tool-a", "Tool A", "tool-b", "Tool B");
+    when(context.getReportData()).thenReturn(new ProcessReportDataDto());
+    final AdHocSubProcessStructure structure =
+        new AdHocSubProcessStructure(Set.of("ahsp"), Set.of("tool-a", "tool-b"));
+    final Function<String, List<DistributedByResult>> agentResultExtractor = mock(Function.class);
+    when(agentResultExtractor.apply(any())).thenReturn(List.of());
+    final Function<String, List<DistributedByResult>> innerToolResultExtractor =
+        mock(Function.class);
+    when(innerToolResultExtractor.apply(any())).thenReturn(List.of());
+
+    // when
+    final List<GroupByResult> groups =
+        underTest.mapAgentFlowNodeBucketsToGroupByResults(
+            List.of("agent-task", "ahsp"),
+            Function.identity(),
+            agentResultExtractor,
+            List.of("tool-a", "tool-b"),
+            Function.identity(),
+            innerToolResultExtractor,
+            structure,
+            context,
+            List.of());
+
+    // then the non-container agent node keeps its aggregated value, the inner tools are emitted,
+    // and
+    // the container is not valued from the agent bucket (only backfilled empty)
+    assertThat(groups)
+        .extracting(GroupByResult::getKey)
+        .containsExactlyInAnyOrder("agent-task", "tool-a", "tool-b", "ahsp");
+    verify(agentResultExtractor).apply("agent-task");
+    verify(agentResultExtractor, never()).apply("ahsp");
+    verify(innerToolResultExtractor).apply("tool-a");
+    verify(innerToolResultExtractor).apply("tool-b");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void shouldOnlyEmitInnerToolBucketsThatAreAdHocSubProcessChildren() {
+    // given an inner-tool bucket that is not a child of any ad-hoc subprocess (e.g. an unrelated
+    // flow node instance)
+    underTest = helper();
+    stubFlowNodeNames("ahsp", "AI Agent", "tool-a", "Tool A", "other", "Other Task");
+    when(context.getReportData()).thenReturn(new ProcessReportDataDto());
+    final AdHocSubProcessStructure structure =
+        new AdHocSubProcessStructure(Set.of("ahsp"), Set.of("tool-a"));
+    final Function<String, List<DistributedByResult>> innerToolResultExtractor =
+        mock(Function.class);
+    when(innerToolResultExtractor.apply(any())).thenReturn(List.of());
+
+    // when
+    final List<GroupByResult> groups =
+        underTest.mapAgentFlowNodeBucketsToGroupByResults(
+            List.of("ahsp"),
+            Function.identity(),
+            bucket -> List.of(),
+            List.of("tool-a", "other"),
+            Function.identity(),
+            innerToolResultExtractor,
+            structure,
+            context,
+            List.of());
+
+    // then only the ad-hoc subprocess child tool is valued from the flow-node bucket; the unrelated
+    // node is not (though it is still backfilled as a modelled node)
+    verify(innerToolResultExtractor).apply("tool-a");
+    verify(innerToolResultExtractor, never()).apply("other");
+    assertThat(groups).extracting(GroupByResult::getKey).contains("tool-a", "other", "ahsp");
+  }
+
+  @Test
+  void shouldSetEveryViewMeasureToDocCountInFrequencyResult() {
+    // given a distributed-by result with two (unset) view measures
+    underTest = helper();
+    final ViewMeasure measureA = ViewMeasure.builder().value(null).build();
+    final ViewMeasure measureB = ViewMeasure.builder().value(null).build();
+    final DistributedByResult result =
+        DistributedByResult.createDistributedByNoneResult(
+            ViewResult.builder().viewMeasures(List.of(measureA, measureB)).build());
+
+    // when
+    final List<DistributedByResult> frequencyResult =
+        underTest.toFrequencyResult(new ArrayList<>(List.of(result)), 7L);
+
+    // then every view measure carries the bucket's document count as its value
+    assertThat(frequencyResult).hasSize(1);
+    assertThat(measureA.getValue()).isEqualTo(7.0);
+    assertThat(measureB.getValue()).isEqualTo(7.0);
+  }
+
+  @Test
+  void shouldNotFailFrequencyResultWhenViewResultOrMeasuresAreNull() {
+    // given distributed-by results with a null view result and a null measures list
+    underTest = helper();
+    final DistributedByResult nullViewResult =
+        DistributedByResult.createDistributedByNoneResult(null);
+    final DistributedByResult nullMeasures =
+        DistributedByResult.createDistributedByNoneResult(ViewResult.builder().build());
+
+    // when / then no exception is raised and the same list is returned
+    final List<DistributedByResult> input = new ArrayList<>(List.of(nullViewResult, nullMeasures));
+    assertThat(underTest.toFrequencyResult(input, 3L)).isSameAs(input);
   }
 
   private void stubFlowNodeNames(final String... keyLabelPairs) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/util/BpmnModelUtilTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/util/BpmnModelUtilTest.java
@@ -8,10 +8,12 @@
 package io.camunda.optimize.service.util;
 
 import static io.camunda.optimize.service.util.BpmnModelUtil.parseBpmnModel;
+import static io.camunda.optimize.util.ZeebeBpmnModels.ADHOC_SUB_PROCESS;
 import static io.camunda.optimize.util.ZeebeBpmnModels.END_EVENT;
 import static io.camunda.optimize.util.ZeebeBpmnModels.SERVICE_TASK;
 import static io.camunda.optimize.util.ZeebeBpmnModels.START_EVENT;
 import static io.camunda.optimize.util.ZeebeBpmnModels.USER_TASK;
+import static io.camunda.optimize.util.ZeebeBpmnModels.createAdHocSubProcess;
 import static io.camunda.optimize.util.ZeebeBpmnModels.createSimpleServiceTaskProcess;
 import static io.camunda.optimize.util.ZeebeBpmnModels.createSimpleUserTaskProcess;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Test;
 
@@ -117,5 +120,66 @@ public class BpmnModelUtilTest {
                 put(END_EVENT, null);
               }
             });
+  }
+
+  @Test
+  void shouldExtractOnlyActivatableEntryPointToolsOfAdHocSubProcess() {
+    // given an ad-hoc subprocess with two independent entry-point tools (toolA, toolB) and a
+    // deterministic follow-up step reached from toolA via an internal sequence flow
+    final String adHocSubProcessXml =
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+            id="defs" targetNamespace="http://bpmn.io/schema/bpmn">
+          <bpmn:process id="proc" isExecutable="true">
+            <bpmn:adHocSubProcess id="ahsp">
+              <bpmn:serviceTask id="toolA">
+                <bpmn:outgoing>flowA</bpmn:outgoing>
+              </bpmn:serviceTask>
+              <bpmn:serviceTask id="toolB" />
+              <bpmn:serviceTask id="followUp">
+                <bpmn:incoming>flowA</bpmn:incoming>
+              </bpmn:serviceTask>
+              <bpmn:sequenceFlow id="flowA" sourceRef="toolA" targetRef="followUp" />
+            </bpmn:adHocSubProcess>
+          </bpmn:process>
+        </bpmn:definitions>
+        """;
+
+    // when
+    final Map<String, Set<String>> childElementIds =
+        BpmnModelUtil.extractAdHocSubProcessChildElementIds(adHocSubProcessXml);
+
+    // then only the two entry-point tools are returned; the follow-up step is excluded as it is not
+    // a tool activation
+    assertThat(childElementIds).containsOnlyKeys("ahsp");
+    assertThat(childElementIds.get("ahsp")).containsExactlyInAnyOrder("toolA", "toolB");
+  }
+
+  @Test
+  void shouldExcludeFollowUpStepsReachedBySequenceFlowWithinAdHocSubProcess() {
+    // given an ad-hoc subprocess where the fluent builder chains tool1 -> tool2, so tool2 is a
+    // follow-up step (has an incoming sequence flow) rather than an activatable tool
+    final String adHocSubProcessXml =
+        Bpmn.convertToString(
+            createAdHocSubProcess(PROCESS_NAME, ahsp -> ahsp.task("tool1").task("tool2")));
+
+    // when
+    final Map<String, Set<String>> childElementIds =
+        BpmnModelUtil.extractAdHocSubProcessChildElementIds(adHocSubProcessXml);
+
+    // then only the entry-point tool is returned
+    assertThat(childElementIds).containsOnlyKeys(ADHOC_SUB_PROCESS);
+    assertThat(childElementIds.get(ADHOC_SUB_PROCESS)).containsExactly("tool1");
+  }
+
+  @Test
+  void shouldReturnEmptyMapWhenNoAdHocSubProcessPresent() {
+    // when
+    final Map<String, Set<String>> childElementIds =
+        BpmnModelUtil.extractAdHocSubProcessChildElementIds(SIMPLE_SERVICE_TASK_PROCESS);
+
+    // then
+    assertThat(childElementIds).isEmpty();
   }
 }


### PR DESCRIPTION
## Description

### 1. What this delivers (high level, for product)

Optimize has a process report **"Tool calls per flow node"** that heat-maps how often
an AI Agent invoked its tools. Until now, when an agent was modelled as an **expanded
ad-hoc subprocess (AHSP)** — the "AI Agent" box that contains the individual tool
tasks — the whole container box was coloured as a single block. You could see the agent
was busy, but not **which tool** ran and how often.

This change makes the heatmap **hybrid**:

- **Expanded AI Agent (ad-hoc subprocess):** each **inner tool** is coloured
  individually by its **own** activation count, and the big container box is left
  un-tinted. You can now see, at a glance, which tools are hot (called a lot) and which
  are cold.
- **All other agent shapes are unchanged:**
  - **AI Agent Task** (single task node) keeps its aggregated total tool-call count.
  - **External agent** (service task with an `agentDefinition`) keeps its aggregated
    total.
  - An AI Agent Task that references a **separate** tools ad-hoc subprocess shows both:
    the task's total, plus per-tool heat on the referenced tools.

### Verified scenarios (see screenshots in this folder)

| Screenshot | Model | Result |
|---|---|---|
| `Tool Call Test - AHSP Agent.png` | Agent as expanded AHSP with 3 tools | Each of the 3 tools coloured individually; container not tinted ✅ |
| `Tool Call Test - AHSP Multi-Step Tool.png` | AHSP where one tool has a follow-up step | 3 entry-point tools coloured; the deterministic follow-up step ("Derive risk band") is **not** counted as a tool ✅ |
| `Tool Call Test - AI Agent Task.png` | AI Agent Task + separate Tools AHSP | Task shows aggregated total; tools show per-tool heat ✅ |
| `Tool Call Test - External Agent.png` | Service task with `agentDefinition` | Single node, aggregated total ✅ |

### 2. Handling "AHSP with a multi-step tool"

Inside an AI Agent ad-hoc subprocess, a **tool** is an **entry-point element** — one the
agent can directly choose to run. In BPMN/Zeebe terms, that is an element with **no
incoming sequence flow inside the subprocess**; those are the only elements the agent
activates directly. Anything reached afterwards through a sequence flow (e.g. a `tool →
helper step` chain) is a **deterministic follow-up**, not a separate tool the agent
selected.

To get this right we **do not** colour every child of the ad-hoc subprocess. We parse the
process model and keep only the entry-point children as "tools" (see
`BpmnModelUtil.extractAdHocSubProcessChildElementIds`); follow-up steps are filtered out
of the tool set. This is exactly what the `AHSP Multi-Step Tool` screenshot verifies:
"Look up policy", "Get customer profile" and "Calculate damage estimate" are entry-point
tools and get heat, while "Derive risk band (helper)" — reached by a sequence flow from
"Calculate damage estimate" — is correctly **excluded** from the tool count. The follow-up
step still has its own real execution data; it is simply not mis-counted as a tool call.

### 3. Limitations to communicate

1. **Per-tool sum equals the agent total only when tools are independent entry points.**
   The sum of the per-tool counts equals the agent's aggregated total tool-call count only
   when the tools are independent entry points (the common case, and what we verified:
   38 + 3 = 41). If a model chains tools via sequence flows, the follow-up steps are
   (intentionally) excluded from the tool count, so the per-tool numbers and the
   aggregated agent total can legitimately differ.

## Screenshots

<img width="1414" height="424" alt="Tool Call Test - AHSP Agent" src="https://github.com/user-attachments/assets/6283bae6-2494-4728-8edb-a234d726b940" />
<img width="1422" height="429" alt="Tool Call Test - AHSP Multi-Step Tool" src="https://github.com/user-attachments/assets/e7413a01-8078-4e86-9844-7dfbdd7e7542" />
<img width="1426" height="427" alt="Tool Call Test - AI Agent Task" src="https://github.com/user-attachments/assets/639fd687-e3c5-4237-99e2-8fc4f57e442b" />
<img width="1416" height="428" alt="Tool Call Test - External Agent" src="https://github.com/user-attachments/assets/9fc1a4ca-7bb7-4705-9c43-35493eb2e9c3" />


## Related issues

closes https://github.com/camunda/camunda/issues/56791
