### PR TITLE
fix: run license-check aborted-jobs observer on cancellation

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -181,7 +181,7 @@ jobs:
   observe-aborted-jobs:
     needs:
     - analyze
-    if: failure()
+    if: always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
     permissions:
       actions: read # required to read raw job logs for runner-abort detection
       checks: read


### PR DESCRIPTION
## What

Change the `if:` gate of the `observe-aborted-jobs` job in `check-licenses.yml` from `failure()` to `always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))`.

## Why

In GitHub Actions, `failure()` evaluates to `true` only when an ancestor job *failed* — never when it was *cancelled*. Runner preemption/abort surfaces as a **cancelled** `analyze` matrix job, so the observer was skipped in exactly the case it exists to record. On top of that, a cancelled dependency skips dependents by default unless the job opts in via `always()`/`cancelled()`.

The new condition mirrors the gating idiom already used by `ci.yml`'s `check-results` job: `always()` forces the job to run even when a dependency is cancelled, and the `contains(...)` check restricts it to actual failure/cancellation so it doesn't fire on clean success.

Raised from a Copilot review comment.

## Reviewer notes

- No behavior change on the success path — the observer still does not run when `analyze` succeeds.
- `contains(needs.*.result, ...)` is used for consistency with `check-results`; with a single dependency it is equivalent to an explicit `needs.analyze.result` check.
- `actionlint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)