### PR TITLE
ci: add Nexus credentials to Maven Dependency Snapshot workflow

### DIFF
--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -37,6 +37,31 @@ jobs:
         with:
           distribution: temurin
           java-version: '21'
+      # HeroDevs NES artifacts (e.g. spring-security-bom on stable) are private and served from
+      # Nexus, so the snapshot resolution needs authenticated access via the nexus.camunda.cloud mirror.
+      - name: Import secrets
+        id: secrets
+        uses: hashicorp/vault-action@892a26828f195e65540a40b4768ae4571f51ebfc # v4.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
+      - name: Configure Maven credentials
+        uses: s4u/maven-settings-action@894661b3ddae382f1ae8edbeab60987e08cf0788 # v4.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+              "id": "camunda-nexus",
+              "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
+              "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
+            }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       # Scope to shipped modules only (mirrors JAVA_PROJECTS in zeebe-snyk.yml).
       # -am resolves the full transitive tree including BOM-pinned versions.
       # The Spring Boot starter was renamed between main and stable branches, so detect dynamically.


### PR DESCRIPTION
## Problem

`Maven Dependency Snapshot` fails on `stable/8.7` and `stable/8.8`:

```
Non-resolvable import POM: org.springframework.security:spring-security-bom:pom:6.5.11-spring-security-6.5.12 (absent):
Could not transfer artifact ... from/to zeebe (https://artifacts.camunda.com/artifactory/zeebe-io/): status code: 401
```

## Root cause

Renovate bumped `version.spring-security` to the HeroDevs NES extended-support version `6.5.11-spring-security-6.5.12` on the stable branches. Those artifacts are **private** (served from Nexus, require auth).

The stable copy of `maven-dependency-snapshot.yml` is stale: it lacks the Vault `Import secrets` + `s4u/maven-settings-action` (nexus.camunda.cloud mirror) steps that `main` already has (added in e987f8c60d6, never backported). Push-triggered workflows run the branch's own copy, so the snapshot job resolves without credentials and 401s on the private artifact.

`main` is unaffected: it uses public spring-security `7.1.0` and already has the credential steps.

See Slack PSA: https://camunda.slack.com/archives/C01H4NG9XDY/p1783937128682599

## Fix

Backport the credential setup to this stable branch:
- `permissions: id-token: write` (Vault JWT)
- `Import secrets` (Vault -> `NEXUS_USR`/`NEXUS_PSW`)
- `Configure Maven credentials` (`s4u/maven-settings-action`, `camunda-nexus` server + `nexus.camunda.cloud` mirror, `mirrorOf: *`)

The nexus internal group serves central + zeebe + herodevs-nes (per stable `setup-build`), so the mirror resolves the private artifacts. Identical to what `main` already runs.

## Test
[Successful CI run](https://github.com/camunda/camunda/actions/runs/29249168067)