### PR TITLE
Validate cluster ID against secondary storage to prevent cross-cluster data corruption

### DIFF
--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -81,11 +81,7 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   /** Whether to schedule the cleanup of legacy indexes */
   private boolean performCleanup = false;
 
-  /**
-   * If true, startup fails when the cluster ID recorded in the database schema does not match this
-   * cluster's ID. Disable only if intentionally re-pointing this cluster at storage belonging to a
-   * different installation.
-   */
+  /** If true, startup fails when this cluster's ID doesn't match the one recorded in storage. */
   private boolean clusterIdCheckRestrictionEnabled = true;
 
   @NestedConfigurationProperty

--- a/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
+++ b/configuration/src/main/java/io/camunda/configuration/DocumentBasedSecondaryStorageDatabase.java
@@ -81,6 +81,13 @@ public abstract class DocumentBasedSecondaryStorageDatabase
   /** Whether to schedule the cleanup of legacy indexes */
   private boolean performCleanup = false;
 
+  /**
+   * If true, startup fails when the cluster ID recorded in the database schema does not match this
+   * cluster's ID. Disable only if intentionally re-pointing this cluster at storage belonging to a
+   * different installation.
+   */
+  private boolean clusterIdCheckRestrictionEnabled = true;
+
   @NestedConfigurationProperty
   private IncidentNotifier incidentNotifier = new IncidentNotifier(databaseName());
 
@@ -194,6 +201,14 @@ public abstract class DocumentBasedSecondaryStorageDatabase
 
   public void setPerformCleanup(final boolean performCleanup) {
     this.performCleanup = performCleanup;
+  }
+
+  public boolean isClusterIdCheckRestrictionEnabled() {
+    return clusterIdCheckRestrictionEnabled;
+  }
+
+  public void setClusterIdCheckRestrictionEnabled(final boolean clusterIdCheckRestrictionEnabled) {
+    this.clusterIdCheckRestrictionEnabled = clusterIdCheckRestrictionEnabled;
   }
 
   public Cache getBatchOperationCache() {

--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -71,11 +71,7 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   private int batchOperationItemInsertBlockSize =
       RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
 
-  /**
-   * If true, startup fails when the cluster ID recorded in the database schema does not match this
-   * cluster's ID. Disable only if intentionally re-pointing this cluster at storage belonging to a
-   * different installation.
-   */
+  /** If true, startup fails when this cluster's ID doesn't match the one recorded in storage. */
   private boolean clusterIdCheckRestrictionEnabled = true;
 
   @NestedConfigurationProperty private RdbmsHistory history = new RdbmsHistory();

--- a/configuration/src/main/java/io/camunda/configuration/Rdbms.java
+++ b/configuration/src/main/java/io/camunda/configuration/Rdbms.java
@@ -71,6 +71,13 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
   private int batchOperationItemInsertBlockSize =
       RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
 
+  /**
+   * If true, startup fails when the cluster ID recorded in the database schema does not match this
+   * cluster's ID. Disable only if intentionally re-pointing this cluster at storage belonging to a
+   * different installation.
+   */
+  private boolean clusterIdCheckRestrictionEnabled = true;
+
   @NestedConfigurationProperty private RdbmsHistory history = new RdbmsHistory();
 
   @NestedConfigurationProperty private RdbmsMetrics metrics = new RdbmsMetrics();
@@ -165,6 +172,14 @@ public class Rdbms extends SecondaryStorageDatabase<RdbmsHistory> {
 
   public void setBatchOperationItemInsertBlockSize(final int batchOperationItemInsertBlockSize) {
     this.batchOperationItemInsertBlockSize = batchOperationItemInsertBlockSize;
+  }
+
+  public boolean isClusterIdCheckRestrictionEnabled() {
+    return clusterIdCheckRestrictionEnabled;
+  }
+
+  public void setClusterIdCheckRestrictionEnabled(final boolean clusterIdCheckRestrictionEnabled) {
+    this.clusterIdCheckRestrictionEnabled = clusterIdCheckRestrictionEnabled;
   }
 
   @Override

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/BrokerBasedPropertiesOverride.java
@@ -993,6 +993,7 @@ public class BrokerBasedPropertiesOverride {
     config.setFlushInterval(database.getFlushInterval());
     config.setExportBatchOperationItemsOnCreation(database.isExportBatchOperationItemsOnCreation());
     config.setBatchOperationItemInsertBlockSize(database.getBatchOperationItemInsertBlockSize());
+    config.setClusterIdCheckRestrictionEnabled(database.isClusterIdCheckRestrictionEnabled());
     config.setAuditLog(camunda.getData().getAuditLog().toConfiguration());
     config.setWaitState(camunda.getData().getWaitStates().toConfiguration());
     config.setHistoryDeletion(camunda.getData().getHistoryDeletion().toConfiguration());

--- a/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
+++ b/configuration/src/main/java/io/camunda/configuration/beanoverrides/CamundaExporterConfigurationApplier.java
@@ -224,6 +224,8 @@ public final class CamundaExporterConfigurationApplier {
     }
 
     exporterConfiguration.setCreateSchema(source.isCreateSchema());
+    exporterConfiguration.setClusterIdCheckRestrictionEnabled(
+        source.isClusterIdCheckRestrictionEnabled());
     exporterConfiguration
         .getBatchOperationCache()
         .setMaxCacheSize(source.getBatchOperationCache().getMaxSize());

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageElasticsearchTest.java
@@ -76,6 +76,7 @@ public class SecondaryStorageElasticsearchTest {
   private static final int EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS = 12000;
 
   private static final boolean EXPECTED_CREATE_SCHEMA = false;
+  private static final boolean EXPECTED_CLUSTER_ID_CHECK_RESTRICTION_ENABLED = false;
 
   private static final String EXPECTED_INCIDENT_NOTIFIER_WEBHOOK =
       "https://test-webhook.example.com";
@@ -155,6 +156,8 @@ public class SecondaryStorageElasticsearchTest {
             + EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS
             + "ms",
         "camunda.data.secondary-storage.elasticsearch.create-schema=" + EXPECTED_CREATE_SCHEMA,
+        "camunda.data.secondary-storage.elasticsearch.cluster-id-check-restriction-enabled="
+            + EXPECTED_CLUSTER_ID_CHECK_RESTRICTION_ENABLED,
         "camunda.data.secondary-storage.elasticsearch.incident-notifier.webhook="
             + EXPECTED_INCIDENT_NOTIFIER_WEBHOOK,
         "camunda.data.secondary-storage.elasticsearch.incident-notifier.auth0-domain="
@@ -308,6 +311,8 @@ public class SecondaryStorageElasticsearchTest {
       assertThat(exporterConfiguration.getHistory().getMaxDelayBetweenRuns())
           .isEqualTo(EXPECTED_HISTORY_MAX_DELAY_BETWEEN_RUNS);
       assertThat(exporterConfiguration.isCreateSchema()).isEqualTo(EXPECTED_CREATE_SCHEMA);
+      assertThat(exporterConfiguration.isClusterIdCheckRestrictionEnabled())
+          .isEqualTo(EXPECTED_CLUSTER_ID_CHECK_RESTRICTION_ENABLED);
       assertThat(exporterConfiguration.getNotifier().getWebhook())
           .isEqualTo(EXPECTED_INCIDENT_NOTIFIER_WEBHOOK);
       assertThat(exporterConfiguration.getNotifier().getAuth0Domain())

--- a/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
+++ b/configuration/src/test/java/io/camunda/configuration/SecondaryStorageRdbmsTest.java
@@ -126,6 +126,7 @@ public class SecondaryStorageRdbmsTest {
             + ASYNC_REPLICATION_MAX_LAG,
         "camunda.data.secondary-storage.rdbms.async-replication.pause-on-max-lag-exceeded=true",
         "camunda.data.secondary-storage.rdbms.max-varchar-field-length=200",
+        "camunda.data.secondary-storage.rdbms.cluster-id-check-restriction-enabled=false",
       })
   class WithOnlyUnifiedConfigSet {
     final OperateProperties operateProperties;
@@ -213,6 +214,7 @@ public class SecondaryStorageRdbmsTest {
       assertThat(exporterConfiguration.getAsyncReplication().getMaxLag())
           .isEqualTo(Duration.parse(ASYNC_REPLICATION_MAX_LAG));
       assertThat(exporterConfiguration.getAsyncReplication().isPauseOnMaxLagExceeded()).isTrue();
+      assertThat(exporterConfiguration.isClusterIdCheckRestrictionEnabled()).isFalse();
     }
 
     @Test

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/overridable-properties.golden.txt
@@ -100,6 +100,7 @@ data.secondary-storage.elasticsearch.batch-operation-cache.cache-name
 data.secondary-storage.elasticsearch.batch-operation-cache.database-name
 data.secondary-storage.elasticsearch.batch-operations.database-name
 data.secondary-storage.elasticsearch.bulk.database-name
+data.secondary-storage.elasticsearch.cluster-id-check-restriction-enabled
 data.secondary-storage.elasticsearch.cluster-name
 data.secondary-storage.elasticsearch.connection-timeout
 data.secondary-storage.elasticsearch.create-schema
@@ -144,6 +145,7 @@ data.secondary-storage.opensearch.batch-operation-cache.cache-name
 data.secondary-storage.opensearch.batch-operation-cache.database-name
 data.secondary-storage.opensearch.batch-operations.database-name
 data.secondary-storage.opensearch.bulk.database-name
+data.secondary-storage.opensearch.cluster-id-check-restriction-enabled
 data.secondary-storage.opensearch.cluster-name
 data.secondary-storage.opensearch.connection-timeout
 data.secondary-storage.opensearch.create-schema
@@ -190,6 +192,7 @@ data.secondary-storage.rdbms.async-replication.polling-interval
 data.secondary-storage.rdbms.auto-ddl
 data.secondary-storage.rdbms.batch-operation-cache
 data.secondary-storage.rdbms.batch-operation-item-insert-block-size
+data.secondary-storage.rdbms.cluster-id-check-restriction-enabled
 data.secondary-storage.rdbms.connection-pool.connection-timeout
 data.secondary-storage.rdbms.connection-pool.idle-timeout
 data.secondary-storage.rdbms.connection-pool.leak-detection-threshold

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.10.0.xml
@@ -660,4 +660,15 @@
     </addColumn>
   </changeSet>
 
+  <changeSet id="add_rdbms_schema_version_cluster_id_column" author="camunda">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="${prefix}RDBMS_SCHEMA_VERSION" columnName="CLUSTER_ID"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="${prefix}RDBMS_SCHEMA_VERSION">
+      <column name="CLUSTER_ID" type="VARCHAR(255)"/>
+    </addColumn>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/DefaultRdbmsSchemaManagerRegistry.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/DefaultRdbmsSchemaManagerRegistry.java
@@ -72,4 +72,20 @@ public class DefaultRdbmsSchemaManagerRegistry
     final var schemaManager = schemaManagers.get(physicalTenantId);
     return schemaManager != null && schemaManager.isInitialized();
   }
+
+  @Override
+  public void validateClusterId(
+      final String physicalTenantId,
+      final String clusterId,
+      final boolean clusterIdCheckRestrictionEnabled) {
+    final var schemaManager = schemaManagers.get(physicalTenantId);
+    if (schemaManager == null) {
+      LOG.debug(
+          "[RDBMS Schema] No schema manager for unknown physical tenant '{}', skipping cluster ID "
+              + "check.",
+          physicalTenantId);
+      return;
+    }
+    schemaManager.validateClusterId(clusterId, clusterIdCheckRestrictionEnabled);
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/LiquibaseSchemaManager.java
@@ -115,6 +115,14 @@ public class LiquibaseSchemaManager implements RdbmsSchemaManager {
     return initialized;
   }
 
+  @Override
+  public void validateClusterId(
+      final String clusterId, final boolean clusterIdCheckRestrictionEnabled) {
+    if (versionStore.checkClusterIdCompatibility(clusterId, clusterIdCheckRestrictionEnabled)) {
+      versionStore.recordClusterId(clusterId);
+    }
+  }
+
   @VisibleForTesting
   protected SpringLiquibase buildRunner() {
     final var runner = new SpringLiquibase();

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/NoopSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/NoopSchemaManager.java
@@ -25,4 +25,10 @@ public class NoopSchemaManager implements RdbmsSchemaManager {
   public boolean isInitialized() {
     return true;
   }
+
+  @Override
+  public void validateClusterId(
+      final String clusterId, final boolean clusterIdCheckRestrictionEnabled) {
+    // no-op: the schema is managed externally, so we have no bookkeeping to validate against
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/NoopSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/NoopSchemaManager.java
@@ -29,6 +29,6 @@ public class NoopSchemaManager implements RdbmsSchemaManager {
   @Override
   public void validateClusterId(
       final String clusterId, final boolean clusterIdCheckRestrictionEnabled) {
-    // no-op: the schema is managed externally, so we have no bookkeeping to validate against
+    // no-op: the schema is managed externally
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaManager.java
@@ -32,8 +32,7 @@ public interface RdbmsSchemaManager {
    * it. Called lazily by the exporter itself, once its cluster ID is resolved.
    *
    * @param clusterId this cluster's resolved ID, or blank if unresolved (skips the check)
-   * @param clusterIdCheckRestrictionEnabled if {@code true}, a mismatch throws; otherwise it's only
-   *     logged
+   * @param clusterIdCheckRestrictionEnabled if {@code false}, the check is skipped entirely
    */
   void validateClusterId(String clusterId, boolean clusterIdCheckRestrictionEnabled);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaManager.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaManager.java
@@ -26,4 +26,14 @@ public interface RdbmsSchemaManager {
    * open against it.
    */
   boolean isInitialized();
+
+  /**
+   * Validates {@code clusterId} against the one previously recorded for this schema, and records
+   * it. Called lazily by the exporter itself, once its cluster ID is resolved.
+   *
+   * @param clusterId this cluster's resolved ID, or blank if unresolved (skips the check)
+   * @param clusterIdCheckRestrictionEnabled if {@code true}, a mismatch throws; otherwise it's only
+   *     logged
+   */
+  void validateClusterId(String clusterId, boolean clusterIdCheckRestrictionEnabled);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaManagerRegistry.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaManagerRegistry.java
@@ -23,4 +23,11 @@ public interface RdbmsSchemaManagerRegistry {
    * or has failed.
    */
   boolean isInitialized(String physicalTenantId);
+
+  /**
+   * Delegates to the tenant's {@link RdbmsSchemaManager#validateClusterId(String, boolean)}; no-op
+   * for unknown tenants.
+   */
+  void validateClusterId(
+      String physicalTenantId, String clusterId, boolean clusterIdCheckRestrictionEnabled);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms;
 
+import io.camunda.db.rdbms.exception.RdbmsClusterIdIncompatibleException;
 import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
 import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -207,6 +208,137 @@ public class RdbmsSchemaVersionStore {
       throw new IllegalStateException(
           "[RDBMS Schema] Failed to update schema version in " + tableName + ". Startup aborted.",
           e);
+    }
+  }
+
+  /**
+   * Unlike {@link #checkCompatibility()}, this is called lazily by the RDBMS exporter itself, not
+   * during the Liquibase migration: only the exporter has access to the resolved cluster ID.
+   *
+   * @return {@code true} if the caller should (re-)record {@code clusterId}: no previous value
+   *     existed, or a mismatch was detected but ignored per configuration.
+   */
+  public boolean checkClusterIdCompatibility(
+      final String clusterId, final boolean restrictionEnabled) {
+    if (clusterId == null || clusterId.isBlank()) {
+      LOG.debug(
+          "[RDBMS Schema] No local cluster ID available, skipping cluster ID compatibility check "
+              + "for prefix '{}'.",
+          prefix);
+      return false;
+    }
+
+    final String previousClusterId;
+    try (final var connection = dataSource.getConnection()) {
+      previousClusterId = readClusterId(connection, prefix);
+    } catch (final Exception e) {
+      LOG.error(
+          "[RDBMS Schema] Failed to determine current cluster ID for prefix '{}'. Startup aborted.",
+          prefix,
+          e);
+      throw new IllegalStateException(
+          "[RDBMS Schema] Failed to determine current cluster ID for prefix '" + prefix + "'.", e);
+    }
+
+    if (previousClusterId == null) {
+      LOG.debug(
+          "[RDBMS Schema] No cluster ID recorded yet for prefix '{}', assuming a fresh "
+              + "installation.",
+          prefix);
+      return true;
+    }
+    if (previousClusterId.equals(clusterId)) {
+      LOG.info(
+          "[RDBMS Schema] Cluster ID '{}' matches the one recorded for prefix '{}'",
+          clusterId,
+          prefix);
+      return false;
+    }
+
+    if (restrictionEnabled) {
+      throw new RdbmsClusterIdIncompatibleException(previousClusterId, clusterId);
+    }
+    LOG.warn(
+        "[RDBMS Schema] Detected cluster ID mismatch for prefix '{}': schema was previously "
+            + "initialized by cluster '{}', but this cluster's ID is '{}'. Ignoring as configured.",
+        prefix,
+        previousClusterId,
+        clusterId);
+    return true;
+  }
+
+  /**
+   * No-op if {@code clusterId} is blank. Requires the single {@code RDBMS_SCHEMA_VERSION} row to
+   * already exist; if not (e.g. an unparseable {@link #applicationVersion}), logs a warning instead
+   * of claiming success.
+   */
+  public void recordClusterId(final String clusterId) {
+    if (clusterId == null || clusterId.isBlank()) {
+      return;
+    }
+
+    final var tableName = prefix + SCHEMA_VERSION_TABLE;
+    try (final var connection = dataSource.getConnection()) {
+      final var autoCommit = connection.getAutoCommit();
+      connection.setAutoCommit(false);
+      try {
+        final var updatedRows = updateClusterIdById(connection, tableName, clusterId);
+        connection.commit();
+        if (updatedRows == 0) {
+          LOG.warn(
+              "[RDBMS Schema] Could not record cluster ID for prefix '{}': no row exists yet in "
+                  + "{}. This is expected if the application version is not a parseable semantic "
+                  + "version (e.g. local development); cluster ID compatibility will not be "
+                  + "tracked until a real version is recorded.",
+              prefix,
+              tableName);
+          return;
+        }
+        LOG.info("[RDBMS Schema] Updated cluster ID to {} for prefix '{}'.", clusterId, prefix);
+      } catch (final SQLException e) {
+        connection.rollback();
+        throw e;
+      } finally {
+        connection.setAutoCommit(autoCommit);
+      }
+    } catch (final Exception e) {
+      LOG.error(
+          "[RDBMS Schema] Failed to update cluster ID in {} for prefix '{}'. Startup aborted.",
+          tableName,
+          prefix,
+          e);
+      throw new IllegalStateException(
+          "[RDBMS Schema] Failed to update cluster ID in " + tableName + ". Startup aborted.", e);
+    }
+  }
+
+  /**
+   * Reads the recorded cluster ID from {@code RDBMS_SCHEMA_VERSION}. Returns {@code null} if the
+   * table does not exist, contains no rows, or the column is {@code NULL} (e.g. upgrading from
+   * before this check existed).
+   */
+  @VisibleForTesting
+  protected String readClusterId(final Connection connection, final String prefix)
+      throws SQLException {
+    final var tableName = prefix + SCHEMA_VERSION_TABLE;
+    if (!tableExists(connection, tableName)) {
+      return null;
+    }
+    try (final var stmt = connection.prepareStatement("SELECT CLUSTER_ID FROM " + tableName)) {
+      stmt.setMaxRows(1);
+      try (final var rs = stmt.executeQuery()) {
+        return rs.next() ? rs.getString(1) : null;
+      }
+    }
+  }
+
+  private int updateClusterIdById(
+      final Connection connection, final String tableName, final String clusterId)
+      throws SQLException {
+    try (final var updateStmt =
+        connection.prepareStatement("UPDATE " + tableName + " SET CLUSTER_ID = ? WHERE ID = 1")) {
+      updateStmt.setString(1, clusterId);
+      return updateStmt.executeUpdate();
     }
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -248,7 +248,7 @@ public class RdbmsSchemaVersionStore {
     }
 
     if (previousClusterId == null) {
-      LOG.debug(
+      LOG.info(
           "[RDBMS Schema] No cluster ID recorded yet for prefix '{}', assuming a fresh "
               + "installation.",
           prefix);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsSchemaVersionStore.java
@@ -215,11 +215,18 @@ public class RdbmsSchemaVersionStore {
    * Unlike {@link #checkCompatibility()}, this is called lazily by the RDBMS exporter itself, not
    * during the Liquibase migration: only the exporter has access to the resolved cluster ID.
    *
-   * @return {@code true} if the caller should (re-)record {@code clusterId}: no previous value
-   *     existed, or a mismatch was detected but ignored per configuration.
+   * @return {@code true} if the caller should record {@code clusterId}: no previous value existed
+   *     yet.
    */
   public boolean checkClusterIdCompatibility(
       final String clusterId, final boolean restrictionEnabled) {
+    if (!restrictionEnabled) {
+      LOG.debug(
+          "[RDBMS Schema] Cluster ID check restriction is disabled, skipping cluster ID "
+              + "compatibility check for prefix '{}'.",
+          prefix);
+      return false;
+    }
     if (clusterId == null || clusterId.isBlank()) {
       LOG.debug(
           "[RDBMS Schema] No local cluster ID available, skipping cluster ID compatibility check "
@@ -255,16 +262,7 @@ public class RdbmsSchemaVersionStore {
       return false;
     }
 
-    if (restrictionEnabled) {
-      throw new RdbmsClusterIdIncompatibleException(previousClusterId, clusterId);
-    }
-    LOG.warn(
-        "[RDBMS Schema] Detected cluster ID mismatch for prefix '{}': schema was previously "
-            + "initialized by cluster '{}', but this cluster's ID is '{}'. Ignoring as configured.",
-        prefix,
-        previousClusterId,
-        clusterId);
-    return true;
+    throw new RdbmsClusterIdIncompatibleException(previousClusterId, clusterId);
   }
 
   /**

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/exception/RdbmsClusterIdIncompatibleException.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/exception/RdbmsClusterIdIncompatibleException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.exception;
+
+/**
+ * Thrown when this cluster's ID does not match the one previously recorded in the RDBMS schema.
+ * Only enforced when auto-DDL is enabled; {@code NoopSchemaManager} skips the check entirely.
+ */
+public class RdbmsClusterIdIncompatibleException extends RuntimeException {
+
+  public RdbmsClusterIdIncompatibleException(
+      final String previousClusterId, final String clusterId) {
+    super(
+        ("Secondary storage schema was previously initialized by cluster '%s', but this "
+                + "cluster's ID is '%s'. Pointing a cluster at storage belonging to a different "
+                + "installation can corrupt data. If this is an intentional re-pointing, set "
+                + "clusterIdCheckRestrictionEnabled=false to bypass this check.")
+            .formatted(previousClusterId, clusterId));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/exception/RdbmsClusterIdIncompatibleException.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/exception/RdbmsClusterIdIncompatibleException.java
@@ -7,11 +7,15 @@
  */
 package io.camunda.db.rdbms.exception;
 
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+
 /**
  * Thrown when this cluster's ID does not match the one previously recorded in the RDBMS schema.
  * Only enforced when auto-DDL is enabled; {@code NoopSchemaManager} skips the check entirely.
+ *
+ * <p>Extends {@link UnrecoverableException} since a mismatch won't resolve itself on retry.
  */
-public class RdbmsClusterIdIncompatibleException extends RuntimeException {
+public class RdbmsClusterIdIncompatibleException extends UnrecoverableException {
 
   public RdbmsClusterIdIncompatibleException(
       final String previousClusterId, final String clusterId) {

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/DefaultRdbmsSchemaManagerRegistryTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/DefaultRdbmsSchemaManagerRegistryTest.java
@@ -69,6 +69,29 @@ class DefaultRdbmsSchemaManagerRegistryTest {
   }
 
   @Test
+  void shouldDelegateValidateClusterIdToPerTenantManager() {
+    // given
+    final var managerA = mock(RdbmsSchemaManager.class);
+    final var registry = new DefaultRdbmsSchemaManagerRegistry(Map.of(TENANT_A, managerA));
+
+    // when
+    registry.validateClusterId(TENANT_A, "this-cluster", true);
+
+    // then
+    verify(managerA).validateClusterId("this-cluster", true);
+  }
+
+  @Test
+  void shouldSkipValidateClusterIdForUnknownTenant() {
+    // given
+    final var registry =
+        new DefaultRdbmsSchemaManagerRegistry(Map.of(TENANT_A, mock(RdbmsSchemaManager.class)));
+
+    // when / then - no exception
+    registry.validateClusterId("unknown", "this-cluster", true);
+  }
+
+  @Test
   void shouldFailFastWhenAnyTenantInitializationFails() throws Exception {
     // given - A succeeds, B fails. LinkedHashMap preserves iteration order (A then B).
     final var managerA = mock(RdbmsSchemaManager.class);

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/LiquibaseSchemaManagerTest.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -80,6 +81,40 @@ class LiquibaseSchemaManagerTest {
     verify(versionStore).checkCompatibility();
     verify(versionStore).recordCurrentVersion();
     assertThat(schemaManager.isInitialized()).isTrue();
+  }
+
+  // ---- validateClusterId ----
+
+  @Test
+  void shouldDelegateValidateClusterIdToVersionStore() {
+    // given - validateClusterId is called lazily by the RDBMS exporter, not during initialize()
+    final var versionStore = mock(RdbmsSchemaVersionStore.class);
+    when(versionStore.checkClusterIdCompatibility("this-cluster", true)).thenReturn(true);
+    final var schemaManager =
+        new TestLiquibaseSchemaManager(autoDdlConfig(), "8.10.0", versionStore);
+
+    // when
+    schemaManager.validateClusterId("this-cluster", true);
+
+    // then
+    verify(versionStore).checkClusterIdCompatibility("this-cluster", true);
+    verify(versionStore).recordClusterId("this-cluster");
+  }
+
+  @Test
+  void shouldSkipRecordingClusterIdWhenNoWriteIsNeeded() {
+    // given - e.g. the previous value already matches, so checkClusterIdCompatibility signals no
+    // write is needed
+    final var versionStore = mock(RdbmsSchemaVersionStore.class);
+    when(versionStore.checkClusterIdCompatibility("this-cluster", true)).thenReturn(false);
+    final var schemaManager =
+        new TestLiquibaseSchemaManager(autoDdlConfig(), "8.10.0", versionStore);
+
+    // when
+    schemaManager.validateClusterId("this-cluster", true);
+
+    // then
+    verify(versionStore, never()).recordClusterId(anyString());
   }
 
   // ---- stale lock (mock-based) ----

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreTest.java
@@ -219,12 +219,14 @@ class RdbmsSchemaVersionStoreTest {
   }
 
   @Test
-  void shouldWarnOnClusterIdMismatchWhenRestrictionDisabled() throws Exception {
+  void shouldSkipClusterIdCheckEntirelyWhenRestrictionDisabled() throws Exception {
     // given
-    final var store = clusterIdStore("other-cluster");
+    final var dataSource = mock(DataSource.class);
+    final var store = new RdbmsSchemaVersionStore(dataSource, "", "8.10.0");
 
-    // when / then - no exception; the new value is adopted going forward
-    assertThat(store.checkClusterIdCompatibility("this-cluster", false)).isTrue();
+    // when / then - no exception, no read or write ever happens
+    assertThat(store.checkClusterIdCompatibility("this-cluster", false)).isFalse();
+    verify(dataSource, never()).getConnection();
   }
 
   @Test

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/RdbmsSchemaVersionStoreTest.java
@@ -9,13 +9,16 @@ package io.camunda.db.rdbms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.db.rdbms.exception.RdbmsClusterIdIncompatibleException;
 import io.camunda.db.rdbms.exception.RdbmsSchemaVersionIncompatibleException;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
@@ -170,6 +173,116 @@ class RdbmsSchemaVersionStoreTest {
     verify(dataSource, never()).getConnection();
   }
 
+  // ---- cluster ID check ----
+
+  @Test
+  void shouldSkipClusterIdCheckWhenLocalClusterIdBlank() throws Exception {
+    // given
+    final var dataSource = mock(DataSource.class);
+    final var store = new RdbmsSchemaVersionStore(dataSource, "", "8.10.0");
+
+    // when
+    assertThat(store.checkClusterIdCompatibility("", true)).isFalse();
+    assertThat(store.checkClusterIdCompatibility(null, true)).isFalse();
+
+    // then - the datasource is never touched
+    verify(dataSource, never()).getConnection();
+  }
+
+  @Test
+  void shouldSkipClusterIdCheckWhenNoPreviousClusterIdRecorded() throws Exception {
+    // given - fresh install, or upgrading from before this check existed
+    final var store = clusterIdStore(null);
+
+    // when / then - no exception, and the caller is told to record the value
+    assertThat(store.checkClusterIdCompatibility("this-cluster", true)).isTrue();
+  }
+
+  @Test
+  void shouldAllowMatchingClusterId() throws Exception {
+    final var store = clusterIdStore("this-cluster");
+
+    // nothing changed, so no redundant write is needed
+    assertThat(store.checkClusterIdCompatibility("this-cluster", true)).isFalse();
+  }
+
+  @Test
+  void shouldThrowOnClusterIdMismatchWhenRestrictionEnabled() throws Exception {
+    // given
+    final var store = clusterIdStore("other-cluster");
+
+    // when / then
+    assertThatThrownBy(() -> store.checkClusterIdCompatibility("this-cluster", true))
+        .isInstanceOf(RdbmsClusterIdIncompatibleException.class)
+        .hasMessageContaining("other-cluster")
+        .hasMessageContaining("this-cluster");
+  }
+
+  @Test
+  void shouldWarnOnClusterIdMismatchWhenRestrictionDisabled() throws Exception {
+    // given
+    final var store = clusterIdStore("other-cluster");
+
+    // when / then - no exception; the new value is adopted going forward
+    assertThat(store.checkClusterIdCompatibility("this-cluster", false)).isTrue();
+  }
+
+  @Test
+  void shouldFailWhenClusterIdCheckEncountersUnexpectedError() throws Exception {
+    // given
+    final var dataSource = mock(DataSource.class);
+    when(dataSource.getConnection()).thenThrow(new RuntimeException("DB connection refused"));
+    final var store = new RdbmsSchemaVersionStore(dataSource, "", "8.10.0");
+
+    // when / then
+    assertThatThrownBy(() -> store.checkClusterIdCompatibility("this-cluster", true))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Failed to determine current cluster ID");
+  }
+
+  @Test
+  void shouldSkipClusterIdRecordingWhenBlank() throws Exception {
+    // given
+    final var dataSource = mock(DataSource.class);
+    final var store = new RdbmsSchemaVersionStore(dataSource, "", "8.10.0");
+
+    // when
+    store.recordClusterId("");
+    store.recordClusterId(null);
+
+    // then - the datasource is never touched
+    verify(dataSource, never()).getConnection();
+  }
+
+  @Test
+  void shouldFailWhenClusterIdRecordingFails() throws Exception {
+    // given
+    final var dataSource = mock(DataSource.class);
+    when(dataSource.getConnection()).thenThrow(new RuntimeException("DB write refused"));
+    final var store = new RdbmsSchemaVersionStore(dataSource, "", "8.10.0");
+
+    // when / then
+    assertThatThrownBy(() -> store.recordClusterId("this-cluster"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Failed to update cluster ID");
+  }
+
+  @Test
+  void shouldWarnRatherThanClaimSuccessWhenNoSchemaVersionRowExistsYet() throws Exception {
+    // given - the UPDATE affects 0 rows, e.g. because recordCurrentVersion() never inserted the
+    // row (unparseable application version, such as local development builds)
+    final var dataSource = mock(DataSource.class);
+    final var connection = mock(Connection.class);
+    final var statement = mock(PreparedStatement.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    when(connection.prepareStatement(anyString())).thenReturn(statement);
+    when(statement.executeUpdate()).thenReturn(0);
+    final var store = new RdbmsSchemaVersionStore(dataSource, "", "8.10.0");
+
+    // when / then - does not throw, and does not falsely report success
+    store.recordClusterId("this-cluster");
+  }
+
   // ---- toStableVersion ----
 
   @Test
@@ -206,6 +319,25 @@ class RdbmsSchemaVersionStoreTest {
       protected String resolveCurrentSchemaVersion(
           final Connection connection, final String prefix) {
         return schemaVersion;
+      }
+    };
+  }
+
+  /**
+   * Builds a {@link RdbmsSchemaVersionStore} whose {@link #readClusterId} returns {@code
+   * previousClusterId}, backed by a mock data source that yields a mock connection.
+   */
+  private static RdbmsSchemaVersionStore clusterIdStore(final String previousClusterId) {
+    final var dataSource = mock(DataSource.class);
+    try {
+      when(dataSource.getConnection()).thenReturn(mock(Connection.class));
+    } catch (final SQLException e) {
+      throw new RuntimeException(e);
+    }
+    return new RdbmsSchemaVersionStore(dataSource, "", "8.10.0") {
+      @Override
+      protected String readClusterId(final Connection connection, final String prefix) {
+        return previousClusterId;
       }
     };
   }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/MultiExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/exporter/MultiExporterIT.java
@@ -268,7 +268,9 @@ public class MultiExporterIT {
                                   "usageMetricsMinimumAge",
                                   "0s")),
                           "bulk",
-                          Map.of("size", 1)));
+                          Map.of("size", 1),
+                          "clusterIdCheckRestrictionEnabled",
+                          false));
                 });
             yield DatabaseType.ELASTICSEARCH;
           }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterClusterIdIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterClusterIdIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.exporter;
+
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.cluster.PartitionId;
+import io.camunda.db.rdbms.RdbmsSchemaManagerRegistry;
+import io.camunda.db.rdbms.RdbmsServiceFactory;
+import io.camunda.exporter.rdbms.RdbmsExporterWrapper;
+import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.broker.exporter.context.ExporterContext;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
+import java.util.UUID;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Boots the real production {@link RdbmsExporterWrapper} against a live H2 database (no mocks) and
+ * confirms {@code configure()} actually persists the cluster ID into {@code
+ * RDBMS_SCHEMA_VERSION.CLUSTER_ID}. The H2 instance is in-memory, so the assertion runs while the
+ * Spring context is still alive.
+ */
+@Tag("rdbms")
+@SpringBootTest(classes = {RdbmsTestConfiguration.class})
+@TestPropertySource(
+    properties = {
+      "spring.liquibase.enabled=false",
+      "camunda.data.secondary-storage.type=rdbms",
+      "camunda.data.secondary-storage.rdbms.queue-size=0",
+      // distinguishes this context from RdbmsExporterIT's otherwise-identical configuration so
+      // Spring's test-context cache does not share (and thus does not leak state via) the same
+      // in-memory H2 database between the two test classes.
+      "logging.level.io.camunda.db.rdbms=DEBUG",
+    })
+class RdbmsExporterClusterIdIT {
+
+  private static final String CLUSTER_ID = "cluster-under-test-" + UUID.randomUUID();
+
+  @Autowired private RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry;
+  @Autowired private RdbmsServiceFactory rdbmsServiceFactory;
+  @Autowired private DataSource dataSource;
+
+  private RdbmsExporterWrapper exporter;
+
+  @AfterEach
+  void tearDown() {
+    if (exporter != null) {
+      exporter.close();
+    }
+  }
+
+  @Test
+  void shouldPersistClusterIdIntoRdbmsSchemaVersionTableOnRealStartup() throws Exception {
+    // given - the real RdbmsExporterWrapper, wired with the real production
+    // RdbmsSchemaManagerRegistry/RdbmsServiceFactory beans (no mocks)
+    final var exporterConfiguration = new ExporterConfiguration("rdbms", Map.of("queueSize", 0));
+    exporter =
+        new RdbmsExporterWrapper(
+            rdbmsServiceFactory,
+            rdbmsSchemaManagerRegistry,
+            Map.of(
+                DEFAULT_PHYSICAL_TENANT_ID,
+                exporterConfiguration.instantiate(
+                    io.camunda.exporter.rdbms.ExporterConfiguration.class)));
+
+    // when - configure() is the exact production code path that calls
+    // rdbmsSchemaManagerRegistry.validateClusterId(physicalTenantId, clusterId, restrictionEnabled)
+    exporter.configure(
+        new ExporterContext(
+            null,
+            exporterConfiguration,
+            new PartitionId(DEFAULT_PHYSICAL_TENANT_ID, 1),
+            CLUSTER_ID,
+            null,
+            Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),
+            null));
+
+    // then - query the live H2 database directly via JDBC: the cluster ID was really persisted,
+    // proving the real, production wiring end to end (not a unit-tested mock)
+    try (var connection = dataSource.getConnection();
+        var statement = connection.createStatement();
+        var resultSet = statement.executeQuery("SELECT CLUSTER_ID FROM RDBMS_SCHEMA_VERSION")) {
+      assertThat(resultSet.next()).as("RDBMS_SCHEMA_VERSION must have exactly one row").isTrue();
+      assertThat(resultSet.getString("CLUSTER_ID")).isEqualTo(CLUSTER_ID);
+    }
+  }
+}

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/ElasticsearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/ElasticsearchBackendStrategy.java
@@ -176,6 +176,8 @@ public final class ElasticsearchBackendStrategy implements SearchBackendStrategy
                       "history",
                       Map.of("waitPeriodBeforeArchiving", "1s"),
                       "createSchema",
+                      false,
+                      "clusterIdCheckRestrictionEnabled",
                       false));
             })
         .withExporter(

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/schema/strategy/OpenSearchBackendStrategy.java
@@ -171,6 +171,8 @@ public final class OpenSearchBackendStrategy implements SearchBackendStrategy {
                       "history",
                       Map.of("waitPeriodBeforeArchiving", "1s"),
                       "createSchema",
+                      false,
+                      "clusterIdCheckRestrictionEnabled",
                       false));
             })
         .withExporter(

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -65,6 +65,10 @@ public class MultiDbConfigurator {
               configureDocumentBasedStorage(
                   cfg, elasticsearchUrl, indexPrefix, "", "", retentionEnabled);
             });
+    testApplication.withProperty(
+        "zeebe.broker.exporters.camundaexporter.class-name", "io.camunda.exporter.CamundaExporter");
+    testApplication.withProperty(
+        "zeebe.broker.exporters.camundaexporter.args.clusterIdCheckRestrictionEnabled", "false");
   }
 
   public void configureOpenSearchSupportIncludingOldExporter(
@@ -116,6 +120,10 @@ public class MultiDbConfigurator {
                   cfg, opensearchUrl, indexPrefix, userName, userPassword, retentionEnabled);
               cfg.getData().getSecondaryStorage().getOpensearch().setAwsEnabled(isAws);
             });
+    testApplication.withProperty(
+        "zeebe.broker.exporters.camundaexporter.class-name", "io.camunda.exporter.CamundaExporter");
+    testApplication.withProperty(
+        "zeebe.broker.exporters.camundaexporter.args.clusterIdCheckRestrictionEnabled", "false");
   }
 
   private void configureDocumentBasedStorage(
@@ -177,6 +185,7 @@ public class MultiDbConfigurator {
               rdbms.setPassword(password);
               rdbms.setPrefix(tablePrefix);
               rdbms.setFlushInterval(Duration.ZERO);
+              rdbms.setClusterIdCheckRestrictionEnabled(false);
               if (retentionEnabled) {
                 rdbms.getHistory().setDefaultHistoryTTL(Duration.ofSeconds(1));
                 rdbms.getHistory().setMinHistoryCleanupInterval(Duration.ofSeconds(1));

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -65,10 +65,6 @@ public class MultiDbConfigurator {
               configureDocumentBasedStorage(
                   cfg, elasticsearchUrl, indexPrefix, "", "", retentionEnabled);
             });
-    testApplication.withProperty(
-        "zeebe.broker.exporters.camundaexporter.class-name", "io.camunda.exporter.CamundaExporter");
-    testApplication.withProperty(
-        "zeebe.broker.exporters.camundaexporter.args.clusterIdCheckRestrictionEnabled", "false");
   }
 
   public void configureOpenSearchSupportIncludingOldExporter(
@@ -120,10 +116,6 @@ public class MultiDbConfigurator {
                   cfg, opensearchUrl, indexPrefix, userName, userPassword, retentionEnabled);
               cfg.getData().getSecondaryStorage().getOpensearch().setAwsEnabled(isAws);
             });
-    testApplication.withProperty(
-        "zeebe.broker.exporters.camundaexporter.class-name", "io.camunda.exporter.CamundaExporter");
-    testApplication.withProperty(
-        "zeebe.broker.exporters.camundaexporter.args.clusterIdCheckRestrictionEnabled", "false");
   }
 
   private void configureDocumentBasedStorage(
@@ -138,6 +130,7 @@ public class MultiDbConfigurator {
     final var documentBasedDatabase =
         cfg.getData().getSecondaryStorage().getDocumentBasedDatabase();
     documentBasedDatabase.setCreateSchema(true);
+    documentBasedDatabase.setClusterIdCheckRestrictionEnabled(false);
     documentBasedDatabase.setUrl(url);
     documentBasedDatabase.setIndexPrefix(indexPrefix);
     documentBasedDatabase.getHistory().setPolicyName(indexPrefix + "-ilm");

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/ScriptBasedSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/ScriptBasedSchemaManager.java
@@ -121,4 +121,12 @@ public class ScriptBasedSchemaManager implements RdbmsSchemaManagerRegistry, Ini
   public boolean isInitialized(final String physicalTenantId) {
     return initializedTenants.contains(physicalTenantId);
   }
+
+  @Override
+  public void validateClusterId(
+      final String physicalTenantId,
+      final String clusterId,
+      final boolean clusterIdCheckRestrictionEnabled) {
+    // no-op: this is a QA test-acceleration utility, not a production schema manager
+  }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -124,10 +124,7 @@ public class SchemaManager implements CloseableSilently {
     this.schemaValidator = schemaValidator;
     retryDecorator =
         new RetryDecorator(config.schemaManager().getRetry())
-            .withRetryOnException(
-                e ->
-                    !(e instanceof IncompatibleVersionException
-                        || e instanceof IncompatibleClusterIdException));
+            .withRetryOnException(e -> !(e instanceof IncompatibleVersionException));
     this.schemaManagerMetrics = schemaManagerMetrics;
     schemaMetadataStore =
         new SchemaMetadataStore(

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.RetentionConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.search.schema.exceptions.IncompatibleClusterIdException;
 import io.camunda.search.schema.exceptions.IncompatibleVersionException;
 import io.camunda.search.schema.exceptions.SearchEngineException;
 import io.camunda.search.schema.metrics.SchemaManagerMetrics;
@@ -64,6 +65,7 @@ public class SchemaManager implements CloseableSilently {
   private final SchemaManagerMetrics schemaManagerMetrics;
   private final SchemaMetadataStore schemaMetadataStore;
   private final String currentVersion;
+  private final String clusterId;
 
   public SchemaManager(
       final SearchEngineClient searchEngineClient,
@@ -78,6 +80,7 @@ public class SchemaManager implements CloseableSilently {
         config,
         new IndexSchemaValidator(objectMapper),
         VersionUtil.getVersion(),
+        null,
         null);
   }
 
@@ -90,6 +93,27 @@ public class SchemaManager implements CloseableSilently {
       final IndexSchemaValidator schemaValidator,
       final String currentVersion,
       final SchemaManagerMetrics schemaManagerMetrics) {
+    this(
+        searchEngineClient,
+        indexOnlyDescriptors,
+        indexTemplateDescriptors,
+        config,
+        schemaValidator,
+        currentVersion,
+        schemaManagerMetrics,
+        null);
+  }
+
+  @VisibleForTesting
+  SchemaManager(
+      final SearchEngineClient searchEngineClient,
+      final Collection<IndexDescriptor> indexOnlyDescriptors,
+      final Collection<IndexTemplateDescriptor> indexTemplateDescriptors,
+      final SearchEngineConfiguration config,
+      final IndexSchemaValidator schemaValidator,
+      final String currentVersion,
+      final SchemaManagerMetrics schemaManagerMetrics,
+      final String clusterId) {
     virtualThreadExecutor = Executors.newVirtualThreadPerTaskExecutor();
     this.searchEngineClient = searchEngineClient;
     this.indexOnlyDescriptors = indexOnlyDescriptors;
@@ -100,7 +124,10 @@ public class SchemaManager implements CloseableSilently {
     this.schemaValidator = schemaValidator;
     retryDecorator =
         new RetryDecorator(config.schemaManager().getRetry())
-            .withRetryOnException(e -> !(e instanceof IncompatibleVersionException));
+            .withRetryOnException(
+                e ->
+                    !(e instanceof IncompatibleVersionException
+                        || e instanceof IncompatibleClusterIdException));
     this.schemaManagerMetrics = schemaManagerMetrics;
     schemaMetadataStore =
         new SchemaMetadataStore(
@@ -110,6 +137,7 @@ public class SchemaManager implements CloseableSilently {
                 config.connect().getTypeEnum().isElasticSearch()),
             LOG);
     this.currentVersion = currentVersion;
+    this.clusterId = clusterId;
   }
 
   public SchemaManager withMetrics(final SchemaManagerMetrics schemaManagerMetrics) {
@@ -120,7 +148,20 @@ public class SchemaManager implements CloseableSilently {
         config,
         schemaValidator,
         currentVersion,
-        schemaManagerMetrics);
+        schemaManagerMetrics,
+        clusterId);
+  }
+
+  public SchemaManager withClusterId(final String clusterId) {
+    return new SchemaManager(
+        searchEngineClient,
+        indexOnlyDescriptors,
+        indexTemplateDescriptors,
+        config,
+        schemaValidator,
+        currentVersion,
+        schemaManagerMetrics,
+        clusterId);
   }
 
   /**
@@ -188,6 +229,23 @@ public class SchemaManager implements CloseableSilently {
     LOG.info("Schema management completed.");
   }
 
+  /**
+   * Validates this cluster's ID against the one previously recorded in the secondary storage
+   * schema, and records it. Called directly by the exporter, not {@link #startup()}: that method
+   * runs once per broker before any exporter's cluster ID is resolved, so it can't perform this
+   * check itself.
+   */
+  public void validateClusterId() {
+    if (clusterId == null || clusterId.isBlank()) {
+      LOG.debug("No local cluster ID available, skipping cluster ID compatibility check");
+      return;
+    }
+    final var previousClusterId = schemaMetadataStore.getClusterId();
+    if (checkClusterIdCompatibility(previousClusterId, clusterId)) {
+      schemaMetadataStore.storeClusterId(clusterId);
+    }
+  }
+
   private CheckResult checkVersionCompatibility(
       final String previousVersion, final String currentVersion) {
     final var checkResult = VersionCompatibilityCheck.check(previousVersion, currentVersion);
@@ -239,6 +297,37 @@ public class SchemaManager implements CloseableSilently {
           LOG.debug("Schema is compatible with current version: {}", compatible);
     }
     return checkResult;
+  }
+
+  /**
+   * @return {@code true} if the caller should (re-)store {@code currentClusterId}, i.e. there was
+   *     no previous value, or there was a mismatch that got ignored per configuration.
+   */
+  private boolean checkClusterIdCompatibility(
+      final String previousClusterId, final String currentClusterId) {
+    if (previousClusterId == null) {
+      LOG.debug("No cluster ID found in metadata index, assuming a fresh installation");
+      return true;
+    }
+    if (previousClusterId.equals(currentClusterId)) {
+      LOG.info(
+          "Cluster ID '{}' matches the one recorded in the secondary storage schema",
+          currentClusterId);
+      return false;
+    }
+
+    final var errorMsg =
+        ("Secondary storage schema was previously initialized by cluster '%s', but this "
+                + "cluster's ID is '%s'. Pointing a cluster at storage belonging to a different "
+                + "installation can corrupt data. If this is an intentional re-pointing, set "
+                + "clusterIdCheckRestrictionEnabled=false to bypass this check.")
+            .formatted(previousClusterId, currentClusterId);
+    if (config.schemaManager().isClusterIdCheckRestrictionEnabled()) {
+      throw new IncompatibleClusterIdException(errorMsg);
+    } else {
+      LOG.warn("Detected cluster ID mismatch, but ignoring as configured. Details: '{}'", errorMsg);
+      return true;
+    }
   }
 
   private void createLifecyclePolicies() {

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -308,7 +308,7 @@ public class SchemaManager implements CloseableSilently {
   private boolean checkClusterIdCompatibility(
       final String previousClusterId, final String currentClusterId) {
     if (previousClusterId == null) {
-      LOG.debug("No cluster ID found in metadata index, assuming a fresh installation");
+      LOG.info("No cluster ID found in metadata index, assuming a fresh installation");
       return true;
     }
     if (previousClusterId.equals(currentClusterId)) {

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaManager.java
@@ -236,6 +236,11 @@ public class SchemaManager implements CloseableSilently {
    * check itself.
    */
   public void validateClusterId() {
+    if (!config.schemaManager().isClusterIdCheckRestrictionEnabled()) {
+      LOG.debug(
+          "Cluster ID check restriction is disabled, skipping cluster ID compatibility check");
+      return;
+    }
     if (clusterId == null || clusterId.isBlank()) {
       LOG.debug("No local cluster ID available, skipping cluster ID compatibility check");
       return;
@@ -300,8 +305,8 @@ public class SchemaManager implements CloseableSilently {
   }
 
   /**
-   * @return {@code true} if the caller should (re-)store {@code currentClusterId}, i.e. there was
-   *     no previous value, or there was a mismatch that got ignored per configuration.
+   * @return {@code true} if the caller should store {@code currentClusterId}, i.e. there was no
+   *     previous value recorded yet.
    */
   private boolean checkClusterIdCompatibility(
       final String previousClusterId, final String currentClusterId) {
@@ -316,18 +321,12 @@ public class SchemaManager implements CloseableSilently {
       return false;
     }
 
-    final var errorMsg =
+    throw new IncompatibleClusterIdException(
         ("Secondary storage schema was previously initialized by cluster '%s', but this "
                 + "cluster's ID is '%s'. Pointing a cluster at storage belonging to a different "
                 + "installation can corrupt data. If this is an intentional re-pointing, set "
                 + "clusterIdCheckRestrictionEnabled=false to bypass this check.")
-            .formatted(previousClusterId, currentClusterId);
-    if (config.schemaManager().isClusterIdCheckRestrictionEnabled()) {
-      throw new IncompatibleClusterIdException(errorMsg);
-    } else {
-      LOG.warn("Detected cluster ID mismatch, but ignoring as configured. Details: '{}'", errorMsg);
-      return true;
-    }
+            .formatted(previousClusterId, currentClusterId));
   }
 
   private void createLifecyclePolicies() {

--- a/schema-manager/src/main/java/io/camunda/search/schema/SchemaMetadataStore.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/SchemaMetadataStore.java
@@ -15,6 +15,8 @@ import org.slf4j.Logger;
 class SchemaMetadataStore {
   // Schema version metadata constants
   @VisibleForTesting static final String SCHEMA_VERSION_METADATA_ID = "schema-version";
+  // Cluster ID metadata constants
+  @VisibleForTesting static final String CLUSTER_ID_METADATA_ID = "cluster-id";
 
   private final SearchEngineClient searchEngineClient;
   private final MetadataIndex metadataIndex;
@@ -69,6 +71,44 @@ class SchemaMetadataStore {
     } catch (final Exception e) {
       logger.error("Failed to store schema version in metadata", e);
       throw new IllegalStateException("Could not store schema version metadata", e);
+    }
+  }
+
+  /**
+   * Retrieves the cluster ID from metadata storage. Returns null if no cluster ID is stored
+   * (indicating a fresh installation, or an installation predating this check).
+   */
+  String getClusterId() {
+    if (!searchEngineClient.indexExists(metadataIndex.getFullQualifiedName())) {
+      logger.info("Metadata index does not exist, assuming a fresh installation");
+      return null;
+    }
+    final var clusterIdDoc =
+        searchEngineClient.getDocument(
+            metadataIndex.getFullQualifiedName(), CLUSTER_ID_METADATA_ID);
+
+    if (clusterIdDoc != null) {
+      return (String) clusterIdDoc.get(MetadataIndex.VALUE);
+    }
+
+    logger.info("No cluster ID found in metadata index, assuming a fresh installation");
+    return null;
+  }
+
+  void storeClusterId(final String clusterId) {
+    try {
+      final var clusterIdDoc =
+          Map.<String, Object>of(
+              MetadataIndex.ID, CLUSTER_ID_METADATA_ID,
+              MetadataIndex.VALUE, clusterId);
+
+      searchEngineClient.upsertDocument(
+          metadataIndex.getFullQualifiedName(), CLUSTER_ID_METADATA_ID, clusterIdDoc);
+
+      logger.info("Stored cluster ID metadata: {}", clusterId);
+    } catch (final Exception e) {
+      logger.error("Failed to store cluster ID in metadata", e);
+      throw new IllegalStateException("Could not store cluster ID metadata", e);
     }
   }
 }

--- a/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/config/SchemaManagerConfiguration.java
@@ -15,6 +15,7 @@ public class SchemaManagerConfiguration {
   private boolean isCreateSchema = true;
   private SchemaManagerRetryConfiguration retry = new SchemaManagerRetryConfiguration();
   private boolean versionCheckRestrictionEnabled = true;
+  private boolean clusterIdCheckRestrictionEnabled = true;
   private boolean performCleanup = false;
 
   public boolean isCreateSchema() {
@@ -39,6 +40,14 @@ public class SchemaManagerConfiguration {
 
   public void setVersionCheckRestrictionEnabled(final boolean versionCheckRestrictionEnabled) {
     this.versionCheckRestrictionEnabled = versionCheckRestrictionEnabled;
+  }
+
+  public boolean isClusterIdCheckRestrictionEnabled() {
+    return clusterIdCheckRestrictionEnabled;
+  }
+
+  public void setClusterIdCheckRestrictionEnabled(final boolean clusterIdCheckRestrictionEnabled) {
+    this.clusterIdCheckRestrictionEnabled = clusterIdCheckRestrictionEnabled;
   }
 
   public boolean isPerformCleanup() {

--- a/schema-manager/src/main/java/io/camunda/search/schema/exceptions/IncompatibleClusterIdException.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/exceptions/IncompatibleClusterIdException.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.schema.exceptions;
+
+public class IncompatibleClusterIdException extends RuntimeException {
+  public IncompatibleClusterIdException(final String message) {
+    super(message);
+  }
+}

--- a/schema-manager/src/main/java/io/camunda/search/schema/exceptions/IncompatibleClusterIdException.java
+++ b/schema-manager/src/main/java/io/camunda/search/schema/exceptions/IncompatibleClusterIdException.java
@@ -7,7 +7,14 @@
  */
 package io.camunda.search.schema.exceptions;
 
-public class IncompatibleClusterIdException extends RuntimeException {
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+
+/**
+ * A cluster ID mismatch won't resolve itself on retry, so this extends {@link
+ * UnrecoverableException}: the broker's exporter-open retry loop treats it as terminal instead of
+ * retrying forever.
+ */
+public class IncompatibleClusterIdException extends UnrecoverableException {
   public IncompatibleClusterIdException(final String message) {
     super(message);
   }

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.schema.config.IndexConfiguration;
@@ -341,7 +342,7 @@ class SchemaManagerTest {
   }
 
   @Test
-  void shouldIgnoreClusterIdMismatchWhenRestrictionDisabled() {
+  void shouldSkipClusterIdCheckEntirelyWhenRestrictionDisabled() {
     // Given
     config.schemaManager().setClusterIdCheckRestrictionEnabled(false);
     schemaManager = createSpySchemaManager("8.9.0", "this-cluster");
@@ -350,12 +351,8 @@ class SchemaManagerTest {
     // When: should not throw despite the mismatch
     schemaManager.validateClusterId();
 
-    // Then: the mismatched value is still (re-)recorded, matching the ES/OS bootstrap semantics
-    verify(searchEngineClient)
-        .upsertDocument(
-            metadataIndex.getFullQualifiedName(),
-            CLUSTER_ID_METADATA_ID,
-            Map.of(MetadataIndex.ID, CLUSTER_ID_METADATA_ID, MetadataIndex.VALUE, "this-cluster"));
+    // Then: no read or write ever happens, matching a disabled check exactly
+    verifyNoInteractions(searchEngineClient);
   }
 
   @Test

--- a/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
+++ b/schema-manager/src/test/java/io/camunda/search/schema/SchemaManagerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.schema;
 
+import static io.camunda.search.schema.SchemaMetadataStore.CLUSTER_ID_METADATA_ID;
 import static io.camunda.search.schema.SchemaMetadataStore.SCHEMA_VERSION_METADATA_ID;
 import static io.camunda.webapps.schema.descriptors.index.MetadataIndex.ID;
 import static io.camunda.webapps.schema.descriptors.index.MetadataIndex.VALUE;
@@ -24,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.schema.config.IndexConfiguration;
 import io.camunda.search.schema.config.SearchEngineConfiguration;
+import io.camunda.search.schema.exceptions.IncompatibleClusterIdException;
 import io.camunda.search.schema.exceptions.IncompatibleVersionException;
 import io.camunda.search.schema.utils.TestIndexDescriptor;
 import io.camunda.search.schema.utils.TestTemplateDescriptor;
@@ -322,7 +324,94 @@ class SchemaManagerTest {
     verifyInvokedOperations("8.8.0", true);
   }
 
+  @Test
+  void shouldThrowExceptionForClusterIdMismatch() {
+    // Given: validateClusterId() is called directly by the exporter (e.g. CamundaExporter.open()),
+    // independently of startup() - it runs once the exporter has resolved its own cluster ID,
+    // which startup() (broker-wide, pre-gossip) never has.
+    schemaManager = createSpySchemaManager("8.8.0", "this-cluster");
+    mockClusterIdInMetadata("other-cluster");
+
+    // When & Then
+    assertThatThrownBy(() -> schemaManager.validateClusterId())
+        .isInstanceOf(IncompatibleClusterIdException.class)
+        .hasMessageContaining("other-cluster")
+        .hasMessageContaining("this-cluster");
+    verify(searchEngineClient, never()).upsertDocument(anyString(), anyString(), any());
+  }
+
+  @Test
+  void shouldIgnoreClusterIdMismatchWhenRestrictionDisabled() {
+    // Given
+    config.schemaManager().setClusterIdCheckRestrictionEnabled(false);
+    schemaManager = createSpySchemaManager("8.9.0", "this-cluster");
+    mockClusterIdInMetadata("other-cluster");
+
+    // When: should not throw despite the mismatch
+    schemaManager.validateClusterId();
+
+    // Then: the mismatched value is still (re-)recorded, matching the ES/OS bootstrap semantics
+    verify(searchEngineClient)
+        .upsertDocument(
+            metadataIndex.getFullQualifiedName(),
+            CLUSTER_ID_METADATA_ID,
+            Map.of(MetadataIndex.ID, CLUSTER_ID_METADATA_ID, MetadataIndex.VALUE, "this-cluster"));
+  }
+
+  @Test
+  void shouldProceedWhenClusterIdMatches() {
+    // Given
+    schemaManager = createSpySchemaManager("8.9.0", "this-cluster");
+    mockClusterIdInMetadata("this-cluster");
+
+    // When
+    schemaManager.validateClusterId();
+
+    // Then - no exception, and no redundant write since nothing changed
+    verify(searchEngineClient, never())
+        .upsertDocument(
+            eq(metadataIndex.getFullQualifiedName()), eq(CLUSTER_ID_METADATA_ID), any());
+  }
+
+  @Test
+  void shouldStoreClusterIdOnFreshInstall() {
+    // Given: no previous cluster ID stored (fresh installation, or upgrading from before this
+    // feature existed)
+    schemaManager = createSpySchemaManager("8.9.0", "this-cluster");
+    mockClusterIdInMetadata(null);
+
+    // When
+    schemaManager.validateClusterId();
+
+    // Then
+    verify(searchEngineClient)
+        .upsertDocument(
+            metadataIndex.getFullQualifiedName(),
+            CLUSTER_ID_METADATA_ID,
+            Map.of(MetadataIndex.ID, CLUSTER_ID_METADATA_ID, MetadataIndex.VALUE, "this-cluster"));
+  }
+
+  @Test
+  void shouldSkipClusterIdCheckAndStorageWhenLocalClusterIdUnresolved() {
+    // Given: this exporter could not resolve its own cluster ID (e.g. empty string sentinel)
+    schemaManager = createSpySchemaManager("8.9.0", "");
+    mockClusterIdInMetadata("other-cluster");
+
+    // When: should not throw, and should not overwrite the stored cluster ID
+    schemaManager.validateClusterId();
+
+    // Then
+    verify(searchEngineClient, never())
+        .upsertDocument(
+            eq(metadataIndex.getFullQualifiedName()), eq(CLUSTER_ID_METADATA_ID), any());
+  }
+
   private SchemaManager createSpySchemaManager(final String currentVersion) {
+    return createSpySchemaManager(currentVersion, null);
+  }
+
+  private SchemaManager createSpySchemaManager(
+      final String currentVersion, final String clusterId) {
     return spy(
         new SchemaManager(
             searchEngineClient,
@@ -331,7 +420,8 @@ class SchemaManagerTest {
             config,
             mock(IndexSchemaValidator.class),
             currentVersion,
-            null));
+            null,
+            clusterId));
   }
 
   private void mockSchemaVersionInMetadata(final String version) {
@@ -342,6 +432,16 @@ class SchemaManagerTest {
     when(searchEngineClient.getDocument(
             metadataIndex.getFullQualifiedName(), SCHEMA_VERSION_METADATA_ID))
         .thenReturn(versionDoc);
+  }
+
+  private void mockClusterIdInMetadata(final String clusterId) {
+    final var clusterIdDoc =
+        clusterId == null
+            ? null
+            : Map.<String, Object>of(ID, CLUSTER_ID_METADATA_ID, VALUE, clusterId);
+    when(searchEngineClient.getDocument(
+            metadataIndex.getFullQualifiedName(), CLUSTER_ID_METADATA_ID))
+        .thenReturn(clusterIdDoc);
   }
 
   @Nested

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -611,6 +611,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                           "Failed to open exporter '{}'. Not retrying.", container.getId(), e);
                       unrecoverableFailureDetected.set(true);
                       updateHealthStatusWithError(e);
+                      // The container never finished opening (e.g. its writer was never
+                      // assigned), so it must not receive records once exporting starts -
+                      // otherwise every export attempt on this partition would fail on it forever.
+                      containers.remove(container);
+                      recordExporter.resetExporterIndex();
                       return false;
                     } catch (final Exception e) {
                       LOG.warn("Failed to open exporter '{}'. Retrying...", container.getId());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -321,18 +321,24 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       final String exporterId,
       final ExporterInitializationInfo initializationInfo,
       final ExporterDescriptor descriptor) {
+    final var unrecoverableFailureDetected = new AtomicBoolean(false);
     return new BackOffRetryStrategy(actor, Duration.ofSeconds(10))
         .runWithRetry(
             () -> {
               try {
                 addExporter(exporterId, initializationInfo, descriptor);
                 return true;
+              } catch (final UnrecoverableException e) {
+                LOG.error("Failed to add exporter '{}'. Not retrying.", exporterId, e);
+                unrecoverableFailureDetected.set(true);
+                updateHealthStatusWithError(e);
+                return false;
               } catch (final Exception e) {
                 LOG.error("Failed to add exporter '{}'. Retrying...", exporterId, e);
                 return false;
               }
             },
-            this::isClosed);
+            () -> isClosed() || unrecoverableFailureDetected.get());
   }
 
   private void addExporter(
@@ -582,6 +588,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     final var containerOpenFutures = new ArrayList<ActorFuture<Boolean>>();
     for (final ExporterContainer container : containers) {
       container.initMetadata();
+      final var unrecoverableFailureDetected = new AtomicBoolean(false);
       final var openFuture =
           new BackOffRetryStrategy(actor, Duration.ofSeconds(10), Duration.ofMillis(150))
               .runWithRetry(
@@ -597,6 +604,14 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                             container.getId());
                       }
                       return true;
+                    } catch (final UnrecoverableException e) {
+                      // Permanent misconfiguration (e.g. incompatible schema/cluster state) won't
+                      // resolve itself on retry, so retrying forever would just hide the failure.
+                      LOG.error(
+                          "Failed to open exporter '{}'. Not retrying.", container.getId(), e);
+                      unrecoverableFailureDetected.set(true);
+                      updateHealthStatusWithError(e);
+                      return false;
                     } catch (final Exception e) {
                       LOG.warn("Failed to open exporter '{}'. Retrying...", container.getId());
                       LOG.debug(
@@ -604,7 +619,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                       return false;
                     }
                   },
-                  this::isClosed);
+                  () -> isClosed() || unrecoverableFailureDetected.get());
 
       containerOpenFutures.add(openFuture);
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
-import static java.util.Objects.requireNonNullElse;
-
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.cluster.PhysicalTenantIds;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
@@ -132,7 +130,12 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .exporterMode(exporterMode)
             .positionsToSkipFilter(exporterFilter)
             .meterRegistry(context.getPartitionTransitionMeterRegistry())
-            .clusterId(requireNonNullElse(brokerCfg.getCluster().getClusterId(), ""))
+            .clusterId(
+                context
+                    .getClusterConfigurationService()
+                    .getCurrentClusterConfiguration()
+                    .clusterId()
+                    .orElse(""))
             .licenseKey(brokerCfg.getLicenseKey())
             .tenantName(tenantName)
             .receiveOnLegacySubject(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -232,6 +232,37 @@ public final class ExporterDirectorTest {
   }
 
   @Test
+  public void shouldNotExportToContainerThatFailedToOpenUnrecoverably() throws Exception {
+    // given - exporter-1 fails to open unrecoverably. It never finished opening, so it must
+    // never receive an export call - a real exporter relies on state only assigned in open()
+    // (e.g. CamundaExporter's writer field), so exporting to it anyway fails unpredictably.
+    final ControlledTestExporter failingExporter = exporters.get(0);
+    final var failingExportCallCount = new AtomicInteger();
+    failingExporter.onExport(record -> failingExportCallCount.incrementAndGet());
+    doThrow(new UnrecoverableException("permanent misconfiguration"))
+        .when(failingExporter)
+        .open(any());
+
+    // when
+    startExporterDirector(exporterDescriptors);
+    Awaitility.await("director reports the exporter failure as unrecoverable")
+        .untilAsserted(
+            () ->
+                assertThat(rule.getDirector().getHealthReport().status())
+                    .isEqualTo(HealthStatus.DEAD));
+    writeEvent();
+
+    // then - give the pipeline time to attempt exporting, then confirm the failed container was
+    // never called
+    Awaitility.await("healthy exporter has had a chance to export")
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(exporters.get(1).getExportedRecords()).hasSize(1));
+    assertThat(failingExportCallCount.get()).isZero();
+
+    rule.closeExporterDirector();
+  }
+
+  @Test
   public void shouldExportAfterOpenRetried() throws Exception {
     // given
     final var exporter = startExporterWithFaultyOpenCall();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -203,6 +204,29 @@ public final class ExporterDirectorTest {
     Awaitility.await("exporter open has been retried")
         .atMost(Duration.ofSeconds(10))
         .untilAsserted(() -> verify(exporter, times(2)).open(any()));
+
+    rule.closeExporterDirector();
+  }
+
+  @Test
+  public void shouldNotRetryOpenCallOnUnrecoverableException() throws Exception {
+    // given, when
+    final ControlledTestExporter exporter = spy(new ControlledTestExporter());
+    doThrow(new UnrecoverableException("permanent misconfiguration")).when(exporter).open(any());
+    final ExporterDescriptor descriptor =
+        spy(
+            new ExporterDescriptor(
+                "exporter-unrecoverable", exporter.getClass(), Collections.singletonMap("x", 1)));
+    doAnswer(c -> exporter).when(descriptor).newInstance();
+    startExporterDirector(List.of(descriptor));
+
+    // then
+    Awaitility.await("director reports the exporter failure as unrecoverable")
+        .untilAsserted(
+            () ->
+                assertThat(rule.getDirector().getHealthReport().status())
+                    .isEqualTo(HealthStatus.DEAD));
+    verify(exporter, times(1)).open(any());
 
     rule.closeExporterDirector();
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableTest.java
@@ -24,6 +24,8 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+import io.camunda.zeebe.util.health.HealthStatus;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -207,6 +209,30 @@ public class ExporterEnableTest {
     Awaitility.await("exporter open has been retried")
         .atMost(Duration.ofSeconds(10))
         .untilAsserted(() -> verify(exporter, times(2)).open(any()));
+  }
+
+  @Test
+  public void shouldNotRetryExporterEnableOnUnrecoverableException() {
+    // given
+    rule.startExporterDirector(exporterDescriptors);
+    rule.getDirector().removeExporter(EXPORTER_ID_2).join();
+
+    final var descriptor = createExporter(EXPORTER_ID_2, Collections.singletonMap("x", 1));
+    final var exporter = exporters.get(EXPORTER_ID_2);
+    doThrow(new UnrecoverableException("permanent misconfiguration")).when(exporter).open(any());
+
+    // when
+    rule.getDirector()
+        .enableExporterWithRetry(EXPORTER_ID_2, new ExporterInitializationInfo(1, null), descriptor)
+        .join();
+
+    // then
+    Awaitility.await("director reports the exporter failure as unrecoverable")
+        .untilAsserted(
+            () ->
+                assertThat(rule.getDirector().getHealthReport().status())
+                    .isEqualTo(HealthStatus.DEAD));
+    verify(exporter, times(1)).open(any());
   }
 
   private void waitUntilExportersHaveSeenTheExpectedRecords() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -24,11 +24,13 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
+import io.camunda.zeebe.broker.partitioning.topology.ClusterConfigurationService;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldCloseService;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldDoNothing;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldInstallService;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
@@ -70,6 +72,15 @@ class ExporterDirectorPartitionTransitionStepTest {
         .thenReturn(TestActorFuture.completedFuture(null));
     transitionContext.setActorSchedulingService(actorSchedulingService);
     transitionContext.setBrokerCfg(new BrokerCfg());
+
+    final var clusterConfigurationService = mock(ClusterConfigurationService.class);
+    when(clusterConfigurationService.getCurrentClusterConfiguration())
+        .thenReturn(
+            ClusterConfiguration.builder()
+                .from(ClusterConfiguration.init())
+                .clusterId(Optional.of("gossip-resolved-cluster-id"))
+                .build());
+    transitionContext.setClusterConfigurationService(clusterConfigurationService);
 
     final var raftPartition = mock(RaftPartition.class);
     final var raftPartitionConfig = new RaftPartitionConfig();
@@ -314,6 +325,25 @@ class ExporterDirectorPartitionTransitionStepTest {
     // then
     verify(mockedExporterDirector, timeout(1000))
         .enableExporterWithRetry(eq(reEnabledExporterId), any(), any());
+  }
+
+  @Test
+  void shouldUseGossipResolvedClusterIdEvenWhenStaticConfigDiffers() {
+    // given - the static broker config disagrees with the gossip-resolved cluster topology
+    // (e.g. this broker joined an existing cluster without an explicit clusterId configured)
+    final var brokerCfg = new BrokerCfg();
+    brokerCfg.getCluster().setClusterId("locally-configured-candidate-id");
+    transitionContext.setBrokerCfg(brokerCfg);
+
+    final AtomicReference<ExporterDirectorContext> capturedContext = new AtomicReference<>();
+    final var exporterDirectorStep = getExporterDirectorPartitionTransitionStep(capturedContext);
+
+    // when
+    exporterDirectorStep.prepareTransition(transitionContext, 1, Role.LEADER).join();
+    exporterDirectorStep.transitionTo(transitionContext, 1, Role.LEADER).join();
+
+    // then - the exporter observes the cluster-wide agreed id, not the diverged local candidate
+    assertThat(capturedContext.get().getClusterId()).isEqualTo("gossip-resolved-cluster-id");
   }
 
   private void setExportersInContext(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -140,6 +140,7 @@ public class CamundaExporter implements Exporter {
       searchEngineClient = clientAdapter.getSearchEngineClient();
 
       try (final var schemaManager = createSchemaManager()) {
+        schemaManager.validateClusterId();
         if (!schemaManager.isSchemaReadyForUse()) {
           throw new ExporterException("Schema is not ready for use");
         }
@@ -294,17 +295,20 @@ public class CamundaExporter implements Exporter {
   private SchemaManager createSchemaManager() {
     final var schemaManagerConfiguration = new SchemaManagerConfiguration();
     schemaManagerConfiguration.setCreateSchema(configuration.isCreateSchema());
+    schemaManagerConfiguration.setClusterIdCheckRestrictionEnabled(
+        configuration.isClusterIdCheckRestrictionEnabled());
     return new SchemaManager(
-        searchEngineClient,
-        provider.getIndexDescriptors(),
-        provider.getIndexTemplateDescriptors(),
-        SearchEngineConfiguration.of(
-            b ->
-                b.connect(configuration.getConnect())
-                    .index(configuration.getIndex())
-                    .retention(configuration.getHistory().getRetention())
-                    .schemaManager(schemaManagerConfiguration)),
-        clientAdapter.objectMapper());
+            searchEngineClient,
+            provider.getIndexDescriptors(),
+            provider.getIndexTemplateDescriptors(),
+            SearchEngineConfiguration.of(
+                b ->
+                    b.connect(configuration.getConnect())
+                        .index(configuration.getIndex())
+                        .retention(configuration.getHistory().getRetention())
+                        .schemaManager(schemaManagerConfiguration)),
+            clientAdapter.objectMapper())
+        .withClusterId(context.getClusterId());
   }
 
   private List<String> prefixedNames(final String... names) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -97,6 +97,7 @@ public class CamundaExporter implements Exporter {
   private SearchEngineClient searchEngineClient;
   private int partitionId;
   private Context context;
+  private boolean clusterIdValidated;
   private long lastFlushTimestamp = 0L;
 
   private long flushDelayMs;
@@ -140,7 +141,10 @@ public class CamundaExporter implements Exporter {
       searchEngineClient = clientAdapter.getSearchEngineClient();
 
       try (final var schemaManager = createSchemaManager()) {
-        schemaManager.validateClusterId();
+        if (!clusterIdValidated) {
+          schemaManager.validateClusterId();
+          clusterIdValidated = true;
+        }
         if (!schemaManager.isSchemaReadyForUse()) {
           throw new ExporterException("Schema is not ready for use");
         }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -141,12 +141,14 @@ public class CamundaExporter implements Exporter {
       searchEngineClient = clientAdapter.getSearchEngineClient();
 
       try (final var schemaManager = createSchemaManager()) {
+        if (!schemaManager.isSchemaReadyForUse()) {
+          throw new ExporterException("Schema is not ready for use");
+        }
+        // the metadata index validateClusterId() reads/writes is only guaranteed to exist once
+        // isSchemaReadyForUse() returns true, so this must run after that check
         if (!clusterIdValidated) {
           schemaManager.validateClusterId();
           clusterIdValidated = true;
-        }
-        if (!schemaManager.isSchemaReadyForUse()) {
-          throw new ExporterException("Schema is not ready for use");
         }
       }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -32,6 +32,7 @@ public class ExporterConfiguration {
   private HistoryDeletionConfiguration historyDeletion = new HistoryDeletionConfiguration();
   private WaitStateConfiguration waitState = new WaitStateConfiguration();
   private boolean createSchema = true;
+  private boolean clusterIdCheckRestrictionEnabled = true;
   private boolean skipVariableWriteWithoutUserTasks = false;
   private ExtensionPropertyConfiguration extensionProperties = new ExtensionPropertyConfiguration();
 
@@ -123,6 +124,14 @@ public class ExporterConfiguration {
     this.createSchema = createSchema;
   }
 
+  public boolean isClusterIdCheckRestrictionEnabled() {
+    return clusterIdCheckRestrictionEnabled;
+  }
+
+  public void setClusterIdCheckRestrictionEnabled(final boolean clusterIdCheckRestrictionEnabled) {
+    this.clusterIdCheckRestrictionEnabled = clusterIdCheckRestrictionEnabled;
+  }
+
   public boolean isSkipVariableWriteWithoutUserTasks() {
     return skipVariableWriteWithoutUserTasks;
   }
@@ -185,6 +194,8 @@ public class ExporterConfiguration {
         + history
         + ", createSchema="
         + createSchema
+        + ", clusterIdCheckRestrictionEnabled="
+        + clusterIdCheckRestrictionEnabled
         + ", batchOperationCache="
         + batchOperationCache
         + ", processCache="

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -9,10 +9,13 @@ package io.camunda.exporter;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.CacheLoader;
@@ -23,9 +26,11 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.search.schema.SearchEngineClient;
+import io.camunda.search.schema.exceptions.IncompatibleClusterIdException;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.index.AuditLogCleanupIndex;
 import io.camunda.webapps.schema.descriptors.index.HistoryDeletionIndex;
+import io.camunda.webapps.schema.descriptors.index.MetadataIndex;
 import io.camunda.webapps.schema.entities.usertask.TaskEntity.TaskImplementation;
 import io.camunda.zeebe.exporter.common.cache.batchoperation.CachedBatchOperationEntity;
 import io.camunda.zeebe.exporter.common.cache.decisionRequirements.CachedDecisionRequirementsEntity;
@@ -40,6 +45,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -228,6 +234,60 @@ final class CamundaExporterTest {
       assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(3);
       assertThat(metadata.getFirstUserTaskKey(TaskImplementation.JOB_WORKER)).isEqualTo(5);
       assertThat(metadata.getFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK)).isEqualTo(5);
+    }
+
+    @Test
+    void shouldThrowOnOpenWhenClusterIdMismatchIsDetectedAndRestrictionEnabled() {
+      // given
+      testContext.setClusterId("cluster-b");
+      mockPreviouslyRecordedClusterId("cluster-a");
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+
+      // when
+      exporter.configure(testContext);
+
+      // then — open() must invoke createSchemaManager().withClusterId(context.getClusterId())
+      // followed by schemaManager.validateClusterId(), surfacing the mismatch as a hard failure
+      assertThatThrownBy(() -> exporter.open(testController))
+          .isInstanceOf(IncompatibleClusterIdException.class);
+    }
+
+    @Test
+    void shouldNotThrowOnOpenWhenClusterIdMismatchIsDetectedButRestrictionDisabled() {
+      // given
+      testContext.setClusterId("cluster-b");
+      mockPreviouslyRecordedClusterId("cluster-a");
+      configuration.setClusterIdCheckRestrictionEnabled(false);
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+
+      // when
+      exporter.configure(testContext);
+
+      // then — with the restriction disabled, the mismatch is only logged, not thrown
+      assertThatCode(() -> exporter.open(testController)).doesNotThrowAnyException();
+    }
+
+    /**
+     * Stubs the mocked {@link SearchEngineClient} used by {@link StubClientAdapter} so that the
+     * metadata index already exists and holds a previously recorded cluster ID, mirroring what
+     * {@link io.camunda.search.schema.SchemaManager#validateClusterId()} would read on a real
+     * cluster that was previously bootstrapped with a different cluster ID.
+     */
+    private void mockPreviouslyRecordedClusterId(final String previousClusterId) {
+      final var metadataIndex =
+          new MetadataIndex(
+              configuration.getConnect().getIndexPrefix(),
+              configuration.getConnect().getTypeEnum().isElasticSearch());
+      final var searchEngineClient = stubbedClientAdapterInUse.getSearchEngineClient();
+      when(searchEngineClient.indexExists(metadataIndex.getFullQualifiedName())).thenReturn(true);
+      // "cluster-id" is the document id SchemaMetadataStore uses to store/read the cluster ID
+      when(searchEngineClient.getDocument(metadataIndex.getFullQualifiedName(), "cluster-id"))
+          .thenReturn(
+              Map.of(MetadataIndex.ID, "cluster-id", MetadataIndex.VALUE, previousClusterId));
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -12,9 +12,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -255,7 +260,7 @@ final class CamundaExporterTest {
     }
 
     @Test
-    void shouldNotThrowOnOpenWhenClusterIdMismatchIsDetectedButRestrictionDisabled() {
+    void shouldSkipClusterIdCheckEntirelyWhenRestrictionDisabled() {
       // given
       testContext.setClusterId("cluster-b");
       mockPreviouslyRecordedClusterId("cluster-a");
@@ -267,8 +272,42 @@ final class CamundaExporterTest {
       // when
       exporter.configure(testContext);
 
-      // then — with the restriction disabled, the mismatch is only logged, not thrown
+      // then
       assertThatCode(() -> exporter.open(testController)).doesNotThrowAnyException();
+      final var metadataIndex =
+          new MetadataIndex(
+              configuration.getConnect().getIndexPrefix(),
+              configuration.getConnect().getTypeEnum().isElasticSearch());
+      final var searchEngineClient = stubbedClientAdapterInUse.getSearchEngineClient();
+      verify(searchEngineClient, never())
+          .getDocument(metadataIndex.getFullQualifiedName(), "cluster-id");
+      verify(searchEngineClient, never())
+          .upsertDocument(eq(metadataIndex.getFullQualifiedName()), eq("cluster-id"), any());
+    }
+
+    @Test
+    void shouldOnlyValidateClusterIdOnceAcrossRetriedOpenCalls() {
+      // given
+      testContext.setClusterId("cluster-a");
+      exporter =
+          new CamundaExporter(
+              resourceProvider, new ExporterMetadata(TestObjectMapper.objectMapper()));
+      exporter.configure(testContext);
+
+      // when
+      exporter.open(testController);
+      exporter.close();
+      exporter.open(testController);
+
+      // then
+      final var metadataIndex =
+          new MetadataIndex(
+              configuration.getConnect().getIndexPrefix(),
+              configuration.getConnect().getTypeEnum().isElasticSearch());
+      final var searchEngineClient = stubbedClientAdapterInUse.getSearchEngineClient();
+      verify(searchEngineClient, times(1)).indexExists(metadataIndex.getFullQualifiedName());
+      verify(searchEngineClient, times(1))
+          .upsertDocument(eq(metadataIndex.getFullQualifiedName()), eq("cluster-id"), any());
     }
 
     /**

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ExporterConfiguration.java
@@ -37,6 +37,7 @@ public class ExporterConfiguration {
       RdbmsWriterConfig.DEFAULT_EXPORT_BATCH_OPERATION_ITEMS_ON_CREATION;
   private int batchOperationItemInsertBlockSize =
       RdbmsWriterConfig.DEFAULT_BATCH_OPERATION_ITEM_INSERT_BLOCK_SIZE;
+  private boolean clusterIdCheckRestrictionEnabled = true;
   // insert batching configuration
   private InsertBatchingConfiguration insertBatching = new InsertBatchingConfiguration();
   // caches
@@ -101,6 +102,14 @@ public class ExporterConfiguration {
   public void setExportBatchOperationItemsOnCreation(
       final boolean exportBatchOperationItemsOnCreation) {
     this.exportBatchOperationItemsOnCreation = exportBatchOperationItemsOnCreation;
+  }
+
+  public boolean isClusterIdCheckRestrictionEnabled() {
+    return clusterIdCheckRestrictionEnabled;
+  }
+
+  public void setClusterIdCheckRestrictionEnabled(final boolean clusterIdCheckRestrictionEnabled) {
+    this.clusterIdCheckRestrictionEnabled = clusterIdCheckRestrictionEnabled;
   }
 
   public int getBatchOperationItemInsertBlockSize() {
@@ -301,6 +310,8 @@ public class ExporterConfiguration {
         + batchOperationCache
         + ", asyncReplication="
         + asyncReplication
+        + ", clusterIdCheckRestrictionEnabled="
+        + clusterIdCheckRestrictionEnabled
         + '}';
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -118,6 +118,8 @@ public class RdbmsExporterWrapper implements Exporter {
     }
     config.validate(); // throws exception if configuration is invalid
 
+    rdbmsSchemaManagerRegistry.validateClusterId(
+        physicalTenantId, context.getClusterId(), config.isClusterIdCheckRestrictionEnabled());
     final var rdbmsWriterConfig =
         config.createRdbmsWriterConfig(partitionId, physicalTenantId, context.clock());
     // Use the partition-scoped meter registry so the writer metrics inherit the partition and

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterWrapperTest.java
@@ -383,6 +383,40 @@ class RdbmsExporterWrapperTest {
     assertThat(configCaptor.getValue().physicalTenantId()).isEqualTo("mycustomtenant");
   }
 
+  @Test
+  public void shouldValidateClusterIdWithContextValuesAndConfiguredRestrictionFlag() {
+    // given
+    final var configuration = new ExporterConfiguration();
+    configuration.setClusterIdCheckRestrictionEnabled(false);
+    final Context context = mock(Context.class, Mockito.RETURNS_DEEP_STUBS);
+    final RdbmsServiceFactory rdbmsServiceFactory = mock(RdbmsServiceFactory.class);
+    final RdbmsService rdbmsService = mock(RdbmsService.class, Mockito.RETURNS_DEEP_STUBS);
+    final RdbmsWriters rdbmsWriters = mock(RdbmsWriters.class, Mockito.RETURNS_DEEP_STUBS);
+    final RdbmsSchemaManagerRegistry rdbmsSchemaManagerRegistry =
+        mock(RdbmsSchemaManagerRegistry.class);
+    when(rdbmsServiceFactory.createRdbmsService(Mockito.anyString(), any()))
+        .thenReturn(rdbmsService);
+
+    when(context.getPartitionId()).thenReturn(1);
+    when(context.getPhysicalTenantId()).thenReturn("my-custom-tenant");
+    when(context.getClusterId()).thenReturn("cluster-under-test");
+    when(rdbmsService.createWriter(any(RdbmsWriterConfig.class))).thenReturn(rdbmsWriters);
+
+    final RdbmsExporterWrapper exporterWrapper =
+        new RdbmsExporterWrapper(
+            rdbmsServiceFactory,
+            rdbmsSchemaManagerRegistry,
+            Map.of("my-custom-tenant", configuration));
+
+    // when
+    exporterWrapper.configure(context);
+
+    // then - verify the exact arguments passed through to the registry: physical tenant id,
+    // cluster id, and the configured restriction flag, in that order
+    verify(rdbmsSchemaManagerRegistry)
+        .validateClusterId("my-custom-tenant", "cluster-under-test", false);
+  }
+
   private void assertAuditLogExportPresent(
       final Map<ValueType, List<RdbmsExportHandler>> registeredHandlers,
       final Map<Class<?>, ValueType> expectedRegisteredTransformers) {


### PR DESCRIPTION
## Summary

Closes #28286.

A Zeebe cluster can end up pointed at Elasticsearch/OpenSearch or RDBMS storage that already has data from a different installation - a careless backup restore, or reused connection settings. Record keys are partition/position based, so they restart from the same values in a fresh cluster, and exported data silently mixes with whatever was already there.

Key changes:
- Exporters were reading `clusterId` from a static per-broker config bean, not the gossip-resolved cluster configuration - fixed first, since the static value diverges across brokers and would misfire a naive mismatch check on self-managed clusters. This is an independent fix, but needed in order for the later commits to work
- The `camunda-exporter` and `rdbms-exporter` compare this cluster's resolved ID against the one previously recorded in storage, fail startup by default on mismatch. The logic to do this is not completely different to how we already handle the schema manager
- A mismatch is a terminal exporter failure, not a transient one - it never resolves itself, so the exporter's retry loop stops and reports the exporter as dead immediately instead of retrying forever with no clear error
- Skipped when the local cluster ID can't be resolved, and skipped for RDBMS when auto-DDL is disabled (`NoopSchemaManager`) - same as the existing schema-version check it piggybacks on. Also makes sense conceptually for RDBMS as schema management isn't handled by the application
- `clusterIdCheckRestrictionEnabled` flag lets an operator skip the check entirely, for legitimate re-pointing. Disabling it doesn't record the new cluster ID either, so re-enabling the check later will still see the original mismatch - it's meant as a one-time bypass, not a way to adopt a new cluster ID going forward. I will add a Docs PR for this after (or if) the main code changes get approved. My assumption is that customers might want this when promoting environments, for example (pretty sure I have seen this in previous support cases)
- ES/OS exporters are out of scope - no changes to either
- This detects "pointed at a different cluster's storage," not "same cluster, storage restored from an older backup" - the cluster ID isn't regenerated on restore.
- Both `camunda-exporter` and `rdbms-exporter` scope this correctly per physical tenant: physical tenants are validated to never share a secondary-storage location, so each tenant's own exporter compares against its own recorded cluster ID, independent of any other tenant's
