### PR TITLE
test: add Operate decision-instance Business ID UI e2e coverage

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
@@ -9,7 +9,13 @@
 import {Page, Locator, expect} from '@playwright/test';
 
 type OptionalFilter =
-  'Process Instance Key' | 'Decision Instance Key(s)' | 'Evaluation Date Range';
+  | 'Process Instance Key'
+  | 'Decision Instance Key(s)'
+  | 'Business ID'
+  | 'Evaluation Date Range';
+
+export type AdvancedStringFilterOperator =
+  'equals' | 'does not equal' | 'contains' | 'is one of' | 'is not one of';
 
 interface SearchParams {
   evaluated?: string;
@@ -30,6 +36,8 @@ class OperateDecisionsPage {
   readonly evaluatedCheckbox: Locator;
   readonly failedCheckbox: Locator;
   readonly decisionInstancesList: Locator;
+  readonly businessIdFilter: Locator;
+  readonly businessIdFilterType: Locator;
   readonly getOptionByName: (name: string, exact?: boolean) => Locator;
 
   constructor(page: Page) {
@@ -57,6 +65,13 @@ class OperateDecisionsPage {
     this.evaluatedCheckbox = page.getByRole('checkbox', {name: 'Evaluated'});
     this.failedCheckbox = page.getByRole('checkbox', {name: 'Failed'});
     this.decisionInstancesList = page.getByTestId('data-list');
+    this.businessIdFilter = page.getByRole('textbox', {
+      name: 'Business ID',
+      exact: true,
+    });
+    this.businessIdFilterType = page.getByRole('combobox', {
+      name: 'Business ID filter type',
+    });
     this.getOptionByName = (name: string, exact = true) =>
       this.filterRegion.getByRole('option', {name, exact});
   }
@@ -127,6 +142,20 @@ class OperateDecisionsPage {
         name: filterName,
       })
       .click();
+  }
+
+  async fillBusinessIdFilter(value: string): Promise<void> {
+    await this.businessIdFilter.click();
+    await this.businessIdFilter.fill('');
+    await this.businessIdFilter.pressSequentially(value);
+    await expect(this.businessIdFilter).toHaveValue(value, {timeout: 30000});
+  }
+
+  async selectBusinessIdFilterType(
+    operator: AdvancedStringFilterOperator,
+  ): Promise<void> {
+    await this.businessIdFilterType.click();
+    await this.page.getByRole('option', {name: operator, exact: true}).click();
   }
 }
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts
@@ -14,8 +14,7 @@ type OptionalFilter =
   | 'Business ID'
   | 'Evaluation Date Range';
 
-export type AdvancedStringFilterOperator =
-  'equals' | 'does not equal' | 'contains' | 'is one of' | 'is not one of';
+export type AdvancedStringFilterOperator = 'equals' | 'contains' | 'is one of';
 
 interface SearchParams {
   evaluated?: string;
@@ -145,6 +144,8 @@ class OperateDecisionsPage {
   }
 
   async fillBusinessIdFilter(value: string): Promise<void> {
+    await expect(this.businessIdFilter).toBeVisible();
+    await expect(this.businessIdFilter).toBeEnabled();
     await this.businessIdFilter.click();
     await this.businessIdFilter.fill('');
     await this.businessIdFilter.pressSequentially(value);

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstancesBusinessId.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstancesBusinessId.spec.ts
@@ -8,7 +8,6 @@
 
 import {test} from 'fixtures';
 import {expect} from '@playwright/test';
-import {randomUUID} from 'crypto';
 import {deploy} from 'utils/zeebeClient';
 import {jsonHeaders} from 'utils/http';
 import {captureScreenshot, captureFailureVideo} from '@setup';
@@ -18,10 +17,11 @@ import {
   type AdvancedStringFilterOperator,
 } from '@pages/OperateDecisionsPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
+import {extendedAssertionOptions, uniqueBusinessId} from 'utils/constants';
 
 const DMN_PROCESS_ID = 'mammalAnimalProcess';
 
-const runPrefix = `ui-dec-bizid-${randomUUID().slice(0, 8)}`;
+const runPrefix = uniqueBusinessId('ui-dec-bizid');
 const BUSINESS_ID_A = `${runPrefix}-aaa`;
 const BUSINESS_ID_B = `${runPrefix}-zzz`;
 
@@ -38,6 +38,8 @@ async function startDmnProcessWithBusinessId(
     },
   });
   expect(res.status()).toBe(200);
+  const json = await res.json();
+  expect(json.processInstanceKey).toBeTruthy();
 }
 
 async function applyBusinessIdFilter(
@@ -169,7 +171,7 @@ test.describe('Decision Instances - Business ID', () => {
         operateDecisionsPage.decisionInstancesList
           .getByRole('row')
           .filter({hasText: runPrefix}),
-      ).toHaveCount(0);
+      ).toHaveCount(0, {timeout: extendedAssertionOptions.timeout});
     });
   });
 

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstancesBusinessId.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstancesBusinessId.spec.ts
@@ -168,9 +168,9 @@ test.describe('Decision Instances - Business ID', () => {
 
     await test.step('Verify no decision instances are shown', async () => {
       await expect(
-        operateDecisionsPage.decisionInstancesList
-          .getByRole('row')
-          .filter({hasText: runPrefix}),
+        operateDecisionsPage.decisionInstancesList.getByRole('link', {
+          name: /View decision instance/,
+        }),
       ).toHaveCount(0, {timeout: extendedAssertionOptions.timeout});
     });
   });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstancesBusinessId.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/operate/decisionInstancesBusinessId.spec.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {test} from 'fixtures';
+import {expect} from '@playwright/test';
+import {randomUUID} from 'crypto';
+import {deploy} from 'utils/zeebeClient';
+import {jsonHeaders} from 'utils/http';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToAppHome} from '@pages/UtilitiesPage';
+import {
+  OperateDecisionsPage,
+  type AdvancedStringFilterOperator,
+} from '@pages/OperateDecisionsPage';
+import {waitForAssertion} from 'utils/waitForAssertion';
+
+const DMN_PROCESS_ID = 'mammalAnimalProcess';
+
+const runPrefix = `ui-dec-bizid-${randomUUID().slice(0, 8)}`;
+const BUSINESS_ID_A = `${runPrefix}-aaa`;
+const BUSINESS_ID_B = `${runPrefix}-zzz`;
+
+async function startDmnProcessWithBusinessId(
+  request: import('@playwright/test').APIRequestContext,
+  businessId: string,
+): Promise<void> {
+  const res = await request.post('/v2/process-instances', {
+    headers: jsonHeaders(),
+    data: {
+      processDefinitionId: DMN_PROCESS_ID,
+      businessId,
+      variables: {hasHairOrFur: true, warmBlooded: true, givesMilk: true},
+    },
+  });
+  expect(res.status()).toBe(200);
+}
+
+async function applyBusinessIdFilter(
+  operateDecisionsPage: OperateDecisionsPage,
+  value: string,
+  operator?: AdvancedStringFilterOperator,
+) {
+  await operateDecisionsPage.displayOptionalFilter('Business ID');
+  if (operator) {
+    await operateDecisionsPage.selectBusinessIdFilterType(operator);
+  }
+  await operateDecisionsPage.fillBusinessIdFilter(value);
+}
+
+test.beforeAll(async ({request}) => {
+  await deploy([
+    './resources/mammalAnimalProcess.bpmn',
+    './resources/isMammal_.dmn',
+  ]);
+
+  await startDmnProcessWithBusinessId(request, BUSINESS_ID_A);
+  await startDmnProcessWithBusinessId(request, BUSINESS_ID_B);
+
+  await test.step('Wait for both decision instances to be indexed', async () => {
+    await expect
+      .poll(
+        async () => {
+          const response = await request.post('/v2/decision-instances/search', {
+            headers: jsonHeaders(),
+            data: {filter: {businessId: {$like: `${runPrefix}-*`}}},
+          });
+          if (response.status() !== 200) return 0;
+          const result = await response.json();
+          return result.page?.totalItems ?? 0;
+        },
+        {timeout: 60_000, intervals: [2_000, 5_000]},
+      )
+      .toBeGreaterThanOrEqual(2);
+  });
+});
+
+test.describe('Decision Instances - Business ID', () => {
+  test.beforeEach(async ({page, operateHomePage}) => {
+    await navigateToAppHome(page, 'operate');
+    await expect(operateHomePage.operateBanner).toBeVisible();
+    await operateHomePage.clickDecisionsTab();
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Filter decision instances by Business ID (equals)', async ({
+    page,
+    operateDecisionsPage,
+  }) => {
+    await test.step('Apply the Business ID equals filter', async () => {
+      await applyBusinessIdFilter(operateDecisionsPage, BUSINESS_ID_A);
+    });
+
+    await test.step('Verify only the matching decision instance is shown', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          const rowA = operateDecisionsPage.decisionInstancesList
+            .getByRole('row')
+            .filter({hasText: BUSINESS_ID_A});
+          await expect(rowA).toBeVisible();
+          await expect(rowA.getByTestId('cell-businessId')).toHaveText(
+            BUSINESS_ID_A,
+          );
+          await expect(
+            operateDecisionsPage.decisionInstancesList
+              .getByRole('row')
+              .filter({hasText: BUSINESS_ID_B}),
+          ).toHaveCount(0);
+        },
+        onFailure: async () => {
+          await page.reload();
+          await applyBusinessIdFilter(operateDecisionsPage, BUSINESS_ID_A);
+        },
+      });
+    });
+  });
+
+  test('Filter decision instances by Business ID (contains)', async ({
+    page,
+    operateDecisionsPage,
+  }) => {
+    await test.step('Apply the Business ID contains filter', async () => {
+      await applyBusinessIdFilter(operateDecisionsPage, runPrefix, 'contains');
+    });
+
+    await test.step('Verify both decision instances sharing the prefix are shown', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            operateDecisionsPage.decisionInstancesList
+              .getByRole('row')
+              .filter({hasText: BUSINESS_ID_A}),
+          ).toBeVisible();
+          await expect(
+            operateDecisionsPage.decisionInstancesList
+              .getByRole('row')
+              .filter({hasText: BUSINESS_ID_B}),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await applyBusinessIdFilter(
+            operateDecisionsPage,
+            runPrefix,
+            'contains',
+          );
+        },
+      });
+    });
+  });
+
+  test('Filter decision instances by a non-matching Business ID shows no results', async ({
+    operateDecisionsPage,
+  }) => {
+    await test.step('Apply a Business ID filter that matches nothing', async () => {
+      await applyBusinessIdFilter(operateDecisionsPage, `${runPrefix}-none`);
+    });
+
+    await test.step('Verify no decision instances are shown', async () => {
+      await expect(
+        operateDecisionsPage.decisionInstancesList
+          .getByRole('row')
+          .filter({hasText: runPrefix}),
+      ).toHaveCount(0);
+    });
+  });
+
+  test('Decision instance detail shows the Business ID', async ({
+    page,
+    operateDecisionsPage,
+    operateDecisionInstancePage,
+  }) => {
+    const rowA = operateDecisionsPage.decisionInstancesList
+      .getByRole('row')
+      .filter({hasText: BUSINESS_ID_A});
+
+    await test.step('Filter to the target decision instance by Business ID', async () => {
+      await applyBusinessIdFilter(operateDecisionsPage, BUSINESS_ID_A);
+
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(rowA).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+          await applyBusinessIdFilter(operateDecisionsPage, BUSINESS_ID_A);
+        },
+      });
+    });
+
+    await test.step('Open the matching decision instance detail', async () => {
+      await rowA.getByRole('link', {name: /View decision instance/}).click();
+    });
+
+    await test.step('Verify the detail header shows the Business ID', async () => {
+      await expect(operateDecisionInstancePage.instanceHeader).toBeVisible();
+      await expect(
+        operateDecisionInstancePage.instanceHeader.getByText(BUSINESS_ID_A),
+      ).toBeVisible();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds **UI e2e** (Playwright) coverage for **Business ID on Operate decision instances**, part of Priority 1 of the UI automation for the Business ID Visibility and Filtering epic ([product-hub#3436](https://github.com/camunda/product-hub/issues/3436)).

The cross-component Operate/Tasklist UI e2e suite had **no Business ID coverage**. This is PR **B** of three (A = process instances #57716, C = Tasklist).

## What is covered

Decision instances inherit the owning process instance's `businessId`. The test seeds two instances of `mammalAnimalProcess` (business rule task → `isMammal` DMN) with distinct Business IDs via the v2 REST API, then drives the real Operate **Decisions** UI:

1. **Filter by Business ID (equals)** → only the matching decision instance is listed, its `Business ID` cell shows the value, the non-matching one is absent.
2. **Filter by Business ID (contains)** → both instances (sharing the run-unique prefix) are listed.
3. **Non-matching Business ID** → no results.
4. **Decision instance detail** shows the Business ID in the instance header.

## Page object

Extends [OperateDecisionsPage](qa/c8-orchestration-cluster-e2e-test-suite/pages/OperateDecisionsPage.ts) with the `Business ID` optional filter (More Filters menu) and the `AdvancedStringFilter` interactions (`fillBusinessIdFilter`, `selectBusinessIdFilterType`) — mirroring the process-instance page object in PR A.

## Notes

- **Seeding:** instances are created via `POST /v2/process-instances` with `businessId` (using the suite's `demo:demo` basic auth via `jsonHeaders()`), because the `@camunda8/sdk` client used by `zeebeClient` does not yet expose `businessId`. Same approach as the existing decision filter spec.
- Each run uses a unique Business ID prefix (`aaa`/`zzz`) so it isolates its own data via the `contains` filter.
- The `mammalAnimalProcess` instances self-complete after evaluation, so no cleanup is required.

## Testing

- `tsc`, `eslint` (0 errors / 0 warnings), `check:testrail-ids`, prettier — all pass.
- ⚠️ **Runtime not validated locally** — UI e2e needs the full cluster + browsers (nightly UI workflow). Selectors were derived from the legacy Operate source this suite runs against, but a cluster run is needed to confirm.

### Related
- Epic: [product-hub#3436](https://github.com/camunda/product-hub/issues/3436)
- Priority 1 sibling PRs: #57716 (process instances), Tasklist (to follow)



Test Rail test cases
https://camunda.testrail.com/index.php?/suites/view/17028&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=678356

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview