### PR TITLE
test: tighten concurrent auth-refresh dedup assertion

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/SessionAuthenticationRefreshTest.java
@@ -134,23 +134,11 @@ public class SessionAuthenticationRefreshTest {
       final var result = sendMultipleConcurrentRequests(sessionCookie);
 
       assertThat(result.successfulRequests().get()).isEqualTo(result.threads().length);
-      // CSL's HttpSessionBasedAuthenticationHolder deduplicates concurrent refreshes with
-      // synchronized(session), which only serializes requests that share the exact same in-memory
-      // HttpSession Java object. Concurrent requests here can each resolve a distinct object for
-      // the same underlying session, so more than one request can independently observe the
-      // expired interval and refresh — see camunda/camunda-security-library#510. The guarantee
-      // this test can make is that every request refreshes once, within the same narrow window —
-      // not that they all agree on one identical timestamp.
       final var refreshTimes = result.lastRefreshTimes();
       assertThat(refreshTimes).allSatisfy(refresh -> assertThat(refresh).isAfter(oldRefresh));
-      final Instant earliestRefresh = refreshTimes.stream().min(Instant::compareTo).orElseThrow();
       assertThat(refreshTimes)
-          .as("all concurrent requests refresh within the same interval window")
-          .allSatisfy(
-              refresh ->
-                  assertThat(refresh)
-                      .isCloseTo(
-                          earliestRefresh, within(refreshInterval.toMillis(), ChronoUnit.MILLIS)));
+          .as("only one refresh across all concurrent requests")
+          .containsOnly(refreshTimes.get(0));
     }
 
     /**

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha49</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha50</version.camunda-security-library>
     <version.checkstyle>13.7.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>


### PR DESCRIPTION
## Summary
- Bumps `camunda-security-library` to `0.1.0-alpha50` for the concurrent auth-refresh dedup fix (camunda/camunda-security-library#518).
- Tightens `SessionAuthenticationRefreshTest.shouldOnlyRefreshOnceWhenMultipleConcurrentRequests` accordingly.

Closes AC3 of camunda/camunda-security-library#510.