### PR TITLE
feat: add Operate AdvancedStringFilter component

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/knip.config.ts
@@ -20,8 +20,6 @@ const config: KnipConfig = {
 		'shared-test-modules/api-mocks/incident-statistics.ts',
 		// TODO(#55735): remove when consumer migration is complete
 		'src/operate/shared/utils/**',
-		'src/operate/shared/hooks/**',
-		'src/operate/shared/TextInputField/**',
 		'src/operate/shared/TextAreaField/**',
 		'src/operate/shared/AutoSubmit/**',
 		'src/operate/shared/OptionalFiltersMenu/**',

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AdvancedStringFilter/AdvancedStringFilter.test.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AdvancedStringFilter/AdvancedStringFilter.test.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Form} from 'react-final-form';
+import {render} from 'vitest-browser-react';
+import {describe, it, expect, vi} from 'vitest';
+import {userEvent} from 'vitest/browser';
+import {AdvancedStringFilter} from './AdvancedStringFilter';
+
+type SubmittedValues = {businessId?: string};
+
+function getWrapper({
+	onSubmit = vi.fn(),
+	initialValues,
+}: {
+	onSubmit?: (values: SubmittedValues) => void;
+	initialValues?: SubmittedValues;
+} = {}) {
+	const Wrapper: React.FC<{children: React.ReactNode}> = ({children}) => (
+		<Form<SubmittedValues> onSubmit={onSubmit} initialValues={initialValues}>
+			{({handleSubmit}) => (
+				<form onSubmit={handleSubmit}>
+					{children}
+					<button type="submit">submit</button>
+				</form>
+			)}
+		</Form>
+	);
+	return Wrapper;
+}
+
+describe('<AdvancedStringFilter />', () => {
+	it('renders dropdown and input with the first operator selected by default', async () => {
+		const screen = await render(
+			<AdvancedStringFilter name="businessId" label="Business ID" selectableOperators={['$eq', '$like', '$in']} />,
+			{wrapper: getWrapper()},
+		);
+
+		await expect.element(screen.getByRole('combobox', {name: 'Business ID filter type'})).toHaveTextContent('equals');
+		await expect.element(screen.getByLabelText('Business ID', {exact: true})).toBeVisible();
+	});
+
+	it('decodes the initial form value into operator + value', async () => {
+		const screen = await render(
+			<AdvancedStringFilter name="businessId" label="Business ID" selectableOperators={['$eq', '$like', '$in']} />,
+			{wrapper: getWrapper({initialValues: {businessId: 'like_order-123'}})},
+		);
+
+		await expect.element(screen.getByRole('combobox')).toHaveTextContent('contains');
+		await expect.element(screen.getByLabelText('Business ID', {exact: true})).toHaveValue('order-123');
+	});
+
+	it('encodes the form value with the current operator when the user types', async () => {
+		const onSubmit = vi.fn();
+		const screen = await render(
+			<AdvancedStringFilter name="businessId" label="Business ID" selectableOperators={['$eq', '$like', '$in']} />,
+			{wrapper: getWrapper({onSubmit})},
+		);
+
+		await userEvent.type(screen.getByLabelText('Business ID', {exact: true}).element(), 'abc');
+		await screen.getByRole('button', {name: 'submit'}).click();
+
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({businessId: 'eq_abc'}),
+			expect.anything(),
+			expect.anything(),
+		);
+	});
+
+	it('re-encodes the form value when the operator changes', async () => {
+		const onSubmit = vi.fn();
+		const screen = await render(
+			<AdvancedStringFilter name="businessId" label="Business ID" selectableOperators={['$eq', '$like', '$in']} />,
+			{
+				wrapper: getWrapper({
+					onSubmit,
+					initialValues: {businessId: 'eq_abc'},
+				}),
+			},
+		);
+
+		// force: the listbox auto-scrolls to the already-selected item on open, which can push
+		// other options outside the isolated test viewport. Keyboard navigation is reliable regardless.
+		await screen.getByRole('combobox').click();
+		await userEvent.keyboard('{ArrowDown}{Enter}');
+		await screen.getByRole('button', {name: 'submit'}).click();
+
+		expect(onSubmit).toHaveBeenCalledWith(
+			expect.objectContaining({businessId: 'like_abc'}),
+			expect.anything(),
+			expect.anything(),
+		);
+	});
+
+	it('clears the form value to undefined when the input is emptied', async () => {
+		const onSubmit = vi.fn();
+		const screen = await render(
+			<AdvancedStringFilter name="businessId" label="Business ID" selectableOperators={['$eq', '$like', '$in']} />,
+			{
+				wrapper: getWrapper({
+					onSubmit,
+					initialValues: {businessId: 'eq_abc'},
+				}),
+			},
+		);
+
+		await userEvent.clear(screen.getByLabelText('Business ID', {exact: true}).element());
+		await screen.getByRole('button', {name: 'submit'}).click();
+
+		expect(onSubmit).toHaveBeenLastCalledWith({}, expect.anything(), expect.anything());
+	});
+
+	it('preserves the dropdown selection when the input is emptied', async () => {
+		const screen = await render(
+			<AdvancedStringFilter name="businessId" label="Business ID" selectableOperators={['$eq', '$like', '$in']} />,
+			{wrapper: getWrapper({initialValues: {businessId: 'like_order-123'}})},
+		);
+
+		await userEvent.clear(screen.getByLabelText('Business ID', {exact: true}).element());
+
+		await expect.element(screen.getByRole('combobox')).toHaveTextContent('contains');
+	});
+
+	it('preserves the dropdown selection across operator-only changes with an empty value', async () => {
+		const screen = await render(
+			<AdvancedStringFilter name="businessId" label="Business ID" selectableOperators={['$eq', '$like', '$in']} />,
+			{wrapper: getWrapper()},
+		);
+
+		await screen.getByRole('combobox').click();
+		await screen.getByRole('option', {name: 'is one of'}).click({force: true});
+
+		await expect.element(screen.getByRole('combobox')).toHaveTextContent('is one of');
+	});
+
+	it('treats a malformed value as an empty input', async () => {
+		const screen = await render(
+			<AdvancedStringFilter name="businessId" label="Business ID" selectableOperators={['$eq', '$like', '$in']} />,
+			{
+				wrapper: getWrapper({
+					initialValues: {businessId: 'plain-legacy-value'},
+				}),
+			},
+		);
+
+		await expect.element(screen.getByLabelText('Business ID', {exact: true})).toHaveValue('');
+		await expect.element(screen.getByRole('combobox')).toHaveTextContent('equals');
+	});
+});

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AdvancedStringFilter/AdvancedStringFilter.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AdvancedStringFilter/AdvancedStringFilter.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useState} from 'react';
+import {useTranslation} from 'react-i18next';
+import type {TFunction} from 'i18next';
+import {Dropdown} from '@carbon/react';
+import {Field, type FieldInputProps} from 'react-final-form';
+import {TextInputField} from '#/operate/shared/TextInputField/TextInputField';
+import {
+	encodeFilterOperation,
+	splitEncodedFilterOperation,
+	type AdvancedStringFilterOperator,
+} from '#/operate/shared/utils/advancedStringFilter';
+import {Container, Label} from './styled';
+
+const getOperatorConfig = (
+	t: TFunction,
+): Record<AdvancedStringFilterOperator, {label: string; placeholder?: string}> => ({
+	$eq: {label: t('operate.shared.advancedStringFilter.operatorEquals')},
+	$neq: {label: t('operate.shared.advancedStringFilter.operatorNotEquals')},
+	$like: {label: t('operate.shared.advancedStringFilter.operatorContains')},
+	$in: {
+		label: t('operate.shared.advancedStringFilter.operatorIsOneOf'),
+		placeholder: t('operate.shared.advancedStringFilter.operatorListPlaceholder'),
+	},
+	$notIn: {
+		label: t('operate.shared.advancedStringFilter.operatorIsNotOneOf'),
+		placeholder: t('operate.shared.advancedStringFilter.operatorListPlaceholder'),
+	},
+	$exists: {
+		label: t('operate.shared.advancedStringFilter.operatorExists'),
+		placeholder: t('operate.shared.advancedStringFilter.operatorExistsPlaceholder'),
+	},
+});
+
+type Props = {
+	name: string;
+	label: string;
+	selectableOperators: AdvancedStringFilterOperator[];
+};
+
+const AdvancedStringFilter: React.FC<Props> = ({name, label, selectableOperators}) => {
+	return (
+		<Field<string | undefined> name={name}>
+			{({input}) => <AdvancedStringFilterField input={input} label={label} selectableOperators={selectableOperators} />}
+		</Field>
+	);
+};
+
+type FieldProps = {
+	input: FieldInputProps<string | undefined, HTMLElement>;
+	label: string;
+	selectableOperators: AdvancedStringFilterOperator[];
+};
+
+const AdvancedStringFilterField: React.FC<FieldProps> = ({input, label, selectableOperators}) => {
+	const {t} = useTranslation();
+	const operatorConfig = getOperatorConfig(t);
+	const filter = splitEncodedFilterOperation(input.value ?? '');
+
+	const [fallbackOperator, setFallbackOperator] = useState<AdvancedStringFilterOperator>('$eq');
+	const selectedOperator = filter?.operator ?? fallbackOperator;
+
+	const handleOperatorChange = (newOperator: AdvancedStringFilterOperator | null) => {
+		if (newOperator === null) {
+			return;
+		}
+		setFallbackOperator(newOperator);
+		if (filter?.value) {
+			input.onChange(encodeFilterOperation(newOperator, filter.value));
+		}
+	};
+
+	const handleValueChange = (newValue: string) => {
+		if (newValue === '') {
+			setFallbackOperator(selectedOperator);
+			input.onChange(undefined);
+			return;
+		}
+		input.onChange(encodeFilterOperation(selectedOperator, newValue));
+	};
+
+	return (
+		<Container>
+			<Label htmlFor={input.name}>{label}</Label>
+			<Dropdown<AdvancedStringFilterOperator>
+				id={`${input.name}.operator`}
+				size="sm"
+				direction="top"
+				titleText={t('operate.shared.advancedStringFilter.operatorTypeLabel', {label})}
+				hideLabel
+				label={t('operate.shared.advancedStringFilter.selectOperator')}
+				items={selectableOperators}
+				itemToString={(item) => (item ? operatorConfig[item].label : '')}
+				selectedItem={selectedOperator}
+				onChange={({selectedItem}) => handleOperatorChange(selectedItem)}
+			/>
+			<TextInputField
+				name={input.name}
+				id={input.name}
+				size="sm"
+				labelText=""
+				hideLabel
+				placeholder={operatorConfig[selectedOperator].placeholder}
+				value={filter?.value ?? ''}
+				onChange={(event) => handleValueChange(event.target.value)}
+				onBlur={input.onBlur}
+				autoFocus
+			/>
+		</Container>
+	);
+};
+
+export {AdvancedStringFilter};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AdvancedStringFilter/AdvancedStringFilter.tsx
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AdvancedStringFilter/AdvancedStringFilter.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useState} from 'react';
+import {useMemo, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import type {TFunction} from 'i18next';
 import {Dropdown} from '@carbon/react';
@@ -61,7 +61,7 @@ type FieldProps = {
 
 const AdvancedStringFilterField: React.FC<FieldProps> = ({input, label, selectableOperators}) => {
 	const {t} = useTranslation();
-	const operatorConfig = getOperatorConfig(t);
+	const operatorConfig = useMemo(() => getOperatorConfig(t), [t]);
 	const filter = splitEncodedFilterOperation(input.value ?? '');
 
 	const [fallbackOperator, setFallbackOperator] = useState<AdvancedStringFilterOperator>('$eq');

--- a/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AdvancedStringFilter/styled.ts
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/operate/shared/AdvancedStringFilter/styled.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import styled from 'styled-components';
+
+const Container = styled.div`
+	display: grid;
+	grid-template-columns: max-content 1fr;
+	column-gap: var(--cds-spacing-03);
+	align-items: center;
+`;
+
+const Label = styled.label.attrs({
+	className: 'cds--label',
+})`
+	grid-column: 1 / -1;
+`;
+
+export {Container, Label};

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/de.json
@@ -500,6 +500,18 @@
 				},
 				"optionalFiltersMenu": {
 					"moreFilters": "Weitere Filter"
+				},
+				"advancedStringFilter": {
+					"operatorEquals": "ist gleich",
+					"operatorNotEquals": "ist nicht gleich",
+					"operatorContains": "enthält",
+					"operatorIsOneOf": "ist eines von",
+					"operatorIsNotOneOf": "ist keines von",
+					"operatorExists": "existiert",
+					"operatorListPlaceholder": "durch Leerzeichen oder Komma getrennt",
+					"operatorExistsPlaceholder": "true oder false",
+					"operatorTypeLabel": "{{label}} Filtertyp",
+					"selectOperator": "Operator auswählen"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/en.json
@@ -514,6 +514,18 @@
 				},
 				"optionalFiltersMenu": {
 					"moreFilters": "More Filters"
+				},
+				"advancedStringFilter": {
+					"operatorEquals": "equals",
+					"operatorNotEquals": "does not equal",
+					"operatorContains": "contains",
+					"operatorIsOneOf": "is one of",
+					"operatorIsNotOneOf": "is not one of",
+					"operatorExists": "exists",
+					"operatorListPlaceholder": "separated by space or comma",
+					"operatorExistsPlaceholder": "true or false",
+					"operatorTypeLabel": "{{label}} filter type",
+					"selectOperator": "Select operator"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/es.json
@@ -500,6 +500,18 @@
 				},
 				"optionalFiltersMenu": {
 					"moreFilters": "Más filtros"
+				},
+				"advancedStringFilter": {
+					"operatorEquals": "es igual a",
+					"operatorNotEquals": "no es igual a",
+					"operatorContains": "contiene",
+					"operatorIsOneOf": "es uno de",
+					"operatorIsNotOneOf": "no es ninguno de",
+					"operatorExists": "existe",
+					"operatorListPlaceholder": "separados por espacio o coma",
+					"operatorExistsPlaceholder": "true o false",
+					"operatorTypeLabel": "Tipo de filtro {{label}}",
+					"selectOperator": "Seleccionar operador"
 				}
 			}
 		}

--- a/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/src/shared/i18n/locales/fr.json
@@ -503,6 +503,18 @@
 				},
 				"optionalFiltersMenu": {
 					"moreFilters": "Plus de filtres"
+				},
+				"advancedStringFilter": {
+					"operatorEquals": "est égal à",
+					"operatorNotEquals": "n'est pas égal à",
+					"operatorContains": "contient",
+					"operatorIsOneOf": "correspond à l'un de",
+					"operatorIsNotOneOf": "ne correspond à aucun de",
+					"operatorExists": "existe",
+					"operatorListPlaceholder": "séparés par un espace ou une virgule",
+					"operatorExistsPlaceholder": "true ou false",
+					"operatorTypeLabel": "Type de filtre {{label}}",
+					"selectOperator": "Sélectionner un opérateur"
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Part of #57669 (Operate shared filter form components), split 3/3, stacked on #57696 (which stacks on #57695):

1. #57695 — filter validators and the `AdvancedStringFilter` codec utils.
2. #57696 — field primitives, `TenantField`, `OptionalFiltersMenu`.
3. **This PR** — the `AdvancedStringFilter` component, using both.

Ports `operate/client/src/modules/components/AdvancedStringFilter` 1:1: an operator dropdown (`equals`/`does not equal`/`contains`/`is one of`/`is not one of`/`exists`) paired with a `TextInputField`, encoding/decoding through the codec from #57695. UI copy moved to i18n (`operate.shared.advancedStringFilter.*`).

This completes #57669 — `OptionalFiltersFormGroup` (#55984) now has every shared component it needs: text field primitives, `AutoSubmit`, `TenantField`, `OptionalFiltersMenu`, `AdvancedStringFilter`, and the validators.

## Checklist

- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #57669
