### PR TITLE
Extend lease token support to job update commands

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateJobCommandStep1.java
@@ -99,5 +99,28 @@ public interface UpdateJobCommandStep1 {
 
   interface UpdateJobCommandStep2 extends FinalCommandStep<UpdateJobResponse> {
     // the place for new optional parameters
+
+    /**
+     * Sets the lease token identifying the job's activation, fencing this command against a
+     * superseded activation of the same job. Obtain it from {@link
+     * io.camunda.client.api.response.ActivatedJob#getLeaseToken() ActivatedJob#getLeaseToken()}.
+     *
+     * <p>For a leased job, a supplied token is validated to prove the command comes from the worker
+     * that holds the current lease; a command carrying a stale token is rejected, fencing the job
+     * against a superseded activation (e.g. after the job timed out or failed and was re-activated
+     * by another worker). An update without a token always applies, to support operator and bulk
+     * updates of leased jobs; this differs from lifecycle commands like complete, fail, and
+     * throw-error, which always require a token for leased jobs. A job that was activated without a
+     * lease requires no token.
+     *
+     * <p>When this command is created from an activated job (e.g. {@code
+     * newUpdateJobCommand(activatedJob)}) the job's lease token is carried automatically, so this
+     * method is only needed when building the command from a job key.
+     *
+     * @param leaseToken the opaque lease token the worker received when the job was activated
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    UpdateJobCommandStep2 withLeaseToken(String leaseToken);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateJobPriorityCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateJobPriorityCommandStep1.java
@@ -33,5 +33,28 @@ public interface UpdateJobPriorityCommandStep1
       extends CommandWithOperationReferenceStep<UpdateJobPriorityCommandStep2>,
           FinalCommandStep<UpdateJobPriorityResponse> {
     // the place for new optional parameters
+
+    /**
+     * Sets the lease token identifying the job's activation, fencing this command against a
+     * superseded activation of the same job. Obtain it from {@link
+     * io.camunda.client.api.response.ActivatedJob#getLeaseToken() ActivatedJob#getLeaseToken()}.
+     *
+     * <p>For a leased job, a supplied token is validated to prove the command comes from the worker
+     * that holds the current lease; a command carrying a stale token is rejected, fencing the job
+     * against a superseded activation (e.g. after the job timed out or failed and was re-activated
+     * by another worker). An update without a token always applies, to support operator and bulk
+     * updates of leased jobs; this differs from lifecycle commands like complete, fail, and
+     * throw-error, which always require a token for leased jobs. A job that was activated without a
+     * lease requires no token.
+     *
+     * <p>When this command is created from an activated job (e.g. {@code
+     * newUpdateJobPriorityCommand(activatedJob)}) the job's lease token is carried automatically,
+     * so this method is only needed when building the command from a job key.
+     *
+     * @param leaseToken the opaque lease token the worker received when the job was activated
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    UpdateJobPriorityCommandStep2 withLeaseToken(String leaseToken);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateRetriesJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateRetriesJobCommandStep1.java
@@ -35,5 +35,28 @@ public interface UpdateRetriesJobCommandStep1
       extends CommandWithOperationReferenceStep<UpdateRetriesJobCommandStep2>,
           FinalCommandStep<UpdateRetriesJobResponse> {
     // the place for new optional parameters
+
+    /**
+     * Sets the lease token identifying the job's activation, fencing this command against a
+     * superseded activation of the same job. Obtain it from {@link
+     * io.camunda.client.api.response.ActivatedJob#getLeaseToken() ActivatedJob#getLeaseToken()}.
+     *
+     * <p>For a leased job, a supplied token is validated to prove the command comes from the worker
+     * that holds the current lease; a command carrying a stale token is rejected, fencing the job
+     * against a superseded activation (e.g. after the job timed out or failed and was re-activated
+     * by another worker). An update without a token always applies, to support operator and bulk
+     * updates of leased jobs; this differs from lifecycle commands like complete, fail, and
+     * throw-error, which always require a token for leased jobs. A job that was activated without a
+     * lease requires no token.
+     *
+     * <p>When this command is created from an activated job (e.g. {@code
+     * newUpdateRetriesCommand(activatedJob)}) the job's lease token is carried automatically, so
+     * this method is only needed when building the command from a job key.
+     *
+     * @param leaseToken the opaque lease token the worker received when the job was activated
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    UpdateRetriesJobCommandStep2 withLeaseToken(String leaseToken);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -844,7 +844,10 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public UpdateRetriesJobCommandStep1 newUpdateRetriesCommand(final ActivatedJob job) {
-    return newUpdateRetriesCommand(job.getKey());
+    final JobUpdateRetriesCommandImpl command =
+        (JobUpdateRetriesCommandImpl) newUpdateRetriesCommand(job.getKey());
+    command.withLeaseToken(job.getLeaseToken());
+    return command;
   }
 
   @Override
@@ -881,7 +884,10 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public UpdateJobPriorityCommandStep1 newUpdateJobPriorityCommand(final ActivatedJob job) {
-    return newUpdateJobPriorityCommand(job.getKey());
+    final JobUpdatePriorityCommandImpl command =
+        (JobUpdatePriorityCommandImpl) newUpdateJobPriorityCommand(job.getKey());
+    command.withLeaseToken(job.getLeaseToken());
+    return command;
   }
 
   @Override
@@ -933,7 +939,9 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public UpdateJobCommandStep1 newUpdateJobCommand(final ActivatedJob job) {
-    return newUpdateJobCommand(job.getKey());
+    final UpdateJobCommandImpl command = (UpdateJobCommandImpl) newUpdateJobCommand(job.getKey());
+    command.withLeaseToken(job.getLeaseToken());
+    return command;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdatePriorityCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdatePriorityCommandImpl.java
@@ -138,6 +138,11 @@ public final class JobUpdatePriorityCommandImpl
   }
 
   @Override
+  public UpdateJobPriorityCommandStep2 withLeaseToken(final String leaseToken) {
+    return this;
+  }
+
+  @Override
   public UpdateJobPriorityCommandStep1 useRest() {
     useRest = true;
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdatePriorityCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdatePriorityCommandImpl.java
@@ -139,6 +139,11 @@ public final class JobUpdatePriorityCommandImpl
 
   @Override
   public UpdateJobPriorityCommandStep2 withLeaseToken(final String leaseToken) {
+    if (leaseToken == null) {
+      return this;
+    }
+    grpcRequestObjectBuilder.setLeaseToken(leaseToken);
+    httpRequestObject.setLeaseToken(leaseToken);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateRetriesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateRetriesCommandImpl.java
@@ -138,6 +138,11 @@ public final class JobUpdateRetriesCommandImpl
 
   @Override
   public UpdateRetriesJobCommandStep2 withLeaseToken(final String leaseToken) {
+    if (leaseToken == null) {
+      return this;
+    }
+    grpcRequestObjectBuilder.setLeaseToken(leaseToken);
+    httpRequestObject.setLeaseToken(leaseToken);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateRetriesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/JobUpdateRetriesCommandImpl.java
@@ -137,6 +137,11 @@ public final class JobUpdateRetriesCommandImpl
   }
 
   @Override
+  public UpdateRetriesJobCommandStep2 withLeaseToken(final String leaseToken) {
+    return this;
+  }
+
+  @Override
   public UpdateRetriesJobCommandStep1 useRest() {
     useRest = true;
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateJobCommandImpl.java
@@ -108,6 +108,11 @@ public class UpdateJobCommandImpl implements UpdateJobCommandStep1, UpdateJobCom
     return this;
   }
 
+  @Override
+  public UpdateJobCommandStep2 withLeaseToken(final String leaseToken) {
+    return this;
+  }
+
   private io.camunda.client.protocol.rest.JobChangeset getChangesetEnsureInitialized() {
 
     io.camunda.client.protocol.rest.JobChangeset changeset = httpRequestObject.getChangeset();

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateJobCommandImpl.java
@@ -110,6 +110,10 @@ public class UpdateJobCommandImpl implements UpdateJobCommandStep1, UpdateJobCom
 
   @Override
   public UpdateJobCommandStep2 withLeaseToken(final String leaseToken) {
+    if (leaseToken == null) {
+      return this;
+    }
+    httpRequestObject.setLeaseToken(leaseToken);
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/job/JobUpdatePriorityTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/JobUpdatePriorityTest.java
@@ -64,6 +64,70 @@ public final class JobUpdatePriorityTest extends ClientTest {
   }
 
   @Test
+  public void shouldUpdatePriorityWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newUpdateJobPriorityCommand(jobKey).priority(5).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final UpdateJobPriorityRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJob() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newUpdateJobPriorityCommand(job).priority(5).send().join();
+
+    // then
+    final UpdateJobPriorityRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected the activated job's lease token to be carried automatically")
+        .isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOne() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newUpdateJobPriorityCommand(job).priority(5).send().join();
+
+    // then
+    final UpdateJobPriorityRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected no lease token when the activated job carries none")
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKey() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newUpdateJobPriorityCommand(jobKey).priority(5).send().join();
+
+    // then
+    final UpdateJobPriorityRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected no lease token when the command is built from a job key")
+        .isEmpty();
+  }
+
+  @Test
   public void shouldSetRequestTimeout() {
     // given
     final Duration requestTimeout = Duration.ofHours(124);

--- a/clients/java/src/test/java/io/camunda/client/job/JobUpdateRetriesTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/JobUpdateRetriesTest.java
@@ -64,6 +64,70 @@ public final class JobUpdateRetriesTest extends ClientTest {
   }
 
   @Test
+  public void shouldUpdateRetriesWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newUpdateRetriesCommand(jobKey).retries(3).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final UpdateJobRetriesRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJob() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newUpdateRetriesCommand(job).retries(3).send().join();
+
+    // then
+    final UpdateJobRetriesRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected the activated job's lease token to be carried automatically")
+        .isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOne() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newUpdateRetriesCommand(job).retries(3).send().join();
+
+    // then
+    final UpdateJobRetriesRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected no lease token when the activated job carries none")
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKey() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newUpdateRetriesCommand(jobKey).retries(3).send().join();
+
+    // then
+    final UpdateJobRetriesRequest request = gatewayService.getLastRequest();
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected no lease token when the command is built from a job key")
+        .isEmpty();
+  }
+
+  @Test
   public void shouldSetRequestTimeout() {
     // given
     final Duration requestTimeout = Duration.ofHours(124);

--- a/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/JobUpdateRestTest.java
@@ -535,4 +535,196 @@ public class JobUpdateRestTest extends ClientRestTest {
     assertThat(request.getChangeset().getRetries()).isNull();
     assertThat(request.getChangeset().getTimeout()).isNull();
   }
+
+  @Test
+  public void shouldUpdateJobCommandWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newUpdateJobCommand(jobKey).updateRetries(3).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJobForUpdateJobCommand() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newUpdateJobCommand(job).updateRetries(3).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected the activated job's lease token to be carried automatically")
+        .isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOneForUpdateJobCommand() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newUpdateJobCommand(job).updateRetries(3).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected no lease token when the activated job carries none")
+        .isNull();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKeyForUpdateJobCommand() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newUpdateJobCommand(jobKey).updateRetries(3).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected no lease token when the command is built from a job key")
+        .isNull();
+  }
+
+  @Test
+  public void shouldUpdateRetriesWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newUpdateRetriesCommand(jobKey).retries(3).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJobForUpdateRetriesCommand() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newUpdateRetriesCommand(job).retries(3).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected the activated job's lease token to be carried automatically")
+        .isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOneForUpdateRetriesCommand() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newUpdateRetriesCommand(job).retries(3).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected no lease token when the activated job carries none")
+        .isNull();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKeyForUpdateRetriesCommand() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newUpdateRetriesCommand(jobKey).retries(3).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected no lease token when the command is built from a job key")
+        .isNull();
+  }
+
+  @Test
+  public void shouldUpdatePriorityWithLeaseToken() {
+    // given
+    final long jobKey = 12;
+    final String leaseToken = "lease-token";
+
+    // when
+    client.newUpdateJobPriorityCommand(jobKey).priority(5).withLeaseToken(leaseToken).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken()).isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldCarryLeaseTokenFromActivatedJobForUpdateJobPriorityCommand() {
+    // given
+    final String leaseToken = "lease-token";
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(leaseToken);
+
+    // when
+    client.newUpdateJobPriorityCommand(job).priority(5).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected the activated job's lease token to be carried automatically")
+        .isEqualTo(leaseToken);
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenFromActivatedJobWithoutOneForUpdateJobPriorityCommand() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+    Mockito.when(job.getLeaseToken()).thenReturn(null);
+
+    // when
+    client.newUpdateJobPriorityCommand(job).priority(5).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected no lease token when the activated job carries none")
+        .isNull();
+  }
+
+  @Test
+  public void shouldNotCarryLeaseTokenByJobKeyForUpdateJobPriorityCommand() {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newUpdateJobPriorityCommand(jobKey).priority(5).send().join();
+
+    // then
+    final JobUpdateRequest request = gatewayService.getLastRequest(JobUpdateRequest.class);
+    assertThat(request.getLeaseToken())
+        .describedAs("Expected no lease token when the command is built from a job key")
+        .isNull();
+  }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -151,8 +151,10 @@ public final class RequestMapper extends RequestUtil {
   public static BrokerUpdateJobRetriesRequest toUpdateJobRetriesRequest(
       final UpdateJobRetriesRequest grpcRequest) {
     final var brokerRequest =
-        new BrokerUpdateJobRetriesRequest(grpcRequest.getJobKey(), grpcRequest.getRetries())
-            .setLeaseToken(grpcRequest.getLeaseToken());
+        new BrokerUpdateJobRetriesRequest(grpcRequest.getJobKey(), grpcRequest.getRetries());
+    if (grpcRequest.hasLeaseToken()) {
+      brokerRequest.setLeaseToken(grpcRequest.getLeaseToken());
+    }
     if (grpcRequest.hasOperationReference()) {
       brokerRequest.setOperationReference(grpcRequest.getOperationReference());
     }
@@ -179,8 +181,10 @@ public final class RequestMapper extends RequestUtil {
           "Expected to update job priority, but priority must be provided");
     }
     final var brokerRequest =
-        new BrokerUpdateJobRequest(grpcRequest.getJobKey(), null, null, grpcRequest.getPriority())
-            .setLeaseToken(grpcRequest.getLeaseToken());
+        new BrokerUpdateJobRequest(grpcRequest.getJobKey(), null, null, grpcRequest.getPriority());
+    if (grpcRequest.hasLeaseToken()) {
+      brokerRequest.setLeaseToken(grpcRequest.getLeaseToken());
+    }
     if (grpcRequest.hasOperationReference()) {
       brokerRequest.setOperationReference(grpcRequest.getOperationReference());
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -151,7 +151,8 @@ public final class RequestMapper extends RequestUtil {
   public static BrokerUpdateJobRetriesRequest toUpdateJobRetriesRequest(
       final UpdateJobRetriesRequest grpcRequest) {
     final var brokerRequest =
-        new BrokerUpdateJobRetriesRequest(grpcRequest.getJobKey(), grpcRequest.getRetries());
+        new BrokerUpdateJobRetriesRequest(grpcRequest.getJobKey(), grpcRequest.getRetries())
+            .setLeaseToken(grpcRequest.getLeaseToken());
     if (grpcRequest.hasOperationReference()) {
       brokerRequest.setOperationReference(grpcRequest.getOperationReference());
     }
@@ -178,7 +179,8 @@ public final class RequestMapper extends RequestUtil {
           "Expected to update job priority, but priority must be provided");
     }
     final var brokerRequest =
-        new BrokerUpdateJobRequest(grpcRequest.getJobKey(), null, null, grpcRequest.getPriority());
+        new BrokerUpdateJobRequest(grpcRequest.getJobKey(), null, null, grpcRequest.getPriority())
+            .setLeaseToken(grpcRequest.getLeaseToken());
     if (grpcRequest.hasOperationReference()) {
       brokerRequest.setOperationReference(grpcRequest.getOperationReference());
     }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -22,8 +22,11 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.FailJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobPriorityRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
 import io.camunda.zeebe.gateway.validation.VariableNameLengthValidator;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.TenantFilter;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -1077,6 +1080,84 @@ public class RequestMapperTest {
 
       // then
       assertThat(brokerRequest.getRequestWriter().getLeaseToken()).isEmpty();
+    }
+  }
+
+  @Nested
+  class UpdateJobRetriesRequestLeaseTokenTest {
+
+    @Test
+    public void shouldMapLeaseTokenToBrokerRequest() {
+      // given
+      final var grpcRequest =
+          UpdateJobRetriesRequest.newBuilder()
+              .setJobKey(123L)
+              .setRetries(5)
+              .setLeaseToken("lease-token-4")
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toUpdateJobRetriesRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getLeaseToken()).isEqualTo("lease-token-4");
+    }
+
+    @Test
+    public void shouldNotSetLeaseTokenByDefault() {
+      // given
+      final var grpcRequest =
+          UpdateJobRetriesRequest.newBuilder().setJobKey(123L).setRetries(5).build();
+
+      // when
+      final var brokerRequest = RequestMapper.toUpdateJobRetriesRequest(grpcRequest);
+
+      // then
+      assertThat(brokerRequest.getRequestWriter().getLeaseToken())
+          .describedAs(
+              "Expected no lease token on the broker request when the gRPC request omits it")
+          .isEmpty();
+    }
+  }
+
+  @Nested
+  class UpdateJobPriorityRequestLeaseTokenTest {
+
+    @Test
+    public void shouldMapLeaseTokenToBrokerRequest() {
+      // given
+      final var grpcRequest =
+          UpdateJobPriorityRequest.newBuilder()
+              .setJobKey(123L)
+              .setPriority(5)
+              .setLeaseToken("lease-token-4")
+              .build();
+
+      // when
+      final var brokerRequest = RequestMapper.toUpdateJobPriorityRequest(grpcRequest);
+
+      // then
+      final var requestWriter = (JobRecord) brokerRequest.getRequestWriter();
+      assertThat(requestWriter.getLeaseToken()).isEqualTo("lease-token-4");
+    }
+
+    @Test
+    public void shouldNotSetLeaseTokenByDefault() {
+      // given
+      // priority must still be set: toUpdateJobPriorityRequest requires it regardless of
+      // leaseToken, so this proves absence of a leaseToken specifically, not absence of priority
+      final var grpcRequest =
+          UpdateJobPriorityRequest.newBuilder().setJobKey(123L).setPriority(5).build();
+
+      // when
+      final var brokerRequest = RequestMapper.toUpdateJobPriorityRequest(grpcRequest);
+
+      // then
+      final var requestWriter = (JobRecord) brokerRequest.getRequestWriter();
+      assertThat(requestWriter.getLeaseToken())
+          .describedAs(
+              "Expected no lease token on the broker request when the gRPC request omits it")
+          .isEmpty();
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -782,6 +782,15 @@ message UpdateJobRetriesRequest {
   int32 retries = 2;
   // a reference key chosen by the user and will be part of all records resulted from this operation
   optional uint64 operationReference = 3;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, a supplied token is validated to prove the command comes from the worker
+  // that holds the current lease; a command carrying a stale token is rejected, fencing the job
+  // against a superseded activation (e.g. after the job timed out or failed and was re-activated
+  // by another worker). An update without a token always applies, to support operator and bulk
+  // updates of leased jobs; this differs from lifecycle commands like complete, fail, and
+  // throw-error, which always require a token for leased jobs. A job that was activated without a
+  // lease requires no token.
+  string leaseToken = 4;
 }
 
 message UpdateJobRetriesResponse {
@@ -815,6 +824,15 @@ message UpdateJobPriorityRequest {
   optional int32 priority = 2;
   // a reference key chosen by the user and will be part of all records resulted from this operation
   optional uint64 operationReference = 3;
+  // the token identifying a leased job's activation, obtained from ActivatedJob.leaseToken.
+  // For a leased job, a supplied token is validated to prove the command comes from the worker
+  // that holds the current lease; a command carrying a stale token is rejected, fencing the job
+  // against a superseded activation (e.g. after the job timed out or failed and was re-activated
+  // by another worker). An update without a token always applies, to support operator and bulk
+  // updates of leased jobs; this differs from lifecycle commands like complete, fail, and
+  // throw-error, which always require a token for leased jobs. A job that was activated without a
+  // lease requires no token.
+  string leaseToken = 4;
 }
 
 message UpdateJobPriorityResponse {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -790,7 +790,7 @@ message UpdateJobRetriesRequest {
   // updates of leased jobs; this differs from lifecycle commands like complete, fail, and
   // throw-error, which always require a token for leased jobs. A job that was activated without a
   // lease requires no token.
-  string leaseToken = 4;
+  optional string leaseToken = 4;
 }
 
 message UpdateJobRetriesResponse {
@@ -832,7 +832,7 @@ message UpdateJobPriorityRequest {
   // updates of leased jobs; this differs from lifecycle commands like complete, fail, and
   // throw-error, which always require a token for leased jobs. A job that was activated without a
   // lease requires no token.
-  string leaseToken = 4;
+  optional string leaseToken = 4;
 }
 
 message UpdateJobPriorityResponse {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRetriesRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRetriesRequest.java
@@ -23,6 +23,11 @@ public final class BrokerUpdateJobRetriesRequest extends BrokerExecuteCommand<Jo
     requestDto.setRetries(retries);
   }
 
+  public BrokerUpdateJobRetriesRequest setLeaseToken(final String leaseToken) {
+    requestDto.setLeaseToken(leaseToken);
+    return this;
+  }
+
   @Override
   public JobRecord getRequestWriter() {
     return requestDto;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/engine/client/command/UpdateJobTest.java
@@ -401,6 +401,54 @@ public class UpdateJobTest {
         .hasMessageContaining(expectedMessage);
   }
 
+  @Test
+  public void shouldUpdateRetriesOfLeasedJobWithoutLeaseToken(final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    createProcessInstance(jobType);
+    final var job = activateLeasedJob(client, false, jobType);
+    assertThat(job.getLeaseToken())
+        .describedAs("Expected the leased job to carry a lease token")
+        .isNotEmpty();
+    final long jobKey = job.getKey();
+    final int retries = 10;
+
+    // when
+    // property-update commands validate the lease only if one is supplied; an absent token
+    // must proceed even on a leased job (operator/bulk paths)
+    getRetriesCommand(client, false, jobKey).retries(retries).send().join();
+
+    // then
+    assertRetriesUpdated(jobKey, false, retries);
+  }
+
+  @Test
+  public void shouldRejectUpdateRetriesOfLeasedJobWithWrongLeaseToken(final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    createProcessInstance(jobType);
+    final var job = activateLeasedJob(client, false, jobType);
+    assertThat(job.getLeaseToken())
+        .describedAs("Expected the leased job to carry a lease token")
+        .isNotEmpty();
+    final long jobKey = job.getKey();
+
+    // when / then
+    final var expectedMessage =
+        String.format(
+            "Expected to process job with key '%d', but the supplied lease token does not match. "
+                + "The job may have been re-activated by another worker.",
+            jobKey);
+    assertThatThrownBy(
+            () ->
+                getRetriesCommand(client, false, jobKey)
+                    .retries(10)
+                    .withLeaseToken("wrong-lease-token")
+                    .send()
+                    .join())
+        .hasMessageContaining(expectedMessage);
+  }
+
   private ActivatedJob activateLeasedJob(
       final CamundaClient client, final boolean useRest, final String jobType) {
     final var activateResponse =


### PR DESCRIPTION
## Description

This PR extends job lease token fencing support to job property-update commands in the Zeebe gateway protocol/mappers and the Java client, ensuring lease tokens are not silently dropped when using different transports and that activated-job commands can automatically carry the token.

Java client users currently have **no way to fence** update-retries, update-priority, or generic-update commands — PR2 didn't add a `withLeaseToken` method to those three builders at all, on either transport. This PR closes that gap.

It adds `withLeaseToken` (+ auto-carry from `ActivatedJob`) to all three builders, and `leaseToken` to the two gRPC messages the AC didn't cover — `UpdateJobRetriesRequest` and `UpdateJobPriorityRequest`. The gRPC field isn't optional polish: these builders already support both transports for every other field, so without it, `.useGrpc()` would silently drop fencing while `.useRest()` on the identical call preserved it. Both proto fields are new, optional `string` fields at unused field numbers (4 on each message) — additive, no wire-compatibility risk. The engine is untouched: PR1 already validates a supplied lease on all three property-update processors, so this is pure gateway/client plumbing.

### Scope

Split from PR2 so the AC-exact scope could merge independently. Given the capability gap above, adding the field is the straightforward call — flag if you see a reason these three should stay REST-only instead.

### How it's verified

- **Gateway mapper unit tests** (gRPC): token lands on the broker request when set, isn't set when absent — for `UpdateJobRetriesRequest` (dedicated broker request) and `UpdateJobPriorityRequest` (translated at the gateway into the generic broker request).
- **Java client unit tests** (stub gateway, both transports): `withLeaseToken(…)` and auto-carry put the token on the captured request, for all three builders.
- **Integration test** (gRPC): update-retries — no token accepted, wrong token rejected `INVALID_STATE` — proving the field flows client → gateway → broker → engine end to end. Priority isn't given its own integration test: its gRPC path is translated into the same generic broker request PR2's suite already exercises over REST, so a gRPC-only round-trip wouldn't prove anything the mapper test doesn't already establish.

## Checklist

- [ ] Enable backports when necessary. Not needed — feature, not a bug fix / CI / docs change.

## Related issues

closes #54847