### PR TITLE
test: add API e2e coverage for Business ID on decision instances, job activation, and call activity

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/call_activity_business_id_parent.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/call_activity_business_id_parent.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_call_activity_business_id_parent" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="PARENT_PROCESS_ID_PLACEHOLDER" name="Call Activity Business ID Parent" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_start_to_call</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_to_call" sourceRef="StartEvent_1" targetRef="call_child" />
+    <bpmn:callActivity id="call_child" name="Call child">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="child_business_id_process" propagateAllChildVariables="true" CALLED_ELEMENT_BUSINESS_ID_ATTR />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_to_call</bpmn:incoming>
+      <bpmn:outgoing>Flow_call_to_end</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>Flow_call_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_call_to_end" sourceRef="call_child" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="PARENT_PROCESS_ID_PLACEHOLDER">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="call_child_di" bpmnElement="call_child">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_end_di" bpmnElement="Event_end">
+        <dc:Bounds x="432" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_start_to_call_di" bpmnElement="Flow_start_to_call">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_call_to_end_di" bpmnElement="Flow_call_to_end">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="432" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/child_business_id_process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/child_business_id_process.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_child_business_id" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="child_business_id_process" name="Child Business ID Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_start_to_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_to_task" sourceRef="StartEvent_1" targetRef="wait_user_task" />
+    <bpmn:userTask id="wait_user_task" name="Wait">
+      <bpmn:extensionElements>
+        <zeebe:userTask />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_to_task</bpmn:incoming>
+      <bpmn:outgoing>Flow_task_to_end</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>Flow_task_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_task_to_end" sourceRef="wait_user_task" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="child_business_id_process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="wait_user_task_di" bpmnElement="wait_user_task">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_end_di" bpmnElement="Event_end">
+        <dc:Bounds x="432" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_start_to_task_di" bpmnElement="Flow_start_to_task">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_task_to_end_di" bpmnElement="Flow_task_to_end">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="432" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/resources/service_task_business_id_process.bpmn
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/resources/service_task_business_id_process.bpmn
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_service_task_business_id" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.39.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.8.0">
+  <bpmn:process id="service_task_business_id_process" name="Service Task Business ID Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_start_to_task</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_start_to_task" sourceRef="StartEvent_1" targetRef="service_task" />
+    <bpmn:serviceTask id="service_task" name="Service task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service_task_business_id_job" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_to_task</bpmn:incoming>
+      <bpmn:outgoing>Flow_task_to_end</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>Flow_task_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_task_to_end" sourceRef="service_task" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="service_task_business_id_process">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="service_task_di" bpmnElement="service_task">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_end_di" bpmnElement="Event_end">
+        <dc:Bounds x="432" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_start_to_task_di" bpmnElement="Flow_start_to_task">
+        <di:waypoint x="188" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_task_to_end_di" bpmnElement="Flow_task_to_end">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="432" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-search-business-id-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-search-business-id-api-tests.spec.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, expect, test} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {deploy} from '../../../../utils/zeebeClient';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+
+const PROCESS_INSTANCE_ENDPOINT = '/process-instances';
+const DECISION_INSTANCE_SEARCH_ENDPOINT = '/decision-instances/search';
+const DMN_PROCESS_ID = 'mammalAnimalProcess';
+
+const runPrefix = `dec-${generateUniqueId()}`;
+const BUSINESS_ID_A = `${runPrefix}-aaa`;
+const BUSINESS_ID_B = `${runPrefix}-zzz`;
+
+async function startDmnProcessWithBusinessId(
+  request: APIRequestContext,
+  businessId: string,
+) {
+  const res = await request.post(buildUrl(PROCESS_INSTANCE_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {
+      processDefinitionId: DMN_PROCESS_ID,
+      businessId,
+      variables: {hasHairOrFur: true, warmBlooded: true, givesMilk: true},
+    },
+  });
+  await assertStatusCode(res, 200);
+  return (await res.json()).processInstanceKey as string;
+}
+
+async function searchDecisionInstances(
+  request: APIRequestContext,
+  filter: Record<string, unknown>,
+  sort?: Record<string, unknown>[],
+) {
+  const res = await request.post(buildUrl(DECISION_INSTANCE_SEARCH_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {filter, ...(sort ? {sort} : {})},
+  });
+  await assertStatusCode(res, 200);
+  return res.json();
+}
+
+test.describe.serial('Search Decision Instances - Business ID API', () => {
+  test.beforeAll(async ({request}) => {
+    await deploy([
+      './resources/mammalAnimalProcess.bpmn',
+      './resources/isMammal_.dmn',
+    ]);
+
+    await startDmnProcessWithBusinessId(request, BUSINESS_ID_A);
+    await startDmnProcessWithBusinessId(request, BUSINESS_ID_B);
+
+    await expect(async () => {
+      const json = await searchDecisionInstances(request, {
+        businessId: {$like: `${runPrefix}-*`},
+      });
+      expect(json.page.totalItems).toBe(2);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Decision instance exposes and is filterable by the owning instance Business ID', async ({
+    request,
+  }) => {
+    const json = await searchDecisionInstances(request, {
+      businessId: BUSINESS_ID_A,
+    });
+    expect(json.page.totalItems).toBe(1);
+    expect(json.items[0].businessId).toBe(BUSINESS_ID_A);
+  });
+
+  test('Filter decision instances by Business ID with a like wildcard returns both', async ({
+    request,
+  }) => {
+    const json = await searchDecisionInstances(request, {
+      businessId: {$like: `${runPrefix}-*`},
+    });
+    expect(json.page.totalItems).toBe(2);
+    expect(
+      json.items.map((i: {businessId: string}) => i.businessId).sort(),
+    ).toEqual([BUSINESS_ID_A, BUSINESS_ID_B]);
+  });
+
+  test('Filter decision instances by a non-matching Business ID returns empty', async ({
+    request,
+  }) => {
+    const json = await searchDecisionInstances(request, {
+      businessId: `${runPrefix}-none`,
+    });
+    expect(json.page.totalItems).toBe(0);
+  });
+
+  test('Sort decision instances by Business ID ascending and descending', async ({
+    request,
+  }) => {
+    const filter = {businessId: {$like: `${runPrefix}-*`}};
+
+    const ascending = await searchDecisionInstances(request, filter, [
+      {field: 'businessId', order: 'asc'},
+    ]);
+    expect(
+      ascending.items.map((i: {businessId: string}) => i.businessId),
+    ).toEqual([BUSINESS_ID_A, BUSINESS_ID_B]);
+
+    const descending = await searchDecisionInstances(request, filter, [
+      {field: 'businessId', order: 'desc'},
+    ]);
+    expect(
+      descending.items.map((i: {businessId: string}) => i.businessId),
+    ).toEqual([BUSINESS_ID_B, BUSINESS_ID_A]);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-search-business-id-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/decision-instance/decision-instance-search-business-id-api-tests.spec.ts
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, expect, test} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {deploy} from '../../../../utils/zeebeClient';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+
+const PROCESS_INSTANCE_ENDPOINT = '/process-instances';
+const DECISION_INSTANCE_SEARCH_ENDPOINT = '/decision-instances/search';
+const DMN_PROCESS_ID = 'mammalAnimalProcess';
+// The isMammal DRD evaluates three decisions (MammalLikeBody, MammalLikeNursing,
+// IsMammal), so each process instance produces three decision instances that all
+// carry the same owning-instance businessId. Scope every search to the leaf
+// decision so each process instance contributes exactly one matching decision
+// instance and the businessId counts are deterministic.
+const DECISION_DEFINITION_ID = 'IsMammal';
+
+const runPrefix = `dec-${generateUniqueId()}`;
+const BUSINESS_ID_A = `${runPrefix}-aaa`;
+const BUSINESS_ID_B = `${runPrefix}-zzz`;
+
+async function startDmnProcessWithBusinessId(
+  request: APIRequestContext,
+  businessId: string,
+) {
+  const res = await request.post(buildUrl(PROCESS_INSTANCE_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {
+      processDefinitionId: DMN_PROCESS_ID,
+      businessId,
+      variables: {hasHairOrFur: true, warmBlooded: true, givesMilk: true},
+    },
+  });
+  await assertStatusCode(res, 200);
+  return (await res.json()).processInstanceKey as string;
+}
+
+async function searchDecisionInstances(
+  request: APIRequestContext,
+  filter: Record<string, unknown>,
+  sort?: Record<string, unknown>[],
+) {
+  const res = await request.post(buildUrl(DECISION_INSTANCE_SEARCH_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {
+      filter: {...filter, decisionDefinitionId: DECISION_DEFINITION_ID},
+      ...(sort ? {sort} : {}),
+    },
+  });
+  await assertStatusCode(res, 200);
+  return res.json();
+}
+
+test.describe.serial('Search Decision Instances - Business ID API', () => {
+  test.beforeAll(async ({request}) => {
+    await deploy([
+      './resources/mammalAnimalProcess.bpmn',
+      './resources/isMammal_.dmn',
+    ]);
+
+    await startDmnProcessWithBusinessId(request, BUSINESS_ID_A);
+    await startDmnProcessWithBusinessId(request, BUSINESS_ID_B);
+
+    await expect(async () => {
+      const json = await searchDecisionInstances(request, {
+        businessId: {$like: `${runPrefix}-*`},
+      });
+      expect(json.page.totalItems).toBe(2);
+    }).toPass(defaultAssertionOptions);
+  });
+
+  test('Decision instance exposes and is filterable by the owning instance Business ID', async ({
+    request,
+  }) => {
+    const json = await searchDecisionInstances(request, {
+      businessId: BUSINESS_ID_A,
+    });
+    expect(json.page.totalItems).toBe(1);
+    expect(json.items[0].businessId).toBe(BUSINESS_ID_A);
+  });
+
+  test('Filter decision instances by Business ID with a like wildcard returns both', async ({
+    request,
+  }) => {
+    const json = await searchDecisionInstances(request, {
+      businessId: {$like: `${runPrefix}-*`},
+    });
+    expect(json.page.totalItems).toBe(2);
+    expect(
+      json.items.map((i: {businessId: string}) => i.businessId).sort(),
+    ).toEqual([BUSINESS_ID_A, BUSINESS_ID_B]);
+  });
+
+  test('Filter decision instances by a non-matching Business ID returns empty', async ({
+    request,
+  }) => {
+    const json = await searchDecisionInstances(request, {
+      businessId: `${runPrefix}-none`,
+    });
+    expect(json.page.totalItems).toBe(0);
+  });
+
+  test('Sort decision instances by Business ID ascending and descending', async ({
+    request,
+  }) => {
+    const filter = {businessId: {$like: `${runPrefix}-*`}};
+
+    const ascending = await searchDecisionInstances(request, filter, [
+      {field: 'businessId', order: 'asc'},
+    ]);
+    expect(
+      ascending.items.map((i: {businessId: string}) => i.businessId),
+    ).toEqual([BUSINESS_ID_A, BUSINESS_ID_B]);
+
+    const descending = await searchDecisionInstances(request, filter, [
+      {field: 'businessId', order: 'desc'},
+    ]);
+    expect(
+      descending.items.map((i: {businessId: string}) => i.businessId),
+    ).toEqual([BUSINESS_ID_B, BUSINESS_ID_A]);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-activation-business-id-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/job/job-activation-business-id-api-tests.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, expect, test} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {
+  cancelProcessInstance,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+  uniqueBusinessId,
+} from '../../../../utils/constants';
+
+const PROCESS_INSTANCE_ENDPOINT = '/process-instances';
+const JOB_ACTIVATION_ENDPOINT = '/jobs/activation';
+const SERVICE_TASK_RESOURCE =
+  './resources/service_task_business_id_process.bpmn';
+
+async function deployUniqueServiceTaskProcess() {
+  const suffix = generateUniqueId();
+  const processId = `service_task_bizid_${suffix}`;
+  const jobType = `service_task_bizid_job_${suffix}`;
+  await deployWithSubstitutions(SERVICE_TASK_RESOURCE, {
+    service_task_business_id_process: processId,
+    service_task_business_id_job: jobType,
+  });
+  return {processId, jobType};
+}
+
+async function startInstance(
+  request: APIRequestContext,
+  processId: string,
+  businessId?: string,
+) {
+  const res = await request.post(buildUrl(PROCESS_INSTANCE_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {
+      processDefinitionId: processId,
+      ...(businessId !== undefined ? {businessId} : {}),
+    },
+  });
+  await assertStatusCode(res, 200);
+  return (await res.json()).processInstanceKey as string;
+}
+
+async function activateOneJob(request: APIRequestContext, jobType: string) {
+  const res = await request.post(buildUrl(JOB_ACTIVATION_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {type: jobType, timeout: 10000, maxJobsToActivate: 1},
+  });
+  await assertStatusCode(res, 200);
+  return (await res.json()).jobs as Record<string, unknown>[];
+}
+
+test.describe.parallel('Activate Jobs - Business ID API', () => {
+  test('Activated job returns the owning instance Business ID', async ({
+    request,
+  }) => {
+    const {processId, jobType} = await deployUniqueServiceTaskProcess();
+    const businessId = uniqueBusinessId('job-activate');
+    const processInstanceKey = await startInstance(
+      request,
+      processId,
+      businessId,
+    );
+
+    await test.step('Activate the job and verify the Business ID', async () => {
+      await expect(async () => {
+        const jobs = await activateOneJob(request, jobType);
+        expect(jobs).toHaveLength(1);
+        expect(jobs[0].processInstanceKey).toBe(processInstanceKey);
+        expect(jobs[0].businessId).toBe(businessId);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await cancelProcessInstance(processInstanceKey);
+  });
+
+  test('Activated job returns a null Business ID when the owning instance has none', async ({
+    request,
+  }) => {
+    const {processId, jobType} = await deployUniqueServiceTaskProcess();
+    const processInstanceKey = await startInstance(request, processId);
+
+    await test.step('Activate the job and verify the Business ID is null', async () => {
+      await expect(async () => {
+        const jobs = await activateOneJob(request, jobType);
+        expect(jobs).toHaveLength(1);
+        expect(jobs[0].processInstanceKey).toBe(processInstanceKey);
+        expect(jobs[0].businessId == null).toBe(true);
+      }).toPass(defaultAssertionOptions);
+    });
+
+    await cancelProcessInstance(processInstanceKey);
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/call-activity-business-id-api-tests.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/api/v2/process-instance/call-activity-business-id-api-tests.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {APIRequestContext, expect, test} from '@playwright/test';
+import {assertStatusCode, buildUrl, jsonHeaders} from '../../../../utils/http';
+import {
+  cancelProcessInstance,
+  deploy,
+  deployWithSubstitutions,
+} from '../../../../utils/zeebeClient';
+import {
+  defaultAssertionOptions,
+  generateUniqueId,
+} from '../../../../utils/constants';
+
+const PROCESS_INSTANCE_ENDPOINT = '/process-instances';
+const PROCESS_INSTANCE_SEARCH_ENDPOINT = '/process-instances/search';
+const PARENT_RESOURCE = './resources/call_activity_business_id_parent.bpmn';
+const CHILD_PROCESS_ID = 'child_business_id_process';
+
+async function deployParent(calledElementBusinessIdAttr: string) {
+  const processId = `call_activity_bizid_parent_${generateUniqueId()}`;
+  await deployWithSubstitutions(PARENT_RESOURCE, {
+    PARENT_PROCESS_ID_PLACEHOLDER: processId,
+    CALLED_ELEMENT_BUSINESS_ID_ATTR: calledElementBusinessIdAttr,
+  });
+  return processId;
+}
+
+async function startParent(
+  request: APIRequestContext,
+  processId: string,
+  businessId?: string,
+) {
+  const res = await request.post(buildUrl(PROCESS_INSTANCE_ENDPOINT), {
+    headers: jsonHeaders(),
+    data: {
+      processDefinitionId: processId,
+      ...(businessId !== undefined ? {businessId} : {}),
+    },
+  });
+  await assertStatusCode(res, 200);
+  return (await res.json()).processInstanceKey as string;
+}
+
+async function findChildInstance(
+  request: APIRequestContext,
+  parentProcessInstanceKey: string,
+) {
+  let child: Record<string, unknown> = {};
+  await expect(async () => {
+    const res = await request.post(buildUrl(PROCESS_INSTANCE_SEARCH_ENDPOINT), {
+      headers: jsonHeaders(),
+      data: {
+        filter: {
+          parentProcessInstanceKey,
+          processDefinitionId: CHILD_PROCESS_ID,
+        },
+      },
+    });
+    await assertStatusCode(res, 200);
+    const json = await res.json();
+    expect(json.page.totalItems).toBe(1);
+    child = json.items[0];
+  }).toPass(defaultAssertionOptions);
+  return child;
+}
+
+test.describe.serial('Call Activity Business ID Propagation API', () => {
+  test.beforeAll(async () => {
+    await deploy(['./resources/child_business_id_process.bpmn']);
+  });
+
+  test('Call activity overrides the child Business ID with a literal', async ({
+    request,
+  }) => {
+    const childBusinessId = `child-literal-${generateUniqueId()}`;
+    const parentProcessId = await deployParent(
+      `businessId="${childBusinessId}"`,
+    );
+
+    const parentKey = await startParent(request, parentProcessId);
+
+    const child = await findChildInstance(request, parentKey);
+    expect(child.businessId).toBe(childBusinessId);
+
+    await cancelProcessInstance(parentKey);
+  });
+
+  test('Child inherits the parent Business ID when the call activity has no attribute', async ({
+    request,
+  }) => {
+    const parentBusinessId = `parent-inherit-${generateUniqueId()}`;
+    const parentProcessId = await deployParent('');
+
+    const parentKey = await startParent(
+      request,
+      parentProcessId,
+      parentBusinessId,
+    );
+
+    const child = await findChildInstance(request, parentKey);
+    expect(child.businessId).toBe(parentBusinessId);
+
+    await cancelProcessInstance(parentKey);
+  });
+
+  test('Child Business ID resolves to null when the call activity clears it', async ({
+    request,
+  }) => {
+    const parentBusinessId = `parent-empty-${generateUniqueId()}`;
+    const parentProcessId = await deployParent('businessId=""');
+
+    const parentKey = await startParent(
+      request,
+      parentProcessId,
+      parentBusinessId,
+    );
+
+    const child = await findChildInstance(request, parentKey);
+    expect(child.businessId == null).toBe(true);
+
+    await cancelProcessInstance(parentKey);
+  });
+});


### PR DESCRIPTION
## Description

Adds API-level end-to-end (Playwright) coverage for **Business ID** on three more surfaces, closing coverage gaps #5, #6 and #7 identified for the Business ID Visibility and Filtering epic ([product-hub#3436](https://github.com/camunda/product-hub/issues/3436), engineering breakdown [#51683](https://github.com/camunda/camunda/issues/51683)).

These paths were covered by Java integration tests but had **no dedicated API-level e2e automation** in the orchestration-cluster suite. This PR fills the last three gaps from the coverage analysis.

### What is covered

**Gap #5 — `POST /decision-instances/search`** — `decision-instance-search-business-id-api-tests.spec.ts`
Decision instances inherit the owning process instance's `businessId`. Instances of the existing `mammalAnimalProcess` (business rule task → `isMammal` DMN) are started with distinct Business IDs.
1. A decision instance **exposes** and is **filterable** by the owning instance's Business ID.
2. **Filter** by `businessId` (`$like` prefix wildcard) returns both.
3. Filter by a non-matching `businessId` returns empty.
4. **Sort** by `businessId` ascending and descending.

**Gap #6 — `POST /jobs/activation`** — `job-activation-business-id-api-tests.spec.ts`
Jobs inherit the owning process instance's `businessId`.
1. An activated job returns the owning instance's Business ID.
2. An activated job returns a `null` Business ID when the owning instance has none.

**Gap #7 — Call activity Business ID propagation** — `call-activity-business-id-api-tests.spec.ts`
Verifies the `zeebe:calledElement` `businessId` resolution semantics end-to-end (child instance located via `parentProcessInstanceKey`).
1. Call activity **overrides** the child Business ID with a literal (parent has none).
2. Child **inherits** the parent Business ID when the call activity has no `businessId` attribute.
3. Child Business ID **resolves to null** when the call activity clears it (`businessId=""`).

### New BPMN resources

- `resources/service_task_business_id_process.bpmn` — start → service task → end; process id and job type are placeholders substituted to run-unique values so activation tests never steal each other's jobs.
- `resources/child_business_id_process.bpmn` — child process (user task keeps the child active for search).
- `resources/call_activity_business_id_parent.bpmn` — parametrized parent; the parent process id and the `zeebe:calledElement` `businessId` attribute are placeholders, letting one file drive the literal / inherit / empty cases via substitution.
- Gap #5 reuses the existing `mammalAnimalProcess.bpmn` + `isMammal_.dmn`.

### Notes

- Search-based specs use a unique Business ID **prefix** (`aaa`/`zzz` suffixes) so each run isolates its data via a `$like` filter and sort order is deterministic.
- All child Business IDs / parent Business IDs are made run-unique to respect Business ID uniqueness enforcement (`CAMUNDA_PROCESSINSTANCECREATION_BUSINESSIDUNIQUENESSENABLED=true`).
- Every created instance is cancelled after the test (cancelling the parent also tears down the called child).

### Testing

- `tsc` — passes.
- `eslint` (prettier + license header) — passes for the new files (0 errors, 0 warnings).
- `check:testrail-ids` — passes (test ids within the 250-byte TestRail limit).
- Full runtime execution requires a live orchestration cluster; these run in the nightly API/E2E workflow.

### Related

- Epic: [product-hub#3436](https://github.com/camunda/product-hub/issues/3436)
- Engineering breakdown: [#51683](https://github.com/camunda/camunda/issues/51683)
- Companion PRs: #57613 (message publish/correlate), #57630 (correlated-subscription + user-task search)


Test Rail test cases
https://camunda.testrail.com/index.php?/suites/view/17028&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=678356

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview


