### PR TITLE
feat: add Operate filter validators and advanced-string-filter codec utils

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/advancedStringFilter.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/advancedStringFilter.test.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {encodeFilterOperation, splitEncodedFilterOperation} from './advancedStringFilter';
+
+describe('encodeFilterOperation', () => {
+	it('should strip the $ prefix from the operator', () => {
+		expect(encodeFilterOperation('$eq', 'order-123')).toBe('eq_order-123');
+		expect(encodeFilterOperation('$like', 'order')).toBe('like_order');
+	});
+});
+
+describe('splitEncodedFilterOperation', () => {
+	it('should split on the first separator and restore the $ prefix', () => {
+		expect(splitEncodedFilterOperation('eq_order_123')).toEqual({
+			operator: '$eq',
+			value: 'order_123',
+		});
+	});
+
+	it('should return null when no separator is present', () => {
+		expect(splitEncodedFilterOperation('eqorder')).toBeNull();
+	});
+
+	it('should return null for an unknown operator slug', () => {
+		expect(splitEncodedFilterOperation('foo_value')).toBeNull();
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/advancedStringFilter.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/advancedStringFilter.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {z} from 'zod';
+import type {QueryProcessInstancesRequestBody} from '@camunda/camunda-api-zod-schemas/8.10';
+
+const VALUE_SEPARATOR = '_';
+
+// `AdvancedStringFilter` type derived because it is not exposed by @camunda/camunda-api-zod-schemas.
+type AdvancedStringFilter = Extract<NonNullable<QueryProcessInstancesRequestBody['filter']>['businessId'], object>;
+type AdvancedStringFilterOperator = keyof AdvancedStringFilter;
+
+const advancedStringFilterSchema = z.object({
+	$eq: z.string().optional(),
+	$neq: z.string().optional(),
+	$exists: z.stringbool().optional(),
+	$in: z.array(z.string().min(1)).min(1).optional(),
+	$notIn: z.array(z.string().min(1)).min(1).optional(),
+	$like: z.string().optional(),
+}) satisfies z.ZodType<AdvancedStringFilter>;
+const advancedStringFilterKeySchema = z.keyof(advancedStringFilterSchema);
+
+/** Turns an operator value pair into a URL-ready string. */
+function encodeFilterOperation(operator: AdvancedStringFilterOperator, rawValue: string) {
+	return `${operator.slice(1)}${VALUE_SEPARATOR}${rawValue}`;
+}
+
+/** Splits a URL-ready string into an operator value pair and verifies the operator is valid. */
+function splitEncodedFilterOperation(encodedOperation: string) {
+	const separatorIndex = encodedOperation.indexOf(VALUE_SEPARATOR);
+	if (separatorIndex === -1) {
+		return null;
+	}
+
+	const operator = `$${encodedOperation.slice(0, separatorIndex)}`;
+	const value = encodedOperation.slice(separatorIndex + 1);
+	const result = advancedStringFilterKeySchema.safeParse(operator);
+	if (!result.success) {
+		return null;
+	}
+	return {operator: result.data, value};
+}
+
+export {encodeFilterOperation, splitEncodedFilterOperation};
+export type {AdvancedStringFilterOperator, AdvancedStringFilter};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/mergeValidators.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/mergeValidators.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {mergeValidators} from './mergeValidators';
+
+describe('mergeValidators', () => {
+	it('returns undefined when all validators pass', () => {
+		const validator = mergeValidators(
+			() => undefined,
+			() => undefined,
+		);
+
+		expect(validator('value', {}, undefined)).toBeUndefined();
+	});
+
+	it('returns the first sync error, short-circuiting later validators', () => {
+		const validator = mergeValidators(
+			() => 'first error',
+			() => 'second error',
+		);
+
+		expect(validator('value', {}, undefined)).toBe('first error');
+	});
+
+	it('resolves with an async error when no sync error is found', async () => {
+		const validator = mergeValidators(
+			() => undefined,
+			() => Promise.resolve('async error'),
+		);
+
+		await expect(validator('value', {}, undefined)).resolves.toBe('async error');
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/mergeValidators.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/mergeValidators.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {FieldValidator} from 'final-form';
+
+const isPromise = (value: unknown): value is Promise<unknown> => {
+	return Boolean(
+		value && typeof value === 'object' && 'then' in value && typeof (value as {then: unknown}).then === 'function',
+	);
+};
+
+const mergeValidators = (
+	...validators: Array<FieldValidator<string | undefined>>
+): FieldValidator<string | undefined> => {
+	return (...validateParams: Parameters<FieldValidator<string | undefined>>) => {
+		const executedValidators = validators.map((validator) => validator(...validateParams));
+		const syncValidators = executedValidators.filter((validator) => !isPromise(validator));
+		const asyncValidators = executedValidators.filter((validator) => isPromise(validator));
+
+		const immediateError = syncValidators.reduce((error, result) => error ?? result, undefined);
+
+		if (immediateError !== undefined) {
+			return immediateError;
+		}
+
+		if (asyncValidators.length === 0) {
+			return undefined;
+		}
+
+		return new Promise((resolve) => {
+			asyncValidators.forEach((result) => resolve(result));
+		});
+	};
+};
+
+export {mergeValidators};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/parseIds.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/parseIds.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+/** Splits a comma/whitespace separated list of ids into individual ids. */
+function parseIds(value: string) {
+	return value
+		.trim()
+		.replace(/,\s/g, '|')
+		.replace(/\s{1,}/g, '|')
+		.replace(/,{1,}/g, '|')
+		.split('|');
+}
+
+export {parseIds};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/promisifyValidator.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/promisifyValidator.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {FieldValidator} from 'final-form';
+
+const promisifyValidator = (validator: FieldValidator<string | undefined>, debounceTimeout: number) => {
+	return (...params: Parameters<FieldValidator<string | undefined>>) => {
+		const errorMessage = validator(...params);
+		if (errorMessage === undefined) {
+			return undefined;
+		}
+
+		return new Promise((resolve) => {
+			setTimeout(() => {
+				resolve(errorMessage);
+			}, debounceTimeout);
+		});
+	};
+};
+
+export {promisifyValidator};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/validators.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/validators.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import i18n from 'i18next';
+import {
+	validateIdsCharacters,
+	validateIdsLength,
+	validatesIdsComplete,
+	validateParentInstanceIdCharacters,
+	validateParentInstanceIdComplete,
+	validateParentInstanceIdNotTooLong,
+	validateBatchOperationKeyCharacters,
+	validateBatchOperationKeyComplete,
+} from './validators';
+
+const ERRORS = {
+	ids: i18n.t('operate.shared.validators.ids'),
+	parentInstanceId: i18n.t('operate.shared.validators.parentInstanceId'),
+	batchOperationKey: i18n.t('operate.shared.validators.batchOperationKey'),
+};
+
+describe('validators', () => {
+	beforeEach(() => {
+		vi.useFakeTimers({shouldAdvanceTime: true});
+	});
+	afterEach(() => {
+		vi.clearAllTimers();
+		vi.useRealTimers();
+	});
+
+	it('should validate ids without delay', () => {
+		const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+		expect(validateIdsCharacters('', {})).toBeUndefined();
+
+		expect(validateIdsCharacters('2251799813685543', {})).toBeUndefined();
+		expect(validateIdsCharacters('22517998136855430', {})).toBeUndefined();
+
+		expect(validateIdsCharacters('2251799813685543a', {})).toBe(ERRORS.ids);
+		expect(validateIdsCharacters('a', {})).toBe(ERRORS.ids);
+		expect(validateIdsCharacters('-', {})).toBe(ERRORS.ids);
+
+		expect(validateIdsCharacters('2251799813685543 2251799813685543', {})).toBeUndefined();
+		expect(validateIdsCharacters('2251799813685543,2251799813685543', {})).toBeUndefined();
+		expect(validateIdsCharacters('2251799813685543, 2251799813685543', {})).toBeUndefined();
+
+		expect(validateIdsCharacters('2251799813685543 a 2251799813685543 ', {})).toBe(ERRORS.ids);
+
+		expect(validateIdsLength('2251799813685543 2251799813685543 11111111111111111111', {})).toBe(ERRORS.ids);
+
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(0);
+	});
+
+	it('should validate ids with delay', async () => {
+		const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+		vi.runAllTimersAsync();
+
+		await expect(validatesIdsComplete('1', {})).resolves.toBe(ERRORS.ids);
+		await expect(validatesIdsComplete('1 1 1 ', {})).resolves.toBe(ERRORS.ids);
+		await expect(validatesIdsComplete('225179981368554', {})).resolves.toBe(ERRORS.ids);
+		expect(validatesIdsComplete('2251799813685543', {})).toBeUndefined();
+
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(3);
+	});
+
+	it('should validate parent instance id without delay', () => {
+		const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+		expect(validateParentInstanceIdCharacters('', {})).toBeUndefined();
+		expect(validateParentInstanceIdCharacters('2251799813685543', {})).toBeUndefined();
+
+		expect(validateParentInstanceIdCharacters('2251799813685543a', {})).toBe(ERRORS.parentInstanceId);
+		expect(validateParentInstanceIdCharacters('a', {})).toBe(ERRORS.parentInstanceId);
+		expect(validateParentInstanceIdCharacters('-', {})).toBe(ERRORS.parentInstanceId);
+		expect(validateParentInstanceIdCharacters('2251799813685543 2251799813685543', {})).toBe(ERRORS.parentInstanceId);
+
+		expect(validateParentInstanceIdNotTooLong('11111111111111111111', {})).toBe(ERRORS.parentInstanceId);
+
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(0);
+	});
+
+	it('should validate parent instance id with delay', async () => {
+		const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+		vi.runAllTimersAsync();
+
+		await expect(validateParentInstanceIdComplete('1', {})).resolves.toBe(ERRORS.parentInstanceId);
+		await expect(validateParentInstanceIdComplete('225179981368554', {})).resolves.toBe(ERRORS.parentInstanceId);
+		expect(validateParentInstanceIdComplete('2251799813685543', {})).toBeUndefined();
+
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('should validate batchOperationKey without delay', () => {
+		const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+		expect(validateBatchOperationKeyCharacters('', {})).toBeUndefined();
+		expect(validateBatchOperationKeyCharacters('f', {})).toBeUndefined();
+		expect(validateBatchOperationKeyCharacters('1', {})).toBeUndefined();
+		expect(validateBatchOperationKeyCharacters('1f4d40c3-7cce-4e51-8abe-0cda8d42f04f', {})).toBeUndefined();
+		expect(validateBatchOperationKeyCharacters('2251799813685871', {})).toBeUndefined();
+
+		expect(validateBatchOperationKeyCharacters('&', {})).toBe(ERRORS.batchOperationKey);
+		expect(validateBatchOperationKeyCharacters('g', {})).toBe(ERRORS.batchOperationKey);
+
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(0);
+	});
+
+	it('should validate batchOperationKey with delay', async () => {
+		const setTimeoutSpy = vi.spyOn(window, 'setTimeout');
+		vi.runAllTimersAsync();
+
+		await expect(validateBatchOperationKeyComplete('1f4d40c3-7cce-4e51-', {})).resolves.toBe(ERRORS.batchOperationKey);
+		await expect(validateBatchOperationKeyComplete('0e8481e6-b652-41c9-a72a-f531c783122', {})).resolves.toBe(
+			ERRORS.batchOperationKey,
+		);
+		await expect(validateBatchOperationKeyComplete('a', {})).resolves.toBe(ERRORS.batchOperationKey);
+		await expect(validateBatchOperationKeyComplete('0', {})).resolves.toBe(ERRORS.batchOperationKey);
+		await expect(validateBatchOperationKeyComplete('12345689', {})).resolves.toBe(ERRORS.batchOperationKey);
+		expect(validateBatchOperationKeyComplete('1f4d40c3-7cce-4e51-8abe-0cda8d42f04f', {})).toBeUndefined();
+
+		expect(setTimeoutSpy).toHaveBeenCalledTimes(5);
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/validators.test.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/validators.test.ts
@@ -104,6 +104,10 @@ describe('validators', () => {
 
 		expect(validateBatchOperationKeyCharacters('&', {})).toBe(ERRORS.batchOperationKey);
 		expect(validateBatchOperationKeyCharacters('g', {})).toBe(ERRORS.batchOperationKey);
+		expect(validateBatchOperationKeyCharacters('a&', {})).toBe(ERRORS.batchOperationKey);
+		expect(validateBatchOperationKeyCharacters('1f4d40c3-7cce-4e51-8abe-0cda8d42f04f$', {})).toBe(
+			ERRORS.batchOperationKey,
+		);
 
 		expect(setTimeoutSpy).toHaveBeenCalledTimes(0);
 	});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/validators.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/validators.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {FieldValidator} from 'final-form';
+import i18n from 'i18next';
+import {z} from 'zod';
+import {parseIds} from './parseIds';
+import {promisifyValidator} from './promisifyValidator';
+
+const VALIDATION_TIMEOUT = 750;
+
+const areIdsTooLong = (value: string) => {
+	return parseIds(value).some((id) => id.length > 19);
+};
+
+const areIdsComplete = (value: string) => {
+	return value === '' || parseIds(value).every((id) => /^[0-9]{16,19}$/.test(id));
+};
+
+const validateIdsCharacters: FieldValidator<string | undefined> = (value = '') => {
+	if (value !== '' && !/^[0-9]+$/g.test(value.replace(/,/g, '').replace(/\s/g, ''))) {
+		return i18n.t('operate.shared.validators.ids');
+	}
+	return undefined;
+};
+
+const validateIdsLength: FieldValidator<string | undefined> = (value = '') => {
+	if (areIdsTooLong(value)) {
+		return i18n.t('operate.shared.validators.ids');
+	}
+	return undefined;
+};
+
+const validatesIdsComplete: FieldValidator<string | undefined> = promisifyValidator((value = '') => {
+	if (!areIdsComplete(value)) {
+		return i18n.t('operate.shared.validators.ids');
+	}
+	return undefined;
+}, VALIDATION_TIMEOUT);
+
+const validateParentInstanceIdCharacters: FieldValidator<string | undefined> = (value = '') => {
+	if (value !== '' && !/^[0-9]+$/.test(value)) {
+		return i18n.t('operate.shared.validators.parentInstanceId');
+	}
+	return undefined;
+};
+
+const validateParentInstanceIdComplete: FieldValidator<string | undefined> = promisifyValidator((value = '') => {
+	if (!areIdsComplete(value)) {
+		return i18n.t('operate.shared.validators.parentInstanceId');
+	}
+	return undefined;
+}, VALIDATION_TIMEOUT);
+
+const validateParentInstanceIdNotTooLong: FieldValidator<string | undefined> = (value = '') => {
+	if (areIdsTooLong(value)) {
+		return i18n.t('operate.shared.validators.parentInstanceId');
+	}
+	return undefined;
+};
+
+/**
+ * Validates if value contains only characters from a key or UUID
+ */
+const validateBatchOperationKeyCharacters: FieldValidator<string | undefined> = (value = '') => {
+	const schema = z.union([z.string().length(0), z.string().regex(/^[0-9]+$/), z.string().regex(/^[a-f0-9-]{1,36}/)]);
+
+	if (!schema.safeParse(value).success) {
+		return i18n.t('operate.shared.validators.batchOperationKey');
+	}
+	return undefined;
+};
+
+/**
+ * Validates if value is a complete key (16-19 characters) or a complete UUID
+ */
+const validateBatchOperationKeyComplete: FieldValidator<string | undefined> = promisifyValidator((value = '') => {
+	const schema = z.union([z.string().length(0), z.string().regex(/^[0-9]{16,19}$/), z.uuid()]);
+
+	if (!schema.safeParse(value).success) {
+		return i18n.t('operate.shared.validators.batchOperationKey');
+	}
+	return undefined;
+}, VALIDATION_TIMEOUT);
+
+export {
+	validateIdsCharacters,
+	validateIdsLength,
+	validatesIdsComplete,
+	validateParentInstanceIdCharacters,
+	validateParentInstanceIdComplete,
+	validateParentInstanceIdNotTooLong,
+	validateBatchOperationKeyCharacters,
+	validateBatchOperationKeyComplete,
+	VALIDATION_TIMEOUT,
+};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/validators.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/utils/validators.ts
@@ -68,7 +68,7 @@ const validateParentInstanceIdNotTooLong: FieldValidator<string | undefined> = (
  * Validates if value contains only characters from a key or UUID
  */
 const validateBatchOperationKeyCharacters: FieldValidator<string | undefined> = (value = '') => {
-	const schema = z.union([z.string().length(0), z.string().regex(/^[0-9]+$/), z.string().regex(/^[a-f0-9-]{1,36}/)]);
+	const schema = z.union([z.string().length(0), z.string().regex(/^[0-9]+$/), z.string().regex(/^[a-f0-9-]{1,36}$/)]);
 
 	if (!schema.safeParse(value).success) {
 		return i18n.t('operate.shared.validators.batchOperationKey');

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -470,6 +470,11 @@
 				"filtersPanel": {
 					"label": "Filter",
 					"resetFilters": "Filter zurücksetzen"
+				},
+				"validators": {
+					"ids": "Schlüssel muss eine 16- bis 19-stellige Zahl sein, getrennt durch Leerzeichen oder Komma",
+					"parentInstanceId": "Schlüssel muss eine 16- bis 19-stellige Zahl sein",
+					"batchOperationKey": "Schlüssel muss eine 16- bis 19-stellige Zahl oder eine UUID sein"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -484,6 +484,11 @@
 				"filtersPanel": {
 					"label": "Filter",
 					"resetFilters": "Reset filters"
+				},
+				"validators": {
+					"ids": "Key has to be a 16 to 19 digit number, separated by a space or a comma",
+					"parentInstanceId": "Key has to be a 16 to 19 digit number",
+					"batchOperationKey": "Key has to be a 16 to 19 digit number or a UUID"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -470,6 +470,11 @@
 				"filtersPanel": {
 					"label": "Filtro",
 					"resetFilters": "Restablecer filtros"
+				},
+				"validators": {
+					"ids": "La clave debe ser un número de 16 a 19 dígitos, separado por un espacio o una coma",
+					"parentInstanceId": "La clave debe ser un número de 16 a 19 dígitos",
+					"batchOperationKey": "La clave debe ser un número de 16 a 19 dígitos o un UUID"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -473,6 +473,11 @@
 				"filtersPanel": {
 					"label": "Filtre",
 					"resetFilters": "Réinitialiser les filtres"
+				},
+				"validators": {
+					"ids": "La clé doit être un nombre de 16 à 19 chiffres, séparé par un espace ou une virgule",
+					"parentInstanceId": "La clé doit être un nombre de 16 à 19 chiffres",
+					"batchOperationKey": "La clé doit être un nombre de 16 à 19 chiffres ou un UUID"
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Part of #57669 (Operate shared filter form components), split 1/3 to stay under the 500-line PR limit:

1. **This PR** — filter validators and the `AdvancedStringFilter` codec utils (no React).
2. Field primitives + `TenantField` + `OptionalFiltersMenu` (stacked on this PR).
3. `AdvancedStringFilter` component (stacked on PR 2, needs both).

Ports, 1:1, from `operate/client/src/modules/validators`, `operate/client/src/modules/utils/validators`, and `operate/client/src/modules/utils/filter/advancedStringFilter.ts`:

- `parseIds`, `mergeValidators`, `promisifyValidator` — byte-identical logic, reformatted.
- `validators.ts` — the process-instance field validators consumed by the optional filters (`validateIdsCharacters/Length/Complete`, `validateParentInstanceId*`, `validateBatchOperationKey*`). Error strings moved to i18n (`operate.shared.validators.*`) instead of the legacy hardcoded `ERRORS` object.
- `advancedStringFilter.ts` — `encodeFilterOperation`/`splitEncodedFilterOperation` only (the full `advancedStringFilterCodec` used for query building is out of scope here).

Not ported: `validateDecisionIds*`, `validateTime*`, `validateVariable*`, `validateMultipleVariableValues*` — these belong to the Decisions filters and the variables filter (#57671/#57672), not the Processes optional filters this ticket serves.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [x] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #57669
