### PR TITLE
docs: clarify CI workflow concurrency guidance

### DIFF
--- a/.claude/skills/ci-workflow-authoring/SKILL.md
+++ b/.claude/skills/ci-workflow-authoring/SKILL.md
@@ -18,6 +18,30 @@ Check `docs/monorepo-docs/ci.md` first.
 - Ensure each job ends with `observe-build-status` step.
 - Fail fast: validate cheap preconditions (required secrets, Vault reachability, input/tag contracts) in a preflight step or job before expensive build/test steps.
 
+## Recommendation: restrict `on: push` to main/stable branches
+
+Use `push` only for workflows on `main`/`stable/*`, where every commit needs a full build for
+confidence. Use `pull_request` everywhere else, so a branch doesn't get two trigger sources to
+deduplicate.
+
+## Recommendation: concurrency groups for PR, push, and scheduled workflows
+
+Add a `concurrency:` group to cancel superseded runs, reduce race conditions, and avoid wasted
+runner cost. Copy the pattern from
+[`ci.yml`](https://github.com/camunda/camunda/blob/b4da8ace350ca5f64564bf764b7d85833c366995/.github/workflows/ci.yml#L20-L25)
+rather than inventing a new one:
+
+```yaml
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}-{2}', github.workflow, github.event_name, (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/stable/')) && github.sha || github.ref) }}
+```
+
+`github.event_name` keeps different trigger sources on the same ref from colliding, especially
+scheduled cache-refresh runs and push builds on `main`/`stable/*`. The `github.sha` fallback for
+`main`/`stable/*` is intentional: those branches need complete builds for every pushed commit, and
+a cancelled push run can mean a missed alert or skipped artifact push.
+
 ## Unified CI Criteria
 
 - Runtime <= 30 minutes
@@ -37,4 +61,3 @@ Check `docs/monorepo-docs/ci.md` first.
 
 - Workflow template: `references/workflow-template.md`
 - Composite action template: `references/composite-action-template.md`
-


### PR DESCRIPTION
## Description

Clarifies the `ci-workflow-authoring` skill's concurrency recommendation: copy the `ci.yml` group expression for PR, push, and scheduled workflows so superseded runs are canceled, cross-trigger collisions are avoided, and race conditions and runner waste are reduced.

Also adds guidance to use `push` only for protected long-lived branches (`main`/`stable/*`) and rely on `pull_request` for feature branches.

## Checklist

- [ ] Enable backports when necessary

## Related issues

None
