### PR TITLE
feat: reflect late business ID assignment in secondary storage (ES/OS + RDBMS)

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
@@ -27,6 +27,8 @@ public interface ProcessInstanceMapper {
 
   void updateStateAndEndDate(EndProcessInstanceDto dto);
 
+  void updateBusinessId(UpdateBusinessIdDto dto);
+
   void incrementIncidentCount(Long processInstanceKey);
 
   void decrementIncidentCount(Long processInstanceKey);
@@ -102,6 +104,8 @@ public interface ProcessInstanceMapper {
       long processInstanceKey,
       ProcessInstanceEntity.ProcessInstanceState state,
       OffsetDateTime endDate) {}
+
+  record UpdateBusinessIdDto(long processInstanceKey, String businessId) {}
 
   record SelectExpiredRootProcessInstancesDto(
       int partitionId, OffsetDateTime cleanupDate, DbQueryPage page) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.service;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper.EndProcessInstanceDto;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper.ProcessInstanceTagsDto;
+import io.camunda.db.rdbms.sql.ProcessInstanceMapper.UpdateBusinessIdDto;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper.UpdateHistoryCleanupDateDto;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessInstanceDbModelBuilder;
@@ -78,6 +79,20 @@ public class ProcessInstanceWriter implements RdbmsWriter {
               key,
               "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateStateAndEndDate",
               dto));
+    }
+  }
+
+  public void updateBusinessId(final long key, final String businessId) {
+    final boolean wasMerged = mergeToQueue(key, b -> b.businessId(businessId));
+
+    if (!wasMerged) {
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.PROCESS_INSTANCE,
+              WriteStatementType.UPDATE,
+              key,
+              "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateBusinessId",
+              new UpdateBusinessIdDto(key, businessId)));
     }
   }
 

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -476,6 +476,13 @@
     WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
   </update>
 
+  <update id="updateBusinessId"
+    parameterType="io.camunda.db.rdbms.sql.ProcessInstanceMapper$UpdateBusinessIdDto">
+    UPDATE ${prefix}PROCESS_INSTANCE
+    SET BUSINESS_ID = #{businessId}
+    WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
+  </update>
+
   <update id="incrementIncidentCount" parameterType="java.lang.Long">
     UPDATE ${prefix}PROCESS_INSTANCE
     SET NUM_INCIDENTS = NUM_INCIDENTS + 1

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -245,6 +245,30 @@ class RdbmsExporterIT {
   }
 
   @Test
+  public void shouldUpdateBusinessIdOnLateAssignment() {
+    // given - a running process instance is exported
+    final var startedRecord = FIXTURES.getProcessInstanceStartedRecord();
+    exporter.export(startedRecord);
+    final var key = ((ProcessInstanceRecordValue) startedRecord.getValue()).getProcessInstanceKey();
+    final var before = rdbmsService.getProcessInstanceReader().findOne(key);
+    assertThat(before).isNotEmpty();
+
+    // when - a business id is assigned late to that running instance
+    final var assignedRecord =
+        FIXTURES.getProcessInstanceBusinessIdAssignedRecord(key, "late-business-id");
+    exporter.export(assignedRecord);
+
+    // then - only the business id of the existing row changed, nothing else
+    final var after = rdbmsService.getProcessInstanceReader().findOne(key);
+    assertThat(after).isNotEmpty();
+    assertThat(after.get().businessId()).isEqualTo("late-business-id");
+    assertThat(after.get().state()).isEqualTo(before.get().state());
+    assertThat(after.get().processDefinitionId()).isEqualTo(before.get().processDefinitionId());
+    assertThat(after.get().processDefinitionKey()).isEqualTo(before.get().processDefinitionKey());
+    assertThat(after.get().startDate()).isEqualTo(before.get().startDate());
+  }
+
+  @Test
   public void shouldExportProcessDefinition() {
     // given
     final var processDefinitionRecord = FIXTURES.getProcessDefinitionCreatedRecord();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.protocol.record.intent.HistoryDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobMetricsBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingRuleIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
@@ -64,6 +65,7 @@ import io.camunda.zeebe.protocol.record.value.ImmutableHistoryDeletionRecordValu
 import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobMetricsBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceBusinessIdRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceMigrationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceModificationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
@@ -73,6 +75,7 @@ import io.camunda.zeebe.protocol.record.value.ImmutableUserRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobMetricsBatchRecordValue.JobMetricsValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
@@ -166,6 +169,26 @@ public class RecordFixtures {
                 .withParentProcessInstanceKey(parentProcessInstanceKey)
                 .withParentElementInstanceKey(parentProcessInstanceKey)
                 .withVersion(1)
+                .build())
+        .build();
+  }
+
+  public ImmutableRecord<RecordValue> getProcessInstanceBusinessIdAssignedRecord(
+      final long processInstanceKey, final String businessId) {
+    final io.camunda.zeebe.protocol.record.Record<RecordValue> recordValueRecord =
+        FACTORY.generateRecord(ValueType.PROCESS_INSTANCE_BUSINESS_ID);
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(ProcessInstanceBusinessIdIntent.ASSIGNED)
+        .withPosition(nextPosition())
+        .withPartitionId(1)
+        .withTimestamp(System.currentTimeMillis())
+        .withKey(processInstanceKey)
+        .withValue(
+            ImmutableProcessInstanceBusinessIdRecordValue.builder()
+                .from((ProcessInstanceBusinessIdRecordValue) recordValueRecord.getValue())
+                .withProcessInstanceKey(processInstanceKey)
+                .withBusinessId(businessId)
                 .build())
         .build();
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -32,6 +32,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.MESSAGE_START_EVENT_SUB
 import static io.camunda.zeebe.protocol.record.ValueType.MESSAGE_SUBSCRIPTION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
+import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_BUSINESS_ID;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_CREATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MIGRATION;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE_MODIFICATION;
@@ -399,6 +400,7 @@ public class CamundaExporter implements Exporter {
             DECISION,
             DECISION_REQUIREMENTS,
             PROCESS_INSTANCE,
+            PROCESS_INSTANCE_BUSINESS_ID,
             PROCESS_INSTANCE_CREATION,
             PROCESS_INSTANCE_MIGRATION,
             PROCESS_INSTANCE_MODIFICATION,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -46,6 +46,7 @@ import io.camunda.exporter.handlers.JobHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromIncidentHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromJobHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromProcessInstanceHandler;
+import io.camunda.exporter.handlers.ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler;
 import io.camunda.exporter.handlers.ListViewProcessInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.ListViewVariableFromVariableHandler;
 import io.camunda.exporter.handlers.MappingRuleCreatedUpdatedHandler;
@@ -257,6 +258,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 decisionRequirementsCache),
             new ListViewProcessInstanceFromProcessInstanceHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(), processCache),
+            new ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler(
+                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ListViewFlowNodeFromIncidentHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ListViewFlowNodeFromJobHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.exporter.utils.ExporterUtil.emptyToNull;
+import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reflects a late Business ID assignment (ADR 0006) in the process-instance list-view document.
+ * Only the {@code businessId} of the already-existing document is updated; no other field is
+ * touched and no document is created, mirroring the forward-only, non-retroactive semantics of the
+ * feature.
+ */
+public class ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler
+    implements ExportHandler<
+        ProcessInstanceForListViewEntity, ProcessInstanceBusinessIdRecordValue> {
+
+  private final String indexName;
+
+  public ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler(
+      final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.PROCESS_INSTANCE_BUSINESS_ID;
+  }
+
+  @Override
+  public Class<ProcessInstanceForListViewEntity> getEntityType() {
+    return ProcessInstanceForListViewEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<ProcessInstanceBusinessIdRecordValue> record) {
+    return record.getIntent() == ProcessInstanceBusinessIdIntent.ASSIGNED;
+  }
+
+  @Override
+  public List<String> generateIds(final Record<ProcessInstanceBusinessIdRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getProcessInstanceKey()));
+  }
+
+  @Override
+  public ProcessInstanceForListViewEntity createNewEntity(final String id) {
+    return new ProcessInstanceForListViewEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<ProcessInstanceBusinessIdRecordValue> record,
+      final ProcessInstanceForListViewEntity entity) {
+    final var recordValue = record.getValue();
+    entity
+        .setId(String.valueOf(recordValue.getProcessInstanceKey()))
+        .setProcessInstanceKey(recordValue.getProcessInstanceKey())
+        .setKey(recordValue.getProcessInstanceKey())
+        .setTenantId(tenantOrDefault(recordValue.getTenantId()))
+        .setPartitionId(record.getPartitionId())
+        .setPosition(record.getPosition())
+        .setBusinessId(emptyToNull(recordValue.getBusinessId()));
+  }
+
+  @Override
+  public void flush(
+      final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest) {
+    final Map<String, Object> updateFields = new HashMap<>();
+    updateFields.put(ListViewTemplate.BUSINESS_ID, emptyToNull(entity.getBusinessId()));
+    batchRequest.update(indexName, entity.getId(), updateFields);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -40,6 +40,7 @@ import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.search.test.utils.TestObjectMapper;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.VariableEntity;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
@@ -51,9 +52,16 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceBusinessIdRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import io.camunda.zeebe.util.ObjectSizeEstimator;
@@ -335,6 +343,93 @@ final class CamundaExporterIT {
                   exportHandler.getClass().getSimpleName(), exportHandler.getHandledValueType())
               .isEqualTo(expectedEntity);
         });
+  }
+
+  @TestTemplate
+  void shouldUpdateBusinessIdOnLateAssignment(
+      final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
+      throws IOException {
+    // given - a running process instance already exported into the list view
+    config.getConnect().setIndexPrefix(testPrefix);
+    config.getIndex().setNumberOfReplicas(0);
+    createSchemas(config);
+
+    final long processInstanceKey = 4503599627370497L;
+    final Record<ProcessInstanceRecordValue> activatingRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r ->
+                r.withBrokerVersion("8.8.0")
+                    .withPosition(1L)
+                    .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                    .withTimestamp(System.currentTimeMillis())
+                    .withValue(
+                        ImmutableProcessInstanceRecordValue.builder()
+                            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+                            .withProcessInstanceKey(processInstanceKey)
+                            .withBpmnElementType(BpmnElementType.PROCESS)
+                            .withParentProcessInstanceKey(-1L)
+                            .withElementInstancePath(List.of())
+                            .withBusinessId("")
+                            .build()));
+
+    final CamundaExporter camundaExporter = new CamundaExporter();
+    camundaExporter.configure(
+        new ExporterTestContext()
+            .setConfiguration(new ExporterTestConfiguration<>("camundaExporter", config)));
+    camundaExporter.open(new ExporterTestController());
+    camundaExporter.export(activatingRecord);
+
+    final var resourceProvider = new DefaultExporterResourceProvider();
+    resourceProvider.init(
+        config,
+        mock(ExporterEntityCacheProvider.class),
+        new ExporterTestContext(),
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
+    final var listViewIndex =
+        resourceProvider.getExportHandlers().stream()
+            .filter(h -> h.getHandledValueType() == ValueType.PROCESS_INSTANCE_BUSINESS_ID)
+            .findFirst()
+            .orElseThrow()
+            .getIndexName();
+    final var documentId = String.valueOf(processInstanceKey);
+
+    final ProcessInstanceForListViewEntity before =
+        clientAdapter.get(documentId, listViewIndex, ProcessInstanceForListViewEntity.class);
+    assertThat(before).isNotNull();
+    assertThat(before.getBusinessId()).isNull();
+
+    // when - a business id is assigned late to that running instance
+    final Record<ProcessInstanceBusinessIdRecordValue> assignedRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE_BUSINESS_ID,
+            r ->
+                r.withBrokerVersion("8.8.0")
+                    .withPosition(2L)
+                    .withIntent(ProcessInstanceBusinessIdIntent.ASSIGNED)
+                    .withTimestamp(System.currentTimeMillis())
+                    .withValue(
+                        ImmutableProcessInstanceBusinessIdRecordValue.builder()
+                            .from(
+                                factory.generateObject(ProcessInstanceBusinessIdRecordValue.class))
+                            .withProcessInstanceKey(processInstanceKey)
+                            .withBusinessId("late-business-id")
+                            .build()));
+    camundaExporter.export(assignedRecord);
+
+    // then - only the business id of the existing document changed, nothing else
+    final ProcessInstanceForListViewEntity after =
+        clientAdapter.get(documentId, listViewIndex, ProcessInstanceForListViewEntity.class);
+    assertThat(after).isNotNull();
+    assertThat(after.getBusinessId()).isEqualTo("late-business-id");
+    assertThat(after.getState()).isEqualTo(before.getState());
+    assertThat(after.getBpmnProcessId()).isEqualTo(before.getBpmnProcessId());
+    assertThat(after.getProcessDefinitionKey()).isEqualTo(before.getProcessDefinitionKey());
+    assertThat(after.getPosition()).isEqualTo(before.getPosition());
+    assertThat(after.getPartitionId()).isEqualTo(before.getPartitionId());
+    assertThat(after.getTenantId()).isEqualTo(before.getTenantId());
+    assertThat(after.getProcessInstanceKey()).isEqualTo(before.getProcessInstanceKey());
   }
 
   @TestTemplate

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandlerTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceBusinessIdRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+
+public class ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-list-view";
+  private final ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler underTest =
+      new ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler(indexName);
+
+  @Test
+  public void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.PROCESS_INSTANCE_BUSINESS_ID);
+  }
+
+  @Test
+  public void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(ProcessInstanceForListViewEntity.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessInstanceBusinessIdIntent.class,
+      names = {"ASSIGNED"},
+      mode = Mode.INCLUDE)
+  public void shouldHandleRecord(final ProcessInstanceBusinessIdIntent intent) {
+    final Record<ProcessInstanceBusinessIdRecordValue> record = createRecord(intent);
+    // when - then
+    assertThat(underTest.handlesRecord(record)).as("Handles intent %s", intent).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessInstanceBusinessIdIntent.class,
+      names = {"ASSIGNED"},
+      mode = Mode.EXCLUDE)
+  public void shouldNotHandleRecord(final ProcessInstanceBusinessIdIntent intent) {
+    final Record<ProcessInstanceBusinessIdRecordValue> record = createRecord(intent);
+    // when - then
+    assertThat(underTest.handlesRecord(record)).as("Does not handle intent %s", intent).isFalse();
+  }
+
+  @Test
+  public void shouldGenerateIds() {
+    // given
+    final long expectedId = 123;
+    final Record<ProcessInstanceBusinessIdRecordValue> record =
+        createRecord(
+            ProcessInstanceBusinessIdIntent.ASSIGNED, b -> b.withProcessInstanceKey(expectedId));
+
+    // when
+    final var idList = underTest.generateIds(record);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(expectedId));
+  }
+
+  @Test
+  public void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateOnlyBusinessIdOnFlush() {
+    // given
+    final ProcessInstanceForListViewEntity inputEntity =
+        new ProcessInstanceForListViewEntity().setId("111").setBusinessId("my-business-id");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
+    expectedUpdateFields.put(ListViewTemplate.BUSINESS_ID, "my-business-id");
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).update(indexName, "111", expectedUpdateFields);
+  }
+
+  @Test
+  void shouldNotCreateDocumentAndNormalizeEmptyBusinessIdToNullOnFlush() {
+    // given
+    final ProcessInstanceForListViewEntity inputEntity =
+        new ProcessInstanceForListViewEntity().setId("111").setBusinessId("");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
+    expectedUpdateFields.put(ListViewTemplate.BUSINESS_ID, null);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).update(indexName, "111", expectedUpdateFields);
+  }
+
+  @Test
+  void shouldPopulateBusinessIdOnUpdateEntity() {
+    // given
+    final Record<ProcessInstanceBusinessIdRecordValue> record =
+        createRecord(
+            ProcessInstanceBusinessIdIntent.ASSIGNED,
+            b -> b.withProcessInstanceKey(111L).withBusinessId("my-business-id"));
+    final ProcessInstanceForListViewEntity entity = underTest.createNewEntity(String.valueOf(111L));
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getId()).isEqualTo("111");
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(111L);
+    assertThat(entity.getKey()).isEqualTo(111L);
+    assertThat(entity.getBusinessId()).isEqualTo("my-business-id");
+  }
+
+  @Test
+  void shouldNormalizeEmptyBusinessIdToNullOnUpdateEntity() {
+    // given
+    final Record<ProcessInstanceBusinessIdRecordValue> record =
+        createRecord(
+            ProcessInstanceBusinessIdIntent.ASSIGNED,
+            b -> b.withProcessInstanceKey(111L).withBusinessId(""));
+    final ProcessInstanceForListViewEntity entity = underTest.createNewEntity(String.valueOf(111L));
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getBusinessId()).isNull();
+  }
+
+  private Record<ProcessInstanceBusinessIdRecordValue> createRecord(
+      final ProcessInstanceBusinessIdIntent intent) {
+    return createRecord(intent, b -> b);
+  }
+
+  private Record<ProcessInstanceBusinessIdRecordValue> createRecord(
+      final ProcessInstanceBusinessIdIntent intent,
+      final java.util.function.UnaryOperator<ImmutableProcessInstanceBusinessIdRecordValue.Builder>
+          customizer) {
+    final ProcessInstanceBusinessIdRecordValue value =
+        customizer
+            .apply(
+                ImmutableProcessInstanceBusinessIdRecordValue.builder()
+                    .from(factory.generateObject(ProcessInstanceBusinessIdRecordValue.class)))
+            .build();
+    return factory.generateRecord(
+        ValueType.PROCESS_INSTANCE_BUSINESS_ID, r -> r.withIntent(intent).withValue(value));
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -39,6 +39,7 @@ import io.camunda.exporter.rdbms.handlers.MappingRuleExportHandler;
 import io.camunda.exporter.rdbms.handlers.MessageSubscriptionExportHandler;
 import io.camunda.exporter.rdbms.handlers.MessageSubscriptionFromMessageStartEventSubscriptionExportHandler;
 import io.camunda.exporter.rdbms.handlers.ProcessExportHandler;
+import io.camunda.exporter.rdbms.handlers.ProcessInstanceBusinessIdExportHandler;
 import io.camunda.exporter.rdbms.handlers.ProcessInstanceExportHandler;
 import io.camunda.exporter.rdbms.handlers.ProcessInstanceIncidentExportHandler;
 import io.camunda.exporter.rdbms.handlers.ResourceExportHandler;
@@ -251,6 +252,9 @@ public class RdbmsExporterWrapper implements Exporter {
             historyCleanupService,
             cacheRegistry.processCache(),
             rdbmsWriters.getErrorMessageSize()));
+    builder.withHandler(
+        ValueType.PROCESS_INSTANCE_BUSINESS_ID,
+        new ProcessInstanceBusinessIdExportHandler(rdbmsWriters.getProcessInstanceWriter()));
     builder.withHandler(
         ValueType.PROCESS_INSTANCE,
         new FlowNodeExportHandler(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceBusinessIdExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceBusinessIdExportHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.exporter.rdbms.utils.ExportUtil;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
+
+/**
+ * Reflects a late Business ID assignment (ADR 0006) on the process-instance row. Only the {@code
+ * businessId} column of the already-existing row is updated; nothing else is touched, in line with
+ * the forward-only, non-retroactive semantics of the feature.
+ */
+public class ProcessInstanceBusinessIdExportHandler
+    implements RdbmsExportHandler<ProcessInstanceBusinessIdRecordValue> {
+
+  private final ProcessInstanceWriter processInstanceWriter;
+
+  public ProcessInstanceBusinessIdExportHandler(final ProcessInstanceWriter processInstanceWriter) {
+    this.processInstanceWriter = processInstanceWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<ProcessInstanceBusinessIdRecordValue> record) {
+    return record.getValueType() == ValueType.PROCESS_INSTANCE_BUSINESS_ID
+        && record.getIntent() == ProcessInstanceBusinessIdIntent.ASSIGNED;
+  }
+
+  @Override
+  public void export(final Record<ProcessInstanceBusinessIdRecordValue> record) {
+    final var value = record.getValue();
+    processInstanceWriter.updateBusinessId(
+        value.getProcessInstanceKey(), ExportUtil.emptyToNull(value.getBusinessId()));
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceBusinessIdExportHandlerTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceBusinessIdExportHandlerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBusinessIdIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceBusinessIdRecordValue;
+import org.junit.jupiter.api.Test;
+
+class ProcessInstanceBusinessIdExportHandlerTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 42L;
+  private static final String BUSINESS_ID = "my-business-id";
+
+  private final ProcessInstanceWriter processInstanceWriter = mock(ProcessInstanceWriter.class);
+  private final ProcessInstanceBusinessIdExportHandler handler =
+      new ProcessInstanceBusinessIdExportHandler(processInstanceWriter);
+
+  @Test
+  void shouldExportAssignedRecord() {
+    // given
+    final var record =
+        record(ValueType.PROCESS_INSTANCE_BUSINESS_ID, ProcessInstanceBusinessIdIntent.ASSIGNED);
+
+    // when - then
+    assertThat(handler.canExport(record)).isTrue();
+  }
+
+  @Test
+  void shouldNotExportAssignCommand() {
+    // given
+    final var record =
+        record(ValueType.PROCESS_INSTANCE_BUSINESS_ID, ProcessInstanceBusinessIdIntent.ASSIGN);
+
+    // when - then
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldNotExportOtherValueType() {
+    // given
+    final var record = record(ValueType.PROCESS_INSTANCE, ProcessInstanceBusinessIdIntent.ASSIGNED);
+
+    // when - then
+    assertThat(handler.canExport(record)).isFalse();
+  }
+
+  @Test
+  void shouldUpdateBusinessIdOnExport() {
+    // given
+    final var record =
+        record(ValueType.PROCESS_INSTANCE_BUSINESS_ID, ProcessInstanceBusinessIdIntent.ASSIGNED);
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(processInstanceWriter).updateBusinessId(PROCESS_INSTANCE_KEY, BUSINESS_ID);
+  }
+
+  @Test
+  void shouldNormalizeEmptyBusinessIdToNullOnExport() {
+    // given
+    final var record =
+        record(ValueType.PROCESS_INSTANCE_BUSINESS_ID, ProcessInstanceBusinessIdIntent.ASSIGNED);
+    when(record.getValue().getBusinessId()).thenReturn("");
+
+    // when
+    handler.export(record);
+
+    // then
+    verify(processInstanceWriter).updateBusinessId(PROCESS_INSTANCE_KEY, null);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Record<ProcessInstanceBusinessIdRecordValue> record(
+      final ValueType valueType, final ProcessInstanceBusinessIdIntent intent) {
+    final Record<ProcessInstanceBusinessIdRecordValue> record = mock(Record.class);
+    when(record.getValueType()).thenReturn(valueType);
+    when(record.getIntent()).thenReturn(intent);
+    final ProcessInstanceBusinessIdRecordValue value =
+        mock(ProcessInstanceBusinessIdRecordValue.class);
+    when(value.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+    when(value.getBusinessId()).thenReturn(BUSINESS_ID);
+    when(record.getValue()).thenReturn(value);
+    return record;
+  }
+}


### PR DESCRIPTION
## Description

When a Business ID is assigned to an already-running process instance (ADR 0006), secondary
storage did not reflect the change: the `camunda-exporter` dropped the
`PROCESS_INSTANCE_BUSINESS_ID` record at its filter, and the RDBMS exporter had no handler for
it at all.

This PR makes both exporters react to the `ASSIGNED` event and propagate the business ID to
the appropriate storage layer — without disturbing any other field or entity.

### camunda-exporter (ES/OS)

- Registers `PROCESS_INSTANCE_BUSINESS_ID` in `CamundaExporter`'s record filter.
- Adds `ListViewProcessInstanceBusinessIdFromProcessInstanceBusinessIdHandler`, which upserts
  only the `BUSINESS_ID` field of the existing process-instance list-view document. All other
  fields (state, BPMN process ID, flow nodes, incidents, variables) are left untouched,
  preserving the forward-only, non-retroactive contract of the feature.

### rdbms-exporter (RDBMS)

- Adds `ProcessInstanceBusinessIdExportHandler`, which calls a dedicated single-column
  `UPDATE … SET BUSINESS_ID = ?` on the existing process-instance row via
  `ProcessInstanceWriter.updateBusinessId`. No other column or related table is written.

### Testing

- Unit tests for both new handlers, including negative cases (wrong value type, non-`ASSIGNED`
  intent).
- `CamundaExporterIT` extended with an integration test verifying that after a late assignment
  only the `businessId` field changes in the list-view document.
- `RdbmsExporterIT` extended with an integration test verifying the same invariant against the
  relational read model.

### Non-goals

- Task, decision, job, and flow-node documents/rows are **not** updated as a result of a
  Business ID assignment — asserted in tests.
- No changes to the data model; the `BUSINESS_ID` column / field already exists.

## Related issues

closes #57629