### PR TITLE
test: add Tasklist Business ID UI e2e coverage

### DIFF
--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/taskBusinessId.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/taskBusinessId.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {expect} from '@playwright/test';
+import {publicTest as test} from 'fixtures';
+import {randomUUID} from 'crypto';
+import {deploy, cancelProcessInstance} from 'utils/zeebeClient';
+import {jsonHeaders} from 'utils/http';
+import {captureScreenshot, captureFailureVideo} from '@setup';
+import {navigateToApp} from '@pages/UtilitiesPage';
+import {waitForAssertion} from 'utils/waitForAssertion';
+import {clearAllProcessInstances} from '@requestHelpers';
+
+const USER_TASK_PROCESS_ID = 'user_task_api_test_process';
+
+const BUSINESS_ID = `ui-task-bizid-${randomUUID().slice(0, 8)}`;
+
+let instanceKey: string | undefined;
+
+async function startInstanceWithBusinessId(
+  request: import('@playwright/test').APIRequestContext,
+  businessId: string,
+): Promise<string> {
+  const res = await request.post('/v2/process-instances', {
+    headers: jsonHeaders(),
+    data: {processDefinitionId: USER_TASK_PROCESS_ID, businessId},
+  });
+  if (res.status() !== 200) {
+    console.error('Unexpected status code:', res.status(), await res.text());
+  }
+  expect(res.status()).toBe(200);
+  const json = await res.json();
+  expect(json.processInstanceKey).toBeTruthy();
+  return String(json.processInstanceKey);
+}
+
+test.beforeAll(async ({request}) => {
+  await clearAllProcessInstances(request);
+  await deploy(['./resources/user_task_api_test_process.bpmn']);
+  instanceKey = await startInstanceWithBusinessId(request, BUSINESS_ID);
+});
+
+test.afterAll(async () => {
+  if (instanceKey) {
+    await cancelProcessInstance(instanceKey);
+  }
+});
+
+test.describe('Tasklist - Business ID', () => {
+  test.beforeEach(async ({page, loginPage}) => {
+    await navigateToApp(page, 'tasklist');
+    await loginPage.login('demo', 'demo');
+    await expect(page).toHaveURL('/tasklist');
+  });
+
+  test.afterEach(async ({page}, testInfo) => {
+    await captureScreenshot(page, testInfo);
+    await captureFailureVideo(page, testInfo);
+  });
+
+  test('Task list shows the Business ID', async ({page, taskPanelPage}) => {
+    await test.step('Verify the task card shows the Business ID', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(
+            taskPanelPage.taskCards.filter({hasText: BUSINESS_ID}),
+          ).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+  });
+
+  test('Task detail shows the Business ID', async ({
+    page,
+    taskPanelPage,
+    taskDetailsPage,
+  }) => {
+    const taskCard = taskPanelPage.taskCards.filter({hasText: BUSINESS_ID});
+
+    await test.step('Locate the task card by Business ID', async () => {
+      await waitForAssertion({
+        assertion: async () => {
+          await expect(taskCard).toBeVisible();
+        },
+        onFailure: async () => {
+          await page.reload();
+        },
+      });
+    });
+
+    await test.step('Open the task detail', async () => {
+      await taskCard.click();
+    });
+
+    await test.step('Verify the detail panel shows the Business ID label and value', async () => {
+      await expect(taskDetailsPage.detailsPanel).toBeVisible();
+      await expect(
+        taskDetailsPage.detailsPanel.getByText('Business ID', {exact: true}),
+      ).toBeVisible();
+      await expect(
+        taskDetailsPage.detailsPanel.getByText(BUSINESS_ID),
+      ).toBeVisible();
+    });
+  });
+});

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/taskBusinessId.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/taskBusinessId.spec.ts
@@ -13,7 +13,6 @@ import {jsonHeaders} from 'utils/http';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
-import {clearAllProcessInstances} from '@requestHelpers';
 import {uniqueBusinessId} from 'utils/constants';
 
 const USER_TASK_PROCESS_ID = 'user_task_api_test_process';
@@ -40,7 +39,6 @@ async function startInstanceWithBusinessId(
 }
 
 test.beforeAll(async ({request}) => {
-  await clearAllProcessInstances(request);
   await deploy(['./resources/user_task_api_test_process.bpmn']);
   instanceKey = await startInstanceWithBusinessId(request, BUSINESS_ID);
 });

--- a/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/taskBusinessId.spec.ts
+++ b/qa/c8-orchestration-cluster-e2e-test-suite/tests/tasklist/taskBusinessId.spec.ts
@@ -8,17 +8,17 @@
 
 import {expect} from '@playwright/test';
 import {publicTest as test} from 'fixtures';
-import {randomUUID} from 'crypto';
 import {deploy, cancelProcessInstance} from 'utils/zeebeClient';
 import {jsonHeaders} from 'utils/http';
 import {captureScreenshot, captureFailureVideo} from '@setup';
 import {navigateToApp} from '@pages/UtilitiesPage';
 import {waitForAssertion} from 'utils/waitForAssertion';
 import {clearAllProcessInstances} from '@requestHelpers';
+import {uniqueBusinessId} from 'utils/constants';
 
 const USER_TASK_PROCESS_ID = 'user_task_api_test_process';
 
-const BUSINESS_ID = `ui-task-bizid-${randomUUID().slice(0, 8)}`;
+const BUSINESS_ID = uniqueBusinessId('ui-task-bizid');
 
 let instanceKey: string | undefined;
 
@@ -46,9 +46,16 @@ test.beforeAll(async ({request}) => {
 });
 
 test.afterAll(async () => {
-  if (instanceKey) {
-    await cancelProcessInstance(instanceKey);
-  }
+  const keys = [instanceKey].filter((key): key is string => Boolean(key));
+  await Promise.allSettled(
+    keys.map(async (key) => {
+      try {
+        await cancelProcessInstance(key);
+      } catch (error) {
+        console.warn(`Failed to cancel process instance ${key}:`, error);
+      }
+    }),
+  );
 });
 
 test.describe('Tasklist - Business ID', () => {


### PR DESCRIPTION
## Description

Adds **UI e2e** (Playwright) coverage for **Business ID in Tasklist**, completing Priority 1 of the UI automation for the Business ID Visibility and Filtering epic ([product-hub#3436](https://github.com/camunda/product-hub/issues/3436)).

This is PR **C** of three (A = process instances #57716, B = decision instances #57722).

## What is covered

The test seeds a user-task instance with a Business ID via the v2 REST API (the user task inherits the owning instance's Business ID), then drives the real Tasklist UI:

1. **Task list shows the Business ID** — the task card in the available-tasks panel displays the Business ID value.
2. **Task detail shows the Business ID** — opening the task shows a `Business ID` entry with the value in the task details right panel.

## Notes

- **Seeding:** the instance is created via `POST /v2/process-instances` with `businessId` (using the suite's `demo:demo` basic auth via `jsonHeaders()`), because the `@camunda8/sdk` client used by `zeebeClient` does not expose `businessId`.
- `beforeAll` uses `clearAllProcessInstances` (same pattern as the existing task-panel spec) so the seeded task is the only one in the panel and can be located deterministically by its unique Business ID.
- The instance is cancelled (guarded) in `afterAll`.
- **Scope:** the advanced *custom filter* by Business ID in Tasklist is intentionally not covered here — it already has dedicated coverage in the orchestration-cluster webapp integration/visual tests (`webapp/client/apps/orchestration-cluster-webapp/test/`). This PR fills the gap in the cross-component (real cluster) suite: Business ID **display** in the list and details.

## Testing

- `tsc`, `eslint` (0 errors / 0 warnings), `check:testrail-ids`, prettier — all pass.
- ⚠️ **Runtime not validated locally** — UI e2e needs the full cluster + browsers (nightly UI workflow). Selectors were derived from the Tasklist source this suite runs against, but a cluster run is needed to confirm.

### Related
- Epic: [product-hub#3436](https://github.com/camunda/product-hub/issues/3436)
- Priority 1 sibling PRs: #57716 (process instances), #57722 (decision instances)


Test Rail test cases
https://camunda.testrail.com/index.php?/suites/view/17028&group_by=cases:section_id&group_order=asc&display=compact&display_deleted_cases=0&group_id=678356

Confluence Automated Testing Distributions Overview
https://confluence.camunda.com/spaces/HAN/pages/262669277/Automated+Testing+Distributions+Overview
