### PR TITLE
test: enable PT-scoped unprotected API session regression case

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.bouncycastle>1.84</version.bouncycastle>
     <version.camunda>7.24.0</version.camunda>
     <version.camunda-license-check>2.11.2</version.camunda-license-check>
-    <version.camunda-security-library>0.1.0-alpha49</version.camunda-security-library>
+    <version.camunda-security-library>0.1.0-alpha50</version.camunda-security-library>
     <version.checkstyle>13.7.0</version.checkstyle>
     <version.commons-beanutils>1.11.0</version.commons-beanutils>
     <version.commons-lang>3.20.0</version.commons-lang>

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/PhysicalTenantWebSessionUnprotectedApiIT.java
@@ -25,7 +25,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.springframework.http.HttpHeaders;
@@ -39,10 +38,7 @@ import org.springframework.http.HttpStatus;
  *
  * <p>Covers two surfaces: the default (non-PT) path, and the physical tenant's own scoped path
  * ({@code /physical-tenants/<id>/...}), whose unprotected API variant is built via {@code
- * ScopedApiSecurityChainBuilder#buildUnprotectedScopedApiChain}. The scoped case is {@link
- * Disabled @Disabled} until this repo bumps CSL to the release carrying its session-filter fix
- * (camunda-security-library#521); until then that chain installs no session filter and the scoped
- * {@code /v2/authentication/me} returns 401.
+ * ScopedApiSecurityChainBuilder#buildUnprotectedScopedApiChain}.
  */
 @MultiDbTest
 @MultiDbPhysicalTenants({PhysicalTenantWebSessionUnprotectedApiIT.TENANT_A})
@@ -95,11 +91,6 @@ public class PhysicalTenantWebSessionUnprotectedApiIT {
   }
 
   @Test
-  @Disabled(
-      "Enable once this repo bumps CSL to the release carrying the scoped unprotected"
-          + " session-filter fix (camunda-security-library#521); until then the PT-scoped"
-          + " unprotected chain installs no session filter and /physical-tenants/<id>"
-          + "/v2/authentication/me returns 401.")
   void shouldRecognizeAndInvalidatePhysicalTenantScopedSessionOnUnprotectedApiChain()
       throws Exception {
     final String base = CAMUNDA.restAddress().toString().replaceAll("/+$", "");


### PR DESCRIPTION
## Description

Bumps `camunda-security-library` to `0.1.0-alpha50` (carrying camunda/camunda-security-library#521) and enables the previously `@Disabled` per-physical-tenant case in `PhysicalTenantWebSessionUnprotectedApiIT` — a session minted on a tenant-scoped `/login` is recognised on that tenant's unprotected `/v2/authentication/me` and invalidated after logout. Verified locally (2/2, H2).

## Related issues

Relates to #57499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)