### PR TITLE
docs: rename Monorepo DevOps team to EngOps

### DIFF
--- a/.ci/scripts/ci/setup-medic-lookup.sh
+++ b/.ci/scripts/ci/setup-medic-lookup.sh
@@ -51,7 +51,7 @@ lookupTeamMedic["@camunda/qa-engineering"]=$qaMedic
 
 # @monorepo-ci-medic
 monorepoCIMedic="<!subteam^S07D6C6B18T|monorepo-ci-medic>"
-lookupTeamMedic["@camunda/monorepo-devops-team"]=$monorepoCIMedic
+lookupTeamMedic["@camunda/engineering-operations"]=$monorepoCIMedic
 
 # failure in QA test
 lookupTeamMedic["QA"]="QA Acceptance Test, requires investigation"

--- a/.ci/scripts/stale-backport-scripts/format-slack-report.sh
+++ b/.ci/scripts/stale-backport-scripts/format-slack-report.sh
@@ -101,7 +101,7 @@ jq -c --argjson total "$total_prs" --argjson groups "$total_groups" --argjson re
 
 # Warning when user map artifact was not accessible
 if [[ "${SLACK_USER_MAP_FALLBACK:-}" == "true" ]]; then
-  jq -c '. + [{type: "context", elements: [{type: "mrkdwn", text: "⚠️ _GitHub-Slack user map not available — author names shown as GitHub logins/real names instead of Slack mentions. cc <!subteam^S09E9P9TPAA|@monorepo-devops-team>_"}]}]' \
+  jq -c '. + [{type: "context", elements: [{type: "mrkdwn", text: "⚠️ _GitHub-Slack user map not available — author names shown as GitHub logins/real names instead of Slack mentions. cc <!subteam^S09E9P9TPAA|@engineering-operations-team>_"}]}]' \
     "$TMPDIR_WORK/blocks.json" > "$TMPDIR_WORK/blocks_tmp.json" && mv "$TMPDIR_WORK/blocks_tmp.json" "$TMPDIR_WORK/blocks.json"
 fi
 

--- a/.codeowners
+++ b/.codeowners
@@ -64,41 +64,41 @@ buf.yaml                    @camunda/orchestration-cluster
 /spring-utils/              @camunda/core-features
 
 ################################
-## @camunda/monorepo-devops-team
+## @camunda/engineering-operations
 ################################
 
-/.claude/skills/act-testing/ @camunda/monorepo-devops-team
-/.claude/skills/agentic-workflows/ @camunda/monorepo-devops-team
-/.claude/skills/ci-fix-failure/ @camunda/monorepo-devops-team
-/.claude/skills/ci-incident/ @camunda/monorepo-devops-team
-/.claude/skills/ci-push-workflow-health/ @camunda/monorepo-devops-team
-/.claude/skills/ci-scheduled-workflow-health/ @camunda/monorepo-devops-team
-/.claude/skills/ci-runner-utilization/ @camunda/monorepo-devops-team
-/.claude/skills/ci-security-compliance/ @camunda/monorepo-devops-team
-/.claude/skills/ci-validation/ @camunda/monorepo-devops-team
-/.claude/skills/ci-workflow-authoring/ @camunda/monorepo-devops-team
+/.claude/skills/act-testing/ @camunda/engineering-operations
+/.claude/skills/agentic-workflows/ @camunda/engineering-operations
+/.claude/skills/ci-fix-failure/ @camunda/engineering-operations
+/.claude/skills/ci-incident/ @camunda/engineering-operations
+/.claude/skills/ci-push-workflow-health/ @camunda/engineering-operations
+/.claude/skills/ci-scheduled-workflow-health/ @camunda/engineering-operations
+/.claude/skills/ci-runner-utilization/ @camunda/engineering-operations
+/.claude/skills/ci-security-compliance/ @camunda/engineering-operations
+/.claude/skills/ci-validation/ @camunda/engineering-operations
+/.claude/skills/ci-workflow-authoring/ @camunda/engineering-operations
 
-/.ci/                       @camunda/monorepo-devops-team
-/.github/                   @camunda/monorepo-devops-team
-/.mvn/                      @camunda/monorepo-devops-team
-/cmd/                       @camunda/monorepo-devops-team
-/pom.xml                    @camunda/monorepo-devops-team
-/library-parent/            @camunda/monorepo-devops-team
-/parent/                    @camunda/monorepo-devops-team
-/bom/                       @camunda/monorepo-devops-team
-/bom-deprecated/            @camunda/monorepo-devops-team
-/scripts/                   @camunda/monorepo-devops-team
-/monorepo-docs-site/        @camunda/monorepo-devops-team
+/.ci/                       @camunda/engineering-operations
+/.github/                   @camunda/engineering-operations
+/.mvn/                      @camunda/engineering-operations
+/cmd/                       @camunda/engineering-operations
+/pom.xml                    @camunda/engineering-operations
+/library-parent/            @camunda/engineering-operations
+/parent/                    @camunda/engineering-operations
+/bom/                       @camunda/engineering-operations
+/bom-deprecated/            @camunda/engineering-operations
+/scripts/                   @camunda/engineering-operations
+/monorepo-docs-site/        @camunda/engineering-operations
 
-.fossa.yml                  @camunda/monorepo-devops-team
-.hadolint.yaml              @camunda/monorepo-devops-team
-.snyk                       @camunda/monorepo-devops-team
-.supressions.xml            @camunda/monorepo-devops-team
-/maven-settings.xml         @camunda/monorepo-devops-team
-mvnw*                       @camunda/monorepo-devops-team
+.fossa.yml                  @camunda/engineering-operations
+.hadolint.yaml              @camunda/engineering-operations
+.snyk                       @camunda/engineering-operations
+.supressions.xml            @camunda/engineering-operations
+/maven-settings.xml         @camunda/engineering-operations
+mvnw*                       @camunda/engineering-operations
 
-Makefile                    @camunda/monorepo-devops-team
-mwnw*                       @camunda/monorepo-devops-team
+Makefile                    @camunda/engineering-operations
+mwnw*                       @camunda/engineering-operations
 
 ################################
 ## @camunda/qa-engineering
@@ -432,7 +432,7 @@ optimize.Dockerfile         @camunda/core-features
 /.github/workflows/c8-orchestration-cluster-request-validation-nightly.yml @camunda/core-features
 /.github/workflows/ci-database-integration-tests-reusable.yml @camunda/data-layer
 /.github/workflows/frontend-sbom-snyk-nightly.yml @camunda/hub-frontend
-/.github/workflows/zeebe-release-stable-dry-run.yml @camunda/monorepo-devops-team
+/.github/workflows/zeebe-release-stable-dry-run.yml @camunda/engineering-operations
 /.github/workflows/c8-orchestration-cluster-e2e-nightly-close-stale-fix-prs.yml    @camunda/test-automation-team
 /.github/workflows/c8-orchestration-cluster-nightly-8.7-api-es.yml                 @camunda/test-automation-team
 /.github/workflows/c8-orchestration-cluster-nightly-8.7-e2e.yml                    @camunda/test-automation-team

--- a/.github/actions/adjust-pom-for-license-analysis/README.md
+++ b/.github/actions/adjust-pom-for-license-analysis/README.md
@@ -31,4 +31,4 @@ steps:
 
 ## Owner
 
-@camunda/monorepo-devops-team
+@camunda/engineering-operations

--- a/.github/actions/adjust-pom-for-license-analysis/action.yml
+++ b/.github/actions/adjust-pom-for-license-analysis/action.yml
@@ -4,7 +4,7 @@ description: |
   Adjusts pom.xml files so that Maven analysis tools (FOSSA, depgraph, etc.)
   can correctly resolve the full module hierarchy from bom/pom.xml as the root.
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 runs:
   using: composite

--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -1,7 +1,7 @@
 ---
 name: Build Frontend
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: Builds the frontend project in a certain Yarn workspace
 

--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -4,7 +4,7 @@
 ---
 name: Build Docker Image
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: Builds the Docker image
 

--- a/.github/actions/collect-flaky-tests/action.yml
+++ b/.github/actions/collect-flaky-tests/action.yml
@@ -1,7 +1,7 @@
 name: 'Collect Flaky Tests'
 description: 'Collects and aggregates flaky test results from multiple CI jobs'
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 inputs:
     general-unit-tests-result:

--- a/.github/actions/collect-flaky-tests/scripts/collect-flaky-tests.sh
+++ b/.github/actions/collect-flaky-tests/scripts/collect-flaky-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Helper functions for collecting flaky test data
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 set -euo pipefail
 flaky_data='[]'

--- a/.github/actions/collect-test-artifacts/action.yml
+++ b/.github/actions/collect-test-artifacts/action.yml
@@ -1,7 +1,7 @@
 ---
 name: Collect test artifacts
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: Collects test outputs and uploads them as artifact
 

--- a/.github/actions/detect-new-flaky-tests/action.yml
+++ b/.github/actions/detect-new-flaky-tests/action.yml
@@ -1,4 +1,4 @@
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Detect New Flaky Tests
 
 description: >

--- a/.github/actions/flaky-tests-summary-comment/action.yml
+++ b/.github/actions/flaky-tests-summary-comment/action.yml
@@ -3,7 +3,7 @@ name: Flaky Tests Summary Comment
 
 description: Creates or updates a PR comment with flaky test summary across all test jobs
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 inputs:
   flaky-tests-data:
@@ -47,9 +47,9 @@ runs:
           }
 
           // Validate data structure
-          const isValidData = flakyTestsData.every(item => 
-            typeof item === 'object' && 
-            typeof item.job === 'string' && 
+          const isValidData = flakyTestsData.every(item =>
+            typeof item === 'object' &&
+            typeof item.job === 'string' &&
             typeof item.flaky_tests === 'string'
           );
           if (!isValidData) {

--- a/.github/actions/frontend-sbom-snyk/action.yml
+++ b/.github/actions/frontend-sbom-snyk/action.yml
@@ -1,7 +1,7 @@
 ---
 name: Frontend SBOM Snyk
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: Generate a frontend SBOM and scan it with Snyk
 

--- a/.github/actions/gcs-build-cache-auth/action.yml
+++ b/.github/actions/gcs-build-cache-auth/action.yml
@@ -1,4 +1,4 @@
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: GCS build-cache auth
 description: >-
   Vault-fetch the monorepo-build-cache service account and authenticate gcloud

--- a/.github/actions/is-fork/action.yml
+++ b/.github/actions/is-fork/action.yml
@@ -1,7 +1,7 @@
 ---
 name: Is Fork
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: |
   Checks if current job runs on code from a forked repository (via PR).

--- a/.github/actions/npm-ci-with-retry/action.yml
+++ b/.github/actions/npm-ci-with-retry/action.yml
@@ -1,7 +1,7 @@
 ---
 name: npm ci with retry
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: >
   Runs `npm ci` wrapped in retry logic so a singular transient npm-registry

--- a/.github/actions/observe-aborted-jobs/action.yml
+++ b/.github/actions/observe-aborted-jobs/action.yml
@@ -7,7 +7,7 @@
 ---
 name: Observe Aborted Jobs
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: Checks failed jobs of a GHA workflow for runner problems and submits https://confluence.camunda.com/display/HAN/CI+Analytics data on their behalf
 

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -7,7 +7,7 @@
 ---
 name: Observe Build Status
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: Records the build status remotely for analytic purposes
 

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -1,7 +1,7 @@
 ---
 name: Common paths filter for camunda/camunda
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: |
   Common filters to detect and group changes against a base branch

--- a/.github/actions/post-ci-failure-reasons/action.yml
+++ b/.github/actions/post-ci-failure-reasons/action.yml
@@ -1,6 +1,6 @@
 # This action collects annotations from unsuccessful GitHub Actions jobs and posts them as a PR comment
 #
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Post CI Failure Reasons
 

--- a/.github/actions/print-metadata/action.yml
+++ b/.github/actions/print-metadata/action.yml
@@ -3,7 +3,7 @@
 ---
 name: Print Metadata
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: Prints the job's metadata for easier owner attribution in build logs.
 

--- a/.github/actions/renew-github-token/action.yml
+++ b/.github/actions/renew-github-token/action.yml
@@ -13,7 +13,7 @@
 # See: https://github.com/actions/checkout/pull/2286 (persist-creds change)
 # See: https://github.com/camunda/camunda/issues/47369 (expired token in release job)
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Renew GitHub Token
 

--- a/.github/actions/restore-shared-m2/action.yml
+++ b/.github/actions/restore-shared-m2/action.yml
@@ -1,4 +1,4 @@
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Restore shared m2 SNAPSHOTs
 description: >-
   Download the run-scoped m2-installed.tar (the io.camunda SNAPSHOTs that build-distball

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -1,7 +1,7 @@
 ---
 name: Setup build
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: Sets up the required stack to build, install, and run monorepo projects
 

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -1,7 +1,7 @@
 ---
 name: Setup Maven Cache
 
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 description: Configured GHA cache for Maven global cache dir (no save on PRs), see https://camunda.github.io/camunda/ci/#caching-strategy
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -162,7 +162,7 @@
       "enabled": false
     },
     {
-      "description": "Identify updates related to builds, tooling, etc. that should be routed to Monorepo DevOps team.",
+      "description": "Identify updates related to builds, tooling, etc. that should be routed to Engineering Operations team.",
       "matchManagers": [
         "dockerfile",
         "maven-wrapper",
@@ -193,7 +193,7 @@
       "enabled": false
     },
     {
-      "description": "Identify updates related to builds, tooling, etc. that should be routed to Monorepo DevOps team.",
+      "description": "Identify updates related to builds, tooling, etc. that should be routed to Engineering Operations team.",
       "matchManagers": [
         "custom.regex"
       ],

--- a/.github/scripts/test-codeowners.sh
+++ b/.github/scripts/test-codeowners.sh
@@ -338,9 +338,9 @@ assert_owner \
   "@camunda/reliability-testing"
 
 assert_owner \
-  ".claude/skills/ci-validation/ → monorepo-devops-team (overrides orchestration-cluster)" \
+  ".claude/skills/ci-validation/ → engineering-operations (overrides orchestration-cluster)" \
   ".claude/skills/ci-validation/SKILL.md" \
-  "@camunda/monorepo-devops-team"
+  "@camunda/engineering-operations"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""

--- a/.github/workflows/add-release-comments-to-issues.yml
+++ b/.github/workflows/add-release-comments-to-issues.yml
@@ -3,19 +3,19 @@
 # owner: camunda/engineering-operations
 #
 # This workflow automatically adds comments to issues that have been resolved in recent releases.
-# 
+#
 # Usage:
 #   - Manual trigger with optional parameters:
 #     - days_back: Number of days to look back for releases (default: 10)
 #     - dry_run: If true, logs what would be done without posting comments (default: false)
-# 
+#
 # The workflow:
 #   1. Fetches releases from the specified lookback period
 #   2. Extracts issue references from release notes/changelog
 #   3. For each referenced closed issue (excluding PRs):
 #      - Checks if a release comment already exists
 #      - Adds: "This has been released in version [x.x.x](release-url). See release notes [here](release-url) for details."
-# 
+#
 # Safety features:
 #   - Only processes closed issues
 #   - Excludes pull requests
@@ -42,7 +42,7 @@ on:
         default: false
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 permissions: {}

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -1,5 +1,5 @@
 # type: Project Management
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Assign new issues to the default projects
 
@@ -168,13 +168,13 @@ jobs:
           github-token: ${{ steps.github-token.outputs.token }}
           labeled: component/feel-js, component/feel-scala
 
-      # Monorepo DevOps (#115)
+      # Engineering Operations (#115)
       - id: add-to-devops
         if: >
           github.event.action != 'labeled'
             || github.event.label.name == 'component/build-pipeline'
             || github.event.label.name == 'component/release'
-        name: Add to Monorepo DevOps Team project
+        name: Add to Engineering Operations Team project
         uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/camunda/projects/115

--- a/.github/workflows/alwaysgreen-streak-detector.yml
+++ b/.github/workflows/alwaysgreen-streak-detector.yml
@@ -224,7 +224,7 @@ jobs:
                   case "$owner" in
                     "@camunda/test-automation-team")   mentions+=("${MEDIC_TEST_AUTOMATION}") ;;
                     "@camunda/distribution")            mentions+=("${MEDIC_DISTRIBUTION}") ;;
-                    "@camunda/monorepo-devops-team")    mentions+=("${MEDIC_MONOREPO_DEVOPS}") ;;
+                    "@camunda/engineering-operations")    mentions+=("${MEDIC_MONOREPO_DEVOPS}") ;;
                     "@camunda/core-features")           mentions+=("${MEDIC_CORE_FEATURES}") ;;
                   esac
                 done <<<"$OWNERS"

--- a/.github/workflows/auto-merge-back-to-stable.yml
+++ b/.github/workflows/auto-merge-back-to-stable.yml
@@ -3,7 +3,7 @@
 # waits for required checks to complete, auto-merges using merge queue or direct merge,
 # and notifies the relevant C8 release process about the merge status.
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Auto-merge release to stable
 
 on:
@@ -30,14 +30,14 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DRY_RUN: ${{ vars.AUTO_MERGE_DRY_RUN || 'false' }}
       MERGE_QUEUE_TIMEOUT_MINUTES: ${{ vars.MERGE_QUEUE_TIMEOUT_MINUTES || '180' }}
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
-      
+
       - name: Validate branch matching
         id: validate_branches
         env:
@@ -56,7 +56,7 @@ jobs:
             echo "❌ Invalid release branch format: $HEAD_REF"
             exit 1
           fi
-      
+
       - name: Check for merge conflicts
         id: check_conflicts
         run: |
@@ -67,7 +67,7 @@ jobs:
             echo "Checking mergeability (attempt $i/$MAX_RETRIES)..."
             # GitHub API provides mergeable status
             MERGEABLE=$(gh pr view ${{ github.event.pull_request.number }} --json mergeable --jq '.mergeable')
-            
+
             if [ "$MERGEABLE" = "MERGEABLE" ]; then
              echo "✅ PR is mergeable!"
               exit 0
@@ -77,7 +77,7 @@ jobs:
             elif [ "$MERGEABLE" = "UNKNOWN" ]; then
               if [ "$i" -eq "$MAX_RETRIES" ]; then
                 echo "❌ Mergeability still UNKNOWN after $MAX_RETRIES attempts"
-                exit 1  
+                exit 1
               fi
               echo "⏳ Mergeability is UNKNOWN, waiting ${RETRY_DELAY}s before retry..."
               sleep "$RETRY_DELAY"
@@ -91,13 +91,13 @@ jobs:
               sleep "$RETRY_DELAY"
             fi
           done
-      
+
       - name: Validate changes are version bumps only
         id: validate_changes
         run: |
           # Use glob pattern to capture all pom.xml files at any depth
           POM_DIFF=$(git diff origin/${{ github.base_ref }}...HEAD -- ':(glob)**/pom.xml')
-          
+
           # Check only pom.xml files changed
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
           if echo "$CHANGED_FILES" | grep -E -v 'pom\.xml$' | grep -q .; then
@@ -108,13 +108,13 @@ jobs:
           # Verify all changed pom.xml files are captured in POM_DIFF
           CHANGED_POM_COUNT=$(echo "$CHANGED_FILES" | grep -c 'pom\.xml$' || true)
           POM_DIFF_FILE_COUNT=$(echo "$POM_DIFF" | grep -c '^diff --git' || true)
-          
+
           if [ "$CHANGED_POM_COUNT" -ne "$POM_DIFF_FILE_COUNT" ]; then
             echo "❌ Pattern mismatch: GitHub reports $CHANGED_POM_COUNT pom.xml changed, glob captured $POM_DIFF_FILE_COUNT"
             exit 1
           fi
           echo "✅ Validated $CHANGED_POM_COUNT pom.xml files"
-          
+
           # Check only version tags modified in pom.xml
           # Whitelist of allowed property changes in release PRs:
           # - <version>: Main project version (X.Y.Z-SNAPSHOT)
@@ -129,38 +129,38 @@ jobs:
             '^[+-]\s*<version\.identity>'          # Identity version
             '^[+-]\s*<zeebe\.version>'             # Zeebe component version
           )
-          
+
           # Build regex from allowed patterns (join with |)
           ALLOWED_REGEX=$(IFS='|'; echo "${ALLOWED_PATTERNS[*]}")
-          
+
           NON_VERSION_CHANGES=$(echo "$POM_DIFF" | grep -E '^[+-]' | grep -vE "($ALLOWED_REGEX)" || true)
           if [ -n "$NON_VERSION_CHANGES" ]; then
             echo "❌ Non-version changes in pom.xml:"
             (echo "$NON_VERSION_CHANGES" | head -10) || true
             exit 1
           fi
-          
+
           # Validate version increment: X.Y.Z-SNAPSHOT → X.Y.(Z+1)-SNAPSHOT
           OLD_VER=$( (echo "$POM_DIFF" | grep -E '^-\s*<version>' | head -1 | sed -E 's/.*<version>([^<]+)<.*/\1/') 2>/dev/null || true)
           NEW_VER=$( (echo "$POM_DIFF" | grep -E '^\+\s*<version>' | head -1 | sed -E 's/.*<version>([^<]+)<.*/\1/') 2>/dev/null || true)
-          
+
           if [[ -n "$OLD_VER" && -n "$NEW_VER" ]]; then
             [[ "$OLD_VER" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-SNAPSHOT$ ]] || { echo "❌ Invalid old version: $OLD_VER"; exit 1; }
             OLD_MAJ="${BASH_REMATCH[1]}"
             OLD_MIN="${BASH_REMATCH[2]}"
             OLD_PAT="${BASH_REMATCH[3]}"
-            
+
             [[ "$NEW_VER" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)-SNAPSHOT$ ]] || { echo "❌ Invalid new version: $NEW_VER"; exit 1; }
             NEW_MAJ="${BASH_REMATCH[1]}"
             NEW_MIN="${BASH_REMATCH[2]}"
             NEW_PAT="${BASH_REMATCH[3]}"
-            
+
             [[ "$NEW_MAJ" == "$OLD_MAJ" && "$NEW_MIN" == "$OLD_MIN" && "$NEW_PAT" == $((OLD_PAT + 1)) ]] || {
               echo "❌ Expected ${OLD_MAJ}.${OLD_MIN}.$((OLD_PAT + 1))-SNAPSHOT, got $NEW_VER"
               exit 1
             }
             echo "✅ Version: $OLD_VER → $NEW_VER"
-          fi      
+          fi
       - name: Wait for required checks
         id: wait_checks
         uses: camunda/infra-global-github-actions/wait-for-required-checks@f074308b33bf66e4a50d6a4a22a4a4ce9557f19e # main
@@ -181,8 +181,8 @@ jobs:
           vault-auth-method: approle
           vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
-          vault-url: ${{ secrets.VAULT_ADDR }}     
-      
+          vault-url: ${{ secrets.VAULT_ADDR }}
+
       - name: Approve PR
         # Proceed when checks pass OR when no required checks configured (skipped outcome)
         if: steps.wait_checks.outcome != 'failure'
@@ -194,7 +194,7 @@ jobs:
             # Override GH_TOKEN with GitHub App installation token.
             GH_TOKEN="${{ steps.github-token.outputs.token }}" gh pr review ${{ github.event.pull_request.number }} --approve --body "Auto-approved: Version bump changes validated successfully."
           fi
-         
+
       - name: Enable auto-merge (for merge queue)
         # Proceed when checks pass OR when no required checks configured (skipped outcome)
         if: steps.wait_checks.outcome != 'failure'
@@ -209,7 +209,7 @@ jobs:
             GH_TOKEN="${{ steps.github-token.outputs.token }}" gh pr merge ${{ github.event.pull_request.number }} --auto --squash
             echo "✅ Auto-merge enabled - PR will enter merge queue"
           fi
-      
+
       - name: Monitor merge queue status
         id: monitor_merge
         if: steps.wait_checks.outcome != 'failure'
@@ -222,7 +222,7 @@ jobs:
           app-token: ${{ steps.github-token.outputs.token }}
           repository-owner: ${{ github.repository_owner }}
           repository-name: ${{ github.event.repository.name }}
-      
+
       - name: Import Secrets
         if: always() && env.DRY_RUN != 'true'
         id: secrets
@@ -234,7 +234,7 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
-            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig    
+            secret/data/products/camunda/ci/monorepo-release CLIENT_CONFIG | clientConfig
       - name: Report auto-merge result to Monorepo Release Process
         if: always() && env.DRY_RUN != 'true'
         continue-on-error: true
@@ -251,7 +251,7 @@ jobs:
               "pr_url": "${{ github.event.pull_request.html_url }}",
               "workflow_run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
-      
+
       - name: Dry run summary
         if: always() && env.DRY_RUN == 'true'
         run: |
@@ -265,7 +265,7 @@ jobs:
           echo "  - Required checks: ${{ steps.wait_checks.outcome }}"
           echo "🔍 To enable actual execution, set repository variable AUTO_MERGE_DRY_RUN to 'false'"
           echo "🔍 ========================================"
-      
+
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -274,4 +274,4 @@ jobs:
           build_status: ${{ job.status }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}    
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,5 +1,5 @@
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Backport labeled merged pull requests
 

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -1,5 +1,5 @@
 # type: CI
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Camunda Helm Chart Integration Test
 
 on:
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -1,5 +1,5 @@
 # type: CI Helper - Manual
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Deploy Camunda Docker Images to SaaS registry
 

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -1,5 +1,5 @@
 # type: Release
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Camunda Platform Release Dry Run from main
 
@@ -20,7 +20,7 @@ on:
     - cron: '0 1 * * 1-5'
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
 
 jobs:
   setup:

--- a/.github/workflows/camunda-platform-release-manual.yml
+++ b/.github/workflows/camunda-platform-release-manual.yml
@@ -1,5 +1,5 @@
 # type: Release
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Camunda Platform Release
 

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -1,5 +1,5 @@
 # type: Release
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Camunda Platform Release Workflow
 

--- a/.github/workflows/chatops-command-ci-problems.yml
+++ b/.github/workflows/chatops-command-ci-problems.yml
@@ -1,5 +1,5 @@
 # type: CI Helper - ChatOps
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: chatops-command-ci-problems
 

--- a/.github/workflows/chatops-command-disable-cache.yml
+++ b/.github/workflows/chatops-command-disable-cache.yml
@@ -1,5 +1,5 @@
 # type: CI Helper - ChatOps
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: chatops-command-ci-disable-cache
 

--- a/.github/workflows/chatops-command-dispatch.yml
+++ b/.github/workflows/chatops-command-dispatch.yml
@@ -1,5 +1,5 @@
 # type: CI Helper - ChatOps
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: ChatOps Command Dispatch
 

--- a/.github/workflows/check-licenses-active-issues.yml
+++ b/.github/workflows/check-licenses-active-issues.yml
@@ -1,5 +1,5 @@
 # Checks for active licensing issues across all tracking branches for camunda/camunda@* FOSSA projects
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Check Licenses (Active Issues)
 
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:
@@ -84,7 +84,7 @@ jobs:
 
           project_issues=""
           project_total=0
-          
+
           # Iterate over each branch in this project
           while read -r branch; do
             branch_name=$(echo "$branch" | jq -r '.branch')
@@ -104,7 +104,7 @@ jobs:
               issues_list="${issues_list}*${project_name}* (${project_total} total)\n${project_issues}\n"
           fi
         done < <(echo "$ISSUES" | jq -s 'add | group_by(."project-title")' | jq -c '.[]')
-        
+
         echo "Total licensing issues: $total_issues"
 
         {

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -1,7 +1,7 @@
 # description: Checks for license issues by using FOSSA. If a PR introduces a denied or flagged license, this check will fail
 # test location: /
 # type: CI
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Check Licenses
 
@@ -20,7 +20,7 @@ on:
     - synchronize
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/check-outdated-prs.yml
+++ b/.github/workflows/check-outdated-prs.yml
@@ -1,7 +1,7 @@
 # type: CI
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
-#Description: 
+#Description:
 #This GitHub Actions workflow automatically monitors pull requests that are significantly behind the main branch and adds warning labels/comments to notify contributors.
 #It runs daily at 4 AM UTC to check all open PRs, can be triggered manually with dry-run or live modes, and also processes individual PRs during PR events.
 #The workflow intelligently filters out bot PRs and draft PRs, focusing only on human-created, ready-for-review pull requests.
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
 
 jobs:
   get-prs:
@@ -62,9 +62,9 @@ jobs:
             echo "Getting list of human-created, ready PRs..."
             pr_list=$(gh api repos/"$GITHUB_REPOSITORY"/pulls --paginate --slurp | \
             jq -c '[.[][] | select(
-              .base.ref == "main" and 
+              .base.ref == "main" and
               .state == "open" and
-              .head.repo.owner != null and 
+              .head.repo.owner != null and
               .draft == false and
               (.user.login | IN("app/dependabot", "dependabot[bot]", "backport-action", "app/renovate", "app/copilot-swe-agent", "app/", "renovate[bot]", "mend[bot]") | not) and
               ([.labels[].name] | contains(["outdated-branch"]) | not)
@@ -75,7 +75,7 @@ jobs:
               repo_owner: .head.repo.owner.login
             }]')
           fi
-          
+
           printf "pr_list=%s\n" "$pr_list" >> "$GITHUB_OUTPUT"
           echo "Found $(echo "$pr_list" | jq length) PRs to process"
       - name: Checkout
@@ -118,7 +118,7 @@ jobs:
           else
             echo "🚀 Running in LIVE mode - will add labels and comments"
           fi
-          
+
           echo '${{ needs.get-prs.outputs.pr_list }}' | ./.ci/scripts/outdated-pr-scripts/process-pr.sh "$DRY_RUN"
       - name: Observe build status
         if: always()

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -1,5 +1,5 @@
 # type: Preview Environments
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Check for PR conflicts
 
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
 
 jobs:
   check-all-pr-conflicts:

--- a/.github/workflows/ci-webapp-client.yml
+++ b/.github/workflows/ci-webapp-client.yml
@@ -2,7 +2,7 @@
 # test location: /webapp/client
 # called by: ci.yml
 # type: CI
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Webapp Client Jobs
 
 on:

--- a/.github/workflows/ci-zeebe.yml
+++ b/.github/workflows/ci-zeebe.yml
@@ -503,7 +503,7 @@ jobs:
       checks: read
       pull-requests: write
     env:
-      TEST_OWNER: '@camunda/monorepo-devops-team'
+      TEST_OWNER: '@camunda/engineering-operations'
     steps:
       - uses: camunda/infra-global-github-actions/start-build-monitor@f074308b33bf66e4a50d6a4a22a4a4ce9557f19e # main
       - name: Generate GitHub token

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # description: The Unified CI for the monorepo. This workflow runs tests for all modules in the monorepo. Any new tests are required to adhere to inclusion rules
 # test location: /
 # type: CI
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: CI
 
@@ -31,7 +31,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
   GHA_BEST_PRACTICES_LINTER: enabled
   FLAKY_TEST_RERUN_COUNT: ${{ github.event_name == 'pull_request' && '3' || '7' }}
@@ -867,7 +867,7 @@ jobs:
               "runs-on": "gcp-perf-core-16-default",
               "docker-repository": "localhost:5000/camunda/camunda",
               "docker-file": "camunda.Dockerfile",
-              "owner": "@camunda/monorepo-devops-team",
+              "owner": "@camunda/engineering-operations",
               "module": "Zeebe",
               "test-filter": "!io.camunda.zeebe.it.engine.**,!io.camunda.zeebe.it.cluster.**,!**/*${DOLLAR}*.java",
               "stressRun": 1

--- a/.github/workflows/codeowners-file-owner.yml
+++ b/.github/workflows/codeowners-file-owner.yml
@@ -19,7 +19,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -2,7 +2,7 @@
 # see_also: https://docs.github.com/en/enterprise-cloud@latest/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment
 # test location: /
 # type: AGENT_SETUP
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: "Copilot Setup Steps"
 

--- a/.github/workflows/create-urgent-hotfix-img.yml
+++ b/.github/workflows/create-urgent-hotfix-img.yml
@@ -1,5 +1,5 @@
 # type: CI
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 # Description:
 # This GitHub Actions workflow creates Docker images for urgent hotfixes.

--- a/.github/workflows/docker-build-helm-integration.yml
+++ b/.github/workflows/docker-build-helm-integration.yml
@@ -72,7 +72,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/monorepo-devops-team"
+            OWNER_TEAM="@camunda/engineering-operations"
             FAILURE_CATEGORY="orchestration_should_run"
           fi
           jq -n \
@@ -558,7 +558,7 @@ jobs:
           OWNER_TEAM="none"
           FAILURE_CATEGORY="none"
           if [[ "${{ job.status }}" == "failure" || "${{ job.status }}" == "cancelled" ]]; then
-            OWNER_TEAM="@camunda/monorepo-devops-team"
+            OWNER_TEAM="@camunda/engineering-operations"
             FAILURE_CATEGORY="orchestration_identifier"
           fi
           jq -n \
@@ -1018,7 +1018,7 @@ jobs:
                 DOWNLOAD_ERR=$(tr '\n' ' ' < "$DOWNLOAD_LOG" 2>/dev/null | sed 's/  */ /g' | cut -c1-300)
                 echo "::warning::Could not download downstream json-report artifact: ${DOWNLOAD_ERR:-no stderr}" >&2
                 DOWNSTREAM_CATEGORY="unknown_artifact_unreachable"
-                DOWNSTREAM_OWNER="@camunda/monorepo-devops-team"
+                DOWNSTREAM_OWNER="@camunda/engineering-operations"
                 {
                   echo "### Downstream Category Unavailable"
                   echo ""
@@ -1089,7 +1089,7 @@ jobs:
               OWNER_TEAM="@camunda/test-automation-team"
               FAILURE_CATEGORY="saas_e2e"
             else
-              OWNER_TEAM="@camunda/monorepo-devops-team"
+              OWNER_TEAM="@camunda/engineering-operations"
               FAILURE_CATEGORY="orchestration_dispatch_or_wait"
             fi
           fi

--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -1,6 +1,6 @@
 # description: Build and deploy Docusaurus documentation site to GitHub Pages
 # type: ci
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Docs Build and Deploy
 
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   # renovate: datasource=node-version depName=node
   NODE_VERSION: '24.18.0'
   DOCS_DIR: monorepo-docs-site

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,6 +1,6 @@
 # description: Weekly cleanup of orphaned documentation preview deployments
 # type: maintenance
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Docs Preview Cleanup
 
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
 
 jobs:
   cleanup-orphaned-previews:
@@ -47,10 +47,10 @@ jobs:
             exit 0
           }
           git checkout gh-pages
-          
+
           # Check if pr-preview directory exists
           [[ ! -d "pr-preview" ]] && { echo "ℹ️ No pr-preview directory found"; exit 0; }
-          
+
           echo "📁 Current pr-preview contents:"
           ls -la pr-preview/
           echo ""
@@ -58,16 +58,16 @@ jobs:
           # Get open PRs and extract preview directories
           open_prs=$(gh pr list --state open --json number --jq '.[].number' --limit 500 | sort -n)
           cleaned_count=0
-          
+
           echo "Open PRs: $(echo "$open_prs" | tr '\n' ' ')"
-          
+
           # Process each preview directory
           for dir in pr-preview/pr-*/; do
             [[ ! -d "$dir" ]] && continue
-            
+
             pr_num=$(basename "$dir" | sed 's/pr-//')
             echo "Checking preview directory for PR #$pr_num"
-            
+
             # Check if this PR number exists in the open PRs list
             if echo "$open_prs" | grep -Fxq "$pr_num"; then
               echo "✅ PR #$pr_num is open, keeping preview"
@@ -86,7 +86,7 @@ jobs:
               fi
             fi
           done
-          
+
           echo "Summary: Purged $cleaned_count orphaned preview(s)"
 
       - name: Commit cleanup changes

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,6 +1,6 @@
 # description: Build and deploy Docusaurus documentation previews for pull requests
 # type: preview
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Docs PR Preview
 
@@ -27,7 +27,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   # renovate: datasource=node-version depName=node
   NODE_VERSION: '24.18.0'
   DOCS_DIR: monorepo-docs-site

--- a/.github/workflows/generate-concurrency-group.yml
+++ b/.github/workflows/generate-concurrency-group.yml
@@ -1,6 +1,6 @@
 # description: Generate a branch-aware concurrency group name.
 # type: CI
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Generate Concurrency Group
 
 permissions:

--- a/.github/workflows/generate-snapshot-docker-tag.yml
+++ b/.github/workflows/generate-snapshot-docker-tag.yml
@@ -22,7 +22,7 @@
 # because each stable branch maps to exactly one version.
 #
 # type: CI
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Generate Docker Snapshot Tag
 
 permissions:

--- a/.github/workflows/issue-add-support-label.yml
+++ b/.github/workflows/issue-add-support-label.yml
@@ -1,5 +1,5 @@
 # type: Project Management
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Add support label to issue
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,5 @@
 # type: Project Management
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: "Pull Request Labeler"
 

--- a/.github/workflows/maven-dependency-snapshot.yml
+++ b/.github/workflows/maven-dependency-snapshot.yml
@@ -3,7 +3,7 @@
 # PR-side (head) snapshot submission is handled by the pr-maven-snapshot job in ci.yml,
 # which pr-vuln-check depends on — ensuring the snapshot is ready before the gate runs.
 # type: Security
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Maven Dependency Snapshot
 
 on:
@@ -22,7 +22,7 @@ defaults:
     shell: bash
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
 
 jobs:
   submit-maven-snapshot:

--- a/.github/workflows/opened_issue_labeler.yml
+++ b/.github/workflows/opened_issue_labeler.yml
@@ -1,5 +1,5 @@
 # type: Project Management
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: "Opened Issue Labeler"
 on:
   issues:

--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -1,5 +1,5 @@
 # type: Preview Environment
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Preview Environment Build and Deploy
 

--- a/.github/workflows/preview-env-clean.yml
+++ b/.github/workflows/preview-env-clean.yml
@@ -1,5 +1,5 @@
 # type: Preview Environment
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Preview Env Clean
 
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
 
 jobs:
   preview-env-clean:

--- a/.github/workflows/preview-env-smoke-test.yml
+++ b/.github/workflows/preview-env-smoke-test.yml
@@ -1,5 +1,5 @@
 # type: Preview Environment
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Preview Environment Smoke Test
 
@@ -62,7 +62,7 @@ on:
         default: 'stable/8.9'
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   E2E_DIR: e2e-tests
 
 jobs:

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -1,5 +1,5 @@
 # type: Preview Environment
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Preview Environment Teardown
 
@@ -24,7 +24,7 @@ on:
 jobs:
   teardown-preview:
     # For workflow_call: inputs.app-name is set (github.event_name is inherited from caller, not 'workflow_call')
-    # For PR events: check whether the unlabel name was deploy-preview || 
+    # For PR events: check whether the unlabel name was deploy-preview ||
     #   check whether the PR was closed/merged with deploy-preview label
     if: >
       inputs.app-name != '' || (
@@ -105,8 +105,8 @@ jobs:
 
   clean:
     if: >
-      always() && 
-        needs.teardown-preview.result != 'skipped' && 
+      always() &&
+        needs.teardown-preview.result != 'skipped' &&
         github.event_name == 'pull_request'
     uses: camunda/camunda/.github/workflows/preview-env-clean.yml@main
     needs: [teardown-preview]
@@ -116,8 +116,8 @@ jobs:
 
   comment:
     if: >
-      always() && 
-        needs.teardown-preview.result != 'skipped' && 
+      always() &&
+        needs.teardown-preview.result != 'skipped' &&
         github.event_name == 'pull_request'
     name: Remove Deployment Result Summary
     runs-on: ubuntu-latest

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -6,7 +6,7 @@
 # It is allowed to have merge commits in a pull request.
 # An example is a pull request that builds upon the work of another pull request.
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 name: Reject Merge Commits
 

--- a/.github/workflows/release-branch-notifications.yml
+++ b/.github/workflows/release-branch-notifications.yml
@@ -1,6 +1,6 @@
 # description: The workflow sends notifications to Slack for activities on release branches
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Release Branch Notifications
 
@@ -15,7 +15,7 @@ on:
       - release-*
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
 
 jobs:
   validate-event:

--- a/.github/workflows/renovate-daily.yml
+++ b/.github/workflows/renovate-daily.yml
@@ -1,6 +1,6 @@
 # description: Runs daily to assign Renovate PRs to team members and manage stale PRs
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 ---
 name: Renovate Daily
@@ -15,7 +15,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/renovate-pr-maintainer.yml
+++ b/.github/workflows/renovate-pr-maintainer.yml
@@ -1,6 +1,6 @@
 # description: Keeps open Renovate PRs fresh and unstuck (rebaseWhen=conflicted companion).
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 ---
 name: Renovate PR maintainer

--- a/.github/workflows/renovate-weekly.yml
+++ b/.github/workflows/renovate-weekly.yml
@@ -1,6 +1,6 @@
 # description: Runs a weekly check to see if Renovate configuration migration is needed and posts it to Slack
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 ---
 name: Renovate Weekly
@@ -14,7 +14,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/retry-workflow.yml
+++ b/.github/workflows/retry-workflow.yml
@@ -2,7 +2,7 @@
 # This is useful, for example, to retry dependency update PRs automatically in case of network
 # errors, flaky tests, etc.
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Retry Workflow Run
 
 on:

--- a/.github/workflows/stale-backport-tracker.yml
+++ b/.github/workflows/stale-backport-tracker.yml
@@ -1,7 +1,7 @@
 # description: Tracks stale backport PRs and notifies authors via GitHub comments and Slack.
 # Runs every hours on weekdays, on manual dispatch, and can be called by other workflows.
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Stale Backport Tracker
 
@@ -82,7 +82,7 @@ defaults:
 permissions: {}
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
 
 jobs:
   collect-stale-backports:
@@ -204,10 +204,10 @@ jobs:
           vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           vault-url: ${{ secrets.VAULT_ADDR }}
           repositories: "camunda,zeebe-process-test"
-  
+
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-  
+
       - name: Notify stale backport PRs
         env:
           GH_TOKEN: ${{ steps.github-token.outputs.token }}
@@ -394,7 +394,7 @@ jobs:
           response=$(curl -s -X POST "https://slack.com/api/pins.add" \
             -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
             -H "Content-Type: application/json" \
-            -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${MESSAGE_TS}\"}") 
+            -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${MESSAGE_TS}\"}")
           ok=$(echo "$response" | jq -r '.ok')
           err=$(echo "$response" | jq -r '.error // "none"')
           echo "pins.add ok: $ok, error: $err" >&2
@@ -426,7 +426,7 @@ jobs:
             resp=$(curl -s -X POST "https://slack.com/api/pins.remove" \
               -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
               -H "Content-Type: application/json" \
-              -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${ts}\"}") 
+              -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${ts}\"}")
             echo "pins.remove ok: $(echo "$resp" | jq -r '.ok'), error: $(echo "$resp" | jq -r '.error // "none"')" >&2
           done
 
@@ -459,7 +459,7 @@ jobs:
           response=$(curl -s -X POST "https://slack.com/api/pins.add" \
             -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
             -H "Content-Type: application/json" \
-            -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${message_ts}\"}") 
+            -d "{\"channel\":\"${SLACK_CHANNEL}\",\"timestamp\":\"${message_ts}\"}")
           ok=$(echo "$response" | jq -r '.ok')
           err=$(echo "$response" | jq -r '.error // "none"')
           echo "pins.add ok: $ok, error: $err" >&2

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -1,5 +1,5 @@
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 name: Statistics Daily
 
@@ -13,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/statistics-weekly.yml
+++ b/.github/workflows/statistics-weekly.yml
@@ -1,6 +1,6 @@
 # description: Generates a weekly summary about CI aspects like failing tests and posts it to Slack
 # type: CI Helper
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 
 ---
 name: Statistics Weekly
@@ -16,7 +16,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
   GHA_BEST_PRACTICES_LINTER: enabled
 
 jobs:

--- a/.github/workflows/update-backwards-compat-version.yml
+++ b/.github/workflows/update-backwards-compat-version.yml
@@ -1,5 +1,5 @@
 # type: CI Helper - Post-release
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Update Backwards Compat Version
 
 on:

--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -1,5 +1,5 @@
 # type: CI Helper - Manual
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 name: Update Identity Version
 
 on:

--- a/.github/workflows/zeebe-aws-os-dispatch-tests.yml
+++ b/.github/workflows/zeebe-aws-os-dispatch-tests.yml
@@ -119,7 +119,7 @@ jobs:
             maven-test-fork-count: 2
             maven-test-profiles: multi-db-test-client
             runs-on: aws-core-8-default
-            owner: '@camunda/monorepo-devops-team'
+            owner: '@camunda/engineering-operations'
           - group: camunda-qa-acceptance-tests-non-client
             name: "Camunda QA Module Non-Client Tests"
             maven-modules: "'io.camunda:camunda-qa-acceptance-tests'"
@@ -127,7 +127,7 @@ jobs:
             maven-test-fork-count: 2
             maven-test-profiles: multi-db-test-non-client
             runs-on: aws-core-8-default
-            owner: '@camunda/monorepo-devops-team'
+            owner: '@camunda/engineering-operations'
           - group: search-client-opensearch
             name: "Search Client OpenSearch ITs"
             maven-modules: "'io.camunda:camunda-search-client-connect,io.camunda:camunda-search-client-opensearch'"

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -1,5 +1,5 @@
 # type: Release
-# owner: @camunda/monorepo-devops-team
+# owner: @camunda/engineering-operations
 ---
 # NOTE: This workflow is not just for Zeebe, but also for 8.7+ monorepo release!
 name: Zeebe Release Dry Run from stable branches
@@ -11,7 +11,7 @@ on:
     - cron: '0 2 * * 1-5'
 
 env:
-  TEST_OWNER: '@camunda/monorepo-devops-team'
+  TEST_OWNER: '@camunda/engineering-operations'
 
 jobs:
   # Create short-lived branches from each stable branch so that dry-run pushes

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,16 +15,16 @@
 .github/workflows/c8run* @camunda/distribution
 /c8run/ @camunda/distribution
 
-# General Automation, Unified CI and release helpers by Monorepo DevOps team
-/.github/actions/build*/*                                @camunda/monorepo-devops-team
-/.github/actions/is-fork/*                               @camunda/monorepo-devops-team
-/.github/actions/observe*/*                              @camunda/monorepo-devops-team
-/.github/actions/paths-filter/*                          @camunda/monorepo-devops-team
-/.github/actions/setup-build/*                           @camunda/monorepo-devops-team
-/.github/actions/setup-maven*/*                          @camunda/monorepo-devops-team
-/.github/actions/renew-github-token/*                    @camunda/monorepo-devops-team
-/.github/actions/dependency-vuln-check/*                 @camunda/monorepo-devops-team
-/.github/dependency-review-config.json                   @camunda/monorepo-devops-team
+# General Automation, Unified CI and release helpers by Engineering Operations team
+/.github/actions/build*/*                                @camunda/engineering-operations
+/.github/actions/is-fork/*                               @camunda/engineering-operations
+/.github/actions/observe*/*                              @camunda/engineering-operations
+/.github/actions/paths-filter/*                          @camunda/engineering-operations
+/.github/actions/setup-build/*                           @camunda/engineering-operations
+/.github/actions/setup-maven*/*                          @camunda/engineering-operations
+/.github/actions/renew-github-token/*                    @camunda/engineering-operations
+/.github/actions/dependency-vuln-check/*                 @camunda/engineering-operations
+/.github/dependency-review-config.json                   @camunda/engineering-operations
 
 ###################
 ## Core Features ##
@@ -146,16 +146,16 @@
 /.claude/skills/load-test-ops/ @camunda/reliability-testing
 
 # CI skills
-/.claude/skills/act-testing/**                   @camunda/monorepo-devops-team
-/.claude/skills/agentic-workflows/**             @camunda/monorepo-devops-team
-/.claude/skills/ci-fix-failure/**                @camunda/monorepo-devops-team
-/.claude/skills/ci-incident/**                   @camunda/monorepo-devops-team
-/.claude/skills/ci-push-workflow-health/**       @camunda/monorepo-devops-team
-/.claude/skills/ci-runner-utilization/**         @camunda/monorepo-devops-team
-/.claude/skills/ci-scheduled-workflow-health/**  @camunda/monorepo-devops-team
-/.claude/skills/ci-security-compliance/**        @camunda/monorepo-devops-team
-/.claude/skills/ci-validation/**                 @camunda/monorepo-devops-team
-/.claude/skills/ci-workflow-authoring/**         @camunda/monorepo-devops-team
+/.claude/skills/act-testing/**                   @camunda/engineering-operations
+/.claude/skills/agentic-workflows/**             @camunda/engineering-operations
+/.claude/skills/ci-fix-failure/**                @camunda/engineering-operations
+/.claude/skills/ci-incident/**                   @camunda/engineering-operations
+/.claude/skills/ci-push-workflow-health/**       @camunda/engineering-operations
+/.claude/skills/ci-runner-utilization/**         @camunda/engineering-operations
+/.claude/skills/ci-scheduled-workflow-health/**  @camunda/engineering-operations
+/.claude/skills/ci-security-compliance/**        @camunda/engineering-operations
+/.claude/skills/ci-validation/**                 @camunda/engineering-operations
+/.claude/skills/ci-workflow-authoring/**         @camunda/engineering-operations
 
 # Engine-expert skill
 /.claude/skills/engine-expert/  @korthout @camunda/core-features

--- a/docs/monorepo-docs/ci-runbooks.md
+++ b/docs/monorepo-docs/ci-runbooks.md
@@ -58,7 +58,7 @@ other PRs e.g. from Renovate to be automatically merged even though they fail CI
    is needed and why the merge queue needs to be bypassed.
 2. Ask a repository admin to temporarily change the
    [unified-ci-merges-*-branch ruleset for the desired branch](https://github.com/camunda/camunda/settings/rules)
-   to add your group (`Monorepo DevOps Team`) to the `Bypass list` and save.
+   to add your group (`Engineering Operations Team`) to the `Bypass list` and save.
 3. Merge your Pull Request with admin override.
 4. Ask a repository admin to temporarily change the
    [unified-ci-merges-*-branch ruleset for the desired branch](https://github.com/camunda/camunda/settings/rules)

--- a/docs/monorepo-docs/ci.md
+++ b/docs/monorepo-docs/ci.md
@@ -511,7 +511,7 @@ For `camunda/camunda` GHA workflows we use a GitHub feature to [technically limi
 * Allow actions in any [Camunda GitHub Enterprise organization](https://github.com/enterprises/camunda/organizations) like `camunda`, `bpmn-io`, etc.
 * Allow specific actions from 3rd parties that we need (full list see below).
 
-If you need to use a 3rd party action not on the list, ask the Monorepo DevOps team via Slack and explain the motivation.
+If you need to use a 3rd party action not on the list, ask the Engineering Operations team via Slack and explain the motivation.
 
 <details>
 <summary>List of allowed 3rd party actions and reusable workflows</summary>

--- a/docs/monorepo-docs/collaboration-guidelines.md
+++ b/docs/monorepo-docs/collaboration-guidelines.md
@@ -4,9 +4,9 @@ Guidelines for collaborating on CI/CD, build automation, release processes, and 
 
 ## Core Principles
 
-* **You own your domain workflows** – Teams are encouraged to design their own CI/CD logic with support from the Monorepo DevOps team when needed.
+* **You own your domain workflows** – Teams are encouraged to design their own CI/CD logic with support from the Engineering Operations team when needed.
 * **Accountability follows ownership** – The requesting team owns results, failures, and communication.
-* **No surprises** – Reach out to the Monorepo DevOps team before promising timelines, blocking behavior, or release changes.
+* **No surprises** – Reach out to the Engineering Operations team before promising timelines, blocking behavior, or release changes.
 * **Release changes require alignment** – Any change to the monorepo release train must be explicitly discussed and written down.
 * **Clarity first** – Vague or underspecified requests will pause until scope, ownership, and impact are clear.
 
@@ -32,7 +32,7 @@ Guidelines for collaborating on CI/CD, build automation, release processes, and 
 * Performance-sensitive changes
 * Cross-team dependency workflows
 
-✋ **When in Doubt: Ask early in #ask-monorepo-devops. The Monorepo DevOps team is here to help! A 5-minute chat can save hours.**
+✋ **When in Doubt: Ask early in #ask-monorepo-devops. The Engineering Operations team is here to help! A 5-minute chat can save hours.**
 
 ## Heads-Up Pattern (Start Here) 📣
 
@@ -73,17 +73,17 @@ Use this to make requests scoping-friendly and reviewable.
 ### Timeline & Coordination
 
 * **Timeline:** Target v2.1 in ~3 weeks
-* **Questions for Monorepo DevOps team:** Best way to hook into the existing monorepo release process?
+* **Questions for Engineering Operations team:** Best way to hook into the existing monorepo release process?
 
 ## Code Review, Integration & Independence 💻
 
-### When the Monorepo DevOps Team Reviews
+### When the Engineering Operations Team Reviews
 
 * Shared CI infrastructure/templates changes
 * Release orchestration/train behavior changes
 * Integration points that affect cadence, artifacts, or shared patterns
 * Performance/reliability risks
-* Loop in the Monorepo DevOps team for scoping + review via [#epo-reviews](https://camunda.slack.com/archives/C090HGYE5T2) when it could affect release cadence or shared CI patterns.
+* Loop in the Engineering Operations team for scoping + review via [#epo-reviews](https://camunda.slack.com/archives/C090HGYE5T2) when it could affect release cadence or shared CI patterns.
 
 ### All Teams Are Encouraged To 🏅
 
@@ -95,14 +95,14 @@ Use this to make requests scoping-friendly and reviewable.
   * Change release train behavior
   * Impact other teams without coordination
 
-When any of those become true → reach out to the Monorepo DevOps team for collaboration.
+When any of those become true → reach out to the Engineering Operations team for collaboration.
 
 ## Quick Reference
 
 ### Support Contacts
 
-* Slack: [#ask-monorepo-devops](https://camunda.slack.com/archives/C08NZ7E9ZT2) (Monorepo DevOps team)
-* Escalation: Engineering manager – see [Monorepo DevOps Team page](https://confluence.camunda.com/spaces/HAN/pages/277021448/Monorepo+DevOps+Team) for current EM/DRI details.
+* Slack: [#ask-monorepo-devops](https://camunda.slack.com/archives/C08NZ7E9ZT2) (Engineering Operations team)
+* Escalation: Engineering manager – see [Engineering Operations Team page](https://confluence.camunda.com/spaces/HAN/pages/277021448/Monorepo+DevOps+Team) for current EM/DRI details.
 
 ### Key Documentation
 

--- a/docs/monorepo-docs/eng-ops-processes.md
+++ b/docs/monorepo-docs/eng-ops-processes.md
@@ -1,4 +1,4 @@
-# Monorepo DevOps Team Processes
+# Engineering Operations Team Processes
 
 ## Code Reviews
 

--- a/docs/monorepo-docs/index.md
+++ b/docs/monorepo-docs/index.md
@@ -13,12 +13,12 @@ There you'll find anything to get started using Camunda 8, best practices, and r
 
 ### Collaboration
 
-**[Monorepo DevOps Team Processes](./monorepo-devops-team-processes.md)** - Internal processes and policies for the Monorepo DevOps team, including code review policy and the 4-eye principle.
+**[Engineering Operations Team Processes](./eng-ops-processes.md)** - Internal processes and policies for the Engineering Operations team, including code review policy and the 4-eye principle.
 
 **[Collaboration guidelines](./collaboration-guidelines.md)** - Guidelines for collaborating on CI/CD, releases, and monorepo infrastructure. All teams are welcome to contribute and improve these processes:
 
 - Core collaboration principles and ownership boundaries
-- When and how to reach out to the Monorepo DevOps team for support
+- When and how to reach out to the Engineering Operations team for support
 - Heads-Up Pattern for scoping and requests
 - Code review and integration expectations
 - How all teams can independently own and maintain their workflows

--- a/docs/monorepo-docs/processes.md
+++ b/docs/monorepo-docs/processes.md
@@ -59,9 +59,9 @@ We have GitHub teams of engineers grouped by expertise:
 
 - [Monorepo Backend engineers](https://github.com/orgs/camunda/teams/monorepo-backend-engineers)
 - [Monorepo Frontend engineers](https://github.com/orgs/camunda/teams/monorepo-frontend-engineers)
-- [Monorepo DevOps team](https://github.com/orgs/camunda/teams/monorepo-devops-team)
+- [Engineering Operations team](https://github.com/orgs/camunda/teams/engineering-operations)
 
-If you spot errors in the grouping, reach out to the Monorepo DevOps team!
+If you spot errors in the grouping, reach out to the Engineering Operations team!
 
 ### Overview
 

--- a/docs/monorepo-docs/release/release-monorepo.md
+++ b/docs/monorepo-docs/release/release-monorepo.md
@@ -239,7 +239,7 @@ Changes to the release process are done in these steps:
   * If testable in isolation/with dry run: demonstrate that change works
   * If not testable with dry run: wait for next release
 * Review:
-  * Get a peer review from a Monorepo DevOps team member or C8 engineer familiar with the process
+  * Get a peer review from a Engineering Operations team member or C8 engineer familiar with the process
 * Rollout:
   * Merge the Pull Request
   * If necessary, migrate currently running process instances in [Operate](#runtime) to new version of the process

--- a/monorepo-docs-site/sidebars.js
+++ b/monorepo-docs-site/sidebars.js
@@ -15,7 +15,7 @@
 const sidebars = {
   tutorialSidebar: [
     'index',
-    'monorepo-devops-team-processes',
+    'eng-ops-processes',
     'collaboration-guidelines',
     {
       type: 'category',


### PR DESCRIPTION
## Description

⚠️ Merge only in coordination with rename of https://github.com/orgs/camunda/teams/monorepo-devops-team

Change code references from old to new name of the team. GH App is not renamed (yet).

## Checklist

<!--- Please delete options that are not relevant. -->
- [x] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
