### PR TITLE
feat: add unified config mapping for engine experimental properties

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Distribution.java
+++ b/configuration/src/main/java/io/camunda/configuration/Distribution.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_COMMAND_REDISTRIBUTION_MAX_BACKOFF_DURATION;
 
@@ -21,6 +22,8 @@ public class Distribution {
       Set.of("zeebe.broker.experimental.engine.distribution.maxBackoffDuration");
   private static final Set<String> LEGACY_REDISTRIBUTION_INTERVAL_PROPERTIES =
       Set.of("zeebe.broker.experimental.engine.distribution.redistributionInterval");
+  private static final Set<String> LEGACY_PAUSE_COMMAND_DISTRIBUTION_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.distribution.pauseCommandDistribution");
 
   /**
    * Allows configuring the maximum backoff duration for command redistribution retries. The retry
@@ -33,6 +36,9 @@ public class Distribution {
    * when retrying command distributions that have not been acknowledged.
    */
   private Duration redistributionInterval = DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
+
+  /** Allows pausing command redistribution entirely, for debugging or operational purposes. */
+  private boolean pauseCommandDistribution = DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
 
   public Duration getMaxBackoffDuration() {
     return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
@@ -58,5 +64,18 @@ public class Distribution {
 
   public void setRedistributionInterval(final Duration redistributionInterval) {
     this.redistributionInterval = redistributionInterval;
+  }
+
+  public boolean isPauseCommandDistribution() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".pause-command-distribution",
+        pauseCommandDistribution,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_PAUSE_COMMAND_DISTRIBUTION_PROPERTIES);
+  }
+
+  public void setPauseCommandDistribution(final boolean pauseCommandDistribution) {
+    this.pauseCommandDistribution = pauseCommandDistribution;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Distribution.java
+++ b/configuration/src/main/java/io/camunda/configuration/Distribution.java
@@ -37,7 +37,7 @@ public class Distribution {
    */
   private Duration redistributionInterval = DEFAULT_COMMAND_REDISTRIBUTION_INTERVAL;
 
-  /** Allows pausing command redistribution entirely, for debugging or operational purposes. */
+  /** Allows pausing command distribution entirely, for debugging or operational purposes. */
   private boolean pauseCommandDistribution = DEFAULT_COMMAND_DISTRIBUTION_PAUSED;
 
   public Duration getMaxBackoffDuration() {

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -37,9 +37,12 @@ public class Engine {
   /** Configuration properties for the engine's usage metrics export. */
   @NestedConfigurationProperty private EngineUsageMetrics usageMetrics = new EngineUsageMetrics();
 
+  /** Configuration properties for the engine's BPMN/DMN validators. */
+  @NestedConfigurationProperty private EngineValidators validators = new EngineValidators();
+
   /**
-   * Configures the maximum depth of nested call activities allowed before an incident is raised,
-   * to guard against unbounded process recursion.
+   * Configures the maximum depth of nested call activities allowed before an incident is raised, to
+   * guard against unbounded process recursion.
    */
   private int maxProcessDepth = DEFAULT_MAX_PROCESS_DEPTH;
 
@@ -89,6 +92,14 @@ public class Engine {
 
   public void setUsageMetrics(final EngineUsageMetrics usageMetrics) {
     this.usageMetrics = usageMetrics;
+  }
+
+  public EngineValidators getValidators() {
+    return validators;
+  }
+
+  public void setValidators(final EngineValidators validators) {
+    this.validators = validators;
   }
 
   public int getMaxProcessDepth() {

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -31,6 +31,9 @@ public class Engine {
   /** Configuration properties for the engine's caches. */
   @NestedConfigurationProperty private EngineCaches caches = new EngineCaches();
 
+  /** Configuration properties for the engine's message TTL checker. */
+  @NestedConfigurationProperty private EngineMessages messages = new EngineMessages();
+
   /**
    * Configures the maximum depth of nested call activities allowed before an incident is raised,
    * to guard against unbounded process recursion.
@@ -67,6 +70,14 @@ public class Engine {
 
   public void setCaches(final EngineCaches caches) {
     this.caches = caches;
+  }
+
+  public EngineMessages getMessages() {
+    return messages;
+  }
+
+  public void setMessages(final EngineMessages messages) {
+    this.messages = messages;
   }
 
   public int getMaxProcessDepth() {

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -7,9 +7,17 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class Engine {
+  private static final String PREFIX = "camunda.processing.engine";
+
+  private static final Set<String> LEGACY_MAX_PROCESS_DEPTH_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.maxProcessDepth");
 
   /** Configuration properties for the engine's distribution settings. */
   @NestedConfigurationProperty private Distribution distribution = new Distribution();
@@ -22,6 +30,12 @@ public class Engine {
 
   /** Configuration properties for the engine's caches. */
   @NestedConfigurationProperty private EngineCaches caches = new EngineCaches();
+
+  /**
+   * Configures the maximum depth of nested call activities allowed before an incident is raised,
+   * to guard against unbounded process recursion.
+   */
+  private int maxProcessDepth = DEFAULT_MAX_PROCESS_DEPTH;
 
   public Distribution getDistribution() {
     return distribution;
@@ -53,5 +67,18 @@ public class Engine {
 
   public void setCaches(final EngineCaches caches) {
     this.caches = caches;
+  }
+
+  public int getMaxProcessDepth() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".max-process-depth",
+        maxProcessDepth,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_MAX_PROCESS_DEPTH_PROPERTIES);
+  }
+
+  public void setMaxProcessDepth(final int maxProcessDepth) {
+    this.maxProcessDepth = maxProcessDepth;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -20,6 +20,9 @@ public class Engine {
 
   @NestedConfigurationProperty private EngineJob job = new EngineJob();
 
+  /** Configuration properties for the engine's caches. */
+  @NestedConfigurationProperty private EngineCaches caches = new EngineCaches();
+
   public Distribution getDistribution() {
     return distribution;
   }
@@ -42,5 +45,13 @@ public class Engine {
 
   public void setJob(final EngineJob job) {
     this.job = job;
+  }
+
+  public EngineCaches getCaches() {
+    return caches;
+  }
+
+  public void setCaches(final EngineCaches caches) {
+    this.caches = caches;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Engine.java
+++ b/configuration/src/main/java/io/camunda/configuration/Engine.java
@@ -34,6 +34,9 @@ public class Engine {
   /** Configuration properties for the engine's message TTL checker. */
   @NestedConfigurationProperty private EngineMessages messages = new EngineMessages();
 
+  /** Configuration properties for the engine's usage metrics export. */
+  @NestedConfigurationProperty private EngineUsageMetrics usageMetrics = new EngineUsageMetrics();
+
   /**
    * Configures the maximum depth of nested call activities allowed before an incident is raised,
    * to guard against unbounded process recursion.
@@ -78,6 +81,14 @@ public class Engine {
 
   public void setMessages(final EngineMessages messages) {
     this.messages = messages;
+  }
+
+  public EngineUsageMetrics getUsageMetrics() {
+    return usageMetrics;
+  }
+
+  public void setUsageMetrics(final EngineUsageMetrics usageMetrics) {
+    this.usageMetrics = usageMetrics;
   }
 
   public int getMaxProcessDepth() {

--- a/configuration/src/main/java/io/camunda/configuration/EngineCaches.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineCaches.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_AUTHORIZATIONS_CACHE_TTL;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_CANDIDATE_GROUP_NAME_RESOLUTION;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_DRG_CACHE_CAPACITY;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_FORM_CACHE_CAPACITY;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_GROUP_NAME_CACHE_CAPACITY;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_PROCESS_CACHE_CAPACITY;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class EngineCaches {
+  private static final String PREFIX = "camunda.processing.engine.caches";
+
+  private static final Set<String> LEGACY_DRG_CACHE_CAPACITY_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.caches.drgCacheCapacity");
+  private static final Set<String> LEGACY_FORM_CACHE_CAPACITY_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.caches.formCacheCapacity");
+  private static final Set<String> LEGACY_PROCESS_CACHE_CAPACITY_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.caches.processCacheCapacity");
+  private static final Set<String> LEGACY_RESOURCE_CACHE_CAPACITY_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.caches.resourceCacheCapacity");
+  private static final Set<String> LEGACY_AUTHORIZATIONS_CACHE_CAPACITY_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.caches.authorizationsCacheCapacity");
+  private static final Set<String> LEGACY_AUTHORIZATIONS_CACHE_TTL_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.caches.authorizationsCacheTtl");
+  private static final Set<String> LEGACY_GROUP_NAME_CACHE_CAPACITY_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.caches.groupNameCacheCapacity");
+  private static final Set<String> LEGACY_CANDIDATE_GROUP_NAME_RESOLUTION_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.caches.candidateGroupNameResolution");
+
+  /** Configures the maximum number of parsed decision requirements graphs to cache. */
+  private int drgCacheCapacity = DEFAULT_DRG_CACHE_CAPACITY;
+
+  /** Configures the maximum number of parsed forms to cache. */
+  private int formCacheCapacity = DEFAULT_FORM_CACHE_CAPACITY;
+
+  /** Configures the maximum number of parsed processes to cache. */
+  private int processCacheCapacity = DEFAULT_PROCESS_CACHE_CAPACITY;
+
+  /** Configures the maximum number of resources (e.g. RPA scripts) to cache. */
+  private int resourceCacheCapacity = DEFAULT_PROCESS_CACHE_CAPACITY;
+
+  /** Configures the maximum number of authorization decisions to cache. */
+  private int authorizationsCacheCapacity = DEFAULT_AUTHORIZATIONS_CACHE_CAPACITY;
+
+  /** Configures how long a cached authorization decision remains valid before it expires. */
+  private Duration authorizationsCacheTtl = DEFAULT_AUTHORIZATIONS_CACHE_TTL;
+
+  /** Configures the maximum number of resolved group names to cache. */
+  private int groupNameCacheCapacity = DEFAULT_GROUP_NAME_CACHE_CAPACITY;
+
+  /** Configures whether candidate group names are resolved. */
+  private boolean candidateGroupNameResolution = DEFAULT_CANDIDATE_GROUP_NAME_RESOLUTION;
+
+  public int getDrgCacheCapacity() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".drg-cache-capacity",
+        drgCacheCapacity,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_DRG_CACHE_CAPACITY_PROPERTIES);
+  }
+
+  public void setDrgCacheCapacity(final int drgCacheCapacity) {
+    this.drgCacheCapacity = drgCacheCapacity;
+  }
+
+  public int getFormCacheCapacity() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".form-cache-capacity",
+        formCacheCapacity,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_FORM_CACHE_CAPACITY_PROPERTIES);
+  }
+
+  public void setFormCacheCapacity(final int formCacheCapacity) {
+    this.formCacheCapacity = formCacheCapacity;
+  }
+
+  public int getProcessCacheCapacity() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".process-cache-capacity",
+        processCacheCapacity,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_PROCESS_CACHE_CAPACITY_PROPERTIES);
+  }
+
+  public void setProcessCacheCapacity(final int processCacheCapacity) {
+    this.processCacheCapacity = processCacheCapacity;
+  }
+
+  public int getResourceCacheCapacity() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".resource-cache-capacity",
+        resourceCacheCapacity,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_RESOURCE_CACHE_CAPACITY_PROPERTIES);
+  }
+
+  public void setResourceCacheCapacity(final int resourceCacheCapacity) {
+    this.resourceCacheCapacity = resourceCacheCapacity;
+  }
+
+  public int getAuthorizationsCacheCapacity() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".authorizations-cache-capacity",
+        authorizationsCacheCapacity,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_AUTHORIZATIONS_CACHE_CAPACITY_PROPERTIES);
+  }
+
+  public void setAuthorizationsCacheCapacity(final int authorizationsCacheCapacity) {
+    this.authorizationsCacheCapacity = authorizationsCacheCapacity;
+  }
+
+  public Duration getAuthorizationsCacheTtl() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".authorizations-cache-ttl",
+        authorizationsCacheTtl,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_AUTHORIZATIONS_CACHE_TTL_PROPERTIES);
+  }
+
+  public void setAuthorizationsCacheTtl(final Duration authorizationsCacheTtl) {
+    this.authorizationsCacheTtl = authorizationsCacheTtl;
+  }
+
+  public int getGroupNameCacheCapacity() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".group-name-cache-capacity",
+        groupNameCacheCapacity,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_GROUP_NAME_CACHE_CAPACITY_PROPERTIES);
+  }
+
+  public void setGroupNameCacheCapacity(final int groupNameCacheCapacity) {
+    this.groupNameCacheCapacity = groupNameCacheCapacity;
+  }
+
+  public boolean isCandidateGroupNameResolution() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".candidate-group-name-resolution",
+        candidateGroupNameResolution,
+        Boolean.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_CANDIDATE_GROUP_NAME_RESOLUTION_PROPERTIES);
+  }
+
+  public void setCandidateGroupNameResolution(final boolean candidateGroupNameResolution) {
+    this.candidateGroupNameResolution = candidateGroupNameResolution;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/EngineJob.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineJob.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_JOBS_INCLUDE_VARIABLES_IN_JOB_COMPLETED_EVENT;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
 
@@ -26,7 +27,8 @@ public class EngineJob {
   private static final Set<String> LEGACY_TIMEOUT_CHECKER_POLLING_INTERVAL_PROPERTIES =
       Set.of("zeebe.broker.experimental.engine.jobs.timeoutCheckerPollingInterval");
 
-  private boolean includeVariablesInJobCompletedEvent = false;
+  private boolean includeVariablesInJobCompletedEvent =
+      DEFAULT_JOBS_INCLUDE_VARIABLES_IN_JOB_COMPLETED_EVENT;
 
   /** Configures the maximum number of timed-out jobs processed per timeout check. */
   private int timeoutCheckerBatchLimit = DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;

--- a/configuration/src/main/java/io/camunda/configuration/EngineJob.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineJob.java
@@ -7,13 +7,32 @@
  */
 package io.camunda.configuration;
 
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
 /**
  * Defines configurations for jobs in the engine. The prefix for this class is
  * camunda.processing.engine.job.
  */
 public class EngineJob {
+  private static final String PREFIX = "camunda.processing.engine.job";
+
+  private static final Set<String> LEGACY_TIMEOUT_CHECKER_BATCH_LIMIT_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.jobs.timeoutCheckerBatchLimit");
+  private static final Set<String> LEGACY_TIMEOUT_CHECKER_POLLING_INTERVAL_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.jobs.timeoutCheckerPollingInterval");
 
   private boolean includeVariablesInJobCompletedEvent = false;
+
+  /** Configures the maximum number of timed-out jobs processed per timeout check. */
+  private int timeoutCheckerBatchLimit = DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
+
+  /** Configures the interval at which jobs are checked for timeouts. */
+  private Duration timeoutCheckerPollingInterval = DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
 
   /**
    * Configuration option to include variables in the job completed event. This configuration can be
@@ -33,5 +52,31 @@ public class EngineJob {
   public void setIncludeVariablesInJobCompletedEvent(
       final boolean includeVariablesInJobCompletedEvent) {
     this.includeVariablesInJobCompletedEvent = includeVariablesInJobCompletedEvent;
+  }
+
+  public int getTimeoutCheckerBatchLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".timeout-checker-batch-limit",
+        timeoutCheckerBatchLimit,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_TIMEOUT_CHECKER_BATCH_LIMIT_PROPERTIES);
+  }
+
+  public void setTimeoutCheckerBatchLimit(final int timeoutCheckerBatchLimit) {
+    this.timeoutCheckerBatchLimit = timeoutCheckerBatchLimit;
+  }
+
+  public Duration getTimeoutCheckerPollingInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".timeout-checker-polling-interval",
+        timeoutCheckerPollingInterval,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_TIMEOUT_CHECKER_POLLING_INTERVAL_PROPERTIES);
+  }
+
+  public void setTimeoutCheckerPollingInterval(final Duration timeoutCheckerPollingInterval) {
+    this.timeoutCheckerPollingInterval = timeoutCheckerPollingInterval;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/EngineMessages.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineMessages.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class EngineMessages {
+  private static final String PREFIX = "camunda.processing.engine.messages";
+
+  private static final Set<String> LEGACY_TTL_CHECKER_BATCH_LIMIT_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.messages.ttlCheckerBatchLimit");
+  private static final Set<String> LEGACY_TTL_CHECKER_INTERVAL_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.messages.ttlCheckerInterval");
+
+  /** Configures the maximum number of expired messages processed per Time-To-Live check. */
+  private int ttlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
+
+  /** Configures the interval at which buffered messages are checked for expiry. */
+  private Duration ttlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
+
+  public int getTtlCheckerBatchLimit() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".ttl-checker-batch-limit",
+        ttlCheckerBatchLimit,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_TTL_CHECKER_BATCH_LIMIT_PROPERTIES);
+  }
+
+  public void setTtlCheckerBatchLimit(final int ttlCheckerBatchLimit) {
+    this.ttlCheckerBatchLimit = ttlCheckerBatchLimit;
+  }
+
+  public Duration getTtlCheckerInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".ttl-checker-interval",
+        ttlCheckerInterval,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_TTL_CHECKER_INTERVAL_PROPERTIES);
+  }
+
+  public void setTtlCheckerInterval(final Duration ttlCheckerInterval) {
+    this.ttlCheckerInterval = ttlCheckerInterval;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/EngineUsageMetrics.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineUsageMetrics.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_USAGE_METRICS_EXPORT_INTERVAL;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.time.Duration;
+import java.util.Set;
+
+public class EngineUsageMetrics {
+  private static final String PREFIX = "camunda.processing.engine.usage-metrics";
+
+  private static final Set<String> LEGACY_EXPORT_INTERVAL_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.usageMetrics.exportInterval");
+
+  /** Configures the interval at which usage metrics are exported. */
+  private Duration exportInterval = DEFAULT_USAGE_METRICS_EXPORT_INTERVAL;
+
+  public Duration getExportInterval() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".export-interval",
+        exportInterval,
+        Duration.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_EXPORT_INTERVAL_PROPERTIES);
+  }
+
+  public void setExportInterval(final Duration exportInterval) {
+    this.exportInterval = exportInterval;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/EngineValidators.java
+++ b/configuration/src/main/java/io/camunda/configuration/EngineValidators.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
+
+import io.camunda.configuration.UnifiedConfigurationHelper.BackwardsCompatibilityMode;
+import java.util.Set;
+
+public class EngineValidators {
+  private static final String PREFIX = "camunda.processing.engine.validators";
+
+  private static final Set<String> LEGACY_RESULTS_OUTPUT_MAX_SIZE_PROPERTIES =
+      Set.of("zeebe.broker.experimental.engine.validators.resultsOutputMaxSize");
+
+  /**
+   * Configures the maximum size, in bytes, of the validation error output produced when deploying
+   * an invalid BPMN or DMN resource.
+   */
+  private int resultsOutputMaxSize = DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
+
+  public int getResultsOutputMaxSize() {
+    return UnifiedConfigurationHelper.validateLegacyConfigurationUnsafe(
+        PREFIX + ".results-output-max-size",
+        resultsOutputMaxSize,
+        Integer.class,
+        BackwardsCompatibilityMode.SUPPORTED,
+        LEGACY_RESULTS_OUTPUT_MAX_SIZE_PROPERTIES);
+  }
+
+  public void setResultsOutputMaxSize(final int resultsOutputMaxSize) {
+    this.resultsOutputMaxSize = resultsOutputMaxSize;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -1210,11 +1210,10 @@ public class BrokerBasedPropertiesOverride {
 
   private static void populateFromJobs(
       final BrokerBasedProperties override, final Camunda camunda) {
-    override
-        .getExperimental()
-        .getEngine()
-        .getJobs()
-        .setIncludeVariablesInJobCompletedEvent(
-            camunda.getProcessing().getEngine().getJob().isIncludeVariablesInJobCompletedEvent());
+    final var job = camunda.getProcessing().getEngine().getJob();
+    final var jobsCfg = override.getExperimental().getEngine().getJobs();
+    jobsCfg.setIncludeVariablesInJobCompletedEvent(job.isIncludeVariablesInJobCompletedEvent());
+    jobsCfg.setTimeoutCheckerBatchLimit(job.getTimeoutCheckerBatchLimit());
+    jobsCfg.setTimeoutCheckerPollingInterval(job.getTimeoutCheckerPollingInterval());
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -258,6 +258,11 @@ public class BrokerBasedPropertiesOverride {
     populateFromProcessInstanceCreation(override, camunda);
     populateFromJobs(override, camunda);
     populateFromCaches(override, camunda);
+
+    override
+        .getExperimental()
+        .getEngine()
+        .setMaxProcessDepth(camunda.getProcessing().getEngine().getMaxProcessDepth());
   }
 
   private static void populateFromDistribution(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -259,6 +259,7 @@ public class BrokerBasedPropertiesOverride {
     populateFromJobs(override, camunda);
     populateFromCaches(override, camunda);
     populateFromMessages(override, camunda);
+    populateFromUsageMetrics(override, camunda);
 
     override
         .getExperimental()
@@ -298,6 +299,17 @@ public class BrokerBasedPropertiesOverride {
     final var messagesCfg = override.getExperimental().getEngine().getMessages();
     messagesCfg.setTtlCheckerBatchLimit(messages.getTtlCheckerBatchLimit());
     messagesCfg.setTtlCheckerInterval(messages.getTtlCheckerInterval());
+  }
+
+  private static void populateFromUsageMetrics(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var usageMetrics = camunda.getProcessing().getEngine().getUsageMetrics();
+
+    override
+        .getExperimental()
+        .getEngine()
+        .getUsageMetrics()
+        .setExportInterval(usageMetrics.getExportInterval());
   }
 
   private static void populateFromBatchOperations(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -257,6 +257,7 @@ public class BrokerBasedPropertiesOverride {
     populateFromExpression(override, camunda);
     populateFromProcessInstanceCreation(override, camunda);
     populateFromJobs(override, camunda);
+    populateFromCaches(override, camunda);
   }
 
   private static void populateFromDistribution(
@@ -266,6 +267,21 @@ public class BrokerBasedPropertiesOverride {
     final var distributionCfg = override.getExperimental().getEngine().getDistribution();
     distributionCfg.setMaxBackoffDuration(distribution.getMaxBackoffDuration());
     distributionCfg.setRedistributionInterval(distribution.getRedistributionInterval());
+  }
+
+  private static void populateFromCaches(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var caches = camunda.getProcessing().getEngine().getCaches();
+
+    final var cachesCfg = override.getExperimental().getEngine().getCaches();
+    cachesCfg.setDrgCacheCapacity(caches.getDrgCacheCapacity());
+    cachesCfg.setFormCacheCapacity(caches.getFormCacheCapacity());
+    cachesCfg.setProcessCacheCapacity(caches.getProcessCacheCapacity());
+    cachesCfg.setResourceCacheCapacity(caches.getResourceCacheCapacity());
+    cachesCfg.setAuthorizationsCacheCapacity(caches.getAuthorizationsCacheCapacity());
+    cachesCfg.setAuthorizationsCacheTtl(caches.getAuthorizationsCacheTtl());
+    cachesCfg.setGroupNameCacheCapacity(caches.getGroupNameCacheCapacity());
+    cachesCfg.setCandidateGroupNameResolution(caches.isCandidateGroupNameResolution());
   }
 
   private static void populateFromBatchOperations(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -258,6 +258,7 @@ public class BrokerBasedPropertiesOverride {
     populateFromProcessInstanceCreation(override, camunda);
     populateFromJobs(override, camunda);
     populateFromCaches(override, camunda);
+    populateFromMessages(override, camunda);
 
     override
         .getExperimental()
@@ -288,6 +289,15 @@ public class BrokerBasedPropertiesOverride {
     cachesCfg.setAuthorizationsCacheTtl(caches.getAuthorizationsCacheTtl());
     cachesCfg.setGroupNameCacheCapacity(caches.getGroupNameCacheCapacity());
     cachesCfg.setCandidateGroupNameResolution(caches.isCandidateGroupNameResolution());
+  }
+
+  private static void populateFromMessages(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var messages = camunda.getProcessing().getEngine().getMessages();
+
+    final var messagesCfg = override.getExperimental().getEngine().getMessages();
+    messagesCfg.setTtlCheckerBatchLimit(messages.getTtlCheckerBatchLimit());
+    messagesCfg.setTtlCheckerInterval(messages.getTtlCheckerInterval());
   }
 
   private static void populateFromBatchOperations(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -267,6 +267,7 @@ public class BrokerBasedPropertiesOverride {
     final var distributionCfg = override.getExperimental().getEngine().getDistribution();
     distributionCfg.setMaxBackoffDuration(distribution.getMaxBackoffDuration());
     distributionCfg.setRedistributionInterval(distribution.getRedistributionInterval());
+    distributionCfg.setPauseCommandDistribution(distribution.isPauseCommandDistribution());
   }
 
   private static void populateFromCaches(

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -260,6 +260,7 @@ public class BrokerBasedPropertiesOverride {
     populateFromCaches(override, camunda);
     populateFromMessages(override, camunda);
     populateFromUsageMetrics(override, camunda);
+    populateFromValidators(override, camunda);
 
     override
         .getExperimental()
@@ -310,6 +311,17 @@ public class BrokerBasedPropertiesOverride {
         .getEngine()
         .getUsageMetrics()
         .setExportInterval(usageMetrics.getExportInterval());
+  }
+
+  private static void populateFromValidators(
+      final BrokerBasedProperties override, final Camunda camunda) {
+    final var validators = camunda.getProcessing().getEngine().getValidators();
+
+    override
+        .getExperimental()
+        .getEngine()
+        .getValidators()
+        .setResultsOutputMaxSize(validators.getResultsOutputMaxSize());
   }
 
   private static void populateFromBatchOperations(

--- a/configuration/src/test/java/io/camunda/configuration/DistributionTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/DistributionTest.java
@@ -32,6 +32,7 @@ public class DistributionTest {
       properties = {
         "camunda.processing.engine.distribution.max-backoff-duration=10m",
         "camunda.processing.engine.distribution.redistribution-interval=20s",
+        "camunda.processing.engine.distribution.pause-command-distribution=true",
       })
   class WithOnlyUnifiedConfigSet {
     final BrokerBasedProperties brokerCfg;
@@ -44,7 +45,8 @@ public class DistributionTest {
     void shouldSetDistribution() {
       assertThat(brokerCfg.getExperimental().getEngine().getDistribution())
           .returns(Duration.ofMinutes(10), DistributionCfg::getMaxBackoffDuration)
-          .returns(Duration.ofSeconds(20), DistributionCfg::getRedistributionInterval);
+          .returns(Duration.ofSeconds(20), DistributionCfg::getRedistributionInterval)
+          .returns(true, DistributionCfg::isPauseCommandDistribution);
     }
   }
 
@@ -52,7 +54,8 @@ public class DistributionTest {
   @TestPropertySource(
       properties = {
         "zeebe.broker.experimental.engine.distribution.maxBackoffDuration=10m",
-        "zeebe.broker.experimental.engine.distribution.redistributionInterval=20s"
+        "zeebe.broker.experimental.engine.distribution.redistributionInterval=20s",
+        "zeebe.broker.experimental.engine.distribution.pauseCommandDistribution=true"
       })
   class WithOnlyLegacySet {
     final BrokerBasedProperties brokerCfg;
@@ -65,7 +68,8 @@ public class DistributionTest {
     void shouldSetDistributionFromLegacy() {
       assertThat(brokerCfg.getExperimental().getEngine().getDistribution())
           .returns(Duration.ofMinutes(10), DistributionCfg::getMaxBackoffDuration)
-          .returns(Duration.ofSeconds(20), DistributionCfg::getRedistributionInterval);
+          .returns(Duration.ofSeconds(20), DistributionCfg::getRedistributionInterval)
+          .returns(true, DistributionCfg::isPauseCommandDistribution);
     }
   }
 
@@ -75,9 +79,11 @@ public class DistributionTest {
         // new
         "camunda.processing.engine.distribution.max-backoff-duration=10m",
         "camunda.processing.engine.distribution.redistribution-interval=20s",
+        "camunda.processing.engine.distribution.pause-command-distribution=true",
         // legacy
         "zeebe.broker.experimental.engine.distribution.maxBackoffDuration=99m",
-        "zeebe.broker.experimental.engine.distribution.redistributionInterval=99s"
+        "zeebe.broker.experimental.engine.distribution.redistributionInterval=99s",
+        "zeebe.broker.experimental.engine.distribution.pauseCommandDistribution=false"
       })
   class WithNewAndLegacySet {
     final BrokerBasedProperties brokerCfg;
@@ -90,7 +96,8 @@ public class DistributionTest {
     void shouldSetDistributionFromNew() {
       assertThat(brokerCfg.getExperimental().getEngine().getDistribution())
           .returns(Duration.ofMinutes(10), DistributionCfg::getMaxBackoffDuration)
-          .returns(Duration.ofSeconds(20), DistributionCfg::getRedistributionInterval);
+          .returns(Duration.ofSeconds(20), DistributionCfg::getRedistributionInterval)
+          .returns(true, DistributionCfg::isPauseCommandDistribution);
     }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/EngineCachesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineCachesTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.engine.CachesCfg;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class EngineCachesTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.engine.caches.drg-cache-capacity=10",
+        "camunda.processing.engine.caches.form-cache-capacity=20",
+        "camunda.processing.engine.caches.process-cache-capacity=30",
+        "camunda.processing.engine.caches.resource-cache-capacity=40",
+        "camunda.processing.engine.caches.authorizations-cache-capacity=50",
+        "camunda.processing.engine.caches.authorizations-cache-ttl=5s",
+        "camunda.processing.engine.caches.group-name-cache-capacity=60",
+        "camunda.processing.engine.caches.candidate-group-name-resolution=false",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetCaches() {
+      assertThat(brokerCfg.getExperimental().getEngine().getCaches())
+          .returns(10, CachesCfg::getDrgCacheCapacity)
+          .returns(20, CachesCfg::getFormCacheCapacity)
+          .returns(30, CachesCfg::getProcessCacheCapacity)
+          .returns(40, CachesCfg::getResourceCacheCapacity)
+          .returns(50, CachesCfg::getAuthorizationsCacheCapacity)
+          .returns(Duration.ofSeconds(5), CachesCfg::getAuthorizationsCacheTtl)
+          .returns(60, CachesCfg::getGroupNameCacheCapacity)
+          .returns(false, CachesCfg::isCandidateGroupNameResolution);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.engine.caches.drgCacheCapacity=10",
+        "zeebe.broker.experimental.engine.caches.formCacheCapacity=20",
+        "zeebe.broker.experimental.engine.caches.processCacheCapacity=30",
+        "zeebe.broker.experimental.engine.caches.resourceCacheCapacity=40",
+        "zeebe.broker.experimental.engine.caches.authorizationsCacheCapacity=50",
+        "zeebe.broker.experimental.engine.caches.authorizationsCacheTtl=5s",
+        "zeebe.broker.experimental.engine.caches.groupNameCacheCapacity=60",
+        "zeebe.broker.experimental.engine.caches.candidateGroupNameResolution=false",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetCachesFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getEngine().getCaches())
+          .returns(10, CachesCfg::getDrgCacheCapacity)
+          .returns(20, CachesCfg::getFormCacheCapacity)
+          .returns(30, CachesCfg::getProcessCacheCapacity)
+          .returns(40, CachesCfg::getResourceCacheCapacity)
+          .returns(50, CachesCfg::getAuthorizationsCacheCapacity)
+          .returns(Duration.ofSeconds(5), CachesCfg::getAuthorizationsCacheTtl)
+          .returns(60, CachesCfg::getGroupNameCacheCapacity)
+          .returns(false, CachesCfg::isCandidateGroupNameResolution);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.engine.caches.drg-cache-capacity=10",
+        "camunda.processing.engine.caches.form-cache-capacity=20",
+        "camunda.processing.engine.caches.process-cache-capacity=30",
+        "camunda.processing.engine.caches.resource-cache-capacity=40",
+        "camunda.processing.engine.caches.authorizations-cache-capacity=50",
+        "camunda.processing.engine.caches.authorizations-cache-ttl=5s",
+        "camunda.processing.engine.caches.group-name-cache-capacity=60",
+        "camunda.processing.engine.caches.candidate-group-name-resolution=false",
+        // legacy
+        "zeebe.broker.experimental.engine.caches.drgCacheCapacity=100",
+        "zeebe.broker.experimental.engine.caches.formCacheCapacity=200",
+        "zeebe.broker.experimental.engine.caches.processCacheCapacity=300",
+        "zeebe.broker.experimental.engine.caches.resourceCacheCapacity=400",
+        "zeebe.broker.experimental.engine.caches.authorizationsCacheCapacity=500",
+        "zeebe.broker.experimental.engine.caches.authorizationsCacheTtl=50s",
+        "zeebe.broker.experimental.engine.caches.groupNameCacheCapacity=600",
+        "zeebe.broker.experimental.engine.caches.candidateGroupNameResolution=true",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetCachesFromNew() {
+      assertThat(brokerCfg.getExperimental().getEngine().getCaches())
+          .returns(10, CachesCfg::getDrgCacheCapacity)
+          .returns(20, CachesCfg::getFormCacheCapacity)
+          .returns(30, CachesCfg::getProcessCacheCapacity)
+          .returns(40, CachesCfg::getResourceCacheCapacity)
+          .returns(50, CachesCfg::getAuthorizationsCacheCapacity)
+          .returns(Duration.ofSeconds(5), CachesCfg::getAuthorizationsCacheTtl)
+          .returns(60, CachesCfg::getGroupNameCacheCapacity)
+          .returns(false, CachesCfg::isCandidateGroupNameResolution);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/EngineJobTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineJobTest.java
@@ -12,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
 import io.camunda.configuration.beans.BrokerBasedProperties;
 import io.camunda.zeebe.broker.system.configuration.engine.JobsCfg;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
@@ -24,18 +26,88 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
   UnifiedConfigurationHelper.class
 })
 @ActiveProfiles("broker")
-@TestPropertySource(
-    properties = {"camunda.processing.engine.job.include-variables-in-job-completed-event=true"})
 public class EngineJobTest {
-  final BrokerBasedProperties brokerCfg;
+  @Nested
+  @TestPropertySource(
+      properties = {"camunda.processing.engine.job.include-variables-in-job-completed-event=true"})
+  class IncludeVariablesInJobCompletedEvent {
+    final BrokerBasedProperties brokerCfg;
 
-  EngineJobTest(@Autowired final BrokerBasedProperties brokerCfg) {
-    this.brokerCfg = brokerCfg;
+    IncludeVariablesInJobCompletedEvent(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetJobs() {
+      assertThat(brokerCfg.getExperimental().getEngine().getJobs())
+          .returns(true, JobsCfg::isIncludeVariablesInJobCompletedEvent);
+    }
   }
 
-  @Test
-  void shouldSetJobs() {
-    assertThat(brokerCfg.getExperimental().getEngine().getJobs())
-        .returns(true, JobsCfg::isIncludeVariablesInJobCompletedEvent);
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.engine.job.timeout-checker-batch-limit=50",
+        "camunda.processing.engine.job.timeout-checker-polling-interval=2s",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetTimeoutChecker() {
+      assertThat(brokerCfg.getExperimental().getEngine().getJobs())
+          .returns(50, JobsCfg::getTimeoutCheckerBatchLimit)
+          .returns(Duration.ofSeconds(2), JobsCfg::getTimeoutCheckerPollingInterval);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.engine.jobs.timeoutCheckerBatchLimit=50",
+        "zeebe.broker.experimental.engine.jobs.timeoutCheckerPollingInterval=2s",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetTimeoutCheckerFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getEngine().getJobs())
+          .returns(50, JobsCfg::getTimeoutCheckerBatchLimit)
+          .returns(Duration.ofSeconds(2), JobsCfg::getTimeoutCheckerPollingInterval);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.engine.job.timeout-checker-batch-limit=50",
+        "camunda.processing.engine.job.timeout-checker-polling-interval=2s",
+        // legacy
+        "zeebe.broker.experimental.engine.jobs.timeoutCheckerBatchLimit=500",
+        "zeebe.broker.experimental.engine.jobs.timeoutCheckerPollingInterval=20s",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetTimeoutCheckerFromNew() {
+      assertThat(brokerCfg.getExperimental().getEngine().getJobs())
+          .returns(50, JobsCfg::getTimeoutCheckerBatchLimit)
+          .returns(Duration.ofSeconds(2), JobsCfg::getTimeoutCheckerPollingInterval);
+    }
   }
 }

--- a/configuration/src/test/java/io/camunda/configuration/EngineMessagesTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineMessagesTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.engine.MessagesCfg;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class EngineMessagesTest {
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "camunda.processing.engine.messages.ttl-checker-batch-limit=50",
+        "camunda.processing.engine.messages.ttl-checker-interval=2m",
+      })
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMessages() {
+      assertThat(brokerCfg.getExperimental().getEngine().getMessages())
+          .returns(50, MessagesCfg::getTtlCheckerBatchLimit)
+          .returns(Duration.ofMinutes(2), MessagesCfg::getTtlCheckerInterval);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        "zeebe.broker.experimental.engine.messages.ttlCheckerBatchLimit=50",
+        "zeebe.broker.experimental.engine.messages.ttlCheckerInterval=2m",
+      })
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMessagesFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getEngine().getMessages())
+          .returns(50, MessagesCfg::getTtlCheckerBatchLimit)
+          .returns(Duration.ofMinutes(2), MessagesCfg::getTtlCheckerInterval);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.engine.messages.ttl-checker-batch-limit=50",
+        "camunda.processing.engine.messages.ttl-checker-interval=2m",
+        // legacy
+        "zeebe.broker.experimental.engine.messages.ttlCheckerBatchLimit=500",
+        "zeebe.broker.experimental.engine.messages.ttlCheckerInterval=20m",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMessagesFromNew() {
+      assertThat(brokerCfg.getExperimental().getEngine().getMessages())
+          .returns(50, MessagesCfg::getTtlCheckerBatchLimit)
+          .returns(Duration.ofMinutes(2), MessagesCfg::getTtlCheckerInterval);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/EngineTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.engine.EngineCfg;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class EngineTest {
+  @Nested
+  @TestPropertySource(properties = {"camunda.processing.engine.max-process-depth=5"})
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMaxProcessDepth() {
+      assertThat(brokerCfg.getExperimental().getEngine()).returns(5, EngineCfg::getMaxProcessDepth);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"zeebe.broker.experimental.engine.maxProcessDepth=5"})
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMaxProcessDepthFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getEngine()).returns(5, EngineCfg::getMaxProcessDepth);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.engine.max-process-depth=5",
+        // legacy
+        "zeebe.broker.experimental.engine.maxProcessDepth=50",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetMaxProcessDepthFromNew() {
+      assertThat(brokerCfg.getExperimental().getEngine()).returns(5, EngineCfg::getMaxProcessDepth);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/EngineUsageMetricsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineUsageMetricsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.engine.UsageMetricsCfg;
+import java.time.Duration;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class EngineUsageMetricsTest {
+  @Nested
+  @TestPropertySource(properties = {"camunda.processing.engine.usage-metrics.export-interval=10m"})
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetUsageMetrics() {
+      assertThat(brokerCfg.getExperimental().getEngine().getUsageMetrics())
+          .returns(Duration.ofMinutes(10), UsageMetricsCfg::getExportInterval);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {"zeebe.broker.experimental.engine.usageMetrics.exportInterval=10m"})
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetUsageMetricsFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getEngine().getUsageMetrics())
+          .returns(Duration.ofMinutes(10), UsageMetricsCfg::getExportInterval);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.engine.usage-metrics.export-interval=10m",
+        // legacy
+        "zeebe.broker.experimental.engine.usageMetrics.exportInterval=100m",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetUsageMetricsFromNew() {
+      assertThat(brokerCfg.getExperimental().getEngine().getUsageMetrics())
+          .returns(Duration.ofMinutes(10), UsageMetricsCfg::getExportInterval);
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/EngineValidatorsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/EngineValidatorsTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.configuration.beanoverrides.BrokerBasedPropertiesOverride;
+import io.camunda.configuration.beans.BrokerBasedProperties;
+import io.camunda.zeebe.broker.system.configuration.engine.ValidatorsCfg;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({
+  UnifiedConfiguration.class,
+  BrokerBasedPropertiesOverride.class,
+  UnifiedConfigurationHelper.class
+})
+@ActiveProfiles("broker")
+public class EngineValidatorsTest {
+  @Nested
+  @TestPropertySource(
+      properties = {"camunda.processing.engine.validators.results-output-max-size=1024"})
+  class WithOnlyUnifiedConfigSet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyUnifiedConfigSet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetValidators() {
+      assertThat(brokerCfg.getExperimental().getEngine().getValidators())
+          .returns(1024, ValidatorsCfg::getResultsOutputMaxSize);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {"zeebe.broker.experimental.engine.validators.resultsOutputMaxSize=1024"})
+  class WithOnlyLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithOnlyLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetValidatorsFromLegacy() {
+      assertThat(brokerCfg.getExperimental().getEngine().getValidators())
+          .returns(1024, ValidatorsCfg::getResultsOutputMaxSize);
+    }
+  }
+
+  @Nested
+  @TestPropertySource(
+      properties = {
+        // new
+        "camunda.processing.engine.validators.results-output-max-size=1024",
+        // legacy
+        "zeebe.broker.experimental.engine.validators.resultsOutputMaxSize=10240",
+      })
+  class WithNewAndLegacySet {
+    final BrokerBasedProperties brokerCfg;
+
+    WithNewAndLegacySet(@Autowired final BrokerBasedProperties brokerCfg) {
+      this.brokerCfg = brokerCfg;
+    }
+
+    @Test
+    void shouldSetValidatorsFromNew() {
+      assertThat(brokerCfg.getExperimental().getEngine().getValidators())
+          .returns(1024, ValidatorsCfg::getResultsOutputMaxSize);
+    }
+  }
+}

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -286,6 +286,7 @@ processing.engine.distribution.redistribution-interval
 processing.engine.job.include-variables-in-job-completed-event
 processing.engine.job.timeout-checker-batch-limit
 processing.engine.job.timeout-checker-polling-interval
+processing.engine.max-process-depth
 processing.flow-control.request.aimd.backoff-ratio
 processing.flow-control.request.aimd.initial-limit
 processing.flow-control.request.aimd.max-limit

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -272,6 +272,14 @@ processing.engine.batch-operations.query-retry-initial-delay
 processing.engine.batch-operations.query-retry-max
 processing.engine.batch-operations.query-retry-max-delay
 processing.engine.batch-operations.scheduler-interval
+processing.engine.caches.authorizations-cache-capacity
+processing.engine.caches.authorizations-cache-ttl
+processing.engine.caches.candidate-group-name-resolution
+processing.engine.caches.drg-cache-capacity
+processing.engine.caches.form-cache-capacity
+processing.engine.caches.group-name-cache-capacity
+processing.engine.caches.process-cache-capacity
+processing.engine.caches.resource-cache-capacity
 processing.engine.distribution.max-backoff-duration
 processing.engine.distribution.redistribution-interval
 processing.engine.job.include-variables-in-job-completed-event

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -287,6 +287,8 @@ processing.engine.job.include-variables-in-job-completed-event
 processing.engine.job.timeout-checker-batch-limit
 processing.engine.job.timeout-checker-polling-interval
 processing.engine.max-process-depth
+processing.engine.messages.ttl-checker-batch-limit
+processing.engine.messages.ttl-checker-interval
 processing.flow-control.request.aimd.backoff-ratio
 processing.flow-control.request.aimd.initial-limit
 processing.flow-control.request.aimd.max-limit

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -290,6 +290,7 @@ processing.engine.max-process-depth
 processing.engine.messages.ttl-checker-batch-limit
 processing.engine.messages.ttl-checker-interval
 processing.engine.usage-metrics.export-interval
+processing.engine.validators.results-output-max-size
 processing.flow-control.request.aimd.backoff-ratio
 processing.flow-control.request.aimd.initial-limit
 processing.flow-control.request.aimd.max-limit

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -289,6 +289,7 @@ processing.engine.job.timeout-checker-polling-interval
 processing.engine.max-process-depth
 processing.engine.messages.ttl-checker-batch-limit
 processing.engine.messages.ttl-checker-interval
+processing.engine.usage-metrics.export-interval
 processing.flow-control.request.aimd.backoff-ratio
 processing.flow-control.request.aimd.initial-limit
 processing.flow-control.request.aimd.max-limit

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -281,6 +281,7 @@ processing.engine.caches.group-name-cache-capacity
 processing.engine.caches.process-cache-capacity
 processing.engine.caches.resource-cache-capacity
 processing.engine.distribution.max-backoff-duration
+processing.engine.distribution.pause-command-distribution
 processing.engine.distribution.redistribution-interval
 processing.engine.job.include-variables-in-job-completed-event
 processing.flow-control.request.aimd.backoff-ratio

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -284,6 +284,8 @@ processing.engine.distribution.max-backoff-duration
 processing.engine.distribution.pause-command-distribution
 processing.engine.distribution.redistribution-interval
 processing.engine.job.include-variables-in-job-completed-event
+processing.engine.job.timeout-checker-batch-limit
+processing.engine.job.timeout-checker-polling-interval
 processing.flow-control.request.aimd.backoff-ratio
 processing.flow-control.request.aimd.initial-limit
 processing.flow-control.request.aimd.max-limit


### PR DESCRIPTION
## Description

Maps 14 of the 15 `zeebe.broker.experimental.engine.*` properties flagged in #56077 into the unified `camunda.processing.engine.*` namespace, following the existing pattern used for sibling properties (`Distribution`, `EngineJob`, `EngineBatchOperation`).

Mapped properties:
- `caches.*` (drg/form/process/resource cache capacity, authorizations cache capacity/ttl) → new `EngineCaches`
- `distribution.pauseCommandDistribution` → added to existing `Distribution`
- `jobs.timeoutCheckerBatchLimit` / `timeoutCheckerPollingInterval` → added to existing `EngineJob`
- `maxProcessDepth` → added directly to `Engine`
- `messages.ttlCheckerBatchLimit` / `ttlCheckerInterval` → new `EngineMessages`
- `usageMetrics.exportInterval` → new `EngineUsageMetrics`
- `validators.resultsOutputMaxSize` → new `EngineValidators`

**Not in this diff:** `globalListeners.userTask` — already migrated in a separate, earlier PR under `camunda.cluster.global-listeners.user-task` (a direct relocation of `GlobalListenersCfg`, wired via `BrokerBasedPropertiesOverride.populateFromGlobalListeners()`). It intentionally has no legacy-key fallback there since it was a straight move, not a new mapping. So all 15 properties from #56077's acceptance criteria are now covered across this PR + the prior one; nothing further needed for that property.

All properties in this diff keep `SUPPORTED` backwards-compatibility mode with their original legacy keys, and the same default values sourced from `EngineConfiguration`. Wiring added in `BrokerBasedPropertiesOverride`, tests added/extended mirroring the existing new-only/legacy-only/both-set pattern.

### Note for reviewers

I could not run the module's Spring/JUnit tests in my environment — `protobuf-maven-plugin` fails locally regenerating `zeebe-gateway-protocol-impl` (`Unable to establish loopback connection`, unrelated to this change), and the cached `.m2` reactor jars are stale relative to current `main`. Code was cross-checked directly against `EngineCfg`/`EngineConfiguration`/legacy `*Cfg` sources for correctness, and `license:format`/`spotless:apply` ran clean on the `configuration` module. Please run `./mvnw verify -pl configuration -am -Dquickly -DskipTests=false` in CI/a clean environment before merging.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #56077
