### PR TITLE
docs: document automated backport workflow in agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,7 +295,23 @@ Load extra context on demand — only when relevant, only if the files exist.
 - Describe why the changes are necessary and note alternatives considered
 - Keep descriptions brief and concise
 - For bug fixes: ask the engineer whether the fix needs backporting to stable branches before
-  opening the PR. If yes, add the appropriate `backport stable/X.Y` label(s) when creating it.
+  opening the PR. If yes, add the appropriate `backport stable/X.Y` label(s) when creating it
+  (see "Backporting" below).
+
+### Backporting
+
+Automated by a GitHub Action (`korthout/backport-action`, see `.github/workflows/backport.yml`;
+human docs in `CONTRIBUTING.md`). **Never create backport PRs, branches, or cherry-picks yourself,
+and never offer to.** Start a backport only by labelling.
+
+- **Start:** add one `backport stable/X.Y` label per target branch (e.g. `backport stable/8.7`).
+  Not-yet-merged PR → runs on merge. Already-merged PR → comment `/backport`. Multiple labels →
+  multiple backport PRs.
+- **Success:** action opens the backport PR; a bot approves and merges it once CI passes.
+- **Conflicts:** action opens a **draft** PR with conflict markers committed as-is plus a comment
+  with resolution steps. You may resolve them (check out the branch, fix conflicts and markers) —
+  but only on a draft PR the action already opened. When asked to backport, first check whether
+  such a draft PR exists.
 
 ### Git workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,8 @@ Load extra context on demand — only when relevant, only if the files exist.
 
 Automated by a GitHub Action (`korthout/backport-action`, see `.github/workflows/backport.yml`;
 human docs in `CONTRIBUTING.md`). **Never create backport PRs, branches, or cherry-picks yourself,
-and never offer to.** Start a backport only by labelling.
+and never offer to.** Trigger a backport only through the automation — a label, or a `/backport`
+comment — never by hand.
 
 - **Start:** add one `backport stable/X.Y` label per target branch (e.g. `backport stable/8.7`).
   Not-yet-merged PR → runs on merge. Already-merged PR → comment `/backport`. Multiple labels →

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,7 +359,7 @@ When this happens and you're still interested in contributing, please feel free 
 
 ## Backporting changes
 
-Some changes need to be copied to other (often older) versions. We use the [backport](https://github.com/zeebe-io/backport-action) Github Action to automate this process. Please follow these steps to port your changes:
+Some changes need to be copied to other (often older) versions. We use the [backport](https://github.com/korthout/backport-action) Github Action to automate this process. Please follow these steps to port your changes:
 
 1. **Label the pull request** with a backport label (e.g. the label `backport stable/1.0` indicates that we want to port this pull request to the `stable/1.0` branch).
    - if the pull request is _not yet_ merged, it will be automatically ported when it gets merged.
@@ -368,7 +368,7 @@ Some changes need to be copied to other (often older) versions. We use the [back
    - a pull request can have multiple backport labels, in which case the action ports the pull request to each of those branches.
 2. The GitHub actions bot comments on the pull request once it finishes:
    - When _successful_, a new backport pull request was automatically created. A bot will automatically approve and merge it when it passes the CI. If it doesn't, you'll need to fix the problems and request a new review.
-   - If it _fails_, the action provides instructions in a comment that you need to follow. Once ready, please request a new review.
+   - If the cherry-pick hits **conflicts**, the action still opens the backport pull request, but as a _draft_ with the conflicts committed as-is, and comments with instructions to resolve them. Resolve the conflicts on that branch, mark the pull request ready, and request a new review.
 
 ## Commit message guidelines
 


### PR DESCRIPTION
## What

Adds a **Backporting** section to `AGENTS.md` documenting how automated backporting works in this repo, and instructing agents not to create backport PRs themselves.

## Why

Agents have been offering to hand-create backport PRs and cherry-picks, duplicating what the [`korthout/backport-action`](https://github.com/korthout/backport-action) (configured in `.github/workflows/backport.yml`) already does automatically on merge. The instructions now make the automation the single source of truth:

- **Start** a backport only by applying `backport stable/X.Y` labels; the bot opens and auto-merges the PR once CI passes.
- **Conflicts** are not a failure — the action commits the conflict markers into a **draft** PR (`conflict_resolution: draft_commit_conflicts`) and comments resolution steps. Agents *may* resolve those, but only on a draft PR the action has already opened.
- Hand-rolled backport PRs, branches, and cherry-picks are explicitly forbidden.

## Testing

Ran a behavioral dry-run eval: three fresh agents loaded the updated `AGENTS.md` and were given realistic backport requests around PR #57705 (no state-changing commands permitted). All three behaved correctly — declined to hand-create backports, pointed to the label mechanism, and (for the conflict case) investigated for an existing draft PR before acting. Reviewers should note this tests the *instructions*; the action's runtime behavior is verified against its config, not a live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)