### PR TITLE
fix: remove hardcoded ES refresh_interval from operate-list-view template

### DIFF
--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
@@ -1,7 +1,6 @@
  {
 	"settings": {
 		"index": {
-			"refresh_interval": "2s",
 			"analysis": {
 				"normalizer": {
 					"case_insensitive": {


### PR DESCRIPTION
## Summary

`operate-list-view.json` was the only Camunda Exporter index template (across both ES and OS) with an explicit `refresh_interval` override (`2s`). All other indices rely on the engine's default (`1s`) via the config-driven overlay (`IndexConfiguration.refreshInterval` / `DocumentBasedSecondaryStorageDatabase.refreshInterval`), which is a no-op when unset.

Removing it makes the template consistent with every other index and lets ES fall back to its 1s default, improving data-visibility latency for the list-view index.

Load-tested (ES) comparing `main` vs this branch at two scenarios:

- **Typical (~50 PI/s, well within cluster capacity)**: data-availability p99, completion-ratio, backpressure, and request-response latency all matched or beat baseline across multiple runs. No regression.
- **Max (~300 PI/s, saturating cluster)**: at this rate, client-side metrics converge for both baseline and branch. Checked ES-side metrics:
  - Branch shows more CPU throttling (avg increase of 20-200% increase based on the benchmark run) and more refreshes/sec, as expected from refreshing twice as often.
  - Branch also runs a bit more Lucene segments, more merges/sec, and more merge-throttle time than baseline — a coherent causal chain (more frequent refresh → more segments → more merging → more CPU throttling) that explains the CPU cost mechanistically.

**Summary**: no observable impact at realistic/typical load (only a small improvement in data availability). Under sustained heavy write pressure, the shorter refresh interval does cost measurably more ES CPU (via more segments/merges/throttling), which is the expected tradeoff of any `refresh_interval` decrease.

Closes #44560

## Test plan

- [x] Load-tested `main` vs branch (typical scenario, ES, ~50 PI/s) — data-availability, completion-ratio, backpressure, request-response latency all steady/improved
- [x] Load-tested `main` vs branch (max scenario, ES, ~300 PI/s, equal ES node count confirmed) — CPU throttling, segment count, and merge rate higher on branch, consistent with more frequent refreshing