### PR TITLE
Make AgentInstanceHistoryItemMetrics sub-fields nullable in zod schema

### DIFF
--- a/webapp/client/apps/orchestration-cluster-webapp/package.json
+++ b/webapp/client/apps/orchestration-cluster-webapp/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@bpmn-io/element-template-icon-renderer": "1.0.0",
-		"@camunda/camunda-api-zod-schemas": "0.0.81",
+		"@camunda/camunda-api-zod-schemas": "0.0.82",
 		"@camunda/camunda-composite-components": "0.25.3",
 		"@carbon/grid": "11.57.0",
 		"@carbon/layout": "11.54.0",

--- a/webapp/client/package-lock.json
+++ b/webapp/client/package-lock.json
@@ -28,7 +28,7 @@
 			"name": "@camunda/orchestration-cluster-webapp",
 			"dependencies": {
 				"@bpmn-io/element-template-icon-renderer": "1.0.0",
-				"@camunda/camunda-api-zod-schemas": "0.0.81",
+				"@camunda/camunda-api-zod-schemas": "0.0.82",
 				"@camunda/camunda-composite-components": "0.25.3",
 				"@carbon/grid": "11.57.0",
 				"@carbon/layout": "11.54.0",
@@ -11682,7 +11682,7 @@
 			"version": "0.0.1",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
-				"@camunda/camunda-api-zod-schemas": "0.0.81",
+				"@camunda/camunda-api-zod-schemas": "0.0.82",
 				"typescript": "7.0.2"
 			}
 		},
@@ -11723,7 +11723,7 @@
 		},
 		"packages/camunda-api-zod-schemas": {
 			"name": "@camunda/camunda-api-zod-schemas",
-			"version": "0.0.81",
+			"version": "0.0.82",
 			"license": "LicenseRef-Camunda-1.0",
 			"devDependencies": {
 				"@types/node": "26.1.1",

--- a/webapp/client/packages/c8-mocks/package.json
+++ b/webapp/client/packages/c8-mocks/package.json
@@ -18,7 +18,7 @@
 		"typecheck": "tsc"
 	},
 	"devDependencies": {
-		"@camunda/camunda-api-zod-schemas": "0.0.81",
+		"@camunda/camunda-api-zod-schemas": "0.0.82",
 		"typescript": "7.0.2"
 	}
 }

--- a/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
+++ b/webapp/client/packages/camunda-api-zod-schemas/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v0.0.82
+
+### 🩹 Fixes
+
+- Mark `AgentInstanceHistoryItemMetrics` sub-fields as nullable in preparation for the upcoming API contract change ([#57703](https://github.com/camunda/camunda/issues/57703)). The following fields are now nullable:
+  - `inputTokens`
+  - `outputTokens`
+  - `durationMs`
+
+### ❤️ Contributors
+
+- [@ce-dmelnych](https://github.com/ce-dmelnych)
+
 ## v0.0.81
 
 ### 🚀 Enhancements

--- a/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
+++ b/webapp/client/packages/camunda-api-zod-schemas/lib/8.10/agent-instance.ts
@@ -164,9 +164,9 @@ const agentInstanceToolCallSchema = z.object({
 type AgentInstanceToolCall = z.infer<typeof agentInstanceToolCallSchema>;
 
 const agentInstanceHistoryItemMetricsSchema = z.object({
-	inputTokens: z.number(),
-	outputTokens: z.number(),
-	durationMs: z.number(),
+	inputTokens: z.number().nullable(),
+	outputTokens: z.number().nullable(),
+	durationMs: z.number().nullable(),
 });
 type AgentInstanceHistoryItemMetrics = z.infer<typeof agentInstanceHistoryItemMetricsSchema>;
 

--- a/webapp/client/packages/camunda-api-zod-schemas/package.json
+++ b/webapp/client/packages/camunda-api-zod-schemas/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@camunda/camunda-api-zod-schemas",
-	"version": "0.0.81",
+	"version": "0.0.82",
 	"license": "LicenseRef-Camunda-1.0",
 	"description": "Zod schemas and TypeScript types for Camunda 8 unified API",
 	"author": "Vinicius Goulart <vinicius.goulart@camunda.com>",


### PR DESCRIPTION
## Description

[#55839](https://github.com/camunda/camunda/issues/55839) identified that the agent instance history Search API always returned a zeroed `metrics` object even when metrics were never provided. PR [#57682](https://github.com/camunda/camunda/pull/57682) fixes this by making the `metrics` object itself nullable, and additionally makes the individual sub-fields (`inputTokens`, `outputTokens`, `durationMs`) nullable — since a client may record only a subset of them.

This PR updates `@camunda/camunda-api-zod-schemas` to reflect that contract change in the TypeScript types before [#57682](https://github.com/camunda/camunda/pull/57682) lands, so frontend consumers can safely adopt the new types ahead of the backend change.

## Checklist

- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

Relates to #57703
Relates to #55839