### PR TITLE
ci: drop the weekly latency load test

### DIFF
--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -1,7 +1,7 @@
 # description: Runs parallel endurance tests weekly against main (TTL: 28 days).
-#              Variants: realistic, rdbms-realistic (PostgreSQL), opensearch-realistic, latency.
+#              Variants: realistic, rdbms-realistic (PostgreSQL), opensearch-realistic.
 #              Naming pattern: medic-y-YYYY-cw-WW-<sha>
-# calls: camunda-load-test.yml (5 parallel calls, one per scenario)
+# calls: camunda-load-test.yml (3 parallel calls, one per scenario)
 # type: CI
 # owner: @camunda/reliability-testing
 name: Camunda weekly medic load test
@@ -235,25 +235,6 @@ jobs:
       reuse-tag: ${{ needs.test-data.outputs.image-tag }}
       scenario: realistic
 
-  setup-latency-test:
-    name: Latency test
-    uses: ./.github/workflows/camunda-load-test.yml
-    secrets: inherit
-    needs:
-      - test-data
-      - build-camunda-image
-      - build-load-test-images
-    if: |
-      always() &&
-      needs.test-data.result == 'success' &&
-      (needs.build-camunda-image.result == 'success' || needs.build-camunda-image.result == 'skipped') &&
-      (needs.build-load-test-images.result == 'success' || needs.build-load-test-images.result == 'skipped')
-    with:
-      name: ${{ needs.test-data.outputs.image-tag }}-latency
-      ttl: ${{ fromJSON(inputs.ttl || '28') }}
-      reuse-tag: ${{ needs.test-data.outputs.image-tag }}
-      scenario: latency
-
   setup-ecs-benchmark:
     name: ECS Weekly Benchmark
     needs:
@@ -276,7 +257,7 @@ jobs:
   notify:
     name: Notify on failure
     runs-on: ubuntu-latest
-    needs: [ build-camunda-image, build-load-test-images, setup-rdbms-realistic-load-test, setup-opensearch-realistic-load-test, setup-realistic-test, setup-latency-test, setup-ecs-benchmark ]
+    needs: [ build-camunda-image, build-load-test-images, setup-rdbms-realistic-load-test, setup-opensearch-realistic-load-test, setup-realistic-test, setup-ecs-benchmark ]
     if: failure()
     timeout-minutes: 5
     permissions: { }

--- a/.github/workflows/camunda-weekly-load-tests.yml
+++ b/.github/workflows/camunda-weekly-load-tests.yml
@@ -1,7 +1,8 @@
 # description: Runs parallel endurance tests weekly against main (TTL: 28 days).
-#              Variants: realistic, rdbms-realistic (PostgreSQL), opensearch-realistic.
+#              Variants: realistic, rdbms-realistic (PostgreSQL), opensearch-realistic, ECS.
 #              Naming pattern: medic-y-YYYY-cw-WW-<sha>
-# calls: camunda-load-test.yml (3 parallel calls, one per scenario)
+# calls: camunda-load-test.yml (3 parallel calls, one per scenario) +
+#        camunda-ecs-weekly-load-test.yml (1 parallel call) — 4 load tests total
 # type: CI
 # owner: @camunda/reliability-testing
 name: Camunda weekly medic load test

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -72,7 +72,7 @@ graph TD
     SCHEDULED -- "verify + delete namespace" --> VERIFY
     DAILY -- "scenario: max" --> CORE
     DAILY -- "always profiles first<br/>30min of both runs" --> PROFILE
-    WEEKLY -- "3 parallel calls:<br/>typical, realistic,<br/>rdbms-realistic" --> CORE
+    WEEKLY -- "3 parallel calls:<br/>realistic, opensearch-realistic,<br/>rdbms-realistic" --> CORE
     WEEKLY -- "ECS" --> ECS
     ROLLING -- "latest release tag<br/>custom helm values" --> CORE
     RELEASE -- "scenario: realistic<br/>orchestration-tag" --> CORE

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -72,7 +72,7 @@ graph TD
     SCHEDULED -- "verify + delete namespace" --> VERIFY
     DAILY -- "scenario: max" --> CORE
     DAILY -- "always profiles first<br/>30min of both runs" --> PROFILE
-    WEEKLY -- "4 parallel calls:<br/>typical, realistic,<br/>rdbms-realistic, latency" --> CORE
+    WEEKLY -- "3 parallel calls:<br/>typical, realistic,<br/>rdbms-realistic" --> CORE
     WEEKLY -- "ECS" --> ECS
     ROLLING -- "latest release tag<br/>custom helm values" --> CORE
     RELEASE -- "scenario: realistic<br/>orchestration-tag" --> CORE
@@ -328,7 +328,7 @@ Results are posted to the `#reliability-testing-alerts` Slack channel.
 
 Weekly load tests run against the state of the **main** branch via the [Camunda load test GitHub workflow](https://github.com/camunda/camunda/actions/workflows/camunda-load-test.yml). They are automatically created every Monday and run for 4 weeks, then cleaned up by the [TTL checker](https://github.com/camunda/camunda/blob/main/.github/workflows/camunda-load-test-ttl-cleanup.yml). This results in several concurrent weekly tests (multiple variants × four weeks).
 
-The weekly tests cover, for example, the [realistic load](../docs/testing/reliability-testing.md#realistic-load) variants (one with Elasticsearch, one with OpenSearch, and one with PostgreSQL) plus the [latency test](../docs/testing/reliability-testing.md#latency-load-test).
+The weekly tests cover, for example, the [realistic load](../docs/testing/reliability-testing.md#realistic-load) variants (one with Elasticsearch, one with OpenSearch, and one with PostgreSQL).
 
 **Goal:** Validating the reliability of the current main, detecting newly introduced instabilities, memory leaks, and performance degradation.
 
@@ -336,7 +336,6 @@ The weekly tests cover, for example, the [realistic load](../docs/testing/reliab
 
 Example running tests (naming pattern: `medic-y-<year>-cw-<week>-<sha>-<variant>`):
 
-- `medic-y-2025-cw-22-a60d64da-test-latency`
 - `medic-y-2025-cw-22-a60d64da-test-realistic`
 - `medic-y-2025-cw-22-a60d64da-test-rdbms-realistic`
 

--- a/monitor/grafana/dashboards/data-layer-medic-dashboard.json
+++ b/monitor/grafana/dashboards/data-layer-medic-dashboard.json
@@ -1121,367 +1121,6 @@
         "x": 0,
         "y": 60
       },
-      "id": 286,
-      "panels": [],
-      "title": "Latency Load Tests",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 5
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 8,
-        "x": 0,
-        "y": 61
-      },
-      "id": 327,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "max"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "adhocFilters": [],
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99,sum by (le, namespace) (rate(starter_data_availability_latency_seconds_bucket{namespace=~\"$prefix.*-latency\"}[$__rate_interval])))",
-          "fromExploreMetrics": true,
-          "interval": "",
-          "legendFormat": "{{namespace}}",
-          "range": true,
-          "refId": "starter_data_availability_latency_seconds_bucket-p99-histogram_quantile"
-        }
-      ],
-      "title": "Data availability latency p99",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 8,
-        "x": 8,
-        "y": 61
-      },
-      "id": 333,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "max"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "adhocFilters": [],
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.9,sum by (le, namespace) (rate(starter_data_availability_latency_seconds_bucket{namespace=~\"$prefix.*-latency\"}[$__rate_interval])))",
-          "fromExploreMetrics": true,
-          "interval": "",
-          "legendFormat": "{{namespace}}",
-          "range": true,
-          "refId": "starter_data_availability_latency_seconds_bucket-p90-histogram_quantile"
-        }
-      ],
-      "title": "Data availability latency p90",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 11,
-        "w": 8,
-        "x": 16,
-        "y": 61
-      },
-      "id": 319,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "max"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "adhocFilters": [],
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.5,sum by (le, namespace) (rate(starter_data_availability_latency_seconds_bucket{namespace=~\"$prefix.*-latency\"}[$__rate_interval])))",
-          "fromExploreMetrics": true,
-          "interval": "",
-          "legendFormat": "{{namespace}}",
-          "range": true,
-          "refId": "starter_data_availability_latency_seconds_bucket-p50-histogram_quantile"
-        }
-      ],
-      "title": "Data availability latency p50",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 0.9
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 72
-      },
-      "id": 330,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(zeebe_camunda_exporter_archiver_process_instances_total{namespace=~\"$prefix.*-latency\", state=\"archived\"}[$__rate_interval])) by (namespace)",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Archiving rate",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 72
-      },
-      "id": 331,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.4.1",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "sum(rate(zeebe_element_instance_events_total{namespace=~\"$prefix.*-latency\", action=\"completed\", type=\"PROCESS\"}[$__rate_interval])) by (namespace)",
-          "legendFormat": "__auto",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "PI Completion rate",
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 80
-      },
       "id": 284,
       "panels": [],
       "title": "Medic Load Tests Health",
@@ -1521,7 +1160,7 @@
         "h": 9,
         "w": 24,
         "x": 0,
-        "y": 81
+        "y": 61
       },
       "id": 39,
       "options": {
@@ -1564,7 +1203,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 90
+        "y": 70
       },
       "id": 290,
       "panels": [],
@@ -1603,7 +1242,7 @@
         "h": 11,
         "w": 8,
         "x": 0,
-        "y": 91
+        "y": 71
       },
       "id": 332,
       "options": {
@@ -1675,7 +1314,7 @@
         "h": 11,
         "w": 8,
         "x": 8,
-        "y": 91
+        "y": 71
       },
       "id": 323,
       "options": {
@@ -1747,7 +1386,7 @@
         "h": 11,
         "w": 8,
         "x": 16,
-        "y": 91
+        "y": 71
       },
       "id": 335,
       "options": {
@@ -1818,7 +1457,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 102
+        "y": 82
       },
       "id": 334,
       "options": {
@@ -1882,7 +1521,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 102
+        "y": 82
       },
       "id": 336,
       "options": {

--- a/monitor/grafana/medic-benchmark-dashboard.json
+++ b/monitor/grafana/medic-benchmark-dashboard.json
@@ -622,563 +622,6 @@
         "x": 0,
         "y": 14
       },
-      "id": 286,
-      "panels": [],
-      "title": "Latency Load Tests",
-      "type": "row"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 15
-      },
-      "id": 297,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "1 - kube_pod_container_status_ready{container!~\"curator|curl\", namespace=~\".*-latency\"}",
-          "legendFormat": "{{pod}} restart",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Pod Restarts",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Average process instance execution latency",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "red",
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "color": "red",
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 0.1
-              },
-              {
-                "color": "red",
-                "value": 0.2
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 0,
-        "y": 22
-      },
-      "id": 232,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "titleSize": 10
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_bucket{namespace=~\"(c8-)?medic.*-latency\"}[$__rate_interval])) by (le, namespace))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{namespace}}",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace=~\"(c8-)?medic.*-latency\"}[$__rate_interval])) by (le, namespace))",
-          "instant": false,
-          "legendFormat": "{{namespace}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "p50 Latency",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "90th percentile process instance execution latency",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "red",
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "color": "red",
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 0.4
-              },
-              {
-                "color": "red",
-                "value": 0.6
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 8,
-        "y": 26
-      },
-      "id": 305,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "titleSize": 10
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(zeebe_process_instance_execution_time_bucket{namespace=~\"(c8-)?medic.*-latency\"}[$__rate_interval])) by (le, namespace))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{namespace}}",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.90, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace=~\"(c8-)?medic.*-latency\"}[$__rate_interval])) by (le, namespace))",
-          "instant": false,
-          "legendFormat": "{{namespace}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Latency Benchmark p90",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "99th percentile process instance execution latency",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "fixedColor": "red",
-            "mode": "thresholds"
-          },
-          "mappings": [
-            {
-              "options": {
-                "match": "null",
-                "result": {
-                  "color": "red",
-                  "text": "0"
-                }
-              },
-              "type": "special"
-            }
-          ],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "yellow",
-                "value": 0.6
-              },
-              {
-                "color": "red",
-                "value": 0.8
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 16,
-        "y": 26
-      },
-      "id": 306,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "percentChangeColorMode": "standard",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showPercentChange": false,
-        "text": {
-          "titleSize": 10
-        },
-        "textMode": "auto",
-        "wideLayout": true
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_bucket{namespace=~\"(c8-)?medic.*-latency\"}[$__rate_interval])) by (le, namespace))",
-          "instant": true,
-          "interval": "",
-          "legendFormat": "{{namespace}}",
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace=~\"(c8-)?medic.*-latency\"}[$__rate_interval])) by (le, namespace))",
-          "instant": false,
-          "legendFormat": "{{namespace}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Latency benchmark p99 Latency",
-      "type": "stat"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
-      },
-      "description": "Shows the execution time of a process instance. This means the time (latency) between creating the instance and completing it.",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "seconds",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "showValues": false,
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "line+area"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "transparent",
-                "value": 0
-              },
-              {
-                "color": "red",
-                "value": 2.1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 30
-      },
-      "id": 288,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2",
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$DS_PROMETHEUS"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_bucket{namespace=~\"(c8-)?medic.*latency\"}[$__rate_interval])) by (le, namespace))",
-          "format": "heatmap",
-          "interval": "30s",
-          "intervalFactor": 1,
-          "legendFormat": "p50 {{namespace}}",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_bucket{namespace=~\"(c8-)?medic.*latency\"}[$__rate_interval])) by (le, namespace))",
-          "interval": "",
-          "legendFormat": "p99 {{namespace}}",
-          "range": true,
-          "refId": "B"
-        },
-        {
-          "datasource": {
-            "uid": "$DS_PROMETHEUS"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace=~\"(c8-)?medic.*latency\"}[$__rate_interval])) by (le, namespace))",
-          "format": "heatmap",
-          "interval": "30s",
-          "intervalFactor": 1,
-          "legendFormat": "p50 {{namespace}}",
-          "range": true,
-          "refId": "C"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(zeebe_process_instance_execution_time_seconds_bucket{namespace=~\"(c8-)?medic.*latency\"}[$__rate_interval])) by (le, namespace))",
-          "interval": "",
-          "legendFormat": "p99 {{namespace}}",
-          "range": true,
-          "refId": "D"
-        }
-      ],
-      "title": "Process Instance Execution Time (avg)",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 38
-      },
       "id": 320,
       "panels": [],
       "title": "ECS Weekly Load Tests",
@@ -1229,7 +672,7 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 39
+        "y": 15
       },
       "id": 321,
       "options": {
@@ -1315,7 +758,7 @@
         "h": 4,
         "w": 8,
         "x": 8,
-        "y": 39
+        "y": 15
       },
       "id": 322,
       "options": {
@@ -1397,7 +840,7 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 39
+        "y": 15
       },
       "id": 323,
       "options": {
@@ -1444,7 +887,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 19
       },
       "id": 284,
       "panels": [],
@@ -1651,7 +1094,7 @@
         "h": 10,
         "w": 11,
         "x": 0,
-        "y": 44
+        "y": 20
       },
       "id": 243,
       "options": {
@@ -1805,7 +1248,7 @@
         "h": 5,
         "w": 13,
         "x": 11,
-        "y": 44
+        "y": 20
       },
       "id": 272,
       "options": {
@@ -1920,7 +1363,7 @@
         "h": 5,
         "w": 13,
         "x": 11,
-        "y": 49
+        "y": 25
       },
       "id": 39,
       "options": {
@@ -1962,7 +1405,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 30
       },
       "id": 290,
       "panels": [],
@@ -2014,7 +1457,7 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 55
+        "y": 31
       },
       "id": 291,
       "options": {
@@ -2100,7 +1543,7 @@
         "h": 4,
         "w": 8,
         "x": 8,
-        "y": 55
+        "y": 31
       },
       "id": 292,
       "options": {
@@ -2182,7 +1625,7 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 55
+        "y": 31
       },
       "id": 293,
       "options": {
@@ -2272,7 +1715,7 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 59
+        "y": 35
       },
       "id": 301,
       "options": {
@@ -2374,7 +1817,7 @@
         "h": 4,
         "w": 8,
         "x": 8,
-        "y": 59
+        "y": 35
       },
       "id": 302,
       "options": {
@@ -2476,7 +1919,7 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 59
+        "y": 35
       },
       "id": 303,
       "options": {
@@ -2717,7 +2160,7 @@
         "h": 9,
         "w": 11,
         "x": 0,
-        "y": 63
+        "y": 39
       },
       "id": 294,
       "options": {
@@ -2849,7 +2292,7 @@
         "h": 9,
         "w": 13,
         "x": 11,
-        "y": 63
+        "y": 39
       },
       "id": 296,
       "options": {


### PR DESCRIPTION
## Description

> [!NOTE]
>
> Deleted the 5 live c8-medic-*-latency namespaces on benchmark-prod (each ~1.5TB of PVCs), freeing that disk immediately.


Removes the weekly `latency` scenario from the medic load test workflow, per the linked issue: nobody has acted on its output since it was added, and the daily `max` scenario already covers latency regressions as throughput degradation.

- Removes the `setup-latency-test` job from `camunda-weekly-load-tests.yml` (main only — scheduled workflows only run from the default branch, so stable branches never actually trigger this job).
- Removes the now-empty "Latency Load Tests" rows/panels from both medic Grafana dashboards (`medic-benchmark-dashboard.json`, `data-layer-medic-dashboard.json`), which would otherwise show empty data going forward.
- Updates `load-tests/README.md` to drop the weekly latency mentions (diagram, description, namespace naming example).
- Deleted the 5 existing live `c8-medic-*-latency` namespaces on the benchmark-prod cluster (~1.5TB of PVCs each).

The underlying `latency` scenario itself (Makefile target, `camunda-load-test.yml` dropdown option) is intentionally kept so it can still be run ad hoc — only the automated weekly scheduling is removed, matching the issue's "future work" note about a possible lightweight variant later.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).

## Related issues

closes #57572