### PR TITLE
fix: handle exceptions during LogStream initialization when changing roles

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.health.HealthIssue;
 import java.time.Duration;
 import java.time.Instant;
@@ -91,13 +92,9 @@ final class PartitionTransitionProcess {
           stepStartedAtMs = ActorClock.currentTimeMillis();
           LOG.debug(
               "Transition to {} on term {} - transitioning {}", role, term, nextStep.getName());
-          try {
-            nextStep
-                .transitionTo(context, term, role)
-                .onComplete((ok, error) -> onStepCompletion(future, error));
-          } catch (final Exception e) {
-            onStepCompletion(future, e);
-          }
+
+          CompletableActorFuture.catching(() -> nextStep.transitionTo(context, term, role))
+              .onComplete((ok, error) -> onStepCompletion(future, error));
         });
   }
 
@@ -151,14 +148,9 @@ final class PartitionTransitionProcess {
               newTerm,
               nextPrepareStep.getName());
 
-          try {
-            nextPrepareStep
-                .prepareTransition(context, newTerm, newRole)
-                .onComplete(
-                    (ok, error) -> onPrepareStepCompletion(future, error, newTerm, newRole));
-          } catch (final Exception e) {
-            onPrepareStepCompletion(future, e, newTerm, newRole);
-          }
+          CompletableActorFuture.catching(
+                  () -> nextPrepareStep.prepareTransition(context, newTerm, newRole))
+              .onComplete((ok, error) -> onPrepareStepCompletion(future, error, newTerm, newRole));
         });
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -91,9 +91,13 @@ final class PartitionTransitionProcess {
           stepStartedAtMs = ActorClock.currentTimeMillis();
           LOG.debug(
               "Transition to {} on term {} - transitioning {}", role, term, nextStep.getName());
-          nextStep
-              .transitionTo(context, term, role)
-              .onComplete((ok, error) -> onStepCompletion(future, error));
+          try {
+            nextStep
+                .transitionTo(context, term, role)
+                .onComplete((ok, error) -> onStepCompletion(future, error));
+          } catch (final Exception e) {
+            onStepCompletion(future, e);
+          }
         });
   }
 
@@ -147,9 +151,14 @@ final class PartitionTransitionProcess {
               newTerm,
               nextPrepareStep.getName());
 
-          nextPrepareStep
-              .prepareTransition(context, newTerm, newRole)
-              .onComplete((ok, error) -> onPrepareStepCompletion(future, error, newTerm, newRole));
+          try {
+            nextPrepareStep
+                .prepareTransition(context, newTerm, newRole)
+                .onComplete(
+                    (ok, error) -> onPrepareStepCompletion(future, error, newTerm, newRole));
+          } catch (final Exception e) {
+            onPrepareStepCompletion(future, e, newTerm, newRole);
+          }
         });
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -35,30 +35,37 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
   @Override
   public ActorFuture<Void> prepareTransition(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
-    final var logStream = context.getLogStream();
-    if (logStream != null
-        && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
-            || targetRole == Role.INACTIVE)) {
-      context.setStreamClock(null);
-      logStream.close();
-      context.setLogStream(null);
+    try {
+      final var logStream = context.getLogStream();
+      if (logStream != null
+          && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
+              || targetRole == Role.INACTIVE)) {
+        context.setStreamClock(null);
+        logStream.close();
+        context.setLogStream(null);
+      }
+      return CompletableActorFuture.completed(null);
+    } catch (final Exception e) {
+      return CompletableActorFuture.completedExceptionally(e);
     }
-    return CompletableActorFuture.completed(null);
   }
 
   @Override
   public ActorFuture<Void> transitionTo(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
-    if ((context.getLogStream() == null && targetRole != Role.INACTIVE)
-        || shouldInstallOnTransition(targetRole, context.getCurrentRole())) {
-      final var clockSource =
-          ActorClock.current() != null ? ActorClock.current() : InstantSource.system();
-      context.setStreamClock(StreamClock.controllable(clockSource));
-      context.setLogStream(buildLogStream(context));
-
+    try {
+      if ((context.getLogStream() == null && targetRole != Role.INACTIVE)
+          || shouldInstallOnTransition(targetRole, context.getCurrentRole())) {
+        final var clockSource =
+            ActorClock.current() != null ? ActorClock.current() : InstantSource.system();
+        context.setStreamClock(StreamClock.controllable(clockSource));
+        context.setLogStream(buildLogStream(context));
+      }
       return CompletableActorFuture.completed(null);
-    } else {
-      return CompletableActorFuture.completed(null);
+    } catch (final Exception e) {
+      context.setStreamClock(null);
+      context.setLogStream(null);
+      return CompletableActorFuture.completedExceptionally(e);
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
@@ -420,7 +420,7 @@ class PartitionTransitionImplTest {
   }
 
   @Test
-  void shouldFailUnrecoverablyIfPreparationStepThrowsSynchronously() {
+  void shouldFailPreparationAndSkipTransitionIfPreparationStepThrowsSynchronously() {
     // given
     final var secondTerm = 2L;
     final var secondRole = Role.FOLLOWER;
@@ -457,7 +457,7 @@ class PartitionTransitionImplTest {
   }
 
   @Test
-  void shouldFailUnrecoverablyIfTransitionStepThrowsSynchronously() {
+  void shouldFailTransitionAndSkipRemainingStepsIfTransitionStepThrowsSynchronously() {
     // given
     final var testException = new IllegalStateException("TEST_EXCEPTION");
     when(mockStep1.transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE)).thenThrow(testException);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionImplTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransition.CancelledPartitionTransition;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransition.FailedPartitionTransitionPreparation;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorTransitionStep;
@@ -416,6 +417,65 @@ class PartitionTransitionImplTest {
 
     verify(mockStreamProcessor1).closeAsync();
     verify(mockStreamProcessor2, never()).closeAsync();
+  }
+
+  @Test
+  void shouldFailUnrecoverablyIfPreparationStepThrowsSynchronously() {
+    // given
+    final var secondTerm = 2L;
+    final var secondRole = Role.FOLLOWER;
+    final var testException = new IllegalStateException("TEST_EXCEPTION");
+
+    when(mockStep1.transitionTo(any(), anyLong(), any()))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.completedFuture(null));
+    when(mockStep2.transitionTo(any(), anyLong(), any()))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.completedFuture(null));
+
+    when(mockStep2.prepareTransition(mockContext, secondTerm, secondRole))
+        .thenReturn(TEST_CONCURRENCY_CONTROL.completedFuture(null));
+    when(mockStep1.prepareTransition(mockContext, secondTerm, secondRole)).thenThrow(testException);
+
+    final var sut = new PartitionTransitionImpl(of(mockStep1, mockStep2));
+    sut.setConcurrencyControl(TEST_CONCURRENCY_CONTROL);
+    sut.updateTransitionContext(mockContext);
+
+    sut.transitionTo(DEFAULT_TERM, DEFAULT_ROLE).join();
+
+    // when
+    final var transitionFuture = sut.transitionTo(secondTerm, secondRole);
+
+    // then
+    verify(mockStep1, never()).transitionTo(mockContext, secondTerm, secondRole);
+    verify(mockStep2, never()).transitionTo(mockContext, secondTerm, secondRole);
+
+    assertThatThrownBy(transitionFuture::join)
+        .isInstanceOf(ExecutionException.class)
+        .cause()
+        .isInstanceOf(FailedPartitionTransitionPreparation.class)
+        .rootCause()
+        .isSameAs(testException);
+  }
+
+  @Test
+  void shouldFailUnrecoverablyIfTransitionStepThrowsSynchronously() {
+    // given
+    final var testException = new IllegalStateException("TEST_EXCEPTION");
+    when(mockStep1.transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE)).thenThrow(testException);
+
+    final var sut = new PartitionTransitionImpl(of(mockStep1, mockStep2));
+    sut.setConcurrencyControl(TEST_CONCURRENCY_CONTROL);
+    sut.updateTransitionContext(mockContext);
+
+    // when
+    final var transitionFuture = sut.transitionTo(DEFAULT_TERM, DEFAULT_ROLE);
+
+    // then
+    verify(mockStep2, never()).transitionTo(mockContext, DEFAULT_TERM, DEFAULT_ROLE);
+
+    assertThatThrownBy(transitionFuture::join)
+        .isInstanceOf(ExecutionException.class)
+        .rootCause()
+        .isSameAs(testException);
   }
 
   private final class WaitingTransitionStep implements PartitionTransitionStep {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStepTest.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -27,10 +29,14 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionT
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.util.health.HealthMonitor;
+import java.time.InstantSource;
+import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
 
 class LogStreamPartitionTransitionStepTest {
   final TestPartitionTransitionContext transitionContext = new TestPartitionTransitionContext();
@@ -115,6 +121,61 @@ class LogStreamPartitionTransitionStepTest {
     assertThat(transitionContext.getStreamProcessor()).isNull();
     verify(logStreamFromPrevRole).close();
     verify(logStreamBuilder, never()).build();
+  }
+
+  @Test
+  void shouldReturnFailedFutureIfClosingLogStreamThrows() {
+    // given
+    final var testException = new IllegalStateException("Failed to close");
+    initializeContext(Role.LEADER);
+    doThrow(testException).when(logStreamFromPrevRole).close();
+
+    // when
+    final var future = step.prepareTransition(transitionContext, 2, Role.FOLLOWER);
+
+    // then
+    assertThatThrownBy(future::join)
+        .isInstanceOf(ExecutionException.class)
+        .hasRootCause(testException);
+
+    assertThat(transitionContext.getLogStream()).isSameAs(logStreamFromPrevRole);
+  }
+
+  @Test
+  void shouldSetStreamClockBeforeBuildingLogStream() {
+    // given
+    transitionContext.setCurrentRole(Role.INACTIVE);
+    final var clockCaptor = ArgumentCaptor.forClass(InstantSource.class);
+
+    // when
+    step.transitionTo(transitionContext, 1, Role.LEADER).join();
+
+    // then
+    verify(logStreamBuilder).withClock(clockCaptor.capture());
+    assertThat(clockCaptor.getValue())
+        .as("log stream is built with the installed stream clock")
+        .isNotNull()
+        .isSameAs(transitionContext.getStreamClock());
+  }
+
+  @Test
+  void shouldReturnFailedFutureIfLogStreamBuildFails() {
+    // given
+    final var testException = new IllegalStateException("Segment is already closed");
+    transitionContext.setCurrentRole(Role.INACTIVE);
+    doThrow(testException).when(logStreamBuilder).build();
+
+    // when
+    final var transitionFuture = step.transitionTo(transitionContext, 1, Role.LEADER);
+
+    // then
+    assertThatThrownBy(transitionFuture::join)
+        .isInstanceOf(ExecutionException.class)
+        .rootCause()
+        .isSameAs(testException);
+
+    assertThat(transitionContext.getLogStream()).isNull();
+    assertThat(transitionContext.getStreamClock()).isNull();
   }
 
   private void initializeContext(final Role currentRole) {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -125,6 +125,23 @@ public final class CompletableActorFuture<V extends @Nullable Object> implements
     return future;
   }
 
+  /**
+   * Executes a supplier that provides an {@code ActorFuture} and catches any synchronous
+   * exceptions, wrapping them in the returned future.
+   *
+   * @param <A> The type of the result provided by the {@code ActorFuture}.
+   * @param supplier A supplier that provides an {@code ActorFuture}.
+   * @return The {@code ActorFuture} provided by the supplier, or an exceptionally-completed {@code
+   *     ActorFuture} if an exception was thrown by the supplier.
+   */
+  public static <A> ActorFuture<A> catching(final Supplier<ActorFuture<A>> supplier) {
+    try {
+      return supplier.get();
+    } catch (final Throwable e) {
+      return CompletableActorFuture.completedExceptionally(e);
+    }
+  }
+
   @Override
   public boolean cancel(final boolean mayInterruptIfRunning) {
     throw new UnsupportedOperationException();

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/future/CompletableActorFutureTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/future/CompletableActorFutureTest.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.IntStream;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Nested;
@@ -25,6 +26,36 @@ import org.junit.jupiter.api.Test;
 public class CompletableActorFutureTest {
 
   @AutoClose private static final ExecutorService EXECUTOR = Executors.newWorkStealingPool();
+
+  @Nested
+  public class Catching {
+    @Test
+    public void shouldReturnExceptionalFutureWhenSupplierThrows() {
+      // given
+      final Supplier<ActorFuture<Void>> supplier =
+          () -> {
+            throw new RuntimeException("Expected");
+          };
+
+      // when
+      final var future = CompletableActorFuture.catching(supplier);
+
+      assertThat(future.getException()).hasMessage("Expected");
+    }
+
+    @Test
+    public void shouldReturnFutureWhenSupplierCompletes() {
+      // given
+      final Supplier<ActorFuture<String>> supplier =
+          () -> CompletableActorFuture.completed("value");
+
+      // when
+      final var future = CompletableActorFuture.catching(supplier);
+
+      // then
+      assertThat(future.join()).isEqualTo("value");
+    }
+  }
 
   @Nested
   class VoidContinuations {


### PR DESCRIPTION
Building the LogStream when transitioning a partition between roles can throw an exception. PartitionTransitionProcess expects all errors in partition transition steps to be returned as failed futures, but these exceptions were being thrown synchronously - as a result, we'd miss the completion of this step and hang indefinitely, preventing any further role transitions until the broker is manually restarted.

I've addressed this by ensuring that any exceptions in LogStreamPartitionTransitionStep are caught and returned as failed futures - for good measure, I've also added defensive handling to PartitionTransitionProcess in case any other transition step implementations now or in the future have similar bugs.

Closes #54752.