### PR TITLE
Set AgentHistory metrics to null when unset

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapper.java
@@ -34,8 +34,21 @@ public class AgentHistoryEntityMapper {
         dbModel.role(),
         dbModel.contentItems() != null ? dbModel.contentItems() : List.of(),
         dbModel.toolCallValues() != null ? dbModel.toolCallValues() : List.of(),
-        new Metrics(dbModel.inputTokens(), dbModel.outputTokens(), dbModel.durationMs()),
+        toMetrics(dbModel.inputTokens(), dbModel.outputTokens(), dbModel.durationMs()),
         dbModel.commitStatus(),
         dbModel.producedAt());
+  }
+
+  /**
+   * Returns null when all three metric fields are null (metrics were never provided). When only
+   * some fields are null (partial absence), constructs a {@link Metrics} preserving the available
+   * values rather than losing them.
+   */
+  private static Metrics toMetrics(
+      final Long inputTokens, final Long outputTokens, final Long durationMs) {
+    if (inputTokens == null && outputTokens == null && durationMs == null) {
+      return null;
+    }
+    return new Metrics(inputTokens, outputTokens, durationMs);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AgentHistoryDbModel.java
@@ -45,9 +45,9 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
   private AgentInstanceHistoryRole role;
   private AgentInstanceHistoryCommitStatus commitStatus;
   private OffsetDateTime producedAt;
-  private long inputTokens;
-  private long outputTokens;
-  private long durationMs;
+  private Long inputTokens;
+  private Long outputTokens;
+  private Long durationMs;
   private String content;
   private List<ContentItem> contentItems;
   private String toolCalls;
@@ -216,27 +216,27 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
     this.producedAt = producedAt;
   }
 
-  public long inputTokens() {
+  public Long inputTokens() {
     return inputTokens;
   }
 
-  public void inputTokens(final long inputTokens) {
+  public void inputTokens(final Long inputTokens) {
     this.inputTokens = inputTokens;
   }
 
-  public long outputTokens() {
+  public Long outputTokens() {
     return outputTokens;
   }
 
-  public void outputTokens(final long outputTokens) {
+  public void outputTokens(final Long outputTokens) {
     this.outputTokens = outputTokens;
   }
 
-  public long durationMs() {
+  public Long durationMs() {
     return durationMs;
   }
 
-  public void durationMs(final long durationMs) {
+  public void durationMs(final Long durationMs) {
     this.durationMs = durationMs;
   }
 
@@ -379,9 +379,9 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
     private AgentInstanceHistoryRole role;
     private AgentInstanceHistoryCommitStatus commitStatus;
     private OffsetDateTime producedAt;
-    private long inputTokens;
-    private long outputTokens;
-    private long durationMs;
+    private Long inputTokens;
+    private Long outputTokens;
+    private Long durationMs;
     private List<ContentItem> contentItems;
     private List<ToolCall> toolCallValues;
 
@@ -460,17 +460,17 @@ public class AgentHistoryDbModel implements Copyable<AgentHistoryDbModel> {
       return this;
     }
 
-    public Builder inputTokens(final long inputTokens) {
+    public Builder inputTokens(final Long inputTokens) {
       this.inputTokens = inputTokens;
       return this;
     }
 
-    public Builder outputTokens(final long outputTokens) {
+    public Builder outputTokens(final Long outputTokens) {
       this.outputTokens = outputTokens;
       return this;
     }
 
-    public Builder durationMs(final long durationMs) {
+    public Builder durationMs(final Long durationMs) {
       this.durationMs = durationMs;
       return this;
     }

--- a/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AgentHistoryMapper.xml
@@ -104,9 +104,9 @@
     <result property="commitStatus" column="COMMIT_STATUS"
       javaType="io.camunda.search.entities.AgentInstanceHistoryEntity$AgentInstanceHistoryCommitStatus"/>
     <result property="producedAt" column="PRODUCED_AT" javaType="java.time.OffsetDateTime"/>
-    <result property="inputTokens" column="INPUT_TOKENS" javaType="long"/>
-    <result property="outputTokens" column="OUTPUT_TOKENS" javaType="long"/>
-    <result property="durationMs" column="DURATION_MS" javaType="long"/>
+    <result property="inputTokens" column="INPUT_TOKENS" javaType="java.lang.Long"/>
+    <result property="outputTokens" column="OUTPUT_TOKENS" javaType="java.lang.Long"/>
+    <result property="durationMs" column="DURATION_MS" javaType="java.lang.Long"/>
     <result property="content" column="CONTENT" javaType="java.lang.String"/>
     <result property="toolCalls" column="TOOL_CALLS" javaType="java.lang.String"/>
   </resultMap>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/AgentHistoryEntityMapperTest.java
@@ -94,6 +94,39 @@ class AgentHistoryEntityMapperTest {
     assertThat(AgentHistoryEntityMapper.toEntity(null)).isNull();
   }
 
+  @Test
+  void shouldMapAllNullMetricsToNullMetrics() {
+    // given — all three null means metrics were never provided
+    final var dbModel = minimalDbModel(43L);
+    dbModel.inputTokens(null);
+    dbModel.outputTokens(null);
+    dbModel.durationMs(null);
+
+    // when
+    final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
+
+    // then
+    assertThat(entity.metrics()).isNull();
+  }
+
+  @Test
+  void shouldPreservePartialMetricsWhenOnlyDurationMsIsNull() {
+    // given — inputTokens and outputTokens set, durationMs absent
+    final var dbModel = minimalDbModel(44L);
+    dbModel.inputTokens(100L);
+    dbModel.outputTokens(200L);
+    dbModel.durationMs(null);
+
+    // when
+    final AgentInstanceHistoryEntity entity = AgentHistoryEntityMapper.toEntity(dbModel);
+
+    // then
+    assertThat(entity.metrics()).isNotNull();
+    assertThat(entity.metrics().inputTokens()).isEqualTo(100L);
+    assertThat(entity.metrics().outputTokens()).isEqualTo(200L);
+    assertThat(entity.metrics().durationMs()).isNull();
+  }
+
   private AgentHistoryDbModel minimalDbModel(final long key) {
     final var model = new AgentHistoryDbModel();
     model.agentHistoryKey(key);

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/mapper/AgentInstanceMapper.java
@@ -157,11 +157,16 @@ public class AgentInstanceMapper {
 
           if (request.getMetrics() != null) {
             final var metrics = request.getMetrics();
-            record
-                .getMetrics()
-                .setInputTokens(metrics.getInputTokens() != null ? metrics.getInputTokens() : 0L)
-                .setOutputTokens(metrics.getOutputTokens() != null ? metrics.getOutputTokens() : 0L)
-                .setDurationMs(metrics.getDurationMs() != null ? metrics.getDurationMs() : 0L);
+            final var recordMetrics = record.getMetrics();
+            if (metrics.getInputTokens() != null) {
+              recordMetrics.setInputTokens(metrics.getInputTokens());
+            }
+            if (metrics.getOutputTokens() != null) {
+              recordMetrics.setOutputTokens(metrics.getOutputTokens());
+            }
+            if (metrics.getDurationMs() != null) {
+              recordMetrics.setDurationMs(metrics.getDurationMs());
+            }
           }
 
           return record;

--- a/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
+++ b/gateways/gateway-mapping-http/src/main/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapper.java
@@ -2191,12 +2191,17 @@ public final class SearchQueryResponseMapper {
             .orElseGet(Collections::emptyList);
 
     final var m = entity.metrics();
-    final var metrics =
-        AgentInstanceHistoryItemMetrics.Builder.create()
-            .inputTokens(m.inputTokens())
-            .outputTokens(m.outputTokens())
-            .durationMs(m.durationMs())
-            .build();
+    final AgentInstanceHistoryItemMetrics metrics;
+    if (m == null) {
+      metrics = null;
+    } else {
+      metrics =
+          AgentInstanceHistoryItemMetrics.Builder.create()
+              .inputTokens(m.inputTokens())
+              .outputTokens(m.outputTokens())
+              .durationMs(m.durationMs())
+              .build();
+    }
 
     return AgentInstanceHistoryItemResult.Builder.create()
         .historyItemKey(keyToString(entity.historyItemKey()))

--- a/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
+++ b/gateways/gateway-mapping-http/src/test/java/io/camunda/gateway/mapping/http/search/SearchQueryResponseMapperTest.java
@@ -1299,7 +1299,7 @@ class SearchQueryResponseMapperTest {
               AgentInstanceHistoryRole.USER,
               List.of(new ContentItem(ContentType.TEXT, "Hello", null, null)),
               List.of(),
-              new Metrics(10, 20, 30),
+              new Metrics(10L, 20L, 30L),
               AgentInstanceHistoryCommitStatus.COMMITTED,
               producedAt);
 
@@ -1343,7 +1343,7 @@ class SearchQueryResponseMapperTest {
               AgentInstanceHistoryRole.ASSISTANT,
               List.of(new ContentItem(ContentType.DOCUMENT, null, docRef, null)),
               List.of(),
-              new Metrics(0, 0, 0),
+              new Metrics(0L, 0L, 0L),
               AgentInstanceHistoryCommitStatus.PENDING,
               OffsetDateTime.now());
 
@@ -1375,7 +1375,7 @@ class SearchQueryResponseMapperTest {
               AgentInstanceHistoryRole.TOOL_RESULT,
               null,
               null,
-              new Metrics(0, 0, 0),
+              new Metrics(0L, 0L, 0L),
               AgentInstanceHistoryCommitStatus.DISCARDED,
               OffsetDateTime.now());
 
@@ -1406,7 +1406,7 @@ class SearchQueryResponseMapperTest {
               AgentInstanceHistoryRole.ASSISTANT,
               List.of(),
               List.of(toolCall),
-              new Metrics(5, 10, 100),
+              new Metrics(5L, 10L, 100L),
               AgentInstanceHistoryCommitStatus.COMMITTED,
               OffsetDateTime.now());
 
@@ -1438,7 +1438,7 @@ class SearchQueryResponseMapperTest {
               AgentInstanceHistoryRole.USER,
               List.of(),
               List.of(),
-              new Metrics(0, 0, 0),
+              new Metrics(0L, 0L, 0L),
               AgentInstanceHistoryCommitStatus.COMMITTED,
               OffsetDateTime.now());
       final var queryResult = new SearchQueryResult<>(1L, false, List.of(entity), null, null);
@@ -1449,6 +1449,67 @@ class SearchQueryResponseMapperTest {
       // then
       assertThat(response.getItems()).hasSize(1);
       assertThat(response.getItems().get(0).getHistoryItemKey()).isEqualTo("42");
+    }
+
+    @Test
+    void shouldReturnNullMetricsWhenEntityMetricsIsNull() {
+      // given — metrics null means they were never provided at creation time
+      final var entity =
+          new AgentInstanceHistoryEntity(
+              1L,
+              2L,
+              3L,
+              4L,
+              5L,
+              "",
+              "<default>",
+              6L,
+              "",
+              null,
+              AgentInstanceHistoryRole.USER,
+              List.of(),
+              List.of(),
+              null,
+              AgentInstanceHistoryCommitStatus.COMMITTED,
+              OffsetDateTime.now());
+
+      // when
+      final var result = SearchQueryResponseMapper.toAgentHistoryItemResult(entity);
+
+      // then
+      assertThat(result.getMetrics()).isNull();
+    }
+
+    @Test
+    void shouldMapPartialMetricsWithNullDurationMs() {
+      // given — inputTokens and outputTokens set, durationMs absent
+      final var entity =
+          new AgentInstanceHistoryEntity(
+              1L,
+              2L,
+              3L,
+              4L,
+              5L,
+              "",
+              "<default>",
+              6L,
+              "",
+              null,
+              AgentInstanceHistoryRole.ASSISTANT,
+              List.of(),
+              List.of(),
+              new Metrics(100L, 200L, null),
+              AgentInstanceHistoryCommitStatus.COMMITTED,
+              OffsetDateTime.now());
+
+      // when
+      final var result = SearchQueryResponseMapper.toAgentHistoryItemResult(entity);
+
+      // then
+      assertThat(result.getMetrics()).isNotNull();
+      assertThat(result.getMetrics().getInputTokens()).isEqualTo(100L);
+      assertThat(result.getMetrics().getOutputTokens()).isEqualTo(200L);
+      assertThat(result.getMetrics().getDurationMs()).isNull();
     }
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/AgentInstanceHistorySearchIT.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.AgentInstanceHistoryContent;
 import io.camunda.client.api.command.AgentInstanceHistoryContent.ObjectContent;
+import io.camunda.client.api.command.AgentInstanceHistoryMetrics;
 import io.camunda.client.api.search.enums.AgentInstanceHistoryRole;
 import io.camunda.client.api.search.response.AgentInstanceHistory;
 import io.camunda.qa.util.compatibility.CompatibilityTest;
@@ -125,6 +126,11 @@ public class AgentInstanceHistorySearchIT {
             .role(AgentInstanceHistoryRole.ASSISTANT)
             .content(List.of(AgentInstanceHistoryContent.text("I can help with many tasks.")))
             .producedAt(OffsetDateTime.parse("2025-06-01T10:01:00Z"))
+            .metrics(
+                new AgentInstanceHistoryMetrics()
+                    .inputTokens(512L)
+                    .outputTokens(148L)
+                    .durationMs(1200L))
             .send()
             .join()
             .getHistoryItemKey();
@@ -271,6 +277,53 @@ public class AgentInstanceHistorySearchIT {
                       42,
                       true,
                       "search-complete");
+            });
+  }
+
+  @Test
+  void shouldReturnNullMetricsWhenNotProvided() {
+    // when — fetch USER and TOOL_RESULT items, both created without metrics
+    final var response =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .filter(f -> f.historyItemKey(p -> p.in(historyItemKey1, historyItemKey3)))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .hasSize(2)
+        .as("USER and TOOL_RESULT items created without metrics must return null metrics")
+        .extracting(AgentInstanceHistory::getMetrics)
+        .containsOnlyNulls();
+  }
+
+  @Test
+  void shouldReturnProvidedMetrics() {
+    // when — fetch ASSISTANT item, created with explicit metrics
+    final var response =
+        camundaClient
+            .newAgentInstanceHistorySearchRequest(agentInstanceKey)
+            .filter(f -> f.historyItemKey(historyItemKey2))
+            .execute();
+
+    // then
+    assertThat(response.items())
+        .singleElement()
+        .extracting(AgentInstanceHistory::getMetrics)
+        .satisfies(
+            m -> {
+              assertThat(m)
+                  .as("ASSISTANT item created with metrics must return non-null metrics")
+                  .isNotNull();
+              assertThat(m.getInputTokens())
+                  .as("inputTokens must match the value provided at creation")
+                  .isEqualTo(512L);
+              assertThat(m.getOutputTokens())
+                  .as("outputTokens must match the value provided at creation")
+                  .isEqualTo(148L);
+              assertThat(m.getDurationMs())
+                  .as("durationMs must match the value provided at creation")
+                  .isEqualTo(1200L);
             });
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformer.java
@@ -42,7 +42,7 @@ public class AgentHistoryEntityTransformer
         toRole(source.getRole()),
         toContent(source.getContent()),
         toToolCalls(source.getToolCalls()),
-        new Metrics(source.getInputTokens(), source.getOutputTokens(), source.getDurationMs()),
+        toMetrics(source.getInputTokens(), source.getOutputTokens(), source.getDurationMs()),
         toCommitStatus(source.getCommitStatus()),
         source.getProducedAt());
   }
@@ -109,5 +109,18 @@ public class AgentHistoryEntityTransformer
     return toolCalls.stream()
         .map(t -> new ToolCall(t.toolCallId(), t.toolName(), t.elementId(), t.arguments()))
         .toList();
+  }
+
+  /**
+   * Returns null when all three metric fields are null (metrics were never provided). When only
+   * some fields are null (partial absence), constructs a {@link Metrics} preserving the available
+   * values rather than losing them.
+   */
+  private static Metrics toMetrics(
+      final Long inputTokens, final Long outputTokens, final Long durationMs) {
+    if (inputTokens == null && outputTokens == null && durationMs == null) {
+      return null;
+    }
+    return new Metrics(inputTokens, outputTokens, durationMs);
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/entity/AgentHistoryEntityTransformerTest.java
@@ -226,4 +226,37 @@ class AgentHistoryEntityTransformerTest {
     assertThat(result.commitStatus()).isNotNull();
     assertThat(result.commitStatus().name()).isEqualTo(schemaStatus.name());
   }
+
+  @Test
+  void shouldMapAllNullMetricsToNullMetrics() {
+    // given — all three metric fields null means metrics were never provided
+    final var source = buildSource();
+    source.setInputTokens(null);
+    source.setOutputTokens(null);
+    source.setDurationMs(null);
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.metrics()).isNull();
+  }
+
+  @Test
+  void shouldPreservePartialMetricsWhenOnlyDurationMsIsNull() {
+    // given — inputTokens and outputTokens set, durationMs absent
+    final var source = buildSource();
+    source.setInputTokens(100L);
+    source.setOutputTokens(200L);
+    source.setDurationMs(null);
+
+    // when
+    final AgentInstanceHistoryEntity result = transformer.apply(source);
+
+    // then
+    assertThat(result.metrics()).isNotNull();
+    assertThat(result.metrics().inputTokens()).isEqualTo(100L);
+    assertThat(result.metrics().outputTokens()).isEqualTo(200L);
+    assertThat(result.metrics().durationMs()).isNull();
+  }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AgentInstanceHistoryEntity.java
@@ -35,7 +35,7 @@ public record AgentInstanceHistoryEntity(
     AgentInstanceHistoryRole role,
     List<ContentItem> content,
     List<ToolCall> toolCalls,
-    Metrics metrics,
+    @Nullable Metrics metrics,
     AgentInstanceHistoryCommitStatus commitStatus,
     OffsetDateTime producedAt)
     implements TenantOwnedEntity {
@@ -51,7 +51,6 @@ public record AgentInstanceHistoryEntity(
     Objects.requireNonNull(jobKey, "jobKey");
     Objects.requireNonNull(jobLease, "jobLease");
     Objects.requireNonNull(role, "role");
-    Objects.requireNonNull(metrics, "metrics");
     Objects.requireNonNull(commitStatus, "commitStatus");
     Objects.requireNonNull(producedAt, "producedAt");
     // Mutable lists required — readers may hydrate by calling .add()
@@ -140,7 +139,8 @@ public record AgentInstanceHistoryEntity(
     }
   }
 
-  /** Per-call token and latency metrics. Zero-valued rather than null when not available. */
+  /** Per-call token and latency metrics. Null when metrics were not provided at creation time. */
   @JsonIgnoreProperties(ignoreUnknown = true)
-  public record Metrics(long inputTokens, long outputTokens, long durationMs) {}
+  public record Metrics(
+      @Nullable Long inputTokens, @Nullable Long outputTokens, @Nullable Long durationMs) {}
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/agenthistory/AgentHistoryEntity.java
@@ -79,13 +79,13 @@ public final class AgentHistoryEntity
 
   // Metrics fields — flattened from AgentHistoryMetricsValue
   @SinceVersion(value = "8.10.0", requireDefault = false)
-  private long inputTokens;
+  private Long inputTokens;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
-  private long outputTokens;
+  private Long outputTokens;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
-  private long durationMs;
+  private Long durationMs;
 
   @SinceVersion(value = "8.10.0", requireDefault = false)
   private List<AgentHistoryContentValue> content;
@@ -242,29 +242,29 @@ public final class AgentHistoryEntity
     return this;
   }
 
-  public long getInputTokens() {
+  public Long getInputTokens() {
     return inputTokens;
   }
 
-  public AgentHistoryEntity setInputTokens(final long inputTokens) {
+  public AgentHistoryEntity setInputTokens(final Long inputTokens) {
     this.inputTokens = inputTokens;
     return this;
   }
 
-  public long getOutputTokens() {
+  public Long getOutputTokens() {
     return outputTokens;
   }
 
-  public AgentHistoryEntity setOutputTokens(final long outputTokens) {
+  public AgentHistoryEntity setOutputTokens(final Long outputTokens) {
     this.outputTokens = outputTokens;
     return this;
   }
 
-  public long getDurationMs() {
+  public Long getDurationMs() {
     return durationMs;
   }
 
-  public AgentHistoryEntity setDurationMs(final long durationMs) {
+  public AgentHistoryEntity setDurationMs(final Long durationMs) {
     this.durationMs = durationMs;
     return this;
   }
@@ -338,9 +338,9 @@ public final class AgentHistoryEntity
         && Objects.equals(role, that.role)
         && Objects.equals(commitStatus, that.commitStatus)
         && Objects.equals(producedAt, that.producedAt)
-        && inputTokens == that.inputTokens
-        && outputTokens == that.outputTokens
-        && durationMs == that.durationMs
+        && Objects.equals(inputTokens, that.inputTokens)
+        && Objects.equals(outputTokens, that.outputTokens)
+        && Objects.equals(durationMs, that.durationMs)
         && Objects.equals(content, that.content)
         && Objects.equals(toolCalls, that.toolCalls);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryCommitTest.java
@@ -82,9 +82,9 @@ public class AgentHistoryCommitTest {
     // insert — the emitted COMMITTED event must carry none of them.
     assertThat(committed.getValue().getContent()).isEmpty();
     assertThat(committed.getValue().getToolCalls()).isEmpty();
-    assertThat(committed.getValue().getMetrics().getInputTokens()).isZero();
-    assertThat(committed.getValue().getMetrics().getOutputTokens()).isZero();
-    assertThat(committed.getValue().getMetrics().getDurationMs()).isZero();
+    assertThat(committed.getValue().getMetrics().getInputTokens()).isEqualTo(-1L);
+    assertThat(committed.getValue().getMetrics().getOutputTokens()).isEqualTo(-1L);
+    assertThat(committed.getValue().getMetrics().getDurationMs()).isEqualTo(-1L);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/agenthistory/AgentHistoryDiscardTest.java
@@ -144,9 +144,9 @@ public class AgentHistoryDiscardTest {
     // insert — the emitted DISCARDED event must carry none of them.
     assertThat(discarded.getValue().getContent()).isEmpty();
     assertThat(discarded.getValue().getToolCalls()).isEmpty();
-    assertThat(discarded.getValue().getMetrics().getInputTokens()).isZero();
-    assertThat(discarded.getValue().getMetrics().getOutputTokens()).isZero();
-    assertThat(discarded.getValue().getMetrics().getDurationMs()).isZero();
+    assertThat(discarded.getValue().getMetrics().getInputTokens()).isEqualTo(-1L);
+    assertThat(discarded.getValue().getMetrics().getOutputTokens()).isEqualTo(-1L);
+    assertThat(discarded.getValue().getMetrics().getDurationMs()).isEqualTo(-1L);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AgentHistoryHandler.java
@@ -103,9 +103,9 @@ public class AgentHistoryHandler
             DateUtil.toOffsetDateTime(
                 Instant.ofEpochMilli(
                     value.getProducedAt() > 0 ? value.getProducedAt() : record.getTimestamp())))
-        .setInputTokens(value.getMetrics().getInputTokens())
-        .setOutputTokens(value.getMetrics().getOutputTokens())
-        .setDurationMs(value.getMetrics().getDurationMs())
+        .setInputTokens(ExporterUtil.nullIfNegative(value.getMetrics().getInputTokens()))
+        .setOutputTokens(ExporterUtil.nullIfNegative(value.getMetrics().getOutputTokens()))
+        .setDurationMs(ExporterUtil.nullIfNegative(value.getMetrics().getDurationMs()))
         .setContent(mapContent(value.getContent()))
         .setToolCalls(mapToolCalls(value.getToolCalls()));
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
@@ -56,6 +56,10 @@ public final class ExporterUtil {
     return value <= 0 ? null : value;
   }
 
+  public static Long nullIfNegative(final long value) {
+    return value < 0 ? null : value;
+  }
+
   public static String toStringOrDefault(final Object object, final String defaultString) {
     return object == null ? defaultString : object.toString();
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AgentHistoryHandlerTest.java
@@ -602,6 +602,34 @@ final class AgentHistoryHandlerTest {
         .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
   }
 
+  @Test
+  void shouldMapUnsetMetricsToNull() {
+    // given — -1L is the protocol sentinel for "not provided"
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildMinimalRecordValue(1L, 1))
+            .withMetrics(
+                ImmutableAgentHistoryMetricsValue.builder()
+                    .withInputTokens(-1L)
+                    .withOutputTokens(-1L)
+                    .withDurationMs(-1L)
+                    .build())
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withValue(recordValue));
+    final var entity = new AgentHistoryEntity().setId("1");
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getInputTokens()).isNull();
+    assertThat(entity.getOutputTokens()).isNull();
+    assertThat(entity.getDurationMs()).isNull();
+  }
+
   // --- helpers ---
 
   private Record<AgentHistoryRecordValue> generateRecord(final AgentHistoryIntent intent) {

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandler.java
@@ -81,9 +81,9 @@ public class AgentHistoryExportHandler implements RdbmsExportHandler<AgentHistor
         .role(mapRole(value.getRole()))
         .commitStatus(mapCommitStatus(intent))
         .producedAt(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(producedAtMillis)))
-        .inputTokens(value.getMetrics().getInputTokens())
-        .outputTokens(value.getMetrics().getOutputTokens())
-        .durationMs(value.getMetrics().getDurationMs())
+        .inputTokens(ExportUtil.nullIfNegative(value.getMetrics().getInputTokens()))
+        .outputTokens(ExportUtil.nullIfNegative(value.getMetrics().getOutputTokens()))
+        .durationMs(ExportUtil.nullIfNegative(value.getMetrics().getDurationMs()))
         .contentItems(mapContent(value.getContent()))
         .toolCallValues(mapToolCalls(value.getToolCalls()))
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ExportUtil.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/utils/ExportUtil.java
@@ -86,4 +86,15 @@ public class ExportUtil {
   public static Integer positiveOrNull(final int value) {
     return value > 0 ? value : null;
   }
+
+  /**
+   * Returns {@code null} when {@code value} is negative (i.e., the protocol sentinel for "not
+   * set"), otherwise returns the boxed value.
+   *
+   * <p>Unlike {@link #positiveOrNull}, this helper treats {@code 0} as a valid explicit value —
+   * callers that use it must not conflate zero with "absent".
+   */
+  public static Long nullIfNegative(final long value) {
+    return value < 0 ? null : value;
+  }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/AgentHistoryExportHandlerTest.java
@@ -542,6 +542,35 @@ class AgentHistoryExportHandlerTest {
     assertThat(mappedItem.object()).isEqualTo(arrayValue);
   }
 
+  @Test
+  void shouldMapUnsetMetricsToNull() {
+    // given — -1L is the protocol sentinel meaning "metrics not provided"
+    final var recordValue =
+        ImmutableAgentHistoryRecordValue.builder()
+            .from(buildRecordValue())
+            .withMetrics(
+                ImmutableAgentHistoryMetricsValue.builder()
+                    .withInputTokens(-1L)
+                    .withOutputTokens(-1L)
+                    .withDurationMs(-1L)
+                    .build())
+            .build();
+    final Record<AgentHistoryRecordValue> record =
+        factory.generateRecord(
+            ValueType.AGENT_HISTORY,
+            r -> r.withIntent(AgentHistoryIntent.CREATED).withKey(63L).withValue(recordValue));
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(writer).create(modelCaptor.capture());
+    final var model = modelCaptor.getValue();
+    assertThat(model.inputTokens()).isNull();
+    assertThat(model.outputTokens()).isNull();
+    assertThat(model.durationMs()).isNull();
+  }
+
   /**
    * Builds a fully-populated record value that will not throw during export. In particular: - role
    * is non-UNSPECIFIED - metrics is populated - content has a TEXT item (no UNSPECIFIED content

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/utils/ExportUtilTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/utils/ExportUtilTest.java
@@ -74,4 +74,18 @@ class ExportUtilTest {
     // then
     assertThat(treePath).isEqualTo("123/456");
   }
+
+  @Test
+  void shouldReturnNullForNegativeValuesInNullIfNegative() {
+    assertThat(ExportUtil.nullIfNegative(-1L)).isNull();
+    assertThat(ExportUtil.nullIfNegative(-100L)).isNull();
+    assertThat(ExportUtil.nullIfNegative(Long.MIN_VALUE)).isNull();
+  }
+
+  @Test
+  void shouldReturnValueForNonNegativeValuesInNullIfNegative() {
+    assertThat(ExportUtil.nullIfNegative(0L)).isEqualTo(0L);
+    assertThat(ExportUtil.nullIfNegative(1L)).isEqualTo(1L);
+    assertThat(ExportUtil.nullIfNegative(512L)).isEqualTo(512L);
+  }
 }

--- a/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/v2/agent-instances.yaml
@@ -983,7 +983,8 @@ components:
           items:
             $ref: '#/components/schemas/AgentInstanceToolCall'
         metrics:
-          description: Per-call token and latency metrics. Zero-valued when not available.
+          description: Per-call token and latency metrics. Null when metrics were not provided at creation time.
+          nullable: true
           allOf:
             - $ref: '#/components/schemas/AgentInstanceHistoryItemMetrics'
         commitStatus:
@@ -1127,15 +1128,18 @@ components:
         - durationMs
       properties:
         inputTokens:
-          description: Input tokens consumed by this LLM call.
+          description: Input tokens consumed by this LLM call. Null when not provided.
+          nullable: true
           type: integer
           format: int64
         outputTokens:
-          description: Output tokens produced by this LLM call.
+          description: Output tokens produced by this LLM call. Null when not provided.
+          nullable: true
           type: integer
           format: int64
         durationMs:
-          description: Wall-clock duration of the LLM call in milliseconds.
+          description: Wall-clock duration of the LLM call in milliseconds. Null when not provided.
+          nullable: true
           type: integer
           format: int64
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceControllerTest.java
@@ -791,6 +791,10 @@ class AgentInstanceControllerTest extends RestControllerTest {
                   assertThat(record.getContent()).hasSize(1);
                   assertThat(record.getContent().get(0).getText())
                       .isEqualTo("I will process the invoice.");
+                  // no metrics in the request — protocol record carries the -1 sentinel
+                  assertThat(record.getMetrics().getInputTokens()).isEqualTo(-1L);
+                  assertThat(record.getMetrics().getOutputTokens()).isEqualTo(-1L);
+                  assertThat(record.getMetrics().getDurationMs()).isEqualTo(-1L);
                 }),
             any());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AgentInstanceHistorySearchControllerTest.java
@@ -242,4 +242,49 @@ class AgentInstanceHistorySearchControllerTest extends RestControllerTest {
                     .build()),
             any());
   }
+
+  @Test
+  void shouldSearchAgentHistoryReturnsNullMetricsWhenNotSet() {
+    // given — entity with metrics == null (history item created without metrics)
+    final var entityNoMetrics =
+        new AgentInstanceHistoryEntity(
+            HISTORY_ITEM_KEY,
+            AGENT_INSTANCE_KEY,
+            ELEMENT_INSTANCE_KEY,
+            9007199254741001L,
+            9007199254740992L,
+            "myProcess",
+            "<default>",
+            JOB_KEY,
+            "job-lease-1",
+            1,
+            AgentInstanceHistoryRole.USER,
+            List.of(new ContentItem(ContentType.TEXT, "Hello agent", null, null)),
+            List.of(),
+            null,
+            AgentInstanceHistoryCommitStatus.COMMITTED,
+            PRODUCED_AT);
+
+    when(agentHistoryServices.search(any(AgentInstanceHistoryQuery.class), any()))
+        .thenReturn(
+            new SearchQueryResult.Builder<AgentInstanceHistoryEntity>()
+                .total(1)
+                .startCursor("f")
+                .endCursor("v")
+                .items(List.of(entityNoMetrics))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri(HISTORY_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .jsonPath("$.items[0].metrics")
+        .isEqualTo(null);
+  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryMetrics.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryMetrics.java
@@ -15,9 +15,9 @@ import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHisto
 @JsonIgnoreProperties({"encodedLength", "empty"})
 public final class AgentHistoryMetrics extends ObjectValue implements AgentHistoryMetricsValue {
 
-  private final LongProperty inputTokensProp = new LongProperty("inputTokens", 0L);
-  private final LongProperty outputTokensProp = new LongProperty("outputTokens", 0L);
-  private final LongProperty durationMsProp = new LongProperty("durationMs", 0L);
+  private final LongProperty inputTokensProp = new LongProperty("inputTokens", -1L);
+  private final LongProperty outputTokensProp = new LongProperty("outputTokens", -1L);
+  private final LongProperty durationMsProp = new LongProperty("durationMs", -1L);
 
   public AgentHistoryMetrics() {
     super(3);

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -5240,7 +5240,7 @@ final class JsonSerializableToJsonTest {
             }
           ],
           "toolCalls": [],
-          "metrics": { "inputTokens": 0, "outputTokens": 0, "durationMs": 0 },
+          "metrics": { "inputTokens": -1, "outputTokens": -1, "durationMs": -1 },
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,
@@ -5264,7 +5264,7 @@ final class JsonSerializableToJsonTest {
           "producedAt": -1,
           "content": [],
           "toolCalls": [],
-          "metrics": { "inputTokens": 0, "outputTokens": 0, "durationMs": 0 },
+          "metrics": { "inputTokens": -1, "outputTokens": -1, "durationMs": -1 },
           "tenantId": "<default>",
           "processInstanceKey": -1,
           "rootProcessInstanceKey": -1,

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/record/value/agenthistory/AgentHistoryRecordTest.java
@@ -212,9 +212,9 @@ final class AgentHistoryRecordTest {
     final AgentHistoryRecord record = new AgentHistoryRecord();
 
     // then
-    assertThat(record.getMetrics().getInputTokens()).isEqualTo(0L);
-    assertThat(record.getMetrics().getOutputTokens()).isEqualTo(0L);
-    assertThat(record.getMetrics().getDurationMs()).isEqualTo(0L);
+    assertThat(record.getMetrics().getInputTokens()).isEqualTo(-1L);
+    assertThat(record.getMetrics().getOutputTokens()).isEqualTo(-1L);
+    assertThat(record.getMetrics().getDurationMs()).isEqualTo(-1L);
   }
 
   @Test

--- a/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryMetrics.golden
+++ b/zeebe/protocol-impl/src/test/resources/protocol/records/golden/AgentHistoryMetrics.golden
@@ -15,9 +15,9 @@ import io.camunda.zeebe.protocol.record.value.AgentHistoryRecordValue.AgentHisto
 @JsonIgnoreProperties({"encodedLength", "empty"})
 public final class AgentHistoryMetrics extends ObjectValue implements AgentHistoryMetricsValue {
 
-  private final LongProperty inputTokensProp = new LongProperty("inputTokens", 0L);
-  private final LongProperty outputTokensProp = new LongProperty("outputTokens", 0L);
-  private final LongProperty durationMsProp = new LongProperty("durationMs", 0L);
+  private final LongProperty inputTokensProp = new LongProperty("inputTokens", -1L);
+  private final LongProperty outputTokensProp = new LongProperty("outputTokens", -1L);
+  private final LongProperty durationMsProp = new LongProperty("durationMs", -1L);
 
   public AgentHistoryMetrics() {
     super(3);


### PR DESCRIPTION
## Description

The Search API for agent instance history items always returned a `metrics` object populated with zeroed values (`inputTokens: 0`, `outputTokens: 0`, `durationMs: 0`) even when metrics were never provided at creation time. This made it impossible for consumers (AI Agent connector, frontend) to distinguish "metrics were never set" from "metrics were explicitly set to zero" — both of which are valid and semantically different states (user messages and tool-result items legitimately carry no metrics, while an explicit zero is meaningful data).

**Root cause:** `AgentHistoryMetrics` in the Zeebe protocol defaulted all three fields to `0L`, and the exporter layer wrote those defaults directly to secondary storage without any sentinel distinction.

**Fix:** Use `-1L` as a protocol-level sentinel for "not set", converted to `null` at the exporter boundary via a new `negativeOrNull` helper — following the established pattern used for `loopIteration` (`positiveOrNull`). This avoids the complexity of adding `changedAttributes` tracking to `AgentHistoryRecord`.

**What changed in the API contract:**

- `AgentInstanceHistoryItemMetrics` in `AgentInstanceHistoryItemResult` is now **nullable**: when none of the metric fields were provided at creation, the search response returns `null` instead of a zeroed object.
- The individual properties of `AgentInstanceHistoryItemMetrics` (`inputTokens`, `outputTokens`, `durationMs`) are also now **nullable**. This was necessary to faithfully represent *partial* metric data — a client may record `inputTokens` and `outputTokens` but not `durationMs` or vice versa. Storing absent sub-fields as `0` would silently recreate the same ambiguity this fix resolves at the object level, discarding the data that *was* provided. Both fields remain present in the JSON response (`required: true`, `nullable: true`).

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #55839