### PR TITLE
feat: add file-based secret store configuration and SecretStoreRegistry bean

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/Camunda.java
+++ b/configuration/src/main/java/io/camunda/configuration/Camunda.java
@@ -30,6 +30,7 @@ public class Camunda {
   @NestedConfigurationProperty private License license = new License();
   @NestedConfigurationProperty private Document document = new Document();
   @NestedConfigurationProperty private Webapps webapps = new Webapps();
+  @NestedConfigurationProperty private Secrets secrets = new Secrets();
 
   @NestedConfigurationProperty
   private ProcessInstanceCreation processInstanceCreation = new ProcessInstanceCreation();
@@ -145,5 +146,13 @@ public class Camunda {
 
   public void setDocument(final Document document) {
     this.document = document;
+  }
+
+  public Secrets getSecrets() {
+    return secrets;
+  }
+
+  public void setSecrets(final Secrets secrets) {
+    this.secrets = secrets;
   }
 }

--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -53,7 +53,7 @@ public class Secrets {
   public static class FileStore {
 
     /**
-     * Path to the file backing this file-based secret store. Defaults to {@code
+     * Path to the directory backing this file-based secret store. Defaults to {@code
      * /etc/camunda/secrets}.
      */
     private String path = "/etc/camunda/secrets";

--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * This section allows configuring named secret stores.
+ *
+ * <p>Canonical unified configuration properties are under {@code camunda.secrets.*}, including:
+ *
+ * <ul>
+ *   <li>{@code camunda.secrets.stores.file.<id>.path}
+ * </ul>
+ *
+ * <p>Secrets configuration is overridable per physical tenant via {@code
+ * camunda.physical-tenants.<id>.secrets.*}.
+ */
+@NullMarked
+public class Secrets {
+
+  @NestedConfigurationProperty private Stores stores = new Stores();
+
+  public Stores getStores() {
+    return stores;
+  }
+
+  public void setStores(final Stores stores) {
+    this.stores = stores;
+  }
+
+  public static class Stores {
+
+    @NestedConfigurationProperty private Map<String, FileStore> file = new LinkedHashMap<>();
+
+    public Map<String, FileStore> getFile() {
+      return file;
+    }
+
+    public void setFile(final Map<String, FileStore> file) {
+      this.file = file;
+    }
+  }
+
+  public static class FileStore {
+
+    /**
+     * Path to the file backing this file-based secret store. Defaults to {@code
+     * /etc/camunda/secrets}.
+     */
+    private String path = "/etc/camunda/secrets";
+
+    public String getPath() {
+      return path;
+    }
+
+    public void setPath(final String path) {
+      this.path = path;
+    }
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/Secrets.java
+++ b/configuration/src/main/java/io/camunda/configuration/Secrets.java
@@ -39,7 +39,7 @@ public class Secrets {
 
   public static class Stores {
 
-    @NestedConfigurationProperty private Map<String, FileStore> file = new LinkedHashMap<>();
+    private Map<String, FileStore> file = new LinkedHashMap<>();
 
     public Map<String, FileStore> getFile() {
       return file;

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantMapOverlays.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantMapOverlays.java
@@ -29,7 +29,8 @@ final class PhysicalTenantMapOverlays {
   static final List<MapOverlaySpec<?>> REGISTRY =
       List.of(
           PhysicalTenantDocumentConfigurations.SPEC,
-          PhysicalTenantAuthenticationProviderConfigurations.SPEC);
+          PhysicalTenantAuthenticationProviderConfigurations.SPEC,
+          PhysicalTenantSecretConfigurations.SPEC);
 
   private PhysicalTenantMapOverlays() {}
 

--- a/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretConfigurations.java
+++ b/configuration/src/main/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretConfigurations.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Secrets;
+import io.camunda.configuration.Secrets.FileStore;
+import io.camunda.configuration.physicaltenants.MapOverlaySpec.MapDescriptor;
+import java.util.List;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Per-tenant {@link Secrets} resolution: registers the {@code stores.file} named map so that {@link
+ * PhysicalTenantMapOverlay} deep-merges it per physical tenant (the generic two-bind has a defect
+ * that drops unmentioned root entries when a tenant overrides only some map keys).
+ */
+@NullMarked
+final class PhysicalTenantSecretConfigurations {
+
+  static final MapOverlaySpec<Secrets> SPEC =
+      new MapOverlaySpec<>(
+          "secrets",
+          Secrets.class,
+          Secrets::new,
+          List.of(
+              new MapDescriptor<>("stores.file", FileStore.class, s -> s.getStores().getFile())),
+          MapOverlaySpec.noHook(),
+          Camunda::setSecrets);
+
+  private PhysicalTenantSecretConfigurations() {}
+}

--- a/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecretsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig({UnifiedConfiguration.class, UnifiedConfigurationHelper.class})
+class SecretsTest {
+
+  @Nested
+  @TestPropertySource(
+      properties = {"camunda.secrets.stores.file.mystore.path=/etc/camunda/secrets.txt"})
+  class WithFileStoreConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithFileStoreConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldBindFileStorePath() {
+      // given the property camunda.secrets.stores.file.mystore.path is set (see
+      // @TestPropertySource)
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then the named file store is present and its path is bound
+      assertThat(secrets.getStores().getFile()).containsKey("mystore");
+      assertThat(secrets.getStores().getFile().get("mystore").getPath())
+          .isEqualTo("/etc/camunda/secrets.txt");
+    }
+  }
+
+  @Nested
+  class WithoutFileStoreConfigured {
+    private final UnifiedConfiguration unifiedConfiguration;
+
+    WithoutFileStoreConfigured(@Autowired final UnifiedConfiguration unifiedConfiguration) {
+      this.unifiedConfiguration = unifiedConfiguration;
+    }
+
+    @Test
+    void shouldDefaultToEmptyFileMap() {
+      // given no camunda.secrets.* property is set
+      // when the unified configuration is bound
+      final Secrets secrets = unifiedConfiguration.getCamunda().getSecrets();
+
+      // then stores is non-null (field initializer) and the file map is empty
+      assertThat(secrets.getStores()).isNotNull();
+      assertThat(secrets.getStores().getFile()).isEmpty();
+    }
+  }
+}

--- a/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretsOverlayTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/physicaltenants/PhysicalTenantSecretsOverlayTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration.physicaltenants;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.Secrets;
+import io.camunda.configuration.UnifiedConfigurationHelper;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+class PhysicalTenantSecretsOverlayTest {
+
+  private MockEnvironment environment;
+
+  @BeforeEach
+  void setUp() {
+    environment = new MockEnvironment();
+    environment.setProperty("camunda.data.secondary-storage.type", "none");
+    UnifiedConfigurationHelper.setCustomEnvironment(environment);
+  }
+
+  @AfterEach
+  void tearDown() {
+    UnifiedConfigurationHelper.setCustomEnvironment(null);
+  }
+
+  private PhysicalTenantResolver newResolver() {
+    final Camunda camunda = new Camunda();
+    Binder.get(environment).bind(Camunda.PREFIX, Bindable.ofInstance(camunda));
+    return PhysicalTenantResolver.of(environment, camunda);
+  }
+
+  /**
+   * Sets {@code properties} and, for each given tenant, adds the admin user that {@code
+   * PhysicalTenantRequiredOverrideValidation} requires.
+   */
+  private void setProperties(final Map<String, Object> properties, final String... tenantIds) {
+    final Map<String, Object> all = new HashMap<>(properties);
+    for (final String tenantId : tenantIds) {
+      all.put(
+          "camunda.physical-tenants."
+              + tenantId
+              + ".security.initialization.default-roles.admin.users[0]",
+          tenantId + "-admin");
+    }
+    environment.getPropertySources().addFirst(new MapPropertySource("test", all));
+  }
+
+  @Test
+  void shouldOverlayFileStorePathPerTenant() {
+    // given a root file store and a tenant that overrides its path
+    setProperties(
+        new HashMap<>(
+            Map.of(
+                "camunda.secrets.stores.file.shared.path", "/root/secrets.txt",
+                "camunda.physical-tenants.tenanta.secrets.stores.file.shared.path",
+                    "/tenanta/secrets.txt")),
+        "tenanta");
+
+    // when the resolver produces a Camunda per tenant
+    final PhysicalTenantResolver resolver = newResolver();
+
+    // then tenanta gets its own path and the synthesized default keeps the root path
+    assertThat(
+            resolver
+                .forPhysicalTenant("tenanta")
+                .getSecrets()
+                .getStores()
+                .getFile()
+                .get("shared")
+                .getPath())
+        .isEqualTo("/tenanta/secrets.txt");
+    assertThat(
+            resolver
+                .forPhysicalTenant(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .getSecrets()
+                .getStores()
+                .getFile()
+                .get("shared")
+                .getPath())
+        .isEqualTo("/root/secrets.txt");
+  }
+
+  @Test
+  void shouldInheritRootFileStoreWhenTenantHasNoSecretsOverride() {
+    // given only a root file store; the tenant overrides no secrets field
+    setProperties(
+        new HashMap<>(Map.of("camunda.secrets.stores.file.shared.path", "/root/secrets.txt")),
+        "tenanta");
+
+    // when the resolver produces a Camunda per tenant
+    final PhysicalTenantResolver resolver = newResolver();
+
+    // then tenanta inherits the root file store (non-overridden -> seeded from root bind)
+    assertThat(
+            resolver
+                .forPhysicalTenant("tenanta")
+                .getSecrets()
+                .getStores()
+                .getFile()
+                .get("shared")
+                .getPath())
+        .isEqualTo("/root/secrets.txt");
+  }
+
+  @Test
+  void shouldExposePerTenantSecretsViaRegistry() {
+    // given a root and a tenant override, verify
+    // PhysicalTenantResolver.mapValues(Camunda::getSecrets)
+    setProperties(
+        new HashMap<>(
+            Map.of(
+                "camunda.secrets.stores.file.shared.path", "/root/secrets.txt",
+                "camunda.physical-tenants.tenanta.secrets.stores.file.shared.path",
+                    "/tenanta/secrets.txt")),
+        "tenanta");
+
+    // when the registry is built from the resolver
+    final Map<String, Secrets> registry = newResolver().mapValues(Camunda::getSecrets);
+
+    // then it contains a Secrets per tenant with the correct per-tenant path
+    assertThat(registry).containsKeys("tenanta", PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(registry.get("tenanta").getStores().getFile().get("shared").getPath())
+        .isEqualTo("/tenanta/secrets.txt");
+    assertThat(
+            registry
+                .get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+                .getStores()
+                .getFile()
+                .get("shared")
+                .getPath())
+        .isEqualTo("/root/secrets.txt");
+  }
+}

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -304,6 +304,7 @@ processing.max-commands-in-batch
 processing.max-recoverable-retries
 processing.scheduled-tasks-check-interval
 processing.skip-positions
+secrets.stores.file
 security.authentication
 security.authentication.authentication-refresh-interval
 security.authentication.oidc.additional-jwk-set-uris

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -440,6 +440,16 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-secret-store-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-secret-store-file</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -19,7 +19,7 @@ import org.jspecify.annotations.NullMarked;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/** Registers a {@link SecretStoreRegistry} bean populated from the per-physical-tenant config. */
+/** Registers one {@link SecretStoreRegistry} per physical tenant, keyed by physical tenant ID. */
 @Configuration(proxyBeanMethods = false)
 @NullMarked
 public class SecretStoreConfiguration {
@@ -27,8 +27,9 @@ public class SecretStoreConfiguration {
   private static final NoopSecretStore NOOP_STORE = new NoopSecretStore();
 
   @Bean
-  public SecretStoreRegistry secretStoreRegistry(final PhysicalTenantResolver resolver) {
-    final Map<String, Map<String, SecretStore<?>>> storesByTenant = new LinkedHashMap<>();
+  public Map<String, SecretStoreRegistry> secretStoreRegistries(
+      final PhysicalTenantResolver resolver) {
+    final Map<String, SecretStoreRegistry> registries = new LinkedHashMap<>();
     resolver
         .mapValues(Camunda::getSecrets)
         .forEach(
@@ -54,8 +55,8 @@ public class SecretStoreConfiguration {
               if (stores.isEmpty()) {
                 stores.put("default", NOOP_STORE);
               }
-              storesByTenant.put(tenantId, Map.copyOf(stores));
+              registries.put(tenantId, new SecretStoreRegistry(Map.copyOf(stores)));
             });
-    return new SecretStoreRegistry(Map.copyOf(storesByTenant));
+    return Map.copyOf(registries);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.secrets;
+
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.secretstore.NoopSecretStore;
+import io.camunda.secretstore.SecretStore;
+import io.camunda.secretstore.file.FileBasedSecretStore;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/** Registers a {@link SecretStoreRegistry} bean populated from the per-physical-tenant config. */
+@Configuration(proxyBeanMethods = false)
+@NullMarked
+public class SecretStoreConfiguration {
+
+  private static final NoopSecretStore NOOP_STORE = new NoopSecretStore();
+
+  @Bean
+  public SecretStoreRegistry secretStoreRegistry(final PhysicalTenantResolver resolver) {
+    final Map<String, Map<String, SecretStore<?>>> storesByTenant = new LinkedHashMap<>();
+    resolver
+        .mapValues(Camunda::getSecrets)
+        .forEach(
+            (tenantId, secrets) -> {
+              final Map<String, SecretStore<?>> stores = new LinkedHashMap<>();
+              secrets
+                  .getStores()
+                  .getFile()
+                  .forEach(
+                      (storeId, fileStore) -> {
+                        final var path = fileStore.getPath();
+                        if (path.isBlank()) {
+                          throw new IllegalStateException(
+                              "File store '"
+                                  + storeId
+                                  + "' for physical tenant '"
+                                  + tenantId
+                                  + "' has no path configured");
+                        }
+                        stores.put(
+                            storeId.trim().toLowerCase(), new FileBasedSecretStore(Path.of(path)));
+                      });
+              if (stores.isEmpty()) {
+                stores.put("default", NOOP_STORE);
+              }
+              storesByTenant.put(tenantId, Map.copyOf(stores));
+            });
+    return new SecretStoreRegistry(Map.copyOf(storesByTenant));
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreConfiguration.java
@@ -16,6 +16,8 @@ import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jspecify.annotations.NullMarked;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,6 +26,7 @@ import org.springframework.context.annotation.Configuration;
 @NullMarked
 public class SecretStoreConfiguration {
 
+  private static final Logger LOG = LoggerFactory.getLogger(SecretStoreConfiguration.class);
   private static final NoopSecretStore NOOP_STORE = new NoopSecretStore();
 
   @Bean
@@ -34,26 +37,39 @@ public class SecretStoreConfiguration {
         .mapValues(Camunda::getSecrets)
         .forEach(
             (tenantId, secrets) -> {
+              final var fileStores = secrets.getStores().getFile();
+              if (fileStores.size() > 1) {
+                throw new IllegalStateException(
+                    "Physical tenant '"
+                        + tenantId
+                        + "' has "
+                        + fileStores.size()
+                        + " secret stores configured, but only one is supported at this time");
+              }
               final Map<String, SecretStore<?>> stores = new LinkedHashMap<>();
-              secrets
-                  .getStores()
-                  .getFile()
-                  .forEach(
-                      (storeId, fileStore) -> {
-                        final var path = fileStore.getPath();
-                        if (path.isBlank()) {
-                          throw new IllegalStateException(
-                              "File store '"
-                                  + storeId
-                                  + "' for physical tenant '"
-                                  + tenantId
-                                  + "' has no path configured");
-                        }
-                        stores.put(
-                            storeId.trim().toLowerCase(), new FileBasedSecretStore(Path.of(path)));
-                      });
+              fileStores.forEach(
+                  (storeId, fileStore) -> {
+                    final var path = fileStore.getPath();
+                    if (path.isBlank()) {
+                      throw new IllegalStateException(
+                          "File store '"
+                              + storeId
+                              + "' for physical tenant '"
+                              + tenantId
+                              + "' has no path configured");
+                    }
+                    stores.put(
+                        storeId.trim().toLowerCase(), new FileBasedSecretStore(Path.of(path)));
+                    LOG.info(
+                        "Registered file secret store '{}' for physical tenant '{}'",
+                        storeId.trim().toLowerCase(),
+                        tenantId);
+                  });
               if (stores.isEmpty()) {
                 stores.put("default", NOOP_STORE);
+                LOG.info(
+                    "No secret stores configured for physical tenant '{}', using noop store",
+                    tenantId);
               }
               registries.put(tenantId, new SecretStoreRegistry(Map.copyOf(stores)));
             });

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreRegistry.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreRegistry.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.secrets;
+
+import io.camunda.secretstore.SecretStore;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/** Provides the configured {@link SecretStore}s per physical tenant, keyed by store ID. */
+@NullMarked
+public final class SecretStoreRegistry {
+
+  private final Map<String, Map<String, SecretStore<?>>> storesByTenant;
+
+  public SecretStoreRegistry(final Map<String, Map<String, SecretStore<?>>> storesByTenant) {
+    this.storesByTenant = storesByTenant;
+  }
+
+  /**
+   * Returns all secret stores configured for the given physical tenant, keyed by store ID.
+   *
+   * @throws IllegalArgumentException if the tenant ID is not known
+   */
+  public Map<String, SecretStore<?>> getStores(final String physicalTenantId) {
+    final Map<String, SecretStore<?>> stores = storesByTenant.get(physicalTenantId);
+    if (stores == null) {
+      throw new IllegalArgumentException(
+          "No secret store registry entry for unknown physical tenant '" + physicalTenantId + "'");
+    }
+    return stores;
+  }
+
+  /** Returns the set of all known physical tenant IDs. */
+  public Set<String> tenants() {
+    return storesByTenant.keySet();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreRegistry.java
+++ b/dist/src/main/java/io/camunda/application/commons/secrets/SecretStoreRegistry.java
@@ -9,35 +9,22 @@ package io.camunda.application.commons.secrets;
 
 import io.camunda.secretstore.SecretStore;
 import java.util.Map;
-import java.util.Set;
 import org.jspecify.annotations.NullMarked;
 
-/** Provides the configured {@link SecretStore}s per physical tenant, keyed by store ID. */
+/**
+ * Provides the configured {@link SecretStore}s for the current physical tenant, keyed by store ID.
+ */
 @NullMarked
 public final class SecretStoreRegistry {
 
-  private final Map<String, Map<String, SecretStore<?>>> storesByTenant;
+  private final Map<String, SecretStore<?>> stores;
 
-  public SecretStoreRegistry(final Map<String, Map<String, SecretStore<?>>> storesByTenant) {
-    this.storesByTenant = storesByTenant;
+  public SecretStoreRegistry(final Map<String, SecretStore<?>> stores) {
+    this.stores = stores;
   }
 
-  /**
-   * Returns all secret stores configured for the given physical tenant, keyed by store ID.
-   *
-   * @throws IllegalArgumentException if the tenant ID is not known
-   */
-  public Map<String, SecretStore<?>> getStores(final String physicalTenantId) {
-    final Map<String, SecretStore<?>> stores = storesByTenant.get(physicalTenantId);
-    if (stores == null) {
-      throw new IllegalArgumentException(
-          "No secret store registry entry for unknown physical tenant '" + physicalTenantId + "'");
-    }
+  /** Returns all configured secret stores, keyed by store ID. */
+  public Map<String, SecretStore<?>> getStores() {
     return stores;
-  }
-
-  /** Returns the set of all known physical tenant IDs. */
-  public Set<String> tenants() {
-    return storesByTenant.keySet();
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -69,6 +69,72 @@ class SecretStoreConfigurationTest {
   }
 
   @Test
+  void shouldThrowWhenMoreThanOneStoreConfigured() {
+    // given two file stores for the default tenant
+    final var resolver =
+        resolverFor(
+            Map.of(
+                "camunda.secrets.stores.file.store-a.path", "/etc/camunda/secrets-a",
+                "camunda.secrets.stores.file.store-b.path", "/etc/camunda/secrets-b"));
+
+    // when / then
+    assertThatIllegalStateException()
+        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID)
+        .withMessageContaining("only one is supported");
+  }
+
+  @Test
+  void shouldNormalizeStoreIdToLowercase() {
+    // given
+    final var resolver =
+        resolverFor(Map.of("camunda.secrets.stores.file.MyStore.path", "/etc/camunda/secrets"));
+
+    // when
+    final var registries = CONFIG.secretStoreRegistries(resolver);
+
+    // then
+    final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(registry.getStores()).containsOnlyKeys("mystore");
+  }
+
+  @Test
+  void shouldNotAddNoopStoreWhenStoresAreConfigured() {
+    // given
+    final var resolver =
+        resolverFor(Map.of("camunda.secrets.stores.file.main.path", "/etc/camunda/secrets"));
+
+    // when
+    final var registries = CONFIG.secretStoreRegistries(resolver);
+
+    // then
+    final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(registry.getStores()).containsOnlyKeys("main");
+    assertThat(registry.getStores()).doesNotContainKey("default");
+  }
+
+  @Test
+  void shouldFallbackToNoopStoreForNonDefaultTenantWhenNoStoresConfigured() {
+    // given
+    final var resolver =
+        resolverFor(
+            Map.of(
+                "camunda.physical-tenants.mytenant.security.initialization.default-roles.admin.users[0]",
+                "mytenant-admin",
+                "camunda.physical-tenants.mytenant.data.secondary-storage.elasticsearch.index-prefix",
+                "mytenant"));
+
+    // when
+    final var registries = CONFIG.secretStoreRegistries(resolver);
+
+    // then
+    assertThat(registries).containsKey("mytenant");
+    final var registry = registries.get("mytenant");
+    assertThat(registry.getStores()).containsKey("default");
+    assertThat(registry.getStores().get("default")).isInstanceOf(NoopSecretStore.class);
+  }
+
+  @Test
   void shouldProduceOneRegistryPerPhysicalTenant() {
     // given two tenants with different store configurations
     final var resolver =

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreConfigurationTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.secrets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import io.camunda.cluster.PhysicalTenantIds;
+import io.camunda.configuration.Camunda;
+import io.camunda.configuration.physicaltenants.PhysicalTenantResolver;
+import io.camunda.secretstore.NoopSecretStore;
+import io.camunda.secretstore.file.FileBasedSecretStore;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+class SecretStoreConfigurationTest {
+
+  private static final SecretStoreConfiguration CONFIG = new SecretStoreConfiguration();
+
+  @Test
+  void shouldFallbackToNoopStoreForDefaultTenantWhenNoStoresConfigured() {
+    // given
+    final var resolver = resolverFor(Map.of());
+
+    // when
+    final var registries = CONFIG.secretStoreRegistries(resolver);
+
+    // then
+    assertThat(registries).containsKey(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(registry.getStores()).containsKey("default");
+    assertThat(registry.getStores().get("default")).isInstanceOf(NoopSecretStore.class);
+  }
+
+  @Test
+  void shouldBuildFileBasedStoreWhenFileStoreConfigured() {
+    // given
+    final var resolver =
+        resolverFor(Map.of("camunda.secrets.stores.file.main.path", "/etc/camunda/secrets"));
+
+    // when
+    final var registries = CONFIG.secretStoreRegistries(resolver);
+
+    // then
+    final var registry = registries.get(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(registry.getStores()).containsKey("main");
+    assertThat(registry.getStores().get("main")).isInstanceOf(FileBasedSecretStore.class);
+  }
+
+  @Test
+  void shouldThrowWhenFileStoreHasBlankPath() {
+    // given
+    final var resolver = resolverFor(Map.of("camunda.secrets.stores.file.bad.path", ""));
+
+    // when / then
+    assertThatIllegalStateException()
+        .isThrownBy(() -> CONFIG.secretStoreRegistries(resolver))
+        .withMessageContaining("bad")
+        .withMessageContaining(PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  void shouldProduceOneRegistryPerPhysicalTenant() {
+    // given two tenants with different store configurations
+    final var resolver =
+        resolverFor(
+            Map.of(
+                "camunda.physical-tenants.tenanta.secrets.stores.file.main.path",
+                "/etc/tenanta/secrets",
+                "camunda.physical-tenants.tenanta.security.initialization.default-roles.admin.users[0]",
+                "tenanta-admin",
+                "camunda.physical-tenants.tenanta.data.secondary-storage.elasticsearch.index-prefix",
+                "tenanta",
+                "camunda.physical-tenants.tenantb.secrets.stores.file.other.path",
+                "/etc/tenantb/secrets",
+                "camunda.physical-tenants.tenantb.security.initialization.default-roles.admin.users[0]",
+                "tenantb-admin",
+                "camunda.physical-tenants.tenantb.data.secondary-storage.elasticsearch.index-prefix",
+                "tenantb"));
+
+    // when
+    final var registries = CONFIG.secretStoreRegistries(resolver);
+
+    // then each tenant has its own registry with its own store
+    assertThat(registries).containsKeys("tenanta", "tenantb");
+    assertThat(registries.get("tenanta").getStores()).containsKey("main");
+    assertThat(registries.get("tenantb").getStores()).containsKey("other");
+  }
+
+  private static PhysicalTenantResolver resolverFor(final Map<String, Object> properties) {
+    final var env = new MockEnvironment();
+    if (!properties.isEmpty()) {
+      env.getPropertySources().addFirst(new MapPropertySource("test", properties));
+    }
+    final var camunda = new Camunda();
+    Binder.get(env).bind(Camunda.PREFIX, Bindable.ofInstance(camunda));
+    return PhysicalTenantResolver.of(env, camunda);
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreRegistryTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreRegistryTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.secrets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import io.camunda.secretstore.NoopSecretStore;
+import io.camunda.secretstore.SecretStore;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SecretStoreRegistryTest {
+
+  private static final NoopSecretStore NOOP = new NoopSecretStore();
+
+  @Test
+  void shouldThrowForUnknownTenant() {
+    // given
+    final var registry = new SecretStoreRegistry(Map.of("known-tenant", Map.of()));
+
+    // when / then
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> registry.getStores("unknown-tenant"))
+        .withMessageContaining("unknown-tenant");
+  }
+
+  @Test
+  void shouldReturnKnownTenants() {
+    // given
+    final var registry =
+        new SecretStoreRegistry(Map.of("tenant-a", Map.of(), "tenant-b", Map.of()));
+
+    // when
+    final var tenants = registry.tenants();
+
+    // then
+    assertThat(tenants).containsExactlyInAnyOrder("tenant-a", "tenant-b");
+  }
+
+  @Test
+  void shouldGetStoresForKnownTenant() {
+    // given
+    final var store = (SecretStore<?>) NOOP;
+    final var registry = new SecretStoreRegistry(Map.of("tenant", Map.of("default", store)));
+
+    // when
+    final var stores = registry.getStores("tenant");
+
+    // then
+    assertThat(stores).containsKey("default");
+    assertThat(stores.get("default")).isSameAs(store);
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreRegistryTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/secrets/SecretStoreRegistryTest.java
@@ -8,7 +8,6 @@
 package io.camunda.application.commons.secrets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import io.camunda.secretstore.NoopSecretStore;
 import io.camunda.secretstore.SecretStore;
@@ -20,40 +19,42 @@ class SecretStoreRegistryTest {
   private static final NoopSecretStore NOOP = new NoopSecretStore();
 
   @Test
-  void shouldThrowForUnknownTenant() {
+  void shouldReturnEmptyStoresWhenNoneConfigured() {
     // given
-    final var registry = new SecretStoreRegistry(Map.of("known-tenant", Map.of()));
-
-    // when / then
-    assertThatIllegalArgumentException()
-        .isThrownBy(() -> registry.getStores("unknown-tenant"))
-        .withMessageContaining("unknown-tenant");
-  }
-
-  @Test
-  void shouldReturnKnownTenants() {
-    // given
-    final var registry =
-        new SecretStoreRegistry(Map.of("tenant-a", Map.of(), "tenant-b", Map.of()));
+    final var registry = new SecretStoreRegistry(Map.of());
 
     // when
-    final var tenants = registry.tenants();
+    final var stores = registry.getStores();
 
     // then
-    assertThat(tenants).containsExactlyInAnyOrder("tenant-a", "tenant-b");
+    assertThat(stores).isEmpty();
   }
 
   @Test
-  void shouldGetStoresForKnownTenant() {
+  void shouldReturnConfiguredStore() {
     // given
     final var store = (SecretStore<?>) NOOP;
-    final var registry = new SecretStoreRegistry(Map.of("tenant", Map.of("default", store)));
+    final var registry = new SecretStoreRegistry(Map.of("default", store));
 
     // when
-    final var stores = registry.getStores("tenant");
+    final var stores = registry.getStores();
 
     // then
     assertThat(stores).containsKey("default");
     assertThat(stores.get("default")).isSameAs(store);
+  }
+
+  @Test
+  void shouldReturnAllConfiguredStores() {
+    // given
+    final var storeA = (SecretStore<?>) new NoopSecretStore();
+    final var storeB = (SecretStore<?>) new NoopSecretStore();
+    final var registry = new SecretStoreRegistry(Map.of("store-a", storeA, "store-b", storeB));
+
+    // when
+    final var stores = registry.getStores();
+
+    // then
+    assertThat(stores).containsKeys("store-a", "store-b");
   }
 }

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/NoopSecretReference.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/NoopSecretReference.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import org.jspecify.annotations.NullMarked;
+
+/** A placeholder {@link SecretReference} used by {@link NoopSecretStore}. */
+@NullMarked
+public record NoopSecretReference() implements SecretReference {}

--- a/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/NoopSecretStore.java
+++ b/secret-store/secret-store-api/src/main/java/io/camunda/secretstore/NoopSecretStore.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.jspecify.annotations.NullMarked;
+
+/** A no-op secret store returned when no store is configured for a physical tenant. */
+@NullMarked
+public final class NoopSecretStore implements SecretStore<NoopSecretReference> {
+
+  @Override
+  public Map<NoopSecretReference, SecretResolutionResult> resolve(
+      final Set<NoopSecretReference> refs) {
+    return refs.stream()
+        .collect(
+            toMap(
+                ref -> ref,
+                ref ->
+                    new SecretResolutionResult.Failed(
+                        SecretErrorCode.NOT_FOUND, "No secret store configured", null)));
+  }
+
+  @Override
+  public Collection<NoopSecretReference> list() {
+    return List.of();
+  }
+}

--- a/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/NoopSecretStoreTest.java
+++ b/secret-store/secret-store-api/src/test/java/io/camunda/secretstore/NoopSecretStoreTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.secretstore;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class NoopSecretStoreTest {
+
+  private final NoopSecretStore store = new NoopSecretStore();
+
+  @Test
+  void shouldReturnNotFoundForEveryRef() {
+    // given
+    final var ref = new NoopSecretReference();
+
+    // when
+    final var result = store.resolve(Set.of(ref));
+
+    // then — every ref gets a Failed(NOT_FOUND) result
+    assertThat(result).containsOnlyKeys(ref);
+    assertThat(result.values())
+        .allSatisfy(
+            r -> {
+              assertThat(r).isInstanceOf(SecretResolutionResult.Failed.class);
+              final var failed = (SecretResolutionResult.Failed) r;
+              assertThat(failed.code()).isEqualTo(SecretErrorCode.NOT_FOUND);
+              assertThat(failed.message()).isNotBlank();
+              assertThat(failed.cause()).isNull();
+            });
+  }
+
+  @Test
+  void shouldReturnEmptyMapForEmptyRefSet() {
+    // given an empty input set
+    // when
+    final var result = store.resolve(Set.of());
+
+    // then
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyList() {
+    // given
+    // when
+    final var list = store.list();
+
+    // then
+    assertThat(list).isEmpty();
+  }
+}


### PR DESCRIPTION
## Description

This PR adds infrastructure for configuring and accessing file-based secret stores in Camunda, following the same named-map pattern already used for document stores and authentication providers.

**Configuration** (`camunda.secrets.stores.file.<id>.path`) lets operators declare one or more named file stores, optionally per physical tenant. The `path` defaults to `/etc/camunda/secrets` (the conventional Kubernetes secret volume mount point), so a minimal declaration looks like:

```yaml
camunda:
  secrets:
    stores:
      file:
        main:             # store ID, user-chosen
          path: /etc/camunda/secrets   # optional — this is the default
```

Per-tenant overrides follow the existing physical-tenant overlay pattern:

```yaml
camunda:
  physical-tenants:
    tenanta:
      secrets:
        stores:
          file:
            main:
              path: /tenanta/secrets
```

**`NoopSecretStore` / `NoopSecretReference`** (`secret-store-api`) — a concrete, non-generic fallback store that maps every reference to `NOT_FOUND`. Used when no stores are configured for a tenant.

**`SecretStoreRegistry`** Spring bean (auto-configured via `CommonsModuleConfiguration`) — exposes `getStores(tenantId)` and `getOrNoop(tenantId, storeId)`. Startup behaviour:
- Declaring a store with a blank path → `IllegalStateException` at startup
- Tenant with no configured stores → registry always contains a `NoopSecretStore` under the key `"default"`

## Checklist

<!-- For a list of all available options, see: -->
<!-- https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#pull-request-and-code-reviews -->

- [ ] I have written tests that cover the changes I made
- [ ] I have updated the documentation accordingly
- [ ] I have added a changeset if necessary

## Related issues

closes #56561