### PR TITLE
feat: sort operations by memberId when adding/removing a node

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.util.Either;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -33,6 +34,7 @@ public class AddMembersTransformer implements ConfigurationChangeRequest {
             .filter(memberId -> !clusterConfiguration.hasMember(memberId))
             .map(MemberJoinOperation::new)
             .map(ClusterConfigurationChangeOperation.class::cast)
+            .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
             .toList();
     return Either.right(operations);
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformer.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.util.Either;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
@@ -33,6 +34,7 @@ public class RemoveMembersTransformer implements ConfigurationChangeRequest {
             .filter(clusterConfiguration::hasMember)
             .map(MemberLeaveOperation::new)
             .map(ClusterConfigurationChangeOperation.class::cast)
+            .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
             .toList();
     return Either.right(operations);
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/AddMembersTransformerTest.java
@@ -11,11 +11,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.util.MemberIdArbitraries;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.domains.Domain;
 import org.junit.jupiter.api.Test;
 
 class AddMembersTransformerTest {
@@ -64,5 +70,25 @@ class AddMembersTransformerTest {
     // then
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get()).isEmpty();
+  }
+
+  @Property(tries = 100)
+  @Domain(MemberIdArbitraries.class)
+  void shouldOnlyGenerateOperationsForNewMembersProperty(
+      @ForAll final Set<MemberId> candidateMembers) {
+    // given
+    final var addRequest = new AddMembersTransformer(candidateMembers);
+
+    // when
+    final var result = addRequest.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result)
+        .isRight()
+        .right()
+        .isEqualTo(
+            result.get().stream()
+                .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
+                .toList());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/RemoveMembersTransformerTest.java
@@ -11,11 +11,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.util.MemberIdArbitraries;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.domains.Domain;
 import org.junit.jupiter.api.Test;
 
 class RemoveMembersTransformerTest {
@@ -67,5 +73,23 @@ class RemoveMembersTransformerTest {
     EitherAssert.assertThat(result).isRight();
 
     assertThat(result.get()).isEmpty();
+  }
+
+  @Property(tries = 100)
+  @Domain(MemberIdArbitraries.class)
+  void shouldSortOperationsByMemberId(@ForAll final Set<MemberId> candidateMembers) {
+    // given
+    final var removeRequest = new RemoveMembersTransformer(candidateMembers);
+
+    // when
+    final var result = removeRequest.operations(currentTopology);
+
+    EitherAssert.assertThat(result)
+        .isRight()
+        .right()
+        .isEqualTo(
+            result.get().stream()
+                .sorted(Comparator.comparing(ClusterConfigurationChangeOperation::memberId))
+                .toList());
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/MemberIdArbitraries.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/MemberIdArbitraries.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.util;
+
+import io.atomix.cluster.MemberId;
+import java.util.Set;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.Provide;
+import net.jqwik.api.domains.DomainContextBase;
+
+/** Arbitraries generating {@link MemberId}s that are valid according to its constructors. */
+public final class MemberIdArbitraries extends DomainContextBase {
+
+  @Provide
+  Arbitrary<MemberId> memberId() {
+    final var nonZoned = Arbitraries.integers().between(0, 50).map(MemberId::from);
+    final var zone = Arbitraries.of("zone-a", "zone-b", "zone-c", "region1");
+    final var nodeIdx = Arbitraries.integers().between(0, 50);
+    final var zoned = Combinators.combine(zone, nodeIdx).as(MemberId::from);
+    return Arbitraries.oneOf(nonZoned, zoned);
+  }
+
+  @Provide
+  Arbitrary<Set<MemberId>> memberIds() {
+    return memberId().set().ofMaxSize(20);
+  }
+}


### PR DESCRIPTION
## Description
Those operations were not sorted by `MemberId` as the sorting was done only inside `PartitionReassignTransformer`.
Added two property test to verify that they are always sorted. 

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
