### PR TITLE
fix: realign ci-cost-analysis agentic workflow with its gh-aw compiler version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -176,6 +176,23 @@
       ]
     },
     {
+      "description": "Do not let Renovate edit generated agentic-workflow lock files *.lock.yml and managed upstream. Update by upgrading the gh-aw toolchain and recompiling, never via Renovate.",
+      "matchFileNames": [
+        ".github/workflows/*.lock.yml"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Keep the hand-authored copilot-setup-steps.yml gh-aw CLI installer in lockstep with the compiler version used for the *.lock.yml files. Upgrade the gh-aw toolchain deliberately (bump here + recompile), not via Renovate.",
+      "matchFileNames": [
+        ".github/workflows/copilot-setup-steps.yml"
+      ],
+      "matchPackageNames": [
+        "github/gh-aw-actions"
+      ],
+      "enabled": false
+    },
+    {
       "description": "Identify updates related to builds, tooling, etc. that should be routed to Monorepo DevOps team.",
       "matchManagers": [
         "custom.regex"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -188,7 +188,7 @@
         ".github/workflows/copilot-setup-steps.yml"
       ],
       "matchPackageNames": [
-        "github/gh-aw-actions"
+        "/^github/gh-aw-actions(/.+)?$/"
       ],
       "enabled": false
     },

--- a/.github/workflows/ci-cost-analysis.lock.yml
+++ b/.github/workflows/ci-cost-analysis.lock.yml
@@ -31,7 +31,7 @@
 #   - GITHUB_TOKEN
 #
 # Custom actions used:
-#   - actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+#   - actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@bf7ba42ce6443bf79fa184c9c6a35de202690bfc # v0.82.7
+        uses: github/gh-aw-actions/setup@3ea13c02d765410340d533515cb31a7eef2baaf0 # v0.77.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -131,7 +131,7 @@ jobs:
         env:
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       - name: Checkout .github and .agents folders
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           sparse-checkout: |
@@ -353,7 +353,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@bf7ba42ce6443bf79fa184c9c6a35de202690bfc # v0.82.7
+        uses: github/gh-aw-actions/setup@3ea13c02d765410340d533515cb31a7eef2baaf0 # v0.77.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -374,7 +374,7 @@ jobs:
             echo "GH_AW_SAFE_OUTPUTS_TOOLS_PATH=${RUNNER_TEMP}/gh-aw/safeoutputs/tools.json"
           } >> "$GITHUB_OUTPUT"
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -1021,7 +1021,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@bf7ba42ce6443bf79fa184c9c6a35de202690bfc # v0.82.7
+        uses: github/gh-aw-actions/setup@3ea13c02d765410340d533515cb31a7eef2baaf0 # v0.77.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1166,7 +1166,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@bf7ba42ce6443bf79fa184c9c6a35de202690bfc # v0.82.7
+        uses: github/gh-aw-actions/setup@3ea13c02d765410340d533515cb31a7eef2baaf0 # v0.77.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1194,7 +1194,7 @@ jobs:
           echo "GH_AW_AGENT_OUTPUT=/tmp/gh-aw/agent_output.json" >> "$GITHUB_OUTPUT"
       - name: Checkout repository for patch context
         if: needs.agent.outputs.has_patch == 'true'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       # --- Threat Detection ---
@@ -1401,7 +1401,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@bf7ba42ce6443bf79fa184c9c6a35de202690bfc # v0.82.7
+        uses: github/gh-aw-actions/setup@3ea13c02d765410340d533515cb31a7eef2baaf0 # v0.77.5
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}


### PR DESCRIPTION
## Description

The `ci-cost-analysis` agentic workflow has been failing on `main` ([example run](https://github.com/camunda/camunda/actions/runs/29339381377)). The `agent` job crashes at *Execute GitHub Copilot CLI* with:

```
Error: Cannot find module '/home/runner/work/_temp/gh-aw/actions/merge_awf_model_multipliers.cjs'
code: 'MODULE_NOT_FOUND'
##[error]Process completed with exit code 1.
```

**Root cause:** `ci-cost-analysis.lock.yml` is a generated `gh-aw` artifact (`# ... generated by gh-aw (v0.77.5). DO NOT EDIT`). Its inline harness is compiled against a specific gh-aw version, but Renovate was bumping the `github/gh-aw-actions/setup` pin *inside* the generated file (most recently v0.82.7). The v0.82.7 setup bundle no longer ships the `merge_awf_model_multipliers.cjs` helper that the v0.77.5 harness calls, so the setup bundle and the harness desynced. Deterministic — not flaky.

**Fix:**
- Recompile the workflow at its original **v0.77.5** via `gh aw compile`, restoring internal consistency. This reverts the pins Renovate had bumped in the generated file (`gh-aw-actions/setup` and `actions/checkout`). The lock file is 100% generator output — no manual edits.
- Add two Renovate rules:
  - Disable Renovate on `*.lock.yml` — every pin there is baked in by the compiler; updates must flow through a deliberate toolchain upgrade + recompile, never piecemeal.
  - Keep `github/gh-aw-actions` in the hand-authored `copilot-setup-steps.yml` pinned so the CLI installer stays in lockstep with the compiler version.

**Verification:** `gh aw compile` reports 0 errors/0 warnings; recompile is byte-identical (deterministic); `renovate.json` is valid JSON. After merge the `Execute GitHub Copilot CLI` step will load its helpers from the matching v0.77.5 setup bundle.

## Checklist

- [ ] Enable backports when necessary — n/a, this workflow only exists on `main`.

## Related issues

n/a