### PR TITLE
test: regenerate API response assertions from latest main OpenAPI spec

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/json-body-assertions/_generated/responses.json
@@ -1,10 +1,10 @@
 {
   "metadata": {
-    "sourceRepo": "camunda/camunda",
-    "commit": "local",
-    "generatedAt": "2026-07-09T05:24:52.827Z",
+    "sourceRepo": "https://github.com/camunda/camunda",
+    "commit": "e2c94564e6d33fa39bfb5aad7e48fc2ef3f02e00",
+    "generatedAt": "2026-07-11T12:19:58.854Z",
     "specPath": "zeebe/gateway-protocol/src/main/proto/v2/rest-api.yaml",
-    "specSha256": "83de8fd83575f90fb6e752f180e2bc4091c6dfe27d7ca87ede315cdde909bb4c"
+    "specSha256": "918daa62b9927977ef6e98a642756e296ac8edae35019452790ad6f2af39d580"
   },
   "responses": [
     {
@@ -423,7 +423,11 @@
                 {
                   "name": "commitStatus",
                   "type": "string",
-                  "enumValues": ["COMMITTED", "PENDING", "DISCARDED"]
+                  "enumValues": [
+                    "COMMITTED",
+                    "PENDING",
+                    "DISCARDED"
+                  ]
                 },
                 {
                   "name": "content",
@@ -560,7 +564,12 @@
                 {
                   "name": "actorType",
                   "type": "string",
-                  "enumValues": ["ANONYMOUS", "CLIENT", "UNKNOWN", "USER"],
+                  "enumValues": [
+                    "ANONYMOUS",
+                    "CLIENT",
+                    "UNKNOWN",
+                    "USER"
+                  ],
                   "nullable": true
                 },
                 {
@@ -585,7 +594,11 @@
                 {
                   "name": "category",
                   "type": "string",
-                  "enumValues": ["ADMIN", "DEPLOYED_RESOURCES", "USER_TASKS"]
+                  "enumValues": [
+                    "ADMIN",
+                    "DEPLOYED_RESOURCES",
+                    "USER_TASKS"
+                  ]
                 },
                 {
                   "name": "decisionDefinitionId",
@@ -725,7 +738,10 @@
                 {
                   "name": "result",
                   "type": "string",
-                  "enumValues": ["FAIL", "SUCCESS"]
+                  "enumValues": [
+                    "FAIL",
+                    "SUCCESS"
+                  ]
                 },
                 {
                   "name": "rootProcessInstanceKey",
@@ -795,7 +811,12 @@
           {
             "name": "actorType",
             "type": "string",
-            "enumValues": ["ANONYMOUS", "CLIENT", "UNKNOWN", "USER"],
+            "enumValues": [
+              "ANONYMOUS",
+              "CLIENT",
+              "UNKNOWN",
+              "USER"
+            ],
             "nullable": true
           },
           {
@@ -820,7 +841,11 @@
           {
             "name": "category",
             "type": "string",
-            "enumValues": ["ADMIN", "DEPLOYED_RESOURCES", "USER_TASKS"]
+            "enumValues": [
+              "ADMIN",
+              "DEPLOYED_RESOURCES",
+              "USER_TASKS"
+            ]
           },
           {
             "name": "decisionDefinitionId",
@@ -960,7 +985,10 @@
           {
             "name": "result",
             "type": "string",
-            "enumValues": ["FAIL", "SUCCESS"]
+            "enumValues": [
+              "FAIL",
+              "SUCCESS"
+            ]
           },
           {
             "name": "rootProcessInstanceKey",
@@ -1552,7 +1580,10 @@
                 {
                   "name": "type",
                   "type": "string",
-                  "enumValues": ["QUERY_FAILED", "RESULT_BUFFER_SIZE_EXCEEDED"]
+                  "enumValues": [
+                    "QUERY_FAILED",
+                    "RESULT_BUFFER_SIZE_EXCEEDED"
+                  ]
                 }
               ],
               "optional": []
@@ -1605,7 +1636,10 @@
           {
             "name": "scope",
             "type": "string",
-            "enumValues": ["GLOBAL", "TENANT"]
+            "enumValues": [
+              "GLOBAL",
+              "TENANT"
+            ]
           },
           {
             "name": "tenantId",
@@ -1633,7 +1667,10 @@
           {
             "name": "scope",
             "type": "string",
-            "enumValues": ["GLOBAL", "TENANT"]
+            "enumValues": [
+              "GLOBAL",
+              "TENANT"
+            ]
           },
           {
             "name": "tenantId",
@@ -1661,7 +1698,10 @@
           {
             "name": "scope",
             "type": "string",
-            "enumValues": ["GLOBAL", "TENANT"]
+            "enumValues": [
+              "GLOBAL",
+              "TENANT"
+            ]
           },
           {
             "name": "tenantId",
@@ -1698,7 +1738,10 @@
                 {
                   "name": "scope",
                   "type": "string",
-                  "enumValues": ["GLOBAL", "TENANT"]
+                  "enumValues": [
+                    "GLOBAL",
+                    "TENANT"
+                  ]
                 },
                 {
                   "name": "tenantId",
@@ -1757,7 +1800,10 @@
           {
             "name": "scope",
             "type": "string",
-            "enumValues": ["GLOBAL", "TENANT"]
+            "enumValues": [
+              "GLOBAL",
+              "TENANT"
+            ]
           },
           {
             "name": "tenantId",
@@ -1785,7 +1831,10 @@
           {
             "name": "scope",
             "type": "string",
-            "enumValues": ["GLOBAL", "TENANT"]
+            "enumValues": [
+              "GLOBAL",
+              "TENANT"
+            ]
           },
           {
             "name": "tenantId",
@@ -1813,7 +1862,10 @@
           {
             "name": "scope",
             "type": "string",
-            "enumValues": ["GLOBAL", "TENANT"]
+            "enumValues": [
+              "GLOBAL",
+              "TENANT"
+            ]
           },
           {
             "name": "tenantId",
@@ -2563,7 +2615,12 @@
           {
             "name": "state",
             "type": "string",
-            "enumValues": ["EVALUATED", "FAILED", "UNSPECIFIED", "UNKNOWN"]
+            "enumValues": [
+              "EVALUATED",
+              "FAILED",
+              "UNSPECIFIED",
+              "UNKNOWN"
+            ]
           },
           {
             "name": "tenantId",
@@ -2912,7 +2969,9 @@
           {
             "name": "camunda.document.type",
             "type": "string",
-            "enumValues": ["camunda"]
+            "enumValues": [
+              "camunda"
+            ]
           },
           {
             "name": "contentHash",
@@ -2985,7 +3044,9 @@
                 {
                   "name": "camunda.document.type",
                   "type": "string",
-                  "enumValues": ["camunda"]
+                  "enumValues": [
+                    "camunda"
+                  ]
                 },
                 {
                   "name": "contentHash",
@@ -3087,7 +3148,9 @@
                 {
                   "name": "camunda.document.type",
                   "type": "string",
-                  "enumValues": ["camunda"]
+                  "enumValues": [
+                    "camunda"
+                  ]
                 },
                 {
                   "name": "contentHash",
@@ -3362,7 +3425,11 @@
                 {
                   "name": "state",
                   "type": "string",
-                  "enumValues": ["ACTIVE", "COMPLETED", "TERMINATED"]
+                  "enumValues": [
+                    "ACTIVE",
+                    "COMPLETED",
+                    "TERMINATED"
+                  ]
                 },
                 {
                   "name": "tenantId",
@@ -3492,7 +3559,11 @@
           {
             "name": "state",
             "type": "string",
-            "enumValues": ["ACTIVE", "COMPLETED", "TERMINATED"]
+            "enumValues": [
+              "ACTIVE",
+              "COMPLETED",
+              "TERMINATED"
+            ]
           },
           {
             "name": "tenantId",
@@ -3754,7 +3825,10 @@
           {
             "name": "source",
             "type": "string",
-            "enumValues": ["CONFIGURATION", "API"]
+            "enumValues": [
+              "CONFIGURATION",
+              "API"
+            ]
           },
           {
             "name": "type",
@@ -3796,7 +3870,10 @@
           {
             "name": "source",
             "type": "string",
-            "enumValues": ["CONFIGURATION", "API"]
+            "enumValues": [
+              "CONFIGURATION",
+              "API"
+            ]
           },
           {
             "name": "type",
@@ -3838,7 +3915,10 @@
           {
             "name": "source",
             "type": "string",
-            "enumValues": ["CONFIGURATION", "API"]
+            "enumValues": [
+              "CONFIGURATION",
+              "API"
+            ]
           },
           {
             "name": "type",
@@ -3885,7 +3965,10 @@
                 {
                   "name": "source",
                   "type": "string",
-                  "enumValues": ["CONFIGURATION", "API"]
+                  "enumValues": [
+                    "CONFIGURATION",
+                    "API"
+                  ]
                 },
                 {
                   "name": "type",
@@ -5710,12 +5793,20 @@
                 {
                   "name": "messageSubscriptionState",
                   "type": "string",
-                  "enumValues": ["CORRELATED", "CREATED", "DELETED", "MIGRATED"]
+                  "enumValues": [
+                    "CORRELATED",
+                    "CREATED",
+                    "DELETED",
+                    "MIGRATED"
+                  ]
                 },
                 {
                   "name": "messageSubscriptionType",
                   "type": "string",
-                  "enumValues": ["START_EVENT", "PROCESS_EVENT"]
+                  "enumValues": [
+                    "START_EVENT",
+                    "PROCESS_EVENT"
+                  ]
                 },
                 {
                   "name": "processDefinitionId",
@@ -6519,7 +6610,11 @@
                 {
                   "name": "state",
                   "type": "string",
-                  "enumValues": ["ACTIVE", "COMPLETED", "TERMINATED"]
+                  "enumValues": [
+                    "ACTIVE",
+                    "COMPLETED",
+                    "TERMINATED"
+                  ]
                 },
                 {
                   "name": "tags",
@@ -6636,7 +6731,11 @@
           {
             "name": "state",
             "type": "string",
-            "enumValues": ["ACTIVE", "COMPLETED", "TERMINATED"]
+            "enumValues": [
+              "ACTIVE",
+              "COMPLETED",
+              "TERMINATED"
+            ]
           },
           {
             "name": "tags",
@@ -7542,7 +7641,11 @@
                 {
                   "name": "stage",
                   "type": "string",
-                  "enumValues": ["dev", "int", "prod"],
+                  "enumValues": [
+                    "dev",
+                    "int",
+                    "prod"
+                  ],
                   "nullable": true
                 }
               ],
@@ -8045,7 +8148,11 @@
                       {
                         "name": "health",
                         "type": "string",
-                        "enumValues": ["healthy", "unhealthy", "dead"]
+                        "enumValues": [
+                          "healthy",
+                          "unhealthy",
+                          "dead"
+                        ]
                       },
                       {
                         "name": "partitionId",
@@ -8054,7 +8161,11 @@
                       {
                         "name": "role",
                         "type": "string",
-                        "enumValues": ["leader", "follower", "inactive"]
+                        "enumValues": [
+                          "leader",
+                          "follower",
+                          "inactive"
+                        ]
                       }
                     ],
                     "optional": []
@@ -8105,6 +8216,38 @@
       "path": "/mode",
       "method": "PATCH",
       "status": "200",
+      "schema": {
+        "required": [
+          {
+            "name": "changeId",
+            "type": "string"
+          },
+          {
+            "name": "plannedChanges",
+            "type": "array<object>",
+            "children": {
+              "required": [
+                {
+                  "name": "mode",
+                  "type": "string",
+                  "nullable": true
+                },
+                {
+                  "name": "operation",
+                  "type": "string"
+                }
+              ],
+              "optional": []
+            }
+          }
+        ],
+        "optional": []
+      }
+    },
+    {
+      "path": "/restore",
+      "method": "POST",
+      "status": "202",
       "schema": {
         "required": [
           {
@@ -8590,7 +8733,12 @@
                 {
                   "name": "actorType",
                   "type": "string",
-                  "enumValues": ["ANONYMOUS", "CLIENT", "UNKNOWN", "USER"],
+                  "enumValues": [
+                    "ANONYMOUS",
+                    "CLIENT",
+                    "UNKNOWN",
+                    "USER"
+                  ],
                   "nullable": true
                 },
                 {
@@ -8615,7 +8763,11 @@
                 {
                   "name": "category",
                   "type": "string",
-                  "enumValues": ["ADMIN", "DEPLOYED_RESOURCES", "USER_TASKS"]
+                  "enumValues": [
+                    "ADMIN",
+                    "DEPLOYED_RESOURCES",
+                    "USER_TASKS"
+                  ]
                 },
                 {
                   "name": "decisionDefinitionId",
@@ -8755,7 +8907,10 @@
                 {
                   "name": "result",
                   "type": "string",
-                  "enumValues": ["FAIL", "SUCCESS"]
+                  "enumValues": [
+                    "FAIL",
+                    "SUCCESS"
+                  ]
                 },
                 {
                   "name": "rootProcessInstanceKey",


### PR DESCRIPTION
Automated regeneration of the JSON body response assertions via `npm run responses:regenerate` (followed by `npm run lint:fix`).

This PR was opened because the **response schemas** in `json-body-assertions/_generated/responses.json` changed.
Metadata-only differences (`generatedAt`, `commit`, `specSha256`) do not trigger a PR.

Please review the schema changes against the upstream REST API spec.

_Opened by the C8 Orchestration Cluster responses-regeneration workflow for main._
