### PR TITLE
feat: add Phase 2 applier-layer foundation and MemberJoinApplier

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeApplier.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model counterpart of {@code ConfigurationChangeAppliers.ClusterOperationApplier}, scoped to
+ * {@link GlobalConfiguration}. Applies a {@code GlobalChangeOperation}.
+ */
+public interface GlobalConfigurationChangeApplier {
+
+  /**
+   * Called before {@link #apply()}. Validates the operation and returns a transform that marks the
+   * start of the operation (e.g. adding the member in {@code JOINING} state).
+   *
+   * @param currentClusterConfiguration the current state of the whole cluster: cluster-wide broker
+   *     lifecycle plus every partition group. Some global operations (e.g. leaving the cluster)
+   *     must be validated against partition assignment across every group, which {@link
+   *     GlobalConfiguration} alone does not carry.
+   * @return an either containing an exception if the operation is invalid, or a transform to update
+   *     the global configuration
+   */
+  Either<Exception, UnaryOperator<GlobalConfiguration>> init(
+      CurrentClusterConfiguration currentClusterConfiguration);
+
+  /**
+   * Performs the operation, possibly asynchronously, and completes with a transform that marks the
+   * operation as completed (e.g. moving the member to {@code ACTIVE}).
+   *
+   * @return a future completed with the transform once the operation succeeds, or completed
+   *     exceptionally on failure
+   */
+  ActorFuture<UnaryOperator<GlobalConfiguration>> apply();
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliers.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliers.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
+
+/**
+ * New-model counterpart of {@code ConfigurationChangeAppliers}, dispatching a {@link
+ * GlobalChangeOperation} to its {@link GlobalConfigurationChangeApplier}.
+ */
+@FunctionalInterface
+public interface GlobalConfigurationChangeAppliers {
+
+  GlobalConfigurationChangeApplier getApplier(GlobalChangeOperation operation);
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/GlobalConfigurationChangeAppliersImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.dynamic.config.changes.appliers.MemberJoinApplier;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.GlobalChangeOperation.MemberJoinOperation;
+
+public final class GlobalConfigurationChangeAppliersImpl
+    implements GlobalConfigurationChangeAppliers {
+
+  private final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor;
+
+  public GlobalConfigurationChangeAppliersImpl(
+      final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor) {
+    this.clusterMembershipChangeExecutor = clusterMembershipChangeExecutor;
+  }
+
+  @Override
+  public GlobalConfigurationChangeApplier getApplier(final GlobalChangeOperation operation) {
+    return switch (operation) {
+      case final MemberJoinOperation op ->
+          new MemberJoinApplier(op.memberId(), clusterMembershipChangeExecutor);
+      default ->
+          throw new UnsupportedOperationException(
+              "No new-model applier implemented yet for %s".formatted(operation));
+    };
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeApplier.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model counterpart of {@code ConfigurationChangeAppliers.ClusterOperationApplier}, scoped to a
+ * single named {@link PartitionGroupConfiguration}. Applies a {@code PartitionGroupOperation}.
+ *
+ * <p>The applier is group-agnostic: it operates on whichever {@link PartitionGroupConfiguration} it
+ * is given. Selecting the target group (by group id) and writing the result back via {@code
+ * CurrentClusterConfiguration#updatePartitionGroupConfig} is the caller's responsibility.
+ *
+ * <p>{@link #init} also receives the current {@link GlobalConfiguration}, since broker lifecycle
+ * (e.g. whether the local broker is an {@code ACTIVE} member of the cluster at all) is a
+ * cluster-wide concern tracked there, not in any single partition group.
+ */
+public interface PartitionGroupConfigurationChangeApplier {
+
+  /**
+   * Called before {@link #apply()}. Validates the operation and returns a transform that marks the
+   * start of the operation (e.g. adding the partition in {@code JOINING} state).
+   *
+   * @param currentGlobalConfiguration the current cluster-wide broker lifecycle state
+   * @param currentPartitionGroupConfiguration the current state of the target partition group
+   * @return an either containing an exception if the operation is invalid, or a transform to update
+   *     the partition group configuration
+   */
+  Either<Exception, UnaryOperator<PartitionGroupConfiguration>> init(
+      GlobalConfiguration currentGlobalConfiguration,
+      PartitionGroupConfiguration currentPartitionGroupConfiguration);
+
+  /**
+   * Performs the operation, possibly asynchronously, and completes with a transform that marks the
+   * operation as completed (e.g. moving the partition to {@code ACTIVE}).
+   *
+   * @return a future completed with the transform once the operation succeeds, or completed
+   *     exceptionally on failure
+   */
+  ActorFuture<UnaryOperator<PartitionGroupConfiguration>> apply();
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliers.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliers.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+
+/**
+ * New-model counterpart of {@code ConfigurationChangeAppliers}, dispatching a {@link
+ * PartitionGroupOperation} to its {@link PartitionGroupConfigurationChangeApplier}.
+ */
+@FunctionalInterface
+public interface PartitionGroupConfigurationChangeAppliers {
+
+  PartitionGroupConfigurationChangeApplier getApplier(PartitionGroupOperation operation);
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionGroupConfigurationChangeAppliersImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.dynamic.config.state.PartitionGroupOperation;
+
+public final class PartitionGroupConfigurationChangeAppliersImpl
+    implements PartitionGroupConfigurationChangeAppliers {
+
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  public PartitionGroupConfigurationChangeAppliersImpl(
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public PartitionGroupConfigurationChangeApplier getApplier(
+      final PartitionGroupOperation operation) {
+    throw new UnsupportedOperationException(
+        "No new-model applier implemented yet for %s".formatted(operation));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberJoinApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberJoinApplier.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.GlobalConfigurationChangeApplier;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+/**
+ * New-model applier for {@code GlobalChangeOperation.MemberJoinOperation}, operating on {@link
+ * GlobalConfiguration} instead of the legacy {@code ClusterConfiguration}. Mirrors the legacy
+ * {@code MemberJoinApplier} in {@code changes/}, which this does not replace or modify.
+ *
+ * <p>Unlike the legacy {@code ClusterConfiguration#updateMember}, which upserts (adds if absent,
+ * updates if present) via a single method, {@link GlobalConfiguration#addMember} and {@link
+ * GlobalConfiguration#updateMember} are split and each fail on the wrong precondition. This applier
+ * is therefore responsible for choosing between them, rather than that choice being hidden inside a
+ * shared update method as in the legacy model.
+ */
+public final class MemberJoinApplier implements GlobalConfigurationChangeApplier {
+
+  private final MemberId memberId;
+  private final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor;
+
+  public MemberJoinApplier(
+      final MemberId memberId,
+      final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor) {
+    this.memberId = memberId;
+    this.clusterMembershipChangeExecutor = clusterMembershipChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<GlobalConfiguration>> init(
+      final CurrentClusterConfiguration currentClusterConfiguration) {
+    final var currentGlobalConfiguration = currentClusterConfiguration.globalConfiguration();
+    if (currentGlobalConfiguration.hasMember(memberId)) {
+      final var currentState = currentGlobalConfiguration.getMember(memberId).state();
+      if (currentState != State.JOINING) {
+        return Either.left(
+            new IllegalStateException(
+                "Expected to join member %s, but the member is already part of the cluster"
+                    .formatted(memberId)));
+      }
+      // Already JOINING: this can happen if the node restarted while applying the join operation.
+      // To ensure that the configuration change can make progress, we do not treat this as an
+      // error.
+      return Either.right(UnaryOperator.identity());
+    }
+
+    return Either.right(
+        config -> config.addMember(memberId, BrokerState.uninitialized().setState(State.JOINING)));
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<GlobalConfiguration>> apply() {
+    final var future = new CompletableActorFuture<UnaryOperator<GlobalConfiguration>>();
+    clusterMembershipChangeExecutor
+        .addBroker(memberId)
+        .onComplete(
+            (ignored, error) -> {
+              if (error == null) {
+                future.complete(
+                    config ->
+                        config.updateMember(memberId, broker -> broker.setState(State.ACTIVE)));
+              } else {
+                future.completeExceptionally(error);
+              }
+            });
+    return future;
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberJoinApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/appliers/MemberJoinApplierTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes.appliers;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
+import io.camunda.zeebe.dynamic.config.state.BrokerState;
+import io.camunda.zeebe.dynamic.config.state.BrokerState.State;
+import io.camunda.zeebe.dynamic.config.state.CurrentClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.GlobalConfiguration;
+import io.camunda.zeebe.dynamic.config.state.PhasedChangeState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Map;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class MemberJoinApplierTest {
+
+  private final MemberId memberId = MemberId.from("1");
+  private final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor =
+      new NoopClusterMembershipChangeExecutor();
+
+  private static GlobalConfiguration globalConfigurationWith(
+      final Map<MemberId, BrokerState> members) {
+    return new GlobalConfiguration(
+        GlobalConfiguration.INITIAL_VERSION,
+        Optional.empty(),
+        members,
+        Optional.empty(),
+        Optional.empty(),
+        Optional.empty());
+  }
+
+  private static CurrentClusterConfiguration currentClusterConfigurationWith(
+      final GlobalConfiguration globalConfiguration) {
+    return new CurrentClusterConfiguration(
+        CurrentClusterConfiguration.INITIAL_VERSION,
+        globalConfiguration,
+        Map.of(),
+        PhasedChangeState.empty());
+  }
+
+  @Test
+  void shouldAddNewMemberAsJoining() {
+    // given
+    final var initialConfig = globalConfigurationWith(Map.of());
+    final var applier = new MemberJoinApplier(memberId, clusterMembershipChangeExecutor);
+
+    // when
+    final var result = applier.init(currentClusterConfigurationWith(initialConfig));
+
+    // then
+    assertThat(result).isRight();
+    final var updatedConfig = result.get().apply(initialConfig);
+    Assertions.assertThat(updatedConfig.hasMember(memberId)).isTrue();
+    Assertions.assertThat(updatedConfig.getMember(memberId).state()).isEqualTo(State.JOINING);
+  }
+
+  @Test
+  void shouldRejectJoinIfMemberIsAlreadyActive() {
+    // given
+    final var initialConfig =
+        globalConfigurationWith(Map.of(memberId, BrokerState.initializeAsActive()));
+    final var applier = new MemberJoinApplier(memberId, clusterMembershipChangeExecutor);
+
+    // when
+    final var result = applier.init(currentClusterConfigurationWith(initialConfig));
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("already part of the cluster");
+  }
+
+  @Test
+  void shouldNotFailOnInitIfMemberIsAlreadyJoining() {
+    // given — restart-safe retry: the member was already marked JOINING before a restart
+    final var initialConfig =
+        globalConfigurationWith(
+            Map.of(memberId, BrokerState.uninitialized().setState(State.JOINING)));
+    final var applier = new MemberJoinApplier(memberId, clusterMembershipChangeExecutor);
+
+    // when
+    final var result = applier.init(currentClusterConfigurationWith(initialConfig));
+
+    // then
+    assertThat(result).isRight();
+    final var updatedConfig = result.get().apply(initialConfig);
+    Assertions.assertThat(updatedConfig.getMember(memberId).state()).isEqualTo(State.JOINING);
+  }
+
+  @Test
+  void shouldExecuteJoinCallback() {
+    // given
+    final var initialConfig = globalConfigurationWith(Map.of());
+    final var applier = new MemberJoinApplier(memberId, clusterMembershipChangeExecutor);
+    final var configWithJoining =
+        applier.init(currentClusterConfigurationWith(initialConfig)).get().apply(initialConfig);
+
+    // when
+    final var resultingConfig = applier.apply().join().apply(configWithJoining);
+
+    // then
+    Assertions.assertThat(resultingConfig.getMember(memberId).state()).isEqualTo(State.ACTIVE);
+  }
+
+  @Test
+  void shouldReturnExceptionWhenJoinFailed() {
+    // given
+    final ClusterMembershipChangeExecutor failingExecutor =
+        new ClusterMembershipChangeExecutor() {
+          @Override
+          public ActorFuture<Void> addBroker(final MemberId memberId) {
+            return CompletableActorFuture.completedExceptionally(new RuntimeException("Expected"));
+          }
+
+          @Override
+          public ActorFuture<Void> removeBroker(final MemberId memberId) {
+            return CompletableActorFuture.completed(null);
+          }
+        };
+    final var applier = new MemberJoinApplier(memberId, failingExecutor);
+
+    // when
+    final var joinFuture = applier.apply();
+
+    // then
+    Assertions.assertThat(joinFuture)
+        .failsWithin(java.time.Duration.ofMillis(100))
+        .withThrowableOfType(java.util.concurrent.ExecutionException.class)
+        .withCauseInstanceOf(RuntimeException.class)
+        .withMessageContaining("Expected");
+  }
+}


### PR DESCRIPTION
## Summary
- First slice of the Phase 2 applier-layer work for #56018
- Introduces the new-model applier interfaces (`GlobalConfigurationChangeApplier`, `PartitionGroupConfigurationChangeApplier`) and their dispatch tables, alongside the legacy appliers they will eventually replace.
- Ports `MemberJoinOperation` as the first operation, in a new `changes.appliers` sub-package to avoid name collisions with the legacy `MemberJoinApplier`.
- No existing production behavior changes: legacy appliers and gossip remain untouched; new appliers are unit-tested only, not yet wired into production.

Follow-up PRs will port the remaining operations one at a time.

related to #57717