### PR TITLE
ci: wire vuln gate head-snapshot guard to step outcome, not job result

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1945,6 +1945,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     continue-on-error: true  # snapshot failure falls back to auto-parse; gate still runs
+    # Expose the real submit-step outcome so pr-vuln-check can fail closed on a
+    # failed snapshot. needs.<job>.result cannot be used here: job-level
+    # continue-on-error masks a failed job to result == 'success' (actions/toolkit#1739),
+    # which would silently no-op the gate's head-snapshot-succeeded guard.
+    outputs:
+      submitted: ${{ steps.submit.outcome }}
     permissions:
       contents: write  # required by Dependency Submission API
     steps:
@@ -1955,6 +1961,7 @@ jobs:
           distribution: temurin
           java-version: '21'
       - name: Submit Maven dependency snapshot
+        id: submit
         uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0
         with:
           token: ${{ github.token }}
@@ -2002,6 +2009,9 @@ jobs:
           head-sha: ${{ github.event.pull_request.head.sha }}
           base-ref: ${{ github.event.pull_request.base.ref }}
           snapshot-workflow: maven-dependency-snapshot.yml
+          # Real submit-step outcome, not needs.<job>.result (masked to 'success' by
+          # the snapshot job's continue-on-error). Empty (job died before the step) → fail closed.
+          head-snapshot-succeeded: ${{ needs.pr-maven-snapshot.outputs.submitted || 'failure' }}
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## What

Wires the dependency vulnerability gate's `head-snapshot-succeeded` guard to the **real submit-step outcome** instead of `needs.pr-maven-snapshot.result`.

## Why

`pr-maven-snapshot` is `continue-on-error: true` (so a snapshot failure falls back to auto-parse without failing the run). Job-level `continue-on-error` masks a failed job to `needs.<job>.result == 'success'` — there is no job-level outcome/conclusion to read ([actions/toolkit#1739](https://github.com/actions/toolkit/issues/1739)).

So if the head-SBOM submission fails, `.result` still reads `success`. Feeding that to the gate's `head-snapshot-succeeded` input hands it a legit-looking success → the head side of the compare is stale/empty → a genuinely new vulnerable dependency passes silently. Harmless while the gate is observe-only; a **false green once it blocks**.

The gate guard itself (camunda/infra-global-github-actions#749) is correct — it fails closed on any non-success value. It just cannot distinguish a masked-failure `'success'` from a true one; both arrive as the same string. The fix has to be at the source, in this consumer wiring.

## Change

- `pr-maven-snapshot`: expose `outputs.submitted: ${{ steps.submit.outcome }}` (`id: submit` on the submit step). Step `outcome` is pre-continue-on-error, so a failed step reads `failure`.
- `pr-vuln-check`: `head-snapshot-succeeded: ${{ needs.pr-maven-snapshot.outputs.submitted || 'failure' }}`. The `|| 'failure'` coalesces an empty output (job died before the submit step ran) to fail-closed.

## Ordering

- Input `head-snapshot-succeeded` lands with camunda/infra-global-github-actions#749; it is inert (ignored) until that action SHA is pinned here (Renovate), so this is safe to merge before or after #749.
- **Must land before** the blocking flip (#57561) — otherwise blocking runs on an unguarded gate that can emit false greens with merge authority.