### PR TITLE
feat: per-client credentials and single-auth-type validation for multi-client config

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolver.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolver.java
@@ -53,6 +53,10 @@ import org.springframework.core.env.Environment;
  *
  * <p>Exactly one entry may be marked with {@code camunda.clients.<name>.primary=true} to designate
  * the default client; if only one client is configured it is the primary implicitly.
+ *
+ * <p>All configured clients must share a single authentication <em>type</em> ({@code auth.method});
+ * per-client credentials/identities may differ, but mixing e.g. {@code basic} and {@code oidc}
+ * across clients fails fast. This mirrors the parent physical-tenant design.
  */
 public final class MultiCamundaClientPropertiesResolver {
 
@@ -86,7 +90,30 @@ public final class MultiCamundaClientPropertiesResolver {
       validatePhysicalTenantId(name, properties.getPhysicalTenantId());
       resolved.put(name, properties);
     }
+    validateSingleAuthType(resolved);
     return new MultiCamundaClientProperties(resolved, resolvePrimaryClientName(binder, names));
+  }
+
+  /**
+   * Validates that all configured clients share a single authentication type ({@code auth.method}).
+   * Per-client credentials/identities may differ, but the type must be uniform.
+   *
+   * @throws IllegalArgumentException if clients declare more than one distinct {@code auth.method}
+   */
+  private static void validateSingleAuthType(final Map<String, CamundaClientProperties> clients) {
+    final Map<String, CamundaClientAuthProperties.AuthMethod> methodByClient =
+        new LinkedHashMap<>();
+    clients.forEach(
+        (name, properties) -> methodByClient.put(name, properties.getAuth().getMethod()));
+    final long distinctMethods = methodByClient.values().stream().distinct().count();
+    if (distinctMethods > 1) {
+      throw new IllegalArgumentException(
+          String.format(
+              "All 'camunda.clients.*' must use the same authentication method (auth.method); found "
+                  + "mixed methods %s. Per-client credentials may differ, but the auth type must be "
+                  + "uniform.",
+              methodByClient));
+    }
   }
 
   /**

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolver.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolver.java
@@ -104,7 +104,8 @@ public final class MultiCamundaClientPropertiesResolver {
     final Map<String, CamundaClientAuthProperties.AuthMethod> methodByClient =
         new LinkedHashMap<>();
     clients.forEach(
-        (name, properties) -> methodByClient.put(name, properties.getAuth().getMethod()));
+        (name, properties) ->
+            methodByClient.put(name, normalizeAuthMethod(properties.getAuth().getMethod())));
     final long distinctMethods = methodByClient.values().stream().distinct().count();
     if (distinctMethods > 1) {
       throw new IllegalArgumentException(
@@ -114,6 +115,16 @@ public final class MultiCamundaClientPropertiesResolver {
                   + "uniform.",
               methodByClient));
     }
+  }
+
+  /**
+   * Normalizes an unset {@code auth.method} to {@link CamundaClientAuthProperties.AuthMethod#none}:
+   * both a {@code null} method and an explicit {@code none} resolve to a {@code
+   * NoopCredentialsProvider}, so they must count as the same auth type.
+   */
+  private static CamundaClientAuthProperties.AuthMethod normalizeAuthMethod(
+      final CamundaClientAuthProperties.AuthMethod method) {
+    return method == null ? CamundaClientAuthProperties.AuthMethod.none : method;
   }
 
   /**

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/MultiCamundaClientAutoConfigurationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/MultiCamundaClientAutoConfigurationTest.java
@@ -155,6 +155,20 @@ class MultiCamundaClientAutoConfigurationTest {
   }
 
   @Test
+  void shouldFailStartupOnMixedAuthTypes() {
+    contextRunner
+        .withPropertyValues(
+            "camunda.clients.finance.auth.method=oidc", "camunda.clients.risk.auth.method=basic")
+        .run(
+            context -> {
+              assertThat(context).hasFailed();
+              assertThat(context.getStartupFailure())
+                  .isInstanceOf(IllegalArgumentException.class)
+                  .hasMessageContaining("authentication method");
+            });
+  }
+
+  @Test
   void shouldFailStartupOnInvalidPhysicalTenantId() {
     contextRunner
         .withPropertyValues("camunda.clients.bad.physical-tenant-id=risk-production")

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/PerClientCredentialsIsolationTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/configuration/PerClientCredentialsIsolationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.configuration;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.ok;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.CredentialsProvider;
+import io.camunda.client.spring.bean.CamundaClientRegistry;
+import io.camunda.client.spring.properties.MultiCamundaClientProperties;
+import io.camunda.client.spring.properties.MultiCamundaClientPropertiesResolver;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+
+/**
+ * Verifies that each configured client derives its own {@link CredentialsProvider} from its merged
+ * {@code auth} block, so one client cannot present another client's credentials — both at the
+ * provider level and end-to-end over HTTP through the registered per-client beans.
+ */
+class PerClientCredentialsIsolationTest {
+
+  @RegisterExtension
+  static final WireMockExtension WM =
+      WireMockExtension.newInstance().options(new WireMockConfiguration().dynamicPort()).build();
+
+  private final CredentialsProviderConfiguration credentials =
+      new CredentialsProviderConfiguration();
+
+  private static String basicAuthHeader(final String username, final String password) {
+    return "Basic "
+        + Base64.getEncoder()
+            .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+  }
+
+  private static void sendTopology(final CamundaClient client) {
+    try {
+      client.newTopologyRequest().send().join();
+    } catch (final Exception ignored) {
+      // only the outgoing request (and its credentials) is under test; the response is irrelevant
+    }
+  }
+
+  private static StandardEnvironment environmentWith(final Map<String, Object> properties) {
+    final StandardEnvironment environment = new StandardEnvironment();
+    environment.getPropertySources().addFirst(new MapPropertySource("test", properties));
+    return environment;
+  }
+
+  private static Map<String, String> appliedHeaders(final CredentialsProvider provider)
+      throws IOException {
+    final Map<String, String> headers = new HashMap<>();
+    provider.applyCredentials(headers::put);
+    return headers;
+  }
+
+  @Test
+  void shouldGiveEachClientItsOwnCredentials() throws IOException {
+    // given two clients sharing the basic auth type but with distinct credentials
+    final MultiCamundaClientProperties properties =
+        MultiCamundaClientPropertiesResolver.resolve(
+            environmentWith(
+                Map.of(
+                    "camunda.client.auth.method", "basic",
+                    "camunda.clients.finance.auth.username", "financeuser",
+                    "camunda.clients.finance.auth.password", "financepw",
+                    "camunda.clients.risk.auth.username", "riskuser",
+                    "camunda.clients.risk.auth.password", "riskpw")));
+
+    // when each client's credentials are built from its own resolved auth block and applied
+    final Map<String, String> financeHeaders =
+        appliedHeaders(
+            credentials.camundaClientCredentialsProvider(properties.getClients().get("finance")));
+    final Map<String, String> riskHeaders =
+        appliedHeaders(
+            credentials.camundaClientCredentialsProvider(properties.getClients().get("risk")));
+
+    // then each carries credentials, and finance cannot present risk's credentials (they differ)
+    assertThat(financeHeaders).isNotEmpty();
+    assertThat(riskHeaders).isNotEmpty();
+    assertThat(financeHeaders).isNotEqualTo(riskHeaders);
+  }
+
+  @Test
+  void shouldPresentEachClientsOwnCredentialsOverHttp() {
+    // given two configured clients with distinct basic-auth credentials, pointed at WireMock
+    WM.stubFor(WireMock.any(anyUrl()).willReturn(ok()));
+
+    new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(MultiCamundaClientAutoConfiguration.class))
+        .withPropertyValues(
+            "camunda.client.auth.method=basic",
+            "camunda.client.rest-address=http://localhost:" + WM.getPort(),
+            "camunda.client.prefer-rest-over-grpc=true",
+            "camunda.clients.finance.auth.username=financeuser",
+            "camunda.clients.finance.auth.password=financepw",
+            "camunda.clients.finance.prefix-physical-tenant-path=false",
+            "camunda.clients.risk.auth.username=riskuser",
+            "camunda.clients.risk.auth.password=riskpw",
+            "camunda.clients.risk.prefix-physical-tenant-path=false")
+        .run(
+            context -> {
+              final CamundaClientRegistry registry = context.getBean(CamundaClientRegistry.class);
+
+              // when each client issues a request
+              sendTopology(registry.get("finance"));
+              sendTopology(registry.get("risk"));
+
+              // then WireMock received exactly the two clients' own credentials
+              final Set<String> authHeaders =
+                  WM.getAllServeEvents().stream()
+                      .map(event -> event.getRequest().getHeader("Authorization"))
+                      .filter(Objects::nonNull)
+                      .collect(Collectors.toSet());
+              assertThat(authHeaders)
+                  .containsExactlyInAnyOrder(
+                      basicAuthHeader("financeuser", "financepw"),
+                      basicAuthHeader("riskuser", "riskpw"));
+            });
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolverTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolverTest.java
@@ -224,6 +224,24 @@ class MultiCamundaClientPropertiesResolverTest {
   }
 
   @Test
+  void shouldAllowExplicitNoneAndUnsetAuthMethodTogether() {
+    // given one client with an explicit 'none' method and another leaving it unset - both mean no
+    // auth (NoopCredentialsProvider), so they must not be treated as mixed auth types
+    final StandardEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.clients.finance.auth.method", "none",
+                "camunda.clients.risk.grpc-address", "http://localhost:26500"));
+
+    // when
+    final MultiCamundaClientProperties properties =
+        MultiCamundaClientPropertiesResolver.resolve(environment);
+
+    // then both clients are resolved without a mixed-auth-type rejection
+    assertThat(properties.getClients()).containsKeys("finance", "risk");
+  }
+
+  @Test
   void shouldRejectMixedAuthTypes() {
     // given two clients declaring different auth methods
     final StandardEnvironment environment =

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolverTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/properties/MultiCamundaClientPropertiesResolverTest.java
@@ -200,4 +200,43 @@ class MultiCamundaClientPropertiesResolverTest {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("primary");
   }
+
+  @Test
+  void shouldAllowSameAuthTypeWithDistinctCredentials() {
+    // given two clients sharing the basic auth type but with distinct credentials
+    final StandardEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.client.auth.method", "basic",
+                "camunda.clients.finance.auth.username", "financeuser",
+                "camunda.clients.finance.auth.password", "financepw",
+                "camunda.clients.risk.auth.username", "riskuser",
+                "camunda.clients.risk.auth.password", "riskpw"));
+
+    // when
+    final MultiCamundaClientProperties properties =
+        MultiCamundaClientPropertiesResolver.resolve(environment);
+
+    // then both inherit the same method, with their own identities
+    assertThat(properties.getClients().get("finance").getAuth().getUsername())
+        .isEqualTo("financeuser");
+    assertThat(properties.getClients().get("risk").getAuth().getUsername()).isEqualTo("riskuser");
+  }
+
+  @Test
+  void shouldRejectMixedAuthTypes() {
+    // given two clients declaring different auth methods
+    final StandardEnvironment environment =
+        environmentWith(
+            Map.of(
+                "camunda.clients.finance.auth.method", "oidc",
+                "camunda.clients.risk.auth.method", "basic"));
+
+    // when / then
+    assertThatThrownBy(() -> MultiCamundaClientPropertiesResolver.resolve(environment))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("authentication method")
+        .hasMessageContaining("oidc")
+        .hasMessageContaining("basic");
+  }
 }


### PR DESCRIPTION
## Description

Builds on the multi-client registry (#57338) to give each configured client its own credentials and to enforce a single authentication *type* across clients.

- **Per-client credentials** — each `camunda.clients.<name>.*` client already derives its own `CredentialsProvider` from that client's merged `auth` block (OAuth / Basic / none) via `CamundaClientFactory` + `CredentialsProviderConfiguration`. This PR locks that behaviour in with tests.
- **Single-auth-type validation** — `MultiCamundaClientPropertiesResolver` now fails fast at startup if the configured clients declare more than one distinct `auth.method` (e.g. mixing `basic` and `oidc`). Per-client identities/credentials may still differ; only the *type* must be uniform, mirroring the parent physical-tenant design.

## Related issues

closes #56725 
