### PR TITLE
Let job workers supply a lease token on commands

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -84,6 +84,27 @@ public interface CompleteJobCommandStep1
   CompleteJobCommandStep1 withResult(
       Function<CompleteJobCommandJobResultStep, CompleteJobResult> consumer);
 
+  /**
+   * Sets the lease token identifying the job's activation, fencing this command against a
+   * superseded activation of the same job. Obtain it from {@link
+   * io.camunda.client.api.response.ActivatedJob#getLeaseToken() ActivatedJob#getLeaseToken()}.
+   *
+   * <p>For a leased job, the matching token must be supplied to prove the command comes from the
+   * worker that holds the current lease; a command with no token is rejected. A command carrying a
+   * stale token is likewise rejected, fencing the job against a superseded activation (e.g. after
+   * the job timed out or failed and was re-activated by another worker). A job that was activated
+   * without a lease requires no token.
+   *
+   * <p>When this command is created from an activated job (e.g. {@code
+   * newCompleteCommand(activatedJob)}) the job's lease token is carried automatically, so this
+   * method is only needed when building the command from a job key.
+   *
+   * @param leaseToken the opaque lease token the worker received when the job was activated
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  CompleteJobCommandStep1 withLeaseToken(String leaseToken);
+
   interface CompleteJobCommandJobResultStep {
     /**
      * Initializes the job result to allow corrections or a denial to be configured.

--- a/clients/java/src/main/java/io/camunda/client/api/command/FailJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/FailJobCommandStep1.java
@@ -62,6 +62,27 @@ public interface FailJobCommandStep1 extends CommandWithCommunicationApiStep<Fai
     FailJobCommandStep2 errorMessage(String errorMsg);
 
     /**
+     * Sets the lease token identifying the job's activation, fencing this command against a
+     * superseded activation of the same job. Obtain it from {@link
+     * io.camunda.client.api.response.ActivatedJob#getLeaseToken() ActivatedJob#getLeaseToken()}.
+     *
+     * <p>For a leased job, the matching token must be supplied to prove the command comes from the
+     * worker that holds the current lease; a command with no token is rejected. A command carrying
+     * a stale token is likewise rejected, fencing the job against a superseded activation (e.g.
+     * after the job timed out or failed and was re-activated by another worker). A job that was
+     * activated without a lease requires no token.
+     *
+     * <p>When this command is created from an activated job (e.g. {@code
+     * newFailCommand(activatedJob)}) the job's lease token is carried automatically, so this method
+     * is only needed when building the command from a job key.
+     *
+     * @param leaseToken the opaque lease token the worker received when the job was activated
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    FailJobCommandStep2 withLeaseToken(String leaseToken);
+
+    /**
      * Set the variables of this job.
      *
      * @param variables the variables (JSON) as String

--- a/clients/java/src/main/java/io/camunda/client/api/command/ThrowErrorCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ThrowErrorCommandStep1.java
@@ -47,6 +47,27 @@ public interface ThrowErrorCommandStep1
     ThrowErrorCommandStep2 errorMessage(String errorMsg);
 
     /**
+     * Sets the lease token identifying the job's activation, fencing this command against a
+     * superseded activation of the same job. Obtain it from {@link
+     * io.camunda.client.api.response.ActivatedJob#getLeaseToken() ActivatedJob#getLeaseToken()}.
+     *
+     * <p>For a leased job, the matching token must be supplied to prove the command comes from the
+     * worker that holds the current lease; a command with no token is rejected. A command carrying
+     * a stale token is likewise rejected, fencing the job against a superseded activation (e.g.
+     * after the job timed out or failed and was re-activated by another worker). A job that was
+     * activated without a lease requires no token.
+     *
+     * <p>When this command is created from an activated job (e.g. {@code
+     * newThrowErrorCommand(activatedJob)}) the job's lease token is carried automatically, so this
+     * method is only needed when building the command from a job key.
+     *
+     * @param leaseToken the opaque lease token the worker received when the job was activated
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    ThrowErrorCommandStep2 withLeaseToken(String leaseToken);
+
+    /**
      * Set the variables of this job.
      *
      * @param variables the variables (JSON) as String

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateTimeoutJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateTimeoutJobCommandStep1.java
@@ -49,5 +49,28 @@ public interface UpdateTimeoutJobCommandStep1
       extends CommandWithOperationReferenceStep<UpdateTimeoutJobCommandStep2>,
           FinalCommandStep<UpdateTimeoutJobResponse> {
     // the place for new optional parameters
+
+    /**
+     * Sets the lease token identifying the job's activation, fencing this command against a
+     * superseded activation of the same job. Obtain it from {@link
+     * io.camunda.client.api.response.ActivatedJob#getLeaseToken() ActivatedJob#getLeaseToken()}.
+     *
+     * <p>For a leased job, a supplied token is validated to prove the command comes from the worker
+     * that holds the current lease; a command carrying a stale token is rejected, fencing the job
+     * against a superseded activation (e.g. after the job timed out or failed and was re-activated
+     * by another worker). An update without a token always applies, to support operator and bulk
+     * updates of leased jobs; this differs from lifecycle commands like complete, fail, and
+     * throw-error, which always require a token for leased jobs. A job that was activated without a
+     * lease requires no token.
+     *
+     * <p>When this command is created from an activated job (e.g. {@code
+     * newUpdateTimeoutCommand(activatedJob)}) the job's lease token is carried automatically, so
+     * this method is only needed when building the command from a job key.
+     *
+     * @param leaseToken the opaque lease token the worker received when the job was activated
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    UpdateTimeoutJobCommandStep2 withLeaseToken(String leaseToken);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivatedJob.java
@@ -185,7 +185,7 @@ public interface ActivatedJob {
 
   /**
    * The lease token identifying this activation. Pass it along to commands (e.g. complete, fail,
-   * throw-error) to fence them against superseded activations of the same job.
+   * throw-error, update-timeout) to fence them against superseded activations of the same job.
    *
    * @return the lease token, or {@code null} if the job was activated without a lease
    */

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -861,7 +861,10 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public UpdateTimeoutJobCommandStep1 newUpdateTimeoutCommand(final ActivatedJob job) {
-    return newUpdateTimeoutCommand(job.getKey());
+    final JobUpdateTimeoutCommandImpl command =
+        (JobUpdateTimeoutCommandImpl) newUpdateTimeoutCommand(job.getKey());
+    command.withLeaseToken(job.getLeaseToken());
+    return command;
   }
 
   @Override
@@ -1830,7 +1833,7 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public CompleteJobCommandStep1 newCompleteCommand(final ActivatedJob job) {
-    return newCompleteCommand(job.getKey());
+    return jobClient.newCompleteCommand(job);
   }
 
   @Override
@@ -1840,7 +1843,7 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public FailJobCommandStep1 newFailCommand(final ActivatedJob job) {
-    return newFailCommand(job.getKey());
+    return jobClient.newFailCommand(job);
   }
 
   @Override
@@ -1850,7 +1853,7 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public ThrowErrorCommandStep1 newThrowErrorCommand(final ActivatedJob job) {
-    return newThrowErrorCommand(job.getKey());
+    return jobClient.newThrowErrorCommand(job);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -59,6 +59,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   private boolean useRest;
   private final long jobKey;
   private final JsonMapper jsonMapper;
+  private String leaseToken;
 
   public CompleteJobCommandImpl(
       final GatewayStub asyncStub,
@@ -110,6 +111,12 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
       throw new IllegalArgumentException(
           "Unsupported job result type: " + result.getClass().getName());
     }
+    return this;
+  }
+
+  @Override
+  public CompleteJobCommandStep1 withLeaseToken(final String leaseToken) {
+    this.leaseToken = leaseToken;
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -59,7 +59,6 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   private boolean useRest;
   private final long jobKey;
   private final JsonMapper jsonMapper;
-  private String leaseToken;
 
   public CompleteJobCommandImpl(
       final GatewayStub asyncStub,
@@ -116,7 +115,11 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
 
   @Override
   public CompleteJobCommandStep1 withLeaseToken(final String leaseToken) {
-    this.leaseToken = leaseToken;
+    if (leaseToken == null) {
+      return this;
+    }
+    grpcRequestObjectBuilder.setLeaseToken(leaseToken);
+    httpRequestObject.setLeaseToken(leaseToken);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/FailJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/FailJobCommandImpl.java
@@ -49,6 +49,7 @@ public final class FailJobCommandImpl extends CommandWithVariables<FailJobComman
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
   private final long jobKey;
+  private String leaseToken;
 
   public FailJobCommandImpl(
       final GatewayStub asyncStub,
@@ -89,6 +90,12 @@ public final class FailJobCommandImpl extends CommandWithVariables<FailJobComman
   public FailJobCommandStep2 errorMessage(final String errorMsg) {
     grpcRequestObjectBuilder.setErrorMessage(errorMsg);
     httpRequestObject.setErrorMessage(errorMsg);
+    return this;
+  }
+
+  @Override
+  public FailJobCommandStep2 withLeaseToken(final String leaseToken) {
+    this.leaseToken = leaseToken;
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/FailJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/FailJobCommandImpl.java
@@ -49,7 +49,6 @@ public final class FailJobCommandImpl extends CommandWithVariables<FailJobComman
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
   private final long jobKey;
-  private String leaseToken;
 
   public FailJobCommandImpl(
       final GatewayStub asyncStub,
@@ -95,7 +94,11 @@ public final class FailJobCommandImpl extends CommandWithVariables<FailJobComman
 
   @Override
   public FailJobCommandStep2 withLeaseToken(final String leaseToken) {
-    this.leaseToken = leaseToken;
+    if (leaseToken == null) {
+      return this;
+    }
+    grpcRequestObjectBuilder.setLeaseToken(leaseToken);
+    httpRequestObject.setLeaseToken(leaseToken);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateTimeoutCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateTimeoutCommandImpl.java
@@ -51,6 +51,7 @@ public class JobUpdateTimeoutCommandImpl
   private final RequestConfig.Builder httpRequestConfig;
   private final long jobKey;
   private final JsonMapper jsonMapper;
+  private String leaseToken;
 
   public JobUpdateTimeoutCommandImpl(
       final GatewayStub asyncStub,
@@ -137,6 +138,12 @@ public class JobUpdateTimeoutCommandImpl
   public UpdateTimeoutJobCommandStep2 operationReference(final long operationReference) {
     grpcRequestObjectBuilder.setOperationReference(operationReference);
     httpRequestObject.setOperationReference(operationReference);
+    return this;
+  }
+
+  @Override
+  public UpdateTimeoutJobCommandStep2 withLeaseToken(final String leaseToken) {
+    this.leaseToken = leaseToken;
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateTimeoutCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateTimeoutCommandImpl.java
@@ -51,7 +51,6 @@ public class JobUpdateTimeoutCommandImpl
   private final RequestConfig.Builder httpRequestConfig;
   private final long jobKey;
   private final JsonMapper jsonMapper;
-  private String leaseToken;
 
   public JobUpdateTimeoutCommandImpl(
       final GatewayStub asyncStub,
@@ -143,7 +142,11 @@ public class JobUpdateTimeoutCommandImpl
 
   @Override
   public UpdateTimeoutJobCommandStep2 withLeaseToken(final String leaseToken) {
-    this.leaseToken = leaseToken;
+    if (leaseToken == null) {
+      return this;
+    }
+    grpcRequestObjectBuilder.setLeaseToken(leaseToken);
+    httpRequestObject.setLeaseToken(leaseToken);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ThrowErrorCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ThrowErrorCommandImpl.java
@@ -49,6 +49,7 @@ public final class ThrowErrorCommandImpl extends CommandWithVariables<ThrowError
   private final JobErrorRequest httpRequestObject;
   private boolean useRest;
   private final long jobKey;
+  private String leaseToken;
 
   public ThrowErrorCommandImpl(
       final GatewayStub asyncStub,
@@ -82,6 +83,12 @@ public final class ThrowErrorCommandImpl extends CommandWithVariables<ThrowError
   public ThrowErrorCommandStep2 errorMessage(final String errorMsg) {
     grpcRequestObjectBuilder.setErrorMessage(errorMsg);
     httpRequestObject.setErrorMessage(errorMsg);
+    return this;
+  }
+
+  @Override
+  public ThrowErrorCommandStep2 withLeaseToken(final String leaseToken) {
+    this.leaseToken = leaseToken;
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ThrowErrorCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ThrowErrorCommandImpl.java
@@ -49,7 +49,6 @@ public final class ThrowErrorCommandImpl extends CommandWithVariables<ThrowError
   private final JobErrorRequest httpRequestObject;
   private boolean useRest;
   private final long jobKey;
-  private String leaseToken;
 
   public ThrowErrorCommandImpl(
       final GatewayStub asyncStub,
@@ -88,7 +87,11 @@ public final class ThrowErrorCommandImpl extends CommandWithVariables<ThrowError
 
   @Override
   public ThrowErrorCommandStep2 withLeaseToken(final String leaseToken) {
-    this.leaseToken = leaseToken;
+    if (leaseToken == null) {
+      return this;
+    }
+    grpcRequestObjectBuilder.setLeaseToken(leaseToken);
+    httpRequestObject.setLeaseToken(leaseToken);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/worker/JobClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/worker/JobClientImpl.java
@@ -69,7 +69,7 @@ public final class JobClientImpl implements JobClient {
 
   @Override
   public CompleteJobCommandStep1 newCompleteCommand(final ActivatedJob job) {
-    return newCompleteCommand(job.getKey());
+    return newCompleteCommand(job.getKey()).withLeaseToken(job.getLeaseToken());
   }
 
   @Override
@@ -86,7 +86,9 @@ public final class JobClientImpl implements JobClient {
 
   @Override
   public FailJobCommandStep1 newFailCommand(final ActivatedJob job) {
-    return newFailCommand(job.getKey());
+    final FailJobCommandImpl command = (FailJobCommandImpl) newFailCommand(job.getKey());
+    command.withLeaseToken(job.getLeaseToken());
+    return command;
   }
 
   @Override
@@ -103,7 +105,10 @@ public final class JobClientImpl implements JobClient {
 
   @Override
   public ThrowErrorCommandStep1 newThrowErrorCommand(final ActivatedJob job) {
-    return newThrowErrorCommand(job.getKey());
+    final ThrowErrorCommandImpl command =
+        (ThrowErrorCommandImpl) newThrowErrorCommand(job.getKey());
+    command.withLeaseToken(job.getLeaseToken());
+    return command;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
@@ -85,6 +85,64 @@ public final class CompleteJobTest extends ClientTest {
   }
 
   @Test
+  public void shouldCompleteJobWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newCompleteCommand(jobKey).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJob() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newCompleteCommand(job).send().join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOne() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newCompleteCommand(job).send().join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEmpty();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKey() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newCompleteCommand(jobKey).send().join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEmpty();
+  }
+
+  @Test
   public void shouldCompleteWithJsonStringVariables() {
     // given
     final long jobKey = 12;

--- a/clients/java/src/test/java/io/camunda/client/job/FailJobTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/FailJobTest.java
@@ -129,6 +129,64 @@ public final class FailJobTest extends ClientTest {
   }
 
   @Test
+  public void shouldFailJobWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newFailCommand(jobKey).retries(1).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final FailJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJob() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newFailCommand(job).retries(1).send().join();
+
+    // then
+    final FailJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOne() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newFailCommand(job).retries(1).send().join();
+
+    // then
+    final FailJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEmpty();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKey() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newFailCommand(jobKey).retries(1).send().join();
+
+    // then
+    final FailJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEmpty();
+  }
+
+  @Test
   public void shouldSetRequestTimeout() {
     // given
     final Duration requestTimeout = Duration.ofHours(124);

--- a/clients/java/src/test/java/io/camunda/client/job/JobUpdateTimeoutTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/JobUpdateTimeoutTest.java
@@ -99,6 +99,64 @@ public class JobUpdateTimeoutTest extends ClientTest {
   }
 
   @Test
+  public void shouldUpdateTimeoutWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newUpdateTimeoutCommand(jobKey).timeout(100).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final UpdateJobTimeoutRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJob() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newUpdateTimeoutCommand(job).timeout(100).send().join();
+
+    // then
+    final UpdateJobTimeoutRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOne() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newUpdateTimeoutCommand(job).timeout(100).send().join();
+
+    // then
+    final UpdateJobTimeoutRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEmpty();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKey() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newUpdateTimeoutCommand(jobKey).timeout(100).send().join();
+
+    // then
+    final UpdateJobTimeoutRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEmpty();
+  }
+
+  @Test
   public void shouldSetRequestTimeout() {
     // given
     final Duration requestTimeout = Duration.ofHours(124);

--- a/clients/java/src/test/java/io/camunda/client/job/ThrowErrorTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/ThrowErrorTest.java
@@ -86,6 +86,73 @@ public final class ThrowErrorTest extends ClientTest {
   }
 
   @Test
+  public void shouldThrowErrorWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String errorCode = "errorCode";
+    final String leaseToken = "lease-token";
+
+    // when
+    client
+        .newThrowErrorCommand(jobKey)
+        .errorCode(errorCode)
+        .withLeaseToken(leaseToken)
+        .send()
+        .join();
+
+    // then
+    final ThrowErrorRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJob() {
+    // given
+    final String errorCode = "errorCode";
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newThrowErrorCommand(job).errorCode(errorCode).send().join();
+
+    // then
+    final ThrowErrorRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOne() {
+    // given
+    final String errorCode = "errorCode";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newThrowErrorCommand(job).errorCode(errorCode).send().join();
+
+    // then
+    final ThrowErrorRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEmpty();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKey() {
+    // given
+    final long jobKey = 12;
+    final String errorCode = "errorCode";
+
+    // when
+    client.newThrowErrorCommand(jobKey).errorCode(errorCode).send().join();
+
+    // then
+    final ThrowErrorRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEmpty();
+  }
+
+  @Test
   public void shouldSetRequestTimeout() {
     // given
     final Duration requestTimeout = Duration.ofHours(124);

--- a/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
@@ -78,6 +78,64 @@ class CompleteJobRestTest extends ClientRestTest {
   }
 
   @Test
+  void shouldCompleteJobWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newCompleteCommand(jobKey).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  void shouldCarryLeaseTokenFromActivatedJob() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newCompleteCommand(job).send().join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  void shouldNotCarryLeaseTokenFromActivatedJobWithoutOne() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newCompleteCommand(job).send().join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getLeaseToken()).isNull();
+  }
+
+  @Test
+  void shouldNotCarryLeaseTokenByJobKey() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newCompleteCommand(jobKey).send().join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getLeaseToken()).isNull();
+  }
+
+  @Test
   void shouldCompleteWithJsonStringVariables() {
     // given
     final long jobKey = 12;

--- a/clients/java/src/test/java/io/camunda/client/job/rest/FailJobRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/FailJobRestTest.java
@@ -116,6 +116,64 @@ public class FailJobRestTest extends ClientRestTest {
   }
 
   @Test
+  public void shouldFailJobWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newFailCommand(jobKey).retries(1).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final JobFailRequest request = gatewayService.getLastRequest(JobFailRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJob() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newFailCommand(job).retries(1).send().join();
+
+    // then
+    final JobFailRequest request = gatewayService.getLastRequest(JobFailRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOne() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newFailCommand(job).retries(1).send().join();
+
+    // then
+    final JobFailRequest request = gatewayService.getLastRequest(JobFailRequest.class);
+    assertThat(request.getLeaseToken()).isNull();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKey() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newFailCommand(jobKey).retries(1).send().join();
+
+    // then
+    final JobFailRequest request = gatewayService.getLastRequest(JobFailRequest.class);
+    assertThat(request.getLeaseToken()).isNull();
+  }
+
+  @Test
   public void shouldFailJobWithJsonStringVariables() {
     // given
     final long jobKey = 12;

--- a/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
@@ -145,6 +145,64 @@ public class JobUpdateRestTest extends ClientRestTest {
   }
 
   @Test
+  public void shouldUpdateTimeoutWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newUpdateTimeoutCommand(jobKey).timeout(100).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJob() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newUpdateTimeoutCommand(job).timeout(100).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOne() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newUpdateTimeoutCommand(job).timeout(100).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken()).isNull();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKey() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newUpdateTimeoutCommand(jobKey).timeout(100).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken()).isNull();
+  }
+
+  @Test
   public void shouldUpdateRetriesAndTimeoutByKey() {
     // given
     final long jobKey = 12;

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ThrowErrorRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ThrowErrorRestTest.java
@@ -75,6 +75,73 @@ public class ThrowErrorRestTest extends ClientRestTest {
   }
 
   @Test
+  public void shouldThrowErrorWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String errorCode = "errorCode";
+    final String leaseToken = "lease-token";
+
+    // when
+    client
+        .newThrowErrorCommand(jobKey)
+        .errorCode(errorCode)
+        .withLeaseToken(leaseToken)
+        .send()
+        .join();
+
+    // then
+    final JobErrorRequest request = gatewayService.getLastRequest(JobErrorRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJob() {
+    // given
+    final String errorCode = "errorCode";
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newThrowErrorCommand(job).errorCode(errorCode).send().join();
+
+    // then
+    final JobErrorRequest request = gatewayService.getLastRequest(JobErrorRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOne() {
+    // given
+    final String errorCode = "errorCode";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newThrowErrorCommand(job).errorCode(errorCode).send().join();
+
+    // then
+    final JobErrorRequest request = gatewayService.getLastRequest(JobErrorRequest.class);
+    assertThat(request.getLeaseToken()).isNull();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKey() {
+    // given
+    final long jobKey = 12;
+    final String errorCode = "errorCode";
+
+    // when
+    client.newThrowErrorCommand(jobKey).errorCode(errorCode).send().join();
+
+    // then
+    final JobErrorRequest request = gatewayService.getLastRequest(JobErrorRequest.class);
+    assertThat(request.getLeaseToken()).isNull();
+  }
+
+  @Test
   public void shouldThrowErrorWithJsonStringVariables() {
     // given
     final long jobKey = 12;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -253,7 +253,8 @@ public class RequestMapper {
         getIntOrZero(failRequest, JobFailRequest::getRetries),
         getStringOrEmpty(failRequest, JobFailRequest::getErrorMessage),
         getLongOrZero(failRequest, JobFailRequest::getRetryBackOff),
-        getMapOrEmpty(failRequest, JobFailRequest::getVariables));
+        getMapOrEmpty(failRequest, JobFailRequest::getVariables),
+        null);
   }
 
   public static Either<ProblemDetail, ErrorJobRequest> toJobErrorRequest(
@@ -267,7 +268,8 @@ public class RequestMapper {
                 jobKey,
                 errorRequest.getErrorCode(),
                 getStringOrEmpty(errorRequest, JobErrorRequest::getErrorMessage),
-                getMapOrEmpty(errorRequest, JobErrorRequest::getVariables)));
+                getMapOrEmpty(errorRequest, JobErrorRequest::getVariables),
+                null));
   }
 
   public static Either<ProblemDetail, CorrelateMessageRequest> toMessageCorrelationRequest(
@@ -297,7 +299,8 @@ public class RequestMapper {
     return new CompleteJobRequest(
         jobKey,
         getMapOrEmpty(completionRequest, JobCompletionRequest::getVariables),
-        getJobResultOrDefault(completionRequest));
+        getJobResultOrDefault(completionRequest),
+        null);
   }
 
   public static Either<ProblemDetail, UpdateJobRequest> toJobUpdateRequest(
@@ -312,7 +315,8 @@ public class RequestMapper {
                 new UpdateJobChangeset(
                     updateRequest.getChangeset().getRetries(),
                     updateRequest.getChangeset().getTimeout(),
-                    updateRequest.getChangeset().getPriority())));
+                    updateRequest.getChangeset().getPriority()),
+                null));
   }
 
   public static Either<ProblemDetail, BatchUpdateJobRequest> toJobBatchUpdateRequest(
@@ -1261,15 +1265,24 @@ public class RequestMapper {
       int retries,
       String errorMessage,
       Long retryBackoff,
-      Map<String, Object> variables) {}
+      Map<String, Object> variables,
+      @Nullable String leaseToken) {}
 
   public record ErrorJobRequest(
-      long jobKey, String errorCode, String errorMessage, Map<String, Object> variables) {}
+      long jobKey,
+      String errorCode,
+      String errorMessage,
+      Map<String, Object> variables,
+      @Nullable String leaseToken) {}
 
-  public record CompleteJobRequest(long jobKey, Map<String, Object> variables, JobResult result) {}
+  public record CompleteJobRequest(
+      long jobKey, Map<String, Object> variables, JobResult result, @Nullable String leaseToken) {}
 
   public record UpdateJobRequest(
-      long jobKey, @Nullable Long operationReference, UpdateJobChangeset changeset) {}
+      long jobKey,
+      @Nullable Long operationReference,
+      UpdateJobChangeset changeset,
+      @Nullable String leaseToken) {}
 
   public record BroadcastSignalRequest(
       String signalName, Map<String, Object> variables, String tenantId) {}

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/RequestMapper.java
@@ -254,7 +254,7 @@ public class RequestMapper {
         getStringOrEmpty(failRequest, JobFailRequest::getErrorMessage),
         getLongOrZero(failRequest, JobFailRequest::getRetryBackOff),
         getMapOrEmpty(failRequest, JobFailRequest::getVariables),
-        null);
+        failRequest == null ? null : failRequest.getLeaseToken());
   }
 
   public static Either<ProblemDetail, ErrorJobRequest> toJobErrorRequest(
@@ -269,7 +269,7 @@ public class RequestMapper {
                 errorRequest.getErrorCode(),
                 getStringOrEmpty(errorRequest, JobErrorRequest::getErrorMessage),
                 getMapOrEmpty(errorRequest, JobErrorRequest::getVariables),
-                null));
+                errorRequest.getLeaseToken()));
   }
 
   public static Either<ProblemDetail, CorrelateMessageRequest> toMessageCorrelationRequest(
@@ -300,7 +300,7 @@ public class RequestMapper {
         jobKey,
         getMapOrEmpty(completionRequest, JobCompletionRequest::getVariables),
         getJobResultOrDefault(completionRequest),
-        null);
+        completionRequest == null ? null : completionRequest.getLeaseToken());
   }
 
   public static Either<ProblemDetail, UpdateJobRequest> toJobUpdateRequest(
@@ -316,7 +316,7 @@ public class RequestMapper {
                     updateRequest.getChangeset().getRetries(),
                     updateRequest.getChangeset().getTimeout(),
                     updateRequest.getChangeset().getPriority()),
-                null));
+                updateRequest.getLeaseToken()));
   }
 
   public static Either<ProblemDetail, BatchUpdateJobRequest> toJobBatchUpdateRequest(

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/rest/RequestMapperTest.java
@@ -14,6 +14,9 @@ import io.camunda.gateway.protocol.model.AdvancedStringFilter;
 import io.camunda.gateway.protocol.model.DeleteResourceRequest;
 import io.camunda.gateway.protocol.model.JobActivationRequest;
 import io.camunda.gateway.protocol.model.JobChangeset;
+import io.camunda.gateway.protocol.model.JobCompletionRequest;
+import io.camunda.gateway.protocol.model.JobErrorRequest;
+import io.camunda.gateway.protocol.model.JobFailRequest;
 import io.camunda.gateway.protocol.model.JobUpdateRequest;
 import io.camunda.gateway.protocol.model.MigrateProcessInstanceMappingInstruction;
 import io.camunda.gateway.protocol.model.ProcessInstanceFilter;
@@ -684,6 +687,114 @@ class RequestMapperTest {
       assertThat(result.isLeft()).isTrue();
       assertThat(result.getLeft().getStatus()).isEqualTo(400);
       assertThat(result.getLeft().getDetail()).contains("retries", "timeout", "priority");
+    }
+  }
+
+  @Nested
+  class LeaseTokenMappingTest {
+
+    @Test
+    void shouldMapLeaseTokenOnJobCompletion() {
+      // given
+      final var request = JobCompletionRequest.Builder.create().leaseToken("lease-1").build();
+
+      // when
+      final var result = RequestMapper.toJobCompletionRequest(request, 1L);
+
+      // then
+      assertThat(result.leaseToken()).isEqualTo("lease-1");
+    }
+
+    @Test
+    void shouldMapAbsentLeaseTokenOnJobCompletion() {
+      // given
+      final var request = JobCompletionRequest.Builder.create().build();
+
+      // when
+      final var result = RequestMapper.toJobCompletionRequest(request, 1L);
+
+      // then
+      assertThat(result.leaseToken()).isNull();
+    }
+
+    @Test
+    void shouldMapLeaseTokenOnJobFail() {
+      // given
+      final var request = JobFailRequest.Builder.create().leaseToken("lease-1").build();
+
+      // when
+      final var result = RequestMapper.toJobFailRequest(request, 1L);
+
+      // then
+      assertThat(result.leaseToken()).isEqualTo("lease-1");
+    }
+
+    @Test
+    void shouldMapAbsentLeaseTokenOnJobFail() {
+      // given
+      final var request = JobFailRequest.Builder.create().build();
+
+      // when
+      final var result = RequestMapper.toJobFailRequest(request, 1L);
+
+      // then
+      assertThat(result.leaseToken()).isNull();
+    }
+
+    @Test
+    void shouldMapLeaseTokenOnJobError() {
+      // given
+      final var request =
+          JobErrorRequest.Builder.create().errorCode("error-1").leaseToken("lease-1").build();
+
+      // when
+      final var result = RequestMapper.toJobErrorRequest(request, 1L);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.get().leaseToken()).isEqualTo("lease-1");
+    }
+
+    @Test
+    void shouldMapAbsentLeaseTokenOnJobError() {
+      // given
+      final var request = JobErrorRequest.Builder.create().errorCode("error-1").build();
+
+      // when
+      final var result = RequestMapper.toJobErrorRequest(request, 1L);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.get().leaseToken()).isNull();
+    }
+
+    @Test
+    void shouldMapLeaseTokenOnJobUpdate() {
+      // given
+      final var changeset = JobChangeset.Builder.create().priority(80).build();
+      final var request =
+          JobUpdateRequest.Builder.create().changeset(changeset).leaseToken("lease-1").build();
+
+      // when
+      final var result = RequestMapper.toJobUpdateRequest(request, 1L);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.get().leaseToken()).isEqualTo("lease-1");
+    }
+
+    @Test
+    void shouldMapAbsentLeaseTokenOnJobUpdate() {
+      // given
+      final var changeset = JobChangeset.Builder.create().priority(80).build();
+      final var request = JobUpdateRequest.Builder.create().changeset(changeset).build();
+
+      // when
+      final var result = RequestMapper.toJobUpdateRequest(request, 1L);
+
+      // then
+      assertThat(result.isRight()).isTrue();
+      assertThat(result.get().leaseToken()).isNull();
     }
   }
 }

--- a/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
+++ b/gateways/gateway-mcp/src/main/java/io/camunda/gateway/mcp/tool/incident/IncidentTools.java
@@ -144,7 +144,8 @@ public class IncidentTools {
           CallToolResultMapper.executeServiceMethod(
               serviceRegistry
                   .<JobActivationResult>jobServices(physicalTenantId)
-                  .updateJob(jobKey, null, new UpdateJobChangeset(1, null, null), authentication));
+                  .updateJob(
+                      jobKey, null, new UpdateJobChangeset(1, null, null), null, authentication));
       if (updateResult.isLeft()) {
         return CallToolResultMapper.mapErrorToResult(updateResult.getLeft());
       }

--- a/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
+++ b/gateways/gateway-mcp/src/test/java/io/camunda/gateway/mcp/tool/incident/IncidentToolsTest.java
@@ -439,7 +439,7 @@ class IncidentToolsTest extends OperationalToolsTest {
               CompletableFuture.completedFuture(new IncidentRecord()));
       when(incidentEntity.jobKey()).thenReturn(4L);
       when(incidentServices.getByKey(anyLong(), any())).thenReturn(incidentEntity);
-      when(jobServices.updateJob(anyLong(), any(), any(UpdateJobChangeset.class), any()))
+      when(jobServices.updateJob(anyLong(), any(), any(UpdateJobChangeset.class), any(), any()))
           .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
       // when
@@ -462,7 +462,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       verify(incidentServices, times(2)).resolveIncident(eq(5L), isNull(), any());
       verify(incidentServices).getByKey(eq(5L), any());
       verify(jobServices)
-          .updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null, null)), any());
+          .updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null, null)), isNull(), any());
     }
 
     @Test
@@ -477,7 +477,7 @@ class IncidentToolsTest extends OperationalToolsTest {
               CompletableFuture.completedFuture(new IncidentRecord()));
       when(incidentEntity.jobKey()).thenReturn(4L);
       when(incidentServices.getByKey(anyLong(), any())).thenReturn(incidentEntity);
-      when(jobServices.updateJob(anyLong(), any(), any(UpdateJobChangeset.class), any()))
+      when(jobServices.updateJob(anyLong(), any(), any(UpdateJobChangeset.class), any(), any()))
           .thenReturn(
               CompletableFuture.failedFuture(
                   new ServiceException("Expected failure", Status.NOT_FOUND)));
@@ -502,7 +502,7 @@ class IncidentToolsTest extends OperationalToolsTest {
       verify(incidentServices).resolveIncident(eq(5L), isNull(), any());
       verify(incidentServices).getByKey(eq(5L), any());
       verify(jobServices)
-          .updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null, null)), any());
+          .updateJob(eq(4L), isNull(), eq(new UpdateJobChangeset(1, null, null)), isNull(), any());
 
       assertTextContentFallback(result);
     }

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -123,11 +123,15 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final String errorMessage,
       final Long retryBackOff,
       final Map<String, Object> variables,
+      final String leaseToken,
       final CamundaAuthentication authentication) {
     final var request =
         new BrokerFailJobRequest(jobKey, retries, retryBackOff)
             .setVariables(getDocumentOrEmpty(variables))
             .setErrorMessage(errorMessage);
+    if (leaseToken != null) {
+      request.setLeaseToken(leaseToken);
+    }
     return sendBrokerRequest(request, authentication);
   }
 
@@ -136,11 +140,15 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final String errorCode,
       final String errorMessage,
       final Map<String, Object> variables,
+      final String leaseToken,
       final CamundaAuthentication authentication) {
     final var request =
         new BrokerThrowErrorRequest(jobKey, errorCode)
             .setErrorMessage(errorMessage)
             .setVariables(getDocumentOrEmpty(variables));
+    if (leaseToken != null) {
+      request.setLeaseToken(leaseToken);
+    }
     return sendBrokerRequest(request, authentication);
   }
 
@@ -148,23 +156,31 @@ public final class JobServices<T> extends SearchQueryService<JobServices<T>, Job
       final long jobKey,
       final Map<String, Object> variables,
       final JobResult result,
+      final String leaseToken,
       final CamundaAuthentication authentication) {
-    return sendBrokerRequest(
+    final var request =
         new BrokerCompleteJobRequest(
-            jobKey, getDocumentOrEmpty(variables), result, maxVariableNameLength),
-        authentication);
+            jobKey, getDocumentOrEmpty(variables), result, maxVariableNameLength);
+    if (leaseToken != null) {
+      request.setLeaseToken(leaseToken);
+    }
+    return sendBrokerRequest(request, authentication);
   }
 
   public CompletableFuture<JobRecord> updateJob(
       final long jobKey,
       final Long operationReference,
       final UpdateJobChangeset changeset,
+      final String leaseToken,
       final CamundaAuthentication authentication) {
     final var brokerRequest =
         new BrokerUpdateJobRequest(
             jobKey, changeset.retries(), changeset.timeout(), changeset.priority());
     if (operationReference != null) {
       brokerRequest.setOperationReference(operationReference);
+    }
+    if (leaseToken != null) {
+      brokerRequest.setLeaseToken(leaseToken);
     }
     return sendBrokerRequest(brokerRequest, authentication);
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -162,6 +162,9 @@ public final class RequestMapper extends RequestUtil {
       final UpdateJobTimeoutRequest grpcRequest) {
     final var brokerRequest =
         new BrokerUpdateJobTimeoutRequest(grpcRequest.getJobKey(), grpcRequest.getTimeout());
+    if (grpcRequest.hasLeaseToken()) {
+      brokerRequest.setLeaseToken(grpcRequest.getLeaseToken());
+    }
     if (grpcRequest.hasOperationReference()) {
       brokerRequest.setOperationReference(grpcRequest.getOperationReference());
     }
@@ -183,26 +186,41 @@ public final class RequestMapper extends RequestUtil {
   }
 
   public static BrokerFailJobRequest toFailJobRequest(final FailJobRequest grpcRequest) {
-    return new BrokerFailJobRequest(
-            grpcRequest.getJobKey(), grpcRequest.getRetries(), grpcRequest.getRetryBackOff())
-        .setErrorMessage(grpcRequest.getErrorMessage())
-        .setVariables(ensureJsonSet(grpcRequest.getVariables()));
+    final var brokerRequest =
+        new BrokerFailJobRequest(
+                grpcRequest.getJobKey(), grpcRequest.getRetries(), grpcRequest.getRetryBackOff())
+            .setErrorMessage(grpcRequest.getErrorMessage())
+            .setVariables(ensureJsonSet(grpcRequest.getVariables()));
+    if (grpcRequest.hasLeaseToken()) {
+      brokerRequest.setLeaseToken(grpcRequest.getLeaseToken());
+    }
+    return brokerRequest;
   }
 
   public static BrokerThrowErrorRequest toThrowErrorRequest(final ThrowErrorRequest grpcRequest) {
-    return new BrokerThrowErrorRequest(grpcRequest.getJobKey(), grpcRequest.getErrorCode())
-        .setErrorMessage(grpcRequest.getErrorMessage())
-        .setVariables(ensureJsonSet(grpcRequest.getVariables()));
+    final var brokerRequest =
+        new BrokerThrowErrorRequest(grpcRequest.getJobKey(), grpcRequest.getErrorCode())
+            .setErrorMessage(grpcRequest.getErrorMessage())
+            .setVariables(ensureJsonSet(grpcRequest.getVariables()));
+    if (grpcRequest.hasLeaseToken()) {
+      brokerRequest.setLeaseToken(grpcRequest.getLeaseToken());
+    }
+    return brokerRequest;
   }
 
   public static BrokerCompleteJobRequest toCompleteJobRequest(
       final CompleteJobRequest grpcRequest) {
 
-    return new BrokerCompleteJobRequest(
-        grpcRequest.getJobKey(),
-        ensureJsonSet(grpcRequest.getVariables()),
-        getJobResultOrDefault(grpcRequest),
-        maxVariableNameLength);
+    final var brokerRequest =
+        new BrokerCompleteJobRequest(
+            grpcRequest.getJobKey(),
+            ensureJsonSet(grpcRequest.getVariables()),
+            getJobResultOrDefault(grpcRequest),
+            maxVariableNameLength);
+    if (grpcRequest.hasLeaseToken()) {
+      brokerRequest.setLeaseToken(grpcRequest.getLeaseToken());
+    }
+    return brokerRequest;
   }
 
   private static JobResult getJobResultOrDefault(final CompleteJobRequest request) {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -18,8 +18,11 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeleteResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
 import io.camunda.zeebe.gateway.validation.VariableNameLengthValidator;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -948,6 +951,132 @@ public class RequestMapperTest {
 
       // then
       assertThat(brokerRequest.getRequestWriter().getBusinessId()).isEmpty();
+    }
+  }
+
+  @Nested
+  class CompleteJobRequestLeaseTokenTest {
+
+    @Test
+    public void shouldMapLeaseTokenToBrokerRequest() {
+      // given
+      final var grpcRequest =
+          CompleteJobRequest.newBuilder().setJobKey(123L).setLeaseToken("lease-token-1").build();
+
+      // when
+      final var brokerRequest = RequestMapper.toCompleteJobRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getLeaseToken()).isEqualTo("lease-token-1");
+    }
+
+    @Test
+    public void shouldNotSetLeaseTokenByDefault() {
+      // given
+      final var grpcRequest = CompleteJobRequest.newBuilder().setJobKey(123L).build();
+
+      // when
+      final var brokerRequest = RequestMapper.toCompleteJobRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getLeaseToken()).isEmpty();
+    }
+  }
+
+  @Nested
+  class FailJobRequestLeaseTokenTest {
+
+    @Test
+    public void shouldMapLeaseTokenToBrokerRequest() {
+      // given
+      final var grpcRequest =
+          FailJobRequest.newBuilder().setJobKey(123L).setLeaseToken("lease-token-2").build();
+
+      // when
+      final var brokerRequest = RequestMapper.toFailJobRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getLeaseToken()).isEqualTo("lease-token-2");
+    }
+
+    @Test
+    public void shouldNotSetLeaseTokenByDefault() {
+      // given
+      final var grpcRequest = FailJobRequest.newBuilder().setJobKey(123L).build();
+
+      // when
+      final var brokerRequest = RequestMapper.toFailJobRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getLeaseToken()).isEmpty();
+    }
+  }
+
+  @Nested
+  class ThrowErrorRequestLeaseTokenTest {
+
+    @Test
+    public void shouldMapLeaseTokenToBrokerRequest() {
+      // given
+      final var grpcRequest =
+          ThrowErrorRequest.newBuilder()
+              .setJobKey(123L)
+              .setErrorCode("error-code")
+              .setLeaseToken("lease-token-3")
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toThrowErrorRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getLeaseToken()).isEqualTo("lease-token-3");
+    }
+
+    @Test
+    public void shouldNotSetLeaseTokenByDefault() {
+      // given
+      final var grpcRequest =
+          ThrowErrorRequest.newBuilder().setJobKey(123L).setErrorCode("error-code").build();
+
+      // when
+      final var brokerRequest = RequestMapper.toThrowErrorRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getLeaseToken()).isEmpty();
+    }
+  }
+
+  @Nested
+  class UpdateJobTimeoutRequestLeaseTokenTest {
+
+    @Test
+    public void shouldMapLeaseTokenToBrokerRequest() {
+      // given
+      final var grpcRequest =
+          UpdateJobTimeoutRequest.newBuilder()
+              .setJobKey(123L)
+              .setTimeout(5000L)
+              .setLeaseToken("lease-token-4")
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toUpdateJobTimeoutRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getLeaseToken()).isEqualTo("lease-token-4");
+    }
+
+    @Test
+    public void shouldNotSetLeaseTokenByDefault() {
+      // given
+      final var grpcRequest =
+          UpdateJobTimeoutRequest.newBuilder().setJobKey(123L).setTimeout(5000L).build();
+
+      // when
+      final var brokerRequest = RequestMapper.toUpdateJobTimeoutRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getLeaseToken()).isEmpty();
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -197,6 +197,13 @@ message CompleteJobRequest {
   // The result of the completed job as determined by the worker.
   // This functionality is currently supported only by user task listeners.
   optional JobResult result = 3;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, the matching token must be supplied to prove the command comes from the
+  // worker that holds the current lease; a command with no token is rejected. A command carrying
+  // a stale token is likewise rejected, fencing the job against a superseded activation (e.g.
+  // after the job timed out or failed and was re-activated by another worker). A job that was
+  // activated without a lease requires no token.
+  optional string leaseToken = 4;
 }
 
 message JobResult{
@@ -631,6 +638,13 @@ message FailJobRequest {
   // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
   // valid argument, as the root of the JSON document is an array and not an object.
   string variables = 5;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, the matching token must be supplied to prove the command comes from the
+  // worker that holds the current lease; a command with no token is rejected. A command carrying
+  // a stale token is likewise rejected, fencing the job against a superseded activation (e.g.
+  // after the job timed out or failed and was re-activated by another worker). A job that was
+  // activated without a lease requires no token.
+  optional string leaseToken = 6;
 }
 
 message FailJobResponse {
@@ -649,6 +663,13 @@ message ThrowErrorRequest {
   // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
   // valid argument, as the root of the JSON document is an array and not an object.
   string variables = 4;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, the matching token must be supplied to prove the command comes from the
+  // worker that holds the current lease; a command with no token is rejected. A command carrying
+  // a stale token is likewise rejected, fencing the job against a superseded activation (e.g.
+  // after the job timed out or failed and was re-activated by another worker). A job that was
+  // activated without a lease requires no token.
+  optional string leaseToken = 5;
 }
 
 message ThrowErrorResponse {
@@ -773,6 +794,15 @@ message UpdateJobTimeoutRequest {
   int64 timeout = 2;
   // a reference key chosen by the user and will be part of all records resulted from this operation
   optional uint64 operationReference = 3;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, a supplied token is validated to prove the command comes from the worker
+  // that holds the current lease; a command carrying a stale token is rejected, fencing the job
+  // against a superseded activation (e.g. after the job timed out or failed and was re-activated
+  // by another worker). An update without a token always applies, to support operator and bulk
+  // updates of leased jobs; this differs from lifecycle commands like complete, fail, and
+  // throw-error, which always require a token for leased jobs. A job that was activated without a
+  // lease requires no token.
+  optional string leaseToken = 4;
 }
 
 message UpdateJobTimeoutResponse {

--- a/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/jobs.yaml
@@ -559,7 +559,7 @@ components:
           type: integer
           format: int32
         leaseToken:
-          description: |
+          description: >
             The lease token identifying this activation. This is `null` when the job was
             activated without a lease.
           nullable: true
@@ -1035,6 +1035,23 @@ components:
             associated task.
           type: object
           additionalProperties: true
+        leaseToken:
+          description: >
+            The token identifying a leased job's activation, obtained from
+            `ActivatedJobResult.leaseToken`.
+
+            For a leased job, the matching token must be supplied to prove the command comes from
+            the worker that holds the current lease; a command with no token is rejected. A command
+            carrying a stale token is likewise rejected, fencing the job against a superseded
+            activation (for example, after the job timed out or failed and was re-activated by
+            another worker).
+
+            A job that was activated without a lease requires no token.
+          type: string
+          nullable: true
+      x-properties-added-in-version:
+        - propertyName: leaseToken
+          addedInVersion: "8.10"
 
     JobErrorRequest:
       type: object
@@ -1055,8 +1072,25 @@ components:
             JSON object that will instantiate the variables at the local scope of the error catch event that catches the thrown error.
           type: object
           nullable: true
+        leaseToken:
+          description: >
+            The token identifying a leased job's activation, obtained from
+            `ActivatedJobResult.leaseToken`.
+
+            For a leased job, the matching token must be supplied to prove the command comes from
+            the worker that holds the current lease; a command with no token is rejected. A command
+            carrying a stale token is likewise rejected, fencing the job against a superseded
+            activation (for example, after the job timed out or failed and was re-activated by
+            another worker).
+
+            A job that was activated without a lease requires no token.
+          type: string
+          nullable: true
       required:
         - errorCode
+      x-properties-added-in-version:
+        - propertyName: leaseToken
+          addedInVersion: "8.10"
 
     JobCompletionRequest:
       type: object
@@ -1069,9 +1103,25 @@ components:
           nullable: true
         result:
           $ref: '#/components/schemas/JobResult'
+        leaseToken:
+          description: >
+            The token identifying a leased job's activation, obtained from
+            `ActivatedJobResult.leaseToken`.
+
+            For a leased job, the matching token must be supplied to prove the command comes from
+            the worker that holds the current lease; a command with no token is rejected. A command
+            carrying a stale token is likewise rejected, fencing the job against a superseded
+            activation (for example, after the job timed out or failed and was re-activated by
+            another worker).
+
+            A job that was activated without a lease requires no token.
+          type: string
+          nullable: true
       x-properties-added-in-version:
         - propertyName: result
           addedInVersion: "8.8"
+        - propertyName: leaseToken
+          addedInVersion: "8.10"
 
     JobResult:
       description: >
@@ -1213,11 +1263,30 @@ components:
           $ref: '#/components/schemas/JobChangeset'
         operationReference:
           $ref: "keys.yaml#/components/schemas/OperationReference"
+        leaseToken:
+          description: >
+            The token identifying a leased job's activation, obtained from
+            `ActivatedJobResult.leaseToken`.
+
+            For a leased job, a supplied token is validated to prove the command comes from the
+            worker that holds the current lease; a command carrying a stale token is rejected,
+            fencing the job against a superseded activation (for example, after the job timed out or
+            failed and was re-activated by another worker).
+
+            An update without a token always applies to support operator and bulk updates of
+            leased jobs. Note that this is different from lifecycle requests like complete, fail, and
+            throw-error that always require a token for leased jobs.
+
+            A job that was activated without a lease requires no token.
+          type: string
+          nullable: true
       required:
         - changeset
       x-properties-added-in-version:
         - propertyName: operationReference
           addedInVersion: "8.8"
+        - propertyName: leaseToken
+          addedInVersion: "8.10"
 
     JobChangeset:
       description: JSON object with changed job attribute values. The job cannot be completed or failed with this endpoint, use the complete job or fail job endpoints instead.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -238,6 +238,7 @@ public class JobController {
                 failJobRequest.errorMessage(),
                 failJobRequest.retryBackoff(),
                 failJobRequest.variables(),
+                failJobRequest.leaseToken(),
                 authenticationProvider.getCamundaAuthentication()));
   }
 
@@ -251,6 +252,7 @@ public class JobController {
                 errorJobRequest.errorCode(),
                 errorJobRequest.errorMessage(),
                 errorJobRequest.variables(),
+                errorJobRequest.leaseToken(),
                 authenticationProvider.getCamundaAuthentication()));
   }
 
@@ -263,6 +265,7 @@ public class JobController {
                 completeJobRequest.jobKey(),
                 completeJobRequest.variables(),
                 completeJobRequest.result(),
+                completeJobRequest.leaseToken(),
                 authenticationProvider.getCamundaAuthentication()));
   }
 
@@ -275,6 +278,7 @@ public class JobController {
                 updateJobRequest.jobKey(),
                 updateJobRequest.operationReference(),
                 updateJobRequest.changeset(),
+                updateJobRequest.leaseToken(),
                 authenticationProvider.getCamundaAuthentication()));
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -84,7 +84,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldFailJob() {
     // given
-    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any()))
+    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -109,13 +109,13 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .failJob(eq(1L), eq(1), eq("error"), eq(1L), eq(Map.of("foo", "bar")), any());
+        .failJob(eq(1L), eq(1), eq("error"), eq(1L), eq(Map.of("foo", "bar")), isNull(), any());
   }
 
   @Test
   void shouldFailJobWithoutBody() {
     // given
-    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any()))
+    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     // when/then
@@ -127,13 +127,14 @@ public class JobControllerTest extends RestControllerTest {
         .exchange()
         .expectStatus()
         .isNoContent();
-    Mockito.verify(jobServices).failJob(eq(1L), eq(0), eq(""), eq(0L), eq(Map.of()), any());
+    Mockito.verify(jobServices)
+        .failJob(eq(1L), eq(0), eq(""), eq(0L), eq(Map.of()), isNull(), any());
   }
 
   @Test
   void shouldFailJobWithEmptyBody() {
     // given
-    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any()))
+    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -152,13 +153,14 @@ public class JobControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    Mockito.verify(jobServices).failJob(eq(1L), eq(0), eq(""), eq(0L), eq(Map.of()), any());
+    Mockito.verify(jobServices)
+        .failJob(eq(1L), eq(0), eq(""), eq(0L), eq(Map.of()), isNull(), any());
   }
 
   @Test
   void shouldThrowErrorJob() {
     // given
-    when(jobServices.errorJob(anyLong(), anyString(), anyString(), any(), any()))
+    when(jobServices.errorJob(anyLong(), anyString(), anyString(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -182,7 +184,7 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .errorJob(eq(1L), eq("400"), eq("error"), eq(Map.of("foo", "bar")), any());
+        .errorJob(eq(1L), eq("400"), eq("error"), eq(Map.of("foo", "bar")), isNull(), any());
   }
 
   @Test
@@ -336,7 +338,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJob() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
     // when/then
     webClient
@@ -348,13 +350,14 @@ public class JobControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    Mockito.verify(jobServices).completeJob(eq(1L), eq(Map.of()), any(JobResult.class), any());
+    Mockito.verify(jobServices)
+        .completeJob(eq(1L), eq(Map.of()), any(JobResult.class), isNull(), any());
   }
 
   @Test
   void shouldCompleteJobWithResultDeniedTrue() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -382,14 +385,14 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
     assertThat(jobResultArgumentCaptor.getValue().isDenied()).isTrue();
   }
 
   @Test
   void shouldCompleteJobWithResultDeniedTrueAndDeniedReason() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -418,7 +421,7 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
     assertThat(jobResultArgumentCaptor.getValue().isDenied()).isTrue();
     assertThat(jobResultArgumentCaptor.getValue().getDeniedReason())
         .isEqualTo("Reason to deny lifecycle transition");
@@ -427,7 +430,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultWithCorrections() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -462,7 +465,7 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
 
     assertThat(jobResultArgumentCaptor.getValue().getCorrections())
         .isEqualTo(
@@ -487,7 +490,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultWithCorrectionsPartiallySet() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -520,7 +523,7 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
 
     assertThat(jobResultArgumentCaptor.getValue().getCorrections())
         .isEqualTo(
@@ -541,7 +544,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultWithCorrectionsPartiallySetAndDefault() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -573,7 +576,7 @@ public class JobControllerTest extends RestControllerTest {
 
     final var jobResultArgumentCaptor = ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
 
     assertThat(jobResultArgumentCaptor.getValue().getCorrections())
         .isEqualTo(
@@ -594,7 +597,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithResultDeniedFalse() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -622,7 +625,7 @@ public class JobControllerTest extends RestControllerTest {
     final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), any());
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture(), isNull(), any());
     assertThat(jobResultArgumentCaptor.getValue().isDenied()).isFalse();
     assertThat(jobResultArgumentCaptor.getValue().getDeniedReason()).isEqualTo("");
   }
@@ -630,7 +633,7 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJobWithVariables() {
     // given
-    when(jobServices.completeJob(anyLong(), any(), any(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -654,13 +657,13 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of("foo", "bar")), any(JobResult.class), any());
+        .completeJob(eq(1L), eq(Map.of("foo", "bar")), any(JobResult.class), isNull(), any());
   }
 
   @Test
   void shouldUpdateJob() {
     // given
-    when(jobServices.updateJob(anyLong(), any(), any(), any()))
+    when(jobServices.updateJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -684,13 +687,13 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, 1000L, null)), any());
+        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, 1000L, null)), isNull(), any());
   }
 
   @Test
   void shouldUpdateJobWithOnlyRetries() {
     // given
-    when(jobServices.updateJob(anyLong(), any(), any(), any()))
+    when(jobServices.updateJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -713,13 +716,13 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, null, null)), any());
+        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(5, null, null)), isNull(), any());
   }
 
   @Test
   void shouldUpdateJobWithOnlyTimeout() {
     // given
-    when(jobServices.updateJob(anyLong(), any(), any(), any()))
+    when(jobServices.updateJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -741,13 +744,14 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(null, 1000L, null)), any());
+        .updateJob(
+            eq(1L), isNull(), eq(new UpdateJobChangeset(null, 1000L, null)), isNull(), any());
   }
 
   @Test
   void shouldUpdateJobWithOperationReference() {
     // given
-    when(jobServices.updateJob(anyLong(), any(), any(), any()))
+    when(jobServices.updateJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -770,13 +774,14 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), eq(12345678L), eq(new UpdateJobChangeset(null, 1000L, null)), any());
+        .updateJob(
+            eq(1L), eq(12345678L), eq(new UpdateJobChangeset(null, 1000L, null)), isNull(), any());
   }
 
   @Test
   void shouldUpdateJobWithPriority() {
     // given
-    when(jobServices.updateJob(anyLong(), any(), any(), any()))
+    when(jobServices.updateJob(anyLong(), any(), any(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -798,7 +803,7 @@ public class JobControllerTest extends RestControllerTest {
         .isNoContent();
 
     Mockito.verify(jobServices)
-        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(null, null, 80)), any());
+        .updateJob(eq(1L), isNull(), eq(new UpdateJobChangeset(null, null, 80)), isNull(), any());
   }
 
   @Test

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCompleteJobRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCompleteJobRequest.java
@@ -36,6 +36,11 @@ public final class BrokerCompleteJobRequest extends BrokerExecuteCommand<JobReco
     requestDto.setResult(result);
   }
 
+  public BrokerCompleteJobRequest setLeaseToken(final String leaseToken) {
+    requestDto.setLeaseToken(leaseToken);
+    return this;
+  }
+
   @Override
   public JobRecord getRequestWriter() {
     return requestDto;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerFailJobRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerFailJobRequest.java
@@ -34,6 +34,11 @@ public final class BrokerFailJobRequest extends BrokerExecuteCommand<JobRecord> 
     return this;
   }
 
+  public BrokerFailJobRequest setLeaseToken(final String leaseToken) {
+    requestDto.setLeaseToken(leaseToken);
+    return this;
+  }
+
   @Override
   public JobRecord getRequestWriter() {
     return requestDto;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerThrowErrorRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerThrowErrorRequest.java
@@ -35,6 +35,11 @@ public final class BrokerThrowErrorRequest extends BrokerExecuteCommand<JobRecor
     return this;
   }
 
+  public BrokerThrowErrorRequest setLeaseToken(final String leaseToken) {
+    requestDto.setLeaseToken(leaseToken);
+    return this;
+  }
+
   @Override
   public JobRecord getRequestWriter() {
     return requestDto;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRequest.java
@@ -40,6 +40,11 @@ public class BrokerUpdateJobRequest extends BrokerExecuteCommand<JobRecord> {
     requestDto.setChangedAttributes(changedAttributes);
   }
 
+  public BrokerUpdateJobRequest setLeaseToken(final String leaseToken) {
+    requestDto.setLeaseToken(leaseToken);
+    return this;
+  }
+
   @Override
   public BufferWriter getRequestWriter() {
     return requestDto;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobTimeoutRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobTimeoutRequest.java
@@ -23,6 +23,11 @@ public class BrokerUpdateJobTimeoutRequest extends BrokerExecuteCommand<JobRecor
     requestDto.setTimeout(timeout);
   }
 
+  public BrokerUpdateJobTimeoutRequest setLeaseToken(final String leaseToken) {
+    requestDto.setLeaseToken(leaseToken);
+    return this;
+  }
+
   @Override
   public JobRecord getRequestWriter() {
     return requestDto;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CompleteJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CompleteJobTest.java
@@ -12,10 +12,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.CompleteJobCommandStep1.CompleteJobCommandJobResultStep;
+import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.zeebe.it.util.ZeebeAssertHelper;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
@@ -211,6 +214,118 @@ public final class CompleteJobTest {
     // when
     assertThatThrownBy(() -> getCommand(client, useRest, jobKey).variable(null, null).send().join())
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldCompleteLeasedJobWithMatchingLeaseToken(
+      final boolean useRest, final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    final var job = activateLeasedJob(client, useRest, jobType);
+    assertThat(job.getLeaseToken())
+        .describedAs("Expected the leased job to carry a lease token")
+        .isNotEmpty();
+
+    // when
+    getCommand(client, useRest, job.getKey()).withLeaseToken(job.getLeaseToken()).send().join();
+
+    // then
+    ZeebeAssertHelper.assertJobCompleted(jobType);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldRejectCompleteLeasedJobWithWrongLeaseToken(
+      final boolean useRest, final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    final var job = activateLeasedJob(client, useRest, jobType);
+    assertThat(job.getLeaseToken())
+        .describedAs("Expected the leased job to carry a lease token")
+        .isNotEmpty();
+
+    // when / then
+    final var expectedMessage =
+        String.format(
+            "Expected to process job with key '%d', but the supplied lease token does not match "
+                + "the lease token of the job",
+            job.getKey());
+    assertThatThrownBy(
+            () ->
+                getCommand(client, useRest, job.getKey())
+                    .withLeaseToken("wrong-lease-token")
+                    .send()
+                    .join())
+        .hasMessageContaining(expectedMessage);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldRejectCompleteLeasedJobWithoutLeaseToken(
+      final boolean useRest, final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    final var job = activateLeasedJob(client, useRest, jobType);
+    assertThat(job.getLeaseToken())
+        .describedAs("Expected the leased job to carry a lease token")
+        .isNotEmpty();
+
+    // when / then
+    final var expectedMessage =
+        String.format(
+            "Expected to process job with key '%d', but a matching lease token must be provided "
+                + "because the job is currently leased",
+            job.getKey());
+    assertThatThrownBy(() -> getCommand(client, useRest, job.getKey()).send().join())
+        .hasMessageContaining(expectedMessage);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldCompleteLeasedJobWithLeaseTokenCarriedFromActivatedJob(
+      final boolean useRest, final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    final var job = activateLeasedJob(client, useRest, jobType);
+    assertThat(job.getLeaseToken())
+        .describedAs("Expected the leased job to carry a lease token")
+        .isNotEmpty();
+
+    // when
+    final CompleteJobCommandStep1 command = client.newCompleteCommand(job);
+    (useRest ? command.useRest() : command.useGrpc()).send().join();
+
+    // then
+    ZeebeAssertHelper.assertJobCompleted(jobType);
+  }
+
+  private ActivatedJob activateLeasedJob(
+      final CamundaClient client, final boolean useRest, final String jobType) {
+    final var processDefinitionKey =
+        resourcesHelper.deployProcess(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(jobType))
+                .endEvent()
+                .done());
+    resourcesHelper.createProcessInstance(processDefinitionKey);
+
+    final ActivateJobsCommandStep1 activateCommand = client.newActivateJobsCommand();
+    final var activateResponse =
+        (useRest ? activateCommand.useRest() : activateCommand.useGrpc())
+            .jobType(jobType)
+            .maxJobsToActivate(1)
+            .timeout(Duration.ofMinutes(14))
+            .withLease(true)
+            .send()
+            .join();
+
+    assertThat(activateResponse.getJobs())
+        .describedAs("Expected one job to be activated")
+        .hasSize(1);
+
+    return activateResponse.getJobs().get(0);
   }
 
   private CompleteJobCommandStep1 getCommand(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CompleteJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/CompleteJobTest.java
@@ -248,8 +248,8 @@ public final class CompleteJobTest {
     // when / then
     final var expectedMessage =
         String.format(
-            "Expected to process job with key '%d', but the supplied lease token does not match "
-                + "the lease token of the job",
+            "Expected to process job with key '%d', but the supplied lease token does not match. "
+                + "The job may have been re-activated by another worker.",
             job.getKey());
     assertThatThrownBy(
             () ->

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateJobTest.java
@@ -388,8 +388,8 @@ public class UpdateJobTest {
     // when / then
     final var expectedMessage =
         String.format(
-            "Expected to process job with key '%d', but the supplied lease token does not match "
-                + "the lease token of the job",
+            "Expected to process job with key '%d', but the supplied lease token does not match. "
+                + "The job may have been re-activated by another worker.",
             jobKey);
     assertThatThrownBy(
             () ->

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateJobTest.java
@@ -347,6 +347,78 @@ public class UpdateJobTest {
         .hasMessageContaining(expectedMessage);
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldUpdateTimeoutOfLeasedJobWithoutLeaseToken(
+      final boolean useRest, final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    createProcessInstance(jobType);
+    final var job = activateLeasedJob(client, useRest, jobType);
+    assertThat(job.getLeaseToken())
+        .describedAs("Expected the leased job to carry a lease token")
+        .isNotEmpty();
+    final long jobKey = job.getKey();
+    final long initialDeadline = job.getDeadline();
+    final long timeout = Duration.ofMinutes(15).toMillis();
+
+    // when
+    // property-update commands validate the lease only if one is supplied; an absent token
+    // must proceed even on a leased job (operator/bulk paths)
+    getTimeoutCommand(client, useRest, jobKey).timeout(timeout).send().join();
+
+    // then
+    assertTimeoutIncreased(initialDeadline, jobKey, useRest);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldRejectUpdateTimeoutOfLeasedJobWithWrongLeaseToken(
+      final boolean useRest, final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    createProcessInstance(jobType);
+    final var job = activateLeasedJob(client, useRest, jobType);
+    assertThat(job.getLeaseToken())
+        .describedAs("Expected the leased job to carry a lease token")
+        .isNotEmpty();
+    final long jobKey = job.getKey();
+    final long timeout = Duration.ofMinutes(15).toMillis();
+
+    // when / then
+    final var expectedMessage =
+        String.format(
+            "Expected to process job with key '%d', but the supplied lease token does not match "
+                + "the lease token of the job",
+            jobKey);
+    assertThatThrownBy(
+            () ->
+                getTimeoutCommand(client, useRest, jobKey)
+                    .timeout(timeout)
+                    .withLeaseToken("wrong-lease-token")
+                    .send()
+                    .join())
+        .hasMessageContaining(expectedMessage);
+  }
+
+  private ActivatedJob activateLeasedJob(
+      final CamundaClient client, final boolean useRest, final String jobType) {
+    final var activateResponse =
+        getActivateCommand(client, useRest)
+            .jobType(jobType)
+            .maxJobsToActivate(1)
+            .timeout(Duration.ofMinutes(14))
+            .withLease(true)
+            .send()
+            .join();
+
+    assertThat(activateResponse.getJobs())
+        .describedAs("Expected one job to be activated")
+        .hasSize(1);
+
+    return activateResponse.getJobs().get(0);
+  }
+
   private void assertTimeoutIncreased(
       final long initialDeadline, final long jobKey, final boolean useRest) {
     final Long updatedDeadline =


### PR DESCRIPTION
## Description

Lets a worker supply its lease token on a job command so the engine fence from #57335 (PR1) works end to end. PR1 taught the engine to reject a command whose lease token doesn't match the one stored on the job; this PR is the plumbing that carries a client-supplied token from the Java client, through the gateway (gRPC and REST), to the broker.

The token is optional on every request, so existing clients are unaffected. The Java client also carries it automatically: `newCompleteCommand(activatedJob)` and friends forward the token from the job that was activated, so a worker gets fenced without writing any lease-handling code.

### Scope and follow-up

Scoped to the worker-hot-path commands: complete, fail, throw-error, and update-timeout. One side effect worth flagging — because every property update shares the one REST `JobUpdateRequest`, update-retries/priority/generic-update are already fenceable **over REST**, but not yet over gRPC or via their client builders. A follow-up (PR3) closes that transport asymmetry; nothing here leaves a worker unprotected in the meantime.

### How it's verified

- **Gateway mapper unit tests** (gRPC + REST): the token lands on the broker request when set, and isn't set when absent.
- **Java client unit tests** (stub gateway, both transports): `withLeaseToken(…)` and the auto-carry path put the token on the captured request.
- **Integration tests** over both transports: matching token accepted, wrong token rejected `INVALID_STATE`, missing token rejected, auto-carry accepted.

## Checklist

- [ ] Enable backports when necessary. Not needed — feature, not a bug fix / CI / docs change.

## Related issues

Relates to #54847 (PR 2 of 3).
