### PR TITLE
Add cluster-admin basic auth 

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -228,7 +228,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-crypto</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminAuthenticationConverter.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminAuthenticationConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import io.camunda.security.api.context.CamundaAuthenticationConverter;
+import io.camunda.security.api.model.CamundaAuthentication;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Converts a cluster-admin {@link Authentication} into a {@link CamundaAuthentication} with only
+ * the configured username.
+ *
+ * <p>Registered ahead of CSL's DB-backed converter so cluster-admin principals do not pick up DB
+ * memberships on name collision. It only claims authentications marked with {@link
+ * ClusterAdminSecurityConfiguration#CLUSTER_ADMIN_AUTHORITY}.
+ */
+public final class ClusterAdminAuthenticationConverter
+    implements CamundaAuthenticationConverter<Authentication> {
+
+  @Override
+  public boolean supports(final Authentication authentication) {
+    return authentication != null
+        && authentication.isAuthenticated()
+        && authentication.getAuthorities().stream()
+            .anyMatch(
+                authority ->
+                    ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY.equals(
+                        authority.getAuthority()));
+  }
+
+  @Override
+  public CamundaAuthentication convert(final Authentication authentication) {
+    // Username only; groups/roles/tenants deliberately left empty (no MembershipPort lookup).
+    return CamundaAuthentication.of(builder -> builder.user(authentication.getName()));
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminBasicAuthProperties.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminBasicAuthProperties.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.core.env.Environment;
+
+/**
+ * Binds and validates the statically configured cluster-admin Basic Auth users from {@code
+ * camunda.security.cluster-admin.basic.users}.
+ *
+ * <p>An empty or entirely absent configuration is a legitimate, silently-accepted state (no
+ * cluster-admin Basic users provisioned yet) — only a malformed entry (duplicate name, blank name
+ * or password) fails startup.
+ */
+public final class ClusterAdminBasicAuthProperties {
+
+  private static final String USERS_PROPERTY = "camunda.security.cluster-admin.basic.users";
+
+  private ClusterAdminBasicAuthProperties() {}
+
+  /**
+   * Binds the configured cluster-admin Basic Auth users and validates them.
+   *
+   * @param environment the Spring {@link Environment} to bind from
+   * @return the validated list of configured users
+   * @throws IllegalStateException if any entry has a blank/missing {@code name} or {@code
+   *     password}, or if two entries share the same {@code name}
+   */
+  public static List<ClusterAdminUser> loadAndValidate(final Environment environment) {
+    final List<ClusterAdminUser> users =
+        Binder.get(environment)
+            .bind(USERS_PROPERTY, Bindable.listOf(ClusterAdminUser.class))
+            .orElse(List.of());
+    validate(users);
+    return users;
+  }
+
+  private static void validate(final List<ClusterAdminUser> users) {
+    final Set<String> seenNames = new HashSet<>();
+    for (final ClusterAdminUser user : users) {
+      if (user.name() == null || user.name().isBlank()) {
+        throw new IllegalStateException(
+            "%s contains an entry with a blank or missing 'name'".formatted(USERS_PROPERTY));
+      }
+      if (user.password() == null || user.password().isBlank()) {
+        throw new IllegalStateException(
+            "%s entry '%s' has a blank or missing 'password'"
+                .formatted(USERS_PROPERTY, user.name()));
+      }
+      if (!seenNames.add(user.name())) {
+        throw new IllegalStateException(
+            "%s contains a duplicate name: '%s'".formatted(USERS_PROPERTY, user.name()));
+      }
+    }
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.context.NullSecurityContextRepository;
 import org.springframework.security.web.savedrequest.NullRequestCache;
 
 /**
@@ -50,6 +51,10 @@ import org.springframework.security.web.savedrequest.NullRequestCache;
  * accidentally suppressing CSL's global DB-backed auth beans, and allowing unknown in-memory
  * credentials to fall through to the global manager. Without this isolation, a DB-backed user could
  * authenticate on {@code /cluster/v2/**}.
+ *
+ * <p><strong>Statelessness:</strong> the chain binds a session-free {@link
+ * NullSecurityContextRepository} explicitly and never creates a session, so an existing webapp
+ * session cookie can never authenticate {@code /cluster/v2/**}.
  *
  * <p><strong>#57708 (OIDC):</strong> {@code cluster-admin.basic} and {@code cluster-admin.oidc} are
  * independent sibling config trees, so either mechanism can authenticate this chain based on the
@@ -96,9 +101,12 @@ public class ClusterAdminSecurityConfiguration {
         .cors(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
         .anonymous(AbstractHttpConfigurer::disable)
-        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.NEVER))
+        // Explicit session-free context repository so a webapp session cookie can't authenticate
+        // this chain. Explicit is required: STATELESS installs one only if none was set already
+        // (SessionManagementConfigurer's `if (repo == null)` guard).
+        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+        .securityContext(sc -> sc.securityContextRepository(new NullSecurityContextRepository()))
         .requestCache(cache -> cache.requestCache(new NullRequestCache()))
-        // Stateless per-request Basic auth: no session, no CSRF surface, so disable it explicitly.
         .csrf(AbstractHttpConfigurer::disable);
 
     SecurityFilterChainSupport.setupSecureHeaders(http, properties.getHttpHeaders());

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
@@ -9,7 +9,6 @@ package io.camunda.authentication.clusteradmin;
 
 import static io.camunda.security.spring.security.CamundaSecurityFilterChainConstants.ORDER_WEBAPP_API;
 
-import io.camunda.authentication.config.spi.SecurityPathAdapter;
 import io.camunda.security.api.context.CamundaAuthenticationConverter;
 import io.camunda.security.api.model.config.AuthenticationMethod;
 import io.camunda.security.spring.CamundaSecurityLibraryProperties;
@@ -121,10 +120,10 @@ public class ClusterAdminSecurityConfiguration {
         .formLogin(AbstractHttpConfigurer::disable)
         .anonymous(AbstractHttpConfigurer::disable)
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.NEVER))
-        .requestCache(cache -> cache.requestCache(new NullRequestCache()));
+        .requestCache(cache -> cache.requestCache(new NullRequestCache()))
+        // Stateless per-request Basic auth: no session, no CSRF surface, so disable it explicitly.
+        .csrf(AbstractHttpConfigurer::disable);
 
-    SecurityFilterChainSupport.applyCsrfConfiguration(
-        http, properties, SecurityPathAdapter.INSTANCE);
     SecurityFilterChainSupport.setupSecureHeaders(http, properties.getHttpHeaders());
 
     return http.build();

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
@@ -22,6 +22,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.Customizer;
@@ -83,31 +84,7 @@ public class ClusterAdminSecurityConfiguration {
       final AuthFailureHandler authFailureHandler,
       final CamundaSecurityLibraryProperties properties)
       throws Exception {
-    final var users = ClusterAdminBasicAuthProperties.loadAndValidate(environment);
-
-    // The shared PasswordEncoder bean is present because this chain and that bean share the same
-    // @ConditionalOnAuthenticationMethod(BASIC) gate. It encodes the configured passwords below and
-    // verifies them on every request, so encode and verify always agree.
-    final var userDetailsManager = new InMemoryUserDetailsManager();
-    for (final ClusterAdminUser user : users) {
-      userDetailsManager.createUser(
-          User.withUsername(user.name())
-              .password(passwordEncoder.encode(user.password()))
-              .authorities(CLUSTER_ADMIN_AUTHORITY)
-              .build());
-    }
-    LOG.info(
-        "Loaded {} cluster-admin basic-auth user(s) for {}",
-        users.size(),
-        CLUSTER_ADMIN_API_PATTERN);
-
-    // Use an explicit, parent-less ProviderManager so credentials are checked only against the
-    // in-memory store. Not http.getSharedObject(AuthenticationManagerBuilder.class): its builder
-    // parents to the global manager, so unknown users would fall through to the DB-backed manager
-    // and a DB user could authenticate on /cluster/v2/**.
-    final var authenticationProvider = new DaoAuthenticationProvider(userDetailsManager);
-    authenticationProvider.setPasswordEncoder(passwordEncoder);
-    http.authenticationManager(new ProviderManager(authenticationProvider));
+    http.authenticationManager(clusterAdminAuthenticationManager(environment, passwordEncoder));
 
     http.securityMatcher(CLUSTER_ADMIN_API_PATTERN)
         .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
@@ -127,6 +104,38 @@ public class ClusterAdminSecurityConfiguration {
     SecurityFilterChainSupport.setupSecureHeaders(http, properties.getHttpHeaders());
 
     return http.build();
+  }
+
+  /**
+   * Builds the isolated authentication manager for this chain: the configured cluster-admin users
+   * in in-memory store behind an explicit, parent-less {@link ProviderManager}. Parent-less (not
+   * {@code http.getSharedObject(AuthenticationManagerBuilder.class)}) so credentials are checked
+   * only against this store — otherwise unknown users would fall through to the global DB-backed
+   * manager and a DB user could authenticate on {@code /cluster/v2/**}.
+   */
+  private AuthenticationManager clusterAdminAuthenticationManager(
+      final Environment environment, final PasswordEncoder passwordEncoder) {
+    final var users = ClusterAdminBasicAuthProperties.loadAndValidate(environment);
+
+    // The shared PasswordEncoder bean is present because this chain and that bean share the same
+    // @ConditionalOnAuthenticationMethod(BASIC) gate. It encodes the configured passwords below and
+    // verifies them on every request, so encode and verify always agree.
+    final var userDetailsManager = new InMemoryUserDetailsManager();
+    for (final ClusterAdminUser user : users) {
+      userDetailsManager.createUser(
+          User.withUsername(user.name())
+              .password(passwordEncoder.encode(user.password()))
+              .authorities(CLUSTER_ADMIN_AUTHORITY)
+              .build());
+    }
+    LOG.info(
+        "Loaded {} cluster-admin basic-auth user(s) for {}",
+        users.size(),
+        CLUSTER_ADMIN_API_PATTERN);
+
+    final var authenticationProvider = new DaoAuthenticationProvider(userDetailsManager);
+    authenticationProvider.setPasswordEncoder(passwordEncoder);
+    return new ProviderManager(authenticationProvider);
   }
 
   /**

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminSecurityConfiguration.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import static io.camunda.security.spring.security.CamundaSecurityFilterChainConstants.ORDER_WEBAPP_API;
+
+import io.camunda.authentication.config.spi.SecurityPathAdapter;
+import io.camunda.security.api.context.CamundaAuthenticationConverter;
+import io.camunda.security.api.model.config.AuthenticationMethod;
+import io.camunda.security.spring.CamundaSecurityLibraryProperties;
+import io.camunda.security.spring.annotation.ConditionalOnAuthenticationMethod;
+import io.camunda.security.spring.handler.AuthFailureHandler;
+import io.camunda.security.spring.security.SecurityFilterChainSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.savedrequest.NullRequestCache;
+
+/**
+ * Dedicated security chain for the cluster-admin API under {@code /cluster/v2/**}.
+ *
+ * <p>All paths under {@code /cluster/v2/**} require HTTP Basic authentication against the
+ * statically configured cluster-admin users ({@code camunda.security.cluster-admin.basic.users}).
+ * Registered only under the basic authentication method (the default); under OIDC this chain is not
+ * present and cluster-admin OIDC support follows in #57708.
+ *
+ * <p><strong>Isolation:</strong> keep the cluster-admin user store isolated as a plain in-memory
+ * object behind a dedicated, parent-less {@link ProviderManager} for this chain. Do not expose it
+ * as a {@code UserDetailsService} or {@code PasswordEncoder} bean. This avoids two problems:
+ * accidentally suppressing CSL's global DB-backed auth beans, and allowing unknown in-memory
+ * credentials to fall through to the global manager. Without this isolation, a DB-backed user could
+ * authenticate on {@code /cluster/v2/**}.
+ *
+ * <p><strong>#57708 (OIDC):</strong> {@code cluster-admin.basic} and {@code cluster-admin.oidc} are
+ * independent sibling config trees, so either mechanism can authenticate this chain based on the
+ * {@code Authorization} header scheme. For #57708, OIDC should be added to the same chain through a
+ * parallel {@code .oauth2ResourceServer(...)} block gated by {@code cluster-admin.oidc} presence,
+ * not through a second same-path chain, since Spring only dispatches to one matching chain per
+ * request.
+ */
+@Configuration
+@ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
+public class ClusterAdminSecurityConfiguration {
+
+  /**
+   * Marker authority assigned to every cluster-admin principal. The chain does not check it
+   * directly, because authentication alone is enough in this all-or-nothing model. {@link
+   * ClusterAdminAuthenticationConverter} uses it to identify these principals and skip the
+   * DB-backed membership lookup.
+   */
+  public static final String CLUSTER_ADMIN_AUTHORITY = "ROLE_CLUSTER_ADMIN";
+
+  static final String CLUSTER_ADMIN_API_PATTERN = "/cluster/v2/**";
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ClusterAdminSecurityConfiguration.class);
+
+  @Bean
+  @Order(ORDER_WEBAPP_API)
+  public SecurityFilterChain clusterAdminSecurityFilterChain(
+      final HttpSecurity http,
+      final Environment environment,
+      final PasswordEncoder passwordEncoder,
+      final AuthFailureHandler authFailureHandler,
+      final CamundaSecurityLibraryProperties properties)
+      throws Exception {
+    final var users = ClusterAdminBasicAuthProperties.loadAndValidate(environment);
+
+    // The shared PasswordEncoder bean is present because this chain and that bean share the same
+    // @ConditionalOnAuthenticationMethod(BASIC) gate. It encodes the configured passwords below and
+    // verifies them on every request, so encode and verify always agree.
+    final var userDetailsManager = new InMemoryUserDetailsManager();
+    for (final ClusterAdminUser user : users) {
+      userDetailsManager.createUser(
+          User.withUsername(user.name())
+              .password(passwordEncoder.encode(user.password()))
+              .authorities(CLUSTER_ADMIN_AUTHORITY)
+              .build());
+    }
+    LOG.info(
+        "Loaded {} cluster-admin basic-auth user(s) for {}",
+        users.size(),
+        CLUSTER_ADMIN_API_PATTERN);
+
+    // Use an explicit, parent-less ProviderManager so credentials are checked only against the
+    // in-memory store. Not http.getSharedObject(AuthenticationManagerBuilder.class): its builder
+    // parents to the global manager, so unknown users would fall through to the DB-backed manager
+    // and a DB user could authenticate on /cluster/v2/**.
+    final var authenticationProvider = new DaoAuthenticationProvider(userDetailsManager);
+    authenticationProvider.setPasswordEncoder(passwordEncoder);
+    http.authenticationManager(new ProviderManager(authenticationProvider));
+
+    http.securityMatcher(CLUSTER_ADMIN_API_PATTERN)
+        .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+        .httpBasic(Customizer.withDefaults())
+        .exceptionHandling(
+            eh ->
+                eh.authenticationEntryPoint(authFailureHandler)
+                    .accessDeniedHandler(authFailureHandler))
+        .cors(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .anonymous(AbstractHttpConfigurer::disable)
+        .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.NEVER))
+        .requestCache(cache -> cache.requestCache(new NullRequestCache()));
+
+    SecurityFilterChainSupport.applyCsrfConfiguration(
+        http, properties, SecurityPathAdapter.INSTANCE);
+    SecurityFilterChainSupport.setupSecureHeaders(http, properties.getHttpHeaders());
+
+    return http.build();
+  }
+
+  /**
+   * Converter that prevents cluster-admin principals from going through the DB-backed membership
+   * path. It runs before CSL's DB converter and only claims authentications marked with {@link
+   * #CLUSTER_ADMIN_AUTHORITY}, letting all others fall through.
+   *
+   * <p>It is registered now to prevent a future cross-chain leak on {@code /cluster/v2/**}: without
+   * it, a cluster-admin token could be treated as a DB user and inherit that user's groups, roles,
+   * and tenants on name collision.
+   */
+  @Bean
+  @Order(Ordered.HIGHEST_PRECEDENCE)
+  public CamundaAuthenticationConverter<Authentication> clusterAdminAuthenticationConverter() {
+    return new ClusterAdminAuthenticationConverter();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/clusteradmin/ClusterAdminUser.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+/**
+ * A cluster-admin user for HTTP Basic authentication against the {@code /cluster/v2/**} API.
+ *
+ * <p>Intentionally duplicated from {@code io.camunda.configuration.ClusterAdminUser} (configuration
+ * module): {@code authentication} does not depend on {@code configuration} (see {@code
+ * PhysicalTenantAuthConfigurations#VALID_TENANT_ID} for the same constraint on an analogous case),
+ * so this module binds the {@code camunda.security.cluster-admin.basic.users} property path
+ * independently. The configuration-module type exists for typed config metadata only; this one is
+ * what actually gets bound and consumed. Keep the two in sync.
+ *
+ * @param name the login name, unique among configured cluster-admin users
+ * @param password the plaintext password, encoded once at startup
+ */
+public record ClusterAdminUser(String name, String password) {}

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.config;
 
+import io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration;
 import io.camunda.authentication.config.spi.AdminUserPresenceAdapter;
 import io.camunda.authentication.config.spi.AuthorizationRepositoryAdapter;
 import io.camunda.authentication.config.spi.BasicAuthUserDetailsAdapter;
@@ -67,6 +68,7 @@ import org.springframework.security.web.firewall.StrictHttpFirewall;
   BasicAuthBeansConfiguration.class,
   SaasCspModeCompatibility.class,
   PhysicalTenantSecurityConfiguration.class,
+  ClusterAdminSecurityConfiguration.class,
 })
 public class WebSecurityConfig {
 

--- a/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminAuthenticationConverterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminAuthenticationConverterTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import static io.camunda.authentication.clusteradmin.ClusterAdminSecurityConfiguration.CLUSTER_ADMIN_AUTHORITY;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.api.model.CamundaAuthentication;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+class ClusterAdminAuthenticationConverterTest {
+
+  private final ClusterAdminAuthenticationConverter converter =
+      new ClusterAdminAuthenticationConverter();
+
+  @Test
+  void shouldSupportAuthenticatedClusterAdminPrincipal() {
+    // given
+    final var authentication =
+        UsernamePasswordAuthenticationToken.authenticated(
+            "admin", "n/a", List.of(new SimpleGrantedAuthority(CLUSTER_ADMIN_AUTHORITY)));
+
+    // when/then
+    assertThat(converter.supports(authentication)).isTrue();
+  }
+
+  @Test
+  void shouldNotSupportPrincipalWithoutClusterAdminAuthority() {
+    // given — a plain authenticated username/password token, as the DB-backed chain produces
+    final var authentication =
+        UsernamePasswordAuthenticationToken.authenticated("demo", "n/a", List.of());
+
+    // when/then
+    assertThat(converter.supports(authentication))
+        .as("only principals carrying the cluster-admin marker authority must be claimed")
+        .isFalse();
+  }
+
+  @Test
+  void shouldNotSupportPrincipalWithDifferentAuthority() {
+    // given — authenticated, but with an authority other than the cluster-admin marker
+    final var authentication =
+        UsernamePasswordAuthenticationToken.authenticated(
+            "someone", "n/a", List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+    // when/then
+    assertThat(converter.supports(authentication))
+        .as("a non-cluster-admin authority must not be claimed")
+        .isFalse();
+  }
+
+  @Test
+  void shouldNotSupportUnauthenticatedClusterAdminToken() {
+    // given — carries the marker authority but is not authenticated
+    final var authentication =
+        UsernamePasswordAuthenticationToken.authenticated(
+            "admin", "n/a", List.of(new SimpleGrantedAuthority(CLUSTER_ADMIN_AUTHORITY)));
+    authentication.setAuthenticated(false);
+
+    // when/then
+    assertThat(converter.supports(authentication))
+        .as("an unauthenticated token must not be claimed even with the marker authority")
+        .isFalse();
+  }
+
+  @Test
+  void shouldNotSupportNullAuthentication() {
+    // when/then
+    assertThat(converter.supports(null)).isFalse();
+  }
+
+  @Test
+  void shouldConvertToUsernameOnlyAuthenticationWithoutMembership() {
+    // given
+    final var authentication =
+        UsernamePasswordAuthenticationToken.authenticated(
+            "admin", "n/a", List.of(new SimpleGrantedAuthority(CLUSTER_ADMIN_AUTHORITY)));
+
+    // when
+    final CamundaAuthentication result = converter.convert(authentication);
+
+    // then — username carried through, no groups/roles/tenants resolved
+    assertThat(result.authenticatedUsername()).isEqualTo("admin");
+    assertThat(result.authenticatedClientId()).isNull();
+    assertThat(result.authenticatedGroupIds()).isEmpty();
+    assertThat(result.authenticatedRoleIds()).isEmpty();
+    assertThat(result.authenticatedTenantIds()).isEmpty();
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminBasicAuthPropertiesTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/clusteradmin/ClusterAdminBasicAuthPropertiesTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.clusteradmin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+
+/**
+ * Unit tests for {@link ClusterAdminBasicAuthProperties}.
+ *
+ * <p>All tests bind config from a {@link MockEnvironment} — no Spring context is loaded.
+ */
+class ClusterAdminBasicAuthPropertiesTest {
+
+  @Test
+  void shouldReturnEmptyListWhenNoClusterAdminConfigured() {
+    // given
+    final var env = env(Map.of());
+
+    // when
+    final List<ClusterAdminUser> users = ClusterAdminBasicAuthProperties.loadAndValidate(env);
+
+    // then
+    assertThat(users).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyListWhenUsersListIsEmpty() {
+    // given — the users key is declared but the list itself is empty
+    final var env = env(Map.of("camunda.security.cluster-admin.basic.users", ""));
+
+    // when
+    final List<ClusterAdminUser> users = ClusterAdminBasicAuthProperties.loadAndValidate(env);
+
+    // then
+    assertThat(users).isEmpty();
+  }
+
+  @Test
+  void shouldBindConfiguredUsers() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.cluster-admin.basic.users[0].name", "admin",
+                "camunda.security.cluster-admin.basic.users[0].password", "secret",
+                "camunda.security.cluster-admin.basic.users[1].name", "admin2",
+                "camunda.security.cluster-admin.basic.users[1].password", "secret2"));
+
+    // when
+    final List<ClusterAdminUser> users = ClusterAdminBasicAuthProperties.loadAndValidate(env);
+
+    // then
+    assertThat(users)
+        .containsExactly(
+            new ClusterAdminUser("admin", "secret"), new ClusterAdminUser("admin2", "secret2"));
+  }
+
+  @Test
+  void shouldRejectDuplicateNames() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.cluster-admin.basic.users[0].name", "admin",
+                "camunda.security.cluster-admin.basic.users[0].password", "secret",
+                "camunda.security.cluster-admin.basic.users[1].name", "admin",
+                "camunda.security.cluster-admin.basic.users[1].password", "other-secret"));
+
+    // when/then
+    assertThatThrownBy(() -> ClusterAdminBasicAuthProperties.loadAndValidate(env))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("duplicate")
+        .hasMessageContaining("admin");
+  }
+
+  @Test
+  void shouldRejectBlankName() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.cluster-admin.basic.users[0].name", " ",
+                "camunda.security.cluster-admin.basic.users[0].password", "secret"));
+
+    // when/then
+    assertThatThrownBy(() -> ClusterAdminBasicAuthProperties.loadAndValidate(env))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("name");
+  }
+
+  @Test
+  void shouldRejectBlankPassword() {
+    // given
+    final var env =
+        env(
+            Map.of(
+                "camunda.security.cluster-admin.basic.users[0].name", "admin",
+                "camunda.security.cluster-admin.basic.users[0].password", ""));
+
+    // when/then
+    assertThatThrownBy(() -> ClusterAdminBasicAuthProperties.loadAndValidate(env))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("password")
+        .hasMessageContaining("admin");
+  }
+
+  private static MockEnvironment env(final Map<String, String> properties) {
+    final MockEnvironment env = new MockEnvironment();
+    properties.forEach(env::setProperty);
+    return env;
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminBasicAuthWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminBasicAuthWebSecurityConfigTest.java
@@ -118,7 +118,7 @@ public class ClusterAdminBasicAuthWebSecurityConfigTest extends AbstractWebSecur
             .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_ENDPOINT)
             .exchange();
 
-    // then — the chain is SessionCreationPolicy.NEVER, so the request creates no session
+    // then — the chain is SessionCreationPolicy.STATELESS, so the request creates no session
     assertThat(result.getRequest().getSession(false))
         .as("cluster-admin Basic auth is stateless and must not establish a session")
         .isNull();

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminBasicAuthWebSecurityConfigTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminBasicAuthWebSecurityConfigTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.config.controllers.TestApiController;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+/**
+ * Tests for the cluster-admin security chain ({@code /cluster/v2/**}) with Basic auth.
+ *
+ * <p>Runs against {@link TestApiController}'s cluster-admin dummy endpoints (the real {@code
+ * DummyClusterTopologyController} lives in another module); the chain is exercised by path, so the
+ * behavior is identical.
+ */
+@SpringBootTest(
+    classes = {WebSecurityConfigTestContext.class, WebSecurityConfig.class},
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=basic",
+      "camunda.security.cluster-admin.basic.users[0].name=cluster-operator",
+      "camunda.security.cluster-admin.basic.users[0].password=cluster-secret"
+    })
+public class ClusterAdminBasicAuthWebSecurityConfigTest extends AbstractWebSecurityConfigTest {
+
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
+
+  @Test
+  public void shouldReturn200ForProtectedEndpointWithValidClusterAdminCredentials() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatusOk();
+  }
+
+  @Test
+  public void shouldReturn401ForProtectedEndpointWithoutCredentials() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  public void shouldReturn401ForProtectedEndpointWithWrongPassword() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuth(CLUSTER_ADMIN_USER, "wrong-password"))
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  public void shouldReturn401ForProtectedEndpointWithUnknownUsername() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuth("someone-else", CLUSTER_ADMIN_PASSWORD))
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result).hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  public void shouldReturn404ForUnknownClusterAdminPathWithValidCredentials() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
+            .uri("https://localhost/cluster/v2/does-not-exist")
+            .exchange();
+
+    // then — authenticated, but no handler for the path
+    assertThat(result).hasStatus(HttpStatus.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldNotEstablishSessionForClusterAdminRequest() {
+    // when
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_ENDPOINT)
+            .exchange();
+
+    // then — the chain is SessionCreationPolicy.NEVER, so the request creates no session
+    assertThat(result.getRequest().getSession(false))
+        .as("cluster-admin Basic auth is stateless and must not establish a session")
+        .isNull();
+  }
+
+  private static HttpHeaders basicAuth(final String username, final String password) {
+    final HttpHeaders headers = new HttpHeaders();
+    headers.add(
+        HttpHeaders.AUTHORIZATION,
+        "Basic "
+            + Base64.getEncoder()
+                .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8)));
+    return headers;
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminChainIsolationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminChainIsolationTest.java
@@ -14,10 +14,16 @@ import io.camunda.authentication.config.controllers.TestUserDetailsService;
 import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
 /**
@@ -69,6 +75,33 @@ public class ClusterAdminChainIsolationTest extends AbstractWebSecurityConfigTes
     // then
     assertThat(result)
         .as("a DB-backed user must not authenticate against the cluster-admin API")
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  public void shouldRejectWebappSessionOnClusterAdminEndpoint() {
+    // given — a session holding an authenticated DB user's security context, exactly what a webapp
+    // form login leaves behind (the browser then carries the JSESSIONID cookie)
+    final SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+    securityContext.setAuthentication(
+        UsernamePasswordAuthenticationToken.authenticated(
+            TestUserDetailsService.DEMO_USERNAME, null, List.of()));
+    final MockHttpSession session = new MockHttpSession();
+    session.setAttribute(
+        HttpSessionSecurityContextRepository.SPRING_SECURITY_CONTEXT_KEY, securityContext);
+
+    // when — that session cookie is presented to the cluster-admin API with no Basic credentials
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .session(session)
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_ENDPOINT)
+            .exchange();
+
+    // then — the chain binds a session-free context repository, so the session must not
+    // authenticate
+    assertThat(result)
+        .as("a webapp session cookie must not authenticate the cluster-admin API")
         .hasStatus(HttpStatus.UNAUTHORIZED);
   }
 

--- a/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminChainIsolationTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClusterAdminChainIsolationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.authentication.config.controllers.TestApiController;
+import io.camunda.authentication.config.controllers.TestUserDetailsService;
+import io.camunda.authentication.config.controllers.WebSecurityConfigTestContext;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+
+/**
+ * Cross-chain isolation ("leak trap") for the cluster-admin chain: a cluster-admin credential must
+ * not authenticate on the regular {@code /v2/**} API, and a DB-backed credential ({@code demo})
+ * must not authenticate on {@code /cluster/v2/**}.
+ */
+@SpringBootTest(
+    classes = {WebSecurityConfigTestContext.class, WebSecurityConfig.class},
+    properties = {
+      "camunda.security.authentication.unprotected-api=false",
+      "camunda.security.authentication.method=basic",
+      "camunda.security.cluster-admin.basic.users[0].name=cluster-operator",
+      "camunda.security.cluster-admin.basic.users[0].password=cluster-secret"
+    })
+public class ClusterAdminChainIsolationTest extends AbstractWebSecurityConfigTest {
+
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
+
+  @Test
+  public void shouldRejectClusterAdminCredentialsOnRegularV2Endpoint() {
+    // when — cluster-admin credential presented to the regular /v2 API
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD))
+            .uri("https://localhost" + TestApiController.DUMMY_V2_API_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result)
+        .as("a cluster-admin credential must not authenticate against the regular /v2 API")
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  @Test
+  public void shouldRejectDbBackedUserCredentialsOnClusterAdminEndpoint() {
+    // when — the DB-backed demo credential presented to the cluster-admin API
+    final MvcTestResult result =
+        mockMvcTester
+            .get()
+            .headers(
+                basicAuth(
+                    TestUserDetailsService.DEMO_USERNAME, TestUserDetailsService.DEMO_USERNAME))
+            .uri("https://localhost" + TestApiController.DUMMY_CLUSTER_ADMIN_ENDPOINT)
+            .exchange();
+
+    // then
+    assertThat(result)
+        .as("a DB-backed user must not authenticate against the cluster-admin API")
+        .hasStatus(HttpStatus.UNAUTHORIZED);
+  }
+
+  private static HttpHeaders basicAuth(final String username, final String password) {
+    final HttpHeaders headers = new HttpHeaders();
+    headers.add(
+        HttpHeaders.AUTHORIZATION,
+        "Basic "
+            + Base64.getEncoder()
+                .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8)));
+    return headers;
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -132,15 +133,8 @@ public class TestApiController {
     return DEFAULT_RESPONSE;
   }
 
-  @RequestMapping(
-      value = DUMMY_CLUSTER_ADMIN_ENDPOINT,
-      method = org.springframework.web.bind.annotation.RequestMethod.GET)
+  @GetMapping(DUMMY_CLUSTER_ADMIN_ENDPOINT)
   public @ResponseBody String dummyClusterAdminEndpoint() {
-    return DEFAULT_RESPONSE;
-  }
-
-  @PostMapping(DUMMY_CLUSTER_ADMIN_ENDPOINT)
-  public @ResponseBody String dummyClusterAdminPostEndpoint() {
     return DEFAULT_RESPONSE;
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -30,6 +30,13 @@ public class TestApiController {
   public static final String DUMMY_UNHANDLED_ENDPOINT = "/non-existent-endpoint";
 
   /**
+   * Cluster-admin dummy endpoint at the real {@code /cluster/v2/topology} path, so the
+   * cluster-admin chain is exercised here (its real controller is in another module, off this
+   * slice's classpath).
+   */
+  public static final String DUMMY_CLUSTER_ADMIN_ENDPOINT = "/cluster/v2/topology";
+
+  /**
    * Isolated, additive endpoint used only by {@code SessionAuthenticationRefreshTest} to force a
    * real, Spring-Session-backed session to exist before the request under test runs. With CSL
    * ADR-0031's per-chain {@code SessionRepositoryFilter}, nothing creates a session for a request
@@ -122,6 +129,16 @@ public class TestApiController {
 
   @PostMapping(DUMMY_V2_API_ENDPOINT)
   public @ResponseBody String dummyV2ApiPostEndpoint() {
+    return DEFAULT_RESPONSE;
+  }
+
+  @RequestMapping(DUMMY_CLUSTER_ADMIN_ENDPOINT)
+  public @ResponseBody String dummyClusterAdminEndpoint() {
+    return DEFAULT_RESPONSE;
+  }
+
+  @PostMapping(DUMMY_CLUSTER_ADMIN_ENDPOINT)
+  public @ResponseBody String dummyClusterAdminPostEndpoint() {
     return DEFAULT_RESPONSE;
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/controllers/TestApiController.java
@@ -132,7 +132,9 @@ public class TestApiController {
     return DEFAULT_RESPONSE;
   }
 
-  @RequestMapping(DUMMY_CLUSTER_ADMIN_ENDPOINT)
+  @RequestMapping(
+      value = DUMMY_CLUSTER_ADMIN_ENDPOINT,
+      method = org.springframework.web.bind.annotation.RequestMethod.GET)
   public @ResponseBody String dummyClusterAdminEndpoint() {
     return DEFAULT_RESPONSE;
   }

--- a/configuration/src/main/java/io/camunda/configuration/ClusterAdmin.java
+++ b/configuration/src/main/java/io/camunda/configuration/ClusterAdmin.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+/**
+ * Configuration for the dedicated cluster-admin security chain protecting {@code /cluster/v2/**}.
+ */
+public class ClusterAdmin {
+
+  /** HTTP Basic authentication for the cluster-admin API. */
+  @NestedConfigurationProperty private ClusterAdminBasic basic = new ClusterAdminBasic();
+
+  public ClusterAdminBasic getBasic() {
+    return basic;
+  }
+
+  public void setBasic(final ClusterAdminBasic basic) {
+    this.basic = basic == null ? new ClusterAdminBasic() : basic;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/ClusterAdminBasic.java
+++ b/configuration/src/main/java/io/camunda/configuration/ClusterAdminBasic.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+import java.util.List;
+
+public class ClusterAdminBasic {
+
+  /** Statically configured cluster-admin users for HTTP Basic authentication. */
+  private List<ClusterAdminUser> users = List.of();
+
+  public List<ClusterAdminUser> getUsers() {
+    return users;
+  }
+
+  public void setUsers(final List<ClusterAdminUser> users) {
+    this.users = users == null ? List.of() : users;
+  }
+}

--- a/configuration/src/main/java/io/camunda/configuration/ClusterAdminUser.java
+++ b/configuration/src/main/java/io/camunda/configuration/ClusterAdminUser.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.configuration;
+
+/**
+ * A cluster-admin user for HTTP Basic authentication against the {@code /cluster/v2/**} API.
+ * Cluster-admin users are configured statically here rather than persisted, since there is no
+ * cluster-wide storage to hold them in.
+ *
+ * @param name the login name, unique among configured cluster-admin users
+ * @param password the plaintext password, encoded once at startup
+ */
+public record ClusterAdminUser(String name, String password) {}

--- a/configuration/src/main/java/io/camunda/configuration/Security.java
+++ b/configuration/src/main/java/io/camunda/configuration/Security.java
@@ -15,11 +15,22 @@ public class Security extends CamundaSecurityLibraryProperties {
   /** TLS configuration. */
   @NestedConfigurationProperty private Tls transportLayerSecurity = new Tls();
 
+  /** Configuration for the dedicated cluster-admin security chain. */
+  @NestedConfigurationProperty private ClusterAdmin clusterAdmin = new ClusterAdmin();
+
   public Tls getTransportLayerSecurity() {
     return transportLayerSecurity;
   }
 
   public void setTransportLayerSecurity(final Tls transportLayerSecurity) {
     this.transportLayerSecurity = transportLayerSecurity;
+  }
+
+  public ClusterAdmin getClusterAdmin() {
+    return clusterAdmin;
+  }
+
+  public void setClusterAdmin(final ClusterAdmin clusterAdmin) {
+    this.clusterAdmin = clusterAdmin == null ? new ClusterAdmin() : clusterAdmin;
   }
 }

--- a/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
+++ b/configuration/src/test/resources/io/camunda/configuration/physicaltenants/non-overridable-properties.golden.txt
@@ -71,6 +71,7 @@ data.secondary-storage.rdbms.max-varchar-field-length
 license.key
 security.authentication.method
 security.authentication.unprotected-api
+security.cluster-admin.basic.users
 security.csrf
 security.csrf.cookie-http-only
 security.csrf.enabled

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -17,7 +17,6 @@ import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -70,7 +69,9 @@ public class ClusterAdminBasicAuthenticationIT {
   void shouldAllowClusterAdminEndpointWithFirstConfiguredUser() throws Exception {
     // when
     final HttpResponse<String> response =
-        send(PATH_CLUSTER_TOPOLOGY, basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
+        send(
+            clusterUri(PATH_CLUSTER_TOPOLOGY),
+            basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
 
     // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
@@ -80,7 +81,9 @@ public class ClusterAdminBasicAuthenticationIT {
   void shouldAllowClusterAdminEndpointWithSecondConfiguredUser() throws Exception {
     // when — proves the whole users[] list is bound, not just the first entry
     final HttpResponse<String> response =
-        send(PATH_CLUSTER_TOPOLOGY, basicAuth(CLUSTER_ADMIN_USER_2, CLUSTER_ADMIN_PASSWORD_2));
+        send(
+            clusterUri(PATH_CLUSTER_TOPOLOGY),
+            basicAuth(CLUSTER_ADMIN_USER_2, CLUSTER_ADMIN_PASSWORD_2));
 
     // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
@@ -90,7 +93,7 @@ public class ClusterAdminBasicAuthenticationIT {
   void shouldRejectClusterAdminEndpointWithBadCredentials() throws Exception {
     // when
     final HttpResponse<String> response =
-        send(PATH_CLUSTER_TOPOLOGY, basicAuth(CLUSTER_ADMIN_USER, "wrong-password"));
+        send(clusterUri(PATH_CLUSTER_TOPOLOGY), basicAuth(CLUSTER_ADMIN_USER, "wrong-password"));
 
     // then
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
@@ -100,7 +103,7 @@ public class ClusterAdminBasicAuthenticationIT {
   void shouldRejectRealDbBackedUserOnClusterAdminEndpoint() throws Exception {
     // when — a real, secondary-storage-backed user presents valid DB credentials to the cluster API
     final HttpResponse<String> response =
-        send(PATH_CLUSTER_TOPOLOGY, basicAuth(DB_USERNAME, DB_PASSWORD));
+        send(clusterUri(PATH_CLUSTER_TOPOLOGY), basicAuth(DB_USERNAME, DB_PASSWORD));
 
     // then — the cluster-admin chain has its own isolated store; a DB user is not known to it
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
@@ -110,16 +113,17 @@ public class ClusterAdminBasicAuthenticationIT {
   void shouldRejectClusterAdminCredentialsOnRegularV2Endpoint() throws Exception {
     // when — cluster-admin credentials presented to the regular /v2 API
     final HttpResponse<String> response =
-        send(PATH_V2_AUTHENTICATION_ME, basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
+        send(
+            apiUri(PATH_V2_AUTHENTICATION_ME),
+            basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
 
     // then — cluster-admin users exist only for /cluster/v2/**
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
   }
 
-  private HttpResponse<String> send(final String path, final String authorizationHeader)
+  private HttpResponse<String> send(final URI uri, final String authorizationHeader)
       throws Exception {
-    final HttpRequest.Builder builder =
-        HttpRequest.newBuilder().uri(createUri(camundaClient, path));
+    final HttpRequest.Builder builder = HttpRequest.newBuilder().uri(uri);
     if (authorizationHeader != null) {
       builder.header("Authorization", authorizationHeader);
     }
@@ -130,10 +134,25 @@ public class ClusterAdminBasicAuthenticationIT {
     return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
   }
 
-  private static URI createUri(final CamundaClient client, final String path)
-      throws URISyntaxException {
-    final String base = client.getConfiguration().getRestAddress().toString();
+  // The cluster-admin API is cluster-wide, so it is always addressed at the gateway root — never
+  // under a /physical-tenants/<id> prefix. In physical-tenant mode the client's REST address
+  // carries that prefix, so strip it to reach the root.
+  private static URI clusterUri(final String path) {
+    final String base =
+        camundaClient
+            .getConfiguration()
+            .getRestAddress()
+            .toString()
+            .replaceAll("/+$", "")
+            .replaceFirst("/physical-tenants/[^/]+$", "");
+    return URI.create(base + "/" + path);
+  }
+
+  // The regular v2 API is addressed through the client's configured REST address, which is
+  // physical-tenant-scoped when the suite runs under a physical tenant.
+  private static URI apiUri(final String path) {
+    final String base = camundaClient.getConfiguration().getRestAddress().toString();
     final String separator = base.endsWith("/") ? "" : "/";
-    return new URI(base + separator + path);
+    return URI.create(base + separator + path);
   }
 }

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/auth/ClusterAdminBasicAuthenticationIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.auth.TestUser;
+import io.camunda.qa.util.auth.UserDefinition;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+
+/**
+ * Full-stack integration tests for the cluster-admin Basic-auth chain ({@code /cluster/v2/**}),
+ * exercised against the real {@link
+ * io.camunda.zeebe.gateway.rest.controller.DummyClusterTopologyController} endpoint.
+ */
+@MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
+public class ClusterAdminBasicAuthenticationIT {
+
+  public static final String PATH_CLUSTER_TOPOLOGY = "cluster/v2/topology";
+  public static final String PATH_V2_AUTHENTICATION_ME = "v2/authentication/me";
+
+  private static final String CLUSTER_ADMIN_USER = "cluster-operator";
+  private static final String CLUSTER_ADMIN_PASSWORD = "cluster-secret";
+  private static final String CLUSTER_ADMIN_USER_2 = "cluster-operator-2";
+  private static final String CLUSTER_ADMIN_PASSWORD_2 = "cluster-secret-2";
+
+  private static final String DB_USERNAME = "db_user";
+  private static final String DB_PASSWORD = "db_password";
+
+  @MultiDbTestApplication
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withBasicAuth()
+          .withAuthenticatedAccess()
+          .withProperty("camunda.security.cluster-admin.basic.users[0].name", CLUSTER_ADMIN_USER)
+          .withProperty(
+              "camunda.security.cluster-admin.basic.users[0].password", CLUSTER_ADMIN_PASSWORD)
+          .withProperty("camunda.security.cluster-admin.basic.users[1].name", CLUSTER_ADMIN_USER_2)
+          .withProperty(
+              "camunda.security.cluster-admin.basic.users[1].password", CLUSTER_ADMIN_PASSWORD_2);
+
+  // A real, secondary-storage-backed user — used to prove it cannot reach the cluster-admin chain.
+  @UserDefinition
+  private static final TestUser DB_USER = new TestUser(DB_USERNAME, DB_PASSWORD, List.of());
+
+  private static CamundaClient camundaClient;
+  @AutoClose private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  @Test
+  void shouldAllowClusterAdminEndpointWithFirstConfiguredUser() throws Exception {
+    // when
+    final HttpResponse<String> response =
+        send(PATH_CLUSTER_TOPOLOGY, basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+  }
+
+  @Test
+  void shouldAllowClusterAdminEndpointWithSecondConfiguredUser() throws Exception {
+    // when — proves the whole users[] list is bound, not just the first entry
+    final HttpResponse<String> response =
+        send(PATH_CLUSTER_TOPOLOGY, basicAuth(CLUSTER_ADMIN_USER_2, CLUSTER_ADMIN_PASSWORD_2));
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_OK);
+  }
+
+  @Test
+  void shouldRejectClusterAdminEndpointWithBadCredentials() throws Exception {
+    // when
+    final HttpResponse<String> response =
+        send(PATH_CLUSTER_TOPOLOGY, basicAuth(CLUSTER_ADMIN_USER, "wrong-password"));
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
+  void shouldRejectRealDbBackedUserOnClusterAdminEndpoint() throws Exception {
+    // when — a real, secondary-storage-backed user presents valid DB credentials to the cluster API
+    final HttpResponse<String> response =
+        send(PATH_CLUSTER_TOPOLOGY, basicAuth(DB_USERNAME, DB_PASSWORD));
+
+    // then — the cluster-admin chain has its own isolated store; a DB user is not known to it
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  @Test
+  void shouldRejectClusterAdminCredentialsOnRegularV2Endpoint() throws Exception {
+    // when — cluster-admin credentials presented to the regular /v2 API
+    final HttpResponse<String> response =
+        send(PATH_V2_AUTHENTICATION_ME, basicAuth(CLUSTER_ADMIN_USER, CLUSTER_ADMIN_PASSWORD));
+
+    // then — cluster-admin users exist only for /cluster/v2/**
+    assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_UNAUTHORIZED);
+  }
+
+  private HttpResponse<String> send(final String path, final String authorizationHeader)
+      throws Exception {
+    final HttpRequest.Builder builder =
+        HttpRequest.newBuilder().uri(createUri(camundaClient, path));
+    if (authorizationHeader != null) {
+      builder.header("Authorization", authorizationHeader);
+    }
+    return httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static String basicAuth(final String user, final String password) {
+    return "Basic " + Base64.getEncoder().encodeToString((user + ":" + password).getBytes());
+  }
+
+  private static URI createUri(final CamundaClient client, final String path)
+      throws URISyntaxException {
+    final String base = client.getConfiguration().getRestAddress().toString();
+    final String separator = base.endsWith("/") ? "" : "/";
+    return new URI(base + separator + path);
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DummyClusterTopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DummyClusterTopologyController.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/cluster/v2")
+public class DummyClusterTopologyController {
+
+  @CamundaGetMapping(path = "/topology")
+  public ResponseEntity<Void> getClusterTopology() {
+    // Placeholder response; the aggregated cluster topology is implemented in a follow-up.
+    return ResponseEntity.ok().build();
+  }
+}


### PR DESCRIPTION
Adds a dedicated security chain protecting the cluster-admin API (`/cluster/v2/**`) with HTTP Basic authentication against statically configured users (`camunda.security.cluster-admin.basic.users`). This is the first slice of cluster-admin support: the API is cluster-wide with no persistence layer, so users are defined in config rather than the Identity store, and the chain is isolated from the regular `/v2/**` and physical-tenant chains.

### Highlights
- Config schema + validation for `cluster-admin.basic.users` (fail-fast on duplicate/blank entries).
- Dedicated chain gated to the basic auth method; credentials resolved against an in-memory store behind a parent-less `AuthenticationManager`, so a DB-backed user can't authenticate on `/cluster/v2/**` and vice versa.
- A converter keeps cluster-admin principals off the DB-backed membership lookup (guards a future name-collision leak).
- A stub `GET /cluster/v2/topology` endpoint so the chain can be exercised end-to-end.

OIDC support for the same chain follows in #57708.

Closes #57707 — part of #54898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
