### PR TITLE
fix: handle duplicate incidents and process instances in incident update task

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -91,6 +91,9 @@ public class CamundaExporterMetrics implements AutoCloseable {
   /** Count of document updated when incident updates were processed. */
   private final Counter incidentUpdatesDocumentsUpdated;
 
+  /** Count of duplicate incidents found. */
+  private final Counter incidentUpdatesDuplicateIncidents;
+
   /** Count of archiver batch retries due to retryable errors. */
   private final Counter archiverBatchRetries;
 
@@ -278,6 +281,11 @@ public class CamundaExporterMetrics implements AutoCloseable {
         Counter.builder(meterName("incident.updates.documents"))
             .tag("action", "updated")
             .description("Count of documents that were updated when incidents were processed.")
+            .register(meterRegistry);
+    incidentUpdatesDuplicateIncidents =
+        Counter.builder(meterName("incident.updates.duplicates"))
+            .tag("type", "incidents")
+            .description("Count of duplicate incidents processed found")
             .register(meterRegistry);
     bulkSize =
         DistributionSummary.builder(meterName("bulk.size"))
@@ -480,6 +488,10 @@ public class CamundaExporterMetrics implements AutoCloseable {
     incidentUpdatesDocumentsUpdated.increment(count);
   }
 
+  public void recordIncidentUpdatesDuplicateIncidents(final int count) {
+    incidentUpdatesDuplicateIncidents.increment(count);
+  }
+
   public void recordFlushFailureType(final String failureType) {
     meterRegistry.counter(FLUSH_FAILURE_TYPE_METER_NAME, "failure_type", failureType).increment();
   }
@@ -595,6 +607,7 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(incidentUpdatesRetriesNeeded);
     meterRegistry.remove(incidentUpdatesProcessed);
     meterRegistry.remove(incidentUpdatesDocumentsUpdated);
+    meterRegistry.remove(incidentUpdatesDuplicateIncidents);
     meterRegistry.remove(jobBatchMetricsArchiving);
     meterRegistry.remove(jobBatchMetricsArchived);
     meterRegistry.remove(usageMetricsArchived);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -94,6 +94,12 @@ public class CamundaExporterMetrics implements AutoCloseable {
   /** Count of duplicate incidents found. */
   private final Counter incidentUpdatesDuplicateIncidents;
 
+  /** Count of duplicate process instances found. */
+  private final Counter incidentUpdatesDuplicateProcessInstances;
+
+  /** Count of duplicate flownode instances found. */
+  private final Counter incidentUpdatesDuplicateFlowNodeInstances;
+
   /** Count of archiver batch retries due to retryable errors. */
   private final Counter archiverBatchRetries;
 
@@ -285,7 +291,17 @@ public class CamundaExporterMetrics implements AutoCloseable {
     incidentUpdatesDuplicateIncidents =
         Counter.builder(meterName("incident.updates.duplicates"))
             .tag("type", "incidents")
-            .description("Count of duplicate incidents processed found")
+            .description("Count of duplicate incidents found")
+            .register(meterRegistry);
+    incidentUpdatesDuplicateProcessInstances =
+        Counter.builder(meterName("incident.updates.duplicates"))
+            .tag("type", "process-instances")
+            .description("Count of duplicate process instances found")
+            .register(meterRegistry);
+    incidentUpdatesDuplicateFlowNodeInstances =
+        Counter.builder(meterName("incident.updates.duplicates"))
+            .tag("type", "flownode-instances")
+            .description("Count of duplicate flownode instances found")
             .register(meterRegistry);
     bulkSize =
         DistributionSummary.builder(meterName("bulk.size"))
@@ -492,6 +508,14 @@ public class CamundaExporterMetrics implements AutoCloseable {
     incidentUpdatesDuplicateIncidents.increment(count);
   }
 
+  public void recordIncidentUpdatesDuplicateProcessInstances(final int count) {
+    incidentUpdatesDuplicateProcessInstances.increment(count);
+  }
+
+  public void recordIncidentUpdatesDuplicateFlowNodeInstances(final int count) {
+    incidentUpdatesDuplicateFlowNodeInstances.increment(count);
+  }
+
   public void recordFlushFailureType(final String failureType) {
     meterRegistry.counter(FLUSH_FAILURE_TYPE_METER_NAME, "failure_type", failureType).increment();
   }
@@ -608,6 +632,8 @@ public class CamundaExporterMetrics implements AutoCloseable {
     meterRegistry.remove(incidentUpdatesProcessed);
     meterRegistry.remove(incidentUpdatesDocumentsUpdated);
     meterRegistry.remove(incidentUpdatesDuplicateIncidents);
+    meterRegistry.remove(incidentUpdatesDuplicateProcessInstances);
+    meterRegistry.remove(incidentUpdatesDuplicateFlowNodeInstances);
     meterRegistry.remove(jobBatchMetricsArchiving);
     meterRegistry.remove(jobBatchMetricsArchived);
     meterRegistry.remove(usageMetricsArchived);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -112,13 +112,14 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
   }
 
   @Override
-  public CompletionStage<Map<String, IncidentDocument>> getIncidentDocuments(
+  public CompletionStage<Collection<IncidentDocument>> getIncidentDocuments(
       final List<String> incidentIds) {
     final var request = createIncidentDocumentsRequest(incidentIds);
 
-    return client
-        .search(request, IncidentEntity.class)
-        .thenApplyAsync(this::createIncidentDocuments, executor);
+    return fetchUnboundedDocumentCollection(
+        request,
+        IncidentEntity.class,
+        hit -> new IncidentDocument(hit.id(), hit.index(), hit.source()));
   }
 
   @Override
@@ -322,7 +323,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
         ._toBulkOperation();
   }
 
-  private SearchRequest createIncidentDocumentsRequest(final List<String> incidentIds) {
+  private SearchRequest.Builder createIncidentDocumentsRequest(final List<String> incidentIds) {
     final var idQ = QueryBuilders.ids(i -> i.values(incidentIds));
     final var partitionQ =
         QueryBuilders.term(t -> t.field(IncidentTemplate.PARTITION_ID).value(partitionId));
@@ -331,19 +332,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
         .query(q -> q.bool(b -> b.must(idQ, partitionQ)))
         .allowNoIndices(true)
         .ignoreUnavailable(true)
-        .sort(s -> s.field(f -> f.field(IncidentTemplate.KEY)))
-        .size(incidentIds.size())
-        .build();
-  }
-
-  private Map<String, IncidentDocument> createIncidentDocuments(
-      final SearchResponse<IncidentEntity> response) {
-    final Map<String, IncidentDocument> documents = new HashMap<>();
-    for (final var hit : response.hits().hits()) {
-      documents.put(hit.id(), new IncidentDocument(hit.id(), hit.index(), hit.source()));
-    }
-
-    return documents;
+        .sort(s -> s.field(f -> f.field(IncidentTemplate.KEY)));
   }
 
   private SearchRequest createPendingIncidentsBatchRequest(final int size, final Query query) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -116,10 +116,9 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
       final List<String> incidentIds) {
     final var request = createIncidentDocumentsRequest(incidentIds);
 
-    return fetchUnboundedDocumentCollection(
-        request,
-        IncidentEntity.class,
-        hit -> new IncidentDocument(hit.id(), hit.index(), hit.source()));
+    return client
+        .search(request, IncidentEntity.class)
+        .thenApplyAsync(this::createIncidentDocuments, executor);
   }
 
   @Override
@@ -323,7 +322,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
         ._toBulkOperation();
   }
 
-  private SearchRequest.Builder createIncidentDocumentsRequest(final List<String> incidentIds) {
+  private SearchRequest createIncidentDocumentsRequest(final List<String> incidentIds) {
     final var idQ = QueryBuilders.ids(i -> i.values(incidentIds));
     final var partitionQ =
         QueryBuilders.term(t -> t.field(IncidentTemplate.PARTITION_ID).value(partitionId));
@@ -332,7 +331,17 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
         .query(q -> q.bool(b -> b.must(idQ, partitionQ)))
         .allowNoIndices(true)
         .ignoreUnavailable(true)
-        .sort(s -> s.field(f -> f.field(IncidentTemplate.KEY)));
+        .sort(s -> s.field(f -> f.field(IncidentTemplate.KEY)))
+        // ask for more documents in case there are duplicates
+        .size(10_000)
+        .build();
+  }
+
+  private Collection<IncidentDocument> createIncidentDocuments(
+      final SearchResponse<IncidentEntity> response) {
+    return response.hits().hits().stream()
+        .map(hit -> new IncidentDocument(hit.id(), hit.index(), hit.source()))
+        .toList();
   }
 
   private SearchRequest createPendingIncidentsBatchRequest(final int size, final Query query) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Stream;
 
 /**
@@ -149,18 +149,21 @@ public interface IncidentUpdateRepository extends AutoCloseable {
    * execute.
    */
   record IncidentBulkUpdate(
-      Map<String, DocumentUpdate> listViewRequests,
-      Map<String, DocumentUpdate> flowNodeInstanceRequests,
-      Map<String, DocumentUpdate> incidentRequests) {
+      Collection<DocumentUpdate> listViewRequests,
+      Collection<DocumentUpdate> flowNodeInstanceRequests,
+      Collection<DocumentUpdate> incidentRequests) {
     public IncidentBulkUpdate() {
-      this(new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>());
+      this(
+          new ConcurrentLinkedQueue<>(),
+          new ConcurrentLinkedQueue<>(),
+          new ConcurrentLinkedQueue<>());
     }
 
     public Stream<DocumentUpdate> stream() {
       return Stream.concat(
-          Stream.concat(
-              listViewRequests.values().stream(), flowNodeInstanceRequests.values().stream()),
-          incidentRequests.values().stream());
+              Stream.concat(listViewRequests.stream(), flowNodeInstanceRequests.stream()),
+              incidentRequests.stream())
+          .distinct();
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -42,9 +42,9 @@ public interface IncidentUpdateRepository extends AutoCloseable {
    * documents may not be visible yet.
    *
    * @param incidentIds the IDs to filter on
-   * @return a map of {@link IncidentDocument} indexed by ID
+   * @return a collection of {@link IncidentDocument}
    */
-  CompletionStage<Map<String, IncidentDocument>> getIncidentDocuments(
+  CompletionStage<Collection<IncidentDocument>> getIncidentDocuments(
       final List<String> incidentIds);
 
   /**
@@ -184,9 +184,9 @@ public interface IncidentUpdateRepository extends AutoCloseable {
     }
 
     @Override
-    public CompletionStage<Map<String, IncidentDocument>> getIncidentDocuments(
+    public CompletionStage<Collection<IncidentDocument>> getIncidentDocuments(
         final List<String> incidentIds) {
-      return CompletableFuture.completedFuture(Map.of());
+      return CompletableFuture.completedFuture(List.of());
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -754,7 +754,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
     final var frequencies =
         ids.stream().collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
     var totalDuplicates = 0;
-    final var duplicates = new ArrayList<T>();
+    final var duplicates = new LinkedHashSet<>();
     for (final var entry : frequencies.entrySet()) {
       if (entry.getValue() > 1L) {
         duplicates.add(entry.getKey());
@@ -794,17 +794,18 @@ public final class IncidentUpdateTask implements BackgroundTask {
 
   private <T> void recordDuplication(
       final int totalDuplicates,
-      final Collection<T> duplicates,
+      final Set<T> duplicates,
       final String type,
       final Consumer<Integer> recordDuplicatesMetric) {
     if (totalDuplicates > 0) {
       logger.warn(
           """
-        Found duplicate {} documents for the following IDs: {} - will update all duplicates.
+        Found {} duplicate {} documents - will update all duplicates. Example IDs: {}.
         This may indicate a problem with archiving.
       """,
+          totalDuplicates,
           type,
-          duplicates);
+          duplicates.stream().limit(10).collect(Collectors.toList()));
       recordDuplicatesMetric.accept(totalDuplicates);
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -730,6 +730,28 @@ public final class IncidentUpdateTask implements BackgroundTask {
           absentIncidents);
     }
 
+    if (incidentIds.size() < incidents.size()) {
+      final var frequencies =
+          incidents.stream()
+              .map(IncidentDocument::id)
+              .collect(Collectors.groupingBy(id -> id, Collectors.counting()));
+      var totalDuplicates = 0;
+      final var duplicates = new ArrayList<String>();
+      for (final var entry : frequencies.entrySet()) {
+        if (entry.getValue() > 1L) {
+          duplicates.add(entry.getKey());
+          totalDuplicates += (entry.getValue().intValue() - 1);
+        }
+      }
+      logger.warn(
+          """
+            Found duplicate incident documents for the following incident IDs: {} - will update all duplicates.
+            This may indicate a problem with archiving.
+          """,
+          duplicates);
+      metrics.recordIncidentUpdatesDuplicateIncidents(totalDuplicates);
+    }
+
     return pendingIncidentsBatch;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -137,7 +137,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
    * </ul>
    */
   private CompletableFuture<Integer> processNextBatch() {
-    final var data = new AdditionalData();
+    final var data = new IncidentsState();
     final var batch = getPendingIncidentsBatch(data);
     if (batch.newIncidentStates().isEmpty()) {
       return CompletableFuture.completedFuture(0);
@@ -181,7 +181,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
             executor);
   }
 
-  private InstancesCheck searchForInstances(final AdditionalData data) {
+  private InstancesCheck searchForInstances(final IncidentsState data) {
     final var incidents = data.incidents().values();
 
     queryData(incidents, data);
@@ -213,7 +213,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
 
   private InstancesCheck checkDataAndCollectParentTreePaths(
       final Collection<IncidentDocument> incidents,
-      final AdditionalData data,
+      final IncidentsState data,
       final boolean forceIgnoreMissingData) {
 
     final Set<Long> processInstanceKeys =
@@ -277,7 +277,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
     return InstancesCheck.OK;
   }
 
-  private void queryData(final Collection<IncidentDocument> incidents, final AdditionalData data) {
+  private void queryData(final Collection<IncidentDocument> incidents, final IncidentsState data) {
     final var processInstanceIds =
         incidents.stream()
             .map(IncidentDocument::incident)
@@ -316,7 +316,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private int processIncidents(
-      final AdditionalData data, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
+      final IncidentsState data, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
     final var bulkUpdate = new IncidentBulkUpdate();
     return mapActiveIncidentsToAffectedInstances(data)
         .thenApplyAsync(
@@ -341,7 +341,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private void seedResolvedIncidentsAsActive(
-      final AdditionalData data, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
+      final IncidentsState data, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
     for (final var incident : data.incidents().values()) {
       final var newState = batch.newIncidentStates().get(incident.incident().getKey());
       if (newState != IncidentState.RESOLVED) {
@@ -364,7 +364,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private CompletableFuture<Void> processIncidentInBatch(
-      final AdditionalData data,
+      final IncidentsState data,
       final IncidentDocument incident,
       final IncidentUpdateRepository.PendingIncidentUpdateBatch batch,
       final IncidentBulkUpdate bulkUpdate) {
@@ -428,7 +428,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private CompletableFuture<Void> createFlowNodeInstanceUpdates(
-      final AdditionalData data,
+      final IncidentsState data,
       final IncidentDocument incident,
       final IncidentState newState,
       final List<String> fniIds,
@@ -501,7 +501,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private void createFlowNodeInstanceUpdate(
-      final AdditionalData data,
+      final IncidentsState data,
       final IncidentDocument incident,
       final IncidentState newState,
       final String fniId,
@@ -536,7 +536,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private CompletableFuture<Void> createProcessInstanceUpdates(
-      final AdditionalData data,
+      final IncidentsState data,
       final IncidentDocument incident,
       final IncidentState newState,
       final List<String> piIds,
@@ -588,7 +588,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private void createProcessInstanceUpdate(
-      final AdditionalData data,
+      final IncidentsState data,
       final String incidentId,
       final IncidentState newState,
       final String piId,
@@ -656,7 +656,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
         id, index, Map.of(FlowNodeInstanceTemplate.INCIDENT, hasIncident), null);
   }
 
-  private CompletableFuture<Void> mapActiveIncidentsToAffectedInstances(final AdditionalData data) {
+  private CompletableFuture<Void> mapActiveIncidentsToAffectedInstances(final IncidentsState data) {
     final CompletableFuture<List<String>> treePathTermsFutures =
         FuturesUtil.parTraverse(
                 data.incidentTreePaths().values(),
@@ -685,7 +685,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private IncidentUpdateRepository.PendingIncidentUpdateBatch getPendingIncidentsBatch(
-      final AdditionalData data) {
+      final IncidentsState data) {
     final IncidentUpdateRepository.PendingIncidentUpdateBatch pendingIncidentsBatch =
         repository
             .getPendingIncidentsBatch(metadata.getLastIncidentUpdatePosition(), batchSize)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -28,12 +28,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.WillCloseWhenClosed;
 import org.agrona.LangUtil;
@@ -201,11 +204,11 @@ public final class IncidentUpdateTask implements BackgroundTask {
             .map(String::valueOf)
             .distinct()
             .toList();
-    repository
-        .getFlowNodesInListView(flowNodeKeys)
-        .toCompletableFuture()
-        .join()
-        .forEach(doc -> state.addFlowNodeInstanceInListView(doc.id(), doc.index()));
+
+    final var flowNodes =
+        repository.getFlowNodesInListView(flowNodeKeys).toCompletableFuture().join();
+
+    flowNodes.forEach(doc -> state.addFlowNodeInstanceInListView(doc.id(), doc.index()));
 
     return InstancesCheck.OK;
   }
@@ -286,6 +289,11 @@ public final class IncidentUpdateTask implements BackgroundTask {
 
     final var instances =
         repository.getProcessInstances(processInstanceIds).toCompletableFuture().join();
+
+    recordDuplicationMetrics(
+        instances.stream().map(IncidentUpdateRepository.ProcessInstanceDocument::id).toList(),
+        "process instance",
+        metrics::recordIncidentUpdatesDuplicateProcessInstances);
 
     instances.forEach(
         instance -> {
@@ -465,6 +473,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
     return CompletableFuture.allOf(futures)
         .thenComposeAsync(
             ignored -> {
+              recordFlownodeDuplicationMetrics(state);
               for (final var fniId : fniIds) {
                 final var listViewIndices = state.flowNodeInstanceInListViewIndices().get(fniId);
                 final var flowNodeIndices = state.flowNodeInstanceIndices().get(fniId);
@@ -731,28 +740,73 @@ public final class IncidentUpdateTask implements BackgroundTask {
     }
 
     if (incidentIds.size() < incidents.size()) {
-      final var frequencies =
-          incidents.stream()
-              .map(IncidentDocument::id)
-              .collect(Collectors.groupingBy(id -> id, Collectors.counting()));
-      var totalDuplicates = 0;
-      final var duplicates = new ArrayList<String>();
-      for (final var entry : frequencies.entrySet()) {
-        if (entry.getValue() > 1L) {
-          duplicates.add(entry.getKey());
-          totalDuplicates += (entry.getValue().intValue() - 1);
-        }
-      }
-      logger.warn(
-          """
-            Found duplicate incident documents for the following incident IDs: {} - will update all duplicates.
-            This may indicate a problem with archiving.
-          """,
-          duplicates);
-      metrics.recordIncidentUpdatesDuplicateIncidents(totalDuplicates);
+      recordDuplicationMetrics(
+          incidents.stream().map(IncidentDocument::id).toList(),
+          "incident",
+          metrics::recordIncidentUpdatesDuplicateIncidents);
     }
 
     return pendingIncidentsBatch;
+  }
+
+  private <T> void recordDuplicationMetrics(
+      final List<T> ids, final String type, final Consumer<Integer> recordDuplicatesMetric) {
+    final var frequencies =
+        ids.stream().collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+    var totalDuplicates = 0;
+    final var duplicates = new ArrayList<T>();
+    for (final var entry : frequencies.entrySet()) {
+      if (entry.getValue() > 1L) {
+        duplicates.add(entry.getKey());
+        totalDuplicates += (entry.getValue().intValue() - 1);
+      }
+    }
+
+    recordDuplication(totalDuplicates, duplicates, type, recordDuplicatesMetric);
+  }
+
+  private void recordFlownodeDuplicationMetrics(final IncidentsState state) {
+    var totalDuplicates = 0;
+    final var duplicates = new LinkedHashSet<>();
+
+    for (final var entry : state.flowNodeInstanceIndices().entrySet()) {
+      final var numIndexes = entry.getValue().size();
+      if (numIndexes > 1) {
+        duplicates.add(entry.getKey());
+        totalDuplicates += (numIndexes - 1);
+      }
+    }
+
+    for (final var entry : state.flowNodeInstanceInListViewIndices().entrySet()) {
+      final var numIndexes = entry.getValue().size();
+      if (numIndexes > 1) {
+        duplicates.add(entry.getKey());
+        totalDuplicates += (numIndexes - 1);
+      }
+    }
+
+    recordDuplication(
+        totalDuplicates,
+        duplicates,
+        "flow node instance",
+        metrics::recordIncidentUpdatesDuplicateFlowNodeInstances);
+  }
+
+  private <T> void recordDuplication(
+      final int totalDuplicates,
+      final Collection<T> duplicates,
+      final String type,
+      final Consumer<Integer> recordDuplicatesMetric) {
+    if (totalDuplicates > 0) {
+      logger.warn(
+          """
+        Found duplicate {} documents for the following IDs: {} - will update all duplicates.
+        This may indicate a problem with archiving.
+      """,
+          type,
+          duplicates);
+      recordDuplicatesMetric.accept(totalDuplicates);
+    }
   }
 
   private void uncheckedThreadSleep() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -703,16 +703,15 @@ public final class IncidentUpdateTask implements BackgroundTask {
 
     final var incidentIds =
         pendingIncidentsBatch.newIncidentStates().keySet().stream().map(String::valueOf).toList();
-    final Map<String, IncidentDocument> incidents =
+    final Collection<IncidentDocument> incidents =
         repository.getIncidentDocuments(incidentIds).toCompletableFuture().join();
-    for (final var incident : incidents.values()) {
+    final var absentIncidents = new HashSet<>(pendingIncidentsBatch.newIncidentStates().keySet());
+    for (final var incident : incidents) {
       state.addIncidentDocument(incident);
+      absentIncidents.remove(incident.incident().getKey());
     }
 
-    if (pendingIncidentsBatch.newIncidentStates().size() > incidents.size()) {
-      final var absentIncidents = new HashSet<>(pendingIncidentsBatch.newIncidentStates().keySet());
-      absentIncidents.removeAll(
-          incidents.values().stream().map(i -> i.incident().getKey()).collect(Collectors.toSet()));
+    if (!absentIncidents.isEmpty()) {
       if (!ignoreMissingData) {
         throw new ExporterException(
             """

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -287,7 +287,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
 
     instances.forEach(
         instance -> {
-          state.processInstanceIndices().put(instance.id(), instance.index());
+          state.addProcessInstance(instance.id(), instance.index());
           // An imported process instance may have a null/empty treePath (e.g. migrated 8.7 data, or
           // a partial list-view document re-created via upsert after archival, where
           // ListViewProcessInstanceFromProcessInstanceHandler only writes treePath when non-null).
@@ -546,9 +546,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
               .thenApply(
                   processInstances -> {
                     for (final var processInstance : processInstances) {
-                      state
-                          .processInstanceIndices()
-                          .put(processInstance.id(), processInstance.index());
+                      state.addProcessInstance(processInstance.id(), processInstance.index());
                     }
                     return null;
                   });
@@ -557,9 +555,9 @@ public final class IncidentUpdateTask implements BackgroundTask {
     return fetchMissingProcessInstances.thenComposeAsync(
         ignored -> {
           for (final var piId : piIds) {
-            final var index = state.processInstanceIndices().get(piId);
-            if (index != null) {
-              createProcessInstanceUpdate(state, incident.id(), newState, piId, updates, index);
+            final var indexes = state.processInstanceIndices().get(piId);
+            if (indexes != null) {
+              createProcessInstanceUpdate(state, incident.id(), newState, piId, updates, indexes);
             } else {
               if (!ignoreMissingData) {
                 return CompletableFuture.failedFuture(
@@ -590,7 +588,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final IncidentState newState,
       final String piId,
       final IncidentBulkUpdate updates,
-      final String index) {
+      final List<String> indexes) {
     final var hasIncident = IncidentState.ACTIVE == newState;
     final boolean changedState;
     if (hasIncident) {
@@ -598,9 +596,10 @@ public final class IncidentUpdateTask implements BackgroundTask {
     } else {
       changedState = state.removeIncidentIdByPiId(piId, incidentId);
     }
-
     if (changedState) {
-      updates.listViewRequests().add(newListViewInstanceUpdate(piId, index, hasIncident, piId));
+      for (final var index : indexes) {
+        updates.listViewRequests().add(newListViewInstanceUpdate(piId, index, hasIncident, piId));
+      }
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -619,6 +619,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
         updatedIds.stream()
             .filter(incidentUpdatesById::containsKey)
             .filter(id -> shouldNotifyAboutUpdate(incidentUpdatesById.get(id).getFirst()))
+            .distinct()
             .map(incidentsById::get)
             .map(List::getFirst)
             .toList();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -403,9 +403,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
 
     return future.thenApplyAsync(
         unused -> {
-          bulkUpdate
-              .incidentRequests()
-              .put(incident.id(), newIncidentUpdate(incident, newState, treePath));
+          bulkUpdate.incidentRequests().add(newIncidentUpdate(incident, newState, treePath));
           return null;
         },
         executor);
@@ -524,12 +522,12 @@ public final class IncidentUpdateTask implements BackgroundTask {
           index ->
               updates
                   .flowNodeInstanceRequests()
-                  .put(fniId, newFlowNodeInstanceUpdate(fniId, index, hasIncident)));
+                  .add(newFlowNodeInstanceUpdate(fniId, index, hasIncident)));
       listViewIndices.forEach(
           index ->
               updates
                   .listViewRequests()
-                  .put(fniId, newListViewInstanceUpdate(fniId, index, hasIncident, routing)));
+                  .add(newListViewInstanceUpdate(fniId, index, hasIncident, routing)));
     }
   }
 
@@ -602,24 +600,24 @@ public final class IncidentUpdateTask implements BackgroundTask {
     }
 
     if (changedState) {
-      updates
-          .listViewRequests()
-          .put(piId, newListViewInstanceUpdate(piId, index, hasIncident, piId));
+      updates.listViewRequests().add(newListViewInstanceUpdate(piId, index, hasIncident, piId));
     }
   }
 
   private CompletableFuture<Integer> notifyIncidents(
       final List<String> updatedIds,
-      final Map<String, DocumentUpdate> incidentUpdates,
+      final Collection<DocumentUpdate> incidentUpdates,
       final Collection<IncidentDocument> incidentDocuments) {
     final var incidentsById =
         incidentDocuments.stream()
             .map(IncidentDocument::incident)
             .collect(Collectors.groupingBy(IncidentEntity::getId));
+    final var incidentUpdatesById =
+        incidentUpdates.stream().collect(Collectors.groupingBy(DocumentUpdate::id));
     final var incidentsToNotify =
         updatedIds.stream()
-            .filter(incidentUpdates::containsKey)
-            .filter(id -> shouldNotifyAboutUpdate(incidentUpdates.get(id)))
+            .filter(incidentUpdatesById::containsKey)
+            .filter(id -> shouldNotifyAboutUpdate(incidentUpdatesById.get(id).getFirst()))
             .map(incidentsById::get)
             .map(List::getFirst)
             .toList();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -154,11 +153,11 @@ public final class IncidentUpdateTask implements BackgroundTask {
     }
 
     state
-        .incidents()
+        .getIncidentDocuments()
         .forEach(
-            (key, incidentDocument) -> {
+            (incidentDocument) -> {
               if (incidentDocument.incident().getTreePath() == null) {
-                final var treePath = state.incidentTreePaths().get(key);
+                final var treePath = state.incidentTreePaths().get(incidentDocument.id());
                 incidentDocument.incident().setTreePath(treePath);
               }
             });
@@ -183,22 +182,20 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private InstancesCheck searchForInstances(final IncidentsState state) {
-    final var incidents = state.incidents().values();
-
-    queryData(incidents, state);
-    if (checkDataAndCollectParentTreePaths(incidents, state, false) != InstancesCheck.OK) {
+    queryData(state);
+    if (checkDataAndCollectParentTreePaths(state, false) != InstancesCheck.OK) {
       // if it failed once we want to give it a chance and to import more data
       // next failure will fail in case ignoring of missing data is not configured
       uncheckedThreadSleep();
-      queryData(incidents, state);
-      final var check = checkDataAndCollectParentTreePaths(incidents, state, ignoreMissingData);
+      queryData(state);
+      final var check = checkDataAndCollectParentTreePaths(state, ignoreMissingData);
       if (check != InstancesCheck.OK) {
         return check;
       }
     }
 
     final var flowNodeKeys =
-        incidents.stream()
+        state.getIncidentDocuments().stream()
             .map(IncidentDocument::incident)
             .map(IncidentEntity::getFlowNodeInstanceKey)
             .map(String::valueOf)
@@ -213,12 +210,10 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private InstancesCheck checkDataAndCollectParentTreePaths(
-      final Collection<IncidentDocument> incidents,
-      final IncidentsState state,
-      final boolean forceIgnoreMissingData) {
-
+      final IncidentsState state, final boolean forceIgnoreMissingData) {
+    final var incidentDocuments = state.getIncidentDocuments();
     final Set<Long> processInstanceKeys =
-        incidents.stream()
+        incidentDocuments.stream()
             .map(IncidentDocument::incident)
             .map(IncidentEntity::getProcessInstanceKey)
             .collect(Collectors.toSet());
@@ -226,8 +221,8 @@ public final class IncidentUpdateTask implements BackgroundTask {
     final Set<Long> deletedProcessInstances =
         repository.deletedProcessInstances(processInstanceKeys).toCompletableFuture().join();
 
-    for (final Iterator<IncidentDocument> iterator = incidents.iterator(); iterator.hasNext(); ) {
-      final IncidentEntity incident = iterator.next().incident();
+    for (final var incidentDocument : incidentDocuments) {
+      final IncidentEntity incident = incidentDocument.incident();
       String piTreePath = state.processInstanceTreePaths().get(incident.getProcessInstanceKey());
       if (piTreePath == null || piTreePath.isEmpty()) {
         if (deletedProcessInstances.contains(incident.getProcessInstanceKey())) {
@@ -238,8 +233,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
               incident.getProcessInstanceKey(),
               incident.getId());
 
-          // Concurrent modify operation: the underlying map is concurrent
-          iterator.remove();
+          state.skipIncident(incidentDocument);
           continue;
         }
         if (!forceIgnoreMissingData) {
@@ -279,7 +273,8 @@ public final class IncidentUpdateTask implements BackgroundTask {
     return InstancesCheck.OK;
   }
 
-  private void queryData(final Collection<IncidentDocument> incidents, final IncidentsState state) {
+  private void queryData(final IncidentsState state) {
+    final var incidents = state.getIncidentDocuments();
     final var processInstanceIds =
         incidents.stream()
             .map(IncidentDocument::incident)
@@ -331,20 +326,21 @@ public final class IncidentUpdateTask implements BackgroundTask {
             ignored ->
                 // processIncident one at a time, stopping if an error is raised
                 FuturesUtil.traverseIgnoring(
-                    state.incidents().values(),
+                    state.getIncidentDocuments(),
                     incident -> processIncidentInBatch(state, incident, batch, bulkUpdate),
                     executor),
             executor)
         .thenCompose(ignored -> repository.bulkUpdate(bulkUpdate))
         .thenCompose(
             updatedIds ->
-                notifyIncidents(updatedIds, bulkUpdate.incidentRequests(), state.incidents()))
+                notifyIncidents(
+                    updatedIds, bulkUpdate.incidentRequests(), state.getIncidentDocuments()))
         .join();
   }
 
   private void seedResolvedIncidentsAsActive(
       final IncidentsState state, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
-    for (final var incident : state.incidents().values()) {
+    for (final var incident : state.getIncidentDocuments()) {
       final var newState = batch.newIncidentStates().get(incident.incident().getKey());
       if (newState != IncidentState.RESOLVED) {
         continue;
@@ -615,13 +611,17 @@ public final class IncidentUpdateTask implements BackgroundTask {
   private CompletableFuture<Integer> notifyIncidents(
       final List<String> updatedIds,
       final Map<String, DocumentUpdate> incidentUpdates,
-      final Map<String, IncidentDocument> incidents) {
+      final Collection<IncidentDocument> incidentDocuments) {
+    final var incidentsById =
+        incidentDocuments.stream()
+            .map(IncidentDocument::incident)
+            .collect(Collectors.groupingBy(IncidentEntity::getId));
     final var incidentsToNotify =
         updatedIds.stream()
             .filter(incidentUpdates::containsKey)
             .filter(id -> shouldNotifyAboutUpdate(incidentUpdates.get(id)))
-            .map(incidents::get)
-            .map(IncidentDocument::incident)
+            .map(incidentsById::get)
+            .map(List::getFirst)
             .toList();
     if (incidentsToNotify.isEmpty()) {
       return CompletableFuture.completedFuture(updatedIds.size());
@@ -707,7 +707,9 @@ public final class IncidentUpdateTask implements BackgroundTask {
         pendingIncidentsBatch.newIncidentStates().keySet().stream().map(String::valueOf).toList();
     final Map<String, IncidentDocument> incidents =
         repository.getIncidentDocuments(incidentIds).toCompletableFuture().join();
-    state.incidents().putAll(incidents);
+    for (final var incident : incidents.values()) {
+      state.addIncidentDocument(incident);
+    }
 
     if (pendingIncidentsBatch.newIncidentStates().size() > incidents.size()) {
       final var absentIncidents = new HashSet<>(pendingIncidentsBatch.newIncidentStates().keySet());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -199,6 +199,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
             .map(IncidentDocument::incident)
             .map(IncidentEntity::getFlowNodeInstanceKey)
             .map(String::valueOf)
+            .distinct()
             .toList();
     repository
         .getFlowNodesInListView(flowNodeKeys)
@@ -280,6 +281,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
             .map(IncidentDocument::incident)
             .map(IncidentEntity::getProcessInstanceKey)
             .map(String::valueOf)
+            .distinct()
             .toList();
 
     final var instances =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -137,13 +137,13 @@ public final class IncidentUpdateTask implements BackgroundTask {
    * </ul>
    */
   private CompletableFuture<Integer> processNextBatch() {
-    final var data = new IncidentsState();
-    final var batch = getPendingIncidentsBatch(data);
+    final var state = new IncidentsState();
+    final var batch = getPendingIncidentsBatch(state);
     if (batch.newIncidentStates().isEmpty()) {
       return CompletableFuture.completedFuture(0);
     }
     logger.trace("Applying the following pending incident updates: {}", batch.newIncidentStates());
-    final var check = searchForInstances(data);
+    final var check = searchForInstances(state);
     final int incidentCount = batch.newIncidentStates().size();
     if (check != InstancesCheck.OK) {
       // there was missing data, but this is often transient, so we just skip this batch for now.
@@ -153,15 +153,16 @@ public final class IncidentUpdateTask implements BackgroundTask {
       return CompletableFuture.completedFuture(incidentCount);
     }
 
-    data.incidents()
+    state
+        .incidents()
         .forEach(
             (key, incidentDocument) -> {
               if (incidentDocument.incident().getTreePath() == null) {
-                final var treePath = data.incidentTreePaths().get(key);
+                final var treePath = state.incidentTreePaths().get(key);
                 incidentDocument.incident().setTreePath(treePath);
               }
             });
-    return CompletableFuture.completedFuture(processIncidents(data, batch))
+    return CompletableFuture.completedFuture(processIncidents(state, batch))
         .thenComposeAsync(
             documentsUpdated -> {
               logger.trace(
@@ -181,16 +182,16 @@ public final class IncidentUpdateTask implements BackgroundTask {
             executor);
   }
 
-  private InstancesCheck searchForInstances(final IncidentsState data) {
-    final var incidents = data.incidents().values();
+  private InstancesCheck searchForInstances(final IncidentsState state) {
+    final var incidents = state.incidents().values();
 
-    queryData(incidents, data);
-    if (checkDataAndCollectParentTreePaths(incidents, data, false) != InstancesCheck.OK) {
+    queryData(incidents, state);
+    if (checkDataAndCollectParentTreePaths(incidents, state, false) != InstancesCheck.OK) {
       // if it failed once we want to give it a chance and to import more data
       // next failure will fail in case ignoring of missing data is not configured
       uncheckedThreadSleep();
-      queryData(incidents, data);
-      final var check = checkDataAndCollectParentTreePaths(incidents, data, ignoreMissingData);
+      queryData(incidents, state);
+      final var check = checkDataAndCollectParentTreePaths(incidents, state, ignoreMissingData);
       if (check != InstancesCheck.OK) {
         return check;
       }
@@ -206,14 +207,14 @@ public final class IncidentUpdateTask implements BackgroundTask {
         .getFlowNodesInListView(flowNodeKeys)
         .toCompletableFuture()
         .join()
-        .forEach(doc -> data.addFlowNodeInstanceInListView(doc.id(), doc.index()));
+        .forEach(doc -> state.addFlowNodeInstanceInListView(doc.id(), doc.index()));
 
     return InstancesCheck.OK;
   }
 
   private InstancesCheck checkDataAndCollectParentTreePaths(
       final Collection<IncidentDocument> incidents,
-      final IncidentsState data,
+      final IncidentsState state,
       final boolean forceIgnoreMissingData) {
 
     final Set<Long> processInstanceKeys =
@@ -227,7 +228,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
 
     for (final Iterator<IncidentDocument> iterator = incidents.iterator(); iterator.hasNext(); ) {
       final IncidentEntity incident = iterator.next().incident();
-      String piTreePath = data.processInstanceTreePaths().get(incident.getProcessInstanceKey());
+      String piTreePath = state.processInstanceTreePaths().get(incident.getProcessInstanceKey());
       if (piTreePath == null || piTreePath.isEmpty()) {
         if (deletedProcessInstances.contains(incident.getProcessInstanceKey())) {
           logger.debug(
@@ -266,7 +267,8 @@ public final class IncidentUpdateTask implements BackgroundTask {
         }
       }
 
-      data.incidentTreePaths()
+      state
+          .incidentTreePaths()
           .put(
               incident.getId(),
               new TreePath(piTreePath)
@@ -277,7 +279,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
     return InstancesCheck.OK;
   }
 
-  private void queryData(final Collection<IncidentDocument> incidents, final IncidentsState data) {
+  private void queryData(final Collection<IncidentDocument> incidents, final IncidentsState state) {
     final var processInstanceIds =
         incidents.stream()
             .map(IncidentDocument::incident)
@@ -290,7 +292,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
 
     instances.forEach(
         instance -> {
-          data.processInstanceIndices().put(instance.id(), instance.index());
+          state.processInstanceIndices().put(instance.id(), instance.index());
           // An imported process instance may have a null/empty treePath (e.g. migrated 8.7 data, or
           // a partial list-view document re-created via upsert after archival, where
           // ListViewProcessInstanceFromProcessInstanceHandler only writes treePath when non-null).
@@ -308,20 +310,20 @@ public final class IncidentUpdateTask implements BackgroundTask {
                 "Process instance {} has no treePath. Falling back to the sparse tree path {} so incident updates can make progress.",
                 instance.key(),
                 sparseTreePath);
-            data.processInstanceTreePaths().put(instance.key(), sparseTreePath);
+            state.processInstanceTreePaths().put(instance.key(), sparseTreePath);
           } else {
-            data.processInstanceTreePaths().put(instance.key(), treePath);
+            state.processInstanceTreePaths().put(instance.key(), treePath);
           }
         });
   }
 
   private int processIncidents(
-      final IncidentsState data, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
+      final IncidentsState state, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
     final var bulkUpdate = new IncidentBulkUpdate();
-    return mapActiveIncidentsToAffectedInstances(data)
+    return mapActiveIncidentsToAffectedInstances(state)
         .thenApplyAsync(
             ignored -> {
-              seedResolvedIncidentsAsActive(data, batch);
+              seedResolvedIncidentsAsActive(state, batch);
               return null;
             },
             executor)
@@ -329,26 +331,26 @@ public final class IncidentUpdateTask implements BackgroundTask {
             ignored ->
                 // processIncident one at a time, stopping if an error is raised
                 FuturesUtil.traverseIgnoring(
-                    data.incidents().values(),
-                    incident -> processIncidentInBatch(data, incident, batch, bulkUpdate),
+                    state.incidents().values(),
+                    incident -> processIncidentInBatch(state, incident, batch, bulkUpdate),
                     executor),
             executor)
         .thenCompose(ignored -> repository.bulkUpdate(bulkUpdate))
         .thenCompose(
             updatedIds ->
-                notifyIncidents(updatedIds, bulkUpdate.incidentRequests(), data.incidents()))
+                notifyIncidents(updatedIds, bulkUpdate.incidentRequests(), state.incidents()))
         .join();
   }
 
   private void seedResolvedIncidentsAsActive(
-      final IncidentsState data, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
-    for (final var incident : data.incidents().values()) {
+      final IncidentsState state, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
+    for (final var incident : state.incidents().values()) {
       final var newState = batch.newIncidentStates().get(incident.incident().getKey());
       if (newState != IncidentState.RESOLVED) {
         continue;
       }
 
-      final var treePath = data.incidentTreePaths().get(incident.id());
+      final var treePath = state.incidentTreePaths().get(incident.id());
       if (treePath == null) {
         continue;
       }
@@ -356,24 +358,24 @@ public final class IncidentUpdateTask implements BackgroundTask {
       final var parsedTreePath = new TreePath(treePath);
       parsedTreePath
           .extractProcessInstanceIds()
-          .forEach(id -> data.addPiIdsWithIncidentIds(id, incident.id()));
+          .forEach(id -> state.addPiIdsWithIncidentIds(id, incident.id()));
       parsedTreePath
           .extractFlowNodeInstanceIds()
-          .forEach(id -> data.addFniIdsWithIncidentIds(id, incident.id()));
+          .forEach(id -> state.addFniIdsWithIncidentIds(id, incident.id()));
     }
   }
 
   private CompletableFuture<Void> processIncidentInBatch(
-      final IncidentsState data,
+      final IncidentsState state,
       final IncidentDocument incident,
       final IncidentUpdateRepository.PendingIncidentUpdateBatch batch,
       final IncidentBulkUpdate bulkUpdate) {
     final var processInstanceKey = incident.incident().getProcessInstanceKey();
-    final var treePath = data.incidentTreePaths().get(incident.id());
+    final var treePath = state.incidentTreePaths().get(incident.id());
     final var newState = batch.newIncidentStates().get(incident.incident().getKey());
 
     final CompletableFuture<?> future;
-    if (!data.processInstanceTreePaths().containsKey(processInstanceKey)) {
+    if (!state.processInstanceTreePaths().containsKey(processInstanceKey)) {
       if (!ignoreMissingData) {
         return CompletableFuture.failedFuture(
             new ExporterException(
@@ -396,10 +398,10 @@ public final class IncidentUpdateTask implements BackgroundTask {
           removeProcessInstanceIds(parsedTreePath.extractFlowNodeInstanceIds(), piIds);
 
       future =
-          createProcessInstanceUpdates(data, incident, newState, piIds, bulkUpdate)
+          createProcessInstanceUpdates(state, incident, newState, piIds, bulkUpdate)
               .thenComposeAsync(
                   unused ->
-                      createFlowNodeInstanceUpdates(data, incident, newState, fniIds, bulkUpdate),
+                      createFlowNodeInstanceUpdates(state, incident, newState, fniIds, bulkUpdate),
                   executor);
     }
 
@@ -428,7 +430,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private CompletableFuture<Void> createFlowNodeInstanceUpdates(
-      final IncidentsState data,
+      final IncidentsState state,
       final IncidentDocument incident,
       final IncidentState newState,
       final List<String> fniIds,
@@ -436,7 +438,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
     final CompletableFuture<?>[] futures = {
       CompletableFuture.completedFuture(null), CompletableFuture.completedFuture(null)
     };
-    if (!data.flowNodeInstanceIndices().keySet().containsAll(fniIds)) {
+    if (!state.flowNodeInstanceIndices().keySet().containsAll(fniIds)) {
       futures[0] =
           repository
               .getFlowNodeInstances(fniIds)
@@ -444,13 +446,13 @@ public final class IncidentUpdateTask implements BackgroundTask {
               .thenApply(
                   documents -> {
                     for (final var document : documents) {
-                      data.addFlowNodeInstance(document.id(), document.index());
+                      state.addFlowNodeInstance(document.id(), document.index());
                     }
                     return null;
                   });
     }
 
-    if (!data.flowNodeInstanceInListViewIndices().keySet().containsAll(fniIds)) {
+    if (!state.flowNodeInstanceInListViewIndices().keySet().containsAll(fniIds)) {
       futures[1] =
           repository
               .getFlowNodesInListView(fniIds)
@@ -458,7 +460,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
               .thenApply(
                   documents -> {
                     for (final var document : documents) {
-                      data.addFlowNodeInstanceInListView(document.id(), document.index());
+                      state.addFlowNodeInstanceInListView(document.id(), document.index());
                     }
                     return null;
                   });
@@ -468,14 +470,14 @@ public final class IncidentUpdateTask implements BackgroundTask {
         .thenComposeAsync(
             ignored -> {
               for (final var fniId : fniIds) {
-                final var listViewIndices = data.flowNodeInstanceInListViewIndices().get(fniId);
-                final var flowNodeIndices = data.flowNodeInstanceIndices().get(fniId);
+                final var listViewIndices = state.flowNodeInstanceInListViewIndices().get(fniId);
+                final var flowNodeIndices = state.flowNodeInstanceIndices().get(fniId);
                 if (listViewIndices != null
                     && !listViewIndices.isEmpty()
                     && flowNodeIndices != null
                     && !flowNodeIndices.isEmpty()) {
                   createFlowNodeInstanceUpdate(
-                      data, incident, newState, fniId, flowNodeIndices, updates, listViewIndices);
+                      state, incident, newState, fniId, flowNodeIndices, updates, listViewIndices);
                 } else {
                   if (!ignoreMissingData) {
                     return CompletableFuture.failedFuture(
@@ -501,7 +503,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private void createFlowNodeInstanceUpdate(
-      final IncidentsState data,
+      final IncidentsState state,
       final IncidentDocument incident,
       final IncidentState newState,
       final String fniId,
@@ -511,9 +513,9 @@ public final class IncidentUpdateTask implements BackgroundTask {
     final var hasIncident = IncidentState.ACTIVE == newState;
     final boolean changedState;
     if (hasIncident) {
-      changedState = data.addFniIdsWithIncidentIds(fniId, incident.id());
+      changedState = state.addFniIdsWithIncidentIds(fniId, incident.id());
     } else {
-      changedState = data.removeIncidentIdByFniId(fniId, incident.id());
+      changedState = state.removeIncidentIdByFniId(fniId, incident.id());
     }
 
     final var treePath = new TreePath(incident.incident().getTreePath());
@@ -536,13 +538,13 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private CompletableFuture<Void> createProcessInstanceUpdates(
-      final IncidentsState data,
+      final IncidentsState state,
       final IncidentDocument incident,
       final IncidentState newState,
       final List<String> piIds,
       final IncidentBulkUpdate updates) {
     var fetchMissingProcessInstances = CompletableFuture.completedFuture(null);
-    if (!data.processInstanceIndices().keySet().containsAll(piIds)) {
+    if (!state.processInstanceIndices().keySet().containsAll(piIds)) {
       fetchMissingProcessInstances =
           repository
               .getProcessInstances(piIds)
@@ -550,7 +552,8 @@ public final class IncidentUpdateTask implements BackgroundTask {
               .thenApply(
                   processInstances -> {
                     for (final var processInstance : processInstances) {
-                      data.processInstanceIndices()
+                      state
+                          .processInstanceIndices()
                           .put(processInstance.id(), processInstance.index());
                     }
                     return null;
@@ -560,9 +563,9 @@ public final class IncidentUpdateTask implements BackgroundTask {
     return fetchMissingProcessInstances.thenComposeAsync(
         ignored -> {
           for (final var piId : piIds) {
-            final var index = data.processInstanceIndices().get(piId);
+            final var index = state.processInstanceIndices().get(piId);
             if (index != null) {
-              createProcessInstanceUpdate(data, incident.id(), newState, piId, updates, index);
+              createProcessInstanceUpdate(state, incident.id(), newState, piId, updates, index);
             } else {
               if (!ignoreMissingData) {
                 return CompletableFuture.failedFuture(
@@ -588,7 +591,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private void createProcessInstanceUpdate(
-      final IncidentsState data,
+      final IncidentsState state,
       final String incidentId,
       final IncidentState newState,
       final String piId,
@@ -597,9 +600,9 @@ public final class IncidentUpdateTask implements BackgroundTask {
     final var hasIncident = IncidentState.ACTIVE == newState;
     final boolean changedState;
     if (hasIncident) {
-      changedState = data.addPiIdsWithIncidentIds(piId, incidentId);
+      changedState = state.addPiIdsWithIncidentIds(piId, incidentId);
     } else {
-      changedState = data.removeIncidentIdByPiId(piId, incidentId);
+      changedState = state.removeIncidentIdByPiId(piId, incidentId);
     }
 
     if (changedState) {
@@ -656,10 +659,11 @@ public final class IncidentUpdateTask implements BackgroundTask {
         id, index, Map.of(FlowNodeInstanceTemplate.INCIDENT, hasIncident), null);
   }
 
-  private CompletableFuture<Void> mapActiveIncidentsToAffectedInstances(final IncidentsState data) {
+  private CompletableFuture<Void> mapActiveIncidentsToAffectedInstances(
+      final IncidentsState state) {
     final CompletableFuture<List<String>> treePathTermsFutures =
         FuturesUtil.parTraverse(
-                data.incidentTreePaths().values(),
+                state.incidentTreePaths().values(),
                 treePath -> repository.analyzeTreePath(treePath).toCompletableFuture())
             .thenApply(lists -> lists.stream().flatMap(List::stream).collect(Collectors.toList()));
 
@@ -675,9 +679,9 @@ public final class IncidentUpdateTask implements BackgroundTask {
                 final var piIds = treePath.extractProcessInstanceIds();
                 final var fniIds = treePath.extractFlowNodeInstanceIds();
 
-                piIds.forEach(id -> data.addPiIdsWithIncidentIds(id, activeIncidentTreePath.id()));
+                piIds.forEach(id -> state.addPiIdsWithIncidentIds(id, activeIncidentTreePath.id()));
                 fniIds.forEach(
-                    id -> data.addFniIdsWithIncidentIds(id, activeIncidentTreePath.id()));
+                    id -> state.addFniIdsWithIncidentIds(id, activeIncidentTreePath.id()));
               }
               return null;
             },
@@ -685,7 +689,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
   }
 
   private IncidentUpdateRepository.PendingIncidentUpdateBatch getPendingIncidentsBatch(
-      final IncidentsState data) {
+      final IncidentsState state) {
     final IncidentUpdateRepository.PendingIncidentUpdateBatch pendingIncidentsBatch =
         repository
             .getPendingIncidentsBatch(metadata.getLastIncidentUpdatePosition(), batchSize)
@@ -703,7 +707,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
         pendingIncidentsBatch.newIncidentStates().keySet().stream().map(String::valueOf).toList();
     final Map<String, IncidentDocument> incidents =
         repository.getIncidentDocuments(incidentIds).toCompletableFuture().join();
-    data.incidents().putAll(incidents);
+    state.incidents().putAll(incidents);
 
     if (pendingIncidentsBatch.newIncidentStates().size() > incidents.size()) {
       final var absentIncidents = new HashSet<>(pendingIncidentsBatch.newIncidentStates().keySet());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentsState.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentsState.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.tasks.incident;
 
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,18 @@ public record IncidentsState(
         new ConcurrentHashMap<>(),
         new ConcurrentHashMap<>(),
         new ConcurrentHashMap<>());
+  }
+
+  public void addIncidentDocument(final IncidentDocument incidentDocument) {
+    incidents.put(incidentDocument.id(), incidentDocument);
+  }
+
+  public Collection<IncidentDocument> getIncidentDocuments() {
+    return List.copyOf(incidents.values());
+  }
+
+  public void skipIncident(final IncidentDocument incidentDocument) {
+    incidents.remove(incidentDocument.id());
   }
 
   public boolean addPiIdsWithIncidentIds(final String piId, final String incidentId) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentsState.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentsState.java
@@ -25,7 +25,7 @@ public record IncidentsState(
     Map<String, List<String>> flowNodeInstanceInListViewIndices,
     Map<Long, String> processInstanceTreePaths,
     Map<String, String> incidentTreePaths,
-    Map<String, String> processInstanceIndices,
+    Map<String, List<String>> processInstanceIndices,
     Map<String, Set<String>> piIdsWithIncidentIds,
     Map<String, Set<String>> fniIdsWithIncidentIds) {
   public IncidentsState() {
@@ -69,6 +69,10 @@ public record IncidentsState(
 
   public boolean removeIncidentIdByFniId(final String fniId, final String incidentId) {
     return deleteIncidentIdByInstance(fniIdsWithIncidentIds, fniId, incidentId);
+  }
+
+  public void addProcessInstance(final String id, final String index) {
+    processInstanceIndices.computeIfAbsent(id, k -> new ArrayList<>()).add(index);
   }
 
   public void addFlowNodeInstanceInListView(final String id, final String index) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentsState.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentsState.java
@@ -16,7 +16,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /** Copied from the old post-importer */
-public record AdditionalData(
+public record IncidentsState(
     Map<String, IncidentDocument> incidents,
     Map<String, List<String>> flowNodeInstanceIndices,
     Map<String, List<String>> flowNodeInstanceInListViewIndices,
@@ -25,7 +25,7 @@ public record AdditionalData(
     Map<String, String> processInstanceIndices,
     Map<String, Set<String>> piIdsWithIncidentIds,
     Map<String, Set<String>> fniIdsWithIncidentIds) {
-  public AdditionalData() {
+  public IncidentsState() {
     this(
         new ConcurrentHashMap<>(),
         new ConcurrentHashMap<>(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentsState.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentsState.java
@@ -15,10 +15,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 /** Copied from the old post-importer */
 public record IncidentsState(
-    Map<String, IncidentDocument> incidents,
+    Collection<IncidentDocument> incidentDocuments,
+    Set<String> incidentIdsToSkip,
     Map<String, List<String>> flowNodeInstanceIndices,
     Map<String, List<String>> flowNodeInstanceInListViewIndices,
     Map<Long, String> processInstanceTreePaths,
@@ -28,7 +30,8 @@ public record IncidentsState(
     Map<String, Set<String>> fniIdsWithIncidentIds) {
   public IncidentsState() {
     this(
-        new ConcurrentHashMap<>(),
+        new ConcurrentLinkedQueue<>(),
+        ConcurrentHashMap.newKeySet(),
         new ConcurrentHashMap<>(),
         new ConcurrentHashMap<>(),
         new ConcurrentHashMap<>(),
@@ -39,15 +42,17 @@ public record IncidentsState(
   }
 
   public void addIncidentDocument(final IncidentDocument incidentDocument) {
-    incidents.put(incidentDocument.id(), incidentDocument);
+    incidentDocuments.add(incidentDocument);
   }
 
   public Collection<IncidentDocument> getIncidentDocuments() {
-    return List.copyOf(incidents.values());
+    return incidentDocuments.stream()
+        .filter(incidentDocument -> !incidentIdsToSkip.contains(incidentDocument.id()))
+        .toList();
   }
 
   public void skipIncident(final IncidentDocument incidentDocument) {
-    incidents.remove(incidentDocument.id());
+    incidentIdsToSkip.add(incidentDocument.id());
   }
 
   public boolean addPiIdsWithIncidentIds(final String piId, final String incidentId) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -111,16 +111,14 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   }
 
   @Override
-  public CompletionStage<Map<String, IncidentDocument>> getIncidentDocuments(
+  public CompletionStage<Collection<IncidentDocument>> getIncidentDocuments(
       final List<String> incidentIds) {
     final var request = createIncidentDocumentsRequest(incidentIds);
-    try {
-      return client
-          .search(request, IncidentEntity.class)
-          .thenApplyAsync(this::createIncidentDocuments, executor);
-    } catch (final Exception e) {
-      return CompletableFuture.failedFuture(e);
-    }
+
+    return fetchUnboundedDocumentCollection(
+        request,
+        IncidentEntity.class,
+        hit -> new IncidentDocument(hit.id(), hit.index(), hit.source()));
   }
 
   @Override
@@ -366,7 +364,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
         ._toBulkOperation();
   }
 
-  private SearchRequest createIncidentDocumentsRequest(final List<String> incidentIds) {
+  private SearchRequest.Builder createIncidentDocumentsRequest(final List<String> incidentIds) {
     final var idQ = QueryBuilders.ids().values(incidentIds).build().toQuery();
     final var partitionQ =
         QueryBuilders.term()
@@ -380,19 +378,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
         .query(q -> q.bool(b -> b.must(idQ, partitionQ)))
         .allowNoIndices(true)
         .ignoreUnavailable(true)
-        .sort(s -> s.field(f -> f.field(IncidentTemplate.KEY)))
-        .size(incidentIds.size())
-        .build();
-  }
-
-  private Map<String, IncidentDocument> createIncidentDocuments(
-      final SearchResponse<IncidentEntity> response) {
-    final Map<String, IncidentDocument> documents = new HashMap<>();
-    for (final var hit : response.hits().hits()) {
-      documents.put(hit.id(), new IncidentDocument(hit.id(), hit.index(), hit.source()));
-    }
-
-    return documents;
+        .sort(s -> s.field(f -> f.field(IncidentTemplate.KEY)));
   }
 
   private SearchRequest createPendingIncidentsBatchRequest(final int size, final Query query) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -115,10 +115,13 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
       final List<String> incidentIds) {
     final var request = createIncidentDocumentsRequest(incidentIds);
 
-    return fetchUnboundedDocumentCollection(
-        request,
-        IncidentEntity.class,
-        hit -> new IncidentDocument(hit.id(), hit.index(), hit.source()));
+    try {
+      return client
+          .search(request, IncidentEntity.class)
+          .thenApplyAsync(this::createIncidentDocuments, executor);
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
   }
 
   @Override
@@ -364,7 +367,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
         ._toBulkOperation();
   }
 
-  private SearchRequest.Builder createIncidentDocumentsRequest(final List<String> incidentIds) {
+  private SearchRequest createIncidentDocumentsRequest(final List<String> incidentIds) {
     final var idQ = QueryBuilders.ids().values(incidentIds).build().toQuery();
     final var partitionQ =
         QueryBuilders.term()
@@ -378,7 +381,17 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
         .query(q -> q.bool(b -> b.must(idQ, partitionQ)))
         .allowNoIndices(true)
         .ignoreUnavailable(true)
-        .sort(s -> s.field(f -> f.field(IncidentTemplate.KEY)));
+        .sort(s -> s.field(f -> f.field(IncidentTemplate.KEY)))
+        // ask for more documents in case there are duplicates
+        .size(10_000)
+        .build();
+  }
+
+  private Collection<IncidentDocument> createIncidentDocuments(
+      final SearchResponse<IncidentEntity> response) {
+    return response.hits().hits().stream()
+        .map(hit -> new IncidentDocument(hit.id(), hit.index(), hit.source()))
+        .toList();
   }
 
   private SearchRequest createPendingIncidentsBatchRequest(final int size, final Query query) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskIT.java
@@ -78,7 +78,7 @@ public abstract class BackgroundTaskIT<T extends BackgroundTask> {
   protected void setup() {
     context =
         new ExporterTestContext().setPartitionId(PARTITION_ID).setClock(InstantSource.fixed(NOW));
-    exporterMetrics = new CamundaExporterMetrics(context.getMeterRegistry());
+    exporterMetrics = mock(CamundaExporterMetrics.class);
     executor = Executors.newSingleThreadExecutor();
     testPrefix = RandomStringUtils.insecure().nextAlphabetic(9).toLowerCase(Locale.ROOT);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -712,7 +712,7 @@ abstract class IncidentUpdateRepositoryIT {
       final var bulk = new IncidentBulkUpdate();
 
       // when
-      bulk.incidentRequests().put("2", new DocumentUpdate("2", "doesn't-exist", Map.of(), "3"));
+      bulk.incidentRequests().add(new DocumentUpdate("2", "doesn't-exist", Map.of(), "3"));
       final var result = repository.bulkUpdate(bulk);
 
       // then
@@ -744,16 +744,14 @@ abstract class IncidentUpdateRepositoryIT {
 
       // when
       bulk.incidentRequests()
-          .put(
-              "1",
+          .add(
               new DocumentUpdate(
                   "1",
                   incidentTemplate.getFullQualifiedName(),
                   Map.of(IncidentTemplate.STATE, IncidentState.ACTIVE),
                   "1"));
       bulk.incidentRequests()
-          .put(
-              "2",
+          .add(
               new DocumentUpdate(
                   "2",
                   incidentTemplate.getFullQualifiedName(),
@@ -794,16 +792,14 @@ abstract class IncidentUpdateRepositoryIT {
 
       // when
       bulk.listViewRequests()
-          .put(
-              "1",
+          .add(
               new DocumentUpdate(
                   "1",
                   listViewTemplate.getFullQualifiedName(),
                   Map.of(ListViewTemplate.INCIDENT, true),
                   "1"));
       bulk.listViewRequests()
-          .put(
-              "2",
+          .add(
               new DocumentUpdate(
                   "2",
                   listViewTemplate.getFullQualifiedName(),
@@ -845,16 +841,14 @@ abstract class IncidentUpdateRepositoryIT {
 
       // when
       bulk.flowNodeInstanceRequests()
-          .put(
-              "1",
+          .add(
               new DocumentUpdate(
                   "1",
                   flowNodeInstanceTemplate.getFullQualifiedName(),
                   Map.of(FlowNodeInstanceTemplate.INCIDENT, true),
                   "1"));
       bulk.flowNodeInstanceRequests()
-          .put(
-              "2",
+          .add(
               new DocumentUpdate(
                   "2",
                   flowNodeInstanceTemplate.getFullQualifiedName(),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -59,7 +59,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -201,12 +200,12 @@ abstract class IncidentUpdateRepositoryIT {
       // then
       assertThat(documents)
           .succeedsWithin(REQUEST_TIMEOUT)
-          .asInstanceOf(InstanceOfAssertFactories.map(Long.class, IncidentDocument.class))
+          .asInstanceOf(InstanceOfAssertFactories.collection(IncidentDocument.class))
           .isEmpty();
     }
 
     @Test
-    void shouldReturnIncidentByIds() throws PersistenceException {
+    void shouldReturnIncidentDocuments() throws PersistenceException {
       // given
       final var repository = createRepository();
       final var expected = createIncident(1L);
@@ -218,10 +217,9 @@ abstract class IncidentUpdateRepositoryIT {
       // then
       assertThat(documents)
           .succeedsWithin(REQUEST_TIMEOUT)
-          .asInstanceOf(InstanceOfAssertFactories.map(String.class, IncidentDocument.class))
+          .asInstanceOf(InstanceOfAssertFactories.collection(IncidentDocument.class))
           .hasSize(1)
-          .containsEntry(
-              "1", new IncidentDocument("1", incidentTemplate.getFullQualifiedName(), expected));
+          .contains(new IncidentDocument("1", incidentTemplate.getFullQualifiedName(), expected));
     }
 
     @RegressionTest("https://github.com/camunda/camunda/issues/25968")
@@ -229,12 +227,12 @@ abstract class IncidentUpdateRepositoryIT {
       // given
       final var repository = createRepository();
       final List<String> ids = new ArrayList<>();
-      final Map<String, IncidentDocument> expected = new HashMap<>();
+      final List<IncidentDocument> expected = new ArrayList<>();
       for (int i = 0; i < 20; i++) {
         final var id = String.valueOf(i);
         final var entity = createIncident(i);
         ids.add(id);
-        expected.put(id, new IncidentDocument(id, incidentTemplate.getFullQualifiedName(), entity));
+        expected.add(new IncidentDocument(id, incidentTemplate.getFullQualifiedName(), entity));
       }
 
       // when
@@ -243,9 +241,9 @@ abstract class IncidentUpdateRepositoryIT {
       // then
       assertThat(documents)
           .succeedsWithin(REQUEST_TIMEOUT)
-          .asInstanceOf(InstanceOfAssertFactories.map(String.class, IncidentDocument.class))
+          .asInstanceOf(InstanceOfAssertFactories.collection(IncidentDocument.class))
           .hasSize(20)
-          .containsExactlyEntriesOf(expected);
+          .containsExactlyInAnyOrderElementsOf(expected);
     }
 
     private IncidentEntity createIncident(final long key) throws PersistenceException {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
@@ -1050,6 +1050,9 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           verify(exporterMetrics).recordIncidentUpdatesProcessed(3);
           verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(8);
           verify(exporterMetrics).recordIncidentUpdatesDuplicateIncidents(2);
+          verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateProcessInstances(anyInt());
+          verify(exporterMetrics, never())
+              .recordIncidentUpdatesDuplicateFlowNodeInstances(anyInt());
         });
   }
 
@@ -1173,6 +1176,12 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
           verifyIncidentNotificationsSent(incidentEntity);
+
+          verify(exporterMetrics).recordIncidentUpdatesProcessed(1);
+          verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(10);
+          verify(exporterMetrics).recordIncidentUpdatesDuplicateProcessInstances(2);
+          verify(exporterMetrics).recordIncidentUpdatesDuplicateFlowNodeInstances(4);
+          verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());
         });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
@@ -8,7 +8,9 @@
 package io.camunda.exporter.tasks.incident;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -344,6 +346,10 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
           verifyIncidentNotificationsSent(incidentEntity);
+
+          verify(exporterMetrics).recordIncidentUpdatesProcessed(1);
+          verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(4);
+          verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());
         });
   }
 
@@ -451,6 +457,10 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
           verifyIncidentNotificationsSent(incidentEntity);
+
+          verify(exporterMetrics).recordIncidentUpdatesProcessed(1);
+          verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(4);
+          verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());
         });
   }
 
@@ -525,6 +535,10 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
           verifyIncidentNotificationsSent(updatedIncident);
+
+          verify(exporterMetrics).recordIncidentUpdatesProcessed(1);
+          verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(2);
+          verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());
         });
   }
 
@@ -636,6 +650,10 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
           verifyNoInteractions(incidentNotifier);
+
+          verify(exporterMetrics).recordIncidentUpdatesProcessed(1);
+          verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(4);
+          verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());
         });
   }
 
@@ -768,6 +786,10 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
           verifyNoInteractions(incidentNotifier);
+
+          verify(exporterMetrics).recordIncidentUpdatesProcessed(1);
+          verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(1);
+          verify(exporterMetrics, never()).recordIncidentUpdatesDuplicateIncidents(anyInt());
         });
   }
 
@@ -1024,6 +1046,10 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
 
           // despite duplicates we should only send one notification per incident key
           verifyIncidentNotificationsSent(updatedIncident1, updatedIncident2, updatedIncident3);
+
+          verify(exporterMetrics).recordIncidentUpdatesProcessed(3);
+          verify(exporterMetrics).recordIncidentUpdatesDocumentsUpdated(8);
+          verify(exporterMetrics).recordIncidentUpdatesDuplicateIncidents(2);
         });
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
@@ -9,6 +9,9 @@ package io.camunda.exporter.tasks.incident;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.ExporterResourceProvider;
@@ -36,9 +39,11 @@ import io.camunda.webapps.schema.entities.post.PostImporterQueueEntity;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
+import org.mockito.ArgumentCaptor;
 
 class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
   private static final int BATCH_SIZE = 10;
@@ -61,6 +66,8 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
     super.shouldExecuteWithoutErrorsWhenNothingToDo(config, ignored);
 
     assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(-1L);
+    verify(incidentNotifier).close();
+    verifyNoMoreInteractions(incidentNotifier);
   }
 
   @Override
@@ -114,6 +121,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
               .withMessageContaining("Missing incident IDs: [[9999]]");
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(-1L);
+          verifyNoInteractions(incidentNotifier);
         });
   }
 
@@ -160,6 +168,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           assertThat(updated).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(1);
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(-1L);
+          verifyNoInteractions(incidentNotifier);
         });
   }
 
@@ -226,6 +235,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
               .withMessageContaining(" this will be retried later");
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(-1L);
+          verifyNoInteractions(incidentNotifier);
         });
   }
 
@@ -333,6 +343,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           assertThat(updatedIncident.getState()).isEqualTo(IncidentState.ACTIVE);
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
+          verifyIncidentNotificationsSent(incidentEntity);
         });
   }
 
@@ -439,6 +450,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           assertThat(updatedIncident.getState()).isEqualTo(IncidentState.ACTIVE);
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
+          verifyIncidentNotificationsSent(incidentEntity);
         });
   }
 
@@ -512,6 +524,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
               .isEqualTo(String.format("%s/FNI_%d", treePath, processInstanceKey));
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
+          verifyIncidentNotificationsSent(updatedIncident);
         });
   }
 
@@ -622,9 +635,11 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           assertThat(updatedIncident.getState()).isEqualTo(IncidentState.RESOLVED);
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
+          verifyNoInteractions(incidentNotifier);
         });
   }
 
+  @TestTemplate
   void shouldResolveIncidentButNotUnsetFlagsWhenOtherIncidentsStillActive(
       final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
     withTask(
@@ -752,6 +767,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           assertThat(updatedActiveIncident.getState()).isEqualTo(IncidentState.ACTIVE);
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
+          verifyNoInteractions(incidentNotifier);
         });
   }
 
@@ -841,6 +857,8 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
           final var updatedProcessInstance =
               getFromIndex(listViewTemplate, client, processInstance);
           assertThat(updatedProcessInstance.isIncident()).isFalse();
+
+          verifyNoInteractions(incidentNotifier);
         });
   }
 
@@ -1003,6 +1021,9 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
               .isEqualTo(String.format("%s/FNI_%d", treePath, flowNodeInstanceKey));
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(3L);
+
+          // despite duplicates we should only send one notification per incident key
+          verifyIncidentNotificationsSent(updatedIncident1, updatedIncident2, updatedIncident3);
         });
   }
 
@@ -1125,6 +1146,7 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
               .isEqualTo(String.format("%s/FNI_%d", treePath, flowNodeInstanceKey));
 
           assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
+          verifyIncidentNotificationsSent(incidentEntity);
         });
   }
 
@@ -1193,6 +1215,18 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
         parent.getId(),
         templateDescriptor.getFullQualifiedName() + suffix,
         (Class<T>) entity.getClass());
+  }
+
+  private void verifyIncidentNotificationsSent(final IncidentEntity... incidents) {
+    final ArgumentCaptor<List<IncidentEntity>> captor = ArgumentCaptor.forClass(List.class);
+    verify(incidentNotifier).notifyAsync(captor.capture());
+
+    // just checking the IDs as the other fields may have been updated in the meantime
+    final List<String> expectedIds =
+        Arrays.stream(incidents).map(IncidentEntity::getId).sorted().toList();
+    final List<String> actualIds =
+        captor.getValue().stream().map(IncidentEntity::getId).sorted().toList();
+    assertThat(actualIds).isEqualTo(expectedIds);
   }
 
   private IncidentUpdateRepository createIncidentUpdateRepository(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
@@ -18,6 +18,7 @@ import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.tasks.BackgroundTaskIT;
 import io.camunda.search.test.utils.SearchClientAdapter;
 import io.camunda.search.test.utils.TestObjectMapper;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.template.IncidentTemplate;
@@ -35,6 +36,7 @@ import io.camunda.webapps.schema.entities.post.PostImporterQueueEntity;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 
@@ -842,13 +844,198 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
         });
   }
 
+  // TODO duplicate process instances too
+  // https://github.com/camunda/camunda/issues/57255
+  // we would not normally expect duplicate incidents to be present, but if they are,
+  // we should still be able to update the relevant entities still without getting stuck.
+  @TestTemplate
+  void shouldHandleDuplicateIncidentsWhenUpdating(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withTask(
+        config,
+        (job, resources) -> {
+          final var listViewTemplate = resources.getIndexTemplateDescriptor(ListViewTemplate.class);
+
+          final var processInstanceKey = ID_GENERATOR.getAndIncrement();
+          final var treePath = String.format("PI_%d", processInstanceKey);
+          final ProcessInstanceForListViewEntity processInstance =
+              new ProcessInstanceForListViewEntity()
+                  .setId(String.valueOf(processInstanceKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(processInstanceKey)
+                  .setProcessDefinitionKey(9999L)
+                  .setBpmnProcessId("process-1")
+                  .setTreePath(treePath);
+          store(listViewTemplate, client, processInstance);
+
+          client.refresh(listViewTemplate.getFullQualifiedName());
+
+          final var flowNodeInstanceKey = ID_GENERATOR.getAndIncrement();
+
+          final FlowNodeInstanceForListViewEntity listViewFlowNodeInstance =
+              new FlowNodeInstanceForListViewEntity()
+                  .setId(String.valueOf(flowNodeInstanceKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(flowNodeInstanceKey)
+                  .setProcessInstanceKey(processInstance.getKey())
+                  .setRootProcessInstanceKey(processInstance.getKey());
+          listViewFlowNodeInstance.getJoinRelation().setParent(processInstance.getKey());
+          store(listViewTemplate, client, processInstance, listViewFlowNodeInstance);
+
+          final var flowNodeInstanceTemplate =
+              resources.getIndexTemplateDescriptor(FlowNodeInstanceTemplate.class);
+
+          final FlowNodeInstanceEntity flowNodeInstance =
+              new FlowNodeInstanceEntity()
+                  .setId(String.valueOf(flowNodeInstanceKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(flowNodeInstanceKey)
+                  .setProcessInstanceKey(processInstance.getKey())
+                  .setRootProcessInstanceKey(processInstance.getKey());
+          store(flowNodeInstanceTemplate, client, flowNodeInstance);
+
+          client.refresh(listViewTemplate.getFullQualifiedName());
+          client.refresh(flowNodeInstanceTemplate.getFullQualifiedName());
+
+          final var incidentTemplate = resources.getIndexTemplateDescriptor(IncidentTemplate.class);
+
+          final var incidentKey1 = ID_GENERATOR.getAndIncrement();
+          final IncidentEntity incidentEntity1 =
+              new IncidentEntity()
+                  .setId(String.valueOf(incidentKey1))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(incidentKey1)
+                  .setErrorMessage("An error happened")
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setFlowNodeInstanceKey(flowNodeInstanceKey);
+
+          final var incidentKey2 = ID_GENERATOR.getAndIncrement();
+          final IncidentEntity incidentEntity2 =
+              new IncidentEntity()
+                  .setId(String.valueOf(incidentKey2))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(incidentKey2)
+                  .setErrorMessage("An error happened")
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setFlowNodeInstanceKey(flowNodeInstanceKey);
+
+          final var incidentKey3 = ID_GENERATOR.getAndIncrement();
+          final IncidentEntity incidentEntity3 =
+              new IncidentEntity()
+                  .setId(String.valueOf(incidentKey3))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(incidentKey3)
+                  .setErrorMessage("An error happened")
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setFlowNodeInstanceKey(flowNodeInstanceKey);
+
+          // duplicate incident in main + multiple dated indexes
+          store(incidentTemplate, client, incidentEntity1);
+          storeDuplicates(incidentTemplate, client, incidentEntity1, "2026-07-12", "2026-07-13");
+          store(incidentTemplate, client, incidentEntity2);
+          store(incidentTemplate, client, incidentEntity3);
+          client.refresh(incidentTemplate.getFullQualifiedName() + "*");
+
+          final var postImporterTemplate =
+              resources.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+
+          long position = 1L;
+          for (final var incident : List.of(incidentEntity1, incidentEntity2, incidentEntity3)) {
+            store(
+                postImporterTemplate,
+                client,
+                new PostImporterQueueEntity()
+                    .setId("queue-" + position)
+                    .setPartitionId(PARTITION_ID)
+                    .setActionType(PostImporterActionType.INCIDENT)
+                    .setIntent("CREATED")
+                    .setKey(incident.getKey())
+                    .setPosition(position));
+            position++;
+          }
+          client.refresh(postImporterTemplate.getFullQualifiedName());
+
+          // when
+          final var updated = job.execute();
+
+          // then
+          assertThat(updated).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(8);
+
+          client.refresh(testPrefix);
+
+          final var updatedProcessInstance =
+              getFromIndex(listViewTemplate, client, processInstance);
+          assertThat(updatedProcessInstance.isIncident()).isTrue();
+
+          final var updatedListViewFlowNodeInstance =
+              getChildFromIndex(
+                  listViewTemplate, client, processInstance, listViewFlowNodeInstance);
+          assertThat(updatedListViewFlowNodeInstance.isIncident()).isTrue();
+
+          final var updatedFlowNodeInstance =
+              getFromIndex(flowNodeInstanceTemplate, client, flowNodeInstance);
+          assertThat(updatedFlowNodeInstance.isIncident()).isTrue();
+
+          final var updatedIncident1 = getFromIndex(incidentTemplate, client, incidentEntity1);
+          assertThat(updatedIncident1.getState()).isEqualTo(IncidentState.ACTIVE);
+          assertThat(updatedIncident1.getTreePath())
+              .isEqualTo(String.format("%s/FNI_%d", treePath, flowNodeInstanceKey));
+
+          final var updatedIncident1Dup1 =
+              getFromIndex(incidentTemplate, client, incidentEntity1, "2026-07-12");
+          assertThat(updatedIncident1Dup1.getState()).isEqualTo(IncidentState.ACTIVE);
+          assertThat(updatedIncident1Dup1.getTreePath())
+              .isEqualTo(String.format("%s/FNI_%d", treePath, flowNodeInstanceKey));
+
+          final var updatedIncident1Dup2 =
+              getFromIndex(incidentTemplate, client, incidentEntity1, "2026-07-13");
+          assertThat(updatedIncident1Dup2.getState()).isEqualTo(IncidentState.ACTIVE);
+          assertThat(updatedIncident1Dup2.getTreePath())
+              .isEqualTo(String.format("%s/FNI_%d", treePath, flowNodeInstanceKey));
+
+          final var updatedIncident2 = getFromIndex(incidentTemplate, client, incidentEntity2);
+          assertThat(updatedIncident2.getState()).isEqualTo(IncidentState.ACTIVE);
+          assertThat(updatedIncident2.getTreePath())
+              .isEqualTo(String.format("%s/FNI_%d", treePath, flowNodeInstanceKey));
+
+          final var updatedIncident3 = getFromIndex(incidentTemplate, client, incidentEntity3);
+          assertThat(updatedIncident3.getState()).isEqualTo(IncidentState.ACTIVE);
+          assertThat(updatedIncident3.getTreePath())
+              .isEqualTo(String.format("%s/FNI_%d", treePath, flowNodeInstanceKey));
+
+          assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(3L);
+        });
+  }
+
+  protected void storeDuplicates(
+      final IndexDescriptor indexDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> entity,
+      final String... suffixes)
+      throws IOException {
+    for (final String suffix : suffixes) {
+      client.index(entity.getId(), indexDescriptor.getFullQualifiedName() + suffix, entity);
+    }
+  }
+
   private <T extends ExporterEntity<T>> T getFromIndex(
       final IndexTemplateDescriptor templateDescriptor,
       final SearchClientAdapter client,
       final T entity)
       throws IOException {
+    return getFromIndex(templateDescriptor, client, entity, "");
+  }
+
+  private <T extends ExporterEntity<T>> T getFromIndex(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final T entity,
+      final String suffix)
+      throws IOException {
     return client.get(
-        entity.getId(), templateDescriptor.getFullQualifiedName(), (Class<T>) entity.getClass());
+        entity.getId(),
+        templateDescriptor.getFullQualifiedName() + suffix,
+        (Class<T>) entity.getClass());
   }
 
   private <T extends ExporterEntity<T>> T getChildFromIndex(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskIT.java
@@ -844,7 +844,6 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
         });
   }
 
-  // TODO duplicate process instances too
   // https://github.com/camunda/camunda/issues/57255
   // we would not normally expect duplicate incidents to be present, but if they are,
   // we should still be able to update the relevant entities still without getting stuck.
@@ -1007,6 +1006,128 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
         });
   }
 
+  @TestTemplate
+  void shouldHandleDuplicateProcessInstanceAndFlowNodesWhenUpdating(
+      final ExporterConfiguration config, final SearchClientAdapter client) throws Exception {
+    withTask(
+        config,
+        (job, resources) -> {
+          final var listViewTemplate = resources.getIndexTemplateDescriptor(ListViewTemplate.class);
+
+          final var processInstanceKey = ID_GENERATOR.getAndIncrement();
+          final var treePath = String.format("PI_%d", processInstanceKey);
+          final ProcessInstanceForListViewEntity processInstance =
+              new ProcessInstanceForListViewEntity()
+                  .setId(String.valueOf(processInstanceKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(processInstanceKey)
+                  .setProcessDefinitionKey(9999L)
+                  .setBpmnProcessId("process-1")
+                  .setTreePath(treePath);
+          store(listViewTemplate, client, processInstance);
+          storeDuplicates(listViewTemplate, client, processInstance, "2026-07-12", "2026-07-13");
+
+          client.refresh(listViewTemplate.getFullQualifiedName() + "*");
+
+          final var flowNodeInstanceKey = ID_GENERATOR.getAndIncrement();
+
+          final FlowNodeInstanceForListViewEntity listViewFlowNodeInstance =
+              new FlowNodeInstanceForListViewEntity()
+                  .setId(String.valueOf(flowNodeInstanceKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(flowNodeInstanceKey)
+                  .setProcessInstanceKey(processInstance.getKey())
+                  .setRootProcessInstanceKey(processInstance.getKey());
+          listViewFlowNodeInstance.getJoinRelation().setParent(processInstance.getKey());
+          store(listViewTemplate, client, processInstance, listViewFlowNodeInstance);
+          storeChildDuplicates(
+              listViewTemplate,
+              client,
+              processInstance,
+              listViewFlowNodeInstance,
+              "2026-07-12",
+              "2026-07-13");
+
+          final var flowNodeInstanceTemplate =
+              resources.getIndexTemplateDescriptor(FlowNodeInstanceTemplate.class);
+
+          final FlowNodeInstanceEntity flowNodeInstance =
+              new FlowNodeInstanceEntity()
+                  .setId(String.valueOf(flowNodeInstanceKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(flowNodeInstanceKey)
+                  .setProcessInstanceKey(processInstance.getKey())
+                  .setRootProcessInstanceKey(processInstance.getKey());
+          store(flowNodeInstanceTemplate, client, flowNodeInstance);
+          storeDuplicates(
+              flowNodeInstanceTemplate, client, flowNodeInstance, "2026-07-12", "2026-07-13");
+
+          client.refresh(listViewTemplate.getFullQualifiedName() + "*");
+          client.refresh(flowNodeInstanceTemplate.getFullQualifiedName() + "*");
+
+          final var incidentTemplate = resources.getIndexTemplateDescriptor(IncidentTemplate.class);
+
+          final var incidentKey = ID_GENERATOR.getAndIncrement();
+          final IncidentEntity incidentEntity =
+              new IncidentEntity()
+                  .setId(String.valueOf(incidentKey))
+                  .setPartitionId(PARTITION_ID)
+                  .setKey(incidentKey)
+                  .setErrorMessage("An error happened")
+                  .setProcessInstanceKey(processInstanceKey)
+                  .setFlowNodeInstanceKey(flowNodeInstanceKey);
+
+          store(incidentTemplate, client, incidentEntity);
+          client.refresh(incidentTemplate.getFullQualifiedName());
+
+          final var postImporterTemplate =
+              resources.getIndexTemplateDescriptor(PostImporterQueueTemplate.class);
+
+          store(
+              postImporterTemplate,
+              client,
+              new PostImporterQueueEntity()
+                  .setId("queue-1")
+                  .setPartitionId(PARTITION_ID)
+                  .setActionType(PostImporterActionType.INCIDENT)
+                  .setIntent("CREATED")
+                  .setKey(incidentEntity.getKey())
+                  .setPosition(1L));
+
+          client.refresh(postImporterTemplate.getFullQualifiedName());
+
+          // when
+          final var updated = job.execute();
+
+          // then
+          assertThat(updated).succeedsWithin(EXECUTE_TIMEOUT).isEqualTo(10);
+
+          client.refresh(testPrefix);
+
+          final var suffixes = List.of("", "2026-07-12", "2026-07-13");
+          for (final var suffix : suffixes) {
+            final var updatedProcessInstance =
+                getFromIndex(listViewTemplate, client, processInstance, suffix);
+            assertThat(updatedProcessInstance.isIncident()).isTrue();
+
+            final var updatedListViewFlowNodeInstance =
+                getChildFromIndex(
+                    listViewTemplate, client, processInstance, listViewFlowNodeInstance, suffix);
+            assertThat(updatedListViewFlowNodeInstance.isIncident()).isTrue();
+
+            final var updatedFlowNodeInstance =
+                getFromIndex(flowNodeInstanceTemplate, client, flowNodeInstance, suffix);
+            assertThat(updatedFlowNodeInstance.isIncident()).isTrue();
+          }
+          final var updatedIncident = getFromIndex(incidentTemplate, client, incidentEntity);
+          assertThat(updatedIncident.getState()).isEqualTo(IncidentState.ACTIVE);
+          assertThat(updatedIncident.getTreePath())
+              .isEqualTo(String.format("%s/FNI_%d", treePath, flowNodeInstanceKey));
+
+          assertThat(exporterMetadata.getLastIncidentUpdatePosition()).isEqualTo(1L);
+        });
+  }
+
   protected void storeDuplicates(
       final IndexDescriptor indexDescriptor,
       final SearchClientAdapter client,
@@ -1015,6 +1136,19 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
       throws IOException {
     for (final String suffix : suffixes) {
       client.index(entity.getId(), indexDescriptor.getFullQualifiedName() + suffix, entity);
+    }
+  }
+
+  protected void storeChildDuplicates(
+      final IndexDescriptor indexDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> parent,
+      final ExporterEntity<?> entity,
+      final String... suffixes)
+      throws IOException {
+    for (final String suffix : suffixes) {
+      client.index(
+          entity.getId(), parent.getId(), indexDescriptor.getFullQualifiedName() + suffix, entity);
     }
   }
 
@@ -1044,10 +1178,20 @@ class IncidentUpdateTaskIT extends BackgroundTaskIT<IncidentUpdateTask> {
       final ExporterEntity<?> parent,
       final T entity)
       throws IOException {
+    return getChildFromIndex(templateDescriptor, client, parent, entity, "");
+  }
+
+  private <T extends ExporterEntity<T>> T getChildFromIndex(
+      final IndexTemplateDescriptor templateDescriptor,
+      final SearchClientAdapter client,
+      final ExporterEntity<?> parent,
+      final T entity,
+      final String suffix)
+      throws IOException {
     return client.get(
         entity.getId(),
         parent.getId(),
-        templateDescriptor.getFullQualifiedName(),
+        templateDescriptor.getFullQualifiedName() + suffix,
         (Class<T>) entity.getClass());
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
@@ -216,11 +215,7 @@ final class IncidentUpdateTaskTest {
               inv -> {
                 final IncidentBulkUpdate update = inv.getArgument(0);
                 return CompletableFuture.completedFuture(
-                    ImmutableList.<String>builder()
-                        .addAll(update.incidentRequests().keySet())
-                        .addAll(update.listViewRequests().keySet())
-                        .addAll(update.flowNodeInstanceRequests().keySet())
-                        .build());
+                    update.stream().map(DocumentUpdate::id).toList());
               });
     }
 
@@ -347,8 +342,7 @@ final class IncidentUpdateTaskTest {
       final var update = bulkUpdateCaptor.getValue();
       assertThat(update.incidentRequests())
           .hasSize(1)
-          .containsEntry(
-              "5",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "5",
                   "incidents",
@@ -361,16 +355,12 @@ final class IncidentUpdateTaskTest {
       // only the PI and flow node referenced by the sparse path are touched (no parent ancestry)
       assertThat(update.listViewRequests())
           .hasSize(2)
-          .containsEntry(
-              "3",
-              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"))
-          .containsEntry(
-              "4",
+          .containsExactlyInAnyOrder(
+              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"),
               new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"));
       assertThat(update.flowNodeInstanceRequests())
           .hasSize(1)
-          .containsEntry(
-              "4",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null));
       assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(highestPosition);
@@ -409,8 +399,7 @@ final class IncidentUpdateTaskTest {
       final var update = bulkUpdateCaptor.getValue();
       assertThat(update.incidentRequests())
           .hasSize(1)
-          .containsEntry(
-              "5",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "5",
                   "incidents",
@@ -507,8 +496,7 @@ final class IncidentUpdateTaskTest {
       final var update = bulkUpdateCaptor.getValue();
       assertThat(update.incidentRequests())
           .hasSize(1)
-          .containsEntry(
-              "5",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "5",
                   "incidents",
@@ -555,17 +543,10 @@ final class IncidentUpdateTaskTest {
       final var update = bulkUpdateCaptor.getValue();
       assertThat(update.listViewRequests())
           .hasSize(4)
-          .containsEntry(
-              "1",
-              new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"))
-          .containsEntry(
-              "2",
-              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"))
-          .containsEntry(
-              "3",
-              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"))
-          .containsEntry(
-              "4",
+          .containsExactlyInAnyOrder(
+              new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"),
+              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"),
+              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"),
               new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"));
       final var incident =
           new IncidentEntity()
@@ -604,12 +585,9 @@ final class IncidentUpdateTaskTest {
       final var update = bulkUpdateCaptor.getValue();
       assertThat(update.flowNodeInstanceRequests())
           .hasSize(2)
-          .containsEntry(
-              "2",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate(
-                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null))
-          .containsEntry(
-              "4",
+                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null),
               new DocumentUpdate(
                   "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null));
       final var incident =
@@ -660,8 +638,7 @@ final class IncidentUpdateTaskTest {
       final var update = bulkUpdateCaptor.getValue();
       assertThat(update.incidentRequests())
           .hasSize(1)
-          .containsEntry(
-              "5",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "5",
                   "incidents",
@@ -674,8 +651,7 @@ final class IncidentUpdateTaskTest {
       assertThat(update.flowNodeInstanceRequests()).isEmpty();
       assertThat(update.listViewRequests())
           .hasSize(1)
-          .containsEntry(
-              "1",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"));
 
       final var incident =
@@ -726,33 +702,22 @@ final class IncidentUpdateTaskTest {
       final var update = bulkUpdateCaptor.getValue();
       assertThat(update.incidentRequests())
           .hasSize(1)
-          .containsEntry(
-              "5",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "5", "incidents", Map.of(IncidentTemplate.STATE, IncidentState.RESOLVED), null));
       assertThat(update.flowNodeInstanceRequests())
           .hasSize(2)
-          .containsEntry(
-              "2",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate(
-                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null))
-          .containsEntry(
-              "4",
+                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null),
               new DocumentUpdate(
                   "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null));
       assertThat(update.listViewRequests())
           .hasSize(4)
-          .containsEntry(
-              "1",
-              new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"))
-          .containsEntry(
-              "2",
-              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"))
-          .containsEntry(
-              "3",
-              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"))
-          .containsEntry(
-              "4",
+          .containsExactlyInAnyOrder(
+              new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"),
+              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"),
+              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"),
               new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"));
 
       verify(incidentNotifier, times(0)).notifyAsync(any());
@@ -799,30 +764,21 @@ final class IncidentUpdateTaskTest {
       final var update = bulkUpdateCaptor.getValue();
       assertThat(update.incidentRequests())
           .hasSize(1)
-          .containsEntry(
-              "5",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate(
                   "5", "incidents", Map.of(IncidentTemplate.STATE, IncidentState.RESOLVED), null));
       assertThat(update.flowNodeInstanceRequests())
           .hasSize(2)
-          .containsEntry(
-              "2",
+          .containsExactlyInAnyOrder(
               new DocumentUpdate(
-                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null))
-          .containsEntry(
-              "4",
+                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null),
               new DocumentUpdate(
                   "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null));
       assertThat(update.listViewRequests())
           .hasSize(3)
-          .containsEntry(
-              "2",
-              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"))
-          .containsEntry(
-              "3",
-              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"))
-          .containsEntry(
-              "4",
+          .containsExactlyInAnyOrder(
+              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"),
+              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"),
               new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"));
       verify(metrics).recordIncidentUpdatesProcessed(1);
       verify(metrics).recordIncidentUpdatesDocumentsUpdated(6);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -191,7 +191,7 @@ final class IncidentUpdateTaskTest {
                       highestPosition,
                       Map.of(incident.incident().getKey(), IncidentState.ACTIVE))));
       when(repository.getIncidentDocuments(any()))
-          .thenReturn(CompletableFuture.completedFuture(Map.of(incident.id(), incident)));
+          .thenReturn(CompletableFuture.completedFuture(List.of(incident)));
       when(repository.getFlowNodesInListView(any()))
           .thenReturn(
               CompletableFuture.completedFuture(
@@ -265,7 +265,7 @@ final class IncidentUpdateTaskTest {
               LOGGER,
               Duration.ZERO);
       when(repository.getIncidentDocuments(any()))
-          .thenReturn(CompletableFuture.completedFuture(Map.of()));
+          .thenReturn(CompletableFuture.completedFuture(List.of()));
 
       // when
       final var result = task.execute();


### PR DESCRIPTION
## Description

Sometimes we've had issues with the archiver duplicating process instances (and related data) when archiving. e.g. via https://github.com/camunda/camunda/issues/43902 or https://github.com/camunda/camunda/issues/57808

When this happens the incident update task get get blocked as it wasn't handling the duplicates correctly (misinterpreting them as missing incidents).

This changes the incident update task to handle all duplicate incidents and process instances/flow nodes etc, so it does not get stuck.

Hopefully we can also fix the duplication issue, but this at least makes the task more robust.

## Related issues

closes #57255
