### PR TITLE
feat: add SUSPEND/RESUME lifecycle intents to ProcessInstanceIntent

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.io.IOException;
@@ -178,7 +179,11 @@ public class EventAppliersTest {
             .flatMap(c -> Arrays.stream(c.getEnumConstants()))
             .filter(Intent::isEvent)
             // CheckpointIntent is not handled by the engine
-            .filter(intent -> !(intent instanceof CheckpointIntent));
+            .filter(intent -> !(intent instanceof CheckpointIntent))
+            // todo delete these filters after the suspend/resume appliers are implemented
+            //  (https://github.com/camunda/camunda/issues/57506)
+            .filter(intent -> intent != ProcessInstanceIntent.SUSPENDED)
+            .filter(intent -> intent != ProcessInstanceIntent.RESUMED);
 
     // when
     eventAppliers.registerEventAppliers(mock(MutableProcessingState.class));

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -67,9 +67,15 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
    *
    * <p>This event is not applied to the state, but is used for auditing reasons.
    */
-  CANCELING((short) 16);
+  CANCELING((short) 16),
 
-  private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS = EnumSet.of(CANCEL);
+  SUSPEND((short) 17, false),
+  SUSPENDED((short) 18),
+  RESUME((short) 19, false),
+  RESUMED((short) 20);
+
+  private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS =
+      EnumSet.of(CANCEL, SUSPEND, RESUME);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
       EnumSet.of(
           ACTIVATE_ELEMENT,
@@ -130,6 +136,14 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return SEQUENCE_FLOW_DELETED;
       case 16:
         return CANCELING;
+      case 17:
+        return SUSPEND;
+      case 18:
+        return SUSPENDED;
+      case 19:
+        return RESUME;
+      case 20:
+        return RESUMED;
       default:
         return Intent.UNKNOWN;
     }
@@ -154,6 +168,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
       case ANCESTOR_MIGRATED:
       case SEQUENCE_FLOW_DELETED:
       case CANCELING:
+      case SUSPENDED:
+      case RESUMED:
         return true;
       default:
         return false;

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntentTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+final class ProcessInstanceIntentTest {
+
+  @Test
+  void shouldClassifySuspendAndResumeAsProcessInstanceCommands() {
+    // given / when / then
+    assertThat(ProcessInstanceIntent.isProcessInstanceCommand(ProcessInstanceIntent.SUSPEND))
+        .isTrue();
+    assertThat(ProcessInstanceIntent.isProcessInstanceCommand(ProcessInstanceIntent.RESUME))
+        .isTrue();
+  }
+
+  @Test
+  void shouldNotClassifySuspendAndResumeAsBpmnElementCommands() {
+    // given / when / then
+    assertThat(ProcessInstanceIntent.isBpmnElementCommand(ProcessInstanceIntent.SUSPEND)).isFalse();
+    assertThat(ProcessInstanceIntent.isBpmnElementCommand(ProcessInstanceIntent.RESUME)).isFalse();
+  }
+
+  @Test
+  void shouldMarkSuspendedAndResumedAsEvents() {
+    // given / when / then
+    assertThat(ProcessInstanceIntent.SUSPENDED.isEvent()).isTrue();
+    assertThat(ProcessInstanceIntent.RESUMED.isEvent()).isTrue();
+  }
+
+  @Test
+  void shouldMarkSuspendAndResumeAsCommands() {
+    // given / when / then
+    assertThat(ProcessInstanceIntent.SUSPEND.isEvent()).isFalse();
+    assertThat(ProcessInstanceIntent.RESUME.isEvent()).isFalse();
+  }
+
+  @Test
+  void shouldDecodeSuspendAndResumeIntentsFromShort() {
+    // given / when / then
+    assertThat(ProcessInstanceIntent.from((short) 17)).isEqualTo(ProcessInstanceIntent.SUSPEND);
+    assertThat(ProcessInstanceIntent.from((short) 18)).isEqualTo(ProcessInstanceIntent.SUSPENDED);
+    assertThat(ProcessInstanceIntent.from((short) 19)).isEqualTo(ProcessInstanceIntent.RESUME);
+    assertThat(ProcessInstanceIntent.from((short) 20)).isEqualTo(ProcessInstanceIntent.RESUMED);
+  }
+}


### PR DESCRIPTION
## Description

Adds `SUSPEND`/`SUSPENDED`/`RESUME`/`RESUMED` intents to `ProcessInstanceIntent` as the foundation for the suspend/resume process instance feature (Phase 1 of #56080). `SUSPEND`/`RESUME` are commands, classified as process-instance-level commands alongside `CANCEL` (not part of `BPMN_ELEMENT_COMMANDS`, per the issue); `SUSPENDED`/`RESUMED` are events. Naming and command/event pairing follows the existing `BatchOperationIntent` precedent.

No processors, appliers, exporters, or permission mapping are added here — those are separate downstream Phase 1 tasks tracked under #57506.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57512