### PR TITLE
test: wait for login to be accepted in TestWebappClient

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestWebappClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestWebappClient.java
@@ -18,10 +18,16 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.Builder;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 
 public class TestWebappClient {
+
+  private static final Duration LOGIN_TIMEOUT = Duration.ofSeconds(3);
 
   private final URI endpoint;
 
@@ -29,30 +35,56 @@ public class TestWebappClient {
     this.endpoint = endpoint;
   }
 
-  public TestLoggedInWebappClient logIn(String username, String password) {
+  public TestLoggedInWebappClient logIn(final String username, final String password) {
 
     final var cookieManager = new CookieManager();
     final var httpClient = HttpClient.newBuilder().cookieHandler(cookieManager).build();
-    final var loginUri = endpoint.resolve("login");
+    final var loginRequest = buildLoginRequest(username, password);
+    final var lastResponse = new AtomicReference<HttpResponse<String>>();
 
-    final var loginRequest =
-        HttpRequest.newBuilder()
-            .uri(loginUri)
-            .header("Content-Type", "application/x-www-form-urlencoded")
-            .POST(
-                HttpRequest.BodyPublishers.ofString(
-                    "username=" + username + "&password=" + password))
-            .build();
-
-    final var loginResponse = sendRequestAndThrowExceptionOnFailure(httpClient, loginRequest);
+    // The default user is provisioned asynchronously; on Elasticsearch/OpenSearch it only becomes
+    // searchable after an index refresh. Until then the username lookup misses and login is
+    // rejected, so retry until it is accepted rather than handing back an unauthenticated client
+    // whose failure only surfaces later as a confusing 401 on the first authenticated request.
+    try {
+      Awaitility.await("login of user '%s'".formatted(username))
+          .atMost(LOGIN_TIMEOUT)
+          .pollDelay(Duration.ZERO)
+          .pollInterval(Duration.ofMillis(100))
+          .until(
+              () -> {
+                lastResponse.set(sendRequestAndThrowExceptionOnFailure(httpClient, loginRequest));
+                return isSuccessful(lastResponse.get());
+              });
+    } catch (final ConditionTimeoutException e) {
+      final var response = lastResponse.get();
+      throw new IllegalStateException(
+          "Login of user '%s' did not succeed within %s; last response status was %s"
+              .formatted(username, LOGIN_TIMEOUT, response == null ? "n/a" : response.statusCode()),
+          e);
+    }
 
     final var csrfToken =
-        loginResponse
+        lastResponse
+            .get()
             .headers()
             .firstValue(CamundaSecurityFilterChainConstants.X_CSRF_TOKEN)
             .orElse(null);
 
     return new TestLoggedInWebappClient(httpClient, cookieManager, csrfToken);
+  }
+
+  private HttpRequest buildLoginRequest(final String username, final String password) {
+    return HttpRequest.newBuilder()
+        .uri(endpoint.resolve("login"))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .POST(HttpRequest.BodyPublishers.ofString("username=" + username + "&password=" + password))
+        .build();
+  }
+
+  private static boolean isSuccessful(final HttpResponse<?> response) {
+    final int status = response.statusCode();
+    return status >= 200 && status < 300;
   }
 
   private static Either<Exception, HttpResponse<String>> sendRequest(


### PR DESCRIPTION
## Description

`BasicAuthUnprotectedApiSessionIT#shouldRecognizeAndInvalidateSessionOnUnprotectedApiChain` is flaky on Elasticsearch/OpenSearch (never on RDBMS): the first `GET /v2/authentication/me` after `/login` returns 401 instead of 200.

Root cause: the default `demo` user is provisioned asynchronously and, on ES/OS, only becomes searchable after an index refresh. `TestWebappClient.logIn` sent a single `POST /login` and returned a client regardless of the HTTP status, so a login rejected during the refresh window (username lookup misses → `BadCredentialsException` → 401) handed back an unauthenticated client. The failure then resurfaced later as a confusing anonymous `/me` 401. RDBMS is immune because it has immediate read-after-write consistency.

## Fix

`logIn` now retries the login until it is accepted (2xx) within a bounded 3s timeout (100ms poll), waiting out the refresh window, and fails loudly with the last HTTP status if it never succeeds — instead of silently returning an unauthenticated client. This closes the race for all webapp-login ITs and removes the misleading late 401.

Considered gating default-user readiness once in `CamundaMultiDBExtension`, but the retry is localized to the shared login helper and a transient login rejection during the refresh window is correct eventual-consistency behavior, not a product bug.

## Verifying

The old setup failed on 4th attempt for me locally with Opensearch, after the Fix I had 600+ passes until I manually stopped
<img width="1091" height="71" alt="image" src="https://github.com/user-attachments/assets/ff62d214-03bf-44d9-a547-e41d0035f7aa" />


Closes #57744

🤖 Generated with [Claude Code](https://claude.com/claude-code)
