### PR TITLE
Scope client stream metrics per physical tenant

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobClientStreamMetrics.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobClientStreamMetrics.java
@@ -21,8 +21,11 @@ import java.util.Map;
 
 final class JobClientStreamMetrics implements ClientStreamMetrics {
 
+  private static final String PHYSICAL_TENANT_ID_TAG = "physicalTenantId";
+
   private final Map<ErrorCode, Counter> pushAttempts = new EnumMap<>(ErrorCode.class);
 
+  private final String physicalTenantId;
   private final StatefulGauge aggregatedStreamCount;
   private final StatefulGauge clientCount;
   private final StatefulGauge serverCount;
@@ -30,9 +33,12 @@ final class JobClientStreamMetrics implements ClientStreamMetrics {
   private final Counter pushSuccessCount;
   private final Counter pushFailureCount;
 
-  JobClientStreamMetrics(final MeterRegistry registry) {
+  JobClientStreamMetrics(final MeterRegistry registry, final String physicalTenantId) {
+    this.physicalTenantId = physicalTenantId;
+
     aggregatedClients =
         MicrometerUtil.buildSummary(JobClientStreamMetricsDoc.AGGREGATED_CLIENTS)
+            .tag(PHYSICAL_TENANT_ID_TAG, physicalTenantId)
             .register(registry);
     pushFailureCount =
         registerPushCounter(JobClientStreamMetricsDoc.PUSHES, PushResultTag.FAILURE, registry);
@@ -88,6 +94,7 @@ final class JobClientStreamMetrics implements ClientStreamMetrics {
       final JobClientStreamMetricsDoc doc, final MeterRegistry registry) {
     return StatefulGauge.builder(doc.getName())
         .description(doc.getDescription())
+        .tag(PHYSICAL_TENANT_ID_TAG, physicalTenantId)
         .register(registry);
   }
 
@@ -96,6 +103,7 @@ final class JobClientStreamMetrics implements ClientStreamMetrics {
     return Counter.builder(JobClientStreamMetricsDoc.PUSH_TRY_FAILED_COUNT.getName())
         .description(JobClientStreamMetricsDoc.PUSH_TRY_FAILED_COUNT.getDescription())
         .tag(PushKeyNames.CODE.asString(), errorCode.name())
+        .tag(PHYSICAL_TENANT_ID_TAG, physicalTenantId)
         .register(registry);
   }
 
@@ -106,6 +114,7 @@ final class JobClientStreamMetrics implements ClientStreamMetrics {
     return Counter.builder(doc.getName())
         .description(doc.getDescription())
         .tag(PushKeyNames.STATUS.asString(), result.getTagValue())
+        .tag(PHYSICAL_TENANT_ID_TAG, physicalTenantId)
         .register(registry);
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -36,7 +36,8 @@ public final class JobStreamClientImpl implements JobStreamClient {
     streamService =
         new TransportFactory(schedulingService)
             .createRemoteStreamClient(
-                clusterCommunicationService, new JobClientStreamMetrics(meterRegistry));
+                clusterCommunicationService,
+                physicalTenantId -> new JobClientStreamMetrics(meterRegistry, physicalTenantId));
   }
 
   @Override

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -47,7 +47,7 @@ public final class JobStreamClientImpl implements JobStreamClient {
 
   @Override
   public void brokerRemoved(final BrokerMemberId memberId, final String physicalTenantId) {
-    streamService.onServerRemoved(memberId.memberId());
+    streamService.onServerRemoved(memberId.memberId(), physicalTenantId);
   }
 
   @Override

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -71,7 +71,7 @@ public final class TransportFactory {
 
   public <M extends BufferWriter> ClientStreamService<M> createRemoteStreamClient(
       final ClusterCommunicationService clusterCommunicationService,
-      final ClientStreamMetrics metrics) {
-    return new ClientStreamServiceImpl<>(clusterCommunicationService, metrics);
+      final Function<String, ClientStreamMetrics> metricsFactory) {
+    return new ClientStreamServiceImpl<>(clusterCommunicationService, metricsFactory);
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
@@ -42,10 +42,11 @@ public interface ClientStreamService<M extends BufferWriter> extends AsyncClosab
   void onServerJoined(final MemberId memberId, final String physicalTenantId);
 
   /**
-   * A callback to be invoked when a new streaming server is removed. Implementations should be
-   * idempotent.
+   * A callback to be invoked when a streaming server is confirmed removed from a specific partition
+   * group. Only registrations for streams whose physical tenant matches {@code physicalTenantId}
+   * are torn down for {@code memberId}. Implementations should be idempotent.
    */
-  void onServerRemoved(final MemberId memberId);
+  void onServerRemoved(final MemberId memberId, final String physicalTenantId);
 
   /** Returns the managed {@link ClientStreamer} associated with this service. */
   ClientStreamer<M> streamer();

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamService.java
@@ -15,12 +15,13 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Manages an instance of {@link ClientStreamer}. Intended to be the main entry point when setting
  * up the client side for remote streams, primarily via {@link
  * io.camunda.zeebe.transport.TransportFactory#createRemoteStreamClient(ClusterCommunicationService,
- * ClientStreamMetrics)}.
+ * Function)}.
  *
  * @param <M> the type of the streaming metadata
  */

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
@@ -40,8 +40,17 @@ final class ClientStreamApiHandler {
     return responseFuture;
   }
 
-  byte[] handleRestartRequest(final MemberId sender, final byte[] ignored) {
-    clientStreamManager.onServerRestarted(MemberId.from(sender.id()));
+  /**
+   * The RESTART_STREAMS topic is physicalTenantId-scoped, so this only affects registrations for
+   * {@code physicalTenantId}; the sender may still serve other physical tenants unaffected by this
+   * restart. Reuses the remove+join pair rather than a blanket reset, since a restart is just a
+   * forced re-registration scoped to the one group that signaled it.
+   */
+  byte[] handleRestartRequest(
+      final MemberId sender, final String physicalTenantId, final byte[] ignored) {
+    final var serverId = MemberId.from(sender.id());
+    clientStreamManager.onServerRemoved(serverId, physicalTenantId);
+    clientStreamManager.onServerJoined(serverId, physicalTenantId);
     return ArrayUtil.EMPTY_BYTE_ARRAY;
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,17 +36,17 @@ final class ClientStreamManager<M extends BufferWriter> {
 
   private final ClientStreamRegistry<M> registry;
   private final ClientStreamRequestManager<M> requestManager;
-  private final ClientStreamMetrics metrics;
+  private final Function<String, ClientStreamMetrics> metricsFactory;
   private final ClientStreamPusher streamPusher;
 
   ClientStreamManager(
       final ClientStreamRegistry<M> registry,
       final ClientStreamRequestManager<M> requestManager,
-      final ClientStreamMetrics metrics) {
+      final Function<String, ClientStreamMetrics> metricsFactory) {
     this.registry = registry;
     this.requestManager = requestManager;
-    this.metrics = metrics;
-    streamPusher = new ClientStreamPusher(metrics);
+    this.metricsFactory = metricsFactory;
+    streamPusher = new ClientStreamPusher(metricsFactory);
   }
 
   /**
@@ -56,11 +57,11 @@ final class ClientStreamManager<M extends BufferWriter> {
    * @param physicalTenantId the physical tenant served by this server
    */
   void onServerJoined(final MemberId serverId, final String physicalTenantId) {
-    serversByPhysicalTenantId
-        .computeIfAbsent(physicalTenantId, id -> new HashSet<>())
-        .add(serverId);
+    final var servers =
+        serversByPhysicalTenantId.computeIfAbsent(physicalTenantId, id -> new HashSet<>());
+    servers.add(serverId);
     physicalTenantsByServer.computeIfAbsent(serverId, id -> new HashSet<>()).add(physicalTenantId);
-    metrics.serverCount(physicalTenantsByServer.size());
+    metricsFactory.apply(physicalTenantId).serverCount(servers.size());
 
     registry.list().stream()
         .filter(c -> physicalTenantId.equals(c.physicalTenantId()))
@@ -79,9 +80,14 @@ final class ClientStreamManager<M extends BufferWriter> {
                 serversByPhysicalTenantId.remove(physicalTenantId);
               }
             }
+            metricsFactory
+                .apply(physicalTenantId)
+                .serverCount(
+                    serversByPhysicalTenantId
+                        .getOrDefault(physicalTenantId, Collections.emptySet())
+                        .size());
           });
     }
-    metrics.serverCount(physicalTenantsByServer.size());
     requestManager.onServerRemoved(serverId);
   }
 
@@ -141,6 +147,15 @@ final class ClientStreamManager<M extends BufferWriter> {
     final var streamId = pushStreamRequest.streamId();
     final var payload = pushStreamRequest.payload();
 
+    final var clientStream = registry.get(streamId);
+    // The wire request carries no physicalTenantId; if the stream was already removed, we cannot
+    // attribute this push to any tenant, so the metric is dropped rather than misattributed.
+    final var metrics =
+        clientStream
+            .map(AggregatedClientStream::physicalTenantId)
+            .map(metricsFactory)
+            .orElseGet(ClientStreamMetrics::noop);
+
     responseFuture.onComplete(
         (ok, error) -> {
           if (error != null) {
@@ -150,7 +165,6 @@ final class ClientStreamManager<M extends BufferWriter> {
           }
         });
 
-    final var clientStream = registry.get(streamId);
     clientStream.ifPresentOrElse(
         stream -> {
           try {

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -31,9 +31,6 @@ final class ClientStreamManager<M extends BufferWriter> {
   /** physicalTenantId → set of broker member IDs serving that physical tenant */
   private final Map<String, Set<MemberId>> serversByPhysicalTenantId = new HashMap<>();
 
-  /** broker member ID → set of physicalTenantIds it serves (for RESTART lookup) */
-  private final Map<MemberId, Set<String>> physicalTenantsByServer = new HashMap<>();
-
   private final ClientStreamRegistry<M> registry;
   private final ClientStreamRequestManager<M> requestManager;
   private final Function<String, ClientStreamMetrics> metricsFactory;
@@ -60,7 +57,6 @@ final class ClientStreamManager<M extends BufferWriter> {
     final var servers =
         serversByPhysicalTenantId.computeIfAbsent(physicalTenantId, id -> new HashSet<>());
     servers.add(serverId);
-    physicalTenantsByServer.computeIfAbsent(serverId, id -> new HashSet<>()).add(physicalTenantId);
     metricsFactory.apply(physicalTenantId).serverCount(servers.size());
 
     registry.list().stream()
@@ -68,43 +64,30 @@ final class ClientStreamManager<M extends BufferWriter> {
         .forEach(c -> requestManager.add(c, serverId));
   }
 
-  void onServerRemoved(final MemberId serverId) {
-    final var physicalTenantIds = physicalTenantsByServer.remove(serverId);
-    if (physicalTenantIds != null) {
-      physicalTenantIds.forEach(
-          physicalTenantId -> {
-            final var servers = serversByPhysicalTenantId.get(physicalTenantId);
-            if (servers != null) {
-              servers.remove(serverId);
-              if (servers.isEmpty()) {
-                serversByPhysicalTenantId.remove(physicalTenantId);
-              }
-            }
-            metricsFactory
-                .apply(physicalTenantId)
-                .serverCount(
-                    serversByPhysicalTenantId
-                        .getOrDefault(physicalTenantId, Collections.emptySet())
-                        .size());
-          });
-    }
-    requestManager.onServerRemoved(serverId);
-  }
-
   /**
-   * Called when a server that was already in the topology sends a RESTART_STREAMS signal. Resets
-   * its registrations and re-registers all streams belonging to its known physical tenants —
-   * without touching the topology maps.
+   * Called when a server is confirmed removed from a specific partition group. Only the topology
+   * and registrations for {@code physicalTenantId} are affected; the server may still be known to
+   * serve other physical tenants.
+   *
+   * @param serverId the removed server
+   * @param physicalTenantId the physical tenant the server no longer serves
    */
-  void onServerRestarted(final MemberId serverId) {
-    requestManager.onServerRemoved(serverId);
-    physicalTenantsByServer
-        .getOrDefault(serverId, Collections.emptySet())
-        .forEach(
-            physicalTenantId ->
-                registry.list().stream()
-                    .filter(c -> physicalTenantId.equals(c.physicalTenantId()))
-                    .forEach(c -> requestManager.add(c, serverId)));
+  void onServerRemoved(final MemberId serverId, final String physicalTenantId) {
+    final var servers = serversByPhysicalTenantId.get(physicalTenantId);
+    if (servers != null) {
+      servers.remove(serverId);
+      if (servers.isEmpty()) {
+        serversByPhysicalTenantId.remove(physicalTenantId);
+      }
+    }
+
+    metricsFactory
+        .apply(physicalTenantId)
+        .serverCount(
+            serversByPhysicalTenantId
+                .getOrDefault(physicalTenantId, Collections.emptySet())
+                .size());
+    requestManager.onServerRemoved(serverId, physicalTenantId);
   }
 
   ClientStreamId add(

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusher.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusher.java
@@ -24,6 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.UUID;
+import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,10 +38,14 @@ final class ClientStreamPusher {
   private static final Logger PUSH_ERROR_LOGGER =
       new ThrottledLogger(LOGGER, Duration.ofSeconds(1));
 
-  private final ClientStreamMetrics metrics;
+  private final Function<String, ClientStreamMetrics> metricsFactory;
 
   ClientStreamPusher(final ClientStreamMetrics metrics) {
-    this.metrics = metrics;
+    this(physicalTenantId -> metrics);
+  }
+
+  ClientStreamPusher(final Function<String, ClientStreamMetrics> metricsFactory) {
+    this.metricsFactory = metricsFactory;
   }
 
   /**
@@ -75,7 +80,8 @@ final class ClientStreamPusher {
     final LinkedList<ClientStreamImpl<?>> targets = new LinkedList<>(streams);
     Collections.shuffle(targets);
 
-    tryPush(stream.streamId(), targets, payload, future, new ArrayList<>());
+    final var metrics = metricsFactory.apply(stream.physicalTenantId());
+    tryPush(stream.streamId(), targets, payload, future, new ArrayList<>(), metrics);
   }
 
   private void tryPush(
@@ -83,7 +89,8 @@ final class ClientStreamPusher {
       final Queue<ClientStreamImpl<?>> targets,
       final DirectBuffer buffer,
       final ActorFuture<Void> future,
-      final List<Throwable> errors) {
+      final List<Throwable> errors,
+      final ClientStreamMetrics metrics) {
     final var clientStream = targets.poll();
     if (clientStream == null) {
       failOnStreamExhausted(future, errors);
@@ -102,7 +109,7 @@ final class ClientStreamPusher {
               errors.add(pushFailed);
               logFailedPush(pushFailed, clientStream);
               metrics.pushTryFailed(ErrorResponse.mapErrorToCode(pushFailed));
-              tryPush(streamId, targets, buffer, future, errors);
+              tryPush(streamId, targets, buffer, future, errors, metrics);
             });
   }
 

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -26,14 +27,19 @@ final class ClientStreamRegistry<M extends BufferWriter> {
   private final Map<UUID, AggregatedClientStream<M>> serverStreams = new HashMap<>();
   private final Map<LogicalId<M>, UUID> serverStreamIds = new HashMap<>();
 
-  private final ClientStreamMetrics metrics;
+  private final Function<String, ClientStreamMetrics> metricsFactory;
 
   ClientStreamRegistry() {
-    this(ClientStreamMetrics.noop());
+    this(physicalTenantId -> ClientStreamMetrics.noop());
   }
 
   ClientStreamRegistry(final ClientStreamMetrics metrics) {
-    this.metrics = Objects.requireNonNull(metrics, "must specify metrics");
+    this(physicalTenantId -> metrics);
+    Objects.requireNonNull(metrics, "must specify metrics");
+  }
+
+  ClientStreamRegistry(final Function<String, ClientStreamMetrics> metricsFactory) {
+    this.metricsFactory = Objects.requireNonNull(metricsFactory, "must specify metrics factory");
   }
 
   Optional<AggregatedClientStream<M>> get(final UUID serverStreamId) {
@@ -51,13 +57,15 @@ final class ClientStreamRegistry<M extends BufferWriter> {
       final String physicalTenantId) {
     final var streamTypeBuffer = new UnsafeBuffer(streamType);
     final LogicalId<M> logicalId = new LogicalId<>(streamTypeBuffer, metadata);
+    final var metrics = metricsFactory.apply(physicalTenantId);
     // Find serverStreamId given streamType and metadata. Once a server stream is removed, a new
     // server stream with same streamType and metadata will get a new UUID.
     final var serverStreamId = serverStreamIds.computeIfAbsent(logicalId, k -> UUID.randomUUID());
     final var serverStream =
         serverStreams.computeIfAbsent(
             serverStreamId,
-            k -> new AggregatedClientStream<>(serverStreamId, logicalId, physicalTenantId));
+            k ->
+                new AggregatedClientStream<>(serverStreamId, logicalId, physicalTenantId, metrics));
     final var streamId = new ClientStreamIdImpl(serverStreamId, serverStream.nextLocalId());
     final var clientStream =
         new ClientStreamImpl<>(
@@ -65,8 +73,8 @@ final class ClientStreamRegistry<M extends BufferWriter> {
     serverStream.addClient(clientStream);
     clientStreams.put(streamId, clientStream);
 
-    metrics.aggregatedStreamCount(serverStreams.size());
-    metrics.clientCount(clientStreams.size());
+    metrics.aggregatedStreamCount(countAggregatedStreamsFor(physicalTenantId));
+    metrics.clientCount(countClientsFor(physicalTenantId));
     return clientStream;
   }
 
@@ -77,13 +85,15 @@ final class ClientStreamRegistry<M extends BufferWriter> {
     final var clientStream = clientStreams.remove(streamId);
     if (clientStream != null) {
       final var serverStream = clientStream.serverStream();
+      final var physicalTenantId = serverStream.physicalTenantId();
+      final var metrics = metricsFactory.apply(physicalTenantId);
       serverStream.removeClient(clientStream.streamId());
-      metrics.clientCount(clientStreams.size());
+      metrics.clientCount(countClientsFor(physicalTenantId));
 
       if (serverStream.isEmpty()) {
         serverStreams.remove(serverStream.streamId());
         serverStreamIds.remove(serverStream.logicalId());
-        metrics.aggregatedStreamCount(serverStreams.size());
+        metrics.aggregatedStreamCount(countAggregatedStreamsFor(physicalTenantId));
 
         return Optional.of(serverStream);
       }
@@ -93,15 +103,39 @@ final class ClientStreamRegistry<M extends BufferWriter> {
   }
 
   void clear() {
+    final var physicalTenantIds =
+        serverStreams.values().stream()
+            .map(AggregatedClientStream::physicalTenantId)
+            .distinct()
+            .toList();
+
     clientStreams.clear();
     serverStreams.clear();
     serverStreamIds.clear();
 
-    metrics.clientCount(0);
-    metrics.aggregatedStreamCount(0);
+    physicalTenantIds.forEach(
+        physicalTenantId -> {
+          final var metrics = metricsFactory.apply(physicalTenantId);
+          metrics.clientCount(0);
+          metrics.aggregatedStreamCount(0);
+        });
   }
 
   Optional<ClientStreamImpl<M>> getClient(final ClientStreamId clientStreamId) {
     return Optional.ofNullable(clientStreams.get(clientStreamId));
+  }
+
+  private int countAggregatedStreamsFor(final String physicalTenantId) {
+    return (int)
+        serverStreams.values().stream()
+            .filter(s -> physicalTenantId.equals(s.physicalTenantId()))
+            .count();
+  }
+
+  private int countClientsFor(final String physicalTenantId) {
+    return (int)
+        clientStreams.values().stream()
+            .filter(c -> physicalTenantId.equals(c.serverStream().physicalTenantId()))
+            .count();
   }
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -25,7 +25,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 final class ClientStreamRegistry<M extends BufferWriter> {
   private final Map<ClientStreamId, ClientStreamImpl<M>> clientStreams = new HashMap<>();
   private final Map<UUID, AggregatedClientStream<M>> serverStreams = new HashMap<>();
-  private final Map<LogicalId<M>, UUID> serverStreamIds = new HashMap<>();
+  private final Map<ServerStreamKey<M>, UUID> serverStreamIds = new HashMap<>();
 
   private final Function<String, ClientStreamMetrics> metricsFactory;
 
@@ -57,10 +57,11 @@ final class ClientStreamRegistry<M extends BufferWriter> {
       final String physicalTenantId) {
     final var streamTypeBuffer = new UnsafeBuffer(streamType);
     final LogicalId<M> logicalId = new LogicalId<>(streamTypeBuffer, metadata);
+    final var streamKey = new ServerStreamKey<>(physicalTenantId, logicalId);
     final var metrics = metricsFactory.apply(physicalTenantId);
-    // Find serverStreamId given streamType and metadata. Once a server stream is removed, a new
-    // server stream with same streamType and metadata will get a new UUID.
-    final var serverStreamId = serverStreamIds.computeIfAbsent(logicalId, k -> UUID.randomUUID());
+    // Keyed by physicalTenantId too, so identical (streamType, metadata) pairs from different
+    // tenants don't aggregate into the same stream.
+    final var serverStreamId = serverStreamIds.computeIfAbsent(streamKey, k -> UUID.randomUUID());
     final var serverStream =
         serverStreams.computeIfAbsent(
             serverStreamId,
@@ -92,7 +93,7 @@ final class ClientStreamRegistry<M extends BufferWriter> {
 
       if (serverStream.isEmpty()) {
         serverStreams.remove(serverStream.streamId());
-        serverStreamIds.remove(serverStream.logicalId());
+        serverStreamIds.remove(new ServerStreamKey<>(physicalTenantId, serverStream.logicalId()));
         metrics.aggregatedStreamCount(countAggregatedStreamsFor(physicalTenantId));
 
         return Optional.of(serverStream);
@@ -138,4 +139,10 @@ final class ClientStreamRegistry<M extends BufferWriter> {
             .filter(c -> physicalTenantId.equals(c.serverStream().physicalTenantId()))
             .count();
   }
+
+  /**
+   * Identifies a server stream by physical tenant in addition to its logical id, so identical
+   * (streamType, metadata) pairs from different tenants never aggregate into the same stream.
+   */
+  private record ServerStreamKey<T>(String physicalTenantId, LogicalId<T> logicalId) {}
 }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -236,16 +236,35 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
   }
 
   /**
-   * Closes all pending registrations for this server, and removes them from the in-memory cache.
+   * Closes and removes the pending registrations for this server that belong to {@code
+   * physicalTenantId}, leaving any registrations for other physical tenants the server may still
+   * serve untouched.
    */
-  void onServerRemoved(final MemberId serverId) {
-    final var perHost = registrations.remove(serverId);
+  void onServerRemoved(final MemberId serverId, final String physicalTenantId) {
+    final var perHost = registrations.get(serverId);
     if (perHost == null) {
       return;
     }
 
-    LOGGER.trace("Closing all registrations for server {}", serverId);
-    perHost.values().forEach(ClientStreamRegistration::transitionToClosed);
+    final var toClose =
+        perHost.values().stream()
+            .filter(registration -> physicalTenantId.equals(registration.physicalTenantId()))
+            .toList();
+    if (toClose.isEmpty()) {
+      return;
+    }
+
+    LOGGER.trace(
+        "Closing registrations for server {} and physical tenant {}", serverId, physicalTenantId);
+    toClose.forEach(
+        registration -> {
+          registration.transitionToClosed();
+          perHost.remove(registration.streamId());
+        });
+
+    if (perHost.isEmpty()) {
+      registrations.remove(serverId);
+    }
   }
 
   @VisibleForTesting("Allows easier test set up and validation")

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -124,8 +124,8 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   }
 
   @Override
-  public void onServerRemoved(final MemberId memberId) {
-    actor.run(() -> clientStreamManager.onServerRemoved(memberId));
+  public void onServerRemoved(final MemberId memberId, final String physicalTenantId) {
+    actor.run(() -> clientStreamManager.onServerRemoved(memberId, physicalTenantId));
   }
 
   @Override
@@ -154,7 +154,7 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
       communicationService.replyTo(
           StreamTopics.RESTART_STREAMS.topic(physicalTenantId),
           Function.identity(),
-          apiHandler::handleRestartRequest,
+          (sender, payload) -> apiHandler.handleRestartRequest(sender, physicalTenantId, payload),
           Function.identity(),
           actor::run);
     }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamServiceImpl.java
@@ -25,7 +25,9 @@ import io.camunda.zeebe.transport.stream.impl.messages.StreamTopics;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -47,16 +49,28 @@ public final class ClientStreamServiceImpl<M extends BufferWriter> extends Actor
   /** Tracks which physicalTenantId topics already have a RESTART_STREAMS listener registered. */
   private final Set<String> registeredRestartPhysicalTenants = new HashSet<>();
 
+  /**
+   * Caches one {@link ClientStreamMetrics} instance per physical tenant, shared by the registry and
+   * the manager so each tenant's meters are only registered once.
+   */
+  private final Map<String, ClientStreamMetrics> metricsByPhysicalTenantId = new HashMap<>();
+
   public ClientStreamServiceImpl(
-      final ClusterCommunicationService communicationService, final ClientStreamMetrics metrics) {
+      final ClusterCommunicationService communicationService,
+      final Function<String, ClientStreamMetrics> metricsFactory) {
     this.communicationService = communicationService;
-    registry = new ClientStreamRegistry<>(metrics);
+    final Function<String, ClientStreamMetrics> cachedMetricsFactory =
+        physicalTenantId ->
+            metricsByPhysicalTenantId.computeIfAbsent(physicalTenantId, metricsFactory);
+    registry = new ClientStreamRegistry<>(cachedMetricsFactory);
 
     // ClientStreamRequestManager must use same actor as this because it is mutating shared
     // ClientStream objects.
     clientStreamManager =
         new ClientStreamManager<>(
-            registry, new ClientStreamRequestManager<>(communicationService, actor), metrics);
+            registry,
+            new ClientStreamRequestManager<>(communicationService, actor),
+            cachedMetricsFactory);
     apiHandler = new ClientStreamApiHandler(clientStreamManager, actor);
   }
 

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandlerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandlerTest.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.zeebe.transport.stream.impl;
 
+import static io.camunda.cluster.PhysicalTenantIds.DEFAULT_PHYSICAL_TENANT_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
 import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
@@ -22,14 +25,31 @@ import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponse;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import java.time.Duration;
 import java.util.stream.Stream;
+import org.agrona.collections.ArrayUtil;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 
 final class ClientStreamApiHandlerTest {
   private final ClientStreamManager<?> clientStreamManager = mock(ClientStreamManager.class);
+
+  @Test
+  void shouldRemoveThenRejoinServerForTheSignalingPhysicalTenantOnRestart() {
+    // given
+    final var apiHandler = new ClientStreamApiHandler(clientStreamManager, Runnable::run);
+    final var sender = MemberId.from("1");
+
+    // when
+    apiHandler.handleRestartRequest(sender, DEFAULT_PHYSICAL_TENANT_ID, ArrayUtil.EMPTY_BYTE_ARRAY);
+
+    // then - only the signaling physical tenant is torn down and re-registered, in that order
+    final var inOrder = inOrder(clientStreamManager);
+    inOrder.verify(clientStreamManager).onServerRemoved(sender, DEFAULT_PHYSICAL_TENANT_ID);
+    inOrder.verify(clientStreamManager).onServerJoined(sender, DEFAULT_PHYSICAL_TENANT_ID);
+  }
 
   @ParameterizedTest
   @MethodSource("provideExceptionToErrorMap")

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -54,7 +54,7 @@ class ClientStreamManagerTest {
       new ClientStreamManager<>(
           registry,
           new ClientStreamRequestManager<>(mockTransport, new TestConcurrencyControl()),
-          metrics);
+          physicalTenantId -> metrics);
 
   @BeforeEach
   void setup() {
@@ -294,7 +294,9 @@ class ClientStreamManagerTest {
         .failsWithin(Duration.ofMillis(100))
         .withThrowableOfType(ExecutionException.class)
         .withCauseInstanceOf(NoSuchStreamException.class);
-    assertThat(metrics.getPushFailed()).isOne();
+    // the physicalTenantId of an already-removed stream is unknown, so the failure cannot be
+    // attributed to any tenant's metrics
+    assertThat(metrics.getPushFailed()).isZero();
   }
 
   @Test

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -98,7 +98,7 @@ class ClientStreamManagerTest {
     clientStreamManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
     final var streamId =
         clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
-    clientStreamManager.onServerRemoved(serverId);
+    clientStreamManager.onServerRemoved(serverId, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
     clientStreamManager.onServerJoined(serverId, DEFAULT_PHYSICAL_TENANT_ID);
@@ -336,10 +336,28 @@ class ClientStreamManagerTest {
     assertThat(stream.isConnected(server)).isTrue();
 
     // when
-    clientStreamManager.onServerRemoved(server);
+    clientStreamManager.onServerRemoved(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(stream.isConnected(server)).isFalse();
+  }
+
+  @Test
+  void shouldJoinNormallyAfterRemovingServerThatNeverJoined() {
+    // given — a stream exists but this server never joined the group, mirroring a RESTART_STREAMS
+    // signal arriving before the client has observed the corresponding topology join
+    final var uuid =
+        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
+    final var neverJoinedServer = MemberId.from("never-joined");
+
+    // when / then — removing an unknown server is a no-op, no exception
+    clientStreamManager.onServerRemoved(neverJoinedServer, DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(stream.isConnected(neverJoinedServer)).isFalse();
+
+    // and the server can still join normally afterwards
+    clientStreamManager.onServerJoined(neverJoinedServer, DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(stream.isConnected(neverJoinedServer)).isTrue();
   }
 
   @Test
@@ -361,7 +379,7 @@ class ClientStreamManagerTest {
     clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // when
-    clientStreamManager.onServerRemoved(server);
+    clientStreamManager.onServerRemoved(server, DEFAULT_PHYSICAL_TENANT_ID);
 
     // then
     assertThat(metrics.getServerCount()).isZero();
@@ -401,32 +419,30 @@ class ClientStreamManagerTest {
   }
 
   @Test
-  void shouldRestartOnlyStreamsForKnownGroups() {
-    // given
-    final MemberId server = MemberId.from("1");
+  void shouldOnlyRemoveServerForMatchingPhysicalTenant() {
+    // given - one server serves both physical tenants
+    final MemberId server = MemberId.from("multi-tenant-server");
     clientStreamManager.onServerJoined(server, DEFAULT_PHYSICAL_TENANT_ID);
-    final var uuid =
-        clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
-    final var stream = registry.get(getServerStreamId(uuid)).orElseThrow();
-    assertThat(stream.isConnected(server)).isTrue();
+    clientStreamManager.onServerJoined(server, OTHER_PHYSICAL_TENANT_ID);
 
-    // when - server restarts
-    clientStreamManager.onServerRestarted(server);
+    final var defaultStreamId =
+        clientStreamManager.add(
+            BufferUtil.wrapString("foo"), metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var otherStreamId =
+        clientStreamManager.add(
+            BufferUtil.wrapString("bar"), metadata, NOOP_CONSUMER, OTHER_PHYSICAL_TENANT_ID);
+    final var defaultStream = registry.get(getServerStreamId(defaultStreamId)).orElseThrow();
+    final var otherStream = registry.get(getServerStreamId(otherStreamId)).orElseThrow();
+    assertThat(defaultStream.isConnected(server)).isTrue();
+    assertThat(otherStream.isConnected(server)).isTrue();
 
-    // then - stream re-registered with same server
-    assertThat(stream.isConnected(server)).isTrue();
-  }
+    // when - the server is removed only from the default group
+    clientStreamManager.onServerRemoved(server, DEFAULT_PHYSICAL_TENANT_ID);
 
-  @Test
-  void shouldHandleRestartFromUnknownServerGracefully() {
-    // given — a stream exists but this server never joined any group
-    clientStreamManager.add(streamType, metadata, NOOP_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
-    final MemberId unknownServer = MemberId.from("never-joined");
-
-    // when / then — no exception, stream stays unregistered with unknown server
-    clientStreamManager.onServerRestarted(unknownServer);
-    final var stream = registry.list().stream().findFirst().orElseThrow();
-    assertThat(stream.isConnected(unknownServer)).isFalse();
+    // then - only the default-tenant stream is disconnected; the other tenant's registration
+    // survives since the server still serves that group
+    assertThat(defaultStream.isConnected(server)).isFalse();
+    assertThat(otherStream.isConnected(server)).isTrue();
   }
 
   private UUID getServerStreamId(final ClientStreamId clientStreamId) {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistryTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistryTest.java
@@ -17,12 +17,55 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class ClientStreamRegistryTest {
+  private static final String OTHER_PHYSICAL_TENANT_ID = "other-tenant";
   private static final ClientStreamConsumer CLIENT_STREAM_CONSUMER =
       p -> CompletableActorFuture.completed(null);
 
   private final TestClientStreamMetrics metrics = new TestClientStreamMetrics();
   private final ClientStreamRegistry<TestSerializableData> registry =
       new ClientStreamRegistry<>(metrics);
+
+  @Test
+  void shouldNotAggregateSameStreamTypeAndMetadataAcrossDifferentPhysicalTenants() {
+    // given
+    final var metadata = new TestSerializableData();
+    final var streamType = BufferUtil.wrapString("foo");
+
+    // when - two different tenants subscribe with the exact same streamType and metadata
+    final var defaultTenantClient =
+        registry.addClient(
+            streamType, metadata, CLIENT_STREAM_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var otherTenantClient =
+        registry.addClient(streamType, metadata, CLIENT_STREAM_CONSUMER, OTHER_PHYSICAL_TENANT_ID);
+
+    // then - each tenant gets its own aggregated stream, not a shared one
+    final var defaultServerStream = defaultTenantClient.serverStream();
+    final var otherServerStream = otherTenantClient.serverStream();
+    assertThat(defaultServerStream.streamId()).isNotEqualTo(otherServerStream.streamId());
+    assertThat(defaultServerStream.physicalTenantId()).isEqualTo(DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(otherServerStream.physicalTenantId()).isEqualTo(OTHER_PHYSICAL_TENANT_ID);
+  }
+
+  @Test
+  void shouldAssignFreshServerStreamIdAfterRemovingLastClientForATenant() {
+    // given
+    final var metadata = new TestSerializableData();
+    final var streamType = BufferUtil.wrapString("foo");
+    final var firstClient =
+        registry.addClient(
+            streamType, metadata, CLIENT_STREAM_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    final var firstStreamId = firstClient.serverStream().streamId();
+
+    // when - the only client is removed, closing the aggregated stream entirely
+    registry.removeClient(firstClient.streamId());
+
+    // then - a new subscription for the same tenant and logical id gets a fresh stream id,
+    // proving the stale serverStreamIds entry was actually cleaned up under its tenant-scoped key
+    final var secondClient =
+        registry.addClient(
+            streamType, metadata, CLIENT_STREAM_CONSUMER, DEFAULT_PHYSICAL_TENANT_ID);
+    assertThat(secondClient.serverStream().streamId()).isNotEqualTo(firstStreamId);
+  }
 
   @Test
   void shouldReportStreamCountOnAdd() {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManagerTest.java
@@ -688,6 +688,39 @@ final class ClientStreamRequestManagerTest {
     assertThat(tenantStream.isConnected(serverId)).isFalse();
   }
 
+  @Test
+  void shouldOnlyCloseRegistrationsForMatchingPhysicalTenantOnServerRemoved() {
+    // given - the same server serves both the default and a second physical tenant
+    final String otherPhysicalTenantId = "tenant1";
+    final var otherStream =
+        new AggregatedClientStream<>(
+            UUID.randomUUID(),
+            new LogicalId<>(new UnsafeBuffer(BufferUtil.wrapString("other")), new TestMetadata()),
+            otherPhysicalTenantId);
+    otherStream.open(requestManager, Collections.emptySet());
+
+    final var serverId = MemberId.anonymous();
+    when(mockTransport.send(
+            eq(StreamTopics.ADD.topic(otherPhysicalTenantId)),
+            any(),
+            any(),
+            any(),
+            eq(serverId),
+            any()))
+        .thenReturn(CompletableFuture.completedFuture(addStreamSuccess));
+    requestManager.add(clientStream, serverId);
+    requestManager.add(otherStream, serverId);
+    assertThat(clientStream.isConnected(serverId)).isTrue();
+    assertThat(otherStream.isConnected(serverId)).isTrue();
+
+    // when - the server is removed only from the default physical tenant
+    requestManager.onServerRemoved(serverId, DEFAULT_PHYSICAL_TENANT_ID);
+
+    // then - only the default-tenant registration is torn down
+    assertThat(clientStream.isConnected(serverId)).isFalse();
+    assertThat(otherStream.isConnected(serverId)).isTrue();
+  }
+
   private static Stream<MessagingException> provideMessagingFailures() {
     return Stream.of(
         new NoSuchMemberException("failed"),

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -483,7 +483,7 @@ final class StreamIntegrationTest {
       final var factory = new TransportFactory(actorScheduler);
       streamService =
           factory.createRemoteStreamClient(
-              cluster.getCommunicationService(), ClientStreamMetrics.noop());
+              cluster.getCommunicationService(), physicalTenantId -> ClientStreamMetrics.noop());
     }
 
     private void start() {

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/StreamIntegrationTest.java
@@ -311,7 +311,7 @@ final class StreamIntegrationTest {
       awaitStreamAdded(streamType, streamId, server1, server2);
 
       // when
-      client.streamService.onServerRemoved(server1.memberId());
+      client.streamService.onServerRemoved(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
 
       // then
       awaitStreamOnClient(
@@ -327,7 +327,7 @@ final class StreamIntegrationTest {
       // given
       final var streamType = BufferUtil.wrapString("foo");
       final var properties = new TestSerializableData();
-      client.streamService.onServerRemoved(server1.memberId());
+      client.streamService.onServerRemoved(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
       final var streamId =
           clientStreamer
               .add(
@@ -402,7 +402,7 @@ final class StreamIntegrationTest {
               .join();
       awaitStreamAdded(streamType, streamId, server1, server2);
       server1.close();
-      client.streamService.onServerRemoved(server1.memberId());
+      client.streamService.onServerRemoved(server1.memberId(), DEFAULT_PHYSICAL_TENANT_ID);
       awaitStreamOnClient(
           streamId,
           stream ->


### PR DESCRIPTION
## Description

- Scope `ClientStreamMetrics` per physical tenant (#57364): `JobClientStreamMetrics` now tags all its meters with `physicalTenantId`, so gateway job-stream dashboards can be sliced per tenant instead of all tenants accumulating into one series.
- Scope `ClientStreamManager#onServerRemoved` per physical tenant, mirroring `onServerJoined(MemberId, physicalTenantId)`. Previously a server removal reset topology/registrations across *every* tenant that server served, even though the removal only concerns one partition group.
- Reuse this scoped remove+join pair as the RESTART_STREAMS handling logic instead of a separate blanket `onServerRestarted` path: a restart signal is just a forced re-registration for the one tenant group that signaled it, so `handleRestartRequest` now calls `onServerRemoved(serverId, physicalTenantId)` 
  followed by `onServerJoined(serverId, physicalTenantId)`. This removes the old `ClientStreamManager#onServerRestarted` / `ClientStreamRequestManager#onServerRestarted` machinery (and the `physicalTenantId`-to-server derivation it needed), and fixes the same over-broad-reset bug: a restart on one tenant's 
  topic no longer touches registrations for other tenants that server may also serve.

Multi-tenant job streaming (group-aware stream registration/routing) needs both its metrics and its removal/restart handling scoped per physical tenant — otherwise metrics are unreadable per tenant, and a server event for one tenant incorrectly disturbs another tenant's state.


## Related issues

closes #57364
