### PR TITLE
fix: validate memberIds in AddMembersTransformer not in ClusterEndpoint

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdatePartitionDistributorConfigRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.UpdateRoutingStateRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.Mode;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
@@ -50,8 +49,9 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.http.HttpStatusCode;
@@ -71,6 +71,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Component
 @RestControllerEndpoint(id = "cluster")
 public class ClusterEndpoint {
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterEndpoint.class);
   private static final Set<String> ALLOWED_QUERY_PARAMETERS =
       Set.of("dryRun", "force", "replicationFactor", "mode");
 
@@ -145,13 +146,10 @@ public class ClusterEndpoint {
       @RequestParam(defaultValue = "false") final boolean dryRun) {
     return switch (resource) {
       case brokers ->
-          withValidMembers(
-              List.of(id),
-              members ->
-                  ClusterApiUtils.mapOperationResponse(
-                      requestSender
-                          .removeMembers(new RemoveMembersRequest(Set.copyOf(members), dryRun))
-                          .join()));
+          ClusterApiUtils.mapOperationResponse(
+              requestSender
+                  .removeMembers(new RemoveMembersRequest(Set.of(MemberId.from(id)), dryRun))
+                  .join());
       case partitions -> ResponseEntity.status(501).body("Removing partitions is not supported");
       case changes -> {
         if (dryRun) {
@@ -292,17 +290,10 @@ public class ClusterEndpoint {
                 .map(MemberId::from)
                 .collect(Collectors.toSet())
             : Set.of();
-    final var allIds =
-        Stream.concat(brokersToAdd.stream(), brokersToRemove.stream()).collect(Collectors.toSet());
-    return withValidMemberIds(
-        allIds,
-        members -> {
-          final var patchRequest =
-              new ClusterPatchRequest(
-                  brokersToAdd, brokersToRemove, newPartitionCount, newReplicationFactor, dryRun);
-          return ClusterApiUtils.mapOperationResponse(
-              requestSender.patchCluster(patchRequest).join());
-        });
+    final var patchRequest =
+        new ClusterPatchRequest(
+            brokersToAdd, brokersToRemove, newPartitionCount, newReplicationFactor, dryRun);
+    return ClusterApiUtils.mapOperationResponse(requestSender.patchCluster(patchRequest).join());
   }
 
   private ResponseEntity<?> forceRemoveBrokers(
@@ -528,26 +519,6 @@ public class ClusterEndpoint {
     return items.stream().map(BrokerId::of).map(BrokerId::toString).toList();
   }
 
-  /**
-   * Checks whether the current cluster topology is zone-aware by inspecting the members. A cluster
-   * is zone-aware if any of its members have a zone set.
-   */
-  boolean isClusterZoneAware() {
-    try {
-      final var result = requestSender.getTopology().join();
-      if (result.isRight()) {
-        return isZoneAware(result.get());
-      }
-    } catch (final Exception ignored) {
-      // If we can't determine zone-awareness, assume non-zone-aware for backward compatibility
-    }
-    return false;
-  }
-
-  static boolean isZoneAware(final ClusterConfiguration config) {
-    return config.members().keySet().stream().anyMatch(m -> m.zone() != null);
-  }
-
   ResponseEntity<?> withValidMember(
       final String id, final Function<MemberId, ResponseEntity<?>> action) {
     return withValidMembers(List.of(id), list -> action.apply(list.stream().findFirst().get()));
@@ -579,40 +550,7 @@ public class ClusterEndpoint {
     if (!errors.isEmpty()) {
       return invalidRequest(String.join("; ", errors));
     }
-    return withValidMemberIds(parsed, action);
-  }
-
-  /**
-   * Parses and validates the given member ID strings against the cluster's zone-awareness, then
-   * passes the parsed {@link MemberId}s to the given action. Returns a 400 error response
-   * accumulating all validation errors if any ID is invalid.
-   */
-  ResponseEntity<?> withValidMemberIds(
-      final Collection<MemberId> ids,
-      final Function<Collection<MemberId>, ResponseEntity<?>> action) {
-    final boolean clusterIsZoneAware = isClusterZoneAware();
-    final List<String> errors = new ArrayList<>();
-
-    for (final var memberId : ids) {
-      if (clusterIsZoneAware && memberId.zone() == null) {
-        errors.add(
-            "'"
-                + memberId
-                + "' is a bare node ID, but this cluster is zone-aware — "
-                + "use '$zone_$nodeId' (e.g. 'zone-a_0')");
-      } else if (!clusterIsZoneAware && memberId.zone() != null) {
-        errors.add(
-            "'"
-                + memberId
-                + "' is a composite member ID, but this cluster is not zone-aware — "
-                + "use a bare integer node ID (e.g. '0')");
-      }
-    }
-
-    if (!errors.isEmpty()) {
-      return invalidRequest(String.join("; ", errors));
-    }
-    return action.apply(ids);
+    return action.apply(parsed);
   }
 
   public record PartitionAddRequest(int priority) {}

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -50,8 +50,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.jspecify.annotations.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.http.HttpStatusCode;
@@ -71,7 +69,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Component
 @RestControllerEndpoint(id = "cluster")
 public class ClusterEndpoint {
-  private static final Logger LOG = LoggerFactory.getLogger(ClusterEndpoint.class);
   private static final Set<String> ALLOWED_QUERY_PARAMETERS =
       Set.of("dryRun", "force", "replicationFactor", "mode");
 

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterEndpointTest.java
@@ -14,15 +14,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ModeChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
-import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.Mode;
-import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.util.Either;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
@@ -75,50 +70,8 @@ final class ClusterEndpointTest {
         .hasMessage("Unsupported query parameter(s): x, y");
   }
 
-  @Test
-  void shouldDetectZoneAwareCluster() {
-    // given
-    final var config = zoneAwareConfiguration();
-
-    // when - then
-    assertThat(ClusterEndpoint.isZoneAware(config)).isTrue();
-  }
-
-  @Test
-  void shouldDetectNonZoneAwareCluster() {
-    // given
-    final var config = nonZoneAwareConfiguration();
-
-    // when - then
-    assertThat(ClusterEndpoint.isZoneAware(config)).isFalse();
-  }
-
   private ClusterEndpoint createEndpoint() {
     return new ClusterEndpoint(mock(ClusterConfigurationManagementRequestSender.class));
-  }
-
-  private static ClusterConfiguration zoneAwareConfiguration() {
-    return ClusterConfiguration.init()
-        .addMember(
-            MemberId.from("zone-a", 0),
-            MemberState.initializeAsActive(
-                Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()))))
-        .addMember(
-            MemberId.from("zone-b", 0),
-            MemberState.initializeAsActive(
-                Map.of(1, PartitionState.active(2, DynamicPartitionConfig.init()))));
-  }
-
-  private static ClusterConfiguration nonZoneAwareConfiguration() {
-    return ClusterConfiguration.init()
-        .addMember(
-            MemberId.from("0"),
-            MemberState.initializeAsActive(
-                Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()))))
-        .addMember(
-            MemberId.from("1"),
-            MemberState.initializeAsActive(
-                Map.of(1, PartitionState.active(2, DynamicPartitionConfig.init()))));
   }
 
   @Nested

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/MemberId.java
@@ -123,6 +123,13 @@ public class MemberId extends NodeId {
   }
 
   /**
+   * @return if this memberId is bare, i.e. without a zone
+   */
+  public boolean isBare() {
+    return zone == null;
+  }
+
+  /**
    * @return {@code true} if this member id belongs to the given zone.
    */
   public boolean isInZone(final @Nullable String zone) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformer.java
@@ -33,7 +33,7 @@ public class AddMembersTransformer implements ConfigurationChangeRequest {
       return Either.left(
           new InvalidRequest(
               "Members without a zone cannot be added to a zone-aware cluster: "
-                  + members.stream().filter(MemberId::isBare).toList()));
+                  + members.stream().filter(MemberId::isBare).sorted().toList()));
     }
     final var operations =
         members.stream()

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -28,6 +29,12 @@ public class AddMembersTransformer implements ConfigurationChangeRequest {
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
+    if (clusterConfiguration.isFullyZoneAware() && members.stream().anyMatch(MemberId::isBare)) {
+      return Either.left(
+          new InvalidRequest(
+              "Members without a zone cannot be added to a zone-aware cluster: "
+                  + members.stream().filter(MemberId::isBare).toList()));
+    }
     final var operations =
         members.stream()
             // only add members that are not already part of the cluster

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformer.java
@@ -30,7 +30,7 @@ public class RemoveMembersTransformer implements ConfigurationChangeRequest {
       final ClusterConfiguration clusterConfiguration) {
     final var operations =
         members.stream()
-            // only add members that are not already part of the cluster
+            // only remove members that are not already part of the cluster
             .filter(clusterConfiguration::hasMember)
             .map(MemberLeaveOperation::new)
             .map(ClusterConfigurationChangeOperation.class::cast)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformer.java
@@ -30,7 +30,7 @@ public class RemoveMembersTransformer implements ConfigurationChangeRequest {
       final ClusterConfiguration clusterConfiguration) {
     final var operations =
         members.stream()
-            // only remove members that are not already part of the cluster
+            // only remove members that are already part of the cluster
             .filter(clusterConfiguration::hasMember)
             .map(MemberLeaveOperation::new)
             .map(ClusterConfigurationChangeOperation.class::cast)

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformerTest.java
@@ -10,14 +10,19 @@ package io.camunda.zeebe.dynamic.config.api;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneAwareConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionDistributorConfig.ZoneSpec;
 import io.camunda.zeebe.dynamic.config.util.MemberIdArbitraries;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import net.jqwik.api.ForAll;
 import net.jqwik.api.Property;
@@ -90,5 +95,26 @@ class AddMembersTransformerTest {
             result.get().stream()
                 .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
                 .toList());
+  }
+
+  @Test
+  void shouldReturnErrorForZonedIdInFullyZonedCluster() {
+    final MemberId existingMember = MemberId.from("1");
+    final var addRequest = new AddMembersTransformer(Set.of(existingMember));
+    final var zonedConfiguration =
+        ClusterConfiguration.builder()
+            .members(Map.of(MemberId.from("zon-a", 0), MemberState.uninitialized()))
+            .partitionDistributorConfig(
+                Optional.of(new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1)))))
+            .build();
+
+    // when
+    final var result = addRequest.operations(zonedConfiguration);
+
+    // then
+    EitherAssert.assertThat(result)
+        .isLeft()
+        .left()
+        .satisfies(e -> assertThat(e).isInstanceOf(InvalidRequest.class));
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformerTest.java
@@ -98,12 +98,12 @@ class AddMembersTransformerTest {
   }
 
   @Test
-  void shouldReturnErrorForZonedIdInFullyZonedCluster() {
+  void shouldReturnErrorForBareIdInFullyZonedCluster() {
     final MemberId existingMember = MemberId.from("1");
     final var addRequest = new AddMembersTransformer(Set.of(existingMember));
     final var zonedConfiguration =
         ClusterConfiguration.builder()
-            .members(Map.of(MemberId.from("zon-a", 0), MemberState.uninitialized()))
+            .members(Map.of(MemberId.from("zone-a", 0), MemberState.uninitialized()))
             .partitionDistributorConfig(
                 Optional.of(new ZoneAwareConfig(List.of(new ZoneSpec("zone-a", 1, 1)))))
             .build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ClusterEndpointIT.java
@@ -278,6 +278,24 @@ abstract class ClusterEndpointIT {
   }
 
   @Test
+  void shouldForceRemoveDefaultCoordinatorBroker() {
+    try (final var cluster = createCluster(brokerCount())) {
+      // given -- the default coordinator is the broker with the lowest member ID, i.e. broker 0
+      cluster.awaitCompleteTopology();
+      final var coordinatorMemberId = memberIdForBroker(0);
+      cluster.brokers().get(coordinatorMemberId).close();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      // when -- force remove the dead default coordinator broker
+      final var remainingBrokers = brokerIds(IntStream.range(1, brokerCount()).toArray());
+      final var response = actuator.scaleByBrokerIds(remainingBrokers, false, true);
+
+      // then -- the request succeeds, the zone-awareness pre-check does not block it
+      assertThat(response.getExpectedTopology()).hasSize(brokerCount() - 1);
+    }
+  }
+
+  @Test
   void shouldRequestAddBroker() {
     try (final var cluster = createCluster(minReplicationFactor())) {
       // given

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/cluster/management/ZoneAwareClusterEndpointIT.java
@@ -117,7 +117,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // when - then
       assertThatCode(() -> actuator.scaleBrokers(List.of(0, 1, 2)))
           .isInstanceOf(FeignException.BadRequest.class)
-          .hasMessageContaining("bare node ID");
+          .hasMessageContaining("Members without a zone cannot be added to a zone-aware cluster");
     }
   }
 
@@ -131,7 +131,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // when - then -- bare integer broker ID is rejected on zone-aware clusters
       assertThatCode(() -> actuator.addBroker(2))
           .isInstanceOf(FeignException.BadRequest.class)
-          .hasMessageContaining("bare node ID");
+          .hasMessageContaining("Members without a zone cannot be added to a zone-aware cluster");
     }
   }
 
@@ -145,7 +145,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // when - then -- partition join is rejected on zone-aware clusters
       assertThatCode(() -> actuator.joinPartition(0, 1, 1))
           .isInstanceOf(FeignException.BadRequest.class)
-          .hasMessageContaining("zone-aware");
+          .hasMessageContaining("is not active");
     }
   }
 
@@ -159,7 +159,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
       // when - then -- partition leave is rejected on zone-aware clusters
       assertThatCode(() -> actuator.leavePartition(0, 1))
           .isInstanceOf(FeignException.BadRequest.class)
-          .hasMessageContaining("zone-aware");
+          .hasMessageContaining("local member does not exist");
     }
   }
 
@@ -278,7 +278,7 @@ final class ZoneAwareClusterEndpointIT extends ClusterEndpointIT {
                       .add(List.of(BrokerId.of(0), BrokerId.of(1))));
       assertThatCode(() -> actuator.patchCluster(request, false, false))
           .isInstanceOf(FeignException.BadRequest.class)
-          .hasMessageContaining("bare node ID");
+          .hasMessageContaining("Members without a zone cannot be added to a zone-aware cluster");
     }
   }
 }


### PR DESCRIPTION
## Description
Validations should be done inside the transformer so that the latest configuration in the coordinator is used.
This ensures that all the other requests such as ScaleRequestTransformer or ClusterPatchTransformer apply the validation correctly.

In ClusterEndpoint the only validation done is that the provided id can be "parsed" as a MemberId
## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57617
