### PR TITLE
feat: allow searching for PI by error message with process-level incidents

### DIFF
--- a/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchProcessLevelIncidentIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/client/ProcessInstanceSearchProcessLevelIncidentIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces <a href="https://github.com/camunda/camunda/issues/44398">#44398</a>: searching
+ * process instances by incident error message must also find process instances whose incident is
+ * raised on the process instance level (e.g. a failed execution listener on the process start
+ * event) rather than on a specific element.
+ */
+@MultiDbTest
+class ProcessInstanceSearchProcessLevelIncidentIT {
+
+  private static final String PROCESS_ID = "process_level_incident_process";
+  private static final String START_EL_JOB_TYPE = "process-start-execution-listener";
+  private static final String ERROR_MESSAGE = "Process-level incident error message";
+
+  private static CamundaClient camundaClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .zeebeStartExecutionListener(START_EL_JOB_TYPE)
+            .startEvent()
+            .endEvent()
+            .done();
+    deployResource(camundaClient, process, PROCESS_ID + ".bpmn");
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    startProcessInstance(camundaClient, PROCESS_ID);
+    waitForProcessInstancesToStart(camundaClient, 1);
+
+    // fail the start execution listener job to raise a process-level incident
+    // (elementInstanceKey == processInstanceKey)
+    final long jobKey =
+        await("should activate the start execution listener job")
+            .atMost(TIMEOUT_DATA_AVAILABILITY)
+            .until(
+                () ->
+                    camundaClient
+                        .newActivateJobsCommand()
+                        .jobType(START_EL_JOB_TYPE)
+                        .maxJobsToActivate(1)
+                        .send()
+                        .join()
+                        .getJobs(),
+                jobs -> !jobs.isEmpty())
+            .getFirst()
+            .getKey();
+    camundaClient.newFailCommand(jobKey).retries(0).errorMessage(ERROR_MESSAGE).send().join();
+
+    waitUntilProcessInstanceHasIncidents(camundaClient, 1);
+    waitUntilIncidentsAreActive(camundaClient, 1);
+    // ensure the incident is exported with the expected error message before asserting on the
+    // process instance search, so a failure below cannot be an export race
+    await("should export the process-level incident with the error message")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var incidents = camundaClient.newIncidentSearchRequest().send().join().items();
+              assertThat(incidents).hasSize(1);
+              assertThat(incidents.getFirst().getErrorMessage()).isEqualTo(ERROR_MESSAGE);
+            });
+  }
+
+  @Test
+  void shouldFindProcessInstanceByProcessLevelIncidentErrorMessage() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(b -> b.errorMessage(f -> f.eq(ERROR_MESSAGE)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items())
+        .describedAs(
+            "the process instance should be found by the error message of its process-level incident")
+        .hasSize(1);
+    assertThat(result.items().getFirst().getProcessDefinitionId()).isEqualTo(PROCESS_ID);
+  }
+
+  @Test
+  void shouldFindProcessInstanceByErrorMessageExistsForProcessLevelIncident() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(b -> b.errorMessage(f -> f.exists(true)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items())
+        .describedAs(
+            "the process instance should match the errorMessage exists filter for its process-level incident")
+        .hasSize(1);
+    assertThat(result.items().getFirst().getProcessDefinitionId()).isEqualTo(PROCESS_ID);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -36,12 +36,15 @@ import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.Operator;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.security.core.auth.RequiredAuthorization;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -81,11 +84,8 @@ public final class ProcessInstanceFilterTransformer
       queries.add(processVariableQuery);
     }
 
-    if (filter.errorMessageOperations() != null && !filter.errorMessageOperations().isEmpty()) {
-      queries.add(
-          stringMatchPhraseInSingleHasChild(
-              ERROR_MSG, filter.errorMessageOperations(), ACTIVITIES_JOIN_RELATION));
-    }
+    Optional.ofNullable(getErrorMessageQuery(filter.errorMessageOperations()))
+        .ifPresent(queries::add);
 
     queries.addAll(stringOperations(BATCH_OPERATION_IDS, filter.batchOperationIdOperations()));
 
@@ -163,6 +163,40 @@ public final class ProcessInstanceFilterTransformer
       return term(INCIDENT, hasIncident);
     }
     return null;
+  }
+
+  // an incident's error message is stored either on the child activity document (element-level
+  // incidents) or directly on the process instance document itself (process-level incidents, e.g.
+  // a failed execution listener on the process start event), so both locations must be checked
+  private static SearchQuery getErrorMessageQuery(final List<Operation<String>> operations) {
+    if (operations == null || operations.isEmpty()) {
+      return null;
+    }
+    return and(
+        operations.stream()
+            .map(ProcessInstanceFilterTransformer::errorMessageOperationQuery)
+            .toList());
+  }
+
+  private static SearchQuery errorMessageOperationQuery(final Operation<String> operation) {
+    final SearchQuery fieldQuery =
+        switch (operation.operator()) {
+          case EQUALS, NOT_EQUALS -> matchPhrase(ERROR_MSG, operation.value());
+          case EXISTS, NOT_EXISTS -> exists(ERROR_MSG);
+          case IN ->
+              or(operation.values().stream().map(value -> matchPhrase(ERROR_MSG, value)).toList());
+          case LIKE ->
+              wildcardQuery(ERROR_MSG, Objects.requireNonNull(operation.value()).toLowerCase());
+          default ->
+              throw new IllegalStateException(
+                  "Unsupported operator %s for errorMessage filter"
+                      .formatted(operation.operator()));
+        };
+
+    final var anyLevelQuery = or(hasChildQuery(ACTIVITIES_JOIN_RELATION, fieldQuery), fieldQuery);
+    final boolean negate =
+        operation.operator() == Operator.NOT_EQUALS || operation.operator() == Operator.NOT_EXISTS;
+    return negate ? not(anyLevelQuery) : anyLevelQuery;
   }
 
   private SearchQuery getProcessVariablesQuery(final List<VariableValueFilter> variableFilters) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -37,7 +37,6 @@ import static java.util.Optional.ofNullable;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.filter.Operation;
-import io.camunda.search.filter.Operator;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.security.core.auth.RequiredAuthorization;
@@ -188,14 +187,14 @@ public final class ProcessInstanceFilterTransformer
       case EXISTS -> existsAnyLevel();
       case NOT_EXISTS -> not(existsAnyLevel());
       case IN ->
-          or(operation.values().stream()
-              .map(ProcessInstanceFilterTransformer::matchAnyLevel)
-              .toList());
+          or(
+              operation.values().stream()
+                  .map(ProcessInstanceFilterTransformer::matchAnyLevel)
+                  .toList());
       case LIKE -> wildcardAnyLevel(Objects.requireNonNull(operation.value()).toLowerCase());
       default ->
           throw new IllegalStateException(
-              "Unsupported operator %s for errorMessage filter"
-                  .formatted(operation.operator()));
+              "Unsupported operator %s for errorMessage filter".formatted(operation.operator()));
     };
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -179,24 +179,38 @@ public final class ProcessInstanceFilterTransformer
   }
 
   private static SearchQuery errorMessageOperationQuery(final Operation<String> operation) {
-    final SearchQuery fieldQuery =
-        switch (operation.operator()) {
-          case EQUALS, NOT_EQUALS -> matchPhrase(ERROR_MSG, operation.value());
-          case EXISTS, NOT_EXISTS -> exists(ERROR_MSG);
-          case IN ->
-              or(operation.values().stream().map(value -> matchPhrase(ERROR_MSG, value)).toList());
-          case LIKE ->
-              wildcardQuery(ERROR_MSG, Objects.requireNonNull(operation.value()).toLowerCase());
-          default ->
-              throw new IllegalStateException(
-                  "Unsupported operator %s for errorMessage filter"
-                      .formatted(operation.operator()));
-        };
+    // NOTE: negation must be applied *per level* alongside an explicit existence check,
+    // not to the OR'd result as a whole - otherwise "not equal to X" also matches process
+    // instances that never had an incident at all (no error message present anywhere).
+    return switch (operation.operator()) {
+      case EQUALS -> matchAnyLevel(operation.value());
+      case NOT_EQUALS -> and(existsAnyLevel(), not(matchAnyLevel(operation.value())));
+      case EXISTS -> existsAnyLevel();
+      case NOT_EXISTS -> not(existsAnyLevel());
+      case IN ->
+          or(operation.values().stream()
+              .map(ProcessInstanceFilterTransformer::matchAnyLevel)
+              .toList());
+      case LIKE -> wildcardAnyLevel(Objects.requireNonNull(operation.value()).toLowerCase());
+      default ->
+          throw new IllegalStateException(
+              "Unsupported operator %s for errorMessage filter"
+                  .formatted(operation.operator()));
+    };
+  }
 
-    final var anyLevelQuery = or(hasChildQuery(ACTIVITIES_JOIN_RELATION, fieldQuery), fieldQuery);
-    final boolean negate =
-        operation.operator() == Operator.NOT_EQUALS || operation.operator() == Operator.NOT_EXISTS;
-    return negate ? not(anyLevelQuery) : anyLevelQuery;
+  private static SearchQuery existsAnyLevel() {
+    return or(hasChildQuery(ACTIVITIES_JOIN_RELATION, exists(ERROR_MSG)), exists(ERROR_MSG));
+  }
+
+  private static SearchQuery matchAnyLevel(final String value) {
+    final SearchQuery fieldQuery = matchPhrase(ERROR_MSG, value);
+    return or(hasChildQuery(ACTIVITIES_JOIN_RELATION, fieldQuery), fieldQuery);
+  }
+
+  private static SearchQuery wildcardAnyLevel(final String value) {
+    final SearchQuery fieldQuery = wildcardQuery(ERROR_MSG, value);
+    return or(hasChildQuery(ACTIVITIES_JOIN_RELATION, fieldQuery), fieldQuery);
   }
 
   private SearchQuery getProcessVariablesQuery(final List<VariableValueFilter> variableFilters) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
@@ -384,39 +384,48 @@ public final class ProcessInstanceQueryTransformerTest extends AbstractTransform
         FilterBuilders.processInstance(
             f -> f.errorMessageOperations(List.of(Operation.eq(expectedError))));
 
-    // when: transform the filter into a SearchQuery
+    // when
     final var searchRequest = transformQuery(filter);
 
-    // then: the overall query should be a SearchBoolQuery with two must clauses.
+    // then
     final var queryVariant = searchRequest.queryOption();
     assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
     final SearchBoolQuery boolQuery = (SearchBoolQuery) queryVariant;
-
-    // Expect two must clauses: one for joinRelation and one for errorMessage.
     assertThat(boolQuery.must()).hasSize(2);
 
-    // First must clause: joinRelation term query.
     assertIsSearchTermQuery(
         boolQuery.must().get(0).queryOption(), "joinRelation", "processInstance");
 
+    // errorMessage must now match at either the child (activity) level
+    // or directly on the process instance (process-level incidents)
     assertThat(boolQuery.must().get(1).queryOption())
-        .isInstanceOf(SearchHasChildQuery.class)
-        .satisfies(
-            queryOption -> {
-              final SearchHasChildQuery hasChildQuery = (SearchHasChildQuery) queryOption;
-              assertThat(hasChildQuery.type()).isEqualTo("activity");
-              assertThat(hasChildQuery.query().queryOption())
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            anyLevelQuery -> {
+              assertThat(anyLevelQuery.should()).hasSize(2);
+
+              // branch 1: has-child query against activity documents
+              assertThat(anyLevelQuery.should().get(0).queryOption())
                   .isInstanceOfSatisfying(
-                      SearchBoolQuery.class,
-                      innerBool -> {
-                        assertThat(innerBool.must()).hasSize(1);
-                        assertThat(innerBool.must().get(0).queryOption())
+                      SearchHasChildQuery.class,
+                      hasChildQuery -> {
+                        assertThat(hasChildQuery.type()).isEqualTo("activity");
+                        assertThat(hasChildQuery.query().queryOption())
                             .isInstanceOfSatisfying(
                                 SearchMatchPhraseQuery.class,
-                                searchMatchQuery -> {
-                                  assertThat(searchMatchQuery.field()).isEqualTo("errorMessage");
-                                  assertThat(searchMatchQuery.query()).isEqualTo(expectedError);
+                                m -> {
+                                  assertThat(m.field()).isEqualTo("errorMessage");
+                                  assertThat(m.query()).isEqualTo(expectedError);
                                 });
+                      });
+
+              // branch 2: direct match on the process instance document itself
+              assertThat(anyLevelQuery.should().get(1).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchMatchPhraseQuery.class,
+                      m -> {
+                        assertThat(m.field()).isEqualTo("errorMessage");
+                        assertThat(m.query()).isEqualTo(expectedError);
                       });
             });
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/listview/ProcessInstanceForListViewEntity.java
@@ -50,6 +50,8 @@ public class ProcessInstanceForListViewEntity
 
   @BeforeVersion880 private boolean incident;
 
+  @BeforeVersion880 private String errorMessage;
+
   @BeforeVersion880 private String tenantId = DEFAULT_TENANT_IDENTIFIER;
 
   @BeforeVersion880
@@ -231,6 +233,17 @@ public class ProcessInstanceForListViewEntity
     return this;
   }
 
+  // only set for incidents raised directly on the process instance (no element instance), not
+  // aggregated from child flow node incidents
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  public ProcessInstanceForListViewEntity setErrorMessage(final String errorMessage) {
+    this.errorMessage = errorMessage;
+    return this;
+  }
+
   @Override
   public String getTenantId() {
     return tenantId;
@@ -315,6 +328,7 @@ public class ProcessInstanceForListViewEntity
         parentFlowNodeInstanceKey,
         treePath,
         incident,
+        errorMessage,
         tenantId,
         joinRelation,
         position,
@@ -349,6 +363,7 @@ public class ProcessInstanceForListViewEntity
         && Objects.equals(parentProcessInstanceKey, that.parentProcessInstanceKey)
         && Objects.equals(parentFlowNodeInstanceKey, that.parentFlowNodeInstanceKey)
         && Objects.equals(treePath, that.treePath)
+        && Objects.equals(errorMessage, that.errorMessage)
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(joinRelation, that.joinRelation)
         && Objects.equals(position, that.position)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -46,6 +46,7 @@ import io.camunda.exporter.handlers.JobHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromIncidentHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromJobHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromProcessInstanceHandler;
+import io.camunda.exporter.handlers.ListViewProcessInstanceFromIncidentHandler;
 import io.camunda.exporter.handlers.ListViewProcessInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.ListViewVariableFromVariableHandler;
 import io.camunda.exporter.handlers.MappingRuleCreatedUpdatedHandler;
@@ -258,6 +259,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new ListViewProcessInstanceFromProcessInstanceHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(), processCache),
             new ListViewFlowNodeFromIncidentHandler(
+                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+            new ListViewProcessInstanceFromIncidentHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
             new ListViewFlowNodeFromJobHandler(
                 indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandler.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ERROR_MSG;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.listview.ProcessInstanceForListViewEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles incidents raised directly on a process instance (no specific element/flow node, e.g. a
+ * failed execution listener on the process start event) by writing the error message onto the
+ * process instance's own list-view document, since {@link ListViewFlowNodeFromIncidentHandler}
+ * explicitly skips these (there is no flow node/activity document to attach the error message to).
+ */
+public class ListViewProcessInstanceFromIncidentHandler
+    implements ExportHandler<ProcessInstanceForListViewEntity, IncidentRecordValue> {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ListViewProcessInstanceFromIncidentHandler.class);
+
+  private static final Set<IncidentIntent> SUPPORTED_INTENTS =
+      Set.of(IncidentIntent.CREATED, IncidentIntent.RESOLVED);
+
+  private final String indexName;
+
+  public ListViewProcessInstanceFromIncidentHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.INCIDENT;
+  }
+
+  @Override
+  public Class<ProcessInstanceForListViewEntity> getEntityType() {
+    return ProcessInstanceForListViewEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<IncidentRecordValue> record) {
+    if (!SUPPORTED_INTENTS.contains((IncidentIntent) record.getIntent())) {
+      return false;
+    }
+    final var recordValue = record.getValue();
+    return isProcessLevelIncident(recordValue);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<IncidentRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getProcessInstanceKey()));
+  }
+
+  @Override
+  public ProcessInstanceForListViewEntity createNewEntity(final String id) {
+    return new ProcessInstanceForListViewEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<IncidentRecordValue> record, final ProcessInstanceForListViewEntity entity) {
+
+    final IncidentRecordValue recordValue = record.getValue();
+    final long processInstanceKey = recordValue.getProcessInstanceKey();
+
+    entity
+        .setId(String.valueOf(processInstanceKey))
+        .setKey(processInstanceKey)
+        .setPartitionId(record.getPartitionId())
+        .setPosition(record.getPosition())
+        .setTenantId(tenantOrDefault(recordValue.getTenantId()));
+
+    if (record.getIntent().equals(IncidentIntent.CREATED)) {
+      entity.setErrorMessage(trimWhitespace(recordValue.getErrorMessage()));
+    } else {
+      entity.setErrorMessage(null);
+    }
+  }
+
+  @Override
+  public void flush(
+      final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest) {
+
+    LOGGER.debug("Process instance for list view: id {}", entity.getId());
+    final Map<String, Object> updateFields = new LinkedHashMap<>();
+    updateFields.put(ERROR_MSG, entity.getErrorMessage());
+
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  private String trimWhitespace(final String str) {
+    return (str == null) ? null : str.strip();
+  }
+
+  private boolean isProcessLevelIncident(final IncidentRecordValue recordValue) {
+    return recordValue.getProcessInstanceKey() == recordValue.getElementInstanceKey();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Context:
https://github.com/camunda/camunda/issues/44398

## Checklist

<!--- Please delete options that are not relevant. -->
- [ ] Enable backports when necessary (fex. [for bug fixes](https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#backporting-changes), [for CI changes](https://camunda.github.io/camunda/ci/#when-to-backport-ci-changes), or [for documentation changes](https://camunda.github.io/camunda/ci/#documentation-specific-backporting-monorepo-docs-folders)).
- [ ] If this PR modifies the [C8 Orchestration Cluster E2E Test Suite](qa/c8-orchestration-cluster-e2e-test-suite), the relevant tests have been run via the [on-demand workflow](https://github.com/camunda/camunda/actions/workflows/c8-orchestration-cluster-e2e-tests-on-demand.yml) before requesting review. Any test failures are documented in the PR description and confirmed not to be regressions introduced by this PR.

## Related issues

closes #
