### PR TITLE
test: add API e2e coverage for Business ID on message publish and correlate

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/message_start_business_id_process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/message_start_business_id_process.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_message_start_business_id" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="message_start_business_id_process" name="Message Start Business ID Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start via message">
+      <bpmn:outgoing>Flow_start_to_task</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1" messageRef="Message_start_business_id" />
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_to_task" sourceRef="StartEvent_1" targetRef="wait_user_task" />
+    <bpmn:userTask id="wait_user_task" name="Wait">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_to_task</bpmn:incoming>
+      <bpmn:outgoing>Flow_task_to_end</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>Flow_task_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_task_to_end" sourceRef="wait_user_task" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmn:message id="Message_start_business_id" name="start_business_id_msg" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="message_start_business_id_process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="132" y="145" width="77" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="wait_user_task_di" bpmnElement="wait_user_task">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_end_di" bpmnElement="Event_end">
+        <dc:Bounds x="432" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_start_to_task_di" bpmnElement="Flow_start_to_task">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_task_to_end_di" bpmnElement="Flow_task_to_end">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="432" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-business-id-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/correlate-message-business-id-api-tests.spec.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, expect, test} from '@playwright/test';
+import {
+  assertBadRequest,
+  assertRequiredFields,
+  assertStatusCode,
+  buildUrl,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {cancelProcessInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  defaultAssertionOptions,
+  uniqueBusinessId,
+} from '../../../../utils/constants';
+import {correlateMessageRequiredFields} from '../../../../utils/beans/requestBeans';
+
+const MESSAGE_CORRELATION_ENDPOINT = '/messages/correlation';
+const PROCESS_INSTANCE_SEARCH_ENDPOINT = '/process-instances/search';
+const START_MESSAGE_NAME = 'start_business_id_msg';
+const MESSAGE_START_PROCESS_ID = 'message_start_business_id_process';
+
+// Searches for the process instances started for the message-start process that carry the given
+// Business ID. Business IDs are unique per test, so the result is scoped to the current test.
+async function searchInstancesByBusinessId(
+  request: APIRequestContext,
+  businessId: string,
+) {
+  const res = await request.post(buildUrl(PROCESS_INSTANCE_SEARCH_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {filter: {businessId}},
+  });
+  await assertStatusCode(res, 200);
+  return res.json();
+}
+
+async function correlateStartMessage(
+  request: APIRequestContext,
+  businessId?: string,
+) {
+  return request.post(buildUrl(MESSAGE_CORRELATION_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {
+      name: START_MESSAGE_NAME,
+      correlationKey: '',
+      ...(businessId !== undefined ? {businessId} : {}),
+    },
+  });
+}
+
+/* eslint-disable playwright/expect-expect */
+test.describe.parallel('Correlate Message - Business ID API', () => {
+  test.beforeAll(async () => {
+    await deploy(['./resources/message_start_business_id_process.bpmn']);
+  });
+
+  test('Correlate message to a message start event carries the Business ID to the created instance', async ({
+    request,
+  }) => {
+    const businessId = uniqueBusinessId('correlate-start');
+    const localState: Record<string, string> = {processInstanceKey: ''};
+
+    await test.step('Correlate message with a Business ID', async () => {
+      const res = await correlateStartMessage(request, businessId);
+      await assertStatusCode(res, 200);
+      const json = await res.json();
+      assertRequiredFields(json, correlateMessageRequiredFields);
+      expect(json.processInstanceKey).toBeDefined();
+      localState['processInstanceKey'] = json.processInstanceKey;
+    });
+
+    await test.step('Created instance is searchable by the Business ID', async () => {
+      await expect(async () => {
+        const json = await searchInstancesByBusinessId(request, businessId);
+        expect(json.page.totalItems).toBe(1);
+        expect(json.items[0].businessId).toBe(businessId);
+        expect(json.items[0].processInstanceKey).toBe(
+          localState['processInstanceKey'],
+        );
+        expect(json.items[0].processDefinitionId).toBe(
+          MESSAGE_START_PROCESS_ID,
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await cancelProcessInstance(localState['processInstanceKey']);
+  });
+
+  test('Duplicate Business ID correlation does not start a second instance while the first is active', async ({
+    request,
+  }) => {
+    const businessId = uniqueBusinessId('correlate-duplicate');
+    const localState: Record<string, string> = {processInstanceKey: ''};
+
+    await test.step('Correlate first message with the Business ID', async () => {
+      const res = await correlateStartMessage(request, businessId);
+      await assertStatusCode(res, 200);
+      localState['processInstanceKey'] = (await res.json()).processInstanceKey;
+    });
+
+    await test.step('First instance becomes visible for the Business ID', async () => {
+      await expect(async () => {
+        const json = await searchInstancesByBusinessId(request, businessId);
+        expect(json.page.totalItems).toBe(1);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Correlate second message with the same Business ID', async () => {
+      const res = await correlateStartMessage(request, businessId);
+      // The correlation itself is accepted; instance creation is suppressed by uniqueness.
+      await assertStatusCode(res, 200);
+    });
+
+    await test.step('Still exactly one instance exists for the Business ID', async () => {
+      await expect(async () => {
+        const json = await searchInstancesByBusinessId(request, businessId);
+        expect(json.page.totalItems).toBe(1);
+        expect(json.items[0].processInstanceKey).toBe(
+          localState['processInstanceKey'],
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await cancelProcessInstance(localState['processInstanceKey']);
+  });
+
+  test('Business ID can be reused for correlation after the holding instance is cancelled', async ({
+    request,
+  }) => {
+    const businessId = uniqueBusinessId('correlate-reuse');
+    const localState: Record<string, string> = {
+      firstKey: '',
+      secondKey: '',
+    };
+
+    await test.step('Correlate message and cancel the created instance', async () => {
+      const res = await correlateStartMessage(request, businessId);
+      await assertStatusCode(res, 200);
+      localState['firstKey'] = (await res.json()).processInstanceKey;
+      await expect(async () => {
+        const json = await searchInstancesByBusinessId(request, businessId);
+        expect(json.page.totalItems).toBe(1);
+      }).toPass(defaultAssertionOptions);
+      await cancelProcessInstance(localState['firstKey']);
+    });
+
+    await test.step('Correlate again with the same Business ID after cancellation', async () => {
+      // Wait until the cancelled holder is no longer ACTIVE so the Business ID lock is released,
+      // then correlate exactly once. Retrying the correlate inside `toPass` could create multiple
+      // instances and leak resources.
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(PROCESS_INSTANCE_SEARCH_ENDPOINT),
+          {
+            headers: jsonHeaders(),
+            data: {filter: {businessId, state: 'ACTIVE'}},
+          },
+        );
+        await assertStatusCode(res, 200);
+        const json = await res.json();
+        expect(json.page.totalItems).toBe(0);
+      }).toPass(defaultAssertionOptions);
+
+      const res = await correlateStartMessage(request, businessId);
+      await assertStatusCode(res, 200);
+      const key = (await res.json()).processInstanceKey;
+      expect(key).not.toBe(localState['firstKey']);
+      localState['secondKey'] = key;
+    });
+
+    await cancelProcessInstance(localState['secondKey']);
+  });
+
+  test('Correlate message with a Business ID exceeding the maximum length is rejected', async ({
+    request,
+  }) => {
+    const res = await correlateStartMessage(request, 'a'.repeat(257));
+    await assertBadRequest(res, /businessId|256/i, 'INVALID_ARGUMENT');
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/publish-message-business-id-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/message/publish-message-business-id-api-tests.spec.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, expect, test} from '@playwright/test';
+import {
+  assertBadRequest,
+  assertStatusCode,
+  buildUrl,
+  jsonHeaders,
+} from '../../../../utils/http';
+import {cancelProcessInstance, deploy} from '../../../../utils/zeebeClient';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+  uniqueBusinessId,
+} from '../../../../utils/constants';
+
+const MESSAGE_PUBLICATION_ENDPOINT = '/messages/publication';
+const PROCESS_INSTANCE_SEARCH_ENDPOINT = '/process-instances/search';
+const START_MESSAGE_NAME = 'start_business_id_msg';
+const MESSAGE_START_PROCESS_ID = 'message_start_business_id_process';
+
+const uniqueMessageId = (): string => `msg-${generateUniqueId()}`;
+
+// Searches for the process instances started for the message-start process that carry the given
+// Business ID. Business IDs are unique per test, so the result is scoped to the current test.
+async function searchInstancesByBusinessId(
+  request: APIRequestContext,
+  businessId: string,
+) {
+  const res = await request.post(buildUrl(PROCESS_INSTANCE_SEARCH_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {filter: {businessId}},
+  });
+  await assertStatusCode(res, 200);
+  return res.json();
+}
+
+/* eslint-disable playwright/expect-expect */
+test.describe.parallel('Publish Message - Business ID API', () => {
+  test.beforeAll(async () => {
+    await deploy(['./resources/message_start_business_id_process.bpmn']);
+  });
+
+  test('Publish message to a message start event carries the Business ID to the created instance', async ({
+    request,
+  }) => {
+    const businessId = uniqueBusinessId('publish-start');
+    const localState: Record<string, string> = {processInstanceKey: ''};
+
+    await test.step('Publish message with a Business ID', async () => {
+      const res = await request.post(buildUrl(MESSAGE_PUBLICATION_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          name: START_MESSAGE_NAME,
+          correlationKey: '',
+          messageId: uniqueMessageId(),
+          businessId,
+        },
+      });
+      await assertStatusCode(res, 200);
+      const json = await res.json();
+      expect(json.messageKey).toBeDefined();
+    });
+
+    await test.step('Started instance is searchable by the Business ID', async () => {
+      await expect(async () => {
+        const json = await searchInstancesByBusinessId(request, businessId);
+        expect(json.page.totalItems).toBe(1);
+        expect(json.items[0].businessId).toBe(businessId);
+        expect(json.items[0].processDefinitionId).toBe(
+          MESSAGE_START_PROCESS_ID,
+        );
+        localState['processInstanceKey'] = json.items[0].processInstanceKey;
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await cancelProcessInstance(localState['processInstanceKey']);
+  });
+
+  test('Publish message without a Business ID starts an instance with a null Business ID', async ({
+    request,
+  }) => {
+    const marker = generateUniqueId();
+    const localState: Record<string, string> = {processInstanceKey: ''};
+
+    await test.step('Publish message without a Business ID', async () => {
+      const res = await request.post(buildUrl(MESSAGE_PUBLICATION_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          name: START_MESSAGE_NAME,
+          correlationKey: '',
+          messageId: uniqueMessageId(),
+          variables: {marker},
+        },
+      });
+      await assertStatusCode(res, 200);
+    });
+
+    await test.step('Started instance has a null Business ID', async () => {
+      await expect(async () => {
+        const res = await request.post(
+          buildUrl(PROCESS_INSTANCE_SEARCH_ENDPOINT),
+          {
+            headers: jsonHeaders(),
+            data: {
+              filter: {
+                processDefinitionId: MESSAGE_START_PROCESS_ID,
+                variables: [{name: 'marker', value: `"${marker}"`}],
+              },
+            },
+          },
+        );
+        await assertStatusCode(res, 200);
+        const json = await res.json();
+        expect(json.page.totalItems).toBe(1);
+        expect(json.items[0]).toHaveProperty('businessId', null);
+        localState['processInstanceKey'] = json.items[0].processInstanceKey;
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await cancelProcessInstance(localState['processInstanceKey']);
+  });
+
+  test('Duplicate Business ID publish does not start a second instance while the first is active', async ({
+    request,
+  }) => {
+    const businessId = uniqueBusinessId('publish-duplicate');
+    const localState: Record<string, string> = {processInstanceKey: ''};
+
+    await test.step('Publish first message with the Business ID', async () => {
+      const res = await request.post(buildUrl(MESSAGE_PUBLICATION_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          name: START_MESSAGE_NAME,
+          correlationKey: '',
+          messageId: uniqueMessageId(),
+          businessId,
+        },
+      });
+      await assertStatusCode(res, 200);
+    });
+
+    await test.step('First instance becomes visible for the Business ID', async () => {
+      await expect(async () => {
+        const json = await searchInstancesByBusinessId(request, businessId);
+        expect(json.page.totalItems).toBe(1);
+        localState['processInstanceKey'] = json.items[0].processInstanceKey;
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await test.step('Publish second message with the same Business ID (different message id)', async () => {
+      const res = await request.post(buildUrl(MESSAGE_PUBLICATION_ENDPOINT), {
+        headers: jsonHeaders(),
+        data: {
+          name: START_MESSAGE_NAME,
+          correlationKey: '',
+          messageId: uniqueMessageId(),
+          businessId,
+        },
+      });
+      await assertStatusCode(res, 200);
+    });
+
+    await test.step('Still exactly one instance exists for the Business ID', async () => {
+      // The duplicate publish is suppressed by Business ID uniqueness, so the count must stay at 1.
+      await expect(async () => {
+        const json = await searchInstancesByBusinessId(request, businessId);
+        expect(json.page.totalItems).toBe(1);
+        expect(json.items[0].processInstanceKey).toBe(
+          localState['processInstanceKey'],
+        );
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await cancelProcessInstance(localState['processInstanceKey']);
+  });
+
+  test('Publish message with a Business ID exceeding the maximum length is rejected', async ({
+    request,
+  }) => {
+    const res = await request.post(buildUrl(MESSAGE_PUBLICATION_ENDPOINT), {
+      headers: jsonHeaders(),
+      data: {
+        name: START_MESSAGE_NAME,
+        correlationKey: '',
+        messageId: uniqueMessageId(),
+        businessId: 'a'.repeat(257),
+      },
+    });
+    await assertBadRequest(res, /businessId|256/i, 'INVALID_ARGUMENT');
+  });
+});


### PR DESCRIPTION
## Description

Adds API-level end-to-end (Playwright) coverage for **Business ID on the message APIs**, closing the two coverage gaps identified for the Business ID Visibility and Filtering epic ([product-hub#3436](https://github.com/camunda/product-hub/issues/3436), engineering breakdown [#51683](https://github.com/camunda/camunda/issues/51683)).

Before this change, `businessId` had e2e API coverage only for **process instances** in the orchestration-cluster e2e suite. The message publish/correlate paths — the core of the M2 "Message correlation" milestone — had **no dedicated API-level test in any suite** (only engine-level integration tests). This PR fills that gap.

### What is covered

`businessId` on message publish/correlate only affects **message start events** (it enforces uniqueness of the root process instance a message-start event would create; it has no effect on catch/boundary/intermediate events). The tests therefore drive a new process with a message start event and assert the observable end-state via process-instance search.

**New BPMN resource** — `resources/message_start_business_id_process.bpmn`
- Message start event (`start_business_id_msg`) → user task (keeps the instance active so uniqueness can be exercised) → end.

**`POST /messages/publication` — `publish-message-business-id-api-tests.spec.ts`**
1. Publishing to a message start event with a `businessId` starts an instance that carries the Business ID (searchable by it).
2. Publishing without a `businessId` starts an instance with a `null` Business ID.
3. A duplicate `businessId` publish is suppressed while the first instance is active — no second instance is created.
4. A `businessId` exceeding the 256-char limit is rejected with `400 INVALID_ARGUMENT`.

**`POST /messages/correlation` — `correlate-message-business-id-api-tests.spec.ts`**
1. Correlating a message start event with a `businessId` returns the created `processInstanceKey` and the instance carries the Business ID.
2. A duplicate `businessId` correlation does not create a second instance while the first is active.
3. A `businessId` can be reused for correlation after the holding instance is cancelled.
4. A `businessId` exceeding the 256-char limit is rejected with `400 INVALID_ARGUMENT`.

### Notes

- Uniqueness enforcement is already enabled in the suite (`CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED=true`).
- Duplicate-`businessId` suppression on message start events is **asynchronous / silent** (no synchronous error), matching the engine behavior in `MessageStartEventBusinessIdUniquenessTest`; assertions therefore verify observable state via `/process-instances/search` rather than the publish/correlate response.
- Each test uses a unique `businessId`, so specs run in parallel without interference and clean up the instances they create.

### Testing

- `tsc` — passes.
- `eslint` (prettier + license header) — passes for the new files.
- `check:testrail-ids` — passes (test ids within the 250-byte TestRail limit).
- Full runtime execution requires a live orchestration cluster; these run in the nightly API/E2E workflow.

### Related

- Epic: [product-hub#3436](https://github.com/camunda/product-hub/issues/3436)
- Engineering breakdown: [#51683](https://github.com/camunda/camunda/issues/51683)



Test Rail test cases
https://camunda.testrail.com/index.php?/suites/view/17028&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=678356

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview