### PR TITLE
feat: add ci-flood-triage skill for medic duty

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -36,6 +36,7 @@ When a skill exists for a recurring operation, use it rather than improvising st
 |--------------------------------|-----------------------------------------------------------------------------------------------|
 | `analytics-exporter`           | Add a new event handler or metric to the analytics exporter (`zeebe/exporters/analytics-exporter/`) |
 | `babysit-pr`                   | Self-driving loop to shepherd one or more PRs (incl. backports) to merged: rerun flaky CI, enqueue, re-enqueue |
+| `ci-flood-triage`              | Orient fast when a flood of CI incidents opens at once — find the shared pattern, flag outliers |
 | `ci-push-workflow-health`      | Analyze CI failure patterns for push-triggered workflow jobs on main and stable/* branches    |
 | `ci-runner-utilization`        | Detect CI runner underutilization and give downsizing recommendations for cost savings        |
 | `ci-scheduled-workflow-health` | Generate an HTML health report for all scheduled GitHub Actions workflows                     |

--- a/.claude/skills/ci-flood-triage/SKILL.md
+++ b/.claude/skills/ci-flood-triage/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: ci-flood-triage
-description: Triages a flood of CI incidents in camunda/camunda. Use when multiple CI incidents
-  open in a short window and the medic needs to orient fast — find the shared pattern, identify
-  outliers, and know what to do next. Re-runnable as new incidents arrive.
+description: Triages a flood of CI incidents in camunda/camunda. Use when multiple CI incidents open in a short window and the medic needs to orient fast — find the shared pattern, identify outliers, and know what to do next. Re-runnable as new incidents arrive.
 user-invocable: true
 argument-hint: "[minutes] — how far back to look, default 30"
 ---

--- a/.claude/skills/ci-flood-triage/SKILL.md
+++ b/.claude/skills/ci-flood-triage/SKILL.md
@@ -10,20 +10,29 @@ argument-hint: "[minutes] — how far back to look, default 30"
 # CI Flood Triage
 
 Gives the medic a fast orientation snapshot when a flood of CI incidents opens at once. Finds the
-shared pattern, flags outliers, and drafts a broadcast message — all without touching anything in
-incident.io.
+shared pattern, flags outliers, and drafts a broadcast message. Read-only by default — generating
+the snapshot never writes to incident.io. If the medic explicitly asks to merge incidents
+afterward, this skill can do that too, always with a confirmation step first (see Step 6).
 
 ## Prerequisites
 
-- **incident.io MCP** — required. Verify `incident_show` is available. If not, tell the user to
-  [configure the incident.io MCP server](https://docs.incident.io/ai/remote-mcp) and stop.
+- **incident.io MCP** — required. Verify the `mcp__incident-io__incident_show` tool is available.
+  If not, tell the user to [configure the incident.io MCP server](https://docs.incident.io/ai/remote-mcp)
+  and stop.
 
 Throughout this skill, MCP tools are referenced by their short verb (`incident_list`,
-`incident_show`); the actual identifier depends on which MCP server is configured.
+`incident_show`, `incident_update`); the actual tool name is namespaced by whichever MCP server
+is configured (e.g. `mcp__incident-io__incident_list`).
 
 ## Scope
 
-Multiple incidents only. If the user passes a single incident ID, redirect them to `/ci-incident`.
+Multiple incidents only. If the user passes a single incident ID, redirect them to `/ci-incident`
+for deep-dive investigation of that one incident.
+
+This skill owns the multi-incident merge action when the medic asks for it — it already has the
+correlation context (which incidents share a cause) needed to do that safely. `/ci-incident` is
+scoped to driving a single incident's investigation and status updates once assigned; it does not
+handle cross-incident merging.
 
 ## Procedure
 
@@ -51,8 +60,10 @@ Call `incident_list` with:
   incidents won't appear otherwise)
 - Page through all results until no more pages
 
-Read `config://organisation` to get the CI incident type ID and filter to it. If you can't
-determine the type ID, proceed without the filter and note this in the output.
+If the MCP server exposes a `config://organisation` resource (or equivalent), you may read it to
+find the CI incident type ID and filter to it. This is optional, not a required step — if the
+resource isn't available, or you can't determine the type ID from it, proceed without the filter
+(results may include non-CI incidents) and note this in the output.
 
 Record: total count, the list of (reference, name, summary, reported_at) for each.
 
@@ -75,16 +86,22 @@ data."
 
 ### Step 4 — Dig where uncertain
 
-If the hypothesis is unclear, or if summaries are thin, call `incident_show` on the incidents
-that are ambiguous. Prioritize:
-1. A sample of 3–5 that seem representative of the dominant group
-2. Any that look like outliers
+If the hypothesis is unclear, or summaries are thin, call `incident_show` on the incidents that
+need it — not the whole flood. That's normally:
+1. A handful representative of the dominant group (enough to confirm the shared cause — usually
+   3–5, more only if the group is large and heterogeneous)
+2. Every incident that looks like an outlier (there are usually few)
 
-Call in parallel batches of ~8. From each response, extract:
+Call these in parallel. From each response, extract:
 - Alert payload run URLs / run IDs
 - Any existing investigation content
 
-Use this to confirm or refute the grouping hypothesis.
+If a specific incident is still unclear after `incident_show` — thin alert payload, no shared run
+ID, genuinely ambiguous — invoke `/ci-incident <ID>` for that one incident to pull its full
+investigation context (Slack thread, matched runbook) before deciding where it belongs. Scope this
+to the incidents that actually need it; don't run it broadly across the flood.
+
+Use all of this to confirm or refute the grouping hypothesis.
 
 ### Step 5 — Output the triage snapshot
 
@@ -122,7 +139,7 @@ After the snapshot, stop and wait. Do not act on anything — no merging, no sta
 Slack posts — until the medic explicitly asks.
 
 If asked to merge incidents: list the exact IDs you'll merge and the target, then wait for
-explicit confirmation before calling any write tool.
+explicit confirmation before calling `incident_update` (or the equivalent merge write tool).
 
 If asked to post the draft broadcast: remind the medic that this skill does not post to Slack
 directly — they should copy-paste from the output above.
@@ -130,7 +147,8 @@ directly — they should copy-paste from the output above.
 ## Guardrails
 
 - Never post to Slack.
-- Never merge, update severity, or change status without explicit medic instruction.
+- Never merge, update severity, or change status without explicit medic instruction — the snapshot
+  in Step 5 is a recommendation, not an action.
 - Always show draft wording and get confirmation before any `incident_update` call.
 - Never assume an incident has been investigated — ask or check.
 - If the snapshot is a partial picture (flood still growing), say so and suggest re-running in

--- a/.claude/skills/ci-flood-triage/SKILL.md
+++ b/.claude/skills/ci-flood-triage/SKILL.md
@@ -93,13 +93,22 @@ need it — not the whole flood. That's normally:
 2. Every incident that looks like an outlier (there are usually few)
 
 Call these in parallel. From each response, extract:
-- Alert payload run URLs / run IDs
-- Any existing investigation content
+- Alert payload run URLs / run IDs — **and** the specific job name / workflow step within that run
+  (e.g. `integration-tests/zeebe-opensearch-exporter` vs `integration-tests/camunda-exporter`).
+  Two incidents can share a run URL while testing entirely different components — a shared run ID
+  is a much weaker signal than a shared job/test name. See the run-ID caveat in
+  `references/flood-patterns.md` before treating a shared run as enough to group on.
+- Any existing investigation content — but scope a stated root cause to the incident that stated
+  it. Do not extend one incident's "already tracked under issue #X" claim to a sibling that shares
+  only a run ID or name prefix with it; confirm the sibling's own failure independently.
 
-If a specific incident is still unclear after `incident_show` — thin alert payload, no shared run
-ID, genuinely ambiguous — invoke `/ci-incident <ID>` for that one incident to pull its full
-investigation context (Slack thread, matched runbook) before deciding where it belongs. Scope this
-to the incidents that actually need it; don't run it broadly across the flood.
+If a specific incident's alert payload is thin (e.g. "unsuccessful test cases: none captured") and
+you're relying on it to justify grouping, that's a blocker, not a detail to skip past — a sibling's
+confidence is not a substitute for this incident's own evidence. Before deciding where it belongs:
+pull the actual GHA job log (`gh run view <run_id> --log-failed`) if you have shell access, or
+invoke `/ci-incident <ID>` for that one incident to pull its full investigation context (Slack
+thread, matched runbook). Scope this to the incidents that actually need it; don't run it broadly
+across the flood.
 
 Use all of this to confirm or refute the grouping hypothesis.
 
@@ -151,5 +160,9 @@ directly — they should copy-paste from the output above.
   in Step 5 is a recommendation, not an action.
 - Always show draft wording and get confirmation before any `incident_update` call.
 - Never assume an incident has been investigated — ask or check.
+- Never group an incident into a shared-cause bucket on a shared run ID or name prefix alone, and
+  never let one incident's stated root cause/dedup claim cover a sibling that hasn't been checked
+  independently — especially when that sibling's own alert payload is thin. See "Correlation
+  Pitfalls" in `references/flood-patterns.md`.
 - If the snapshot is a partial picture (flood still growing), say so and suggest re-running in
   5–10 minutes.

--- a/.claude/skills/ci-flood-triage/SKILL.md
+++ b/.claude/skills/ci-flood-triage/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: ci-flood-triage
+description: Triages a flood of CI incidents in camunda/camunda. Use when multiple CI incidents
+  open in a short window and the medic needs to orient fast — find the shared pattern, identify
+  outliers, and know what to do next. Re-runnable as new incidents arrive.
+user-invocable: true
+argument-hint: "[minutes] — how far back to look, default 30"
+---
+
+# CI Flood Triage
+
+Gives the medic a fast orientation snapshot when a flood of CI incidents opens at once. Finds the
+shared pattern, flags outliers, and drafts a broadcast message — all without touching anything in
+incident.io.
+
+## Prerequisites
+
+- **incident.io MCP** — required. Verify `incident_show` is available. If not, tell the user to
+  [configure the incident.io MCP server](https://docs.incident.io/ai/remote-mcp) and stop.
+
+Throughout this skill, MCP tools are referenced by their short verb (`incident_list`,
+`incident_show`); the actual identifier depends on which MCP server is configured.
+
+## Scope
+
+Multiple incidents only. If the user passes a single incident ID, redirect them to `/ci-incident`.
+
+## Procedure
+
+### Step 1 — Parse the time window
+
+Read `$ARGUMENTS`. Supported forms:
+
+| Argument | Meaning |
+|---|---|
+| *(empty)* | last 30 minutes |
+| `60` | last N minutes |
+| `--since 2026-07-06T15:00Z` | from that UTC timestamp to now |
+| `--since 2026-07-06T15:00Z --until 2026-07-06T17:30Z` | specific historical range |
+
+Timestamps must be RFC 3339 / ISO 8601 UTC (append `Z` if no timezone given).
+When `--until` is provided, this is a **historical replay** — adjust Step 2 accordingly.
+
+### Step 2 — Fetch CI incidents
+
+Call `incident_list` with:
+- `created_after`: derived from Step 1
+- `created_before`: `--until` value if provided, otherwise omit
+- `include: ["summary"]`
+- `status_category: ["triage", "active"]` — **omit this filter for historical replays** (closed
+  incidents won't appear otherwise)
+- Page through all results until no more pages
+
+Read `config://organisation` to get the CI incident type ID and filter to it. If you can't
+determine the type ID, proceed without the filter and note this in the output.
+
+Record: total count, the list of (reference, name, summary, reported_at) for each.
+
+### Step 3 — Reason about the pattern
+
+Look at all incident names and summaries together. Ask: do these incidents point to a shared root
+cause, or are they independent failures?
+
+Read `references/flood-patterns.md` for known archetypes — use them to inform your reasoning, not
+to gate it. Real floods may not match either pattern cleanly.
+
+Signals to look for:
+- Common job name fragments across incident names
+- Shared failure description in summaries (same error, same upstream, same timing)
+- Tight timing cluster vs spread over many hours
+- Whether summaries mention the same GHA run URLs
+
+Form a working hypothesis: "probably one cause" vs "probably independent" vs "unclear, need more
+data."
+
+### Step 4 — Dig where uncertain
+
+If the hypothesis is unclear, or if summaries are thin, call `incident_show` on the incidents
+that are ambiguous. Prioritize:
+1. A sample of 3–5 that seem representative of the dominant group
+2. Any that look like outliers
+
+Call in parallel batches of ~8. From each response, extract:
+- Alert payload run URLs / run IDs
+- Any existing investigation content
+
+Use this to confirm or refute the grouping hypothesis.
+
+### Step 5 — Output the triage snapshot
+
+Print to terminal (never post to Slack, never call any write MCP tool):
+
+```
+CI Flood Triage — [timestamp] — [N] incidents in last [M] min
+
+PATTERN: [one sentence describing what you see]
+
+GROUPS:
+  Group 1 ([N] incidents): [pattern — e.g. "all reference runs 28799271420, 28798845890"]
+    → INC-6435, INC-6436, INC-6437 … (list all)
+    → Likely cause: [hypothesis]
+    → Recommended action: [e.g. "merge into one, assign to @zeebe-medic, pull PR #XXXXX"]
+
+  Outliers ([N] incidents): [why they don't fit]
+    → INC-6440: [reason — e.g. "different failure signature, predates the flood window"]
+    → Recommended action: [e.g. "investigate separately via /ci-incident INC-6440"]
+
+DRAFT SLACK BROADCAST (copy-paste to #top-monorepo-ci):
+---
+:alert: Merge queue blocked — [N] incidents, single root cause identified.
+[One sentence: what failed, why, which team owns it.]
+Tracking in [main incident ref]. ICs assigned. Updates to follow.
+---
+```
+
+If the pattern is genuinely unclear after steps 3–4, say so explicitly rather than guessing. List
+what's known and what still needs checking.
+
+### Step 6 — Wait for medic direction
+
+After the snapshot, stop and wait. Do not act on anything — no merging, no status updates, no
+Slack posts — until the medic explicitly asks.
+
+If asked to merge incidents: list the exact IDs you'll merge and the target, then wait for
+explicit confirmation before calling any write tool.
+
+If asked to post the draft broadcast: remind the medic that this skill does not post to Slack
+directly — they should copy-paste from the output above.
+
+## Guardrails
+
+- Never post to Slack.
+- Never merge, update severity, or change status without explicit medic instruction.
+- Always show draft wording and get confirmation before any `incident_update` call.
+- Never assume an incident has been investigated — ask or check.
+- If the snapshot is a partial picture (flood still growing), say so and suggest re-running in
+  5–10 minutes.

--- a/.claude/skills/ci-flood-triage/references/flood-patterns.md
+++ b/.claude/skills/ci-flood-triage/references/flood-patterns.md
@@ -1,0 +1,86 @@
+---
+title: Flood Patterns
+status: current
+---
+
+# Known CI Flood Patterns
+
+These are observed archetypes from real incidents. Use them to inform reasoning — not as rigid
+rules. Real floods may not match either pattern cleanly, or may combine elements of both.
+
+## Pattern A: Merge Queue Flood
+
+**What it looks like:**
+- Many incidents open within a tight window (minutes, not hours)
+- Incident names all contain `high-failure-rate-in-merge-queue`
+- Summaries reference the same 3–5 GHA run URLs
+- Jobs span multiple teams but share a compile failure or infra blip
+
+**Why it happens:**
+A single broken PR or infra issue enters the merge queue. Every job in every batch run fails.
+The alerting fires one incident per job — so one root cause becomes 30 incidents.
+
+**Key correlation signal:** shared GHA run IDs in alert payloads. If 25 of 30 incidents reference
+the same 3 runs, it's almost certainly one cause.
+
+**Right response:**
+1. Identify the dominant run IDs
+2. Find the common failure in those runs (compile error → look at Java Checks / Maven; infra →
+   look at Nexus, GitHub Actions, external upstreams)
+3. If it's a PR conflict: pull the offending PR from the merge queue, fix, re-enqueue
+4. Merge all related incidents into one, assign IC to the owning team
+5. Broadcast to #top-monorepo-ci: "merge queue blocked, cause identified, IC assigned"
+
+**Outlier signal:** an incident that doesn't reference the dominant runs, or has a different
+failure message — investigate separately via `/ci-incident`.
+
+---
+
+## Pattern B: Nightly / Scheduled Flood
+
+**What it looks like:**
+- Incidents open spread over hours (e.g. 21:00 → 03:00), not a burst
+- Incident names contain `nightly`, `scheduled`, `manualscheduled`, or `unsuccessful-job`
+- Different workflows, different teams, no obvious shared run IDs
+- Some jobs may have been failing for days
+
+**Why it happens (two sub-cases):**
+
+*Sub-case B1 — Expired silence:*
+A Grafana silence that was suppressing alerts expires. Pre-existing failures suddenly surface as
+new incidents all at once. The jobs were already broken; the silence expiring is the trigger, not
+a new failure.
+
+Signal: summaries say jobs were failing before the flood window. Check whether a silence was
+recently active on `merge-queue-high-failure-rate` or `unsuccessful-job` alert rules.
+
+Response: re-create the silence if appropriate; route real failures to owning teams.
+
+*Sub-case B2 — Shared infra problem:*
+An upstream goes down (e.g. JBoss Maven repo, AWS, Snyk), affecting many independent nightly
+jobs over hours as they happen to run.
+
+Signal: summaries mention the same external URL or service; failures cluster around the same
+error type (timeouts, 503s, auth failures).
+
+Response: identify the shared upstream, open one incident for it, route nightly job incidents to
+their owning teams.
+
+**Right response (general):**
+- Do NOT merge unrelated incidents just because they opened in the same window
+- Route each to its owning team (check `TEST_OWNER` in the workflow or CODEOWNERS)
+- Only merge if you can confirm they share a root cause
+- If it's a silence expiration, the fix is the silence — not investigating each job
+
+---
+
+## When the Pattern Isn't Clear
+
+If incidents span both merge-queue and nightly names, or if timing and summaries don't fit either
+archetype cleanly, pull `incident_show` on a representative sample and look for:
+
+- Common error strings across summaries
+- Shared external dependencies (Maven repos, AWS regions, third-party APIs)
+- Whether the flood started at an unusual hour (silence expiry tends to happen at fixed times)
+
+State your uncertainty explicitly in the triage output rather than forcing a pattern.

--- a/.claude/skills/ci-flood-triage/references/flood-patterns.md
+++ b/.claude/skills/ci-flood-triage/references/flood-patterns.md
@@ -23,6 +23,16 @@ The alerting fires one incident per job — so one root cause becomes 30 inciden
 **Key correlation signal:** shared GHA run IDs in alert payloads. If 25 of 30 incidents reference
 the same 3 runs, it's almost certainly one cause.
 
+**Caveat — run ID alone is not proof:** a shared run ID means the incidents came from the same CI
+*invocation*, not that they share a cause. This heuristic is strongest here, in a merge-queue batch,
+because a single broken commit really does poison every job in that batch. It is much weaker for a
+scheduled/nightly workflow (see Pattern B) — one nightly run fans out into many independent
+per-component jobs that all legitimately carry the same run URL by construction, whether or not
+their failures are related. Before grouping on run-ID alone, compare the job name segment (e.g.
+`integration-tests/zeebe-opensearch-exporter` vs `integration-tests/camunda-exporter`) — different
+job names sharing one run are a stronger signal of *different* causes than the shared run ID is a
+signal of the same cause. Confirm with the actual failing test/class name when it's available.
+
 **Right response:**
 1. Identify the dominant run IDs
 2. Find the common failure in those runs (compile error → look at Java Checks / Maven; infra →
@@ -43,6 +53,9 @@ failure message — investigate separately via `/ci-incident`.
 - Incident names contain `nightly`, `scheduled`, `manualscheduled`, or `unsuccessful-job`
 - Different workflows, different teams, no obvious shared run IDs
 - Some jobs may have been failing for days
+- A single nightly/scheduled run can trigger several incidents at once — one per failing job in
+  its matrix — that all share the same run URL. That's normal fan-out, not evidence those jobs
+  share a root cause (see the run-ID caveat under Pattern A)
 
 **Why it happens (two sub-cases):**
 
@@ -84,3 +97,23 @@ archetype cleanly, pull `incident_show` on a representative sample and look for:
 - Whether the flood started at an unusual hour (silence expiry tends to happen at fixed times)
 
 State your uncertainty explicitly in the triage output rather than forcing a pattern.
+
+---
+
+## Correlation Pitfalls
+
+Two failure modes have actually caused mis-grouping in practice — check for both before finalizing
+any group of more than one incident:
+
+- **Don't let one incident's narrative anchor its siblings.** If incident A's summary says
+  "already tracked under issue #X," that claim covers incident A's own failure. It does not
+  automatically extend to incident B just because B shares a run ID, workflow-name prefix, or
+  timing with A. Confirm each incident's own failing job/test independently before folding it into
+  A's group — a confident sibling is not evidence about an unrelated one.
+- **A thin alert payload blocks grouping, not just outlier status.** If an alert's "unsuccessful
+  test cases" came back empty or uncaptured, you don't know what actually failed. Don't assume it
+  matches the group's dominant cause just because the surrounding metadata (run ID, name prefix)
+  looks similar — that's exactly the situation where superficial signals get mistaken for a shared
+  cause. Pull the real failing test/job (the GHA job log, e.g. `gh run view <run_id> --log-failed`)
+  or escalate via `/ci-incident` before including it.
+


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/ci-flood-triage/SKILL.md` — a Claude skill that helps the medic orient fast during a CI incident flood. Fetches recent CI incidents via the incident.io MCP, reasons about the shared pattern from names and summaries, digs into ambiguous ones with targeted `incident_show` calls, and outputs a triage snapshot + draft broadcast message to the terminal.
- Adds `.claude/skills/ci-flood-triage/references/flood-patterns.md` — documents the two observed flood archetypes (merge queue burst vs nightly/scheduled spread) as reasoning context for the model, not rigid branching rules.

**Motivation:** During a flood (30+ incidents opening in minutes from a single root cause), the current experience is disorienting — alerts arrive as a wall of Slack pings with no automatic grouping, leaving the medic to manually correlate across 30 separate incident views. The July 6 2026 flood took ~2.5 hours manually; the skill compresses orientation to ~5 minutes.

**Validated** against the July 6 flood data (`--since 2026-07-06T15:00Z --until 2026-07-06T17:30Z`): correctly identified 31 incidents as a single merge queue group (all merged into INC-6454) and surfaced INC-6440 as the one outlier.

## Usage

```
/ci-flood-triage              # last 30 minutes
/ci-flood-triage 60           # last N minutes
/ci-flood-triage --since 2026-07-06T15:00Z              # from timestamp to now
/ci-flood-triage --since 2026-07-06T15:00Z --until 2026-07-06T17:30Z  # historical replay
```

Re-runnable as new incidents arrive during a live flood.

**Requires:** incident.io MCP configured (`mcp__incident-io__*` tools available in session).

### Output example

> CI Flood Triage — 2026-07-05T15:00Z to 2026-07-06T15:00Z (historical replay) — 16 CI incidents
> 
> Note: incident_list's created_before filter didn't strictly honor the 15:00Z cutoff (it returned INC-6454 at 16:13Z and INC-6440 at 15:28Z) — I excluded those two manually since they fall outside your requested window. Of the 34 raw results, 18 were non-CI (support tickets, CVEs, load-test incidents) and excluded per scope.
> 
> PATTERN: Not a single flood with one root cause. This is the "overnight nightly-cascade" archetype — many unrelated scheduled/nightly GitHub Actions workflows failed independently in the same overnight UTC window (00:43–07:28 on 07-06), each producing its own incident. Within that, 5 genuine sub-groups exist where multiple incidents share a workflow run or fix — but 3 of those groups have at least one member with a thin, unconfirmed payload that I did not fold in on a shared-run-ID assumption alone.
> 
> GROUPS:
> 
> Group 1 — AWS OpenSearch integration tests, run 28769880684 (2 confirmed + 1 unconfirmed)
> → INC-6414 (camunda-exporter), INC-6415 (camunda-qa-acceptance-tests-client/non-client)
> → Cause: Data Layer exporter/archiver test failures, both independently deduped to issue [#52892](https://github.com/camunda/camunda/issues/52892)
> → INC-6413 (zeebe-opensearch-exporter) shares the same run ID and same Data Layer owner, but has zero investigation updates and "Unsuccessful test cases: None captured" — no independent confirmation it's the same failure. Don't fold it into #52892 on run-ID alone.
> → Recommended: merge 6414+6415 (already confirmed same cause); check 6413 separately before merging it in.
> 
> Group 2 — C8 Orchestration Cluster Nightly (main), shared fix PR #56715 (2 incidents, confirmed)
> → INC-6395 (RDBMS, run 28763642677, already bundles 10 DB-engine alerts internally), INC-6394 (ES, run 28763533198)
> → Cause: partition-routing bug in "not found" tests (Zeebe key decoding to a non-routable partition). Both explicitly cite the same fix, PR [#56715](https://github.com/camunda/camunda/pull/56715), despite being different runs/workflows.
> → Recommended: already resolved and fixed — merge for record-keeping if desired, no action needed.
> 
> Group 3 — C8 Orchestration Cluster Nightly (stable/8.9), run 28762284649 (2 incidents, weakly confirmed)
> → INC-6393 (Postgres 17), INC-6392 (Postgres 16) — same run ID, same timestamp
> → INC-6393's closure note is garbled ("This PR fixes the issue" links to the run URL, not an actual PR). INC-6392 closed with no message at all.
> → Not confirmed whether this is the same partition-routing bug as Group 2 on the 8.9 branch, or a distinct 8.9-specific issue.
> → Recommended: verify via GHA log or /ci-incident INC-6393 before merging or asserting the cause.
> 
> Group 4 — V2 Stateless Tests Nightly (request-validation-tests), run 28760408351 (2 incidents, unconfirmed)
> → INC-6390 (main), INC-6389 (stable/8.8) — identical run ID, identical creation timestamp, same owning team
> → Both closed 4 days later with no root-cause message on either. Strong structural signal (same run), zero evidence of what actually broke.
> → Recommended: pull gh run view 28760408351 --log-failed before merging.
> 
> Group 5 — Optimize E2E Self-Managed (Nightly) (2 incidents, confirmed)
> → INC-6411 (e2e-full-main), INC-6410 (e2e-full-stable-8.9)
> → Cause: Operate's dev-data generator failing on auth + ES startup-ordering, independently stated in both summaries.
> → Recommended: already resolved — merge for record-keeping if desired.
> 
> Outliers (5 incidents): each a distinct, unrelated cause, already closed
> → INC-6416: AWS Aurora integration tests (different run/workflow from Group 1 despite similar name) — 30-min timeout, fixed via PR #57107
> → INC-6420: webapp-client/integration on main — flaky Playwright test, fixed
> → INC-6409: Frontend SBOM Snyk Nightly — missing TEST_PRODUCT env var, fixed
> → INC-6405: Optimize Release nightly build — missing RELEASE_VERSION, deprecated schedule trigger removed
> → INC-6391: weekly medic load test — eventual-consistency race in namespace creation, fixed
> 
> DRAFT SLACK BROADCAST (copy-paste to #top-monorepo-ci):
> :alert: Retrospective — 16 CI incidents opened overnight 07-06 (00:43–07:28 UTC), all already resolved. No single root cause: 5 independent nightly-workflow failures, 2 already-fixed groups (partition-routing bug PR #56715; Operate dev-data auth issue), and 3 incidents (INC-6413, INC-6392/6393, INC-6389/6390) share a run ID with a sibling but lack independent root-cause confirmation — flagging for cleanup, not urgent.

> CI Flood Triage — 2026-07-06T15:00Z to 2026-07-06T17:30Z (historical replay) — 2 incidents
> 
> Same API caveat as the prior window: created_after/created_before weren't honored precisely (still returned all 34 raw results spanning back to 00:43Z). I filtered manually to the 2 incidents whose reported_at actually falls in [15:00, 17:30]Z.
> 
> PATTERN: Single root cause, confirmed independently by both incidents — a merge-queue-to-main compilation break. This is the textbook "one compile break, many downstream job-alert incidents" archetype, and unlike the earlier grouping calls today, both sides of this one did their own investigation rather than inheriting a sibling's claim.
> 
> GROUPS:
> 
> Group 1 (2 incidents): merge-queue compilation break from PR #56393
> → INC-6454, INC-6440
> → Likely cause: PR #56393 ("feat: introduce recovery mode rest endpoint") introduced RecoveryController.java, which referenced ModeChangeOperation/AwaitModeChangeOperation as inner classes of ClusterConfigurationChangeOperation. A prior refactor (commit 003d964ac3d) had already moved those classes to PartitionGroupOperation, so zeebe-gateway-rest failed to compile whenever the PR entered the merge queue — cascading into 20+ unrelated job failures across 3 consecutive merge-queue batches (runs 28799271420, 28798845890, 28798022569, plus earlier batches 28797806277, 28797692383, 28795325461, 28794733789).
> → INC-6454 is the primary incident: 31 alerts already consolidated under it (validate-pom-metadata, database-integration-tests, identity-tests, zeebe-unit-tests/Client-CamundaEx, smoke-tests, build-distball, etc.), root cause confirmed, fix (4fc834a7b31) merged into PR #56393 at ~17:58 UTC on 07-06, merge queue healthy since.
> → INC-6440 (zeebe-unit-tests/General-CoreFeatures) was investigated separately by Fabio Paini, who independently confirmed the failures co-occurred with the same Java Checks compilation failures and closed it as a false alarm "tied to INC-6454" — this is the incident's own conclusion, not an inherited assumption on my part.
> → Recommended action: merge INC-6440 into INC-6454 for clean record-keeping (both closed, same confirmed cause, fix already shipped) — no live action needed since this resolved 07-06 evening.
> 
> Outliers: none — both incidents in this window belong to the same confirmed cause.
> 
> DRAFT SLACK BROADCAST (copy-paste to #top-monorepo-ci):
> :alert: Retrospective — merge queue to main was blocked 2026-07-06 ~16:00–18:00 UTC by a compilation break in RecoveryController.java (PR #56393), cascading into 20+ job-level CI alerts. Root cause confirmed, fix merged ~17:58 UTC, queue healthy since. INC-6454 is the primary record; INC-6440 was a duplicate.

## Deployment research

Three surfaces were evaluated for invoking this skill during a flood:

**@Claude in Slack** — Claude Tag can access `camunda/camunda` skills when the repo is in the session context, so `/ci-flood-triage` would work in principle. However, incident channels contain external guests, which triggers Slack's guest policy and blocks Claude from responding there. The channels where you most need it are exactly where it can't operate.

**Slack canvas skills** — Slack has a native "skill" concept based on canvas documents. These are unversioned, replicate to everyone on change, and have no MCP integration — so they can't query incident.io. Dead end for anything data-driven.

**Claude Code (terminal)** — works today, as validated by the July 6 replay test. The trade-off is a context switch from Slack to the terminal; in practice, keeping Claude Code open in the camunda repo during medic shifts covers this. Chosen for MVP.

**Actora (future)** — once validated in the field, the skill can be promoted to functions/engineering/skills/ in `camunda/actora`, which makes it available from Claude.ai web. Promotion requires: swapping local doc paths for gh CLI fetches, adding plugin.json + CHANGELOG.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)