### PR TITLE
ci: graduate dependency vulnerability gate from pilot to blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1988,7 +1988,6 @@ jobs:
     needs: [ detect-changes, pr-maven-snapshot ]
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true # pilot phase: observe without blocking merges
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## What

Remove `continue-on-error: true` from the `pr-vuln-check` job (`.github/workflows/ci.yml`) so a **newly-introduced vulnerable dependency** now fails `check-results` and blocks the merge, instead of only posting an advisory comment. Closes the blocking milestone of #29729 (Workstream C).

## Why now

The gate ran observe-only since #53506. The one recurrent **false-positive class** was native-ecosystem (Go/npm) **base-branch drift**: because the Maven snapshot workflow is path-filtered, a Go dep bumped on `main` (e.g. `golang.org/x/crypto` in `load-tests/metrics-exporter/go.mod`) surfaced as "newly added" on *every* unrelated PR. That was fixed by [infra-global-github-actions#741](https://github.com/camunda/infra-global-github-actions/pull/741) (base-sha Pattern A filter), live on main since the ci.yml pin bump to `92af671` (**2026-07-08 20:12 UTC**, now `fa78e4f0`).

**2026-07-13 audit** (window = current logic live, 07-08 20:12 → 07-13):

| | Pre-fix | Post-fix |
|---|---|---|
| Blocking findings | 3 PRs, all the same `x/crypto` go.mod FP (unrelated to the PR) | **0** |
| "Could not verify" | 4 | **0** |
| Deps PRs evaluated | — | ~11 (netty, jackson, tomcat, postgres, log4j2, + feature PRs) all clean |

The pre-fix FP flagged unrelated Renovate PRs (`testcontainers-go`, `langchain4j`, `react-hook-form`) with an identical set of 9 crypto vulns; post-fix it no longer recurs on any representative deps PR. **0 false positives.** Base-side resolution is fully fail-closed (Workstreams D/F/G: snapshotted-ancestor resolution + stacked-PR fallback).

`ci:vuln-gate-override` remains the escape hatch for a genuine false alarm.

## Known limitation (does not gate this flip)

A residual **head-snapshot-indexing race**: if the head Maven SBOM isn't indexed when `dependency-graph/compare` runs, a real new vuln could slip. This is a false **negative** — it cannot wrongly block a PR, and blocking is strictly better than today's observe-only (which enforces nothing). A head-side fail-closed guard (mirroring the base-side check) is tracked as a follow-up issue.

## Mechanism

`pr-vuln-check` is a `needs` of `check-results`, which exits non-zero on any failed dependency. Without `continue-on-error`, a blocking vuln → `check.py` `sys.exit(1)` → job fails → `check-results` fails → merge blocked.