### PR TITLE
fix: stop SegmentedJournal.close() from unmapping during reads

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -244,8 +244,14 @@ public final class SegmentedJournal implements Journal {
     } catch (final FlushException e) {
       LOGGER.warn("Failed to flush when closing", e);
     }
-    segments.close();
-    open = false;
+
+    final var stamp = rwlock.writeLock();
+    try {
+      open = false;
+      segments.close();
+    } finally {
+      rwlock.unlockWrite(stamp);
+    }
   }
 
   /**

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -1049,6 +1049,36 @@ class SegmentedJournalTest {
         .hasMessage("Nope, no free space.");
   }
 
+  @Test
+  void shouldCloseSegmentsWhileHoldingWriteLock() {
+    // given
+    journalFactory = new TestJournalFactory("test", 2);
+    final var segments = spy(journalFactory.segmentsManager(directory));
+    final var barrier = new Phaser(2);
+    doAnswer(
+            invocation -> {
+              barrier.arriveAndAwaitAdvance(); // signal we are inside segments.close()
+              barrier.arriveAndAwaitAdvance(); // wait for the test to inspect the lock
+              return invocation.callRealMethod();
+            })
+        .when(segments)
+        .close();
+    journal = journalFactory.journal(segments);
+    journal.append(journalFactory.entry());
+
+    // when
+    final var closed = CompletableFuture.runAsync(() -> journal.close());
+
+    // then
+    barrier.arriveAndAwaitAdvance();
+    assertThat(journal.rwlock().isWriteLocked()).isTrue();
+    assertThat(journal.rwlock().tryReadLock())
+        .describedAs("a reader cannot acquire the read lock while close() unmaps segments")
+        .isZero();
+    barrier.arrive();
+    assertThat(closed).succeedsWithin(Duration.ofSeconds(5));
+  }
+
   private SegmentedJournal openJournal(final int entriesPerSegment) {
     return openJournal("test", entriesPerSegment);
   }


### PR DESCRIPTION
It was previously possible for concurrent readers to access segments that had been unmapped, because the close method didn't take any lock. Depending on the exact interleaving, this could either produce an exception or a segfault.

It's sufficient for us to guard the actual close operation with a write-lock - we don't need to wrap the flush operation in this too (and can't easily, since the lock isn't reentrant). Write operations are managed by a single thread, so we only need to guard against concurrent reads.

Closes #57702.