### PR TITLE
feat: only poll agent instances for running process instances

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanelTabs/DetailsTab/index.tsx
@@ -35,6 +35,7 @@ import {
 } from './styled';
 import {StructuredList} from 'modules/components/StructuredList';
 import {useProcessInstance} from 'modules/queries/processInstance/useProcessInstance';
+import {useIsProcessInstanceRunning} from 'modules/queries/processInstance/useIsProcessInstanceRunning';
 import {useAgentInstancesForElement} from 'modules/queries/agentInstances/useAgentInstancesForElement';
 import {AgentDetails} from './AgentDetails';
 import {useProcessInstancePageParams} from '../../useProcessInstancePageParams';
@@ -70,6 +71,7 @@ const DetailsTab: React.FC = () => {
   const isProcessScope = !hasSelection;
 
   const {data: processInstance} = useProcessInstance();
+  const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
   const {data: xmlData} = useProcessInstanceXml({
     processDefinitionKey: processInstance?.processDefinitionKey,
   });
@@ -95,7 +97,7 @@ const DetailsTab: React.FC = () => {
     enabled:
       clientConfig.waitStatesEnabled &&
       !!inspectionElementInstanceKey &&
-      processInstance?.state === 'ACTIVE' &&
+      isProcessInstanceRunning &&
       (isProcessScope || resolvedElementInstance?.state === 'ACTIVE'),
   });
 
@@ -179,7 +181,7 @@ const DetailsTab: React.FC = () => {
     elementId: effectiveElementId ?? '',
     elementInstanceKey,
     enabled: !!processInstance?.processInstanceKey && !!effectiveElementId,
-    enablePeriodicRefetch: true,
+    enablePeriodicRefetch: isProcessInstanceRunning,
   });
   const showAgentInstance =
     (agentInstancesResult && agentInstancesResult.items.length > 0) ||

--- a/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
+++ b/operate/client/src/modules/queries/agentInstances/useProcessInstanceAgentInstances.ts
@@ -10,9 +10,11 @@ import {useQuery} from '@tanstack/react-query';
 import {useProcessInstancePageParams} from 'App/ProcessInstance/useProcessInstancePageParams';
 import {agentInstancesSearchOptions} from './agentInstancesSearch';
 import {ACTIVE_STATUSES_ARRAY} from './agentInstanceStatus';
+import {useIsProcessInstanceRunning} from '../processInstance/useIsProcessInstanceRunning';
 
 const useProcessInstanceAgentInstances = () => {
   const {processInstanceId} = useProcessInstancePageParams();
+  const {data: isProcessInstanceRunning} = useIsProcessInstanceRunning();
 
   return useQuery({
     ...agentInstancesSearchOptions({
@@ -25,7 +27,7 @@ const useProcessInstanceAgentInstances = () => {
       },
     }),
     enabled: !!processInstanceId,
-    refetchInterval: 5000,
+    refetchInterval: isProcessInstanceRunning ? 5000 : undefined,
     staleTime: 5000,
   });
 };


### PR DESCRIPTION
## Description

Changes the polling configuration for `useProcessInstanceAgentInstances` and `useAgentInstancesForElement` to only poll data when the process instance is running.

## Related issues

closes #57380
