### PR TITLE
fix: preserve context path in physical-tenant webapps

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdvice.java
+++ b/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdvice.java
@@ -89,11 +89,11 @@ public class PhysicalTenantWebappClientConfigRewriteAdvice implements ResponseBo
     }
     final String prefix = PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + physicalTenantId;
     final String contextPath = servletRequest.getServletRequest().getContextPath();
-    return prefixField(
-        prefixField(body, CONTEXT_PATH, contextPath, prefix), BASE_NAME, contextPath, prefix);
+    return rewritePathField(
+        rewritePathField(body, CONTEXT_PATH, contextPath, prefix), BASE_NAME, contextPath, prefix);
   }
 
-  private static String prefixField(
+  private static String rewritePathField(
       final String body,
       final Pattern field,
       final String contextPath,
@@ -102,17 +102,18 @@ public class PhysicalTenantWebappClientConfigRewriteAdvice implements ResponseBo
     if (!matcher.find()) {
       return body;
     }
-    final String existingPath = matcher.group(2);
-    final String afterContextPath =
-        existingPath.startsWith(contextPath)
-            ? existingPath.substring(contextPath.length())
-            : existingPath;
+    final String rewrittenPath =
+        insertAfterContextPath(matcher.group(2), contextPath, physicalTenantPrefix);
     return matcher.replaceFirst(
-        Matcher.quoteReplacement(
-            matcher.group(1)
-                + contextPath
-                + physicalTenantPrefix
-                + afterContextPath
-                + matcher.group(3)));
+        Matcher.quoteReplacement(matcher.group(1) + rewrittenPath + matcher.group(3)));
+  }
+
+  /** Inserts the physical-tenant segment right after the servlet context path. */
+  private static String insertAfterContextPath(
+      final String path, final String contextPath, final String physicalTenantPrefix) {
+    if (!path.startsWith(contextPath)) {
+      return physicalTenantPrefix + path;
+    }
+    return contextPath + physicalTenantPrefix + path.substring(contextPath.length());
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdvice.java
+++ b/dist/src/main/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdvice.java
@@ -88,16 +88,31 @@ public class PhysicalTenantWebappClientConfigRewriteAdvice implements ResponseBo
       return body;
     }
     final String prefix = PhysicalTenantContext.PHYSICAL_TENANTS_PATH_SEGMENT + physicalTenantId;
-    return prefixField(prefixField(body, CONTEXT_PATH, prefix), BASE_NAME, prefix);
+    final String contextPath = servletRequest.getServletRequest().getContextPath();
+    return prefixField(
+        prefixField(body, CONTEXT_PATH, contextPath, prefix), BASE_NAME, contextPath, prefix);
   }
 
-  private static String prefixField(final String body, final Pattern field, final String prefix) {
+  private static String prefixField(
+      final String body,
+      final Pattern field,
+      final String contextPath,
+      final String physicalTenantPrefix) {
     final Matcher matcher = field.matcher(body);
     if (!matcher.find()) {
       return body;
     }
-    // Re-emit the matched field with the captured value verbatim, prefix-prepended.
+    final String existingPath = matcher.group(2);
+    final String afterContextPath =
+        existingPath.startsWith(contextPath)
+            ? existingPath.substring(contextPath.length())
+            : existingPath;
     return matcher.replaceFirst(
-        Matcher.quoteReplacement(matcher.group(1) + prefix + matcher.group(2) + matcher.group(3)));
+        Matcher.quoteReplacement(
+            matcher.group(1)
+                + contextPath
+                + physicalTenantPrefix
+                + afterContextPath
+                + matcher.group(3)));
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdviceTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/pt/PhysicalTenantWebappClientConfigRewriteAdviceTest.java
@@ -28,6 +28,8 @@ class PhysicalTenantWebappClientConfigRewriteAdviceTest {
       "window.clientConfig = {\"isEnterprise\":true,\"contextPath\":\"\",\"baseName\":\"/operate\"};";
   private static final String TASKLIST_BODY =
       "window.clientConfig = {\"contextPath\":\"\",\"baseName\":\"/tasklist\",\"clientMode\":\"v2\"};";
+  private static final String OPERATE_BODY_WITH_CONTEXT_PATH =
+      "window.clientConfig = {\"contextPath\":\"/core\",\"baseName\":\"/core/operate\"};";
 
   private final PhysicalTenantWebappClientConfigRewriteAdvice advice =
       new PhysicalTenantWebappClientConfigRewriteAdvice();
@@ -103,6 +105,23 @@ class PhysicalTenantWebappClientConfigRewriteAdviceTest {
         .contains("\"contextPath\":\"/physical-tenants/default\"")
         .contains("\"baseName\":\"/physical-tenants/default/tasklist\"")
         .contains("\"clientMode\":\"v2\"");
+  }
+
+  @Test
+  void shouldInsertPhysicalTenantPrefixAfterServletContextPath() throws NoSuchMethodException {
+    // given
+    final MockHttpServletRequest httpRequest = new MockHttpServletRequest();
+    httpRequest.setContextPath("/core");
+    PhysicalTenantContext.setPhysicalTenantId(httpRequest, "tenanta");
+
+    // when
+    final String result = rewrite(OPERATE_BODY_WITH_CONTEXT_PATH, httpRequest);
+
+    // then
+    assertThat(result)
+        .contains("\"contextPath\":\"/core/physical-tenants/tenanta\"")
+        .contains("\"baseName\":\"/core/physical-tenants/tenanta/operate\"")
+        .doesNotContain("/physical-tenants/tenanta/core");
   }
 
   @Test


### PR DESCRIPTION
## Description

Physical-tenant Operate and Tasklist client configuration placed the tenant prefix before a non-empty servlet context path. This produced paths such as `/physical-tenants/tenanta/core/operate`, while the registered route is `/core/physical-tenants/tenanta/operate`.

This change preserves the servlet context path and inserts the physical-tenant segment immediately after it.

Closes #57594

## Tests

- `./mvnw license:format spotless:apply -T1C`
- `./mvnw verify -pl dist -Dtest=PhysicalTenantWebappClientConfigRewriteAdviceTest -DskipTests=false -DskipITs -Dquickly`
- `./mvnw install -Dquickly -T1C`
