### PR TITLE
fix: avoid deadlocks on job stream client shutdown

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobStreamClientImpl.java
@@ -23,17 +23,10 @@ import java.util.Collection;
  * A thin adapter around a {@link ClientStreamService} instance specifically for streaming jobs.
  * It's intended to be the main entry point when setting up the client side of job streaming in the
  * gateway.
- *
- * <p>NOTE: most methods are synchronized to avoid dealing with concurrency issues with
- * startup/shutdown, and that's not on any hot path. Can be reconsidered if this is not true
- * anymore, or not the only constraint.
  */
 public final class JobStreamClientImpl implements JobStreamClient {
   private final ActorSchedulingService schedulingService;
   private final ClientStreamService<JobActivationProperties> streamService;
-
-  private boolean started;
-  private ActorFuture<Void> startedFuture;
 
   public JobStreamClientImpl(
       final ActorSchedulingService schedulingService,
@@ -47,22 +40,12 @@ public final class JobStreamClientImpl implements JobStreamClient {
   }
 
   @Override
-  public synchronized void brokerAdded(
-      final BrokerMemberId memberId, final String physicalTenantId) {
-    if (!started) {
-      return;
-    }
-
+  public void brokerAdded(final BrokerMemberId memberId, final String physicalTenantId) {
     streamService.onServerJoined(memberId.memberId(), physicalTenantId);
   }
 
   @Override
-  public synchronized void brokerRemoved(
-      final BrokerMemberId memberId, final String physicalTenantId) {
-    if (!started) {
-      return;
-    }
-
+  public void brokerRemoved(final BrokerMemberId memberId, final String physicalTenantId) {
     streamService.onServerRemoved(memberId.memberId());
   }
 
@@ -72,13 +55,8 @@ public final class JobStreamClientImpl implements JobStreamClient {
   }
 
   @Override
-  public synchronized ActorFuture<Void> start() {
-    if (startedFuture == null) {
-      startedFuture = streamService.start(schedulingService);
-      started = true;
-    }
-
-    return startedFuture;
+  public ActorFuture<Void> start() {
+    return streamService.start(schedulingService);
   }
 
   @Override
@@ -87,12 +65,7 @@ public final class JobStreamClientImpl implements JobStreamClient {
   }
 
   @Override
-  public synchronized void close() {
-    if (!started) {
-      return;
-    }
-
-    started = false;
+  public void close() {
     streamService.closeAsync().join();
   }
 }


### PR DESCRIPTION
This makes all methods not `synchronized` and relies on the underlying `ClientStreamService` actor to handle its lifecycle reliably.

It fixes a deadlock that could occur while waiting for the shutdown to complete, when the actor trying to shut down can't run because its thread is blocked by another actor trying to call `brokerAdded`/`brokerRemoved`.

The `brokerAdded`/`brokerRemoved` calls are dropped in case the actor is already closed, which matches the previous behavior.

Requests to `start` and `close` are simply forwarded to the actor which means that repeated start/close calls result in errors instead of no-ops. Since start and close are only called in well-defined places, during gateway startup and shutdown, and we don't have to be so gracious about it.

The deadlock this is fixing is quite old, it just became more likely with https://github.com/camunda/camunda/pull/57246 because `brokerAdded`/`brokerRemoved` fire more often now.