### PR TITLE
feat: sort AI agents available tools alphabetically

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.test.tsx
@@ -39,6 +39,21 @@ describe('<AvailableTools />', () => {
     expect(secondTool).toHaveTextContent('Sends an email to a recipient.');
   });
 
+  it('should render tools in alphabetical order by name', () => {
+    const tools: AgentTool[] = [
+      {name: 'send_email', description: null, elementId: null},
+      {name: 'analyze_data', description: null, elementId: null},
+      {name: 'get_weather', description: null, elementId: null},
+    ];
+
+    render(<AvailableTools tools={tools} />);
+
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]).toHaveAccessibleName('analyze_data');
+    expect(items[1]).toHaveAccessibleName('get_weather');
+    expect(items[2]).toHaveAccessibleName('send_email');
+  });
+
   it('should render an empty hint when no tools are configured', () => {
     render(<AvailableTools tools={[]} />);
 

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.tsx
@@ -26,12 +26,12 @@ const AvailableTools: React.FC<AvailableToolsProps> = memo(
 
     return (
       <ToolList>
-        {sortedTools.map((tool, i) => (
+        {sortedTools.map((tool) => (
           <li
-            key={`${tool.name}-${i}`}
-            aria-labelledby={`agent-instance-tool-${tool.name}-${i}`}
+            key={`${tool.name}`}
+            aria-labelledby={`agent-instance-tool-${tool.name}`}
           >
-            <ToolName id={`agent-instance-tool-${tool.name}-${i}`}>
+            <ToolName id={`agent-instance-tool-${tool.name}`}>
               {tool.name}
             </ToolName>
             {tool.description !== null && (

--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/AgentDetails/AvailableTools/index.tsx
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {memo} from 'react';
 import type {AgentTool} from '@camunda/camunda-api-zod-schemas/8.10';
 import {ToolList, ToolName, ToolDescription, EmptyHint} from './styled';
 
@@ -13,28 +14,34 @@ type AvailableToolsProps = {
   tools: AgentTool[];
 };
 
-const AvailableTools: React.FC<AvailableToolsProps> = ({tools}) => {
-  if (tools.length === 0) {
-    return <EmptyHint>No tools available for the AI agent.</EmptyHint>;
-  }
+const AvailableTools: React.FC<AvailableToolsProps> = memo(
+  function AvailableTools({tools}) {
+    if (tools.length === 0) {
+      return <EmptyHint>No tools available for the AI agent.</EmptyHint>;
+    }
 
-  return (
-    <ToolList>
-      {tools.map((tool, i) => (
-        <li
-          key={`${tool.name}-${i}`}
-          aria-labelledby={`agent-instance-tool-${tool.name}-${i}`}
-        >
-          <ToolName id={`agent-instance-tool-${tool.name}-${i}`}>
-            {tool.name}
-          </ToolName>
-          {tool.description !== null && (
-            <ToolDescription>{tool.description}</ToolDescription>
-          )}
-        </li>
-      ))}
-    </ToolList>
-  );
-};
+    const sortedTools = Array.from(tools).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    );
+
+    return (
+      <ToolList>
+        {sortedTools.map((tool, i) => (
+          <li
+            key={`${tool.name}-${i}`}
+            aria-labelledby={`agent-instance-tool-${tool.name}-${i}`}
+          >
+            <ToolName id={`agent-instance-tool-${tool.name}-${i}`}>
+              {tool.name}
+            </ToolName>
+            {tool.description !== null && (
+              <ToolDescription>{tool.description}</ToolDescription>
+            )}
+          </li>
+        ))}
+      </ToolList>
+    );
+  },
+);
 
 export {AvailableTools};


### PR DESCRIPTION
## Description

This PR slightly updates the AI agent's `AvailableTools` to sort the tools alphabetically before rendering them.

## Related issues

closes #57382
