### PR TITLE
feat: add cdbg recover process-definitions command

### DIFF
--- a/debug-cli/README.md
+++ b/debug-cli/README.md
@@ -7,6 +7,7 @@ used by Camunda components, in particular related to Zeebe component.
 ## Scope
 
 - Inspect and print Camunda cluster topology files (e.g., `.topology.meta`)
+- Recover lost secondary-storage data (ES/OS) from a Zeebe primary-storage snapshot
 - Designed for advanced users, operators, and developers
 
 ## Usage
@@ -108,6 +109,64 @@ alias debug-cli="java -jar target/cdbg-${version}.jar"
   The full cluster runbook, including scripts to generate the Kubernetes Jobs that apply the fix
   to all broker PVCs, lives in
   [scripts/reset-incident-position](./scripts/reset-incident-position/README.md).
+
+#### `recover`
+
+- **Description:**
+  Recover secondary-storage (Elasticsearch/OpenSearch) data from Zeebe primary storage (a RocksDB
+  snapshot), for disaster recovery when secondary-storage documents have been lost.
+
+##### `recover process-definitions`
+
+- **Description:**
+  Re-export **ACTIVE** process definitions (and their embedded start forms) from a **partition-1**
+  snapshot into secondary storage. Partition 1 is the deployment partition, so its process state is
+  a complete superset of all deployments across all tenants, and every process-definition key is the
+  id of the corresponding secondary-storage document. The command drives the *real* exporter
+  handlers, so the recovered documents are identical to normally-exported ones.
+
+  The snapshot is read strictly read-only (copied into a throwaway runtime first), so the command can
+  be run **in-pod on a live broker** that hosts a partition-1 replica, leader or follower — **no
+  outage required**.
+  Definitions already present are skipped unless `--override` is given, so the command is idempotent
+  and safe to re-run. Standalone forms and DMN decisions are out of scope.
+
+- **Read options:**
+
+  - `-r`, `--root`: Path of the partition-1 directory (the folder containing `snapshots/`), e.g.
+    `<data>/raft-partition/partitions/1`.
+  - `-s`, `--snapshot`: Id of the snapshot directory to read (a sub-directory of `<root>/snapshots/`).
+  - `--runtime`: Optional temporary runtime directory the snapshot is copied into before reading. A
+    fresh temp directory is created and deleted automatically if omitted.
+- **Connection options** (default from the container env vars shown in parentheses):
+  - `--connect-type`: `elasticsearch`|`opensearch` (`CAMUNDA_DATABASE_TYPE`, default
+    `elasticsearch`).
+  - `--connect-url`: Secondary storage URL (`CAMUNDA_DATABASE_URL`, default `http://localhost:9200`).
+  - `--connect-username` / `--connect-password` (`CAMUNDA_DATABASE_USERNAME` /
+    `CAMUNDA_DATABASE_PASSWORD`).
+  - `--index-prefix`: Index prefix of the target installation (`CAMUNDA_DATABASE_INDEXPREFIX`). **This
+    is the main footgun** — a wrong prefix targets a non-existent index; the command **fails fast** if
+    the target process index does not already exist.
+  - TLS: `--connect-security-enabled`, `--connect-security-certificate-path`,
+    `--connect-security-verify-hostname`, `--connect-security-self-signed`.
+- **Behavior options:**
+  - `--override`: Rewrite definitions that already exist (default: only write missing ones).
+  - `--dry-run`: Compute and report the diff without writing anything.
+  - `--batch-size`: Definitions per bulk request (default `50`).
+- **Output:** human-readable progress and the final summary go to **stderr**; a machine-readable
+  summary line (`total=.. present=.. written=.. skipped=.. failed=..`) goes to **stdout**. Exit code
+  `0` on success, `2` if any definition failed to recover, `1` on a configuration/validation error.
+- **Example (in-pod, connection defaulted from the container env):**
+
+  ```
+  # find the latest partition-1 snapshot id
+  ls /usr/local/camunda/data/raft-partition/partitions/1/snapshots/
+
+  debug-cli recover process-definitions \
+    -r /usr/local/camunda/data/raft-partition/partitions/1 \
+    -s <snapshot-id> --dry-run
+  ```
+- **Note:** RDBMS secondary storage is not yet supported (Elasticsearch/OpenSearch only).
 
 #### `help`
 

--- a/debug-cli/pom.xml
+++ b/debug-cli/pom.xml
@@ -16,7 +16,6 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
-      <version>4.7.7</version>
     </dependency>
 
     <dependency>
@@ -144,6 +143,38 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-workflow-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-schema-manager</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>webapps-schema</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-expression-language</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client-connect</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-exporter-common</artifactId>
     </dependency>
   </dependencies>
 

--- a/debug-cli/src/main/java/io/camunda/debug/cli/Main.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/Main.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.debug.cli;
 
+import io.camunda.debug.cli.recover.RecoverCommand;
 import io.camunda.debug.cli.sbe.SbeCommand;
 import io.camunda.debug.cli.state.StateCommand;
 import picocli.CommandLine;
@@ -22,7 +23,8 @@ import picocli.CommandLine.Command;
       TopologyMetaCommand.class,
       RaftCommand.class,
       StateCommand.class,
-      SbeCommand.class
+      SbeCommand.class,
+      RecoverCommand.class
     })
 public class Main {
 

--- a/debug-cli/src/main/java/io/camunda/debug/cli/recover/NoopProcessCache.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/recover/NoopProcessCache.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.recover;
+
+import io.camunda.zeebe.exporter.common.cache.ExporterEntityCache;
+import io.camunda.zeebe.exporter.common.cache.process.CachedProcessEntity;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Throwaway {@link ExporterEntityCache} for driving {@code ProcessHandler} during recovery. {@code
+ * ProcessHandler#updateEntity} only ever writes to the cache (to speed up sibling handlers during
+ * normal export); it never reads from it, and no sibling handlers run here, so every read returns
+ * empty and every write is discarded.
+ */
+final class NoopProcessCache implements ExporterEntityCache<Long, CachedProcessEntity> {
+
+  @Override
+  public Optional<CachedProcessEntity> get(final Long entityKey) {
+    return Optional.empty();
+  }
+
+  @Override
+  public Map<Long, CachedProcessEntity> getAll(final Iterable<Long> keys) {
+    return Map.of();
+  }
+
+  @Override
+  public void put(final Long entityKey, final CachedProcessEntity entity) {
+    // discarded: see class javadoc
+  }
+
+  @Override
+  public void remove(final Long entityKey) {
+    // discarded: see class javadoc
+  }
+
+  @Override
+  public void clear() {
+    // nothing cached
+  }
+}

--- a/debug-cli/src/main/java/io/camunda/debug/cli/recover/ProcessDefinitionRecovery.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/recover/ProcessDefinitionRecovery.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.recover;
+
+import static io.camunda.debug.cli.util.ErrorMessageUtil.rootMessage;
+
+import io.camunda.exporter.handlers.EmbeddedFormHandler;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.ProcessHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import java.io.PrintWriter;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Re-exports process definitions read from primary storage (RocksDB) into secondary storage (ES/OS)
+ * by driving the real {@link ExportHandler}s off a {@link RecoveredProcessRecord}. Only {@code
+ * ACTIVE} definitions are recovered; a definition already present in secondary storage is skipped
+ * unless {@code override} is set. All writes are id-keyed overwrites, so recovery is idempotent and
+ * safe to re-run.
+ *
+ * <p>This class is deliberately free of any RocksDB or ES/OS wiring so it can be unit-tested with a
+ * fake {@link ExistingDocuments} predicate and a fake {@link BatchRequest}.
+ */
+final class ProcessDefinitionRecovery {
+
+  private final ProcessHandler processHandler;
+  private final EmbeddedFormHandler embeddedFormHandler;
+  private final Supplier<BatchRequest> batchRequestFactory;
+  private final ExistingDocuments existingDocuments;
+  private final boolean override;
+  private final boolean dryRun;
+  private final int batchSize;
+  private final PrintWriter progress;
+
+  ProcessDefinitionRecovery(
+      final ProcessHandler processHandler,
+      final EmbeddedFormHandler embeddedFormHandler,
+      final Supplier<BatchRequest> batchRequestFactory,
+      final ExistingDocuments existingDocuments,
+      final boolean override,
+      final boolean dryRun,
+      final int batchSize,
+      final PrintWriter progress) {
+    this.processHandler = processHandler;
+    this.embeddedFormHandler = embeddedFormHandler;
+    this.batchRequestFactory = batchRequestFactory;
+    this.existingDocuments = existingDocuments;
+    this.override = override;
+    this.dryRun = dryRun;
+    this.batchSize = batchSize;
+    this.progress = progress;
+  }
+
+  /**
+   * Iterates the given source of persisted processes and recovers each one. Never throws for a
+   * single failed definition: failures are counted and reported so a single corrupt definition does
+   * not abort the whole recovery.
+   */
+  Summary run(final ProcessSource source) {
+    final var run = new Run();
+    source.forEach(run::accept);
+    run.flush();
+    return run.summary();
+  }
+
+  /**
+   * Builds every entity the handler derives from {@code record} and, unless {@code batch} is {@code
+   * null} (dry-run), flushes it.
+   */
+  private <T extends ExporterEntity<T>> void drive(
+      final ExportHandler<T, Process> handler,
+      final Record<Process> record,
+      final BatchRequest batch) {
+    for (final String id : handler.generateIds(record)) {
+      final T entity = handler.createNewEntity(id);
+      handler.updateEntity(record, entity);
+      if (batch != null) {
+        handler.flush(entity, batch);
+      }
+    }
+  }
+
+  /** Outcome counts of a recovery run. */
+  record Summary(long total, long alreadyPresent, long written, long skippedInactive, long failed) {
+
+    boolean hasFailures() {
+      return failed > 0;
+    }
+  }
+
+  /** A source of persisted processes, e.g. {@code DbProcessState#forEachProcess}. */
+  @FunctionalInterface
+  interface ProcessSource {
+    void forEach(Consumer<PersistedProcess> consumer);
+  }
+
+  /** Existence check for a process-definition document in secondary storage, keyed by its id. */
+  @FunctionalInterface
+  interface ExistingDocuments {
+    boolean exists(long processDefinitionKey);
+  }
+
+  /** Holds the mutable per-run state (current batch + counters). */
+  private final class Run {
+    private BatchRequest batch;
+    private int pendingInBatch;
+
+    private long total;
+    private long alreadyPresent;
+    private long written;
+    private long skippedInactive;
+    private long failed;
+
+    private void accept(final PersistedProcess process) {
+      if (process.getState() != PersistedProcessState.ACTIVE) {
+        skippedInactive++;
+        return;
+      }
+      total++;
+
+      final long key = process.getKey();
+      try {
+        final boolean exists = existingDocuments.exists(key);
+        if (exists) {
+          alreadyPresent++;
+          if (!override) {
+            return;
+          }
+        }
+
+        final Record<Process> record = RecoveredProcessRecord.from(process);
+        if (dryRun) {
+          // Exercise the mapping to surface any conversion error, but write nothing.
+          drive(processHandler, record, null);
+          drive(embeddedFormHandler, record, null);
+          written++;
+        } else {
+          drive(processHandler, record, currentBatch());
+          drive(embeddedFormHandler, record, currentBatch());
+          // Counted optimistically here; a failing batch flush moves these back to `failed`.
+          written++;
+          pendingInBatch++;
+          if (pendingInBatch >= batchSize) {
+            flush();
+          }
+        }
+      } catch (final Exception e) {
+        failed++;
+        progress.println("Failed to recover process definition " + key + ": " + rootMessage(e));
+      }
+    }
+
+    private BatchRequest currentBatch() {
+      if (batch == null) {
+        batch = batchRequestFactory.get();
+      }
+      return batch;
+    }
+
+    private void flush() {
+      if (batch == null || pendingInBatch == 0) {
+        return;
+      }
+      try {
+        batch.execute();
+      } catch (final Exception e) {
+        // The whole batch failed to apply: move its definitions from written to failed.
+        written -= pendingInBatch;
+        failed += pendingInBatch;
+        progress.println(
+            "Failed to flush a batch of " + pendingInBatch + " definitions: " + rootMessage(e));
+      } finally {
+        batch = null;
+        pendingInBatch = 0;
+      }
+    }
+
+    private Summary summary() {
+      return new Summary(total, alreadyPresent, written, skippedInactive, failed);
+    }
+  }
+}

--- a/debug-cli/src/main/java/io/camunda/debug/cli/recover/RecoverCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/recover/RecoverCommand.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.recover;
+
+import picocli.CommandLine.Command;
+
+/**
+ * Command group for recovering data in secondary storage (ES/OS) from Zeebe primary storage
+ * (RocksDB), for disaster recovery when secondary-storage documents are lost.
+ */
+@Command(
+    name = "recover",
+    description = "Recover secondary-storage data from a Zeebe primary-storage (RocksDB) snapshot",
+    subcommands = {RecoverProcessDefinitionsCommand.class})
+public class RecoverCommand {}

--- a/debug-cli/src/main/java/io/camunda/debug/cli/recover/RecoverProcessDefinitionsCommand.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/recover/RecoverProcessDefinitionsCommand.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.recover;
+
+import static io.camunda.debug.cli.util.ErrorMessageUtil.rootMessage;
+
+import io.camunda.debug.cli.recover.ProcessDefinitionRecovery.Summary;
+import io.camunda.debug.cli.state.SnapshotUtil;
+import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.handlers.EmbeddedFormHandler;
+import io.camunda.exporter.handlers.ProcessHandler;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.descriptors.index.FormIndex;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.el.ExpressionLanguageMetrics;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.deployment.model.BpmnFactory;
+import io.camunda.zeebe.engine.state.deployment.DbProcessState;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.concurrent.Callable;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Spec;
+
+/**
+ * Re-exports process definitions from a Zeebe partition-1 snapshot (primary storage) into secondary
+ * storage (ES/OS). Partition 1 is the deployment partition, so its process state is a complete
+ * superset of all deployments across all tenants, and every process-definition key is the id of the
+ * corresponding secondary-storage document.
+ *
+ * <p>The snapshot is read strictly read-only (copied into a throwaway runtime first), so this can
+ * be run in-pod on a live broker hosting a partition-1 replica — no outage required.
+ *
+ * <p>Output convention: stdout carries the machine-readable summary line; human-readable progress
+ * goes to stderr.
+ */
+@Command(
+    name = "process-definitions",
+    description =
+        "Re-export ACTIVE process definitions (and their embedded start forms) from a partition-1 "
+            + "snapshot into secondary storage (Elasticsearch/OpenSearch).")
+public class RecoverProcessDefinitionsCommand implements Callable<Integer> {
+
+  @Spec private CommandSpec spec;
+
+  // --- Primary-storage (read) options, mirroring the `state` commands ---
+
+  @Option(
+      names = {"-r", "--root"},
+      description =
+          "Path of the partition-1 directory (the folder containing 'snapshots/'), e.g. "
+              + "<data>/raft-partition/partitions/1",
+      required = true)
+  private Path root;
+
+  @Option(
+      names = {"-s", "--snapshot"},
+      description = "Id of the snapshot directory to read (under '<root>/snapshots/')",
+      required = true)
+  private String snapshotId;
+
+  @Option(
+      names = {"--runtime"},
+      description =
+          "Path to a temporary runtime directory the snapshot is copied into before reading. "
+              + "A fresh temp directory is created and deleted automatically if omitted.")
+  private Path runtimePath;
+
+  // --- Secondary-storage (write) connection options, defaulted from the container env ---
+
+  @Option(
+      names = {"--connect-type"},
+      description = "Secondary storage type: elasticsearch|opensearch (default: ${DEFAULT-VALUE})",
+      defaultValue = "${env:CAMUNDA_DATABASE_TYPE:-elasticsearch}")
+  private String connectType;
+
+  @Option(
+      names = {"--connect-url"},
+      description = "Secondary storage URL (default: ${DEFAULT-VALUE})",
+      defaultValue = "${env:CAMUNDA_DATABASE_URL:-http://localhost:9200}")
+  private String connectUrl;
+
+  @Option(
+      names = {"--connect-username"},
+      description = "Secondary storage username",
+      defaultValue = "${env:CAMUNDA_DATABASE_USERNAME}")
+  private String connectUsername;
+
+  @Option(
+      names = {"--connect-password"},
+      description = "Secondary storage password",
+      defaultValue = "${env:CAMUNDA_DATABASE_PASSWORD}")
+  private String connectPassword;
+
+  @Option(
+      names = {"--index-prefix"},
+      description =
+          "Index prefix of the target secondary storage. MUST match the running installation; a "
+              + "wrong prefix targets a non-existent index and the command fails fast.",
+      defaultValue = "${env:CAMUNDA_DATABASE_INDEXPREFIX}")
+  private String indexPrefix;
+
+  @Option(
+      names = {"--connect-security-enabled"},
+      description = "Enable TLS to the secondary storage",
+      defaultValue = "${env:CAMUNDA_DATABASE_SECURITY_ENABLED:-false}")
+  private boolean securityEnabled;
+
+  @Option(
+      names = {"--connect-security-certificate-path"},
+      description = "Path to the CA certificate used for TLS",
+      defaultValue = "${env:CAMUNDA_DATABASE_SECURITY_CERTIFICATEPATH}")
+  private String certificatePath;
+
+  @Option(
+      names = {"--connect-security-verify-hostname"},
+      description = "Verify the TLS hostname (default: ${DEFAULT-VALUE})",
+      defaultValue = "${env:CAMUNDA_DATABASE_SECURITY_VERIFYHOSTNAME:-true}")
+  private boolean verifyHostname;
+
+  @Option(
+      names = {"--connect-security-self-signed"},
+      description = "Accept a self-signed TLS certificate (default: ${DEFAULT-VALUE})",
+      defaultValue = "${env:CAMUNDA_DATABASE_SECURITY_SELFSIGNED:-false}")
+  private boolean selfSigned;
+
+  // --- Behavior options ---
+
+  @Option(
+      names = {"--override"},
+      description =
+          "Rewrite process definitions that already exist in secondary storage (default: only "
+              + "write missing ones).")
+  private boolean override;
+
+  @Option(
+      names = {"--dry-run"},
+      description = "Compute and report the diff without writing anything.")
+  private boolean dryRun;
+
+  @Option(
+      names = {"--batch-size"},
+      description =
+          "Number of process definitions to write per bulk request (default: ${DEFAULT-VALUE}).",
+      defaultValue = "50")
+  private int batchSize;
+
+  @Override
+  public Integer call() throws Exception {
+    final PrintWriter out = spec.commandLine().getOut();
+    final PrintWriter err = spec.commandLine().getErr();
+
+    if (batchSize <= 0) {
+      err.println("--batch-size must be greater than 0");
+      return 1;
+    }
+
+    final ConnectConfiguration connectConfiguration = buildConnectConfiguration(err);
+    if (connectConfiguration == null) {
+      return 1;
+    }
+    final DatabaseType databaseType = connectConfiguration.getTypeEnum();
+    final boolean isElasticsearch = databaseType.isElasticSearch();
+
+    final var indexDescriptors =
+        new IndexDescriptors(connectConfiguration.getIndexPrefix(), isElasticsearch);
+    final String processIndexName = indexDescriptors.get(ProcessIndex.class).getFullQualifiedName();
+    final String formIndexName = indexDescriptors.get(FormIndex.class).getFullQualifiedName();
+
+    final Path snapshotPath =
+        root.resolve(FileBasedSnapshotStoreImpl.SNAPSHOTS_DIRECTORY).resolve(snapshotId);
+    if (!Files.isDirectory(snapshotPath)) {
+      err.println("Snapshot directory does not exist: " + snapshotPath);
+      return 1;
+    }
+
+    final Path runtime;
+    final Path ephemeralParent;
+    if (runtimePath == null) {
+      try {
+        ephemeralParent = Files.createTempDirectory("cdbg-recover-");
+      } catch (final IOException e) {
+        err.println(
+            "Failed to create a temporary runtime directory under "
+                + System.getProperty("java.io.tmpdir")
+                + ": "
+                + rootMessage(e)
+                + ". Retry with --runtime pointing at a directory the current user can write to.");
+        return 1;
+      }
+      runtime = ephemeralParent.resolve("runtime");
+    } else {
+      ephemeralParent = null;
+      runtime = runtimePath;
+    }
+
+    err.println("=== Recovering process definitions ===");
+    err.println("Reading snapshot: " + snapshotPath);
+    err.println(
+        "Target: "
+            + databaseType
+            + " at "
+            + connectConfiguration.getUrl()
+            + " (index prefix '"
+            + connectConfiguration.getIndexPrefix()
+            + "')");
+    err.println(
+        "Mode: "
+            + (dryRun ? "dry-run" : (override ? "override" : "missing-only"))
+            + ", batch size "
+            + batchSize);
+
+    try (final ClientAdapter clientAdapter = ClientAdapter.of(connectConfiguration)) {
+      final var searchEngineClient = clientAdapter.getSearchEngineClient();
+
+      // Fail fast on a wrong --index-prefix: without the ProcessIndex, writes would silently target
+      // a non-existent/mis-prefixed index instead of recovering into the real installation.
+      if (!searchEngineClient.indexExists(processIndexName)) {
+        err.println(
+            "Process index '"
+                + processIndexName
+                + "' does not exist. Check --index-prefix / --connect-type matches the target "
+                + "installation.");
+        return 1;
+      }
+      if (!searchEngineClient.indexExists(formIndexName)) {
+        err.println(
+            "Form index '"
+                + formIndexName
+                + "' does not exist. Check --index-prefix / --connect-type matches the target "
+                + "installation.");
+        return 1;
+      }
+
+      final var processHandler =
+          new ProcessHandler(
+              processIndexName, new NoopProcessCache(), new ExtensionPropertyConfiguration());
+      final var embeddedFormHandler = new EmbeddedFormHandler(formIndexName);
+
+      final var recovery =
+          new ProcessDefinitionRecovery(
+              processHandler,
+              embeddedFormHandler,
+              clientAdapter::createBatchRequest,
+              key -> searchEngineClient.getDocument(processIndexName, String.valueOf(key)) != null,
+              override,
+              dryRun,
+              batchSize,
+              err);
+
+      try (final ZeebeDb<ZbColumnFamilies> db = openReadOnly(snapshotPath, runtime)) {
+        final var processState = openProcessState(db);
+        final Summary summary =
+            recovery.run(
+                consumer ->
+                    processState.forEachProcess(
+                        null,
+                        process -> {
+                          consumer.accept(process);
+                          return true;
+                        }));
+
+        printSummary(err, out, summary);
+        return summary.hasFailures() ? 2 : 0;
+      }
+    } finally {
+      if (ephemeralParent != null) {
+        FileUtil.deleteFolderIfExists(ephemeralParent);
+      }
+    }
+  }
+
+  private ConnectConfiguration buildConnectConfiguration(final PrintWriter err) {
+    final String normalizedType = normalizeType(connectType);
+    if (normalizedType == null) {
+      err.println(
+          "Unsupported --connect-type '" + connectType + "'. Supported: elasticsearch|opensearch.");
+      return null;
+    }
+
+    final var configuration = new ConnectConfiguration();
+    configuration.setType(normalizedType);
+    configuration.setUrl(connectUrl);
+    if (isNotBlank(connectUsername)) {
+      configuration.setUsername(connectUsername);
+    }
+    if (isNotBlank(connectPassword)) {
+      configuration.setPassword(connectPassword);
+    }
+    if (indexPrefix != null) {
+      configuration.setIndexPrefix(indexPrefix);
+    }
+
+    final var security = configuration.getSecurity();
+    security.setEnabled(securityEnabled);
+    security.setVerifyHostname(verifyHostname);
+    security.setSelfSigned(selfSigned);
+    if (isNotBlank(certificatePath)) {
+      security.setCertificatePath(certificatePath);
+    }
+    return configuration;
+  }
+
+  private static String normalizeType(final String type) {
+    if (type == null) {
+      return null;
+    }
+    return switch (type.trim().toLowerCase()) {
+      case "elasticsearch" -> DatabaseType.ELASTICSEARCH.toString();
+      case "opensearch" -> DatabaseType.OPENSEARCH.toString();
+      default -> null;
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ZeebeDb<ZbColumnFamilies> openReadOnly(
+      final Path snapshotPath, final Path runtime) {
+    return (ZeebeDb<ZbColumnFamilies>) new SnapshotUtil().openSnapshot(snapshotPath, runtime);
+  }
+
+  private static DbProcessState openProcessState(final ZeebeDb<ZbColumnFamilies> db) {
+    final var stateTransformer =
+        BpmnFactory.createTransformer(
+            InstantSource.fixed(Instant.EPOCH),
+            ExpressionLanguageMetrics.noop(),
+            Integer.MAX_VALUE);
+    return new DbProcessState(db, db.createContext(), new EngineConfiguration(), stateTransformer);
+  }
+
+  private void printSummary(final PrintWriter err, final PrintWriter out, final Summary summary) {
+    err.println("=== Done ===");
+    err.println("Active process definitions in snapshot: " + summary.total());
+    err.println("Already present in secondary storage:   " + summary.alreadyPresent());
+    err.println(
+        (dryRun ? "Would write:" : "Written:")
+            + "                            "
+            + summary.written());
+    err.println("Skipped (not ACTIVE):                   " + summary.skippedInactive());
+    err.println("Failed:                                 " + summary.failed());
+    // Machine-readable summary on stdout.
+    out.printf(
+        "total=%d present=%d written=%d skipped=%d failed=%d%n",
+        summary.total(),
+        summary.alreadyPresent(),
+        summary.written(),
+        summary.skippedInactive(),
+        summary.failed());
+  }
+
+  private static boolean isNotBlank(final String value) {
+    return value != null && !value.isBlank();
+  }
+}

--- a/debug-cli/src/main/java/io/camunda/debug/cli/recover/RecoveredProcessRecord.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/recover/RecoveredProcessRecord.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.recover;
+
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.Agent;
+import io.camunda.zeebe.protocol.record.ChannelType;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import io.camunda.zeebe.util.VersionUtil;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Map;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/**
+ * A synthetic {@link Record} of a process deployment, reconstructed from a {@link PersistedProcess}
+ * read out of primary storage (RocksDB). It carries a {@link ProcessIntent#CREATED} intent and a
+ * {@link ProcessRecord} value so that it can drive the real {@code ProcessHandler} and {@code
+ * EmbeddedFormHandler} exactly as a freshly-exported deployment would. This guarantees the
+ * recovered secondary-storage documents are identical to normally-exported ones and inherits any
+ * future handler changes for free.
+ *
+ * <p>Only {@link #getIntent()} and {@link #getValue()} are consumed by those handlers; the
+ * remaining record metadata is not persisted by them and therefore throw
+ * UnsupportedOperationException if accessed. It emulates an event record, but position, timestamp
+ * and similar metadata are not recoverable — they were never persisted in primary storage and any
+ * original record has long been compacted.
+ */
+final class RecoveredProcessRecord implements Record<Process> {
+
+  private final ProcessRecord value;
+
+  private RecoveredProcessRecord(final ProcessRecord value) {
+    this.value = value;
+  }
+
+  /**
+   * Reconstructs a synthetic {@code CREATED} process record from a persisted process. The resource
+   * bytes are copied into a fresh buffer so the record stays valid after the (reused) {@link
+   * PersistedProcess} instance is advanced to the next entry during iteration.
+   */
+  static RecoveredProcessRecord from(final PersistedProcess process) {
+    final var record =
+        new ProcessRecord()
+            .setKey(process.getKey())
+            .setBpmnProcessId(BufferUtil.cloneBuffer(process.getBpmnProcessId()))
+            .setResourceName(BufferUtil.cloneBuffer(process.getResourceName()))
+            .setResource(new UnsafeBuffer(BufferUtil.bufferAsArray(process.getResource())))
+            .setVersion(process.getVersion())
+            .setVersionTag(process.getVersionTag())
+            .setTenantId(process.getTenantId())
+            .setDeploymentKey(process.getDeploymentKey());
+    return new RecoveredProcessRecord(record);
+  }
+
+  @Override
+  public String toJson() {
+    return value.toJson();
+  }
+
+  @Override
+  public long getPosition() {
+    throw new UnsupportedOperationException(
+        "getPosition() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public long getSourceRecordPosition() {
+    throw new UnsupportedOperationException(
+        "getSourceRecordPosition() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public long getKey() {
+    return value.getProcessDefinitionKey();
+  }
+
+  @Override
+  public long getTimestamp() {
+    throw new UnsupportedOperationException(
+        "getTimestamp() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public Intent getIntent() {
+    return ProcessIntent.CREATED;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return Protocol.decodePartitionId(getKey());
+  }
+
+  @Override
+  public RecordType getRecordType() {
+    return RecordType.EVENT;
+  }
+
+  @Override
+  public RejectionType getRejectionType() {
+    throw new UnsupportedOperationException(
+        "getRejectionType() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public String getRejectionReason() {
+    throw new UnsupportedOperationException(
+        "getRejectionReason() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public String getBrokerVersion() {
+    return VersionUtil.getVersion();
+  }
+
+  @Override
+  public Map<String, Object> getAuthorizations() {
+    throw new UnsupportedOperationException(
+        "getAuthorizations() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public Agent getAgent() {
+    throw new UnsupportedOperationException(
+        "getAgent() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public ChannelType getRequestChannelType() {
+    throw new UnsupportedOperationException(
+        "getRequestChannelType() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public String getRequestToolName() {
+    throw new UnsupportedOperationException(
+        "getRequestToolName() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public int getRecordVersion() {
+    throw new UnsupportedOperationException(
+        "getRecordVersion() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public ValueType getValueType() {
+    return ValueType.PROCESS;
+  }
+
+  @Override
+  public Process getValue() {
+    return value;
+  }
+
+  @Override
+  public long getOperationReference() {
+    throw new UnsupportedOperationException(
+        "getOperationReference() is not supported for RecoveredProcessRecord");
+  }
+
+  @Override
+  public Record<Process> copyOf() {
+    throw new UnsupportedOperationException("copyOf() is not supported for RecoveredProcessRecord");
+  }
+}

--- a/debug-cli/src/main/java/io/camunda/debug/cli/util/ErrorMessageUtil.java
+++ b/debug-cli/src/main/java/io/camunda/debug/cli/util/ErrorMessageUtil.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.util;
+
+public final class ErrorMessageUtil {
+  private ErrorMessageUtil() {}
+
+  public static String rootMessage(final Throwable t) {
+    Throwable cur = t;
+    while (cur.getCause() != null && cur.getCause() != cur) {
+      cur = cur.getCause();
+    }
+    final var msg = cur.getMessage();
+    return msg != null ? msg : cur.getClass().getSimpleName();
+  }
+}

--- a/debug-cli/src/test/java/io/camunda/debug/cli/recover/FakeBatchRequest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/recover/FakeBatchRequest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.recover;
+
+import io.camunda.exporter.errorhandling.Error;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * In-memory {@link BatchRequest} for unit tests. Records every added entity per index and counts
+ * executions. Can be configured to fail on {@link #execute()} to exercise the failure path. Only
+ * the operations used by the recovery ({@code add}, {@code execute}) are implemented.
+ */
+@SuppressWarnings("rawtypes")
+final class FakeBatchRequest implements BatchRequest {
+
+  final List<Added> added = new ArrayList<>();
+  int executeCount;
+  private final boolean failOnExecute;
+
+  FakeBatchRequest() {
+    this(false);
+  }
+
+  FakeBatchRequest(final boolean failOnExecute) {
+    this.failOnExecute = failOnExecute;
+  }
+
+  List<Added> addedTo(final String index) {
+    return added.stream().filter(a -> a.index().equals(index)).toList();
+  }
+
+  @Override
+  public BatchRequest withMetrics(final CamundaExporterMetrics metrics) {
+    return this;
+  }
+
+  @Override
+  public BatchRequest withMaxBytes(final long maxBulkBytes) {
+    return this;
+  }
+
+  @Override
+  public BatchRequest add(final String index, final ExporterEntity entity) {
+    added.add(new Added(index, entity));
+    return this;
+  }
+
+  // --- Unused operations ---------------------------------------------------
+
+  @Override
+  public BatchRequest addWithId(final String index, final String id, final ExporterEntity entity) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BatchRequest addWithRouting(
+      final String index, final ExporterEntity entity, final String routing) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BatchRequest upsert(
+      final String index,
+      final String id,
+      final ExporterEntity entity,
+      final Map<String, Object> updateFields) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BatchRequest upsertWithRouting(
+      final String index,
+      final String id,
+      final ExporterEntity entity,
+      final Map<String, Object> updateFields,
+      final String routing) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BatchRequest upsertWithScript(
+      final String index,
+      final String id,
+      final ExporterEntity entity,
+      final String script,
+      final Map<String, Object> parameters) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BatchRequest upsertWithScriptAndRouting(
+      final String index,
+      final String id,
+      final ExporterEntity entity,
+      final String script,
+      final Map<String, Object> parameters,
+      final String routing) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BatchRequest update(
+      final String index, final String id, final Map<String, Object> updateFields) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BatchRequest update(final String index, final String id, final ExporterEntity entity) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BatchRequest updateWithScript(
+      final String index,
+      final String id,
+      final String script,
+      final Map<String, Object> parameters) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BatchRequest delete(final String index, final String id) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BatchRequest deleteWithRouting(final String index, final String id, final String routing) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void execute(final BiConsumer<String, Error> customErrorHandlers)
+      throws PersistenceException {
+    executeCount++;
+    if (failOnExecute) {
+      throw new PersistenceException("simulated bulk failure");
+    }
+  }
+
+  @Override
+  public void executeWithRefresh() throws PersistenceException {
+    execute();
+  }
+
+  record Added(String index, ExporterEntity entity) {}
+}

--- a/debug-cli/src/test/java/io/camunda/debug/cli/recover/ProcessDefinitionRecoveryTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/recover/ProcessDefinitionRecoveryTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.recover;
+
+import static io.camunda.debug.cli.recover.RecoverTestSupport.persistedProcess;
+import static io.camunda.debug.cli.recover.RecoverTestSupport.readResource;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.debug.cli.recover.ProcessDefinitionRecovery.ExistingDocuments;
+import io.camunda.debug.cli.recover.ProcessDefinitionRecovery.ProcessSource;
+import io.camunda.debug.cli.recover.ProcessDefinitionRecovery.Summary;
+import io.camunda.exporter.handlers.EmbeddedFormHandler;
+import io.camunda.exporter.handlers.ProcessHandler;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.ProcessEntity;
+import io.camunda.webapps.schema.entities.form.FormEntity;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+final class ProcessDefinitionRecoveryTest {
+
+  private static final String PROCESS_INDEX = "process";
+  private static final String FORM_INDEX = "form";
+
+  private final ProcessHandler processHandler =
+      new ProcessHandler(
+          PROCESS_INDEX, new NoopProcessCache(), new ExtensionPropertyConfiguration());
+  private final EmbeddedFormHandler embeddedFormHandler = new EmbeddedFormHandler(FORM_INDEX);
+
+  @Test
+  void shouldWriteOnlyMissingByDefault() throws IOException {
+    // given — key 1 already present, key 2 missing; key 3 is not ACTIVE.
+    final var batch = new FakeBatchRequest();
+    final var recovery = recovery(batch, existing(1L), false, false, 50);
+
+    // when
+    final Summary summary =
+        recovery.run(source(activeSimple(1L), activeSimple(2L), pendingDeletion(3L)));
+
+    // then
+    assertThat(summary.total()).isEqualTo(2);
+    assertThat(summary.alreadyPresent()).isEqualTo(1);
+    assertThat(summary.written()).isEqualTo(1);
+    assertThat(summary.skippedInactive()).isEqualTo(1);
+    assertThat(summary.failed()).isZero();
+    assertThat(processIds(batch)).containsExactly("2");
+  }
+
+  @Test
+  void shouldRewriteExistingWhenOverride() throws IOException {
+    // given — both present, override on.
+    final var batch = new FakeBatchRequest();
+    final var recovery = recovery(batch, existing(1L, 2L), true, false, 50);
+
+    // when
+    final Summary summary = recovery.run(source(activeSimple(1L), activeSimple(2L)));
+
+    // then
+    assertThat(summary.total()).isEqualTo(2);
+    assertThat(summary.alreadyPresent()).isEqualTo(2);
+    assertThat(summary.written()).isEqualTo(2);
+    assertThat(processIds(batch)).containsExactlyInAnyOrder("1", "2");
+  }
+
+  @Test
+  void shouldWriteNothingOnDryRun() throws IOException {
+    // given
+    final var batch = new FakeBatchRequest();
+    final var recovery = recovery(batch, existing(), false, true, 50);
+
+    // when
+    final Summary summary = recovery.run(source(activeSimple(1L), activeSimple(2L)));
+
+    // then — diff is computed but nothing is written or executed.
+    assertThat(summary.written()).isEqualTo(2);
+    assertThat(summary.alreadyPresent()).isZero();
+    assertThat(batch.added).isEmpty();
+    assertThat(batch.executeCount).isZero();
+  }
+
+  @Test
+  void shouldRecoverEmbeddedStartForm() throws IOException {
+    // given — a process carrying an embedded start form.
+    final var batch = new FakeBatchRequest();
+    final var recovery = recovery(batch, existing(), false, false, 50);
+
+    // when
+    final Summary summary = recovery.run(source(activeEmbeddedForm(7L)));
+
+    // then — both the process doc and its embedded form doc are written.
+    assertThat(summary.written()).isEqualTo(1);
+    assertThat(processIds(batch)).containsExactly("7");
+    final List<FakeBatchRequest.Added> forms = batch.addedTo(FORM_INDEX);
+    assertThat(forms).hasSize(1);
+    final FormEntity form = (FormEntity) forms.get(0).entity();
+    assertThat(form.getId()).isEqualTo("7_my-embedded-form");
+    assertThat(form.getProcessDefinitionId()).isEqualTo("7");
+  }
+
+  @Test
+  void shouldCountFailuresWhenBatchFlushFails() throws IOException {
+    // given — the bulk request fails to apply; batch size 1 so each definition flushes on its own.
+    final var batch = new FakeBatchRequest(true);
+    final var recovery = recovery(batch, existing(), false, false, 1);
+
+    // when
+    final Summary summary = recovery.run(source(activeSimple(1L), activeSimple(2L)));
+
+    // then — both definitions are reported as failed, none as written.
+    assertThat(summary.written()).isZero();
+    assertThat(summary.failed()).isEqualTo(2);
+    assertThat(summary.hasFailures()).isTrue();
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  private ProcessDefinitionRecovery recovery(
+      final BatchRequest batch,
+      final ExistingDocuments existing,
+      final boolean override,
+      final boolean dryRun,
+      final int batchSize) {
+    final Supplier<BatchRequest> factory = () -> batch;
+    return new ProcessDefinitionRecovery(
+        processHandler,
+        embeddedFormHandler,
+        factory,
+        existing,
+        override,
+        dryRun,
+        batchSize,
+        new PrintWriter(new StringWriter()));
+  }
+
+  private static ExistingDocuments existing(final Long... keys) {
+    final Set<Long> set = Set.of(keys);
+    return set::contains;
+  }
+
+  private static ProcessSource source(final PersistedProcess... processes) {
+    return consumer -> {
+      for (final PersistedProcess process : processes) {
+        consumer.accept(process);
+      }
+    };
+  }
+
+  private static List<String> processIds(final FakeBatchRequest batch) {
+    return batch.addedTo(PROCESS_INDEX).stream()
+        .map(a -> ((ProcessEntity) a.entity()).getId())
+        .toList();
+  }
+
+  private static PersistedProcess activeSimple(final long key) throws IOException {
+    return persistedProcess(
+        key,
+        "testProcessId",
+        1,
+        "",
+        "<default>",
+        "simple.bpmn",
+        readResource("recover/simple-process.bpmn"),
+        PersistedProcessState.ACTIVE);
+  }
+
+  private static PersistedProcess activeEmbeddedForm(final long key) throws IOException {
+    return persistedProcess(
+        key,
+        "testProcessId",
+        1,
+        "processTag",
+        "<default>",
+        "embedded-form.bpmn",
+        readResource("recover/embedded-form-process.bpmn"),
+        PersistedProcessState.ACTIVE);
+  }
+
+  private static PersistedProcess pendingDeletion(final long key) throws IOException {
+    return persistedProcess(
+        key,
+        "testProcessId",
+        1,
+        "",
+        "<default>",
+        "simple.bpmn",
+        readResource("recover/simple-process.bpmn"),
+        PersistedProcessState.PENDING_DELETION);
+  }
+}

--- a/debug-cli/src/test/java/io/camunda/debug/cli/recover/RecoverTestSupport.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/recover/RecoverTestSupport.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.recover;
+
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/** Shared helpers for the {@code recover} unit tests. */
+final class RecoverTestSupport {
+
+  private RecoverTestSupport() {}
+
+  static byte[] readResource(final String name) throws IOException {
+    try (final var in = RecoverTestSupport.class.getClassLoader().getResourceAsStream(name)) {
+      if (in == null) {
+        throw new IllegalStateException("Missing test resource: " + name);
+      }
+      return in.readAllBytes();
+    }
+  }
+
+  static String asString(final byte[] resource) {
+    return new String(resource, StandardCharsets.UTF_8);
+  }
+
+  static PersistedProcess persistedProcess(
+      final long key,
+      final String bpmnProcessId,
+      final int version,
+      final String versionTag,
+      final String tenantId,
+      final String resourceName,
+      final byte[] resource,
+      final PersistedProcessState state) {
+    final var record =
+        new ProcessRecord()
+            .setKey(key)
+            .setBpmnProcessId(bpmnProcessId)
+            .setVersion(version)
+            .setVersionTag(versionTag)
+            .setTenantId(tenantId)
+            .setResourceName(resourceName)
+            .setResource(new UnsafeBuffer(resource));
+    final var persisted = new PersistedProcess();
+    persisted.wrap(record, key);
+    persisted.setState(state);
+    return persisted;
+  }
+}

--- a/debug-cli/src/test/java/io/camunda/debug/cli/recover/RecoveredProcessRecordTest.java
+++ b/debug-cli/src/test/java/io/camunda/debug/cli/recover/RecoveredProcessRecordTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.debug.cli.recover;
+
+import static io.camunda.debug.cli.recover.RecoverTestSupport.asString;
+import static io.camunda.debug.cli.recover.RecoverTestSupport.persistedProcess;
+import static io.camunda.debug.cli.recover.RecoverTestSupport.readResource;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.handlers.ProcessHandler;
+import io.camunda.webapps.schema.entities.ProcessEntity;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
+import io.camunda.zeebe.exporter.common.extensionproperty.ExtensionPropertyConfiguration;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+final class RecoveredProcessRecordTest {
+
+  private static final String RESOURCE = "recover/simple-process.bpmn";
+
+  @Test
+  void shouldReconstructRecordFromPersistedProcess() throws IOException {
+    // given
+    final var resource = readResource(RESOURCE);
+    final var persisted =
+        persistedProcess(
+            123L,
+            "testProcessId",
+            2,
+            "processTag",
+            "tenant-a",
+            "simple.bpmn",
+            resource,
+            PersistedProcessState.ACTIVE);
+
+    // when
+    final var record = RecoveredProcessRecord.from(persisted);
+
+    // then
+    assertThat(record.getIntent()).isEqualTo(ProcessIntent.CREATED);
+    assertThat(record.getValueType()).isEqualTo(ValueType.PROCESS);
+    assertThat(record.getKey()).isEqualTo(123L);
+
+    final Process value = record.getValue();
+    assertThat(value.getProcessDefinitionKey()).isEqualTo(123L);
+    assertThat(value.getBpmnProcessId()).isEqualTo("testProcessId");
+    assertThat(value.getVersion()).isEqualTo(2);
+    assertThat(value.getVersionTag()).isEqualTo("processTag");
+    assertThat(value.getTenantId()).isEqualTo("tenant-a");
+    assertThat(value.getResourceName()).isEqualTo("simple.bpmn");
+    assertThat(asString(value.getResource())).isEqualTo(asString(resource));
+  }
+
+  @Test
+  void shouldProduceSameProcessEntityAsRealHandlerReads() throws IOException {
+    // given — the anti-drift guarantee: driving the real ProcessHandler off a record reconstructed
+    // from primary storage yields a document carrying exactly the persisted-process data.
+    final var resource = readResource(RESOURCE);
+    final var persisted =
+        persistedProcess(
+            456L,
+            "testProcessId",
+            3,
+            "processTag",
+            "<default>",
+            "simple.bpmn",
+            resource,
+            PersistedProcessState.ACTIVE);
+    final var handler =
+        new ProcessHandler("process", new NoopProcessCache(), new ExtensionPropertyConfiguration());
+    final var record = RecoveredProcessRecord.from(persisted);
+
+    // when
+    final var entity = new ProcessEntity();
+    handler.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getId()).isEqualTo("456");
+    assertThat(entity.getKey()).isEqualTo(456L);
+    assertThat(entity.getBpmnProcessId()).isEqualTo("testProcessId");
+    assertThat(entity.getVersion()).isEqualTo(3);
+    assertThat(entity.getVersionTag()).isEqualTo("processTag");
+    assertThat(entity.getTenantId()).isEqualTo("<default>");
+    assertThat(entity.getResourceName()).isEqualTo("simple.bpmn");
+    assertThat(entity.getName()).isEqualTo("testProcessName");
+    assertThat(entity.getBpmnXml()).isEqualTo(asString(resource));
+  }
+}

--- a/debug-cli/src/test/resources/recover/embedded-form-process.bpmn
+++ b/debug-cli/src/test/resources/recover/embedded-form-process.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1podyfa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="testProcessId" name="testProcessName" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag value="processTag" />
+      <zeebe:userTaskForm id="my-embedded-form">{
+  "components": [
+    {
+      "label": "Text field",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_14zv75q",
+        "columns": null
+      },
+      "id": "Field_0h71kwj",
+      "key": "textfield_t43iqk"
+    }
+  ],
+  "type": "default",
+  "id": "my-form",
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.6.0",
+  "versionTag": "3",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.28.0"
+  },
+  "schemaVersion": 16
+}</zeebe:userTaskForm>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="startEvent" name="start">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="testForm" />
+        <zeebe:properties>
+          <zeebe:property name="publicAccess" value="true" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0nn8ukk</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="endEvent" name="end">
+      <bpmn:incoming>Flow_0nn8ukk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0nn8ukk" sourceRef="startEvent" targetRef="endEvent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="testProcessId">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEvent">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="125" width="22" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1v78bxg_di" bpmnElement="endEvent">
+        <dc:Bounds x="242" y="82" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="251" y="125" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0nn8ukk_di" bpmnElement="Flow_0nn8ukk">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="242" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/debug-cli/src/test/resources/recover/simple-process.bpmn
+++ b/debug-cli/src/test/resources/recover/simple-process.bpmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1podyfa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="testProcessId" name="testProcessName" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag value="processTag" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="startEvent" name="start">
+      <bpmn:outgoing>Flow_0nn8ukk</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="endEvent" name="end">
+      <bpmn:incoming>Flow_0nn8ukk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0nn8ukk" sourceRef="startEvent" targetRef="endEvent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="testProcessId">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEvent">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="125" width="22" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1v78bxg_di" bpmnElement="endEvent">
+        <dc:Bounds x="242" y="82" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="251" y="125" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0nn8ukk_di" bpmnElement="Flow_0nn8ukk">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="242" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -180,6 +180,7 @@
     <version.commons-collections>20040616</version.commons-collections>
     <version.reflections>0.10.2</version.reflections>
     <version.hikari-cp>7.1.0</version.hikari-cp>
+    <version.picocli>4.7.7</version.picocli>
 
     <version.commons-io>2.22.0</version.commons-io>
     <version.thymeleaf>3.1.5.RELEASE</version.thymeleaf>
@@ -2318,6 +2319,12 @@
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
         <version>${version.hikari-cp}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>info.picocli</groupId>
+        <artifactId>picocli</artifactId>
+        <version>${version.picocli}</version>
       </dependency>
 
     </dependencies>

--- a/qa/acceptance-tests/pom.xml
+++ b/qa/acceptance-tests/pom.xml
@@ -588,6 +588,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>debug-cli</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
@@ -686,6 +691,11 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/recover/RecoverProcessDefinitionsMultiDbIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/recover/RecoverProcessDefinitionsMultiDbIT.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.recover;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.ProblemDetail;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.configuration.beans.SearchEngineConnectProperties;
+import io.camunda.debug.cli.Main;
+import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.webapps.schema.descriptors.index.ProcessIndex;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.stream.Stream;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * End-to-end test for {@code cdbg recover process-definitions}: deploy process definitions, take a
+ * partition-1 snapshot, simulate loss by deleting a document from secondary storage, run the
+ * recovery command against the (still running) broker's snapshot, and assert the lost definition is
+ * restored while the surviving one is left untouched.
+ *
+ * <p>Reads the snapshot in-pod while the broker is live — no outage — exercising the default
+ * execution model. RDBMS is not supported by the command yet and is gated out.
+ */
+@MultiDbTest
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason = "recover process-definitions supports Elasticsearch/OpenSearch only")
+@DisabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "AWS_OS",
+    disabledReason = "AWS OpenSearch requires a dedicated client not built by this test")
+public class RecoverProcessDefinitionsMultiDbIT {
+
+  private static final int TIMEOUT = 60;
+  private static final Path WORKING_DIRECTORY = createWorkingDirectory();
+
+  private static CamundaClient client;
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withWorkingDirectory(WORKING_DIRECTORY)
+          .withUnauthenticatedAccess();
+
+  @Test
+  void shouldRecoverLostProcessDefinition() throws Exception {
+    // given — two deployed, exported process definitions
+    final long lostKey = deployProcessModel("recover-lost");
+    final long survivingKey = deployProcessModel("recover-surviving");
+
+    final ConnectConfiguration connectConfiguration =
+        BROKER.bean(SearchEngineConnectProperties.class);
+    final boolean isElasticsearch = connectConfiguration.getTypeEnum().isElasticSearch();
+    final String processIndexName =
+        new IndexDescriptors(connectConfiguration.getIndexPrefix(), isElasticsearch)
+            .get(ProcessIndex.class)
+            .getFullQualifiedName();
+
+    // capture both definitions in a partition-1 snapshot (partition 1 is the deployment partition)
+    final String snapshotId = takePartitionOneSnapshot();
+
+    // simulate secondary-storage loss: drop one process-definition document
+    deleteDocument(connectConfiguration, processIndexName, lostKey);
+    awaitProcessDefinitionMissing(lostKey);
+
+    // when — recover from the snapshot while the broker keeps running (in-pod, no outage)
+    final ExecResult result = runRecover(connectConfiguration, snapshotId);
+
+    // then — command succeeded and reports one recovered, one already present
+    assertThat(result.exitCode).as(result.err).isZero();
+    assertThat(result.out).contains("written=1").contains("present=1");
+
+    // the lost definition is queryable again; the surviving one is still there
+    awaitProcessDefinitionPresent(lostKey);
+    awaitProcessDefinitionPresent(survivingKey);
+  }
+
+  private ExecResult runRecover(
+      final ConnectConfiguration connectConfiguration, final String snapshotId) throws Exception {
+    final Path partitionOne = partitionOneDirectory();
+
+    final List<String> args = new ArrayList<>();
+    args.add("recover");
+    args.add("process-definitions");
+    args.add("--root=" + partitionOne);
+    args.add("--snapshot=" + snapshotId);
+    args.add("--connect-type=" + connectType(connectConfiguration));
+    args.add("--connect-url=" + connectConfiguration.getUrl());
+    args.add("--index-prefix=" + connectConfiguration.getIndexPrefix());
+    if (isNotBlank(connectConfiguration.getUsername())) {
+      args.add("--connect-username=" + connectConfiguration.getUsername());
+    }
+    if (isNotBlank(connectConfiguration.getPassword())) {
+      args.add("--connect-password=" + connectConfiguration.getPassword());
+    }
+
+    final StringWriter out = new StringWriter();
+    final StringWriter err = new StringWriter();
+    final int exitCode;
+    try (final PrintWriter outWriter = new PrintWriter(out);
+        final PrintWriter errWriter = new PrintWriter(err)) {
+      exitCode =
+          new picocli.CommandLine(new Main())
+              .setOut(outWriter)
+              .setErr(errWriter)
+              .execute(args.toArray(String[]::new));
+    }
+    return new ExecResult(exitCode, out.toString(), err.toString());
+  }
+
+  private static String connectType(final ConnectConfiguration connectConfiguration) {
+    return connectConfiguration.getTypeEnum() == DatabaseType.OPENSEARCH
+        ? "opensearch"
+        : "elasticsearch";
+  }
+
+  private void deleteDocument(
+      final ConnectConfiguration connectConfiguration, final String indexName, final long key)
+      throws Exception {
+    try (final ClientAdapter adapter = ClientAdapter.of(connectConfiguration)) {
+      final var batchRequest = adapter.createBatchRequest();
+      batchRequest.delete(indexName, String.valueOf(key));
+      batchRequest.executeWithRefresh();
+    }
+  }
+
+  private String takePartitionOneSnapshot() {
+    final PartitionsActuator partitions = PartitionsActuator.of(BROKER);
+    partitions.takeSnapshot();
+    return Awaitility.await("until a partition-1 snapshot exists")
+        .atMost(Duration.ofSeconds(TIMEOUT))
+        .until(
+            () -> Optional.ofNullable(partitions.query().get(1).snapshotId()), Optional::isPresent)
+        .orElseThrow();
+  }
+
+  private Path partitionOneDirectory() throws Exception {
+    // The partition group directory is named after the physical tenant ("default"); glob for it
+    // rather than hardcoding the name.
+    try (final Stream<Path> groups = Files.list(WORKING_DIRECTORY.resolve("data"))) {
+      return groups
+          .map(group -> group.resolve("partitions").resolve("1"))
+          .filter(Files::isDirectory)
+          .findFirst()
+          .orElseThrow(() -> new IllegalStateException("No partition-1 directory found"));
+    }
+  }
+
+  private long deployProcessModel(final String bpmnProcessId) {
+    final BpmnModelInstance model =
+        Bpmn.createExecutableProcess(bpmnProcessId).startEvent().endEvent().done();
+    final long processDefinitionKey =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(model, bpmnProcessId + ".bpmn")
+            .send()
+            .join()
+            .getProcesses()
+            .getFirst()
+            .getProcessDefinitionKey();
+    awaitProcessDefinitionPresent(processDefinitionKey);
+    return processDefinitionKey;
+  }
+
+  private void awaitProcessDefinitionPresent(final long processDefinitionKey) {
+    Awaitility.await("until process definition " + processDefinitionKey + " is queryable")
+        .atMost(Duration.ofSeconds(2 * TIMEOUT))
+        .untilAsserted(
+            () -> {
+              final Future<?> request =
+                  client.newProcessDefinitionGetRequest(processDefinitionKey).send();
+              assertThat(request).succeedsWithin(Duration.ofSeconds(TIMEOUT));
+            });
+  }
+
+  private void awaitProcessDefinitionMissing(final long processDefinitionKey) {
+    Awaitility.await("until process definition " + processDefinitionKey + " is gone")
+        .atMost(Duration.ofSeconds(2 * TIMEOUT))
+        .untilAsserted(
+            () -> {
+              final Future<?> request =
+                  client.newProcessDefinitionGetRequest(processDefinitionKey).send();
+              assertThat(request)
+                  .failsWithin(Duration.ofSeconds(TIMEOUT))
+                  .withThrowableOfType(ExecutionException.class)
+                  .extracting(Throwable::getCause)
+                  .asInstanceOf(InstanceOfAssertFactories.type(ProblemException.class))
+                  .extracting(ProblemException::details)
+                  .asInstanceOf(InstanceOfAssertFactories.type(ProblemDetail.class))
+                  .extracting(ProblemDetail::getStatus)
+                  .isEqualTo(404);
+            });
+  }
+
+  private static boolean isNotBlank(final String value) {
+    return value != null && !value.isBlank();
+  }
+
+  private static Path createWorkingDirectory() {
+    try {
+      return Files.createTempDirectory("cdbg-recover-it-");
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to create working directory", e);
+    }
+  }
+
+  private record ExecResult(int exitCode, String out, String err) {}
+}


### PR DESCRIPTION
## Summary
- Adds `cdbg recover process-definitions`: re-exports ACTIVE process definitions (and embedded start forms) from a partition-1 RocksDB snapshot into secondary storage (Elasticsearch/OpenSearch), for disaster recovery when secondary-storage documents have been lost.
- Reads the snapshot strictly read-only (copied into a throwaway runtime first), so it can run in-pod against a live broker hosting a partition-1 replica (leader or follower) — no outage required.
- Reconstructs a synthetic `Record<Process>` from `PersistedProcess` and drives the *real* `ProcessHandler`/`EmbeddedFormHandler`, so recovered documents are identical to normally-exported ones and stay correct as those handlers evolve.
- Missing-only by default (`--override` to force rewrite); skips non-`ACTIVE` definitions (e.g. `PENDING_DELETION`).
- RDBMS secondary storage is out of scope for this change; a phase-2 follow-up will add it.

## Example
```sh
cdbg recover process-definitions \
  --root=/usr/local/zeebe/data/raft-partition/partitions/1 \
  --snapshot=<snapshot-id> \
  --connect-type=elasticsearch \
  --connect-url=http://localhost:9200 \
  --index-prefix=test
```
Dry-run first to see the diff without writing:
```sh
cdbg recover process-definitions --root=... --snapshot=... --dry-run
```
Output: `total=<n> present=<n> written=<n> skipped=<n> failed=<n>` on stdout; human-readable progress on stderr. Exit code `0` success, `2` some definitions failed, `1` configuration error (e.g. wrong `--index-prefix`).

Closes #55028

## Test plan
- [x] Unit tests: mapping/anti-drift (`RecoveredProcessRecordTest`), diff/write logic — missing-only, override, dry-run, embedded-form recovery, batch-failure counting (`ProcessDefinitionRecoveryTest`) — 7/7 green
- [x] `@MultiDbTest` integration test (`RecoverProcessDefinitionsMultiDbIT`, ES/OS; RDBMS and AWS_OS gated out): deploy → snapshot → simulate document loss → recover → assert restored
- [x] `debug-cli` and `qa/acceptance-tests` build and test-compile clean; full repo `install -Dquickly` green
- [x] `README.md` updated with command reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)