### PR TITLE
feat: fan out @JobWorker registration across all configured clients

### DIFF
--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/event/CamundaClientClosingEvent.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/event/CamundaClientClosingEvent.java
@@ -24,4 +24,11 @@ import io.camunda.client.CamundaClient;
  */
 public interface CamundaClientClosingEvent {
   CamundaClient getClient();
+
+  /**
+   * The configured name of the client in multi-client mode, or {@code null} in single-client mode.
+   */
+  default String getClientName() {
+    return null;
+  }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/event/CamundaClientClosingEvent.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/event/CamundaClientClosingEvent.java
@@ -26,9 +26,10 @@ public interface CamundaClientClosingEvent {
   CamundaClient getClient();
 
   /**
-   * The configured name of the client in multi-client mode, or {@code null} in single-client mode.
+   * The configured name of the client; the per-client name in multi-client mode, or {@link
+   * CamundaClientCreatedEvent#DEFAULT_CLIENT_NAME} in single-client mode.
    */
   default String getClientName() {
-    return null;
+    return CamundaClientCreatedEvent.DEFAULT_CLIENT_NAME;
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/event/CamundaClientCreatedEvent.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/event/CamundaClientCreatedEvent.java
@@ -31,4 +31,11 @@ import io.camunda.client.CamundaClient;
  */
 public interface CamundaClientCreatedEvent {
   CamundaClient getClient();
+
+  /**
+   * The configured name of the client in multi-client mode, or {@code null} in single-client mode.
+   */
+  default String getClientName() {
+    return null;
+  }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/event/CamundaClientCreatedEvent.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/event/CamundaClientCreatedEvent.java
@@ -30,12 +30,20 @@ import io.camunda.client.CamundaClient;
  * <p>Furthermore, when `camunda.client.enabled=false`, the event might not be fired ever
  */
 public interface CamundaClientCreatedEvent {
+
+  /**
+   * Logical name used for the single (default) client when no explicit {@code
+   * camunda.clients.<name>} name is configured, so consumers always receive a non-null client name.
+   */
+  String DEFAULT_CLIENT_NAME = "default";
+
   CamundaClient getClient();
 
   /**
-   * The configured name of the client in multi-client mode, or {@code null} in single-client mode.
+   * The configured name of the client; the per-client name in multi-client mode, or {@link
+   * #DEFAULT_CLIENT_NAME} in single-client mode.
    */
   default String getClientName() {
-    return null;
+    return DEFAULT_CLIENT_NAME;
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerManager.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerManager.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,11 @@ public class JobWorkerManager {
   private final List<JobWorkerValueCustomizer> jobWorkerValueCustomizers;
   private final JobWorkerFactory jobWorkerFactory;
 
+  /**
+   * Managed workers keyed by a composite {@code (client identity, type)} key so the same job type
+   * can be registered independently on multiple clients (one per configured multi-client). For a
+   * single-client application this holds exactly one entry per type.
+   */
   private final Map<String, InternalManagedJobWorker> managedJobWorkers = new ConcurrentHashMap<>();
 
   public JobWorkerManager(
@@ -46,65 +52,115 @@ public class JobWorkerManager {
     this.jobWorkerFactory = jobWorkerFactory;
   }
 
+  /** Distinguishes the same job type registered on different client instances. */
+  private static String workerKey(final CamundaClient client, final String type) {
+    return System.identityHashCode(client) + ":" + type;
+  }
+
   public void createJobWorker(
       final CamundaClient client, final ManagedJobWorker managedJobWorker, final Object source) {
+    createJobWorker(client, managedJobWorker, source, null);
+  }
+
+  public void createJobWorker(
+      final CamundaClient client,
+      final ManagedJobWorker managedJobWorker,
+      final Object source,
+      final String clientName) {
     final JobWorkerValue jobWorkerValue = managedJobWorker.jobWorkerValue();
     jobWorkerValueCustomizers.forEach(customizer -> customizer.customize(jobWorkerValue));
     final String type = jobWorkerValue.getType().value();
+    final String key = workerKey(client, type);
     final InternalManagedJobWorker internalManagedJobWorker;
-    if (managedJobWorkers.containsKey(type)) {
-      internalManagedJobWorker = managedJobWorkers.get(type);
+    if (managedJobWorkers.containsKey(key)) {
+      internalManagedJobWorker = managedJobWorkers.get(key);
     } else {
       internalManagedJobWorker = new InternalManagedJobWorker();
       internalManagedJobWorker.setSource(source);
       internalManagedJobWorker.setCurrent(jobWorkerValue);
       internalManagedJobWorker.setCamundaClient(client);
       internalManagedJobWorker.setJobHandlerFactory(managedJobWorker.jobHandlerFactory());
-      managedJobWorkers.put(type, internalManagedJobWorker);
+      internalManagedJobWorker.setType(type);
+      internalManagedJobWorker.setClientName(clientName);
+      managedJobWorkers.put(key, internalManagedJobWorker);
     }
     upsertWorker(internalManagedJobWorker, new CreateChangeSet());
   }
 
   public Map<String, JobWorkerValue> getJobWorkers() {
-    return managedJobWorkers.entrySet().stream()
-        .map(e -> Map.entry(e.getKey(), e.getValue().getCurrent()))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    // keyed by type; if the same type runs on multiple clients any one of them is returned
+    return managedJobWorkers.values().stream()
+        .collect(
+            Collectors.toMap(
+                InternalManagedJobWorker::getType,
+                InternalManagedJobWorker::getCurrent,
+                (existing, replacement) -> existing));
   }
 
   public JobWorkerValue getJobWorker(final String type) {
-    final InternalManagedJobWorker internalManagedJobWorker = findManagedJobWorker(type);
-    return internalManagedJobWorker.getCurrent();
+    return findAnyManagedJobWorker(type).getCurrent();
   }
 
   public void updateJobWorker(final String type, final JobWorkerChangeSet changeSet) {
-    final InternalManagedJobWorker internalManagedJobWorker = findManagedJobWorker(type);
-    upsertWorker(internalManagedJobWorker, changeSet);
+    // update every client's worker of this type
+    findManagedJobWorkers(type).forEach(worker -> upsertWorker(worker, changeSet));
   }
 
   public void updateJobWorkers(final JobWorkerChangeSet changeSet) {
-    managedJobWorkers.keySet().forEach(type -> updateJobWorker(type, changeSet));
+    managedJobWorkers.values().forEach(worker -> upsertWorker(worker, changeSet));
   }
 
   public void resetJobWorker(final String type) {
-    final InternalManagedJobWorker internalManagedJobWorker = findManagedJobWorker(type);
-    upsertWorker(internalManagedJobWorker, new ResetChangeSet());
+    findManagedJobWorkers(type).forEach(worker -> upsertWorker(worker, new ResetChangeSet()));
   }
 
   public void resetJobWorkers() {
-    managedJobWorkers.keySet().forEach(this::resetJobWorker);
+    managedJobWorkers.values().forEach(worker -> upsertWorker(worker, new ResetChangeSet()));
   }
 
   public void closeJobWorker(final String type) {
-    final InternalManagedJobWorker internalManagedJobWorker = findManagedJobWorker(type);
-    upsertWorker(internalManagedJobWorker, new CloseChangeSet());
-    managedJobWorkers.remove(type);
+    // close every client's worker of this type
+    removeWorkers(e -> e.getValue().getType().equals(type));
   }
 
-  private InternalManagedJobWorker findManagedJobWorker(final String type) {
-    if (!managedJobWorkers.containsKey(type)) {
+  /** Closes the workers registered by the given source on the given client only. */
+  public void closeJobWorkers(final Object source, final CamundaClient client) {
+    removeWorkers(
+        e ->
+            Objects.equals(e.getValue().getSource(), source)
+                && e.getValue().getCamundaClient() == client);
+  }
+
+  public void closeAllJobWorkers(final Object source) {
+    removeWorkers(e -> Objects.equals(e.getValue().getSource(), source));
+  }
+
+  private void removeWorkers(final Predicate<Map.Entry<String, InternalManagedJobWorker>> filter) {
+    final List<String> keysToRemove =
+        managedJobWorkers.entrySet().stream().filter(filter).map(Map.Entry::getKey).toList();
+    keysToRemove.forEach(
+        key -> {
+          upsertWorker(managedJobWorkers.get(key), new CloseChangeSet());
+          managedJobWorkers.remove(key);
+        });
+  }
+
+  private InternalManagedJobWorker findAnyManagedJobWorker(final String type) {
+    return managedJobWorkers.values().stream()
+        .filter(worker -> worker.getType().equals(type))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Unknown job worker type: " + type));
+  }
+
+  private List<InternalManagedJobWorker> findManagedJobWorkers(final String type) {
+    final List<InternalManagedJobWorker> workers =
+        managedJobWorkers.values().stream()
+            .filter(worker -> worker.getType().equals(type))
+            .collect(Collectors.toList());
+    if (workers.isEmpty()) {
       throw new IllegalArgumentException("Unknown job worker type: " + type);
     }
-    return managedJobWorkers.get(type);
+    return workers;
   }
 
   private void upsertWorker(
@@ -146,19 +202,14 @@ public class JobWorkerManager {
     }
   }
 
-  public void closeAllJobWorkers(final Object source) {
-    managedJobWorkers.entrySet().stream()
-        .filter(e -> Objects.equals(e.getValue().getSource(), source))
-        .map(Map.Entry::getKey)
-        .forEach(this::closeJobWorker);
-  }
-
   private static final class InternalManagedJobWorker {
     private JobHandlerFactory jobHandlerFactory;
     private JobWorker jobWorker;
     private JobWorkerValue current;
     private CamundaClient camundaClient;
     private Object source;
+    private String type;
+    private String clientName;
 
     public JobWorker getJobWorker() {
       return jobWorker;
@@ -198,6 +249,22 @@ public class JobWorkerManager {
 
     public void setSource(final Object source) {
       this.source = source;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(final String type) {
+      this.type = type;
+    }
+
+    public String getClientName() {
+      return clientName;
+    }
+
+    public void setClientName(final String clientName) {
+      this.clientName = clientName;
     }
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerManager.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerManager.java
@@ -39,22 +39,18 @@ public class JobWorkerManager {
   private final JobWorkerFactory jobWorkerFactory;
 
   /**
-   * Managed workers keyed by a composite {@code (client identity, type)} key so the same job type
-   * can be registered independently on multiple clients (one per configured multi-client). For a
+   * Managed workers keyed by a composite {@code (client, type)} key so the same job type can be
+   * registered independently on multiple clients (one per configured multi-client). For a
    * single-client application this holds exactly one entry per type.
    */
-  private final Map<String, InternalManagedJobWorker> managedJobWorkers = new ConcurrentHashMap<>();
+  private final Map<WorkerKey, InternalManagedJobWorker> managedJobWorkers =
+      new ConcurrentHashMap<>();
 
   public JobWorkerManager(
       final List<JobWorkerValueCustomizer> jobWorkerValueCustomizers,
       final JobWorkerFactory jobWorkerFactory) {
     this.jobWorkerValueCustomizers = jobWorkerValueCustomizers;
     this.jobWorkerFactory = jobWorkerFactory;
-  }
-
-  /** Distinguishes the same job type registered on different client instances. */
-  private static String workerKey(final CamundaClient client, final String type) {
-    return System.identityHashCode(client) + ":" + type;
   }
 
   public void createJobWorker(
@@ -70,20 +66,19 @@ public class JobWorkerManager {
     final JobWorkerValue jobWorkerValue = managedJobWorker.jobWorkerValue();
     jobWorkerValueCustomizers.forEach(customizer -> customizer.customize(jobWorkerValue));
     final String type = jobWorkerValue.getType().value();
-    final String key = workerKey(client, type);
-    final InternalManagedJobWorker internalManagedJobWorker;
-    if (managedJobWorkers.containsKey(key)) {
-      internalManagedJobWorker = managedJobWorkers.get(key);
-    } else {
-      internalManagedJobWorker = new InternalManagedJobWorker();
-      internalManagedJobWorker.setSource(source);
-      internalManagedJobWorker.setCurrent(jobWorkerValue);
-      internalManagedJobWorker.setCamundaClient(client);
-      internalManagedJobWorker.setJobHandlerFactory(managedJobWorker.jobHandlerFactory());
-      internalManagedJobWorker.setType(type);
-      internalManagedJobWorker.setClientName(clientName);
-      managedJobWorkers.put(key, internalManagedJobWorker);
-    }
+    final InternalManagedJobWorker internalManagedJobWorker =
+        managedJobWorkers.computeIfAbsent(
+            new WorkerKey(client, type),
+            key -> {
+              final InternalManagedJobWorker worker = new InternalManagedJobWorker();
+              worker.setSource(source);
+              worker.setCurrent(jobWorkerValue);
+              worker.setCamundaClient(client);
+              worker.setJobHandlerFactory(managedJobWorker.jobHandlerFactory());
+              worker.setType(type);
+              worker.setClientName(clientName);
+              return worker;
+            });
     upsertWorker(internalManagedJobWorker, new CreateChangeSet());
   }
 
@@ -135,13 +130,17 @@ public class JobWorkerManager {
     removeWorkers(e -> Objects.equals(e.getValue().getSource(), source));
   }
 
-  private void removeWorkers(final Predicate<Map.Entry<String, InternalManagedJobWorker>> filter) {
-    final List<String> keysToRemove =
+  private void removeWorkers(
+      final Predicate<Map.Entry<WorkerKey, InternalManagedJobWorker>> filter) {
+    final List<WorkerKey> keysToRemove =
         managedJobWorkers.entrySet().stream().filter(filter).map(Map.Entry::getKey).toList();
     keysToRemove.forEach(
         key -> {
-          upsertWorker(managedJobWorkers.get(key), new CloseChangeSet());
-          managedJobWorkers.remove(key);
+          // remove first so a concurrent removal cannot leave us upserting a null worker
+          final InternalManagedJobWorker worker = managedJobWorkers.remove(key);
+          if (worker != null) {
+            upsertWorker(worker, new CloseChangeSet());
+          }
         });
   }
 
@@ -199,6 +198,37 @@ public class JobWorkerManager {
                   "%s with type %s",
                   internalManagedJobWorker.getCurrent().getName().value(),
                   internalManagedJobWorker.getCurrent().getType().value()));
+    }
+  }
+
+  /**
+   * Composite key distinguishing the same job type registered on different client instances. The
+   * client is compared by reference identity so two distinct client instances never share an entry
+   * (unlike encoding {@link System#identityHashCode(Object)} into the key, which can collide).
+   */
+  private static final class WorkerKey {
+    private final CamundaClient client;
+    private final String type;
+
+    private WorkerKey(final CamundaClient client, final String type) {
+      this.client = client;
+      this.type = type;
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * System.identityHashCode(client) + type.hashCode();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof final WorkerKey other)) {
+        return false;
+      }
+      return client == other.client && type.equals(other.type);
     }
   }
 

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerManager.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/jobhandling/JobWorkerManager.java
@@ -177,10 +177,7 @@ public class JobWorkerManager {
           "Stopping job worker: {}",
           LOGGER.isDebugEnabled()
               ? internalManagedJobWorker.getCurrent()
-              : String.format(
-                  "%s with type %s",
-                  internalManagedJobWorker.getCurrent().getName().value(),
-                  internalManagedJobWorker.getCurrent().getType().value()));
+              : describe(internalManagedJobWorker));
     }
     final boolean enabled = internalManagedJobWorker.getCurrent().getEnabled().value();
     final boolean closed = changeSet instanceof CloseChangeSet;
@@ -194,11 +191,20 @@ public class JobWorkerManager {
           "Starting job worker: {}",
           LOGGER.isDebugEnabled()
               ? internalManagedJobWorker.getCurrent()
-              : String.format(
-                  "%s with type %s",
-                  internalManagedJobWorker.getCurrent().getName().value(),
-                  internalManagedJobWorker.getCurrent().getType().value()));
+              : describe(internalManagedJobWorker));
     }
+  }
+
+  /**
+   * Renders a short worker description for the info-level start/stop logs, including the configured
+   * client name when the worker is bound to a named client (multi-client mode).
+   */
+  private static String describe(final InternalManagedJobWorker worker) {
+    final String clientSuffix =
+        worker.getClientName() == null ? "" : " on client '" + worker.getClientName() + "'";
+    return String.format(
+        "%s with type %s%s",
+        worker.getCurrent().getName().value(), worker.getCurrent().getType().value(), clientSuffix);
   }
 
   /**

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/lifecycle/CamundaClientLifecycleAware.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/lifecycle/CamundaClientLifecycleAware.java
@@ -23,20 +23,24 @@ public interface CamundaClientLifecycleAware {
   void onStop(CamundaClient client);
 
   /**
-   * Called when a client is started, carrying its configured name in multi-client mode.
+   * Called when a client is started, carrying its configured name.
    *
    * @param client the client that was started
-   * @param clientName the configured client name, or {@code null} in single-client mode
+   * @param clientName the per-client name in multi-client mode, or {@link
+   *     io.camunda.client.event.CamundaClientCreatedEvent#DEFAULT_CLIENT_NAME} in single-client
+   *     mode
    */
   default void onStart(final CamundaClient client, final String clientName) {
     onStart(client);
   }
 
   /**
-   * Called when a client is about to stop, carrying its configured name in multi-client mode.
+   * Called when a client is about to stop, carrying its configured name.
    *
    * @param client the client that is stopping
-   * @param clientName the configured client name, or {@code null} in single-client mode
+   * @param clientName the per-client name in multi-client mode, or {@link
+   *     io.camunda.client.event.CamundaClientCreatedEvent#DEFAULT_CLIENT_NAME} in single-client
+   *     mode
    */
   default void onStop(final CamundaClient client, final String clientName) {
     onStop(client);

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/lifecycle/CamundaClientLifecycleAware.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/lifecycle/CamundaClientLifecycleAware.java
@@ -21,4 +21,24 @@ public interface CamundaClientLifecycleAware {
   void onStart(CamundaClient client);
 
   void onStop(CamundaClient client);
+
+  /**
+   * Called when a client is started, carrying its configured name in multi-client mode.
+   *
+   * @param client the client that was started
+   * @param clientName the configured client name, or {@code null} in single-client mode
+   */
+  default void onStart(final CamundaClient client, final String clientName) {
+    onStart(client);
+  }
+
+  /**
+   * Called when a client is about to stop, carrying its configured name in multi-client mode.
+   *
+   * @param client the client that is stopping
+   * @param clientName the configured client name, or {@code null} in single-client mode
+   */
+  default void onStop(final CamundaClient client, final String clientName) {
+    onStop(client);
+  }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/AbstractCamundaAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/AbstractCamundaAnnotationProcessor.java
@@ -17,6 +17,7 @@ package io.camunda.client.spring.annotation.processor;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.bean.BeanInfo;
+import io.camunda.client.event.CamundaClientCreatedEvent;
 import io.camunda.client.lifecycle.CamundaClientLifecycleAware;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -74,7 +75,7 @@ public abstract class AbstractCamundaAnnotationProcessor
 
   @Override
   public void onStart(final CamundaClient client) {
-    onStart(client, null);
+    onStart(client, CamundaClientCreatedEvent.DEFAULT_CLIENT_NAME);
   }
 
   @Override
@@ -102,7 +103,7 @@ public abstract class AbstractCamundaAnnotationProcessor
 
   @Override
   public void onStop(final CamundaClient client) {
-    onStop(client, null);
+    onStop(client, CamundaClientCreatedEvent.DEFAULT_CLIENT_NAME);
   }
 
   @Override

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/AbstractCamundaAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/AbstractCamundaAnnotationProcessor.java
@@ -35,12 +35,41 @@ public abstract class AbstractCamundaAnnotationProcessor
 
   protected abstract void configureFor(final BeanInfo beanInfo);
 
-  protected abstract void start(CamundaClient client);
+  /**
+   * Starts the processor for a client. Subclasses override this (or the {@link
+   * #start(CamundaClient, String)} overload). Defaults to a no-op.
+   */
+  protected void start(final CamundaClient client) {}
 
-  protected abstract void stop(CamundaClient client);
+  /**
+   * Stops the processor for a client. Subclasses override this (or the {@link #stop(CamundaClient,
+   * String)} overload). Defaults to a no-op.
+   */
+  protected void stop(final CamundaClient client) {}
+
+  /**
+   * Starts the processor for a client, carrying its configured name in multi-client mode. Defaults
+   * to the single-client {@link #start(CamundaClient)} for backwards compatibility.
+   */
+  protected void start(final CamundaClient client, final String clientName) {
+    start(client);
+  }
+
+  /**
+   * Stops the processor for a client, carrying its configured name in multi-client mode. Defaults
+   * to the single-client {@link #stop(CamundaClient)} for backwards compatibility.
+   */
+  protected void stop(final CamundaClient client, final String clientName) {
+    stop(client);
+  }
 
   @Override
   public void onStart(final CamundaClient client) {
+    onStart(client, null);
+  }
+
+  @Override
+  public void onStart(final CamundaClient client, final String clientName) {
     for (final String beanName : applicationContext.getBeanDefinitionNames()) {
       final Class<?> beanType = applicationContext.getType(beanName, false);
       if (beanType != null) {
@@ -56,11 +85,16 @@ public abstract class AbstractCamundaAnnotationProcessor
         }
       }
     }
-    start(client);
+    start(client, clientName);
   }
 
   @Override
   public void onStop(final CamundaClient client) {
-    stop(client);
+    onStop(client, null);
+  }
+
+  @Override
+  public void onStop(final CamundaClient client, final String clientName) {
+    stop(client, clientName);
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/AbstractCamundaAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/AbstractCamundaAnnotationProcessor.java
@@ -36,6 +36,15 @@ public abstract class AbstractCamundaAnnotationProcessor
   protected abstract void configureFor(final BeanInfo beanInfo);
 
   /**
+   * Discards any configuration discovered by previous {@link #configureFor(BeanInfo)} calls, so a
+   * re-scan starts from an empty set. {@link #onStart(CamundaClient, String)} runs once per client
+   * in multi-client mode and re-scans each time; without clearing, subclasses that accumulate
+   * discovered values in a collection would register every type again for each subsequent client.
+   * Subclasses that keep such a collection override this to clear it; defaults to a no-op.
+   */
+  protected void clearDiscovered() {}
+
+  /**
    * Starts the processor for a client. Subclasses override this (or the {@link
    * #start(CamundaClient, String)} overload). Defaults to a no-op.
    */
@@ -70,6 +79,9 @@ public abstract class AbstractCamundaAnnotationProcessor
 
   @Override
   public void onStart(final CamundaClient client, final String clientName) {
+    // re-scanning happens once per client, so drop anything discovered for a previous client to
+    // avoid registering the same types again (see clearDiscovered)
+    clearDiscovered();
     for (final String beanName : applicationContext.getBeanDefinitionNames()) {
       final Class<?> beanType = applicationContext.getType(beanName, false);
       if (beanType != null) {

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/ClusterVariablesAnnotationProcessor.java
@@ -92,6 +92,11 @@ public class ClusterVariablesAnnotationProcessor extends AbstractCamundaAnnotati
   }
 
   @Override
+  protected void clearDiscovered() {
+    clusterVariablesValues.clear();
+  }
+
+  @Override
   public void start(final CamundaClient client) {
     // Process global variables from properties
     final Map<String, Object> globalVariables = properties.getGlobal();

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/DeploymentAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/DeploymentAnnotationProcessor.java
@@ -91,6 +91,11 @@ public class DeploymentAnnotationProcessor extends AbstractCamundaAnnotationProc
   }
 
   @Override
+  protected void clearDiscovered() {
+    deploymentValues.clear();
+  }
+
+  @Override
   public void start(final CamundaClient client) {
     if (deploymentValues.isEmpty()) {
       return;

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/JobWorkerAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/JobWorkerAnnotationProcessor.java
@@ -104,16 +104,17 @@ public class JobWorkerAnnotationProcessor extends AbstractCamundaAnnotationProce
   }
 
   @Override
-  public void start(final CamundaClient client) {
+  public void start(final CamundaClient client, final String clientName) {
     managedJobWorkers.forEach(
-        managedJobWorker -> {
-          jobWorkerManager.createJobWorker(client, managedJobWorker, this);
-        });
+        managedJobWorker ->
+            jobWorkerManager.createJobWorker(client, managedJobWorker, this, clientName));
   }
 
   @Override
-  public void stop(final CamundaClient camundaClient) {
-    jobWorkerManager.closeAllJobWorkers(this);
+  public void stop(final CamundaClient client, final String clientName) {
+    // close only the workers registered by this processor on the given client, so stopping one
+    // client's workers does not tear down the others'
+    jobWorkerManager.closeJobWorkers(this, client);
     managedJobWorkers.clear();
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/JobWorkerAnnotationProcessor.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/annotation/processor/JobWorkerAnnotationProcessor.java
@@ -104,6 +104,11 @@ public class JobWorkerAnnotationProcessor extends AbstractCamundaAnnotationProce
   }
 
   @Override
+  protected void clearDiscovered() {
+    managedJobWorkers.clear();
+  }
+
+  @Override
   public void start(final CamundaClient client, final String clientName) {
     managedJobWorkers.forEach(
         managedJobWorker ->

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaClientClosingSpringEvent.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaClientClosingSpringEvent.java
@@ -28,14 +28,26 @@ public class CamundaClientClosingSpringEvent extends ApplicationEvent
     implements CamundaClientClosingEvent {
 
   public final CamundaClient client;
+  private final String clientName;
 
   public CamundaClientClosingSpringEvent(final Object source, final CamundaClient client) {
+    this(source, client, null);
+  }
+
+  public CamundaClientClosingSpringEvent(
+      final Object source, final CamundaClient client, final String clientName) {
     super(source);
     this.client = client;
+    this.clientName = clientName;
   }
 
   @Override
   public CamundaClient getClient() {
     return client;
+  }
+
+  @Override
+  public String getClientName() {
+    return clientName;
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaClientClosingSpringEvent.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaClientClosingSpringEvent.java
@@ -17,6 +17,7 @@ package io.camunda.client.spring.event;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.event.CamundaClientClosingEvent;
+import io.camunda.client.event.CamundaClientCreatedEvent;
 import org.springframework.context.ApplicationEvent;
 
 /**
@@ -31,7 +32,7 @@ public class CamundaClientClosingSpringEvent extends ApplicationEvent
   private final String clientName;
 
   public CamundaClientClosingSpringEvent(final Object source, final CamundaClient client) {
-    this(source, client, null);
+    this(source, client, CamundaClientCreatedEvent.DEFAULT_CLIENT_NAME);
   }
 
   public CamundaClientClosingSpringEvent(

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaClientCreatedSpringEvent.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaClientCreatedSpringEvent.java
@@ -38,7 +38,7 @@ public class CamundaClientCreatedSpringEvent extends ApplicationEvent
   private final String clientName;
 
   public CamundaClientCreatedSpringEvent(final Object source, final CamundaClient client) {
-    this(source, client, null);
+    this(source, client, DEFAULT_CLIENT_NAME);
   }
 
   public CamundaClientCreatedSpringEvent(

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaClientCreatedSpringEvent.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaClientCreatedSpringEvent.java
@@ -35,14 +35,26 @@ public class CamundaClientCreatedSpringEvent extends ApplicationEvent
     implements CamundaClientCreatedEvent {
 
   public final CamundaClient client;
+  private final String clientName;
 
   public CamundaClientCreatedSpringEvent(final Object source, final CamundaClient client) {
+    this(source, client, null);
+  }
+
+  public CamundaClientCreatedSpringEvent(
+      final Object source, final CamundaClient client, final String clientName) {
     super(source);
     this.client = client;
+    this.clientName = clientName;
   }
 
   @Override
   public CamundaClient getClient() {
     return client;
+  }
+
+  @Override
+  public String getClientName() {
+    return clientName;
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaClientEventListener.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/CamundaClientEventListener.java
@@ -33,12 +33,14 @@ public class CamundaClientEventListener {
   @EventListener
   public void handleStart(final CamundaClientCreatedEvent evt) {
     camundaClientLifecycleAwareSet.forEach(
-        camundaClientLifecycleAware -> camundaClientLifecycleAware.onStart(evt.getClient()));
+        camundaClientLifecycleAware ->
+            camundaClientLifecycleAware.onStart(evt.getClient(), evt.getClientName()));
   }
 
   @EventListener
   public void handleStop(final CamundaClientClosingEvent evt) {
     camundaClientLifecycleAwareSet.forEach(
-        camundaClientLifecycleAware -> camundaClientLifecycleAware.onStop(evt.getClient()));
+        camundaClientLifecycleAware ->
+            camundaClientLifecycleAware.onStop(evt.getClient(), evt.getClientName()));
   }
 }

--- a/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/MultiCamundaLifecycleEventProducer.java
+++ b/clients/camunda-spring-boot-starter/src/main/java/io/camunda/client/spring/event/MultiCamundaLifecycleEventProducer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.event;
+
+import io.camunda.client.spring.bean.CamundaClientRegistry;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.SmartLifecycle;
+
+/**
+ * Multi-client counterpart of {@link CamundaLifecycleEventProducer}: publishes one {@link
+ * CamundaClientCreatedSpringEvent} / {@link CamundaClientClosingSpringEvent} per configured client
+ * in the {@link CamundaClientRegistry}, each carrying the client's configured name. This lets
+ * lifecycle-aware components (e.g. the job-worker registration) run once per client.
+ *
+ * <p>Not wired into the multi-client auto-configuration yet: activating it requires the job-worker
+ * infrastructure to be present in multi-client mode, which is delivered by the single-client /
+ * multi-client consolidation.
+ */
+public class MultiCamundaLifecycleEventProducer implements SmartLifecycle {
+
+  private final CamundaClientRegistry registry;
+  private final ApplicationEventPublisher publisher;
+  private boolean running = false;
+
+  public MultiCamundaLifecycleEventProducer(
+      final CamundaClientRegistry registry, final ApplicationEventPublisher publisher) {
+    this.registry = registry;
+    this.publisher = publisher;
+  }
+
+  @Override
+  public void start() {
+    registry
+        .clientNames()
+        .forEach(
+            name ->
+                publisher.publishEvent(
+                    new CamundaClientCreatedSpringEvent(this, registry.get(name), name)));
+    running = true;
+  }
+
+  @Override
+  public void stop() {
+    registry
+        .clientNames()
+        .forEach(
+            name ->
+                publisher.publishEvent(
+                    new CamundaClientClosingSpringEvent(this, registry.get(name), name)));
+    running = false;
+  }
+
+  @Override
+  public boolean isRunning() {
+    return running;
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobWorkerManagerTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/jobhandling/JobWorkerManagerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.jobhandling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.annotation.value.JobWorkerValue;
+import io.camunda.client.annotation.value.SourceAware.FromAnnotation;
+import io.camunda.client.api.worker.JobWorker;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the multi-client fan-out mechanism of {@link JobWorkerManager}: the same job type
+ * can be registered independently on multiple clients, and closing is scoped to a single client.
+ */
+public class JobWorkerManagerTest {
+
+  private static final String TYPE = "my-type";
+  private static final Object SOURCE = new Object();
+
+  private JobWorkerFactory jobWorkerFactory;
+  private JobWorkerManager jobWorkerManager;
+
+  @BeforeEach
+  void setUp() {
+    jobWorkerFactory = mock(JobWorkerFactory.class);
+    jobWorkerManager = new JobWorkerManager(List.of(), jobWorkerFactory);
+  }
+
+  @Test
+  void shouldRegisterSameTypeIndependentlyOnMultipleClients() {
+    // given
+    final CamundaClient clientA = mock(CamundaClient.class);
+    final CamundaClient clientB = mock(CamundaClient.class);
+    when(jobWorkerFactory.createJobWorker(eq(clientA), any(), any()))
+        .thenReturn(mock(JobWorker.class));
+    when(jobWorkerFactory.createJobWorker(eq(clientB), any(), any()))
+        .thenReturn(mock(JobWorker.class));
+
+    // when - the same type is registered on two different clients
+    jobWorkerManager.createJobWorker(clientA, managedWorker(TYPE), SOURCE, "a");
+    jobWorkerManager.createJobWorker(clientB, managedWorker(TYPE), SOURCE, "b");
+
+    // then - a worker is opened on each client, not just once
+    verify(jobWorkerFactory).createJobWorker(eq(clientA), any(), any());
+    verify(jobWorkerFactory).createJobWorker(eq(clientB), any(), any());
+  }
+
+  @Test
+  void shouldCloseOnlyTheGivenClientsWorkers() {
+    // given - the same type registered on two clients
+    final CamundaClient clientA = mock(CamundaClient.class);
+    final CamundaClient clientB = mock(CamundaClient.class);
+    final JobWorker workerA = mock(JobWorker.class);
+    final JobWorker workerB = mock(JobWorker.class);
+    when(jobWorkerFactory.createJobWorker(eq(clientA), any(), any())).thenReturn(workerA);
+    when(jobWorkerFactory.createJobWorker(eq(clientB), any(), any())).thenReturn(workerB);
+    jobWorkerManager.createJobWorker(clientA, managedWorker(TYPE), SOURCE, "a");
+    jobWorkerManager.createJobWorker(clientB, managedWorker(TYPE), SOURCE, "b");
+
+    // when - only client A's workers are closed
+    jobWorkerManager.closeJobWorkers(SOURCE, clientA);
+
+    // then - client A's worker is closed, client B's is left running
+    verify(workerA).close();
+    verify(workerB, never()).close();
+  }
+
+  @Test
+  void shouldCloseWorkersPerClientSequentially() {
+    // given
+    final CamundaClient clientA = mock(CamundaClient.class);
+    final CamundaClient clientB = mock(CamundaClient.class);
+    final JobWorker workerA = mock(JobWorker.class);
+    final JobWorker workerB = mock(JobWorker.class);
+    when(jobWorkerFactory.createJobWorker(eq(clientA), any(), any())).thenReturn(workerA);
+    when(jobWorkerFactory.createJobWorker(eq(clientB), any(), any())).thenReturn(workerB);
+    jobWorkerManager.createJobWorker(clientA, managedWorker(TYPE), SOURCE, "a");
+    jobWorkerManager.createJobWorker(clientB, managedWorker(TYPE), SOURCE, "b");
+
+    // when
+    jobWorkerManager.closeJobWorkers(SOURCE, clientA);
+    jobWorkerManager.closeJobWorkers(SOURCE, clientB);
+
+    // then - each client's worker is eventually closed exactly once
+    verify(workerA).close();
+    verify(workerB).close();
+  }
+
+  @Test
+  void shouldExposeTypeAcrossClients() {
+    // given
+    final CamundaClient clientA = mock(CamundaClient.class);
+    final CamundaClient clientB = mock(CamundaClient.class);
+    when(jobWorkerFactory.createJobWorker(any(), any(), any())).thenReturn(mock(JobWorker.class));
+    jobWorkerManager.createJobWorker(clientA, managedWorker(TYPE), SOURCE, "a");
+    jobWorkerManager.createJobWorker(clientB, managedWorker(TYPE), SOURCE, "b");
+
+    // when / then - the type is discoverable regardless of how many clients run it
+    assertThat(jobWorkerManager.getJobWorkers()).containsKey(TYPE);
+    assertThat(jobWorkerManager.getJobWorker(TYPE)).isNotNull();
+  }
+
+  private static ManagedJobWorker managedWorker(final String type) {
+    final JobWorkerValue value = new JobWorkerValue();
+    value.setType(new FromAnnotation<>(type));
+    value.setName(new FromAnnotation<>(type + "-worker"));
+    value.setEnabled(new FromAnnotation<>(true));
+    return new ManagedJobWorker(value, mock(JobHandlerFactory.class));
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/event/CamundaClientSpringEventTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/event/CamundaClientSpringEventTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.event.CamundaClientCreatedEvent;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the no-name event constructors fall back to {@link
+ * CamundaClientCreatedEvent#DEFAULT_CLIENT_NAME} rather than {@code null}, so consumers always
+ * receive a client name.
+ */
+public class CamundaClientSpringEventTest {
+
+  private final CamundaClient client = mock(CamundaClient.class);
+
+  @Test
+  void shouldDefaultCreatedEventClientNameWhenUnnamed() {
+    // when
+    final CamundaClientCreatedSpringEvent event = new CamundaClientCreatedSpringEvent(this, client);
+
+    // then
+    assertThat(event.getClientName()).isEqualTo(CamundaClientCreatedEvent.DEFAULT_CLIENT_NAME);
+  }
+
+  @Test
+  void shouldDefaultClosingEventClientNameWhenUnnamed() {
+    // when
+    final CamundaClientClosingSpringEvent event = new CamundaClientClosingSpringEvent(this, client);
+
+    // then
+    assertThat(event.getClientName()).isEqualTo(CamundaClientCreatedEvent.DEFAULT_CLIENT_NAME);
+  }
+
+  @Test
+  void shouldKeepExplicitClientName() {
+    // when
+    final CamundaClientCreatedSpringEvent event =
+        new CamundaClientCreatedSpringEvent(this, client, "finance");
+
+    // then
+    assertThat(event.getClientName()).isEqualTo("finance");
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/event/MultiCamundaLifecycleEventProducerTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/event/MultiCamundaLifecycleEventProducerTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.spring.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.spring.bean.CamundaClientRegistry;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationEventPublisher;
+
+/**
+ * Unit tests for {@link MultiCamundaLifecycleEventProducer}: it publishes one created/closing event
+ * per configured client, each carrying the client's configured name.
+ */
+public class MultiCamundaLifecycleEventProducerTest {
+
+  private CamundaClientRegistry registry;
+  private final List<ApplicationEvent> published = new java.util.ArrayList<>();
+  private ApplicationEventPublisher publisher;
+  private CamundaClient clientA;
+  private CamundaClient clientB;
+
+  @BeforeEach
+  void setUp() {
+    published.clear();
+    registry = mock(CamundaClientRegistry.class);
+    publisher = event -> published.add((ApplicationEvent) event);
+    clientA = mock(CamundaClient.class);
+    clientB = mock(CamundaClient.class);
+    final Set<String> names = new LinkedHashSet<>(List.of("a", "b"));
+    when(registry.clientNames()).thenReturn(names);
+    when(registry.get("a")).thenReturn(clientA);
+    when(registry.get("b")).thenReturn(clientB);
+  }
+
+  @Test
+  void shouldPublishCreatedEventPerClientOnStart() {
+    // given
+    final MultiCamundaLifecycleEventProducer producer =
+        new MultiCamundaLifecycleEventProducer(registry, publisher);
+
+    // when
+    producer.start();
+
+    // then - one created event per client, each carrying its name and client
+    assertThat(published).hasSize(2).allMatch(CamundaClientCreatedSpringEvent.class::isInstance);
+    assertThat(published)
+        .extracting(e -> ((CamundaClientCreatedSpringEvent) e).getClientName())
+        .containsExactlyInAnyOrder("a", "b");
+    assertThat(published)
+        .extracting(e -> ((CamundaClientCreatedSpringEvent) e).getClient())
+        .containsExactlyInAnyOrder(clientA, clientB);
+    assertThat(producer.isRunning()).isTrue();
+  }
+
+  @Test
+  void shouldPublishClosingEventPerClientOnStop() {
+    // given
+    final MultiCamundaLifecycleEventProducer producer =
+        new MultiCamundaLifecycleEventProducer(registry, publisher);
+    producer.start();
+    published.clear();
+
+    // when
+    producer.stop();
+
+    // then - one closing event per client, each carrying its name
+    assertThat(published).hasSize(2).allMatch(CamundaClientClosingSpringEvent.class::isInstance);
+    assertThat(published)
+        .extracting(e -> ((CamundaClientClosingSpringEvent) e).getClientName())
+        .containsExactlyInAnyOrder("a", "b");
+    assertThat(producer.isRunning()).isFalse();
+  }
+}

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/JobWorkerAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/JobWorkerAnnotationProcessorTest.java
@@ -19,8 +19,11 @@ import static io.camunda.client.spring.testsupport.BeanInfoUtil.beanInfo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.annotation.JobWorker;
@@ -35,6 +38,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
 
 @ExtendWith(MockitoExtension.class)
 public class JobWorkerAnnotationProcessorTest {
@@ -74,6 +78,31 @@ public class JobWorkerAnnotationProcessorTest {
     verify(jobWorkerManager, times(2))
         .createJobWorker(
             eq(client), any(ManagedJobWorker.class), eq(jobWorkerAnnotationProcessor), isNull());
+  }
+
+  @Test
+  public void shouldRegisterWorkersOncePerClientOnPerClientStart() {
+    // given a context with a single @JobWorker bean, scanned by onStart
+    final ApplicationContext applicationContext = mock(ApplicationContext.class);
+    when(applicationContext.getBeanDefinitionNames()).thenReturn(new String[] {"withJobWorker"});
+    doReturn(WithJobWorker.class).when(applicationContext).getType("withJobWorker", false);
+    jobWorkerAnnotationProcessor.setApplicationContext(applicationContext);
+
+    final CamundaClient clientA = mock(CamundaClient.class);
+    final CamundaClient clientB = mock(CamundaClient.class);
+
+    // when - onStart runs once per client, as MultiCamundaLifecycleEventProducer will drive it
+    jobWorkerAnnotationProcessor.onStart(clientA, "a");
+    jobWorkerAnnotationProcessor.onStart(clientB, "b");
+
+    // then - each client gets the worker registered exactly once; the re-scan on the second client
+    // does not accumulate and re-register (which would be times(2) for client B)
+    verify(jobWorkerManager, times(1))
+        .createJobWorker(
+            eq(clientA), any(ManagedJobWorker.class), eq(jobWorkerAnnotationProcessor), eq("a"));
+    verify(jobWorkerManager, times(1))
+        .createJobWorker(
+            eq(clientB), any(ManagedJobWorker.class), eq(jobWorkerAnnotationProcessor), eq("b"));
   }
 
   private static final class WithJobWorker {

--- a/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/JobWorkerAnnotationProcessorTest.java
+++ b/clients/camunda-spring-boot-starter/src/test/java/io/camunda/client/spring/processor/JobWorkerAnnotationProcessorTest.java
@@ -18,6 +18,7 @@ package io.camunda.client.spring.processor;
 import static io.camunda.client.spring.testsupport.BeanInfoUtil.beanInfo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -54,23 +55,25 @@ public class JobWorkerAnnotationProcessorTest {
   public void shouldClearManagedJobWorkersOnStop() {
     // given - simulate two lifecycle rounds (as with @RepeatedTest)
     jobWorkerAnnotationProcessor.configureFor(beanInfo(new WithJobWorker()));
-    jobWorkerAnnotationProcessor.start(client);
+    jobWorkerAnnotationProcessor.start(client, null);
 
     // verify first round created exactly one job worker
     verify(jobWorkerManager, times(1))
-        .createJobWorker(eq(client), any(ManagedJobWorker.class), eq(jobWorkerAnnotationProcessor));
+        .createJobWorker(
+            eq(client), any(ManagedJobWorker.class), eq(jobWorkerAnnotationProcessor), isNull());
 
     // when - stop should clear the managed job workers
-    jobWorkerAnnotationProcessor.stop(client);
+    jobWorkerAnnotationProcessor.stop(client, null);
 
     // configure and start again (second test run)
     jobWorkerAnnotationProcessor.configureFor(beanInfo(new WithJobWorker()));
-    jobWorkerAnnotationProcessor.start(client);
+    jobWorkerAnnotationProcessor.start(client, null);
 
     // then - createJobWorker should have been called exactly once per lifecycle round (2 total),
     // not accumulating (which would be 3 if the list wasn't cleared)
     verify(jobWorkerManager, times(2))
-        .createJobWorker(eq(client), any(ManagedJobWorker.class), eq(jobWorkerAnnotationProcessor));
+        .createJobWorker(
+            eq(client), any(ManagedJobWorker.class), eq(jobWorkerAnnotationProcessor), isNull());
   }
 
   private static final class WithJobWorker {


### PR DESCRIPTION
## Description

Rework the job-worker registration machinery so the same @JobWorker method can be registered independently on every configured client, in preparation for multi-client mode. Single-client behavior is unchanged.

Why: in multi-client mode each configured client needs its own set of workers. The previous machinery keyed workers by type alone and closed all workers of a source at once, which cannot express "the same type running on several clients" nor tear down one client's workers without the others'.

- JobWorkerManager keys workers by a composite (client identity, type) so a type can be registered on multiple clients, and gains a client-scoped closeJobWorkers(source, client) alongside the existing type-based API.
- The client name is threaded through the lifecycle: CamundaClientLifecycleAware, the created/closing events, the Spring event types and listener, and the annotation-processor start/stop hooks all carry an optional clientName, defaulting to the single-client path for backward compatibility.
- Add MultiCamundaLifecycleEventProducer, which publishes one created/closing event per client in the registry. It is not wired into the multi-client auto-configuration yet; end-to-end activation is tracked separately.

## Related issues

closes #56726
