### PR TITLE
Add regression coverage for session recognition on unprotected API chain

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/BasicAuthWebSecurityConfigTest.java
@@ -9,7 +9,6 @@ package io.camunda.authentication.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
 import io.camunda.authentication.config.controllers.TestApiController;
 import io.camunda.authentication.config.controllers.TestUserDetailsService;
@@ -25,7 +24,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
 @SpringBootTest(
@@ -86,15 +84,14 @@ public class BasicAuthWebSecurityConfigTest extends AbstractWebSecurityConfigTes
 
   @Test
   public void shouldNotRequireCsrfTokenWithGetEndpoint() {
-    // given
-    final MockHttpSession mockHttpSession = new MockHttpSession();
+    // given: a real, cookie-backed session
+    final var sessionCookie = logInAsDemoAndGetSessionCookie();
 
     // when
     final MvcTestResult result =
         mockMvcTester
             .get()
-            .session(mockHttpSession)
-            .with(user("demo"))
+            .cookie(sessionCookie)
             .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
             .exchange();
 
@@ -104,15 +101,14 @@ public class BasicAuthWebSecurityConfigTest extends AbstractWebSecurityConfigTes
 
   @Test
   public void shouldSucceedWithCsrfTokenAndSessionAuthentication() {
-    // given
-    final MockHttpSession mockHttpSession = new MockHttpSession();
+    // given: a real, cookie-backed session
+    final var sessionCookie = logInAsDemoAndGetSessionCookie();
 
     // when
     final MvcTestResult result =
         mockMvcTester
             .post()
-            .session(mockHttpSession)
-            .with(user("demo"))
+            .cookie(sessionCookie)
             .with(csrf())
             .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
             .exchange();

--- a/authentication/src/test/java/io/camunda/authentication/config/UnprotectedWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/UnprotectedWebSecurityConfigTest.java
@@ -9,7 +9,6 @@ package io.camunda.authentication.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
 import io.camunda.authentication.config.controllers.TestApiController;
 import io.camunda.authentication.config.controllers.TestUserDetailsService;
@@ -21,7 +20,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
 @SpringBootTest(
@@ -78,15 +76,14 @@ public class UnprotectedWebSecurityConfigTest extends AbstractWebSecurityConfigT
 
   @Test
   public void shouldNotRequireCsrfTokenWithGetEndpoint() {
-    // given
-    final MockHttpSession mockHttpSession = new MockHttpSession();
+    // given: a real, cookie-backed session
+    final var sessionCookie = logInAsDemoAndGetSessionCookie();
 
     // when
     final MvcTestResult result =
         mockMvcTester
             .get()
-            .session(mockHttpSession)
-            .with(user("demo"))
+            .cookie(sessionCookie)
             .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
             .exchange();
 
@@ -96,15 +93,14 @@ public class UnprotectedWebSecurityConfigTest extends AbstractWebSecurityConfigT
 
   @Test
   public void shouldSucceedWithCsrfTokenAndSessionAuthentication() {
-    // given
-    final MockHttpSession mockHttpSession = new MockHttpSession();
+    // given: a real, cookie-backed session
+    final var sessionCookie = logInAsDemoAndGetSessionCookie();
 
     // when
     final MvcTestResult result =
         mockMvcTester
             .post()
-            .session(mockHttpSession)
-            .with(user("demo"))
+            .cookie(sessionCookie)
             .with(csrf())
             .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
             .exchange();

--- a/authentication/src/test/java/io/camunda/authentication/config/UnprotectedWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/UnprotectedWebSecurityConfigTest.java
@@ -12,11 +12,15 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 
 import io.camunda.authentication.config.controllers.TestApiController;
+import io.camunda.authentication.config.controllers.TestUserDetailsService;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import io.camunda.security.spring.security.CamundaSecurityFilterChainConstants;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
@@ -40,20 +44,36 @@ public class UnprotectedWebSecurityConfigTest extends AbstractWebSecurityConfigT
 
   @Test
   public void shouldRequireCsrfTokenWithSessionAuthentication() {
-    // given
-    final MockHttpSession mockHttpSession = new MockHttpSession();
+    // given: a real, cookie-backed session established via login — the unprotected API chain now
+    // resolves the session from the camunda-session cookie (CSL ADR-0031), not a raw servlet
+    // session, so CSRF protection keys off that cookie just like the protected chains.
+    final var sessionCookie = logInAsDemoAndGetSessionCookie();
 
     // when
     final MvcTestResult result =
         mockMvcTester
             .post()
-            .session(mockHttpSession)
-            .with(user("demo"))
+            .cookie(sessionCookie)
             .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
             .exchange();
 
     // then
     assertMissingCsrfToken(result);
+  }
+
+  private Cookie logInAsDemoAndGetSessionCookie() {
+    final MvcTestResult loginResult =
+        mockMvcTester
+            .post()
+            .uri("https://localhost/login")
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .formField("username", TestUserDetailsService.DEMO_USERNAME)
+            .formField("password", TestUserDetailsService.DEMO_USERNAME)
+            .exchange();
+    final Cookie sessionCookie =
+        loginResult.getResponse().getCookie(CamundaSecurityFilterChainConstants.SESSION_COOKIE);
+    assertThat(sessionCookie).isNotNull();
+    return sessionCookie;
   }
 
   @Test

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha47</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha48</version.camunda-security-library>
     <version.checkstyle>13.7.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BasicAuthUnprotectedApiSessionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BasicAuthUnprotectedApiSessionIT.java
@@ -23,6 +23,7 @@ import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
@@ -36,6 +37,7 @@ import org.springframework.http.HttpStatus;
  * same guard under persistent sessions with physical tenants configured.
  */
 @MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class BasicAuthUnprotectedApiSessionIT {
 
   private static final String ME_ENDPOINT = "/v2/authentication/me";

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BasicAuthUnprotectedApiSessionIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/BasicAuthUnprotectedApiSessionIT.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.security.api.model.config.initialization.InitializationConfiguration.DEFAULT_USER_PASSWORD;
+import static io.camunda.security.api.model.config.initialization.InitializationConfiguration.DEFAULT_USER_USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestWebappClient.TestLoggedInWebappClient;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.api.model.config.CsrfConfiguration;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Verifies that a session created via {@code /login} on the BASIC webapp chain is recognised on the
+ * unprotected API chain (active when {@code camunda.security.authentication.unprotected-api=true}),
+ * and invalidated there after logout.
+ *
+ * <p>Uses no persistent-session storage and no physical tenants — the plain, in-memory-session
+ * shape of c8Run's default deployment. See {@link PhysicalTenantWebSessionUnprotectedApiIT} for the
+ * same guard under persistent sessions with physical tenants configured.
+ */
+@MultiDbTest
+public class BasicAuthUnprotectedApiSessionIT {
+
+  private static final String ME_ENDPOINT = "/v2/authentication/me";
+  private static final String LOGOUT_ENDPOINT = "/logout";
+
+  @MultiDbTestApplication
+  private static final TestCamundaApplication CAMUNDA =
+      new TestCamundaApplication()
+          .withBasicAuth()
+          .withSecurityConfig(
+              sc -> {
+                final var csrf = new CsrfConfiguration();
+                csrf.setEnabled(false);
+                sc.setCsrf(csrf);
+              })
+          .withUnauthenticatedAccess();
+
+  @Test
+  void shouldRecognizeAndInvalidateSessionOnUnprotectedApiChain() throws Exception {
+    try (final var loggedIn =
+        CAMUNDA.newWebappClient().logIn(DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD)) {
+      // given — logging in via POST /login creates a session on the BASIC webapp chain
+
+      // then — it must be recognised on the unprotected API chain, not treated as anonymous
+      assertCurrentUserStatus(
+          loggedIn,
+          HttpStatus.OK,
+          "session created on the BASIC webapp chain must be recognised on the unprotected API"
+              + " chain");
+
+      logOut(loggedIn);
+
+      // then — logout must invalidate the session on the unprotected chain too
+      assertCurrentUserStatus(
+          loggedIn,
+          HttpStatus.UNAUTHORIZED,
+          "logged-out session must not be recognised on the unprotected API chain either");
+    }
+  }
+
+  private static void assertCurrentUserStatus(
+      final TestLoggedInWebappClient client, final HttpStatus expected, final String reason) {
+    final var response = client.send(ME_ENDPOINT).get();
+    assertThat(response.statusCode()).as(reason).isEqualTo(expected.value());
+  }
+
+  private static void logOut(final TestLoggedInWebappClient client)
+      throws IOException, InterruptedException {
+    try (final var httpClient = HttpClient.newBuilder().build()) {
+      final var request =
+          HttpRequest.newBuilder()
+              .uri(client.getRootEndpoint().resolve(LOGOUT_ENDPOINT))
+              .header(HttpHeaders.COOKIE, client.getSessionCookie().toString())
+              .POST(BodyPublishers.noBody())
+              .build();
+      final HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+      assertThat(response.statusCode())
+          .as("logout should succeed")
+          .isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
@@ -12,17 +12,20 @@ import static io.camunda.security.api.model.config.initialization.Initialization
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestWebappClient;
 import io.camunda.qa.util.cluster.TestWebappClient.TestLoggedInWebappClient;
 import io.camunda.qa.util.multidb.MultiDbPhysicalTenants;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.security.api.model.config.CsrfConfiguration;
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.http.HttpHeaders;
@@ -34,11 +37,12 @@ import org.springframework.http.HttpStatus;
  * physical tenant configured alongside it. See {@link BasicAuthUnprotectedApiSessionIT} for the
  * plain, in-memory-session scenario.
  *
- * <p>Only exercises the default (non-PT) path. The tenant is provisioned to prove that behaviour
- * holds when a physical tenant is configured alongside it; whether a physical tenant's own scoped
- * API chain (which also has an unprotected variant when {@code unprotected-api=true}, built via
- * {@code ScopedApiSecurityChainBuilder#buildUnprotectedScopedApiChain}) recognises sessions the
- * same way is a separate, unverified surface not covered here.
+ * <p>Covers two surfaces: the default (non-PT) path, and the physical tenant's own scoped path
+ * ({@code /physical-tenants/<id>/...}), whose unprotected API variant is built via {@code
+ * ScopedApiSecurityChainBuilder#buildUnprotectedScopedApiChain}. The scoped case is {@link
+ * Disabled @Disabled} until this repo bumps CSL to the release carrying its session-filter fix
+ * (camunda-security-library#521); until then that chain installs no session filter and the scoped
+ * {@code /v2/authentication/me} returns 401.
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({PhysicalTenantWebSessionUnprotectedApiIT.TENANT_A})
@@ -90,6 +94,38 @@ public class PhysicalTenantWebSessionUnprotectedApiIT {
     }
   }
 
+  @Test
+  @Disabled(
+      "Enable once this repo bumps CSL to the release carrying the scoped unprotected"
+          + " session-filter fix (camunda-security-library#521); until then the PT-scoped"
+          + " unprotected chain installs no session filter and /physical-tenants/<id>"
+          + "/v2/authentication/me returns 401.")
+  void shouldRecognizeAndInvalidatePhysicalTenantScopedSessionOnUnprotectedApiChain()
+      throws Exception {
+    final String base = CAMUNDA.restAddress().toString().replaceAll("/+$", "");
+    final URI tenantRoot = URI.create(base + "/physical-tenants/" + TENANT_A + "/");
+    try (final var loggedIn =
+        new TestWebappClient(tenantRoot).logIn(DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD)) {
+      // given/when — a session created via the tenant-scoped /login
+
+      // then — recognised on the tenant's own unprotected API chain, not treated as anonymous
+      assertScopedCurrentUserStatus(
+          loggedIn,
+          HttpStatus.OK,
+          "session created on the PT-scoped webapp chain must be recognised on that tenant's"
+              + " unprotected API chain");
+
+      logOutScoped(loggedIn);
+
+      // then — logout must invalidate the scoped session on the unprotected chain too
+      assertScopedCurrentUserStatus(
+          loggedIn,
+          HttpStatus.UNAUTHORIZED,
+          "logged-out scoped session must not be recognised on the PT's unprotected API chain"
+              + " either");
+    }
+  }
+
   private static void assertCurrentUserStatus(
       final TestLoggedInWebappClient client, final HttpStatus expected, final String reason) {
     final var response = client.send(ME_ENDPOINT).get();
@@ -110,5 +146,21 @@ public class PhysicalTenantWebSessionUnprotectedApiIT {
           .as("logout should succeed")
           .isEqualTo(HttpStatus.NO_CONTENT.value());
     }
+  }
+
+  private static void assertScopedCurrentUserStatus(
+      final TestLoggedInWebappClient client, final HttpStatus expected, final String reason) {
+    // relative path so it resolves under the tenant-scoped root, not the default API surface
+    final var response = client.send("v2/authentication/me").get();
+    assertThat(response.statusCode()).as(reason).isEqualTo(expected.value());
+  }
+
+  private static void logOutScoped(final TestLoggedInWebappClient client) {
+    // the client's cookie manager auto-attaches the scoped session cookie; CSRF is disabled
+    final var response =
+        client.send("logout", builder -> builder.POST(BodyPublishers.noBody())).get();
+    assertThat(response.statusCode())
+        .as("scoped logout should succeed")
+        .isEqualTo(HttpStatus.NO_CONTENT.value());
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.security.api.model.config.initialization.InitializationConfiguration.DEFAULT_USER_PASSWORD;
+import static io.camunda.security.api.model.config.initialization.InitializationConfiguration.DEFAULT_USER_USERNAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.qa.util.cluster.TestCamundaApplication;
+import io.camunda.qa.util.cluster.TestWebappClient.TestLoggedInWebappClient;
+import io.camunda.qa.util.multidb.MultiDbPhysicalTenants;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.security.api.model.config.CsrfConfiguration;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+/**
+ * Verifies that a session created via {@code /login} on the default path is recognised on the
+ * unprotected API chain, and invalidated there after logout, with persistent sessions and a
+ * physical tenant configured alongside it. See {@link BasicAuthUnprotectedApiSessionIT} for the
+ * plain, in-memory-session scenario.
+ *
+ * <p>Does not exercise {@code /physical-tenants/<id>/...} paths under {@code unprotected-api}:
+ * {@link io.camunda.authentication.config.spi.SecurityPathAdapter#apiPaths()} excludes
+ * tenant-prefixed paths, which are owned exclusively by per-tenant scoped chains — a PT scope has
+ * no unprotected mode to exercise here. The tenant is provisioned only to prove the default-path
+ * behaviour holds when physical tenants are configured alongside it.
+ */
+@MultiDbTest
+@MultiDbPhysicalTenants({PhysicalTenantWebSessionUnprotectedApiIT.TENANT_A})
+@EnabledIfSystemProperty(
+    named = "test.integration.camunda.database.type",
+    matches = "rdbms.*$",
+    disabledReason = "Per-physical-tenant secondary storage is only supported on RDBMS backends")
+public class PhysicalTenantWebSessionUnprotectedApiIT {
+
+  static final String TENANT_A = "tenanta";
+
+  private static final String ME_ENDPOINT = "/v2/authentication/me";
+  private static final String LOGOUT_ENDPOINT = "/logout";
+
+  @MultiDbTestApplication
+  private static final TestCamundaApplication CAMUNDA =
+      new TestCamundaApplication()
+          .withAuthorizationsEnabled()
+          .withAdditionalProfile("consolidated-auth")
+          .withProperty("camunda.security.session.persistent.enabled", true)
+          .withSecurityConfig(
+              sc -> {
+                final var csrf = new CsrfConfiguration();
+                csrf.setEnabled(false);
+                sc.setCsrf(csrf);
+              })
+          .withUnauthenticatedAccess();
+
+  @Test
+  void shouldRecognizeAndInvalidateDefaultPathSessionOnUnprotectedApiChain() throws Exception {
+    try (final var loggedIn =
+        CAMUNDA.newWebappClient().logIn(DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD)) {
+      // given/when — a session created via /login on the default path, with persistent sessions
+      // and a physical tenant configured alongside it
+
+      // then — it must be recognised on the unprotected API chain, not treated as anonymous
+      assertCurrentUserStatus(
+          loggedIn,
+          HttpStatus.OK,
+          "session created on the default webapp chain must be recognised on the unprotected API"
+              + " chain with persistent sessions and physical tenants configured");
+
+      logOut(loggedIn);
+
+      // then — logout must invalidate the session on the unprotected chain too
+      assertCurrentUserStatus(
+          loggedIn,
+          HttpStatus.UNAUTHORIZED,
+          "logged-out session must not be recognised on the unprotected API chain either");
+    }
+  }
+
+  private static void assertCurrentUserStatus(
+      final TestLoggedInWebappClient client, final HttpStatus expected, final String reason) {
+    final var response = client.send(ME_ENDPOINT).get();
+    assertThat(response.statusCode()).as(reason).isEqualTo(expected.value());
+  }
+
+  private static void logOut(final TestLoggedInWebappClient client)
+      throws IOException, InterruptedException {
+    try (final var httpClient = HttpClient.newBuilder().build()) {
+      final var request =
+          HttpRequest.newBuilder()
+              .uri(client.getRootEndpoint().resolve(LOGOUT_ENDPOINT))
+              .header(HttpHeaders.COOKIE, client.getSessionCookie().toString())
+              .POST(BodyPublishers.noBody())
+              .build();
+      final HttpResponse<String> response = httpClient.send(request, BodyHandlers.ofString());
+      assertThat(response.statusCode())
+          .as("logout should succeed")
+          .isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
@@ -56,8 +56,7 @@ public class PhysicalTenantWebSessionUnprotectedApiIT {
   @MultiDbTestApplication
   private static final TestCamundaApplication CAMUNDA =
       new TestCamundaApplication()
-          .withAuthorizationsEnabled()
-          .withAdditionalProfile("consolidated-auth")
+          .withBasicAuth()
           .withProperty("camunda.security.session.persistent.enabled", true)
           .withSecurityConfig(
               sc -> {

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
@@ -34,11 +34,11 @@ import org.springframework.http.HttpStatus;
  * physical tenant configured alongside it. See {@link BasicAuthUnprotectedApiSessionIT} for the
  * plain, in-memory-session scenario.
  *
- * <p>Does not exercise {@code /physical-tenants/<id>/...} paths under {@code unprotected-api}:
- * {@link io.camunda.authentication.config.spi.SecurityPathAdapter#apiPaths()} excludes
- * tenant-prefixed paths, which are owned exclusively by per-tenant scoped chains — a PT scope has
- * no unprotected mode to exercise here. The tenant is provisioned only to prove the default-path
- * behaviour holds when physical tenants are configured alongside it.
+ * <p>Only exercises the default (non-PT) path. The tenant is provisioned to prove that behaviour
+ * holds when a physical tenant is configured alongside it; whether a physical tenant's own scoped
+ * API chain (which also has an unprotected variant when {@code unprotected-api=true}, built via
+ * {@code ScopedApiSecurityChainBuilder#buildUnprotectedScopedApiChain}) recognises sessions the
+ * same way is a separate, unverified surface not covered here.
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({PhysicalTenantWebSessionUnprotectedApiIT.TENANT_A})


### PR DESCRIPTION
## Description

A session created via /login on the BASIC webapp chain must still be recognised on the unprotected API chain (unprotected-api=true), and invalidated there after logout. Uses plain in-memory sessions, mirroring c8Run's default deployment shape.

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57499
