### PR TITLE
feat: add Operate text field primitives, AutoSubmit, TenantField, and OptionalFiltersMenu

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
@@ -20,6 +20,11 @@ const config: KnipConfig = {
 		'shared-test-modules/api-mocks/incident-statistics.ts',
 		// TODO(#55735): remove when consumer migration is complete
 		'src/operate/shared/utils/**',
+		'src/operate/shared/hooks/**',
+		'src/operate/shared/TextInputField/**',
+		'src/operate/shared/TextAreaField/**',
+		'src/operate/shared/AutoSubmit/**',
+		'src/operate/shared/OptionalFiltersMenu/**',
 		'src/operate/shared/EmptyMessage/**',
 		'src/operate/shared/ErrorMessage/**',
 		'src/operate/shared/StateIcon/**',

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AutoSubmit/AutoSubmit.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AutoSubmit/AutoSubmit.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect, useRef} from 'react';
+import {useForm, useFormState} from 'react-final-form';
+
+// ponytail: trailing-only throttle, replaces lodash/throttle(fn, wait, {leading: false}) — lodash is not a dependency of this app
+function throttleTrailing(fn: () => void, wait: number) {
+	let timeoutId: ReturnType<typeof setTimeout> | undefined;
+	return () => {
+		if (timeoutId === undefined) {
+			timeoutId = setTimeout(() => {
+				timeoutId = undefined;
+				fn();
+			}, wait);
+		}
+	};
+}
+
+type Props = {
+	fieldsToSkipTimeout?: string[];
+};
+
+const AutoSubmit: React.FC<Props> = ({fieldsToSkipTimeout = []}) => {
+	const form = useForm();
+	const throttledSubmit = useRef(throttleTrailing(form.submit, 100));
+
+	const {dirtyFields, values} = useFormState({
+		subscription: {
+			dirtyFields: true,
+			values: true,
+		},
+	});
+	const shouldSkipTimeout = fieldsToSkipTimeout.map((field) => dirtyFields?.[field]).some((field) => field);
+
+	const isDirty = Object.entries(dirtyFields || {}).filter(([, value]) => value).length > 0;
+
+	useEffect(() => {
+		if (isDirty && shouldSkipTimeout) {
+			throttledSubmit.current();
+
+			return;
+		}
+
+		const timeoutId = isDirty ? setTimeout(form.submit, 750) : undefined;
+
+		return () => {
+			if (timeoutId !== undefined) {
+				clearTimeout(timeoutId);
+			}
+		};
+	}, [shouldSkipTimeout, isDirty, values, form]);
+
+	return null;
+};
+
+export {AutoSubmit};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AutoSubmit/AutoSubmit.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AutoSubmit/AutoSubmit.tsx
@@ -12,14 +12,21 @@ import {useForm, useFormState} from 'react-final-form';
 // ponytail: trailing-only throttle, replaces lodash/throttle(fn, wait, {leading: false}) — lodash is not a dependency of this app
 function throttleTrailing(fn: () => void, wait: number) {
 	let timeoutId: ReturnType<typeof setTimeout> | undefined;
-	return () => {
+	function throttled() {
 		if (timeoutId === undefined) {
 			timeoutId = setTimeout(() => {
 				timeoutId = undefined;
 				fn();
 			}, wait);
 		}
+	}
+	throttled.cancel = () => {
+		if (timeoutId !== undefined) {
+			clearTimeout(timeoutId);
+			timeoutId = undefined;
+		}
 	};
+	return throttled;
 }
 
 type Props = {
@@ -42,9 +49,10 @@ const AutoSubmit: React.FC<Props> = ({fieldsToSkipTimeout = []}) => {
 
 	useEffect(() => {
 		if (isDirty && shouldSkipTimeout) {
-			throttledSubmit.current();
+			const throttled = throttledSubmit.current;
+			throttled();
 
-			return;
+			return () => throttled.cancel();
 		}
 
 		const timeoutId = isDirty ? setTimeout(form.submit, 750) : undefined;

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OptionalFiltersMenu/OptionalFiltersMenu.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OptionalFiltersMenu/OptionalFiltersMenu.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {type ReactElement} from 'react';
+import {useTranslation} from 'react-i18next';
+import {OverflowMenuItem} from '@carbon/react';
+import {Filter} from '@carbon/react/icons';
+import {ButtonStack, OverflowMenu, Container} from './styled';
+
+interface Props<T> {
+	visibleFilters: T[];
+	optionalFilters: {id: T; label: string}[];
+	onFilterSelect: (filter: T) => void;
+}
+
+const OptionalFiltersMenu = <T extends string>({
+	visibleFilters,
+	optionalFilters,
+	onFilterSelect,
+}: Props<T>): ReactElement | null => {
+	const {t} = useTranslation();
+	const unselectedOptionalFilters = optionalFilters.filter((filter) => !visibleFilters.includes(filter.id));
+
+	return unselectedOptionalFilters.length > 0 ? (
+		<Container>
+			<OverflowMenu
+				direction="top"
+				aria-label="optional-filters-menu"
+				iconDescription={t('operate.shared.optionalFiltersMenu.moreFilters')}
+				flipped
+				renderIcon={() => (
+					<ButtonStack orientation="horizontal" gap={3}>
+						<span>{t('operate.shared.optionalFiltersMenu.moreFilters')}</span>
+						<Filter />
+					</ButtonStack>
+				)}
+			>
+				{unselectedOptionalFilters.map((filter) => (
+					<OverflowMenuItem
+						key={filter.id}
+						itemText={filter.label}
+						onClick={() => onFilterSelect(filter.id)}
+						data-testid={`optional-filter-menuitem-${filter.id}`}
+					/>
+				))}
+			</OverflowMenu>
+		</Container>
+	) : null;
+};
+
+export {OptionalFiltersMenu};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OptionalFiltersMenu/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/OptionalFiltersMenu/styled.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+import {OverflowMenu as BaseOverflowMenu, Stack} from '@carbon/react';
+
+const Container = styled.div`
+	display: flex;
+	justify-content: end;
+
+	[role='tooltip'] {
+		display: none;
+	}
+`;
+
+const OverflowMenu = styled(BaseOverflowMenu)`
+	width: unset;
+	padding: 0 var(--cds-spacing-04);
+
+	&& svg {
+		fill: var(--cds-link-primary);
+	}
+`;
+
+const ButtonStack = styled(Stack)`
+	align-items: center;
+`;
+
+export {Container, OverflowMenu, ButtonStack};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/TenantField/TenantField.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/TenantField/TenantField.test.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query';
+import {HttpResponse} from 'msw';
+import {Form} from 'react-final-form';
+import {render} from 'vitest-browser-react';
+import {describe, expect} from 'vitest';
+import {it} from '#/vitest-modules/test-extend';
+import {mockCurrentUserEndpoint} from '#/shared-test-modules/mock-handlers';
+import {createCurrentUser} from '#/shared-test-modules/api-mocks/current-user';
+import {TenantField} from './TenantField';
+
+function getWrapper(initialValues?: {tenantId?: string}) {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: {retry: false},
+		},
+	});
+
+	const Wrapper: React.FC<{children: React.ReactNode}> = ({children}) => (
+		<QueryClientProvider client={queryClient}>
+			<Form onSubmit={() => {}} initialValues={initialValues}>
+				{({handleSubmit}) => <form onSubmit={handleSubmit}>{children}</form>}
+			</Form>
+		</QueryClientProvider>
+	);
+
+	return Wrapper;
+}
+
+describe('<TenantField />', () => {
+	it('should only contain all tenants filter', async ({worker}) => {
+		worker.use(
+			mockCurrentUserEndpoint({
+				successResponse: HttpResponse.json(createCurrentUser({tenants: []})),
+			}),
+		);
+
+		const screen = await render(<TenantField />, {wrapper: getWrapper()});
+
+		await screen.getByRole('combobox', {name: 'Select a tenant'}).click();
+
+		await expect.element(screen.getByRole('option', {name: 'All tenants'})).toBeVisible();
+		await expect.poll(() => screen.getByRole('option').elements().length).toBe(1);
+	});
+
+	it('should contain list of tenants', async ({worker}) => {
+		worker.use(
+			mockCurrentUserEndpoint({
+				successResponse: HttpResponse.json(
+					createCurrentUser({
+						tenants: [
+							{tenantId: '<default>', name: 'Default Tenant', description: null},
+							{tenantId: 'tenant-A', name: 'Tenant A', description: null},
+							{tenantId: 'tenant-B', name: 'Tenant B', description: null},
+						],
+					}),
+				),
+			}),
+		);
+
+		const screen = await render(<TenantField />, {wrapper: getWrapper()});
+
+		await screen.getByRole('combobox', {name: 'Select a tenant'}).click();
+
+		await expect.element(screen.getByRole('option', {name: 'All tenants'})).toBeVisible();
+		await expect.element(screen.getByRole('option', {name: 'Default Tenant'})).toBeVisible();
+		await expect.element(screen.getByRole('option', {name: 'Tenant A'})).toBeVisible();
+		await expect.element(screen.getByRole('option', {name: 'Tenant B'})).toBeVisible();
+	});
+
+	it('should not set value if it is not valid', async ({worker}) => {
+		worker.use(
+			mockCurrentUserEndpoint({
+				successResponse: HttpResponse.json(
+					createCurrentUser({
+						tenants: [{tenantId: '<default>', name: 'Default Tenant', description: null}],
+					}),
+				),
+			}),
+		);
+
+		const screen = await render(<TenantField />, {wrapper: getWrapper({tenantId: 'invalid-tenant'})});
+
+		await expect.element(screen.getByRole('combobox', {name: 'Select a tenant'})).toHaveTextContent('Select a tenant');
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/TenantField/TenantField.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/TenantField/TenantField.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Field} from 'react-final-form';
+import {useTranslation} from 'react-i18next';
+import {useSuspenseQuery} from '@tanstack/react-query';
+import {Dropdown} from '@carbon/react';
+import {queries} from '#/shared/http/queries';
+
+type Props = {
+	onChange?: (selectedItem: string) => void;
+};
+
+const TenantField: React.FC<Props> = ({onChange}) => {
+	const {t} = useTranslation();
+	const {data: tenants} = useSuspenseQuery({
+		...queries.getCurrentUser(),
+		select: ({tenants}) => tenants,
+	});
+	const tenantsById = Object.fromEntries(tenants.map(({tenantId, name}) => [tenantId, name]));
+	const items = ['all', ...tenants.map(({tenantId}) => tenantId)];
+
+	return (
+		<Field name="tenantId">
+			{({input}) => {
+				return (
+					<Dropdown
+						label={t('operate.shared.tenantField.selectTenant')}
+						aria-label={t('operate.shared.tenantField.selectTenant')}
+						titleText={t('operate.shared.tenantField.tenant')}
+						hideLabel
+						id="tenantId"
+						onChange={({selectedItem}) => {
+							input.onChange(selectedItem);
+							onChange?.(selectedItem);
+						}}
+						items={items}
+						itemToString={(item: string) => {
+							return item === 'all' ? t('operate.shared.tenantField.allTenants') : (tenantsById[item] ?? item);
+						}}
+						selectedItem={items.includes(input.value) ? input.value : ''}
+						size="sm"
+					/>
+				);
+			}}
+		</Field>
+	);
+};
+
+export {TenantField};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/TextAreaField/TextAreaField.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/TextAreaField/TextAreaField.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {TextArea} from '@carbon/react';
+import {useFieldError} from '#/operate/shared/hooks/useFieldError';
+
+type Props = React.ComponentProps<typeof TextArea> & {
+	name: string;
+};
+
+const TextAreaField: React.FC<Props> = ({name, ...props}) => {
+	const error = useFieldError(name);
+
+	return <TextArea {...props} invalid={error !== undefined} invalidText={error} />;
+};
+
+export {TextAreaField};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/TextAreaField/TextAreaField.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/TextAreaField/TextAreaField.tsx
@@ -14,10 +14,10 @@ type Props = React.ComponentProps<typeof TextArea> & {
 	name: string;
 };
 
-const TextAreaField: React.FC<Props> = ({name, ...props}) => {
+const TextAreaField = React.forwardRef<HTMLTextAreaElement, Props>(({name, ...props}, ref) => {
 	const error = useFieldError(name);
 
-	return <TextArea {...props} invalid={error !== undefined} invalidText={error} />;
-};
+	return <TextArea ref={ref} {...props} invalid={error !== undefined} invalidText={error} />;
+});
 
 export {TextAreaField};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/TextInputField/TextInputField.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/TextInputField/TextInputField.tsx
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {TextInput} from '@carbon/react';
+import {useFieldError} from '#/operate/shared/hooks/useFieldError';
+
+type Props = React.ComponentProps<typeof TextInput> & {
+	name: string;
+};
+
+const TextInputField = React.forwardRef<HTMLInputElement, Props>(({name, ...props}, ref) => {
+	const error = useFieldError(name);
+
+	return <TextInput ref={ref} {...props} invalid={error !== undefined} invalidText={error} />;
+});
+
+export {TextInputField};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/hooks/useFieldError.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/hooks/useFieldError.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect, useState} from 'react';
+import {useField, useFormState} from 'react-final-form';
+import {getIn} from 'final-form';
+
+const useFieldError = (name: string) => {
+	const {
+		input: {value},
+		meta: {active, dirtySinceLastSubmit, validating},
+	} = useField(name);
+
+	const {errors, submitErrors, validating: formValidating} = useFormState();
+
+	const error: string | undefined = getIn(errors ?? {}, name);
+	const submitError: string | undefined = dirtySinceLastSubmit ? undefined : getIn(submitErrors ?? {}, name);
+
+	const [computedError, setComputedError] = useState<string | undefined>();
+
+	useEffect(() => {
+		if ((formValidating || validating) && !active) {
+			return;
+		}
+
+		// eslint-disable-next-line react-hooks/set-state-in-effect
+		setComputedError(error ?? submitError);
+	}, [formValidating, validating, active, error, submitError, setComputedError, value]);
+
+	return computedError;
+};
+
+export {useFieldError};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -492,6 +492,14 @@
 					"ids": "Schlüssel muss eine 16- bis 19-stellige Zahl sein, getrennt durch Leerzeichen oder Komma",
 					"parentInstanceId": "Schlüssel muss eine 16- bis 19-stellige Zahl sein",
 					"batchOperationKey": "Schlüssel muss eine 16- bis 19-stellige Zahl oder eine UUID sein"
+				},
+				"tenantField": {
+					"selectTenant": "Mandant auswählen",
+					"tenant": "Mandant",
+					"allTenants": "Alle Mandanten"
+				},
+				"optionalFiltersMenu": {
+					"moreFilters": "Weitere Filter"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -506,6 +506,14 @@
 					"ids": "Key has to be a 16 to 19 digit number, separated by a space or a comma",
 					"parentInstanceId": "Key has to be a 16 to 19 digit number",
 					"batchOperationKey": "Key has to be a 16 to 19 digit number or a UUID"
+				},
+				"tenantField": {
+					"selectTenant": "Select a tenant",
+					"tenant": "Tenant",
+					"allTenants": "All tenants"
+				},
+				"optionalFiltersMenu": {
+					"moreFilters": "More Filters"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -492,6 +492,14 @@
 					"ids": "La clave debe ser un número de 16 a 19 dígitos, separado por un espacio o una coma",
 					"parentInstanceId": "La clave debe ser un número de 16 a 19 dígitos",
 					"batchOperationKey": "La clave debe ser un número de 16 a 19 dígitos o un UUID"
+				},
+				"tenantField": {
+					"selectTenant": "Seleccionar un Arrendatario",
+					"tenant": "Arrendatario",
+					"allTenants": "Todos los arrendatarios"
+				},
+				"optionalFiltersMenu": {
+					"moreFilters": "Más filtros"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -495,6 +495,14 @@
 					"ids": "La clé doit être un nombre de 16 à 19 chiffres, séparé par un espace ou une virgule",
 					"parentInstanceId": "La clé doit être un nombre de 16 à 19 chiffres",
 					"batchOperationKey": "La clé doit être un nombre de 16 à 19 chiffres ou un UUID"
+				},
+				"tenantField": {
+					"selectTenant": "Sélectionner un client",
+					"tenant": "Client",
+					"allTenants": "Tous les clients"
+				},
+				"optionalFiltersMenu": {
+					"moreFilters": "Plus de filtres"
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Part of #57669 (Operate shared filter form components), split 2/3, stacked on #57695:

1. #57695 — filter validators and the `AdvancedStringFilter` codec utils.
2. **This PR** — field primitives, `TenantField`, `OptionalFiltersMenu`.
3. `AdvancedStringFilter` component (stacked on this PR, needs both).

Ports, 1:1, from `operate/client/src/modules/components/{TextInputField,TextAreaField,TenantField,OptionalFilters}` and `operate/client/src/modules/components/AutoSubmit.tsx`:

- `TextInputField`/`TextAreaField` — thin Carbon wrappers driven by `useFieldError` (final-form field error display).
- `useFieldError` — ported using final-form's own `getIn` instead of `lodash/get` (lodash isn't a dependency of this app); same dotted-path lookup semantics.
- `AutoSubmit` — debounced form auto-submit. Uses a small local trailing-throttle instead of `lodash/throttle(fn, wait, {leading: false})`, marked `ponytail:`; same behavior, no new dependency.
- `TenantField` — the legacy version reads `useCurrentUser()` + `useAvailableTenants()` (two MobX-backed hooks); the port consolidates both into one `useSuspenseQuery(queries.getCurrentUser())` with a `select`, since `useAvailableTenants` derives its map from the same `currentUser.tenants` legacy already fetches. Same tenant list, same "all tenants" fallback behavior.
- `OptionalFiltersMenu` — 1:1, i18n-ified.

No dedicated tests for `TextInputField`/`TextAreaField`/`AutoSubmit`/`OptionalFiltersMenu` — matches legacy, which has none either (exercised indirectly via consumers).

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

related to #57669
