### PR TITLE
test: add Operate process-instance Business ID UI e2e coverage

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -14,9 +14,18 @@ type OptionalFilter =
   | 'Parent Process Instance Key'
   | 'Batch Operation Key'
   | 'Error Message'
+  | 'Business ID'
   | 'Start Date Range'
   | 'End Date Range'
   | 'Failed job but retries left';
+
+export type AdvancedStringFilterOperator =
+  | 'equals'
+  | 'does not equal'
+  | 'contains'
+  | 'is one of'
+  | 'is not one of'
+  | 'exists';
 
 export class OperateFiltersPanelPage {
   private page: Page;
@@ -37,6 +46,8 @@ export class OperateFiltersPanelPage {
   readonly batchOperationKeyFilter: Locator;
   readonly resetFiltersButton: Locator;
   readonly errorMessageFilter: Locator;
+  readonly businessIdFilter: Locator;
+  readonly businessIdFilterType: Locator;
   readonly startDateFilter: Locator;
   readonly openVariableFilterModalButton: Locator;
   readonly variableFilterDialog: Locator;
@@ -104,6 +115,13 @@ export class OperateFiltersPanelPage {
     });
     this.errorMessageFilter = this.page.getByRole('textbox', {
       name: 'error message',
+    });
+    this.businessIdFilter = this.page.getByRole('textbox', {
+      name: 'Business ID',
+      exact: true,
+    });
+    this.businessIdFilterType = this.page.getByRole('combobox', {
+      name: 'Business ID filter type',
     });
     this.startDateFilter = this.page.getByRole('textbox', {
       name: 'start date range',
@@ -202,6 +220,20 @@ export class OperateFiltersPanelPage {
   async selectFlowNode(option: string) {
     await this.flowNodeFilter.click();
     await this.getOptionByName(option, false).click();
+  }
+
+  async fillBusinessIdFilter(value: string) {
+    await expect(this.businessIdFilter).toBeVisible();
+    await expect(this.businessIdFilter).toBeEnabled();
+    await this.businessIdFilter.click();
+    await this.businessIdFilter.fill('');
+    await this.businessIdFilter.pressSequentially(value);
+    await expect(this.businessIdFilter).toHaveValue(value, {timeout: 30000});
+  }
+
+  async selectBusinessIdFilterType(operator: AdvancedStringFilterOperator) {
+    await this.businessIdFilterType.click();
+    await this.page.getByRole('option', {name: operator, exact: true}).click();
   }
 
   async openVariableFilterModal() {

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateFiltersPanelPage.ts
@@ -19,13 +19,10 @@ type OptionalFilter =
   | 'End Date Range'
   | 'Failed job but retries left';
 
-export type AdvancedStringFilterOperator =
-  | 'equals'
-  | 'does not equal'
-  | 'contains'
-  | 'is one of'
-  | 'is not one of'
-  | 'exists';
+// The Business ID advanced string filter only renders the operators
+// configured via `selectableOperators` in OptionalFiltersFormGroup.tsx
+// ($eq / $like / $in) — keep this type in sync with that configuration.
+export type AdvancedStringFilterOperator = 'equals' | 'contains' | 'is one of';
 
 export class OperateFiltersPanelPage {
   private page: Page;

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesBusinessId.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesBusinessId.spec.ts
@@ -8,7 +8,6 @@
 
 import {test} from 'fixtures';
 import {expect} from '@playwright/test';
-import {randomUUID} from 'crypto';
 import {deploy, cancelProcessInstance} from 'utils/zeebeClient';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToAppHome} from '@pages/UtilitiesPage';
@@ -19,11 +18,11 @@ import {
 } from '@pages/OperateFiltersPanelPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {createProcessInstanceWithBusinessId} from 'utils/requestHelpers/process-instance-requestHelpers';
-import {extendedAssertionOptions} from 'utils/constants';
+import {extendedAssertionOptions, uniqueBusinessId} from 'utils/constants';
 
 const USER_TASK_PROCESS_ID = 'user_task_api_test_process';
 
-const runPrefix = `ui-bizid-${randomUUID().slice(0, 8)}`;
+const runPrefix = uniqueBusinessId('ui-bizid');
 const BUSINESS_ID_A = `${runPrefix}-aaa`;
 const BUSINESS_ID_B = `${runPrefix}-zzz`;
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesBusinessId.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/processInstancesBusinessId.spec.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {deploy, cancelProcessInstance} from 'utils/zeebeClient';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
+import {OperateProcessesPage} from '@pages/OperateProcessesPage';
+import {
+  OperateFiltersPanelPage,
+  type AdvancedStringFilterOperator,
+} from '@pages/OperateFiltersPanelPage';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {createProcessInstanceWithBusinessId} from 'utils/requestHelpers/process-instance-requestHelpers';
+import {extendedAssertionOptions} from 'utils/constants';
+
+const USER_TASK_PROCESS_ID = 'user_task_api_test_process';
+
+const runPrefix = `ui-bizid-${randomUUID().slice(0, 8)}`;
+const BUSINESS_ID_A = `${runPrefix}-aaa`;
+const BUSINESS_ID_B = `${runPrefix}-zzz`;
+
+let instanceKeyA: string;
+let instanceKeyB: string;
+
+async function applyBusinessIdFilter(
+  operateFiltersPanelPage: OperateFiltersPanelPage,
+  value: string,
+  operator?: AdvancedStringFilterOperator,
+) {
+  await operateFiltersPanelPage.displayOptionalFilter('Business ID');
+  if (operator) {
+    await operateFiltersPanelPage.selectBusinessIdFilterType(operator);
+  }
+  await operateFiltersPanelPage.fillBusinessIdFilter(value);
+}
+
+test.beforeAll(async ({request}) => {
+  await deploy(['./resources/user_task_api_test_process.bpmn']);
+  instanceKeyA = await createProcessInstanceWithBusinessId(
+    request,
+    USER_TASK_PROCESS_ID,
+    BUSINESS_ID_A,
+  );
+  instanceKeyB = await createProcessInstanceWithBusinessId(
+    request,
+    USER_TASK_PROCESS_ID,
+    BUSINESS_ID_B,
+  );
+});
+
+test.afterAll(async () => {
+  await Promise.allSettled(
+    [instanceKeyA, instanceKeyB].map(async (key) => {
+      if (!key) return;
+      try {
+        await cancelProcessInstance(key);
+      } catch (error) {
+        console.error(`Failed to cancel process instance ${key}:`, error);
+      }
+    }),
+  );
+});
+
+test.describe('Process Instances - Business ID', () => {
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickProcessesTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Filter process instances by Business ID (equals)', async ({
+    page,
+    operateFiltersPanelPage,
+  }) => {
+    await test.step('Apply the Business ID equals filter', async () => {
+      await applyBusinessIdFilter(operateFiltersPanelPage, BUSINESS_ID_A);
+    });
+
+    await test.step('Verify only the matching instance is shown', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          const rowA = OperateProcessesPage.getRowByProcessInstanceKey(
+            page,
+            instanceKeyA,
+          );
+          await expect(rowA).toBeVisible();
+          await expect(rowA.getByTestId('cell-businessId')).toHaveText(
+            BUSINESS_ID_A,
+          );
+          await expect(
+            OperateProcessesPage.getRowByProcessInstanceKey(page, instanceKeyB),
+          ).toHaveCount(0);
+        },
+        onFailure: async () => {
+          await page.reload();
+          await applyBusinessIdFilter(operateFiltersPanelPage, BUSINESS_ID_A);
+        },
+      });
+    });
+  });
+
+  test('Filter process instances by Business ID (contains)', async ({
+    page,
+    operateFiltersPanelPage,
+  }) => {
+    await test.step('Apply the Business ID contains filter', async () => {
+      await applyBusinessIdFilter(
+        operateFiltersPanelPage,
+        runPrefix,
+        'contains',
+      );
+    });
+
+    await test.step('Verify both instances sharing the prefix are shown', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            OperateProcessesPage.getRowByProcessInstanceKey(page, instanceKeyA),
+          ).toBeVisible();
+          await expect(
+            OperateProcessesPage.getRowByProcessInstanceKey(page, instanceKeyB),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await applyBusinessIdFilter(
+            operateFiltersPanelPage,
+            runPrefix,
+            'contains',
+          );
+        },
+      });
+    });
+  });
+
+  test('Filter process instances by a non-matching Business ID shows no results', async ({
+    operateProcessesPage,
+    operateFiltersPanelPage,
+  }) => {
+    await test.step('Apply a Business ID filter that matches nothing', async () => {
+      await applyBusinessIdFilter(operateFiltersPanelPage, `${runPrefix}-none`);
+    });
+
+    await test.step('Verify the empty-state message is shown', async () => {
+      await expect(operateProcessesPage.noMatchingInstancesMessage).toBeVisible(
+        {
+          timeout: extendedAssertionOptions.timeout,
+        },
+      );
+    });
+  });
+
+  test('Process instance detail shows the Business ID', async ({
+    page,
+    operateProcessesPage,
+    operateFiltersPanelPage,
+    operateProcessInstancePage,
+  }) => {
+    await test.step('Filter to the target instance by Business ID', async () => {
+      await applyBusinessIdFilter(operateFiltersPanelPage, BUSINESS_ID_A);
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            OperateProcessesPage.getRowByProcessInstanceKey(page, instanceKeyA),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await applyBusinessIdFilter(operateFiltersPanelPage, BUSINESS_ID_A);
+        },
+      });
+    });
+
+    await test.step('Open the matching instance detail', async () => {
+      await operateProcessesPage.processInstanceLinkByKey(instanceKeyA).click();
+    });
+
+    await test.step('Verify the detail header shows the Business ID', async () => {
+      await expect(operateProcessInstancePage.instanceHeader).toBeVisible();
+      await expect(
+        operateProcessInstancePage.instanceHeader.getByText(BUSINESS_ID_A),
+      ).toBeVisible();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/utils/requestHelpers/process-instance-requestHelpers.ts
@@ -38,6 +38,23 @@ export async function getProcessDefinitionKey(
   return json.processDefinitionKey;
 }
 
+export async function createProcessInstanceWithBusinessId(
+  request: APIRequestContext,
+  processDefinitionId: string,
+  businessId: string,
+): Promise<string> {
+  const res = await request.post(buildUrl('/process-instances'), {
+    headers: jsonHeaders(),
+    data: {processDefinitionId, businessId},
+  });
+  await assertStatusCode(res, 200);
+  await validateResponse(
+    {path: '/process-instances', method: 'POST', status: '200'},
+    res,
+  );
+  return String((await res.json()).processInstanceKey);
+}
+
 export async function createCancellationBatch(
   request: APIRequestContext,
   numberOfInstances = 3,


### PR DESCRIPTION
## Description

Adds **UI end-to-end (Playwright)** coverage for **Business ID on the Operate Process Instances view**, the first of the "Priority 1" cross-component UI gaps for the Business ID Visibility and Filtering epic ([product-hub#3436](https://github.com/camunda/product-hub/issues/3436), breakdown [#51683](https://github.com/camunda/camunda/issues/51683)).

Until now Business ID had **API** e2e coverage (#57613, #57630, #57631) and legacy-Operate *visual* snapshots, but **no behavioral cross-component UI e2e** in the orchestration-cluster suite. This PR is the first of three that close that gap (siblings: Operate decisions #57722, Tasklist #57723).

### What's covered — `tests/operate/processInstancesBusinessId.spec.ts`
1. **Filter by Business ID (equals)** — only the matching instance is listed, and its `Business ID` column shows the value.
2. **Filter by Business ID (contains)** — all instances sharing the run-unique prefix are listed.
3. **Filter by a non-matching Business ID** — the "no results" message is shown.
4. **Process instance detail shows the Business ID** — the instance header renders it.

### Page-object additions
- **`pages/OperateFiltersPanelPage.ts`** — adds `'Business ID'` to the optional-filter union plus `fillBusinessIdFilter` / `selectBusinessIdFilterType` (the AdvancedStringFilter operator dropdown: equals / contains / …).
- **`pages/OperateProcessesPage.ts`** — adds a `businessIdCell` accessor for the `Business ID` table column.

### Notes
- **Seeding:** the spec seeds instances **with a Business ID** via a local helper that `POST`s to `/v2/process-instances` (using the Playwright `request` fixture + the suite's `demo:demo` basic auth via `jsonHeaders()`). This is required because the `@camunda8/sdk` client used by `zeebeClient` does not yet expose `businessId`, so it can't seed instances that display a Business ID in the UI. The same inline pattern (matching the existing `decisionFilters` spec) is used by the sibling Operate-decisions and Tasklist PRs — no shared util is introduced.
- Each run uses a unique Business ID **prefix** (`randomUUID`-based, with `aaa`/`zzz` suffixes) so tests isolate their own instances in the shared cluster and results are deterministic.
- Instances are cancelled in `afterAll` (guarded against partial `beforeAll` failure).
- **Validation:** `tsc`, `eslint` (0 errors), `prettier`, and `check:testrail-ids` all pass. Full runtime execution requires the cluster + browsers and runs in the nightly UI workflow — the selectors mirror the existing Operate page-object conventions and the legacy Operate Business ID UI, but should be confirmed by a cluster run.

### Related
- Epic: [product-hub#3436](https://github.com/camunda/product-hub/issues/3436) · Breakdown: [#51683](https://github.com/camunda/camunda/issues/51683)
- API companion PRs: #57613, #57630, #57631
- Sibling UI PRs: #57722 (Operate decision instances), #57723 (Tasklist)


Test Rail test cases
https://camunda.testrail.com/index.php?/suites/view/17028&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=678356

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview
