### PR TITLE
feat: Late Business ID assignment — protocol definition, engine processing, and forward-propagation semantic

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionDele
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchActivateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchTerminateProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBusinessIdAssignProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCancelProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateWithAwaitingResultProcessor;
@@ -49,6 +50,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessInstructionIntent;
 import io.camunda.zeebe.protocol.record.intent.ConditionalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -134,6 +136,8 @@ public final class BpmnProcessors {
         routingInfo,
         authCheckBehavior,
         keyGenerator);
+    addProcessInstanceBusinessIdStreamProcessors(
+        typedRecordProcessors, processingState, writers, authCheckBehavior, config);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
     addAdHocSubProcessActivityStreamProcessors(
         typedRecordProcessors, processingState, writers, authCheckBehavior, bpmnBehaviors);
@@ -332,6 +336,19 @@ public final class BpmnProcessors {
             routingInfo,
             authCheckBehavior,
             keyGenerator));
+  }
+
+  private static void addProcessInstanceBusinessIdStreamProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final ProcessingState processingState,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final EngineConfiguration config) {
+    typedRecordProcessors.onCommand(
+        ValueType.PROCESS_INSTANCE_BUSINESS_ID,
+        ProcessInstanceBusinessIdIntent.ASSIGN,
+        new ProcessInstanceBusinessIdAssignProcessor(
+            writers, processingState, authCheckBehavior, config.isBusinessIdUniquenessEnabled()));
   }
 
   private static void addProcessInstanceBatchStreamProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -283,7 +283,10 @@ public final class CallActivityProcessor
       final BpmnElementContext context, final ExecutableCallActivity element) {
     final var businessIdExpression = element.getCalledElementBusinessId();
     if (businessIdExpression == null) {
-      return Either.right(context.getBusinessId());
+      // No explicit business id: inherit the parent's. Read it from the process-scope element
+      // instance (not the call-activity element's record copy) so a Business ID assigned late to a
+      // running instance is inherited by children started afterwards.
+      return Either.right(getParentBusinessId(context));
     }
     if (businessIdExpression.isStatic()) {
       return validateBusinessId(businessIdExpression.getExpression(), context);
@@ -292,6 +295,11 @@ public final class CallActivityProcessor
         .evaluateAnyExpression(
             businessIdExpression, context.getElementInstanceKey(), context.getTenantId())
         .flatMap(result -> resolveBusinessIdFromResult(result, context));
+  }
+
+  private String getParentBusinessId(final BpmnElementContext context) {
+    final var processInstance = stateBehavior.getElementInstance(context.getProcessInstanceKey());
+    return processInstance != null ? processInstance.getValue().getBusinessId() : "";
   }
 
   private Either<Failure, String> resolveBusinessIdFromResult(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerCheckScheduler;
 import io.camunda.zeebe.engine.state.conditional.ConditionalSubscription;
 import io.camunda.zeebe.engine.state.immutable.ConditionalSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -73,6 +74,7 @@ public final class CatchEventBehavior {
   private final ProcessMessageSubscriptionState processMessageSubscriptionState;
   private final TimerInstanceState timerInstanceState;
   private final ProcessState processState;
+  private final ElementInstanceState elementInstanceState;
   private final SignalSubscriptionState signalSubscriptionState;
   private final ConditionalSubscriptionState conditionalSubscriptionState;
 
@@ -110,6 +112,7 @@ public final class CatchEventBehavior {
     timerInstanceState = processingState.getTimerState();
     processMessageSubscriptionState = processingState.getProcessMessageSubscriptionState();
     processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
     signalSubscriptionState = processingState.getSignalSubscriptionState();
     conditionalSubscriptionState = processingState.getConditionalSubscriptionState();
 
@@ -120,6 +123,11 @@ public final class CatchEventBehavior {
     this.maxNameFieldLength = maxNameFieldLength;
     this.evaluateBoundaryEventCorrelationKeyInActivityScope =
         evaluateBoundaryEventCorrelationKeyInActivityScope;
+  }
+
+  private String getBusinessId(final long processInstanceKey) {
+    final var processInstance = elementInstanceState.getInstance(processInstanceKey);
+    return processInstance != null ? processInstance.getValue().getBusinessId() : "";
   }
 
   /**
@@ -383,8 +391,10 @@ public final class CatchEventBehavior {
     // Capture the process instance's businessId at subscription-open time and ship it with the
     // OPEN command so the message partition can apply business-id-based filtering locally at
     // correlation time. Reading PI state from another partition at correlation time would
-    // reintroduce the cross-partition chatter the design explicitly avoids.
-    final DirectBuffer businessId = wrapString(context.getBusinessId());
+    // reintroduce the cross-partition chatter the design explicitly avoids. The value is read from
+    // the process-scope element instance (not the subscribing element's record) so that a Business
+    // ID assigned late to a running instance is captured by subscriptions opened afterwards.
+    final DirectBuffer businessId = wrapString(getBusinessId(processInstanceKey));
 
     final int subscriptionPartitionId = routingInfo.partitionForCorrelationKey(correlationKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
@@ -40,6 +40,8 @@ public class ProcessInstanceBusinessIdAssignProcessor
       "Expected to assign a business id to process instance with key '%d', but the element with this key is not a process instance";
   private static final String ERROR_CHILD_INSTANCE =
       "Expected to assign a business id to process instance with key '%d', but it is a child process instance; a business id can only be assigned to root process instances";
+  private static final String ERROR_NOT_ACTIVE =
+      "Expected to assign a business id to process instance with key '%d', but it is not active; a business id can only be assigned to active process instances";
   private static final String ERROR_UNIQUENESS_ENABLED =
       "Expected to assign a business id to process instance with key '%d', but business id assignment is not allowed while business id uniqueness is enabled";
   private static final String ERROR_EMPTY =
@@ -98,6 +100,12 @@ public class ProcessInstanceBusinessIdAssignProcessor
       enrichRejectionCommand(command, processInstanceRecord);
       reject(
           command, RejectionType.INVALID_STATE, ERROR_CHILD_INSTANCE.formatted(processInstanceKey));
+      return;
+    }
+
+    if (!processInstance.isActive()) {
+      enrichRejectionCommand(command, processInstanceRecord);
+      reject(command, RejectionType.INVALID_STATE, ERROR_NOT_ACTIVE.formatted(processInstanceKey));
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBusinessIdAssignProcessor.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.processing.identity.authorization.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.authorization.request.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+/**
+ * Assigns a Business ID once to an already-running root process instance that has none. The
+ * assignment is irreversible and only propagates to artifacts created after it (see ADR 0006). It
+ * is only available while Business ID uniqueness is disabled.
+ */
+public class ProcessInstanceBusinessIdAssignProcessor
+    implements TypedRecordProcessor<ProcessInstanceBusinessIdRecord> {
+
+  private static final String ERROR_NOT_FOUND =
+      "Expected to assign a business id to process instance with key '%d', but no such process instance was found";
+  private static final String ERROR_NOT_A_PROCESS_INSTANCE =
+      "Expected to assign a business id to process instance with key '%d', but the element with this key is not a process instance";
+  private static final String ERROR_CHILD_INSTANCE =
+      "Expected to assign a business id to process instance with key '%d', but it is a child process instance; a business id can only be assigned to root process instances";
+  private static final String ERROR_UNIQUENESS_ENABLED =
+      "Expected to assign a business id to process instance with key '%d', but business id assignment is not allowed while business id uniqueness is enabled";
+  private static final String ERROR_EMPTY =
+      "Expected to assign a business id to process instance with key '%d', but the provided business id is empty";
+  private static final String ERROR_INVALID =
+      "Expected to assign a business id to process instance with key '%d', but the business id %s";
+  private static final String ERROR_ALREADY_ASSIGNED =
+      "Expected to assign a business id to process instance with key '%d', but it already has a business id assigned";
+
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final ElementInstanceState elementInstanceState;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final boolean businessIdUniquenessEnabled;
+
+  public ProcessInstanceBusinessIdAssignProcessor(
+      final Writers writers,
+      final ProcessingState processingState,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final boolean businessIdUniquenessEnabled) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    elementInstanceState = processingState.getElementInstanceState();
+    this.authCheckBehavior = authCheckBehavior;
+    this.businessIdUniquenessEnabled = businessIdUniquenessEnabled;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ProcessInstanceBusinessIdRecord> command) {
+    final ProcessInstanceBusinessIdRecord value = command.getValue();
+    final long processInstanceKey = value.getProcessInstanceKey();
+    final ElementInstance processInstance = elementInstanceState.getInstance(processInstanceKey);
+
+    if (processInstance == null) {
+      reject(command, RejectionType.NOT_FOUND, ERROR_NOT_FOUND.formatted(processInstanceKey));
+      return;
+    }
+
+    final ProcessInstanceRecord processInstanceRecord = processInstance.getValue();
+
+    if (!isAuthorized(command, processInstanceRecord)) {
+      return;
+    }
+
+    if (processInstanceRecord.getBpmnElementType() != BpmnElementType.PROCESS) {
+      reject(
+          command,
+          RejectionType.NOT_FOUND,
+          ERROR_NOT_A_PROCESS_INSTANCE.formatted(processInstanceKey));
+      return;
+    }
+
+    if (processInstanceRecord.hasParentProcessInstance()) {
+      enrichRejectionCommand(command, processInstanceRecord);
+      reject(
+          command, RejectionType.INVALID_STATE, ERROR_CHILD_INSTANCE.formatted(processInstanceKey));
+      return;
+    }
+
+    if (businessIdUniquenessEnabled) {
+      enrichRejectionCommand(command, processInstanceRecord);
+      reject(
+          command,
+          RejectionType.INVALID_STATE,
+          ERROR_UNIQUENESS_ENABLED.formatted(processInstanceKey));
+      return;
+    }
+
+    final String businessId = value.getBusinessId();
+    if (businessId.isEmpty()) {
+      enrichRejectionCommand(command, processInstanceRecord);
+      reject(command, RejectionType.INVALID_ARGUMENT, ERROR_EMPTY.formatted(processInstanceKey));
+      return;
+    }
+
+    final var validation = BusinessIdValidator.validate(businessId);
+    if (validation.isLeft()) {
+      enrichRejectionCommand(command, processInstanceRecord);
+      reject(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          ERROR_INVALID.formatted(processInstanceKey, validation.getLeft()));
+      return;
+    }
+
+    final String existingBusinessId = processInstanceRecord.getBusinessId();
+    if (!existingBusinessId.isEmpty()) {
+      if (existingBusinessId.equals(businessId)) {
+        // Idempotent no-op: the identical value is already assigned. Respond success without
+        // writing a second ASSIGNED event (see ADR 0006, D3).
+        enrichAssignmentCommand(value, processInstanceRecord);
+        responseWriter.writeEventOnCommand(
+            processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value, command);
+        return;
+      }
+      enrichRejectionCommand(command, processInstanceRecord);
+      reject(
+          command,
+          RejectionType.INVALID_STATE,
+          ERROR_ALREADY_ASSIGNED.formatted(processInstanceKey));
+      return;
+    }
+
+    enrichAssignmentCommand(value, processInstanceRecord);
+    stateWriter.appendFollowUpEvent(
+        processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value);
+    responseWriter.writeEventOnCommand(
+        processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGNED, value, command);
+  }
+
+  private boolean isAuthorized(
+      final TypedRecord<ProcessInstanceBusinessIdRecord> command,
+      final ProcessInstanceRecord processInstanceRecord) {
+    final var authorizationRequest =
+        AuthorizationRequest.builder()
+            .command(command)
+            .resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .permissionType(PermissionType.UPDATE_PROCESS_INSTANCE)
+            .tenantId(processInstanceRecord.getTenantId())
+            .addResourceId(processInstanceRecord.getBpmnProcessId())
+            .build();
+    final var isAuthorized = authCheckBehavior.isAuthorizedOrInternalCommand(authorizationRequest);
+    if (isAuthorized.isRight()) {
+      return true;
+    }
+
+    final var rejection = isAuthorized.getLeft();
+    final String errorMessage =
+        RejectionType.NOT_FOUND.equals(rejection.type())
+            ? AuthorizationCheckBehavior.NOT_FOUND_ERROR_MESSAGE.formatted(
+                "assign a business id to a process instance",
+                processInstanceRecord.getProcessInstanceKey(),
+                "such process instance")
+            : rejection.reason();
+    enrichRejectionCommand(command, processInstanceRecord);
+    reject(command, rejection.type(), errorMessage);
+    return false;
+  }
+
+  private void reject(
+      final TypedRecord<ProcessInstanceBusinessIdRecord> command,
+      final RejectionType rejectionType,
+      final String reason) {
+    rejectionWriter.appendRejection(command, rejectionType, reason);
+    responseWriter.writeRejectionOnCommand(command, rejectionType, reason);
+  }
+
+  /**
+   * Enriches the assignment value with the process instance context so the {@code ASSIGNED} event
+   * and its exporters carry the full process information.
+   */
+  private void enrichAssignmentCommand(
+      final ProcessInstanceBusinessIdRecord value,
+      final ProcessInstanceRecord processInstanceRecord) {
+    value
+        .setTenantId(processInstanceRecord.getTenantId())
+        .setProcessDefinitionKey(processInstanceRecord.getProcessDefinitionKey())
+        .setBpmnProcessId(processInstanceRecord.getBpmnProcessId())
+        .setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey());
+  }
+
+  /**
+   * Enriches the rejected command value with fields from the process instance record so rejection
+   * records have the proper context for audit log export.
+   */
+  private void enrichRejectionCommand(
+      final TypedRecord<ProcessInstanceBusinessIdRecord> command,
+      final ProcessInstanceRecord processInstanceRecord) {
+    command
+        .getValue()
+        .setTenantId(processInstanceRecord.getTenantId())
+        .setProcessDefinitionKey(processInstanceRecord.getProcessDefinitionKey())
+        .setBpmnProcessId(processInstanceRecord.getBpmnProcessId())
+        .setRootProcessInstanceKey(processInstanceRecord.getRootProcessInstanceKey());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -58,6 +58,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MultiInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -102,6 +103,7 @@ public final class EventAppliers implements EventApplier {
     registerProcessInstanceCreationAppliers(state);
     registerProcessInstanceModificationAppliers(state);
     registerProcessInstanceMigrationAppliers();
+    registerProcessInstanceBusinessIdAppliers(state);
     register(ProcessInstanceResultIntent.COMPLETED, NOOP_EVENT_APPLIER);
     register(ProcessInstanceBatchIntent.ACTIVATED, NOOP_EVENT_APPLIER);
     register(ProcessInstanceBatchIntent.TERMINATED, NOOP_EVENT_APPLIER);
@@ -425,6 +427,13 @@ public final class EventAppliers implements EventApplier {
 
   private void registerProcessInstanceMigrationAppliers() {
     register(ProcessInstanceMigrationIntent.MIGRATED, NOOP_EVENT_APPLIER);
+  }
+
+  private void registerProcessInstanceBusinessIdAppliers(final MutableProcessingState state) {
+    register(
+        ProcessInstanceBusinessIdIntent.ASSIGNED,
+        1,
+        new ProcessInstanceBusinessIdAssignedV1Applier(state.getElementInstanceState()));
   }
 
   private void registerJobIntentEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceBusinessIdAssignedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceBusinessIdAssignedV1Applier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+
+/**
+ * Applies the late assignment of a Business ID to a running root process instance (see ADR 0006).
+ *
+ * <p>It updates the Business ID on the process-scope element-instance record so that artifacts
+ * created afterwards snapshot it, and inserts the uniqueness index for the root instance so the
+ * existing completion/termination cleanup removes it later. The processor guarantees this event is
+ * only produced for a root process instance that currently has no Business ID.
+ */
+final class ProcessInstanceBusinessIdAssignedV1Applier
+    implements TypedEventApplier<ProcessInstanceBusinessIdIntent, ProcessInstanceBusinessIdRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public ProcessInstanceBusinessIdAssignedV1Applier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceBusinessIdRecord value) {
+    final String businessId = value.getBusinessId();
+
+    elementInstanceState.updateInstance(
+        value.getProcessInstanceKey(), instance -> instance.getValue().setBusinessId(businessId));
+
+    elementInstanceState.insertProcessInstanceKeyByBusinessId(
+        businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareAssignProcessInstanceBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareAssignProcessInstanceBusinessIdTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.multitenancy;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/**
+ * Verifies that late Business ID assignment (ADR 0006) respects multi-tenancy: the ASSIGN command
+ * is rejected when the caller is not authorized for the tenant that owns the process instance, and
+ * succeeds when it is.
+ */
+public class TenantAwareAssignProcessInstanceBusinessIdTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withMultiTenancyChecksEnabled(true)
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+
+  private static final String PROCESS_ID = "process";
+  private static final String CUSTOM_TENANT = "custom-tenant";
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectAssignBusinessIdForUnauthorizedTenant() {
+    // given
+    final var username = "username";
+    final var user = ENGINE.user().newUser(username).create().getValue();
+    ENGINE.tenant().newTenant().withTenantId("another-tenant").create();
+    ENGINE
+        .tenant()
+        .addEntity("another-tenant")
+        .withEntityType(EntityType.USER)
+        .withEntityId(username)
+        .add();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .withTenantId(CUSTOM_TENANT)
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(CUSTOM_TENANT).create();
+
+    // when: the user is not authorized for the tenant that owns the process instance
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .businessIdAssignment()
+            .withBusinessId("biz-1")
+            .expectRejection()
+            .assign(user.getUsername());
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldAssignBusinessIdForAuthorizedTenant() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .withTenantId(CUSTOM_TENANT)
+        .deploy();
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(CUSTOM_TENANT).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .forAuthorizedTenants(CUSTOM_TENANT)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+
+    // then
+    final var assigned =
+        RecordingExporter.processInstanceBusinessIdRecords(ProcessInstanceBusinessIdIntent.ASSIGNED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getValue();
+    assertThat(assigned.getBusinessId()).isEqualTo("biz-1");
+    assertThat(assigned.getTenantId()).isEqualTo(CUSTOM_TENANT);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdAuthorizationTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.config.initialization.ConfiguredUser;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceMatcher;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/** Authorization tests for late Business ID assignment (ADR 0006, D9). */
+public class AssignProcessInstanceBusinessIdAuthorizationTest {
+
+  private static final String PROCESS_ID = "processId";
+  private static final ConfiguredUser DEFAULT_USER =
+      new ConfiguredUser(
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(),
+          UUID.randomUUID().toString());
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withAuthorizationsEnabled(true)
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false))
+          .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)))
+          .withSecurityConfig(
+              cfg -> {
+                final var defaultRoles = new HashMap<>(cfg.getInitialization().getDefaultRoles());
+                defaultRoles.put("admin", Map.of("users", List.of(DEFAULT_USER.username())));
+                cfg.getInitialization().setDefaultRoles(defaultRoles);
+              });
+
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Before
+  public void before() {
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy(DEFAULT_USER.username());
+  }
+
+  @Test
+  public void shouldBeAuthorizedWithDefaultUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign(DEFAULT_USER.username());
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceBusinessIdRecords(
+                    ProcessInstanceBusinessIdIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedWithUpdateProcessInstancePermission() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var user = createUser();
+    addPermissionsToUser(
+        user,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.UPDATE_PROCESS_INSTANCE,
+        AuthorizationResourceMatcher.ID,
+        PROCESS_ID);
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign(user.getUsername());
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceBusinessIdRecords(
+                    ProcessInstanceBusinessIdIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .exists())
+        .isTrue();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedWithoutPermission() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var user = createUser();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .expectRejection()
+        .assign(user.getUsername());
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceBusinessIdRecords().onlyCommandRejections().getFirst())
+        .hasRejectionType(RejectionType.FORBIDDEN)
+        .hasRejectionReason(
+            "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'"
+                .formatted(PROCESS_ID));
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+
+  private void addPermissionsToUser(
+      final UserRecordValue user,
+      final AuthorizationResourceType authorization,
+      final PermissionType permissionType,
+      final AuthorizationResourceMatcher matcher,
+      final String resourceId) {
+    engine
+        .authorization()
+        .newAuthorization()
+        .withPermissions(permissionType)
+        .withOwnerId(user.getUsername())
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceType(authorization)
+        .withResourceMatcher(matcher)
+        .withResourceId(resourceId)
+        .create(DEFAULT_USER.username());
+  }
+
+  private long createProcessInstance() {
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.username());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdPropagationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdPropagationTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies the forward-only propagation of a late-assigned Business ID (ADR 0006, D8): artifacts
+ * created after the assignment carry the Business ID, while artifacts that already existed keep an
+ * empty one. Covers each artifact type that captures the Business ID at creation.
+ */
+public final class AssignProcessInstanceBusinessIdPropagationTest {
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldPropagateToJobsButNotToPreExistingOnes() {
+    // given: a job exists before assignment, and one is created after
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("p")
+                .startEvent()
+                .serviceTask("before", t -> t.zeebeJobType("t-before"))
+                .userTask("wait", AbstractUserTaskBuilder::zeebeUserTask)
+                .serviceTask("after", t -> t.zeebeJobType("t-after"))
+                .endEvent()
+                .done())
+        .deploy();
+    final long pi = engine.processInstance().ofBpmnProcessId("p").create();
+    engine.job().ofInstance(pi).withType("t-before").complete();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(pi)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+    engine.userTask().ofInstance(pi).complete();
+
+    // then
+    assertThat(businessIdOfJob(pi, "t-before")).describedAs("pre-existing job").isEqualTo("");
+    assertThat(businessIdOfJob(pi, "t-after"))
+        .describedAs("job after assignment")
+        .isEqualTo("biz-1");
+  }
+
+  @Test
+  public void shouldPropagateToUserTasksButNotToPreExistingOnes() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("p")
+                .startEvent()
+                .userTask("before", AbstractUserTaskBuilder::zeebeUserTask)
+                .userTask("after", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
+    final long pi = engine.processInstance().ofBpmnProcessId("p").create();
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(pi)
+        .withElementId("before")
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(pi)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+    engine.userTask().ofInstance(pi).complete();
+
+    // then
+    assertThat(businessIdOfUserTask(pi, "before"))
+        .describedAs("pre-existing user task")
+        .isEqualTo("");
+    assertThat(businessIdOfUserTask(pi, "after"))
+        .describedAs("user task after assignment")
+        .isEqualTo("biz-1");
+  }
+
+  @Test
+  public void shouldPropagateToMessageSubscriptionsButNotToPreExistingOnes() {
+    // given: a boundary message subscription exists before assignment, and an intermediate catch
+    // event subscribes after
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("p")
+                .startEvent()
+                .userTask("wait", AbstractUserTaskBuilder::zeebeUserTask)
+                .boundaryEvent(
+                    "boundary",
+                    b -> b.message(m -> m.name("m-before").zeebeCorrelationKeyExpression("key")))
+                .endEvent()
+                .moveToActivity("wait")
+                .intermediateCatchEvent(
+                    "catch",
+                    e -> e.message(m -> m.name("m-after").zeebeCorrelationKeyExpression("key")))
+                .endEvent()
+                .done())
+        .deploy();
+    final long pi =
+        engine.processInstance().ofBpmnProcessId("p").withVariables(Map.of("key", "k1")).create();
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(pi)
+        .withMessageName("m-before")
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(pi)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+    engine.userTask().ofInstance(pi).complete();
+
+    // then
+    assertThat(businessIdOfSubscription(pi, "m-before"))
+        .describedAs("pre-existing message subscription")
+        .isEqualTo("");
+    assertThat(businessIdOfSubscription(pi, "m-after"))
+        .describedAs("message subscription after assignment")
+        .isEqualTo("biz-1");
+  }
+
+  @Test
+  public void shouldPropagateToDecisionsButNotToPreExistingOnes() {
+    // given: a decision evaluated before assignment, and one evaluated after
+    engine
+        .deployment()
+        .withXmlClasspathResource("/dmn/decision-table.dmn")
+        .withXmlResource(
+            Bpmn.createExecutableProcess("p")
+                .startEvent()
+                .businessRuleTask(
+                    "dmn-before",
+                    t -> t.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable("r1"))
+                .userTask("wait", AbstractUserTaskBuilder::zeebeUserTask)
+                .businessRuleTask(
+                    "dmn-after",
+                    t -> t.zeebeCalledDecisionId("jedi_or_sith").zeebeResultVariable("r2"))
+                .endEvent()
+                .done())
+        .deploy();
+    final long pi =
+        engine
+            .processInstance()
+            .ofBpmnProcessId("p")
+            .withVariables(Map.of("lightsaberColor", "blue"))
+            .create();
+    RecordingExporter.decisionEvaluationRecords(DecisionEvaluationIntent.EVALUATED)
+        .withProcessInstanceKey(pi)
+        .withElementId("dmn-before")
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(pi)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+    engine.userTask().ofInstance(pi).complete();
+
+    // then
+    assertThat(businessIdOfDecision(pi, "dmn-before"))
+        .describedAs("pre-existing decision evaluation")
+        .isEqualTo("");
+    assertThat(businessIdOfDecision(pi, "dmn-after"))
+        .describedAs("decision evaluation after assignment")
+        .isEqualTo("biz-1");
+  }
+
+  @Test
+  public void shouldPropagateToCallActivityChildrenButNotToPreExistingOnes() {
+    // given: a child started before assignment, and one started after
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("child-before").startEvent().endEvent().done())
+        .withXmlResource(
+            Bpmn.createExecutableProcess("child-after")
+                .startEvent()
+                .userTask("childTask", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .withXmlResource(
+            Bpmn.createExecutableProcess("p")
+                .startEvent()
+                .callActivity("call-before", c -> c.zeebeProcessId("child-before"))
+                .userTask("wait", AbstractUserTaskBuilder::zeebeUserTask)
+                .callActivity("call-after", c -> c.zeebeProcessId("child-after"))
+                .endEvent()
+                .done())
+        .deploy();
+    final long pi = engine.processInstance().ofBpmnProcessId("p").create();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withParentProcessInstanceKey(pi)
+        .withBpmnProcessId("child-before")
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(pi)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+    engine.userTask().ofInstance(pi).complete();
+
+    // then
+    assertThat(businessIdOfChild(pi, "child-before"))
+        .describedAs("pre-existing call activity child")
+        .isEqualTo("");
+    assertThat(businessIdOfChild(pi, "child-after"))
+        .describedAs("call activity child after assignment")
+        .isEqualTo("biz-1");
+  }
+
+  private String businessIdOfJob(final long processInstanceKey, final String jobType) {
+    return RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(jobType)
+        .getFirst()
+        .getValue()
+        .getBusinessId();
+  }
+
+  private String businessIdOfUserTask(final long processInstanceKey, final String elementId) {
+    return RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(elementId)
+        .getFirst()
+        .getValue()
+        .getBusinessId();
+  }
+
+  private String businessIdOfSubscription(final long processInstanceKey, final String messageName) {
+    return RecordingExporter.processMessageSubscriptionRecords(
+            ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName(messageName)
+        .getFirst()
+        .getValue()
+        .getBusinessId();
+  }
+
+  private String businessIdOfDecision(final long processInstanceKey, final String elementId) {
+    return RecordingExporter.decisionEvaluationRecords(DecisionEvaluationIntent.EVALUATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(elementId)
+        .getFirst()
+        .getValue()
+        .getBusinessId();
+  }
+
+  private String businessIdOfChild(final long processInstanceKey, final String childProcessId) {
+    return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withParentProcessInstanceKey(processInstanceKey)
+        .withBpmnProcessId(childProcessId)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst()
+        .getValue()
+        .getBusinessId();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdTest.java
@@ -136,6 +136,43 @@ public final class AssignProcessInstanceBusinessIdTest {
   }
 
   @Test
+  public void shouldRejectWhenProcessInstanceIsNotActive() {
+    // given: a process with a process-level end execution listener that holds the root process
+    // instance in the (non-active) COMPLETING state until the listener job completes
+    final String endListenerType = "end-listener";
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeExecutionListener(el -> el.end().type(endListenerType))
+                .startEvent()
+                .manualTask()
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // wait until the process instance is completing (i.e. no longer active)
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETING)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS)
+        .getFirst();
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .businessIdAssignment()
+            .withBusinessId("biz-1")
+            .expectRejection()
+            .assign();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+  }
+
+  @Test
   public void shouldRejectWhenBusinessIdIsEmpty() {
     // given
     engine.deployment().withXmlResource(USER_TASK_PROCESS).deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdTest.java
@@ -242,4 +242,61 @@ public final class AssignProcessInstanceBusinessIdTest {
         .filteredOn(r -> r.getIntent() == ProcessInstanceBusinessIdIntent.ASSIGNED)
         .hasSize(1);
   }
+
+  @Test
+  public void shouldCarryAssignedBusinessIdOnCompletion() {
+    // given: a business id is assigned to a running instance
+    engine.deployment().withXmlResource(USER_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+
+    // when: the instance completes
+    engine.userTask().ofInstance(processInstanceKey).complete();
+
+    // then: the process completion carries the late-assigned business id, which drives the existing
+    // uniqueness-index cleanup. The instance completing without error proves the index entry
+    // inserted on assignment is removed symmetrically (ADR 0006, D7).
+    final var completed =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getValue();
+    assertThat(completed.getBusinessId()).isEqualTo("biz-1");
+  }
+
+  @Test
+  public void shouldCarryAssignedBusinessIdOnTermination() {
+    // given: a business id is assigned to a running instance
+    engine.deployment().withXmlResource(USER_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+
+    // when: the instance is canceled
+    engine.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then: the process termination carries the late-assigned business id, which drives the
+    // existing
+    // uniqueness-index cleanup. The instance terminating without error proves the index entry
+    // inserted on assignment is removed symmetrically (ADR 0006, D7).
+    final var terminated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getValue();
+    assertThat(terminated.getBusinessId()).isEqualTo("biz-1");
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdTest.java
@@ -90,7 +90,11 @@ public final class AssignProcessInstanceBusinessIdTest {
             .assign();
 
     // then
-    assertThat(rejection).hasRejectionType(RejectionType.NOT_FOUND);
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but no such process instance was found"
+                .formatted(unknownKey));
   }
 
   @Test
@@ -132,7 +136,11 @@ public final class AssignProcessInstanceBusinessIdTest {
             .assign();
 
     // then
-    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but it is a child process instance; a business id can only be assigned to root process instances"
+                .formatted(childKey));
   }
 
   @Test
@@ -169,7 +177,11 @@ public final class AssignProcessInstanceBusinessIdTest {
             .assign();
 
     // then
-    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but it is not active; a business id can only be assigned to active process instances"
+                .formatted(processInstanceKey));
   }
 
   @Test
@@ -189,7 +201,11 @@ public final class AssignProcessInstanceBusinessIdTest {
             .assign();
 
     // then
-    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but the provided business id is empty"
+                .formatted(processInstanceKey));
   }
 
   @Test
@@ -211,7 +227,11 @@ public final class AssignProcessInstanceBusinessIdTest {
             .assign();
 
     // then
-    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but the business id exceeds the max length of %d"
+                .formatted(processInstanceKey, BusinessIdValidator.MAX_BUSINESS_ID_LENGTH));
   }
 
   @Test
@@ -238,7 +258,11 @@ public final class AssignProcessInstanceBusinessIdTest {
             .assign();
 
     // then
-    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but it already has a business id assigned"
+                .formatted(processInstanceKey));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies the late Business ID assignment command with Business ID uniqueness disabled (ADR 0006):
+ * the happy path, the rejection matrix, and that the assignment integrates with the instance
+ * lifecycle. Rejection when uniqueness is enabled is covered by {@link
+ * AssignProcessInstanceBusinessIdWhenUniquenessEnabledTest}.
+ */
+public final class AssignProcessInstanceBusinessIdTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final BpmnModelInstance USER_TASK_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+          .endEvent()
+          .done();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(false));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldAssignBusinessIdToRunningInstance() {
+    // given
+    engine.deployment().withXmlResource(USER_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+
+    // then
+    final var assigned =
+        RecordingExporter.processInstanceBusinessIdRecords(ProcessInstanceBusinessIdIntent.ASSIGNED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getValue();
+    assertThat(assigned.getBusinessId()).isEqualTo("biz-1");
+    assertThat(assigned.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(assigned.getBpmnProcessId()).isEqualTo(PROCESS_ID);
+  }
+
+  @Test
+  public void shouldRejectWhenProcessInstanceNotFound() {
+    // given
+    final long unknownKey = 123_456_789L;
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(unknownKey)
+            .businessIdAssignment()
+            .withBusinessId("biz-1")
+            .expectRejection()
+            .assign();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectWhenTargetIsChildProcessInstance() {
+    // given
+    final String childProcessId = "childProcess";
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(childProcessId)
+                .startEvent()
+                .userTask("childTask", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .callActivity("call", c -> c.zeebeProcessId(childProcessId))
+                .endEvent()
+                .done())
+        .deploy();
+    final long parentKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long childKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(childKey)
+            .businessIdAssignment()
+            .withBusinessId("biz-1")
+            .expectRejection()
+            .assign();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+  }
+
+  @Test
+  public void shouldRejectWhenBusinessIdIsEmpty() {
+    // given
+    engine.deployment().withXmlResource(USER_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .businessIdAssignment()
+            .withBusinessId("")
+            .expectRejection()
+            .assign();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldRejectWhenBusinessIdExceedsMaxLength() {
+    // given
+    engine.deployment().withXmlResource(USER_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final String tooLong = "b".repeat(BusinessIdValidator.MAX_BUSINESS_ID_LENGTH + 1);
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .businessIdAssignment()
+            .withBusinessId(tooLong)
+            .expectRejection()
+            .assign();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_ARGUMENT);
+  }
+
+  @Test
+  public void shouldRejectWhenAlreadyAssignedWithDifferentValue() {
+    // given
+    engine.deployment().withXmlResource(USER_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .businessIdAssignment()
+            .withBusinessId("biz-2")
+            .expectRejection()
+            .assign();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+  }
+
+  @Test
+  public void shouldAcceptIdenticalAssignmentAsNoOpWithoutSecondEvent() {
+    // given
+    engine.deployment().withXmlResource(USER_TASK_PROCESS).deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assign();
+
+    // when: an identical assignment (no-op) followed by a different one used as a barrier
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-1")
+        .assignExpectingNoEvent();
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .businessIdAssignment()
+        .withBusinessId("biz-2")
+        .expectRejection()
+        .assign();
+
+    // then: only the first assignment produced an ASSIGNED event
+    final var records =
+        RecordingExporter.processInstanceBusinessIdRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .limit(r -> r.getRecordType() == RecordType.COMMAND_REJECTION)
+            .asList();
+    assertThat(records)
+        .filteredOn(r -> r.getIntent() == ProcessInstanceBusinessIdIntent.ASSIGNED)
+        .hasSize(1);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdWhenUniquenessEnabledTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdWhenUniquenessEnabledTest.java
@@ -60,6 +60,10 @@ public final class AssignProcessInstanceBusinessIdWhenUniquenessEnabledTest {
             .assign();
 
     // then
-    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to assign a business id to process instance with key '%d', but business id assignment is not allowed while business id uniqueness is enabled"
+                .formatted(processInstanceKey));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdWhenUniquenessEnabledTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/AssignProcessInstanceBusinessIdWhenUniquenessEnabledTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * Verifies that late Business ID assignment is unavailable while Business ID uniqueness is enabled
+ * (ADR 0006, D5). Kept separate from {@link AssignProcessInstanceBusinessIdTest} so the engine is
+ * configured with uniqueness enabled from the start, avoiding a mid-test configuration change.
+ */
+public final class AssignProcessInstanceBusinessIdWhenUniquenessEnabledTest {
+
+  private static final String PROCESS_ID = "process";
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withEngineConfig(config -> config.setBusinessIdUniquenessEnabled(true));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldRejectAssignmentWhenUniquenessIsEnabled() {
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent()
+                .done())
+        .deploy();
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final var rejection =
+        engine
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .businessIdAssignment()
+            .withBusinessId("biz-1")
+            .expectRejection()
+            .assign();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRuntimeInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
@@ -27,11 +28,13 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
@@ -413,6 +416,11 @@ public final class ProcessInstanceClient {
 
     public ProcessInstanceMigrationClient migration() {
       return new ProcessInstanceMigrationClient(writer, processInstanceKey, authorizedTenants);
+    }
+
+    public ProcessInstanceBusinessIdAssignmentClient businessIdAssignment() {
+      return new ProcessInstanceBusinessIdAssignmentClient(
+          writer, processInstanceKey, authorizedTenants);
     }
   }
 
@@ -1014,6 +1022,95 @@ public final class ProcessInstanceClient {
       } else {
         return expectation.apply(position);
       }
+    }
+  }
+
+  public static class ProcessInstanceBusinessIdAssignmentClient {
+
+    private static final Function<Long, Record<ProcessInstanceBusinessIdRecordValue>>
+        SUCCESS_EXPECTATION =
+            (position) ->
+                RecordingExporter.processInstanceBusinessIdRecords()
+                    .withIntent(ProcessInstanceBusinessIdIntent.ASSIGNED)
+                    .withSourceRecordPosition(position)
+                    .getFirst();
+
+    private static final Function<Long, Record<ProcessInstanceBusinessIdRecordValue>>
+        REJECTION_EXPECTATION =
+            (processInstanceKey) ->
+                RecordingExporter.processInstanceBusinessIdRecords()
+                    .onlyCommandRejections()
+                    .withIntent(ProcessInstanceBusinessIdIntent.ASSIGN)
+                    .withRecordKey(processInstanceKey)
+                    .withProcessInstanceKey(processInstanceKey)
+                    .getFirst();
+
+    private Function<Long, Record<ProcessInstanceBusinessIdRecordValue>> expectation =
+        SUCCESS_EXPECTATION;
+
+    private final CommandWriter writer;
+    private final long processInstanceKey;
+    private final ProcessInstanceBusinessIdRecord record;
+    private String[] authorizedTenants;
+
+    public ProcessInstanceBusinessIdAssignmentClient(
+        final CommandWriter writer,
+        final long processInstanceKey,
+        final String[] authorizedTenants) {
+      this.writer = writer;
+      this.processInstanceKey = processInstanceKey;
+      this.authorizedTenants = authorizedTenants;
+      record = new ProcessInstanceBusinessIdRecord().setProcessInstanceKey(processInstanceKey);
+    }
+
+    public ProcessInstanceBusinessIdAssignmentClient withBusinessId(final String businessId) {
+      record.setBusinessId(businessId);
+      return this;
+    }
+
+    public ProcessInstanceBusinessIdAssignmentClient forAuthorizedTenants(
+        final String... authorizedTenants) {
+      this.authorizedTenants = authorizedTenants;
+      return this;
+    }
+
+    public ProcessInstanceBusinessIdAssignmentClient expectRejection() {
+      expectation = REJECTION_EXPECTATION;
+      return this;
+    }
+
+    public Record<ProcessInstanceBusinessIdRecordValue> assign() {
+      final var position =
+          writer.writeCommand(
+              processInstanceKey,
+              ProcessInstanceBusinessIdIntent.ASSIGN,
+              record,
+              authorizedTenants);
+      return expectation == REJECTION_EXPECTATION
+          ? expectation.apply(processInstanceKey)
+          : expectation.apply(position);
+    }
+
+    public Record<ProcessInstanceBusinessIdRecordValue> assign(final String username) {
+      final var position =
+          writer.writeCommand(
+              processInstanceKey,
+              ProcessInstanceBusinessIdIntent.ASSIGN,
+              username,
+              record,
+              authorizedTenants);
+      return expectation == REJECTION_EXPECTATION
+          ? expectation.apply(processInstanceKey)
+          : expectation.apply(position);
+    }
+
+    /**
+     * Writes the ASSIGN command without awaiting a follow-up event. Used to exercise the idempotent
+     * no-op path, where an identical value produces no {@code ASSIGNED} event (see ADR 0006, D3).
+     */
+    public void assignExpectingNoEvent() {
+      writer.writeCommand(
+          processInstanceKey, ProcessInstanceBusinessIdIntent.ASSIGN, record, authorizedTenants);
     }
   }
 }

--- a/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstanceBusinessId_ASSIGNED_v1.golden
+++ b/zeebe/engine/src/test/resources/state/appliers/golden/ProcessInstanceBusinessId_ASSIGNED_v1.golden
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+
+/**
+ * Applies the late assignment of a Business ID to a running root process instance (see ADR 0006).
+ *
+ * <p>It updates the Business ID on the process-scope element-instance record so that artifacts
+ * created afterwards snapshot it, and inserts the uniqueness index for the root instance so the
+ * existing completion/termination cleanup removes it later. The processor guarantees this event is
+ * only produced for a root process instance that currently has no Business ID.
+ */
+final class ProcessInstanceBusinessIdAssignedV1Applier
+    implements TypedEventApplier<ProcessInstanceBusinessIdIntent, ProcessInstanceBusinessIdRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public ProcessInstanceBusinessIdAssignedV1Applier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceBusinessIdRecord value) {
+    final String businessId = value.getBusinessId();
+
+    elementInstanceState.updateInstance(
+        value.getProcessInstanceKey(), instance -> instance.getValue().setBusinessId(businessId));
+
+    elementInstanceState.insertProcessInstanceKeyByBusinessId(
+        businessId, value.getBpmnProcessId(), value.getTenantId(), value.getProcessInstanceKey());
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -96,6 +96,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
       case PROCESS_INSTANCE_CREATION -> index.processInstanceCreation;
       case PROCESS_INSTANCE_MIGRATION -> index.processInstanceMigration;
       case PROCESS_INSTANCE_MODIFICATION -> index.processInstanceModification;
+      case PROCESS_INSTANCE_BUSINESS_ID -> index.processInstanceBusinessId;
       case PROCESS_MESSAGE_SUBSCRIPTION -> index.processMessageSubscription;
       case DECISION_REQUIREMENTS -> index.decisionRequirements;
       case DECISION -> index.decision;
@@ -220,6 +221,7 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
     public boolean processInstanceCreation = true;
     public boolean processInstanceMigration = true;
     public boolean processInstanceModification = true;
+    public boolean processInstanceBusinessId = true;
     public boolean processMessageSubscription = true;
     public boolean variable = true;
     public boolean variableDocument = true;
@@ -659,6 +661,8 @@ public class ElasticsearchExporterConfiguration implements FilterConfiguration {
           + processInstanceMigration
           + ", processInstanceModification="
           + processInstanceModification
+          + ", processInstanceBusinessId="
+          + processInstanceBusinessId
           + ", processMessageSubscription="
           + processMessageSubscription
           + ", variable="

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterSchemaManager.java
@@ -124,6 +124,9 @@ public class ElasticsearchExporterSchemaManager {
       if (index.processInstanceModification) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION, version);
       }
+      if (index.processInstanceBusinessId) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BUSINESS_ID, version);
+      }
       if (index.processMessageSubscription) {
         createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
       }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-business-id-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/elasticsearch/zeebe-record-process-instance-business-id-template.json
@@ -1,0 +1,51 @@
+{
+  "index_patterns": [
+    "zeebe-record_process-instance-business-id_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-business-id": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "businessId": {
+              "type": "keyword"
+            },
+            "processDefinitionKey": {
+              "type": "long"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "tenantId": {
+              "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "enabled": false
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -45,6 +45,7 @@ final class TestSupport {
       case PROCESS_INSTANCE_CREATION -> config.processInstanceCreation = value;
       case PROCESS_INSTANCE_MIGRATION -> config.processInstanceMigration = value;
       case PROCESS_INSTANCE_MODIFICATION -> config.processInstanceModification = value;
+      case PROCESS_INSTANCE_BUSINESS_ID -> config.processInstanceBusinessId = value;
       case ERROR -> config.error = value;
       case PROCESS -> config.process = value;
       case DECISION -> config.decision = value;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -141,6 +141,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
       case PROCESS_INSTANCE_CREATION -> index.processInstanceCreation;
       case PROCESS_INSTANCE_MIGRATION -> index.processInstanceMigration;
       case PROCESS_INSTANCE_MODIFICATION -> index.processInstanceModification;
+      case PROCESS_INSTANCE_BUSINESS_ID -> index.processInstanceBusinessId;
       case PROCESS_MESSAGE_SUBSCRIPTION -> index.processMessageSubscription;
       case DECISION_REQUIREMENTS -> index.decisionRequirements;
       case DECISION -> index.decision;
@@ -247,6 +248,7 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
     public boolean processInstanceCreation = true;
     public boolean processInstanceMigration = true;
     public boolean processInstanceModification = true;
+    public boolean processInstanceBusinessId = true;
     public boolean processMessageSubscription = true;
     public boolean variable = true;
     public boolean variableDocument = true;
@@ -684,6 +686,8 @@ public class OpensearchExporterConfiguration implements FilterConfiguration {
           + processInstanceMigration
           + ", processInstanceModification="
           + processInstanceModification
+          + ", processInstanceBusinessId="
+          + processInstanceBusinessId
           + ", processMessageSubscription="
           + processMessageSubscription
           + ", decisionRequirements="

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterSchemaManager.java
@@ -98,6 +98,9 @@ public class OpensearchExporterSchemaManager {
       if (index.processInstanceModification) {
         createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION, version);
       }
+      if (index.processInstanceBusinessId) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BUSINESS_ID, version);
+      }
       if (index.processMessageSubscription) {
         createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
       }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-business-id-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/opensearch/zeebe-record-process-instance-business-id-template.json
@@ -1,0 +1,57 @@
+{
+  "index_patterns": [
+    "zeebe-record_process-instance-business-id_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "number_of_replicas": "1",
+        "queries": {
+          "cache": {
+            "enabled": false
+          }
+        }
+      }
+    },
+    "aliases": {
+      "zeebe-record-process-instance-business-id": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "processInstanceKey": {
+              "type": "long"
+            },
+            "businessId": {
+              "type": "keyword"
+            },
+            "processDefinitionKey": {
+              "type": "long"
+            },
+            "rootProcessInstanceKey": {
+              "type": "long"
+            },
+            "bpmnProcessId": {
+              "type": "keyword"
+            },
+            "tenantId": {
+              "type": "keyword"
+            },
+            "elementInstanceKey": {
+              "enabled": false
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -45,6 +45,7 @@ final class TestSupport {
       case PROCESS_INSTANCE_CREATION -> config.processInstanceCreation = value;
       case PROCESS_INSTANCE_MIGRATION -> config.processInstanceMigration = value;
       case PROCESS_INSTANCE_MODIFICATION -> config.processInstanceModification = value;
+      case PROCESS_INSTANCE_BUSINESS_ID -> config.processInstanceBusinessId = value;
       case ERROR -> config.error = value;
       case PROCESS -> config.process = value;
       case DECISION -> config.decision = value;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -63,6 +63,7 @@ import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
 import io.camunda.zeebe.protocol.impl.record.value.multiinstance.MultiInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessEventRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
@@ -184,6 +185,7 @@ public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
       case ValueType.SIGNAL -> new SignalRecord();
       case ValueType.COMMAND_DISTRIBUTION -> new CommandDistributionRecord();
       case ValueType.PROCESS_INSTANCE_BATCH -> new ProcessInstanceBatchRecord();
+      case ValueType.PROCESS_INSTANCE_BUSINESS_ID -> new ProcessInstanceBusinessIdRecord();
       case ValueType.RESOURCE_DELETION -> new ResourceDeletionRecord();
       case ValueType.FORM -> new FormRecord();
       case ValueType.USER_TASK -> new UserTaskRecord();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBusinessIdRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBusinessIdRecord.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+
+public final class ProcessInstanceBusinessIdRecord extends UnifiedRecordValue
+    implements ProcessInstanceBusinessIdRecordValue {
+
+  private static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+
+  private final LongProperty processInstanceKeyProperty =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY, -1);
+  private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
+  private final StringProperty tenantIdProperty =
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProperty =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final LongProperty processDefinitionKeyProperty =
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
+
+  public ProcessInstanceBusinessIdRecord() {
+    super(6);
+    declareProperty(processInstanceKeyProperty)
+        .declareProperty(businessIdProperty)
+        .declareProperty(tenantIdProperty)
+        .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(bpmnProcessIdProperty);
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProperty.getValue());
+  }
+
+  public ProcessInstanceBusinessIdRecord setBusinessId(final String businessId) {
+    businessIdProperty.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBusinessIdRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBusinessIdRecord setProcessDefinitionKey(final long processDefinitionKey) {
+    processDefinitionKeyProperty.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBusinessIdRecord setRootProcessInstanceKey(
+      final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProperty.getValue());
+  }
+
+  public ProcessInstanceBusinessIdRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProperty.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return bufferAsString(tenantIdProperty.getValue());
+  }
+
+  public ProcessInstanceBusinessIdRecord setTenantId(final String tenantId) {
+    tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -77,6 +77,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscri
 import io.camunda.zeebe.protocol.impl.record.value.metrics.UsageMetricRecord;
 import io.camunda.zeebe.protocol.impl.record.value.multiinstance.MultiInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBusinessIdRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationStartInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
@@ -3110,6 +3111,57 @@ final class JsonSerializableToJsonTest {
                   "processInstanceKey": 123,
                   "targetProcessDefinitionKey": 456,
                   "mappingInstructions": [],
+                  "rootProcessInstanceKey": -1,
+                  "processDefinitionKey": -1,
+                  "bpmnProcessId": "",
+                  "elementInstanceKey": -1
+                }
+                """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////// ProcessInstanceBusinessIdRecord
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // ///////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ProcessInstanceBusinessIdRecord",
+        (Supplier<UnifiedRecordValue>)
+            () ->
+                new ProcessInstanceBusinessIdRecord()
+                    .setTenantId("tenantId")
+                    .setProcessInstanceKey(123L)
+                    .setBusinessId("order-42")
+                    .setRootProcessInstanceKey(321L)
+                    .setProcessDefinitionKey(234L)
+                    .setBpmnProcessId("bpmnProcessId"),
+        """
+                {
+                  "tenantId": "tenantId",
+                  "processInstanceKey": 123,
+                  "businessId": "order-42",
+                  "rootProcessInstanceKey": 321,
+                  "processDefinitionKey": 234,
+                  "bpmnProcessId": "bpmnProcessId",
+                  "elementInstanceKey": -1
+                }
+                """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////// Empty ProcessInstanceBusinessIdRecord
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      // /////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty ProcessInstanceBusinessIdRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> new ProcessInstanceBusinessIdRecord().setProcessInstanceKey(123L),
+        """
+                {
+                  "tenantId": "<default>",
+                  "processInstanceKey": 123,
+                  "businessId": "",
                   "rootProcessInstanceKey": -1,
                   "processDefinitionKey": -1,
                   "bpmnProcessId": "",

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBusinessIdRecord.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/ProcessInstanceBusinessIdRecord.golden
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.processinstance;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+
+public final class ProcessInstanceBusinessIdRecord extends UnifiedRecordValue
+    implements ProcessInstanceBusinessIdRecordValue {
+
+  public static final StringValue TENANT_ID_KEY = new StringValue("tenantId");
+  // Static StringValue keys to avoid memory waste
+  private static final StringValue PROCESS_INSTANCE_KEY_KEY = new StringValue("processInstanceKey");
+  private static final StringValue BUSINESS_ID_KEY = new StringValue("businessId");
+  private static final StringValue ROOT_PROCESS_INSTANCE_KEY_KEY =
+      new StringValue("rootProcessInstanceKey");
+  private static final StringValue PROCESS_DEFINITION_KEY_KEY =
+      new StringValue("processDefinitionKey");
+  private static final StringValue BPMN_PROCESS_ID_KEY = new StringValue("bpmnProcessId");
+
+  private final LongProperty processInstanceKeyProperty =
+      new LongProperty(PROCESS_INSTANCE_KEY_KEY);
+  private final StringProperty businessIdProperty = new StringProperty(BUSINESS_ID_KEY, "");
+  private final StringProperty tenantIdProperty =
+      new StringProperty(TENANT_ID_KEY, TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty rootProcessInstanceKeyProperty =
+      new LongProperty(ROOT_PROCESS_INSTANCE_KEY_KEY, -1);
+  private final LongProperty processDefinitionKeyProperty =
+      new LongProperty(PROCESS_DEFINITION_KEY_KEY, -1L);
+  private final StringProperty bpmnProcessIdProperty = new StringProperty(BPMN_PROCESS_ID_KEY, "");
+
+  public ProcessInstanceBusinessIdRecord() {
+    super(6);
+    declareProperty(processInstanceKeyProperty)
+        .declareProperty(businessIdProperty)
+        .declareProperty(tenantIdProperty)
+        .declareProperty(rootProcessInstanceKeyProperty)
+        .declareProperty(processDefinitionKeyProperty)
+        .declareProperty(bpmnProcessIdProperty);
+  }
+
+  @Override
+  public String getBusinessId() {
+    return bufferAsString(businessIdProperty.getValue());
+  }
+
+  public ProcessInstanceBusinessIdRecord setBusinessId(final String businessId) {
+    businessIdProperty.setValue(businessId);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBusinessIdRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProperty.setValue(processInstanceKey);
+    return this;
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBusinessIdRecord setProcessDefinitionKey(final long processDefinitionKey) {
+    processDefinitionKeyProperty.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public long getRootProcessInstanceKey() {
+    return rootProcessInstanceKeyProperty.getValue();
+  }
+
+  public ProcessInstanceBusinessIdRecord setRootProcessInstanceKey(
+      final long rootProcessInstanceKey) {
+    rootProcessInstanceKeyProperty.setValue(rootProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bufferAsString(bpmnProcessIdProperty.getValue());
+  }
+
+  public ProcessInstanceBusinessIdRecord setBpmnProcessId(final String bpmnProcessId) {
+    bpmnProcessIdProperty.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return bufferAsString(tenantIdProperty.getValue());
+  }
+
+  public ProcessInstanceBusinessIdRecord setTenantId(final String tenantId) {
+    tenantIdProperty.setValue(tenantId);
+    return this;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -59,6 +59,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MultiInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -125,6 +126,7 @@ import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MultiInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
@@ -389,6 +391,10 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.AGENT_HISTORY,
         new Mapping<>(AgentHistoryRecordValue.class, AgentHistoryIntent.class));
+    mapping.put(
+        ValueType.PROCESS_INSTANCE_BUSINESS_ID,
+        new Mapping<>(
+            ProcessInstanceBusinessIdRecordValue.class, ProcessInstanceBusinessIdIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypes.java
@@ -34,6 +34,7 @@ public final class ValueTypes {
           ValueType.PROCESS_INSTANCE_CREATION,
           ValueType.DECISION_EVALUATION,
           ValueType.PROCESS_INSTANCE_MODIFICATION,
+          ValueType.PROCESS_INSTANCE_BUSINESS_ID,
           ValueType.SIGNAL,
           ValueType.COMMAND_DISTRIBUTION,
           ValueType.PROCESS_INSTANCE_BATCH,

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -101,6 +101,7 @@ public interface Intent {
     map.put(ValueType.PROCESS_EVENT, ProcessEventIntent.class);
     map.put(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.class);
     map.put(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceBatchIntent.class);
+    map.put(ValueType.PROCESS_INSTANCE_BUSINESS_ID, ProcessInstanceBusinessIdIntent.class);
     map.put(ValueType.PROCESS_INSTANCE_CREATION, ProcessInstanceCreationIntent.class);
     map.put(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationIntent.class);
     map.put(ValueType.PROCESS_INSTANCE_MODIFICATION, ProcessInstanceModificationIntent.class);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBusinessIdIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBusinessIdIntent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ProcessInstanceBusinessIdIntent implements Intent, ProcessInstanceRelatedIntent {
+  ASSIGN((short) 0),
+  ASSIGNED((short) 1);
+
+  private final short value;
+
+  ProcessInstanceBusinessIdIntent(final short value) {
+    this.value = value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case ASSIGNED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return ASSIGN;
+      case 1:
+        return ASSIGNED;
+      default:
+        return UNKNOWN;
+    }
+  }
+
+  @Override
+  public boolean shouldBanInstanceOnError() {
+    // Late Business ID assignment has transactional error handling. No need to ban the instance.
+    return false;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceBusinessIdRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceBusinessIdRecordValue.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+/**
+ * Carries the late assignment of a Business ID to an already-running root process instance that has
+ * none. See ADR 0006 (late Business ID assignment).
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableProcessInstanceBusinessIdRecordValue.Builder.class)
+public interface ProcessInstanceBusinessIdRecordValue
+    extends RecordValue, ProcessInstanceRelated, AuditLogProcessInstanceRelated, TenantOwned {
+
+  /**
+   * @return the Business ID to assign, or an empty string
+   */
+  String getBusinessId();
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -97,6 +97,7 @@
       <validValue name="MESSAGE_START_PROCESS_INSTANCE_REQUEST">71</validValue>
       <validValue name="AGENT_HISTORY">72</validValue>
       <validValue name="MESSAGE_START_CORRELATION_KEY_LOCK_RELEASE">73</validValue>
+      <validValue name="PROCESS_INSTANCE_BUSINESS_ID">74</validValue>
 
       <!-- Management records / record not related to process automation -->
       <!-- value 252 was used for "REDISTRIBUTION, do not use-->

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -139,6 +139,9 @@ final class IntentEncodingDecodingTest {
         buildParameterSets(ProcessInstanceResultIntent.class, ProcessInstanceResultIntent::from));
     result.addAll(
         buildParameterSets(
+            ProcessInstanceBusinessIdIntent.class, ProcessInstanceBusinessIdIntent::from));
+    result.addAll(
+        buildParameterSets(
             ProcessMessageSubscriptionIntent.class, ProcessMessageSubscriptionIntent::from));
     result.addAll(buildParameterSets(ResourceIntent.class, ResourceIntent::from));
     result.addAll(buildParameterSets(ResourceDeletionIntent.class, ResourceDeletionIntent::from));

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -119,6 +119,7 @@ import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MultiInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessEventRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue.ProcessInstanceCreationStartInstructionValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
@@ -281,6 +282,8 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.PROCESS_INSTANCE_CREATION, this::summarizeProcessInstanceCreation);
     valueLoggers.put(
         ValueType.PROCESS_INSTANCE_MODIFICATION, this::summarizeProcessInstanceModification);
+    valueLoggers.put(
+        ValueType.PROCESS_INSTANCE_BUSINESS_ID, this::summarizeProcessInstanceBusinessId);
     valueLoggers.put(
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION, this::summarizeProcessInstanceSubscription);
     valueLoggers.put(
@@ -1983,6 +1986,16 @@ public class CompactRecordLogger {
     }
 
     return summary.toString();
+  }
+
+  private String summarizeProcessInstanceBusinessId(final Record<?> record) {
+    final var value = (ProcessInstanceBusinessIdRecordValue) record.getValue();
+
+    return new StringBuilder()
+        .append(shortenKey(value.getProcessInstanceKey()))
+        .append(" businessId: ")
+        .append(formatId(value.getBusinessId()))
+        .toString();
   }
 
   private String summarizeProcessInstanceMigration(final Record<?> record) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceBusinessIdRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessInstanceBusinessIdRecordStream.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
+import java.util.stream.Stream;
+
+public final class ProcessInstanceBusinessIdRecordStream
+    extends ExporterRecordStream<
+        ProcessInstanceBusinessIdRecordValue, ProcessInstanceBusinessIdRecordStream> {
+
+  public ProcessInstanceBusinessIdRecordStream(
+      final Stream<Record<ProcessInstanceBusinessIdRecordValue>> records) {
+    super(records);
+  }
+
+  @Override
+  protected ProcessInstanceBusinessIdRecordStream supply(
+      final Stream<Record<ProcessInstanceBusinessIdRecordValue>> wrappedStream) {
+    return new ProcessInstanceBusinessIdRecordStream(wrappedStream);
+  }
+
+  public ProcessInstanceBusinessIdRecordStream withProcessInstanceKey(
+      final long processInstanceKey) {
+    return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
+  }
+
+  public ProcessInstanceBusinessIdRecordStream withBusinessId(final String businessId) {
+    return valueFilter(v -> businessId.equals(v.getBusinessId()));
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionInte
 import io.camunda.zeebe.protocol.record.intent.MessageStartProcessInstanceRequestIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -101,6 +102,7 @@ import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecor
 import io.camunda.zeebe.protocol.record.value.MessageStartProcessInstanceRequestRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceModificationRecordValue;
@@ -504,6 +506,17 @@ public final class RecordingExporter implements Exporter {
   public static ProcessInstanceMigrationRecordStream processInstanceMigrationRecords(
       final ProcessInstanceMigrationIntent intent) {
     return processInstanceMigrationRecords().withIntent(intent);
+  }
+
+  public static ProcessInstanceBusinessIdRecordStream processInstanceBusinessIdRecords() {
+    return new ProcessInstanceBusinessIdRecordStream(
+        records(
+            ValueType.PROCESS_INSTANCE_BUSINESS_ID, ProcessInstanceBusinessIdRecordValue.class));
+  }
+
+  public static ProcessInstanceBusinessIdRecordStream processInstanceBusinessIdRecords(
+      final ProcessInstanceBusinessIdIntent intent) {
+    return processInstanceBusinessIdRecords().withIntent(intent);
   }
 
   public static ProcessInstanceResultRecordStream processInstanceResultRecords() {


### PR DESCRIPTION
## Description

Implements late Business ID assignment for already-running root process instances ([ADR 0006](https://github.com/camunda/camunda/blob/main/zeebe/docs/adr/0006-810-late-business-id-assignment.md)). This PR covers the full vertical slice: protocol definition, engine command processing, event application, forward-propagation semantics, and exporter index templates.

### What's included

#### Protocol (`zeebe/protocol`, `zeebe/protocol-impl`)
- Adds `PROCESS_INSTANCE_BUSINESS_ID` value type (`74`) to `protocol.xml`
- Introduces `ProcessInstanceBusinessIdIntent` with `ASSIGN` command and `ASSIGNED` event
- Defines `ProcessInstanceBusinessIdRecordValue` interface carrying `processInstanceKey`, `businessId`, tenant, and process definition context
- Adds concrete `ProcessInstanceBusinessIdRecord`, registered in `UnifiedRecordValue`, `ValueTypeMapping`, and `ValueTypes`
- Adds golden JSON test cases and intent encoding/decoding tests

#### Engine processing (`zeebe/engine`)
- Implements `ProcessInstanceBusinessIdAssignProcessor`, handling the full rejection matrix:
  - Instance not found, not a process instance, child instance, not active, uniqueness enabled, empty/invalid business ID, already assigned (idempotent no-op for same value, rejection for different value), unauthorized
- Implements `ProcessInstanceBusinessIdAssignedV1Applier`: updates the process-scope element instance in state and inserts the uniqueness index entry (so existing cleanup on completion/termination removes it correctly)
- Registers both in `BpmnProcessors` and `EventAppliers` respectively; adds the event-applier golden file

#### Forward-propagation semantics
- Fixes `CatchEventBehavior` and `CallActivityProcessor` to read the Business ID from the live process-scope element instance rather than a stale copied record value, ensuring artifacts created after a late assignment carry the new Business ID without retroactively touching pre-existing ones
- Adds propagation tests covering jobs, user tasks, message subscriptions, decision evaluations, and call-activity child instances

#### Exporters (Elasticsearch / OpenSearch)
- Adds `processInstanceBusinessId` index configuration and index template (`zeebe-record-process-instance-business-id`) to both exporters

#### Tests
- `AssignProcessInstanceBusinessIdTest` — happy path + full rejection matrix + lifecycle (completion & termination)
- `AssignProcessInstanceBusinessIdWhenUniquenessEnabledTest` — guarded rejection when uniqueness is on
- `AssignProcessInstanceBusinessIdAuthorizationTest` — authorization checks (`UPDATE_PROCESS_INSTANCE` permission)
- `TenantAwareAssignProcessInstanceBusinessIdTest` — multi-tenancy enforcement
- `AssignProcessInstanceBusinessIdPropagationTest` — forward-only propagation across all artifact types

### Design decisions
- Assignment is **irreversible** and only available while Business ID uniqueness is disabled (ADR 0006, D5)
- An identical re-assignment is a **no-op** (responds success, no second `ASSIGNED` event) (ADR 0006, D3)
- Propagation is **forward-only**: artifacts created before the assignment retain an empty Business ID (ADR 0006, D8)
- The uniqueness index entry inserted on assignment is cleaned up by the existing completion/termination path (ADR 0006, D7)

## Related issues

Closes #57625
Closes #57627