### PR TITLE
ci: graduate flaky-test gate from pilot to blocking

### DIFF
--- a/.github/actions/detect-new-flaky-tests/README.md
+++ b/.github/actions/detect-new-flaky-tests/README.md
@@ -128,10 +128,10 @@ across every kind of subsequent run, so a genuinely fixed test clears by
 re-running CI — no empty commits. It also removed the artifact entirely
 (no retention window, no `actions:` permission).
 
-Trade-offs (accepted for a pilot advisory gate):
+Trade-offs (accepted):
 
 - **Visibility / tamper** — the base64 state is present in the comment source;
-  a maintainer could edit it. The gate is advisory and already has a
+  a maintainer could edit it. The gate already has a
   `ci:flaky-test-bypass` label escape hatch, so this is not a new trust
   boundary.
 - **Concurrency** — two runs finishing at once do last-writer-wins on the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1874,7 +1874,7 @@ jobs:
           pr-flaky-tests-data: '${{ steps.collect-results.outputs.flaky_tests_data || ''[]'' }}'
           known-flaky-tests-file: '${{ steps.query-known-flaky.outputs.known_flaky_tests_file }}'
           pr-number: ${{ github.event.pull_request.number }}
-          blocking: 'false'  # pilot: observe + comment only, do not fail check-results yet
+          blocking: 'true'  # fail check-results when a PR-introduced flake stays active
           ran-jobs-json: ${{ steps.ran-jobs.outputs.json || '[]' }}
           bypass-label-present: ${{ steps.bypass.outputs.present }}
           head-sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## What

Flip the flaky-test gate from pilot (advisory) to **blocking**: set `blocking: 'true'` on the `detect-new-flaky-tests` step (`.github/workflows/ci.yml`). A PR-introduced flaky test that stays active now fails `check-results` and blocks the merge, rather than only posting a comment. README trade-off wording updated to drop "advisory".

## Why now

The gate has run non-blocking since #54579 (2026-06-04). Precision is clean across the whole fix timeline:

| Phase | Window | FP rate |
|---|---|---|
| Sticky-alerts launch | 06-04 → 06-15 | ~56% |
| After #55572 (touch-check + blank-class + retention) | 06-22 → 06-30 | ~25% |
| After #56218 (root-package hole closed) | 06-30 → 07-06 | **0%** (1 alert, 1 TP) |
| **Fresh audit 2026-07-13** | 07-06 → 07-13 | **0%** (2 alerts, 2 TP) |

The 2026-07-13 audit scanned 511 PRs updated in-window; the gate fired exactly 2 alerts, both **true positives**:
- **#57004** — adds `MigrateServiceTaskTest.shouldRetainLeaseTokenWhenMigratingJob`; the test flaked only on its own PR ref, never elsewhere in 60 days.
- **#57370** — adds a brand-new `NonZoneAwareClusterEndpointIT` (+234/-0); zero prior flaky history.

Both alerts also confirmed the two most recent changes work live in production: the durable `<!-- flaky-gate-state:{base64} -->` comment marker (#56732) and the per-test "Verify in BigQuery" block (#57152).

Zero false positives means blocking will not wrongly stop innocent PRs. The `ci:flaky-test-bypass` label remains the escape hatch for a genuine false alarm.

## Mechanism

`detect-new-flaky-tests` has no `continue-on-error` and is a `needs` of `check-results`, which exits non-zero on any failed dependency. With `blocking: 'true'`, an active flake → the step `sys.exit(1)` → job fails → `check-results` fails → merge blocked.