### PR TITLE
docs: add iron rule against unbounded recursion in engine-expert skill

### DIFF
--- a/.claude/skills/engine-expert/SKILL.md
+++ b/.claude/skills/engine-expert/SKILL.md
@@ -22,6 +22,7 @@ These are summaries. The reference files (linked below) are authoritative — th
 - Hot paths log at trace level only. INFO/DEBUG on a hot path is a performance regression at engine throughput.
 - Values returned from `ColumnFamily.get(...)` / state reads are backed by a shared, mutable buffer reused on the next read of the same column family. Never cache them or hold them across another read — `copyFrom(...)` if you need to keep the value, or use `get(key, valueSupplier)` to allocate a fresh instance.
 - Non-transactional side effects (metrics, post-commit hooks) run only after all state and follow-up command writes that could throw. Exceptions roll back state, but already-executed side effects don't roll back — counters drift.
+- No unbounded recursion over process trees, call activities, or event chains — depth is user-controlled, and a `StackOverflowError` halts the partition. Bound it or use iteration.
 
 ## Where to read next
 

--- a/.claude/skills/engine-expert/SKILL.md
+++ b/.claude/skills/engine-expert/SKILL.md
@@ -22,7 +22,7 @@ These are summaries. The reference files (linked below) are authoritative — th
 - Hot paths log at trace level only. INFO/DEBUG on a hot path is a performance regression at engine throughput.
 - Values returned from `ColumnFamily.get(...)` / state reads are backed by a shared, mutable buffer reused on the next read of the same column family. Never cache them or hold them across another read — `copyFrom(...)` if you need to keep the value, or use `get(key, valueSupplier)` to allocate a fresh instance.
 - Non-transactional side effects (metrics, post-commit hooks) run only after all state and follow-up command writes that could throw. Exceptions roll back state, but already-executed side effects don't roll back — counters drift.
-- No unbounded recursion over process trees, call activities, or event chains — depth is user-controlled, and a `StackOverflowError` halts the partition. Bound it or use iteration.
+- No unbounded recursion unless documented why it's safe. Especially for process trees, call activities, and other user-provided input. A `StackOverflowError` would ban the executing instance. Bound recursion or use iteration/trampolining.
 
 ## Where to read next
 


### PR DESCRIPTION
## Summary
- Adds an iron rule to the engine-expert skill warning against unbounded recursion over process trees, call activities, or event chains, since depth is user-controlled and a `StackOverflowError` halts the partition.

## Test plan
- N/A — documentation-only change to `.claude/skills/engine-expert/SKILL.md`.